### PR TITLE
Configure listen ports' TLS when constructing them.

### DIFF
--- a/src/telemetry/control.rs
+++ b/src/telemetry/control.rs
@@ -11,8 +11,6 @@ use super::tap::Taps;
 use transport::BoundPort;
 use ctx;
 use task;
-use conditional::Conditional;
-use tls;
 
 /// A `Control` which has been configured but not initialized.
 #[derive(Debug)]
@@ -103,8 +101,6 @@ impl Control {
         let fut = {
             let log = log.clone();
             bound_port.listen_and_fold(
-                // TODO: Serve over TLS.
-                Conditional::None(tls::ReasonForNoIdentity::NotImplementedForMetrics.into()),
                 hyper::server::conn::Http::new(),
                 move |hyper, (conn, remote)| {
                     let service = service.clone();


### PR DESCRIPTION
The way TLS is done for a bound port is fixed based on its role and whatever
the TLS settings are, so it makes sense to configure the TLS aspects of the
bound port during construction. This will also make writing tests easier.

Signed-off-by: Brian Smith <brian@briansmith.org>