### PR TITLE
Move `connection` submodule to `transport`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,6 @@ use linkerd2_proxy_router::{Recognize, Router, Error as RouteError};
 pub mod app;
 mod bind;
 pub mod config;
-mod connection;
 pub mod conditional;
 pub mod control;
 pub mod convert;
@@ -96,11 +95,11 @@ mod watch_service; // TODO: move to tower
 
 use bind::Bind;
 use conditional::Conditional;
-use connection::BoundPort;
 use inbound::Inbound;
 use map_err::MapErr;
 use task::MainRuntime;
 use transparency::{HttpBody, Server};
+use transport::{BoundPort, Connection};
 pub use transport::{AddrInfo, GetOriginalDst, SoOriginalDst, tls};
 use outbound::Outbound;
 pub use watch_service::WatchService;
@@ -514,7 +513,7 @@ where
     >
         + Send + 'static,
     tower_h2::server::Connection<
-        connection::Connection,
+        Connection,
         N,
         ::logging::ServerExecutor,
         B,

--- a/src/telemetry/control.rs
+++ b/src/telemetry/control.rs
@@ -9,7 +9,7 @@ use tokio::executor::current_thread::TaskExecutor;
 use super::event::Event;
 use super::metrics;
 use super::tap::Taps;
-use connection;
+use transport::BoundPort;
 use ctx;
 use task;
 use conditional::Conditional;
@@ -94,7 +94,7 @@ impl Control {
         }
     }
 
-    pub fn serve_metrics(&self, bound_port: connection::BoundPort)
+    pub fn serve_metrics(&self, bound_port: BoundPort)
         -> impl Future<Item = (), Error = io::Error>
     {
         use hyper;

--- a/src/telemetry/sensor/mod.rs
+++ b/src/telemetry/sensor/mod.rs
@@ -10,7 +10,7 @@ use tower_h2::{client, Body};
 
 use ctx;
 use telemetry::event;
-use transport::tls;
+use transport::{Connection, tls};
 
 pub mod http;
 mod transport;
@@ -74,7 +74,7 @@ impl Sensors {
 
     pub fn connect<C>(&self, connect: C, ctx: &Arc<ctx::transport::Client>) -> Connect<C>
     where
-        C: tokio_connect::Connect<Connected = ::connection::Connection>,
+        C: tokio_connect::Connect<Connected = Connection>,
     {
         Connect::new(connect, &self.0, ctx)
     }

--- a/src/telemetry/sensor/transport.rs
+++ b/src/telemetry/sensor/transport.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use tokio_connect;
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use connection::{self, Peek};
+use transport::{Connection, Peek};
 use ctx;
 use telemetry::event;
 
@@ -193,7 +193,7 @@ impl<T: AsyncRead + AsyncWrite + Peek> Peek for Transport<T> {
 
 impl<C> Connect<C>
 where
-    C: tokio_connect::Connect<Connected = connection::Connection>,
+    C: tokio_connect::Connect<Connected = Connection>,
 {
     /// Returns a `Connect` to `addr` and `handle`.
     pub(super) fn new(
@@ -211,7 +211,7 @@ where
 
 impl<C> tokio_connect::Connect for Connect<C>
 where
-    C: tokio_connect::Connect<Connected = connection::Connection>,
+    C: tokio_connect::Connect<Connected = Connection>,
 {
     type Connected = Transport<C::Connected>;
     type Error = C::Error;
@@ -230,7 +230,7 @@ where
 
 impl<C> Future for Connecting<C>
 where
-    C: tokio_connect::Connect<Connected = connection::Connection>,
+    C: tokio_connect::Connect<Connected = Connection>,
 {
     type Item = Transport<C::Connected>;
     type Error = C::Error;

--- a/src/transparency/server.rs
+++ b/src/transparency/server.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::NewService;
 use tower_h2;
 
-use connection::{Connection, Peek};
+use transport::{Connection, Peek};
 use ctx::Proxy as ProxyCtx;
 use ctx::transport::{Server as ServerCtx};
 use drain;

--- a/src/transport/connect.rs
+++ b/src/transport/connect.rs
@@ -7,10 +7,9 @@ use std::str::FromStr;
 
 use http;
 
-use connection;
 use convert::TryFrom;
 use dns;
-use transport::tls;
+use transport::{connection, tls};
 
 #[derive(Debug, Clone)]
 pub struct Connect {

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -1,3 +1,5 @@
+/// Tokio-level (not Tower-level) proxy-specific networking.
+
 use bytes::{Buf, BytesMut};
 use futures::{*, future::Either};
 use std;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,14 +1,25 @@
 mod connect;
+mod connection;
 mod addr_info;
 mod io;
 mod prefixed;
 pub mod tls;
 
-pub use self::connect::{
-    Connect,
-    DnsNameAndPort, Host, HostAndPort, HostAndPortError,
-    LookupAddressAndConnect,
+pub use self::{
+    addr_info::{
+        AddrInfo,
+        GetOriginalDst,
+        SoOriginalDst
+    },
+    connect::{
+        Connect,
+        DnsNameAndPort, Host, HostAndPort, HostAndPortError,
+        LookupAddressAndConnect,
+    },
+    connection::{
+        BoundPort,
+        Connection,
+        Peek,
+    },
+    io::BoxedIo,
 };
-pub use self::addr_info::{AddrInfo, GetOriginalDst, SoOriginalDst};
-pub use self::io::BoxedIo;
-


### PR DESCRIPTION
This allows easier logging configuration for the entire transport system
using the common prefix `conduit_proxy::transport`. Previously logging had to be
controlled separately/additionally for `conduit_proxy::connection`.

Signed-off-by: Brian Smith <brian@briansmith.org>