### PR TITLE
WIP: Stop falling back to plaintext on failed TLS connections

### DIFF
--- a/src/ctx/transport.rs
+++ b/src/ctx/transport.rs
@@ -52,7 +52,6 @@ impl fmt::Display for TlsStatus {
         f.pad(match *self {
             Conditional::Some(()) => "true",
             Conditional::None(tls::ReasonForNoTls::NoConfig) => "no_config",
-            Conditional::None(tls::ReasonForNoTls::HandshakeFailed) => "handshake_failed",
             Conditional::None(tls::ReasonForNoTls::Disabled) => "disabled",
             Conditional::None(tls::ReasonForNoTls::InternalTraffic) => "internal_traffic",
             Conditional::None(tls::ReasonForNoTls::NoIdentity(_)) => "no_identity",

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -27,13 +27,9 @@ pub struct BoundPort {
 pub(super) fn connect(addr: &SocketAddr, tls: tls::ConditionalConnectionConfig<tls::ClientConfig>)
     -> Connecting
 {
-    let state = ConnectingState::Plaintext {
+    Connecting::Plaintext {
         connect: TcpStream::connect(addr),
         tls: Some(tls),
-    };
-    Connecting {
-        addr: *addr,
-        state,
     }
 }
 
@@ -50,15 +46,10 @@ struct ConditionallyUpgradeServerToTlsInner {
 }
 
 /// A socket that is in the process of connecting.
-pub struct Connecting {
-    addr: SocketAddr,
-    state: ConnectingState,
-}
-
-enum ConnectingState {
+pub enum Connecting {
     Plaintext {
         connect: ConnectFuture,
-        tls: Option<tls::ConditionalConnectionConfig<tls::ClientConfig>>
+        tls: Option<tls::ConditionalConnectionConfig<tls::ClientConfig>>,
     },
     UpgradeToTls(tls::UpgradeClientToTls),
 }
@@ -321,17 +312,17 @@ impl Future for Connecting {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         loop {
-            self.state = match &mut self.state {
-                ConnectingState::Plaintext { connect, tls } => {
+            *self = match self {
+                Connecting::Plaintext { connect, tls } => {
                     let plaintext_stream = try_ready!(connect.poll());
                     trace!("Connecting: state=plaintext; tls={:?};",tls);
                     set_nodelay_or_warn(&plaintext_stream);
                     match tls.take().expect("Polled after ready") {
                         Conditional::Some(config) => {
                             trace!("plaintext connection established; trying to upgrade");
-                            let upgrade = tls::Connection::connect(
+                            let upgrade_to_tls = tls::Connection::connect(
                                 plaintext_stream, &config.server_identity, config.config);
-                            ConnectingState::UpgradeToTls(upgrade)
+                            Connecting::UpgradeToTls(upgrade_to_tls)
                         },
                         Conditional::None(why) => {
                             trace!("plaintext connection established; no TLS ({:?})", why);
@@ -339,29 +330,9 @@ impl Future for Connecting {
                         },
                     }
                 },
-                ConnectingState::UpgradeToTls(upgrade) => {
-                    match upgrade.poll() {
-                        Ok(Async::NotReady) => return Ok(Async::NotReady),
-                        Ok(Async::Ready(tls_stream)) => {
-                            let conn = Connection::tls(BoxedIo::new(tls_stream));
-                            return Ok(Async::Ready(conn));
-                        },
-                        Err(e) => {
-                            debug!(
-                                "TLS handshake with {:?} failed: {}\
-                                    -> falling back to plaintext",
-                                self.addr, e,
-                            );
-                            let connect = TcpStream::connect(&self.addr);
-                            // TODO: emit a `HandshakeFailed` telemetry event.
-                            let reason = tls::ReasonForNoTls::HandshakeFailed;
-                            // Reset self to try the plaintext connection.
-                            ConnectingState::Plaintext {
-                                connect,
-                                tls: Some(Conditional::None(reason))
-                            }
-                        }
-                    }
+                Connecting::UpgradeToTls(upgrading) => {
+                    let tls_stream = try_ready!(upgrading.poll());
+                    return Ok(Async::Ready(Connection::tls(BoxedIo::new(tls_stream))));
                 },
             };
         }

--- a/src/transport/tls/config.rs
+++ b/src/transport/tls/config.rs
@@ -113,9 +113,6 @@ pub enum ReasonForNoTls {
     /// The connection isn't TLS or it is TLS but not intended to be handled
     /// by the proxy.
     NotProxyTls,
-
-    /// We fell back to plaintext because the TLS handshake failed.
-    HandshakeFailed,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]

--- a/src/transport/tls/mod.rs
+++ b/src/transport/tls/mod.rs
@@ -34,7 +34,6 @@ pub use self::{
     },
     dns_name::{DnsName, InvalidDnsName},
     identity::Identity,
-    rustls::TLSError as Error,
 };
 
 #[cfg(test)]


### PR DESCRIPTION
Revert commit 91108a2d53db29082fbb4307f187b886a003ded6, which required manually fixing lots of merge conflicts.

Fixes #1359.

Signed-off-by: Brian Smith <brian@briansmith.org>