### PR TITLE
Add TLS status to logging contexts

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -321,7 +321,7 @@ impl fmt::Display for Server {
             write!(f, " remote={}", remote)?;
         }
         if let Some(tls_status) = self.tls_status {
-            write!(f, " tls_status={}", tls_status)?;
+            write!(f, " tls={}", tls_status)?;
         }
         write!(f, "}}")
     }
@@ -375,7 +375,7 @@ impl<C: fmt::Display, D: fmt::Display> fmt::Display for Client<C, D> {
             write!(f, " remote={}", remote)?;
         }
         if let Some(tls_status) = self.tls_status {
-            write!(f, " tls_status={}", tls_status)?;
+            write!(f, " tls={}", tls_status)?;
         }
         write!(f, "}}")
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -216,7 +216,7 @@ pub struct Server {
     name: &'static str,
     listen: SocketAddr,
     remote: Option<SocketAddr>,
-    tls: Option<TlsStatus>,
+    tls_status: Option<TlsStatus>,
 }
 
 /// A utility for logging actions taken on behalf of a client task.
@@ -227,7 +227,7 @@ pub struct Client<C: fmt::Display, D: fmt::Display> {
     dst: D,
     protocol: Option<::bind::Protocol>,
     remote: Option<SocketAddr>,
-    tls: Option<TlsStatus>,
+    tls_status: Option<TlsStatus>,
 }
 
 /// A utility for logging actions taken on behalf of a background task.
@@ -251,7 +251,7 @@ impl Section {
             name,
             listen,
             remote: None,
-            tls: None,
+            tls_status: None,
         }
     }
 
@@ -262,7 +262,7 @@ impl Section {
             dst,
             protocol: None,
             remote: None,
-            tls: None,
+            tls_status: None,
         }
     }
 }
@@ -298,9 +298,9 @@ impl Server {
         }
     }
 
-    pub fn with_tls(self, tls: TlsStatus) -> Self {
+    pub fn with_tls_status(self, tls_status: TlsStatus) -> Self {
         Self {
-            tls: Some(tls),
+            tls_status: Some(tls_status),
             ..self
         }
     }
@@ -320,8 +320,8 @@ impl fmt::Display for Server {
         if let Some(remote) = self.remote {
             write!(f, " remote={}", remote)?;
         }
-        if let Some(tls) = self.tls {
-            write!(f, " tls={}", tls)?;
+        if let Some(tls_status) = self.tls_status {
+            write!(f, " tls_status={}", tls_status)?;
         }
         write!(f, "}}")
     }
@@ -353,9 +353,9 @@ impl<C: fmt::Display, D: fmt::Display> Client<C, D> {
         }
     }
 
-    pub fn with_tls(self, tls: TlsStatus) -> Self {
+    pub fn with_tls_status(self, tls_status: TlsStatus) -> Self {
         Self {
-            tls: Some(tls),
+            tls_status: Some(tls_status),
             ..self
         }
     }
@@ -374,8 +374,8 @@ impl<C: fmt::Display, D: fmt::Display> fmt::Display for Client<C, D> {
         if let Some(remote) = self.remote {
             write!(f, " remote={}", remote)?;
         }
-        if let Some(tls) = self.tls {
-            write!(f, " tls={}", tls)?;
+        if let Some(tls_status) = self.tls_status {
+            write!(f, " tls_status={}", tls_status)?;
         }
         write!(f, "}}")
     }

--- a/src/transparency/server.rs
+++ b/src/transparency/server.rs
@@ -121,6 +121,7 @@ where
         let opened_at = Instant::now();
 
         // create Server context
+        let tls = connection.tls_status();
         let orig_dst = connection.original_dst_addr(&self.get_orig_dst);
         let local_addr = connection.local_addr().unwrap_or(self.listen_addr);
         let srv_ctx = ServerCtx::new(
@@ -128,10 +129,11 @@ where
             &local_addr,
             &remote_addr,
             &orig_dst,
-            connection.tls_status(),
+            tls,
         );
         let log = self.log.clone()
-            .with_remote(remote_addr);
+            .with_remote(remote_addr)
+            .with_tls(tls);
 
         // record telemetry
         let io = self.sensors.accept(connection, opened_at, &srv_ctx);

--- a/src/transparency/server.rs
+++ b/src/transparency/server.rs
@@ -121,7 +121,7 @@ where
         let opened_at = Instant::now();
 
         // create Server context
-        let tls = connection.tls_status();
+        let tls_status = connection.tls_status();
         let orig_dst = connection.original_dst_addr(&self.get_orig_dst);
         let local_addr = connection.local_addr().unwrap_or(self.listen_addr);
         let srv_ctx = ServerCtx::new(
@@ -129,11 +129,11 @@ where
             &local_addr,
             &remote_addr,
             &orig_dst,
-            tls,
+            tls_status,
         );
         let log = self.log.clone()
             .with_remote(remote_addr)
-            .with_tls(tls);
+            .with_tls_status(tls_status);
 
         // record telemetry
         let io = self.sensors.accept(connection, opened_at, &srv_ctx);


### PR DESCRIPTION
This branch adds the connection TLS status to the proxy's logging
contexts, if it is known. I added this as I found it useful while 
debugging a different issue, but figured it ought to be added.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>