### PR TITLE
remove busy loop from destination background future during shutdown

### DIFF
--- a/src/telemetry/control.rs
+++ b/src/telemetry/control.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -95,7 +94,7 @@ impl Control {
     }
 
     pub fn serve_metrics(&self, bound_port: connection::BoundPort)
-        -> impl Future<Item = (), Error = io::Error>
+        -> impl Future<Item = (), Error = ()>
     {
         use hyper;
 
@@ -123,6 +122,7 @@ impl Control {
 
                     future::result(r)
                 })
+                .map_err(|err| error!("metrics listener error: {}", err))
         };
 
         log.future(fut)


### PR DESCRIPTION
When the proxy is shutting down, once there are no more outbound
connections, the sender side of the resolver channel is dropped. In the
admin background thread, when the destination background future is
notified of the closure, instead of shutting down itself, it just busy
loops. Now, after seeing shutdown, the background future ends as well.

While examining this, I noticed all the background futures are joined
togther into a single `Future` before being spawned on a dedicated
current_thread executor. Join in this case is inefficient, since *every*
single time *one* of the futures is ready, they are *all* polled again.
Since we have an executor handy, it's better to allow it to manage each
of the futures individually.

------

I can't prove that this is the cause for https://github.com/linkerd/linkerd2/issues/1231, but this was the first obvious thing I could find.