### PR TITLE
Improve error messages in logs

### DIFF
--- a/src/telemetry/sensor/http.rs
+++ b/src/telemetry/sensor/http.rs
@@ -7,10 +7,11 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
 use tower_service::{NewService, Service};
-use tower_h2::{client, Body};
+use tower_h2::Body;
 
 use ctx;
 use telemetry::event::{self, Event};
+use transparency::ClientError;
 
 const GRPC_STATUS: &str = "grpc-status";
 
@@ -118,7 +119,7 @@ where
     N: NewService<
         Request = http::Request<RequestBody<A>>,
         Response = http::Response<B>,
-        Error = client::Error,
+        Error = ClientError,
     >
         + 'static,
 {
@@ -143,7 +144,7 @@ where
     N: NewService<
         Request = http::Request<RequestBody<A>>,
         Response = http::Response<B>,
-        Error = client::Error,
+        Error = ClientError,
     >
         + 'static,
 {
@@ -200,7 +201,7 @@ where
     S: Service<
         Request = http::Request<RequestBody<A>>,
         Response = http::Response<B>,
-        Error = client::Error,
+        Error = ClientError,
     >
         + 'static,
 {
@@ -281,7 +282,7 @@ where
 
 impl<F, B> Future for Respond<F, B>
 where
-    F: Future<Item = http::Response<B>, Error=client::Error>,
+    F: Future<Item = http::Response<B>, Error=ClientError>,
     B: Body + 'static,
 {
     type Item = http::Response<ResponseBody<B>>;

--- a/src/telemetry/sensor/mod.rs
+++ b/src/telemetry/sensor/mod.rs
@@ -6,11 +6,12 @@ use http::{Request, Response};
 use tokio_connect;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tower_service::NewService;
-use tower_h2::{client, Body};
+use tower_h2::Body;
 
 use ctx;
 use telemetry::event;
 use transport::{Connection, tls};
+use transparency::ClientError;
 
 pub mod http;
 mod transport;
@@ -90,7 +91,7 @@ impl Sensors {
         N: NewService<
             Request = Request<http::RequestBody<A>>,
             Response = Response<B>,
-            Error = client::Error
+            Error = ClientError
         >
             + 'static,
     {

--- a/src/transparency/client.rs
+++ b/src/transparency/client.rs
@@ -19,6 +19,13 @@ use std::{self, fmt};
 type HyperClient<C, B> =
     hyper::Client<HyperConnect<C>, BodyPayload<RequestBody<B>>>;
 
+/// A wrapper around the error types produced by the HTTP/1 and HTTP/2 clients.
+///
+/// Note that the names of the variants of this type (`Error::Http1` and
+/// `Error::Http2`) aren't intended to imply that the error was a protocol
+/// error; instead, they refer simply to which client the error occurred in.
+/// Values of either variant may ultimately be caused by IO errors or other
+/// types of error which could effect either protocol client.
 #[derive(Debug)]
 pub enum Error {
     Http1(hyper::Error),

--- a/src/transparency/glue.rs
+++ b/src/transparency/glue.rs
@@ -313,7 +313,7 @@ where
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let mut res = try_ready!(self.inner.poll().map_err(|e| {
-            debug!("h2 error: {}", e);
+            debug!("HTTP/1 error: {}", e);
             h2::Error::from(io::Error::new(io::ErrorKind::Other, e))
         }));
 

--- a/src/transparency/glue.rs
+++ b/src/transparency/glue.rs
@@ -1,7 +1,6 @@
 use std::{
     error::Error,
     fmt,
-    io,
     sync::Arc,
 };
 
@@ -251,7 +250,7 @@ where
 {
     type ReqBody = hyper::Body;
     type ResBody = BodyPayload<B>;
-    type Error = h2::Error;
+    type Error = S::Error;
     type Future = Either<
         HyperServerSvcFuture<S::Future>,
         future::FutureResult<http::Response<Self::ResBody>, Self::Error>,
@@ -309,12 +308,12 @@ where
     F::Error: Error + fmt::Debug + Send + Sync + 'static,
 {
     type Item = http::Response<BodyPayload<B>>;
-    type Error = h2::Error;
+    type Error = F::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let mut res = try_ready!(self.inner.poll().map_err(|e| {
             debug!("HTTP/1 error: {}", e);
-            h2::Error::from(io::Error::new(io::ErrorKind::Other, e))
+            e
         }));
 
         if h1::is_upgrade(&res) {
@@ -412,11 +411,11 @@ impl<C> hyper_connect::Connect for HyperConnect<C>
 where
     C: Connect + Send + Sync,
     C::Future: Send + 'static,
-    <C::Future as Future>::Error: Error + Send + Sync,
+    <C::Future as Future>::Error: Error + Send + Sync + 'static,
     C::Connected: Send + 'static,
 {
     type Transport = C::Connected;
-    type Error = io::Error;
+    type Error = <C::Future as Future>::Error;
     type Future = HyperConnectFuture<C::Future>;
 
     fn connect(&self, _dst: hyper_connect::Destination) -> Self::Future {
@@ -433,12 +432,10 @@ where
     F::Error: Error + Send + Sync,
 {
     type Item = (F::Item, hyper_connect::Connected);
-    type Error = io::Error;
+    type Error = F::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let transport = try_ready!(
-            self.inner.poll().map_err(|e| io::Error::new(io::ErrorKind::Other, e))
-        );
+        let transport = try_ready!(self.inner.poll());
         let connected = hyper_connect::Connected::new()
             .proxy(self.absolute_form);
         Ok(Async::Ready((transport, connected)))

--- a/src/transparency/mod.rs
+++ b/src/transparency/mod.rs
@@ -6,6 +6,6 @@ mod protocol;
 mod server;
 mod tcp;
 
-pub use self::client::Client;
+pub use self::client::{Client, Error as ClientError};
 pub use self::glue::HttpBody;
 pub use self::server::Server;

--- a/src/transparency/server.rs
+++ b/src/transparency/server.rs
@@ -1,7 +1,10 @@
-use std::fmt;
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::{
+    error::Error,
+    fmt,
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use futures::{future::Either, Future};
 use http;
@@ -57,12 +60,11 @@ where
     > + Clone + Send + 'static,
     S::Future: 'static,
     <S as NewService>::Service: Send,
-    S::Error: fmt::Debug,
     <<S as NewService>::Service as ::tower_service::Service>::Future: Send,
     S::InitError: fmt::Debug,
     S::Future: Send + 'static,
     B: tower_h2::Body + 'static,
-    S::Error: Send + fmt::Debug,
+    S::Error: Error + Send + Sync + 'static,
     S::InitError: Send + fmt::Debug,
     B: tower_h2::Body + Send + Default + 'static,
     B::Data: Send,


### PR DESCRIPTION
Currently, the messages that the proxy logs on errors are often not 
very useful. For example, when an error occurred that caused the proxy
to return HTTP 500, we log a message like this:

```
ERR! proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57416} linkerd2_proxy turning Error caused by underlying HTTP/2 error: protocol error: unexpected internal error encountered into 500
```

Note that:
+ Regardless of what the error actually was, the current log message
  *always* says protocol error: unexpected internal error encountered,
  which is both fairly unclear *and* often not actually the case.
+ Regardless of whether the error was encountered by an HTTP/1 or 
  HTTP/2 client, the error message always includes the string
  "underlying HTTP/2 error". This is probably fairly confusing for 
  users who are, say, only proxying HTTP/1 traffic.

This branch fixes several related issues around the clarity of the
proxy's error messages:

+ A couple cases in the `transparency` module that returned
  `io::Error::from(io::ErrorKind::Other)` have been replaced with
  more descriptive errors that propagate the underlying error. This
  necessitated adding bounds on some error types.
+ Introduced a new `transparency::client::Error` enum that can be 
  either a `h2::Error` or a `hyper::Error`, depending on whether
  the client is HTTP/1 or HTTP/2, and proxies its' `std::error::Error`
  impl to the wrapped error types. This way, we don't return a
  `tower_h2::client::Error` (with format output that includes the 
  string "HTTP/2") from everything, and discard significantly less
  error information.

<details>
<summary>Examples</summary>
As an example, here's what happens when I hit the proxy's inbound 
router with no inner service running.

Before this change:
```
➜ LINKERD2_PROXY_POD_NAMESPACE=foo LINKERD2_PROXY_POD_NAME=bar LINKERD2_PROXY_LOG=info,linkerd2_proxy=debug LINKERD2_PROXY_PRIVATE_FORWARD=tcp://127.0.0.1:8888 cargo run
   Compiling linkerd2-proxy v0.1.0 (file:///Users/eliza/Code/linkerd2-proxy)
    Finished dev [unoptimized + debuginfo] target(s) in 28.95s
     Running `target/debug/linkerd2-proxy`
DBUG linkerd2_proxy::task creating single-threaded proxy
INFO linkerd2_proxy using controller at None
INFO linkerd2_proxy routing on V4(127.0.0.1:4140)
INFO linkerd2_proxy proxying on V4(0.0.0.0:4143) to Some(Addr(V4(127.0.0.1:8888)))
INFO linkerd2_proxy serving Prometheus metrics on V4(127.0.0.1:4191)
INFO linkerd2_proxy protocol detection disabled for inbound ports {25, 3306}
INFO linkerd2_proxy protocol detection disabled for outbound ports {25, 3306}
INFO linkerd2_proxy::telemetry::metrics procinfo not supported on this operating system
DBUG proxy={server=in listen=0.0.0.0:4143} linkerd2_proxy::transport::addr_info no support for SO_ORIGINAL_DST
DBUG proxy={server=in listen=0.0.0.0:4143} linkerd2_proxy::telemetry::sensor server connection open
DBUG proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57416} linkerd2_proxy::inbound building inbound Http1 { host: Authority(localhost:4143), was_absolute_form: false } client to 127.0.0.1:8888
DBUG proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57416} linkerd2_proxy::bind bind_stack: endpoint=Endpoint { address: V4(127.0.0.1:8888), metadata: Metadata { dst_labels: None, tls_identity: None(NotProvidedByServiceDiscovery) } }, protocol=Http1 { host: Authority(localhost:4143), was_absolute_form: false }
DBUG proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57416} linkerd2_proxy::bind rebinding endpoint stack for Endpoint { address: V4(127.0.0.1:8888), metadata: Metadata { dst_labels: None, tls_identity: None(NotProvidedByServiceDiscovery) } }:Http1 { host: Authority(localhost:4143), was_absolute_form: false } on TLS config change
DBUG proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57416} linkerd2_proxy::bind bind_inner_stack endpoint=Endpoint { address: V4(127.0.0.1:8888), metadata: Metadata { dst_labels: None, tls_identity: None(NotProvidedByServiceDiscovery) } }, protocol=Http1 { host: Authority(localhost:4143), was_absolute_form: false }
DBUG proxy={client=in dst=local remote=127.0.0.1:8888} linkerd2_proxy::transparency::client client request: method=GET uri=http://localhost:4143/ headers={"host": "localhost:4143", "user-agent": "HTTPie/0.9.9", "accept-encoding": "gzip, deflate", "accept": "*/*"}
DBUG proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57416} linkerd2_proxy::transparency::client http/1 client error: an error occurred trying to connect: other os error
ERR! proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57416} linkerd2_proxy turning Error caused by underlying HTTP/2 error: protocol error: unexpected internal error encountered into 500
```

After this change:
```
➜ LINKERD2_PROXY_POD_NAMESPACE=foo LINKERD2_PROXY_POD_NAME=bar LINKERD2_PROXY_LOG=info,linkerd2_proxy=debug LINKERD2_PROXY_PRIVATE_FORWARD=tcp://127.0.0.1:8888 cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
     Running `target/debug/linkerd2-proxy`
DBUG linkerd2_proxy::task creating single-threaded proxy
INFO linkerd2_proxy using controller at None
INFO linkerd2_proxy routing on V4(127.0.0.1:4140)
INFO linkerd2_proxy proxying on V4(0.0.0.0:4143) to Some(Addr(V4(127.0.0.1:8888)))
INFO linkerd2_proxy serving Prometheus metrics on V4(127.0.0.1:4191)
INFO linkerd2_proxy protocol detection disabled for inbound ports {25, 3306}
INFO linkerd2_proxy protocol detection disabled for outbound ports {25, 3306}
INFO linkerd2_proxy::telemetry::metrics procinfo not supported on this operating system
DBUG proxy={server=in listen=0.0.0.0:4143} linkerd2_proxy::transport::addr_info no support for SO_ORIGINAL_DST
DBUG proxy={server=in listen=0.0.0.0:4143} linkerd2_proxy::telemetry::sensor server connection open
DBUG proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57406} linkerd2_proxy::inbound building inbound Http1 { host: Authority(localhost:4143), was_absolute_form: false } client to 127.0.0.1:8888
DBUG proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57406} linkerd2_proxy::bind bind_stack: endpoint=Endpoint { address: V4(127.0.0.1:8888), metadata: Metadata { dst_labels: None, tls_identity: None(NotProvidedByServiceDiscovery) } }, protocol=Http1 { host: Authority(localhost:4143), was_absolute_form: false }
DBUG proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57406} linkerd2_proxy::bind rebinding endpoint stack for Endpoint { address: V4(127.0.0.1:8888), metadata: Metadata { dst_labels: None, tls_identity: None(NotProvidedByServiceDiscovery) } }:Http1 { host: Authority(localhost:4143), was_absolute_form: false } on TLS config change
DBUG proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57406} linkerd2_proxy::bind bind_inner_stack endpoint=Endpoint { address: V4(127.0.0.1:8888), metadata: Metadata { dst_labels: None, tls_identity: None(NotProvidedByServiceDiscovery) } }, protocol=Http1 { host: Authority(localhost:4143), was_absolute_form: false }
DBUG proxy={client=in dst=local remote=127.0.0.1:8888} linkerd2_proxy::transparency::client client request: method=GET uri=http://localhost:4143/ headers={"host": "localhost:4143", "user-agent": "HTTPie/0.9.9", "accept-encoding": "gzip, deflate", "accept": "*/*"}
DBUG proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57406} linkerd2_proxy::transparency::client http/1 client error: an error occurred trying to connect: Connection refused (os error 61); cause: Connection refused (os error 61);
ERR! proxy={server=in listen=0.0.0.0:4143 remote=127.0.0.1:57406} linkerd2_proxy turning an error occurred trying to connect: Connection refused (os error 61) into 500
^X^CINFO linkerd2_proxy::signal received SIGINT, starting shutdown
DBUG linkerd2_proxy shutdown signaled
DBUG linkerd2_proxy shutdown complete
```

Note that after the changes in this branch, we actually output that the
error was caused by "Connection refused (os error 61)", rather than
an "unexpected internal error", and the string "HTTP/2" is no longer
present in the log output for an HTTP/1 request.

</details>
