### PR TITLE
Limit use of stale TLS configuration to a TTL

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -349,6 +349,8 @@ impl<'a> TryFrom<&'a Strings> for Config {
                     private_key,
                     pod_identity,
                     controller_identity,
+                    // TODO: make configurable
+                    fallback_ttl: Duration::from_secs(900),
                 }))
             },
             (None, None, None, _) => Ok(Conditional::None(tls::ReasonForNoTls::Disabled)),
@@ -499,7 +501,7 @@ fn parse_number<T>(s: &str) -> Result<T, ParseError> where T: FromStr {
     s.parse().map_err(|_| ParseError::NotANumber)
 }
 
-fn parse_duration(s: &str) -> Result<Duration, ParseError> {
+pub fn parse_duration(s: &str) -> Result<Duration, ParseError> {
     use regex::Regex;
 
     let re = Regex::new(r"^\s*(\d+)(ms|s|m|h|d)?\s*$")


### PR DESCRIPTION
Currently, when the proxy attempts to load a TLS configuration (trust 
anchor settings, private key, and certificate) that is invalid, it will
fall back to the last valid configuration. This is necessary, as the
files containing each component of the configuration may be updated
asynchronously, and we may thus enter transient invalid states where
one or more file has been updated before the others. 

However, an invalid configuration state that persists for a long period
of time is likely due to a more serious problem. Therefore, we should 
limit the amount of time during which the proxy will use the last valid
TLS configuration.

This branch adds an environment variable, 
LINKERD2_PROXY_TLS_CONFIG_FALLBACK_TTL, which accepts a duration for 
which we should continue using a prior TLS configuration when a change
results in an invalid configuration state. If the variable is not set,
the TTL defaults to 15 minutes. The 
`CommonSettings::watch_for_config_changes` function has been modified
so that rather than skipping an invalid state entirely, it now waits
for the TTL duration before yielding an empty configuration, which will
cause the proxy to begin failing TLS handshakes.

Initially, I intended to write unit tests for this behaviour. However,
there were some issues which made this difficult without additional
refactoring to the config file loading code, so I decided to punt on 
doing so for now, moving the beginning of the testing work to another
branch. Instead, I verified these changes manually. 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>