### PR TITLE
Add errno label to transport close metrics (when applicable)

### DIFF
--- a/benches/record.rs
+++ b/benches/record.rs
@@ -154,12 +154,14 @@ fn record_one_conn_request(b: &mut Bencher) {
 
         TransportClose(server_transport.clone(), event::TransportClose {
             clean: true,
+            errno: None,
             duration: Duration::from_secs(30_000),
             rx_bytes: 4321,
             tx_bytes: 4321,
         }),
         TransportClose(client_transport.clone(), event::TransportClose {
             clean: true,
+            errno: None,
             duration: Duration::from_secs(30_000),
             rx_bytes: 4321,
             tx_bytes: 4321,
@@ -221,6 +223,7 @@ fn record_many_dsts(b: &mut Bencher) {
 
         events.push(TransportClose(client_transport.clone(), event::TransportClose {
             clean: true,
+            errno: None,
             duration: Duration::from_secs(30_000),
             rx_bytes: 4321,
             tx_bytes: 4321,
@@ -229,6 +232,7 @@ fn record_many_dsts(b: &mut Bencher) {
 
     events.push(TransportClose(server_transport.clone(), event::TransportClose {
         clean: true,
+        errno: None,
         duration: Duration::from_secs(30_000),
         rx_bytes: 4321,
         tx_bytes: 4321,

--- a/src/telemetry/event.rs
+++ b/src/telemetry/event.rs
@@ -27,6 +27,7 @@ pub struct TransportClose {
     /// Indicates that the transport was closed without error.
     // TODO include details.
     pub clean: bool,
+    pub errno: Option<i32>,
 
     pub duration: Duration,
 

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -363,6 +363,7 @@ mod tests {
 
         let end = TransportCloseLabels::new(&client_transport, &event::TransportClose {
             clean: true,
+            errno: None,
             duration: Duration::from_millis(15),
             rx_bytes: 40,
             tx_bytes: 0,

--- a/src/telemetry/metrics/record.rs
+++ b/src/telemetry/metrics/record.rs
@@ -199,6 +199,7 @@ mod test {
              Arc::new(ctx::transport::Ctx::Client(client.clone()));
         let transport_close = event::TransportClose {
             clean: true,
+            errno: None,
             duration: Duration::from_secs(30_000),
             rx_bytes: 4321,
             tx_bytes: 4321,

--- a/src/telemetry/sensor/transport.rs
+++ b/src/telemetry/sensor/transport.rs
@@ -86,11 +86,13 @@ impl<T: AsyncRead + AsyncWrite> Transport<T> {
                         tx_bytes,
                     }) = self.1.take()
                     {
+                        let errno = e.raw_os_error();
                         handle.send(move || {
                             let duration = opened_at.elapsed();
                             let ev = event::TransportClose {
                                 duration,
                                 clean: false,
+                                errno,
                                 rx_bytes,
                                 tx_bytes,
                             };
@@ -119,6 +121,7 @@ impl<T> Drop for Transport<T> {
                 let duration = opened_at.elapsed();
                 let ev = event::TransportClose {
                     clean: true,
+                    errno: None,
                     duration,
                     rx_bytes,
                     tx_bytes,

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -816,6 +816,36 @@ mod transport {
 
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    fn inbound_tcp_connect_err() {
+        let _ = env_logger::try_init();
+        let srv = tcp::server()
+            .accept_fut(move |sock| {
+                sock.shutdown(::std::net::Shutdown::Both).unwrap();
+                future::ok(())
+            })
+            .run();
+        let proxy = proxy::new()
+            .inbound(srv)
+            .run();
+
+        let client = client::tcp(proxy.inbound);
+        let metrics = client::http1(proxy.metrics, "localhost");
+
+        let tcp_client = client.connect();
+
+        tcp_client.write(TcpFixture::HELLO_MSG);
+        assert_eq!(tcp_client.read(), &[]);
+        // Connection to the server should be a failure with the EXFULL error
+        // code.
+        assert_contains!(metrics.get("/metrics"),
+            "tcp_close_total{direction=\"inbound\",peer=\"dst\",tls=\"no_identity\",no_tls_reason=\"not_http\",classification=\"failure\",errno=\"EXFULL\"} 1");
+        // Connection to the client should have closed cleanly.
+        assert_contains!(metrics.get("/metrics"),
+            "tcp_close_total{direction=\"inbound\",peer=\"src\",tls=\"disabled\",classification=\"success\"} 1");
+    }
+
+    #[test]
+    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn inbound_tcp_accept() {
         let _ = env_logger::try_init();
         let TcpFixture { client, metrics, proxy: _proxy } =


### PR DESCRIPTION
This branch adds a label displaying the Unix error code name (or the raw
error code, on other operating systems or if the error code was not 
recognized) to the metrics generated for TCP connection failures.

It also adds a couple of tests for label formatting.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>