### PR TITLE
Revert "remove busy loop from destination background future during shutdown (#8)"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,15 +333,18 @@ where
 
                     let metrics_server = telemetry.serve_metrics(metrics_listener);
 
-                    rt.spawn(::logging::admin().bg("resolver").future(resolver_bg));
-                    rt.spawn(::logging::admin().bg("telemetry").future(telemetry));
-                    // tap is already wrapped in a logging Future.
-                    rt.spawn(tap);
-                    // metrics_server is already wrapped in a logging Future.
-                    rt.spawn(metrics_server);
-                    rt.spawn(::logging::admin().bg("dns-resolver").future(dns_bg));
+                    let fut = ::logging::admin().bg("resolver").future(resolver_bg)
+                        .join5(
+                            ::logging::admin().bg("telemetry").future(telemetry),
+                            tap.map_err(|_| {}),
+                            metrics_server.map_err(|_| {}),
+                            ::logging::admin().bg("dns-resolver").future(dns_bg),
+                        )
+                        // There's no `Future::join6` combinator...
+                        .join(::logging::admin().bg("tls-config").future(tls_cfg_bg))
+                        .map(|_| {});
 
-                    rt.spawn(::logging::admin().bg("tls-config").future(tls_cfg_bg));
+                    rt.spawn(Box::new(fut));
 
                     let shutdown = admin_shutdown_signal.then(|_| Ok::<(), ()>(()));
                     rt.block_on(shutdown).expect("admin");
@@ -501,7 +504,7 @@ where
 fn serve_tap<N, B>(
     bound_port: BoundPort,
     new_service: N,
-) -> impl Future<Item = (), Error = ()> + 'static
+) -> impl Future<Item = (), Error = io::Error> + 'static
 where
     B: tower_h2::Body + Send + 'static,
     <B::Data as bytes::IntoBuf>::Buf: Send,
@@ -543,7 +546,6 @@ where
                 future::result(r)
             },
         )
-            .map_err(|err| error!("tap listen error: {}", err))
     };
 
     log.future(fut)

--- a/src/telemetry/control.rs
+++ b/src/telemetry/control.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -94,7 +95,7 @@ impl Control {
     }
 
     pub fn serve_metrics(&self, bound_port: connection::BoundPort)
-        -> impl Future<Item = (), Error = ()>
+        -> impl Future<Item = (), Error = io::Error>
     {
         use hyper;
 
@@ -122,7 +123,6 @@ impl Control {
 
                     future::result(r)
                 })
-                .map_err(|err| error!("metrics listener error: {}", err))
         };
 
         log.future(fut)


### PR DESCRIPTION
This reverts commit 4bee7b0b55f6556de45f9999a19293ed2ed2b319.

Signed-off-by: Sean McArthur <sean@buoyant.io>