### PR TITLE
Add orig-proto which uses HTTP2 between proxies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
  "inotify 0.5.2-dev (git+https://github.com/inotify-rs/inotify)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "linkerd2-proxy-api 0.1.0 (git+https://github.com/linkerd/linkerd2-proxy-api)",
+ "linkerd2-proxy-api 0.1.1 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.1)",
  "linkerd2-proxy-router 0.1.0",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -524,8 +524,8 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api#a245facbbeb6b5533818caf233983253caf1f397"
+version = "0.1.1"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.1#b0543809839fd0e6bc7cb8e4a644ce48df88b27d"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1253,7 +1253,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#30c1b64365cd01bb64855b1608444e839bb47fd0"
+source = "git+https://github.com/tower-rs/tower-grpc#0afac3d409febe20db4432b5abe06dbd72bd4c95"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1268,7 +1268,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc-build"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#30c1b64365cd01bb64855b1608444e839bb47fd0"
+source = "git+https://github.com/tower-rs/tower-grpc#0afac3d409febe20db4432b5abe06dbd72bd4c95"
 dependencies = [
  "codegen 0.1.0 (git+https://github.com/carllerche/codegen)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1278,7 +1278,7 @@ dependencies = [
 [[package]]
 name = "tower-h2"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2#0c9c5f16497ff97114d41b9dd8830f245d9f86c1"
+source = "git+https://github.com/tower-rs/tower-h2#1299be66fee7be919699d7c1edfb30adac03d4c1"
 dependencies = [
  "bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "tower-service"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#20fb04e3e98bd0e4c28edf2c342e80a66a4d319b"
+source = "git+https://github.com/tower-rs/tower#7b6460dff2e9969c9c998dd77558f803c770c6ea"
 dependencies = [
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1603,7 +1603,7 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.0 (git+https://github.com/linkerd/linkerd2-proxy-api)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.1 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.1)" = "<none>"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ flaky_tests = []
 futures-mpsc-lossy    = { path = "./futures-mpsc-lossy" }
 linkerd2-proxy-router = { path = "./router" }
 
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.1", version = "0.1.1" }
 
 bytes = "0.4"
 deflate = {version = "0.7.18", features = ["gzip"] }
@@ -76,7 +76,7 @@ procinfo = "0.4.2"
 [dev-dependencies]
 net2 = "0.2"
 quickcheck = { version = "0.6", default-features = false }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.1", version = "0.1.1", features = ["arbitrary"] }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.

--- a/benches/record.rs
+++ b/benches/record.rs
@@ -51,6 +51,7 @@ where
         &addr(),
         destination::Metadata::new(
             metrics::DstLabels::new(labels),
+            destination::ProtocolHint::Unknown,
             Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery)),
         TLS_DISABLED,
     )

--- a/src/bind.rs
+++ b/src/bind.rs
@@ -14,7 +14,7 @@ use control;
 use control::destination::Endpoint;
 use ctx;
 use telemetry::{self, sensor};
-use transparency::{self, HttpBody, h1};
+use transparency::{self, HttpBody, h1, orig_proto};
 use transport;
 use tls;
 use ctx::transport::TlsStatus;
@@ -93,6 +93,13 @@ where
 pub enum Protocol {
     Http1 {
         host: Host,
+        /// Whether the request wants to use HTTP/1.1's Upgrade mechanism.
+        ///
+        /// Since these cannot be translated into orig-proto, it must be
+        /// tracked here so as to allow those with `is_h1_upgrade: true` to
+        /// use an explicitly HTTP/1 service, instead of one that might
+        /// utilize orig-proto.
+        is_h1_upgrade: bool,
         /// Whether or not the request URI was in absolute form.
         ///
         /// This is used to configure Hyper's behaviour at the connection
@@ -134,7 +141,7 @@ pub type Service<B> = BoundService<B>;
 
 pub type Stack<B> = WatchService<tls::ConditionalClientConfig, RebindTls<B>>;
 
-type StackInner<B> = Reconnect<NormalizeUri<NewHttp<B>>>;
+type StackInner<B> = Reconnect<orig_proto::Upgrade<NormalizeUri<NewHttp<B>>>>;
 
 pub type NewHttp<B> = sensor::NewHttp<Client<B>, B, HttpBody>;
 
@@ -275,12 +282,13 @@ where
 
         // Rewrite the HTTP/1 URI, if the authorities in the Host header
         // and request URI are not in agreement, or are not present.
-        let proxy = NormalizeUri::new(sensors, protocol.was_absolute_form());
+        let normalize_uri = NormalizeUri::new(sensors, protocol.was_absolute_form());
+        let upgrade_orig_proto = orig_proto::Upgrade::new(normalize_uri, protocol.is_http2());
 
         // Automatically perform reconnects if the connection fails.
         //
         // TODO: Add some sort of backoff logic.
-        Reconnect::new(proxy)
+        Reconnect::new(upgrade_orig_proto)
     }
 
     /// Binds the endpoint stack used to construct a bound service.
@@ -309,6 +317,18 @@ where
     }
 
     pub fn bind_service(&self, ep: &Endpoint, protocol: &Protocol) -> BoundService<B> {
+        // If the endpoint is another instance of this proxy, AND the usage
+        // of HTTP/1.1 Upgrades are not needed, then bind to an HTTP2 service
+        // instead.
+        //
+        // The related `orig_proto` middleware will automatically translate
+        // if the protocol was originally HTTP/1.
+        let protocol = if ep.can_use_orig_proto() && !protocol.is_h1_upgrade() {
+            &Protocol::Http2
+        } else {
+            protocol
+        };
+
         let binding = if protocol.can_reuse_clients() {
             Binding::Bound(self.bind_stack(ep, protocol))
         } else {
@@ -536,7 +556,7 @@ where
 impl Protocol {
     pub fn detect<B>(req: &http::Request<B>) -> Self {
         if req.version() == http::Version::HTTP_2 {
-            return Protocol::Http2
+            return Protocol::Http2;
         }
 
         let was_absolute_form = h1::is_absolute_form(req.uri());
@@ -546,16 +566,15 @@ impl Protocol {
         );
         // If the request has an authority part, use that as the host part of
         // the key for an HTTP/1.x request.
-        let host = req
-            .uri()
-            .authority_part()
-            .cloned()
-            .or_else(|| h1::authority_from_host(req))
-            .map(Host::Authority)
-            .unwrap_or_else(|| Host::NoAuthority);
+        let host = Host::detect(req);
 
+        let is_h1_upgrade = h1::wants_upgrade(req);
 
-        Protocol::Http1 { host, was_absolute_form }
+        Protocol::Http1 {
+            host,
+            is_h1_upgrade,
+            was_absolute_form,
+        }
     }
 
     /// Returns true if the request was originally received in absolute form.
@@ -571,6 +590,32 @@ impl Protocol {
             Protocol::Http2 | Protocol::Http1 { host: Host::Authority(_), .. } => true,
             _ => false,
         }
+    }
+
+    pub fn is_h1_upgrade(&self) -> bool {
+        match *self {
+            Protocol::Http1 { is_h1_upgrade: true, .. } => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_http2(&self) -> bool {
+        match *self {
+            Protocol::Http2 => true,
+            _ => false,
+        }
+    }
+}
+
+impl Host {
+    pub fn detect<B>(req: &http::Request<B>) -> Host {
+        req
+            .uri()
+            .authority_part()
+            .cloned()
+            .or_else(|| h1::authority_from_host(req))
+            .map(Host::Authority)
+            .unwrap_or_else(|| Host::NoAuthority)
     }
 }
 

--- a/src/control/destination/endpoint.rs
+++ b/src/control/destination/endpoint.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 
 use telemetry::metrics::DstLabels;
-use super::Metadata;
+use super::{Metadata, ProtocolHint};
 use tls;
 use conditional::Conditional;
 
@@ -34,6 +34,13 @@ impl Endpoint {
 
     pub fn dst_labels(&self) -> Option<&DstLabels> {
         self.metadata.dst_labels()
+    }
+
+    pub fn can_use_orig_proto(&self) -> bool {
+        match self.metadata.protocol_hint() {
+            ProtocolHint::Unknown => false,
+            ProtocolHint::Http2 => true,
+        }
     }
 
     pub fn tls_identity(&self) -> Conditional<&tls::Identity, tls::ReasonForNoIdentity> {

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -96,10 +96,22 @@ pub struct Metadata {
     /// A set of Prometheus metric labels describing the destination.
     dst_labels: Option<DstLabels>,
 
+    /// A hint from the controller about what protocol (HTTP1, HTTP2, etc) the
+    /// destination understands.
+    protocol_hint: ProtocolHint,
+
     /// How to verify TLS for the endpoint.
     tls_identity: Conditional<tls::Identity, tls::ReasonForNoIdentity>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProtocolHint {
+    /// We don't what the destination understands, so forward messages in the
+    /// protocol we received them in.
+    Unknown,
+    /// The destination can receive HTTP2 messages.
+    Http2,
+}
 
 #[derive(Debug, Clone)]
 enum Update {
@@ -247,6 +259,7 @@ impl Metadata {
     pub fn no_metadata() -> Self {
         Metadata {
             dst_labels: None,
+            protocol_hint: ProtocolHint::Unknown,
             // If we have no metadata on an endpoint, assume it does not support TLS.
             tls_identity:
                 Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery),
@@ -255,10 +268,12 @@ impl Metadata {
 
     pub fn new(
         dst_labels: Option<DstLabels>,
+        protocol_hint: ProtocolHint,
         tls_identity: Conditional<tls::Identity, tls::ReasonForNoIdentity>
     ) -> Self {
         Metadata {
             dst_labels,
+            protocol_hint,
             tls_identity,
         }
     }
@@ -266,6 +281,10 @@ impl Metadata {
     /// Returns the endpoint's labels from the destination service, if it has them.
     pub fn dst_labels(&self) -> Option<&DstLabels> {
         self.dst_labels.as_ref()
+    }
+
+    pub fn protocol_hint(&self) -> ProtocolHint {
+        self.protocol_hint
     }
 
     pub fn tls_identity(&self) -> Conditional<&tls::Identity, tls::ReasonForNoIdentity> {

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -117,6 +117,7 @@ pub mod test_util {
         S: fmt::Display,
     {
         let meta = destination::Metadata::new(DstLabels::new(labels),
+            destination::ProtocolHint::Unknown,
             Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery));
         ctx::transport::Client::new(&proxy, &addr(), meta, tls)
     }

--- a/src/transparency/glue.rs
+++ b/src/transparency/glue.rs
@@ -311,16 +311,11 @@ where
     type Error = F::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let mut res = try_ready!(self.inner.poll().map_err(|e| {
+        let res = try_ready!(self.inner.poll().map_err(|e| {
             debug!("HTTP/1 error: {}", e);
             e
         }));
 
-        if h1::is_upgrade(&res) {
-            trace!("client response is HTTP/1.1 upgrade");
-        } else {
-            h1::strip_connection_headers(res.headers_mut());
-        }
         Ok(Async::Ready(res.map(BodyPayload::new)))
     }
 }

--- a/src/transparency/h1.rs
+++ b/src/transparency/h1.rs
@@ -40,6 +40,15 @@ pub fn normalize_our_view_of_uri<B>(req: &mut http::Request<B>) {
     }
 }
 
+/// Convert any URI into its origin-form (relative path part only).
+pub fn set_origin_form(uri: &mut Uri) {
+    let mut parts = mem::replace(uri, Uri::default()).into_parts();
+    parts.scheme = None;
+    parts.authority = None;
+    *uri = Uri::from_parts(parts)
+        .expect("path only is valid origin-form uri")
+}
+
 /// Returns an Authority from a request's Host header.
 pub fn authority_from_host<B>(req: &http::Request<B>) -> Option<Authority> {
     req.headers().get(HOST)

--- a/src/transparency/mod.rs
+++ b/src/transparency/mod.rs
@@ -2,6 +2,7 @@ mod client;
 mod glue;
 pub mod h1;
 mod upgrade;
+pub mod orig_proto;
 mod protocol;
 mod server;
 mod tcp;

--- a/src/transparency/orig_proto.rs
+++ b/src/transparency/orig_proto.rs
@@ -1,0 +1,244 @@
+use futures::{future, Future, Poll};
+use http;
+use http::header::HeaderValue;
+use tower_service::{Service, NewService};
+
+use bind;
+use super::h1;
+
+const L5D_ORIG_PROTO: &str = "l5d-orig-proto";
+
+/// Upgrades HTTP requests from their original protocol to HTTP2.
+#[derive(Debug)]
+pub struct Upgrade<S> {
+    inner: S,
+    upgrade_h1: bool,
+}
+
+/// Downgrades HTTP2 requests that were previousl upgraded to their original
+/// protocol.
+#[derive(Debug)]
+pub struct Downgrade<S> {
+    inner: S,
+}
+
+pub fn detect<B>(req: &http::Request<B>) -> bind::Protocol {
+    if req.version() == http::Version::HTTP_2 {
+        if let Some(orig_proto) = req.headers().get(L5D_ORIG_PROTO) {
+            trace!("detected orig-proto: {:?}", orig_proto);
+            let val = orig_proto.as_bytes();
+            let was_absolute_form = was_absolute_form(val);
+            let host = bind::Host::detect(req);
+
+            return bind::Protocol::Http1 {
+                host,
+                is_h1_upgrade: false, // orig-proto is never used with upgrades
+                was_absolute_form,
+            };
+        }
+    }
+
+    bind::Protocol::detect(req)
+}
+
+
+// ===== impl Upgrade =====
+
+impl<S> Upgrade<S> {
+    pub fn new(inner: S, upgrade_h1: bool) -> Self {
+        Self {
+            inner,
+            upgrade_h1,
+        }
+    }
+}
+
+impl<S, B1, B2> Service for Upgrade<S>
+where
+    S: Service<Request = http::Request<B1>, Response = http::Response<B2>>,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = future::Map<
+        S::Future,
+        fn(S::Response) -> S::Response
+    >;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, mut req: Self::Request) -> Self::Future {
+        let mut downgrade_response = false;
+
+        if self.upgrade_h1 && req.version() != http::Version::HTTP_2 {
+            debug!("upgrading {:?} to HTTP2 with orig-proto", req.version());
+
+            // absolute-form is far less common, origin-form is the usual,
+            // so only encode the extra information if it's different than
+            // the normal.
+            let was_absolute_form = h1::is_absolute_form(req.uri());
+            if !was_absolute_form {
+                // Since the version is going to set to HTTP_2, the NormalizeUri
+                // middleware won't normalize the URI automatically, so it
+                // needs to be done now.
+                h1::normalize_our_view_of_uri(&mut req);
+            }
+
+            let val = match (req.version(), was_absolute_form) {
+                (http::Version::HTTP_11, false) => "HTTP/1.1",
+                (http::Version::HTTP_11, true) => "HTTP/1.1; absolute-form",
+                (http::Version::HTTP_10, false) => "HTTP/1.0",
+                (http::Version::HTTP_10, true) => "HTTP/1.0; absolute-form",
+                (v, _) => unreachable!("bad orig-proto version: {:?}", v),
+            };
+            req.headers_mut().insert(
+                L5D_ORIG_PROTO,
+                HeaderValue::from_static(val)
+            );
+
+
+            *req.version_mut() = http::Version::HTTP_2;
+            downgrade_response = true;
+        }
+
+        let fut = self.inner.call(req);
+
+        if downgrade_response {
+            fut.map(|mut res| {
+                debug_assert_eq!(res.version(), http::Version::HTTP_2);
+                let version = if let Some(orig_proto) = res.headers().get(L5D_ORIG_PROTO) {
+                    debug!("downgrading {} response: {:?}", L5D_ORIG_PROTO, orig_proto);
+                    if orig_proto == "HTTP/1.1" {
+                        http::Version::HTTP_11
+                    } else if orig_proto == "HTTP/1.0" {
+                        http::Version::HTTP_10
+                    } else {
+                        warn!("unknown {} header value: {:?}", L5D_ORIG_PROTO, orig_proto);
+                        res.version()
+                    }
+                } else {
+                    res.version()
+                };
+                *res.version_mut() = version;
+                res
+            })
+        } else {
+            // Just passing through...
+            fut.map(|res| res)
+        }
+    }
+}
+
+impl<S, B1, B2> NewService for Upgrade<S>
+where
+    S: NewService<Request = http::Request<B1>, Response = http::Response<B2>>,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Service = Upgrade<S::Service>;
+    type InitError = S::InitError;
+    type Future = future::Map<
+        S::Future,
+        fn(S::Service) -> Upgrade<S::Service>
+    >;
+
+    fn new_service(&self) -> Self::Future {
+        let s = self.inner.new_service();
+        // This weird dance is so that the closure doesn't have to
+        // capture `self` and can just be a `fn` (so the `Map`)
+        // can be returned unboxed.
+        if self.upgrade_h1 {
+            s.map(|inner| Upgrade::new(inner, true))
+        } else {
+            s.map(|inner| Upgrade::new(inner, false))
+        }
+    }
+}
+
+// ===== impl Upgrade =====
+
+impl<S> Downgrade<S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+        }
+    }
+}
+
+impl<S, B1, B2> Service for Downgrade<S>
+where
+    S: Service<Request = http::Request<B1>, Response = http::Response<B2>>,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = future::Map<
+        S::Future,
+        fn(S::Response) -> S::Response
+    >;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, mut req: Self::Request) -> Self::Future {
+        let mut upgrade_response = false;
+
+        if req.version() == http::Version::HTTP_2 {
+            if let Some(orig_proto) = req.headers_mut().remove(L5D_ORIG_PROTO) {
+                debug!("translating HTTP2 to orig-proto: {:?}", orig_proto);
+
+                let val: &[u8] = orig_proto.as_bytes();
+
+                if val.starts_with(b"HTTP/1.1") {
+                    *req.version_mut() = http::Version::HTTP_11;
+                } else if val.starts_with(b"HTTP/1.0") {
+                    *req.version_mut() = http::Version::HTTP_10;
+                } else {
+                    warn!(
+                        "unknown {} header value: {:?}",
+                        L5D_ORIG_PROTO,
+                        orig_proto,
+                    );
+                }
+
+                if !was_absolute_form(val) {
+                    h1::set_origin_form(req.uri_mut());
+                }
+                upgrade_response = true;
+            }
+        }
+
+        let fut = self.inner.call(req);
+
+        if upgrade_response {
+            fut.map(|mut res| {
+                let orig_proto = if res.version() == http::Version::HTTP_11 {
+                    "HTTP/1.1"
+                } else if res.version() == http::Version::HTTP_10 {
+                    "HTTP/1.0"
+                } else {
+                    return res;
+                };
+
+                res.headers_mut().insert(
+                    L5D_ORIG_PROTO,
+                    HeaderValue::from_static(orig_proto)
+                );
+                *res.version_mut() = http::Version::HTTP_2;
+                res
+            })
+        } else {
+            fut.map(|res| res)
+        }
+    }
+}
+
+fn was_absolute_form(val: &[u8]) -> bool {
+    val.len() >= "HTTP/1.1; absolute-form".len()
+        && &val[10..23] == b"absolute-form"
+}
+

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -365,7 +365,6 @@ mod http1 {
 
 }
 
-
 #[test]
 fn outbound_updates_newer_services() {
     let _ = env_logger::try_init();
@@ -396,4 +395,73 @@ fn outbound_updates_newer_services() {
     // get into the newer service
     let client2 = client::http1(proxy.outbound, "disco.test.svc.cluster.local");
     assert_eq!(client2.get("/h1"), "hello h1");
+}
+
+mod proxy_to_proxy {
+    use super::*;
+
+    #[test]
+    fn outbound_http1() {
+        let _ = env_logger::try_init();
+
+        // Instead of a second proxy, this mocked h2 server will be the target.
+        let srv = server::http2()
+            .route_fn("/hint", |req| {
+                assert_eq!(req.headers()["l5d-orig-proto"], "HTTP/1.1");
+                Response::builder()
+                    .header("l5d-orig-proto", "HTTP/1.1")
+                    .body(Default::default())
+                    .unwrap()
+            })
+            .run();
+
+        let ctrl = controller::new();
+        let dst = ctrl.destination_tx("disco.test.svc.cluster.local");
+        dst.send_h2_hinted(srv.addr);
+
+        let proxy = proxy::new()
+            .controller(ctrl.run())
+            .run();
+
+        let client = client::http1(proxy.outbound, "disco.test.svc.cluster.local");
+
+        let res = client.request(&mut client.request_builder("/hint"));
+        assert_eq!(res.status(), 200);
+        assert_eq!(res.version(), http::Version::HTTP_11);
+    }
+
+
+    #[test]
+    fn inbound_http1() {
+        let _ = env_logger::try_init();
+
+        let srv = server::http1()
+            .route_fn("/h1", |req| {
+                assert_eq!(req.version(), http::Version::HTTP_11);
+                assert!(
+                    !req.headers().contains_key("l5d-orig-proto"),
+                    "h1 server shouldn't receive l5d-orig-proto header"
+                );
+                Response::default()
+            })
+            .run();
+
+        let ctrl = controller::new();
+
+        let proxy = proxy::new()
+            .controller(ctrl.run())
+            .inbound(srv)
+            .run();
+
+        // This client will be used as a mocked-other-proxy.
+        let client = client::http2(proxy.inbound, "disco.test.svc.cluster.local");
+
+        let res = client.request(
+            client
+                .request_builder("/h1")
+                .header("l5d-orig-proto", "HTTP/1.1")
+        );
+        assert_eq!(res.status(), 200);
+        assert_eq!(res.version(), http::Version::HTTP_2);
+    }
 }

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -141,7 +141,8 @@ impl Server {
 
                 let srv: Box<Fn(TcpStream) -> Box<Future<Item=(), Error=()>>> = match self.version {
                     Run::Http1 => {
-                        let h1 = hyper::server::conn::Http::new();
+                        let mut h1 = hyper::server::conn::Http::new();
+                        h1.http1_only(true);
 
                         Box::new(move |sock| {
                             let h1_clone = h1.clone();


### PR DESCRIPTION
When the destination service returns a hint that an endpoint is another
proxy, eligible HTTP1 requests are translated into HTTP2 and sent over
an HTTP2 connection. The original protocol details are encoded in a
header, `l5d-orig-proto`. When a proxy receives an inbound HTTP2
request with this header, the request is translated back into its HTTP/1
representation before being passed to the internal service.

Ref https://github.com/linkerd/linkerd2/issues/1360