### PR TITLE
Accept TLS connnections even when TLS configuration isn't available

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,12 +274,15 @@ where
                 config.inbound_router_capacity,
                 config.inbound_router_max_idle_age,
             );
-            let tls_settings = config.tls_settings.as_ref().map(|settings| {
-                tls::ConnectionConfig {
-                    identity: settings.pod_identity.clone(),
-                    config: tls_server_config
-                }
-            });
+            let tls_settings: tls::ConditionalConnectionConfig<tls::ServerConfigWatch> =
+                config.tls_settings.as_ref().and_then(|settings| {
+                    tls_server_config.map(|config| {
+                        tls::ConnectionConfig {
+                            identity: settings.pod_identity.clone(),
+                            config,
+                        }
+                    })
+                });
             serve(
                 inbound_listener,
                 tls_settings,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,8 +274,8 @@ where
                 config.inbound_router_capacity,
                 config.inbound_router_max_idle_age,
             );
-            let tls_settings: tls::ConditionalConnectionConfig<tls::ServerConfigWatch> =
-                config.tls_settings.as_ref().and_then(|settings| {
+            let tls_settings = config.tls_settings.as_ref()
+                .and_then(|settings| {
                     tls_server_config.map(|config| {
                         tls::ConnectionConfig {
                             identity: settings.pod_identity.clone(),

--- a/src/transport/tls/cert_resolver.rs
+++ b/src/transport/tls/cert_resolver.rs
@@ -119,15 +119,8 @@ impl rustls::ResolvesServerCert for CertResolver {
             return None;
         };
 
-        let cert = if let Some(ref certified_key) = self.certified_key {
-            &certified_key.cert
-        } else {
-            debug!("no certificate yet");
-            return None;
-        };
-
         // Verify that our certificate is valid for the given SNI name.
-        if let Err(err) = parse_end_entity_cert(cert)
+        if let Err(err) = parse_end_entity_cert(&self.certified_key.as_ref()?.cert)
             .and_then(|cert| cert.verify_is_valid_for_dns_name(server_name)) {
             debug!("our certificate is not valid for the SNI name -> no certificate: {:?}", err);
             return None;

--- a/src/transport/tls/cert_resolver.rs
+++ b/src/transport/tls/cert_resolver.rs
@@ -17,7 +17,7 @@ use ring::{self, rand, signature};
 /// Authentication is symmetric with respect to the client/server roles, so the
 /// same certificate and private key is used for both roles.
 pub struct CertResolver {
-    certified_key: rustls::sign::CertifiedKey,
+    certified_key: Option<rustls::sign::CertifiedKey>,
 }
 
 impl fmt::Debug for CertResolver {
@@ -58,9 +58,20 @@ impl CertResolver {
 
         let signer = Signer { private_key: Arc::new(private_key) };
         let signing_key = SigningKey { signer };
-        let certified_key = rustls::sign::CertifiedKey::new(
-            cert_chain, Arc::new(Box::new(signing_key)));
+        let certified_key = Some(rustls::sign::CertifiedKey::new(
+            cert_chain, Arc::new(Box::new(signing_key))));
         Ok(Self { certified_key })
+    }
+
+    /// Returns a new `CertResolver` which indicates that we don't yet have
+    /// a certificate.
+    ///
+    /// This is used in order to fail handshakes when the TLS configuration
+    /// hasn't been loaded yet. The returned `CertResolver` implements
+    /// `rustls::ResolvesClientCert` and `rustls::ResolvesServerCert`, but
+    /// will always returns `None`.
+    pub fn empty() -> Self {
+        Self { certified_key: None, }
     }
 
     fn resolve_(&self, sigschemes: &[rustls::SignatureScheme]) -> Option<rustls::sign::CertifiedKey>
@@ -70,7 +81,7 @@ impl CertResolver {
             return None;
         }
 
-        Some(self.certified_key.clone())
+        self.certified_key.as_ref().cloned()
     }
 
 }
@@ -94,7 +105,7 @@ impl rustls::ResolvesClientCert for CertResolver {
     }
 
     fn has_certs(&self) -> bool {
-        true
+        self.certified_key.is_some()
     }
 }
 
@@ -108,8 +119,15 @@ impl rustls::ResolvesServerCert for CertResolver {
             return None;
         };
 
+        let cert = if let Some(ref certified_key) = self.certified_key {
+            &certified_key.cert
+        } else {
+            debug!("no certificate yet");
+            return None;
+        };
+
         // Verify that our certificate is valid for the given SNI name.
-        if let Err(err) = parse_end_entity_cert(&self.certified_key.cert)
+        if let Err(err) = parse_end_entity_cert(cert)
             .and_then(|cert| cert.verify_is_valid_for_dns_name(server_name)) {
             debug!("our certificate is not valid for the SNI name -> no certificate: {:?}", err);
             return None;


### PR DESCRIPTION
Closes linkerd/linkerd2#1272.

Currently, if TLS is enabled but the TLS configuration isn't available
(yet), the proxy will pass through all traffic to the application.
However, the destination service will tell other proxies to send TLS
traffic to the pod unconditionally, so the proxy will pass through TLS
handshakes to the application that are destined for the proxy itself.

In linkerd/linkerd2#1272, @briansmith suggested that we change the 
proxy so that when it hasn't yet loaded a TLS configuration, it will
accept TLS handshakes, but fail them. This branch implements that 
behaviour by making the `rustls::sign::CertifiedKey` in `CertResolver`
optional, and changing the `CertResolver` to return `None` when 
`rustls` asks it to resolve a certificate in that case. The server
config watch is now initially created with `Conditional::Some` with an
empty `CertResolver`, rather than `Conditional::None(NoConfig)`, so
that the proxy will accept incoming handshakes, but fail them.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>