### PR TITLE
Point inotify dependency at master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "inotify"
 version = "0.5.2-dev"
-source = "git+https://github.com/hawkw/inotify?branch=eliza/mio#548eafc423f8506fcbee38ae82d9071b2bd0abbd"
+source = "git+https://github.com/inotify-rs/inotify#1cd506ebdd73a787e4c0a1949e90e0f40c5d1d7b"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -484,7 +484,7 @@ dependencies = [
  "httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "inotify 0.5.2-dev (git+https://github.com/hawkw/inotify?branch=eliza/mio)",
+ "inotify 0.5.2-dev (git+https://github.com/inotify-rs/inotify)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-proxy-api 0.1.0 (git+https://github.com/linkerd/linkerd2-proxy-api)",
@@ -1588,7 +1588,7 @@ dependencies = [
 "checksum hyper 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f31c3ce511142fac936539abd3315bdc303a6e501fac5b77e0824310d542d081"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9378f1f3923647a9aea6af4c6b5de68cc8a71415459ad25ef191191c48f5b7"
-"checksum inotify 0.5.2-dev (git+https://github.com/hawkw/inotify?branch=eliza/mio)" = "<none>"
+"checksum inotify 0.5.2-dev (git+https://github.com/inotify-rs/inotify)" = "<none>"
 "checksum inotify-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7dceb94c43f70baf4c4cd6afbc1e9037d4161dbe68df8a2cd4351a23319ee4fb"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9ec4e18c0a0d4340870c14284293632d8421f419008371422dd327892b88877c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ untrusted = "0.6.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
-inotify = { git = "https://github.com/hawkw/inotify", branch = "eliza/mio" }
+inotify = { git = "https://github.com/inotify-rs/inotify" }
 procinfo = "0.4.2"
 
 [dev-dependencies]


### PR DESCRIPTION
Now that inotify-rs/inotify#105 has merged, we will no longer see
rampant CPU use from using the master version of `inotify`. I've updated
Cargo.toml to depend on master rather than on my branch.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>