### PR TITLE
fix control client Backoff to poll its timer when backing off

### DIFF
--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -26,6 +26,7 @@
 
 use std::net::SocketAddr;
 use std::sync::{Arc, Weak};
+use std::time::Duration;
 use tls;
 
 use futures::{
@@ -145,6 +146,7 @@ pub fn new(
     namespaces: Namespaces,
     host_and_port: Option<HostAndPort>,
     controller_tls: tls::ConditionalConnectionConfig<tls::ClientConfigWatch>,
+    control_backoff_delay: Duration,
 ) -> (Resolver, impl Future<Item = (), Error = ()>) {
     let (request_tx, rx) = mpsc::unbounded();
     let disco = Resolver { request_tx };
@@ -154,6 +156,7 @@ pub fn new(
         namespaces,
         host_and_port,
         controller_tls,
+        control_backoff_delay,
     );
     (disco, bg)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,6 +255,7 @@ where
             config.namespaces.clone(),
             control_host_and_port,
             controller_tls,
+            config.control_backoff_delay,
         );
 
         let (drain_tx, drain_rx) = drain::channel();


### PR DESCRIPTION
The `Backoff` service wrapper is used for the controller client service
so that if the proxy can't find the controller (there is a connection
error), it doesn't keep trying in a tight loop, but instead waits a
couple seconds before trying again, presuming that the control plane
was rebooting.

When "backing off", a timer would be set, but it wasn't polled, so the
task was never registered to wake up after the delay. This turns out to
not have been a problem in practice, since the background destination
task was joined with other tasks that were constantly waking up,
allowing it to try again anyways.

To add tests for this, a new `ENV_CONTROL_BACKOFF_DELAY` config value
has been added, so that the tests don't have to wait the default 5
seconds.

Signed-off-by: Sean McArthur <sean@buoyant.io>