### PR TITLE
dev: Add a Dockerfile for development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.travis.yml
+.git
+**/.idea
+**/cmake-*
+**/CMakeLists.txt
+*.iml
+**/Dockerfile*
+Dockerfile*
+**/target
+target

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# Proxy build and runtime
+#
+# This is intended **DEVELOPMENT ONLY**, i.e. so that proxy developers can
+# easily test the proxy in the context of the larger `linkerd2` project.
+#
+# When PROXY_UNOPTIMIZED is set and not empty, unoptimized rust artifacts are produced.
+# This reduces build time and produces binaries with debug symbols, at the expense of
+# runtime perforamnce.
+
+ARG RUST_IMAGE=rust:1.27.1
+ARG RUNTIME_IMAGE=gcr.io/linkerd-io/base:2017-10-30.01
+
+## Builds the proxy as incrementally as possible.
+FROM $RUST_IMAGE as build
+
+WORKDIR /usr/src/linkerd2-proxy
+
+# Fetch external dependencies.
+#
+# Mock out all local code and fetch external dependencies to ensure that
+# external sources are primarily cached on Cargo.lock.
+RUN for d in . futures-mpsc-lossy router ; \
+    do mkdir -p "${d}/src" && touch "${d}/src/lib.rs" ; \
+    done
+COPY Cargo.toml Cargo.lock          ./
+COPY futures-mpsc-lossy/Cargo.toml  futures-mpsc-lossy/Cargo.toml
+COPY router/Cargo.toml              router/Cargo.toml
+RUN cargo fetch --locked
+
+# Build libraries, leaving the proxy mocked out.
+COPY futures-mpsc-lossy futures-mpsc-lossy
+COPY router router
+ARG PROXY_UNOPTIMIZED
+RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
+    then cargo build --frozen ; \
+    else cargo build --frozen --release ; \
+    fi
+
+# Build the proxy binary using the already-built dependencies.
+COPY src src
+RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
+    then \
+    cargo build -p linkerd2-proxy --bin linkerd2-proxy --frozen && \
+    mv target/debug/linkerd1-proxy target/linkerd2-proxy ; \
+    else \
+    cargo build -p linkerd2-proxy --bin linkerd2-proxy --frozen --release && \
+    mv target/release/linkerd2-proxy target/linkerd2-proxy ; \
+    fi
+
+
+## Install the proxy binary into the base runtime image.
+FROM $RUNTIME_IMAGE as runtime
+WORKDIR /linkerd
+COPY --from=build /usr/src/linkerd2-proxy/target/linkerd2-proxy ./linkerd2-proxy
+ENV LINKERD2_PROXY_LOG=warn,linkerd2_proxy=info
+ENTRYPOINT ["/linkerd/linkerd2-proxy"]

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ ifndef TEST_FLAKEY
 endif
 CARGO_TEST = $(CARGO) test --frozen $(RELEASE) $(TEST_FLAGS)
 
+DOCKER = docker
+DOCKER_BUILD = docker build
+ifdef DOCKER_TAG
+	DOCKER_BUILD = docker build -t $(DOCKER_TAG)
+endif
+
 $(TARGET_BIN): fetch
 	$(CARGO_BUILD)
 
@@ -63,6 +69,10 @@ package: $(PKG_ROOT)/$(PKG)
 .PHONY: clean-package
 clean-package:
 	rm -rf $(PKG_ROOT)
+
+.PHONY: docker
+docker: Dockerfile Cargo.lock
+	$(DOCKER_BUILD) .
 
 .PHONY: all
 all: build test


### PR DESCRIPTION
When working on the proxy, it's important to be able to build a Docker
image that can be tested in the context of the existing linkerd2
project.

This change adds a `make docker` target that produces a docker image,
optionally tagged via the `DOCKER_TAG` environment variable.

This is intended to be used for development--especially on non-Linux
OSes.