### PR TITLE
Replace references to _Conduit_

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to Linkerd2 #
+# Contributing to linkerd2-proxy #
 
 :balloon: Thanks for your help improving the project!
 
 ## Getting Help ##
 
-If you have a question about Conduit or have encountered problems using it,
+If you have a question about Linkerd2 or have encountered problems using it,
 start by [asking a question in the forums][discourse] or join us in the
-[#conduit Slack channel][slack].
+(yet-to-be-renamed) [#conduit Slack channel][slack].
 
 ## Certificate of Origin ##
 
@@ -35,8 +35,8 @@ Do you have an improvement?
 3. Fork this repo, develop and test your code changes. See the project's [README](README.md) for further information about working in this repository.
 4. Submit a pull request against this repo's `master` branch.
 5. Your branch may be merged once all configured checks pass, including:
-    - 2 code review approvals, at least 1 of which is from a [runconduit organization member][members].
     - The branch has passed tests in CI.
+    - A review from appropriate maintainers (see [MAINTAINERS.md](MAINTAINERS.md) and [GOVERNANCE.md](GOVERNANCE.md))
 
 ## Committing ##
 
@@ -98,6 +98,8 @@ Describe the testing you've done to validate your change.  Performance-related
 changes should include before- and after- benchmark results.
 
 [discourse]: https://discourse.linkerd.io/c/conduit
+[governance]: GOVERNANCE.md
 [issue]: https://github.com/linkerd/linkerd2/issues/new
+[maintainers]: MAINTAINERS.md
 [members]: https://github.com/orgs/linkerd/people
 [slack]: http://slack.linkerd.io/

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ minutes to review our [code of conduct][coc].
 
 ## License
 
-Conduit is copyright 2018 the linkerd2-proxy authors. All rights reserved.
+linkerd2-proxy is copyright 2018 the linkerd2-proxy authors. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 these files except in compliance with the License. You may obtain a copy of the

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -63,8 +63,8 @@ impl fmt::Display for ResolveOneCtx {
 
 impl Resolver {
 
-    /// Construct a new `Resolver` from the system configuration and Conduit's
-    /// environment variables.
+    /// Construct a new `Resolver` from the system configuration and the
+    /// proxy's environment variables.
     ///
     /// # Returns
     ///

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -4,9 +4,6 @@ use futures::{Poll, Stream};
 ///
 /// Combines two different `Stream`s yielding the same item and error
 /// types into a single type.
-///
-// TODO: This is probably useful outside of Conduit as well. Perhaps it
-//       deserves to be in a library...
 #[derive(Clone, Debug)]
 pub enum Either<A, B> {
     A(A),

--- a/src/telemetry/metrics/labels/mod.rs
+++ b/src/telemetry/metrics/labels/mod.rs
@@ -54,7 +54,7 @@ pub struct RequestLabels {
     direction: Direction,
 
     // Additional labels identifying the destination service of an outbound
-    // request, provided by the Conduit control plane's service discovery.
+    // request, provided by the control plane's service discovery.
     outbound_labels: Option<DstLabels>,
 
     /// The value of the `:authority` (HTTP/2) or `Host` (HTTP/1.1) header of

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -3,7 +3,7 @@
 //! # A note on label formatting
 //!
 //! Prometheus labels are represented as a comma-separated list of values
-//! Since the Conduit proxy labels its metrics with a fixed set of labels
+//! Since the proxy labels its metrics with a fixed set of labels
 //! which we know in advance, we represent these labels using a number of
 //! `struct`s, all of which implement `fmt::Display`. Some of the label
 //! `struct`s contain other structs which represent a subset of the labels

--- a/src/transparency/h1.rs
+++ b/src/transparency/h1.rs
@@ -62,10 +62,10 @@ fn set_authority(uri: &mut http::Uri, auth: Authority) {
 
     // If this was an origin-form target (path only),
     // then we can't *only* set the authority, as that's
-    // an illegal target (such as `conduit.io/docs`).
+    // an illegal target (such as `linkerd.io/docs`).
     //
     // But don't set a scheme if this was authority-form (CONNECT),
-    // since that would change it's meaning (like `https://conduit.io`).
+    // since that would change it's meaning (like `https://linkerd.io`).
     if parts.path_and_query.is_some() {
         parts.scheme = Some(Scheme::HTTP);
     }
@@ -147,12 +147,12 @@ pub fn is_upgrade<B>(res: &http::Response<B>) -> bool {
 
 /// Returns if the request target is in `absolute-form`.
 ///
-/// This is `absolute-form`: `https://conduit.io/docs`
+/// This is `absolute-form`: `https://linkerd.io/docs`
 ///
 /// This is not:
 ///
 /// - `/docs`
-/// - `conduit.io`
+/// - `linkerd.io`
 pub fn is_absolute_form(uri: &Uri) -> bool {
     // It's sufficient just to check for a scheme, since in HTTP1,
     // it's required in absolute-form, and `http::Uri` doesn't
@@ -172,7 +172,7 @@ pub fn is_absolute_form(uri: &Uri) -> bool {
 
 /// Returns if the request target is in `origin-form`.
 ///
-/// This is `origin-form`: `conduit.io`
+/// This is `origin-form`: `linkerd.io`
 fn is_origin_form(uri: &Uri) -> bool {
     uri.scheme_part().is_none() &&
         uri.path_and_query().is_none()
@@ -182,7 +182,7 @@ fn is_origin_form(uri: &Uri) -> bool {
 ///
 /// Just because a request parses doesn't mean it's correct. For examples:
 ///
-/// - `GET conduit.io`
+/// - `GET linkerd.io`
 /// - `CONNECT /just-a-path
 pub fn is_bad_request<B>(req: &http::Request<B>) -> bool {
     if req.method() == &http::Method::CONNECT {

--- a/src/transport/tls/cert_resolver.rs
+++ b/src/transport/tls/cert_resolver.rs
@@ -88,7 +88,7 @@ impl rustls::ResolvesClientCert for CertResolver {
     fn resolve(&self, _acceptable_issuers: &[&[u8]], sigschemes: &[rustls::SignatureScheme])
         -> Option<rustls::sign::CertifiedKey>
     {
-        // Conduit's server side doesn't send the list of acceptable issuers so
+        // The proxy's server-side doesn't send the list of acceptable issuers so
         // don't bother looking at `_acceptable_issuers`.
         self.resolve_(sigschemes)
     }

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -510,7 +510,7 @@ mod outbound_dst_labels {
     // Ignore this test on CI, as it may fail due to the reduced concurrency
     // on CI containers causing the proxy to see both label updates from
     // the mock controller before the first request has finished.
-    // See https://github.com/runconduit/conduit/issues/751
+    // See https://github.com/linkerd/linkerd2/issues/751
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn controller_updates_addr_labels() {
@@ -567,7 +567,7 @@ mod outbound_dst_labels {
     // Ignore this test on CI, as it may fail due to the reduced concurrency
     // on CI containers causing the proxy to see both label updates from
     // the mock controller before the first request has finished.
-    // See https://github.com/runconduit/conduit/issues/751
+    // See https://github.com/linkerd/linkerd2/issues/751
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn controller_updates_set_labels() {
@@ -621,7 +621,7 @@ mod outbound_dst_labels {
 
 #[test]
 fn metrics_have_no_double_commas() {
-    // Test for regressions to runconduit/conduit#600.
+    // Test for regressions to linkerd/linkerd2#600.
     let _ = env_logger::try_init();
 
     info!("running test server");
@@ -824,7 +824,7 @@ mod transport {
             "tcp_close_total{direction=\"inbound\",peer=\"src\",tls=\"disabled\",classification=\"success\"} 2");
     }
 
-    // https://github.com/runconduit/conduit/issues/831
+    // https://github.com/linkerd/linkerd2/issues/831
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn inbound_tcp_duration() {
@@ -1106,7 +1106,7 @@ mod transport {
     }
 }
 
-// https://github.com/runconduit/conduit/issues/613
+// https://github.com/linkerd/linkerd2/issues/613
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn metrics_compression() {


### PR DESCRIPTION
There are various comments, examples, and documentation that refers to
Conduit. This change replaces or removes these refernces.

CONTRIBUTING.md has been updated to refer to GOVERNANCE/MAINTAINERS.