### PR TITLE
Limit concurrent Destination service queries

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -56,7 +56,7 @@ pub struct Config {
 
     /// The maximum number of queries to the Destination service which may be
     /// active concurrently.
-    pub max_dst_queries: usize,
+    pub destination_concurrency_limit: usize,
 
     pub tls_settings: Conditional<tls::CommonSettings, tls::ReasonForNoTls>,
 
@@ -189,7 +189,8 @@ pub const ENV_OUTBOUND_ROUTER_MAX_IDLE_AGE: &str = "LINKERD2_PROXY_OUTBOUND_ROUT
 /// Routes which do not result in service discovery lookups will not be capped
 /// by this limit. This will have no effect if it is greater than the total
 /// router capacity (as configured by `ENV_OUTBOUND_ROUTER_CAPACITY`).
-pub const ENV_MAX_DESTINATION_QUERIES: &str = "LINKERD2_PROXY_MAX_DESTINATION_QUERIES";
+pub const ENV_DESTINATION_CLIENT_CONCURRENCY_LIMIT: &str =
+    "LINKERD2_PROXY_DESTINATION_CLIENT_CONCURRENCY_LIMIT";
 
 // These *disable* our protocol detection for connections whose SO_ORIGINAL_DST
 // has a port in the provided list.
@@ -239,7 +240,7 @@ const DEFAULT_OUTBOUND_ROUTER_CAPACITY: usize = 100;
 const DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE:  Duration = Duration::from_secs(60);
 const DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(60);
 
-const DEFAULT_MAX_DESTINATION_QUERIES: usize = 100;
+const DEFAULT_DESTINATION_CLIENT_CONCURRENCY_LIMIT: usize = 100;
 
 // By default, we keep a list of known assigned ports of server-first protocols.
 //
@@ -285,7 +286,8 @@ impl<'a> TryFrom<&'a Strings> for Config {
         let outbound_router_capacity = parse(strings, ENV_OUTBOUND_ROUTER_CAPACITY, parse_number);
         let inbound_router_max_idle_age = parse(strings, ENV_INBOUND_ROUTER_MAX_IDLE_AGE, parse_duration);
         let outbound_router_max_idle_age = parse(strings, ENV_OUTBOUND_ROUTER_MAX_IDLE_AGE, parse_duration);
-        let max_dst_queries = parse(strings, ENV_MAX_DESTINATION_QUERIES, parse_number);
+        let destination_concurrency_limit =
+            parse(strings, ENV_DESTINATION_CLIENT_CONCURRENCY_LIMIT, parse_number);
         let tls_trust_anchors = parse(strings, ENV_TLS_TRUST_ANCHORS, parse_path);
         let tls_end_entity_cert = parse(strings, ENV_TLS_CERT, parse_path);
         let tls_private_key = parse(strings, ENV_TLS_PRIVATE_KEY, parse_path);
@@ -421,8 +423,8 @@ impl<'a> TryFrom<&'a Strings> for Config {
             outbound_router_max_idle_age: outbound_router_max_idle_age?
                 .unwrap_or(DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE),
 
-            max_dst_queries: max_dst_queries?
-                .unwrap_or(DEFAULT_MAX_DESTINATION_QUERIES),
+            destination_concurrency_limit: destination_concurrency_limit?
+                .unwrap_or(DEFAULT_DESTINATION_CLIENT_CONCURRENCY_LIMIT),
 
             tls_settings,
 

--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -4,7 +4,6 @@ use std::{
     iter::IntoIterator,
     net::SocketAddr,
     time::{Instant, Duration},
-    sync::Weak,
 };
 
 use futures::{Async, Future, Stream,};
@@ -76,7 +75,6 @@ where
         auth: &DnsNameAndPort,
         mut rx: UpdateRx<T>,
         tls_controller_namespace: Option<&str>,
-        active: Weak<()>,
     ) -> (DestinationServiceQuery<T>, Exists<()>) {
         let mut exists = Exists::Unknown;
 
@@ -120,7 +118,7 @@ where
                     return (Remote::NeedsReconnect, exists);
                 },
                 Ok(Async::NotReady) => {
-                    return (Remote::ConnectedOrConnecting { rx, active }, exists);
+                    return (Remote::ConnectedOrConnecting { rx }, exists);
                 },
                 Err(err) => {
                     warn!("Destination.Get stream errored for {:?}: {:?}", auth, err);

--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -179,8 +179,11 @@ where
 }
 
 impl<T: HttpService<ResponseBody = RecvBody>> DestinationSet<T> {
-    pub(super) fn wants_query(&self) -> bool {
-        self.query.wants_query()
+
+    /// Returns `true` if the authority that created this query _should_ query
+    /// the Destination service, but was unable to due to insufficient capaacity.
+    pub(super) fn needs_query_capacity(&self) -> bool {
+        self.query.needs_query_capacity()
     }
 
     pub(super) fn reset_on_next_modification(&mut self) {

--- a/src/control/destination/background/mod.rs
+++ b/src/control/destination/background/mod.rs
@@ -305,13 +305,12 @@ where
         for (auth, set) in &mut self.dsts.destinations {
             // Query the Destination service first.
             let (new_query, found_by_destination_service) = match set.query.take() {
-                Some(Remote::ConnectedOrConnecting { rx, active }) => {
+                Some(Remote::ConnectedOrConnecting { rx }) => {
                     let (new_query, found_by_destination_service) =
                         set.poll_destination_service(
                             auth,
                             rx,
                             self.config.tls_controller_ns(),
-                            active
                         );
                     if let Remote::NeedsReconnect = new_query {
                         set.reset_on_next_modification();
@@ -428,8 +427,7 @@ impl Config {
                 let response = svc.get(grpc::Request::new(req));
                 let active = Arc::downgrade(&self.active_queries);
                 let query = Remote::ConnectedOrConnecting {
-                    rx: Receiver::new(response),
-                    active,
+                    rx: Receiver::new(response, active),
                 };
                 (Some(query), false)
 

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -147,6 +147,7 @@ pub fn new(
     host_and_port: Option<HostAndPort>,
     controller_tls: tls::ConditionalConnectionConfig<tls::ClientConfigWatch>,
     control_backoff_delay: Duration,
+    max_queries: usize,
 ) -> (Resolver, impl Future<Item = (), Error = ()>) {
     let (request_tx, rx) = mpsc::unbounded();
     let disco = Resolver { request_tx };
@@ -157,6 +158,7 @@ pub fn new(
         host_and_port,
         controller_tls,
         control_backoff_delay,
+        max_queries,
     );
     (disco, bg)
 }

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -147,7 +147,7 @@ pub fn new(
     host_and_port: Option<HostAndPort>,
     controller_tls: tls::ConditionalConnectionConfig<tls::ClientConfigWatch>,
     control_backoff_delay: Duration,
-    max_queries: usize,
+    concurrency_limit: usize,
 ) -> (Resolver, impl Future<Item = (), Error = ()>) {
     let (request_tx, rx) = mpsc::unbounded();
     let disco = Resolver { request_tx };
@@ -158,7 +158,7 @@ pub fn new(
         host_and_port,
         controller_tls,
         control_backoff_delay,
-        max_queries,
+        concurrency_limit,
     );
     (disco, bg)
 }

--- a/src/control/remote_stream.rs
+++ b/src/control/remote_stream.rs
@@ -1,7 +1,10 @@
 use futures::{Future, Poll, Stream};
 use http::HeaderMap;
 use prost::Message;
-use std::fmt;
+use std::{
+    fmt,
+    sync::Weak,
+};
 use tower_h2::{HttpService, Body, Data};
 use tower_grpc::{
     self as grpc,
@@ -16,7 +19,8 @@ use tower_grpc::{
 pub enum Remote<M, S: HttpService> {
     NeedsReconnect,
     ConnectedOrConnecting {
-        rx: Receiver<M, S>
+        rx: Receiver<M, S>,
+        active: Weak<()>,
     },
 }
 

--- a/src/control/remote_stream.rs
+++ b/src/control/remote_stream.rs
@@ -30,6 +30,9 @@ pub enum Remote<M, S: HttpService> {
 /// the gRPC response and its streaming body.
 pub struct Receiver<M, S: HttpService> {
     rx: Rx<M, S>,
+
+    /// Used by `background::NewQuery` for counting the number of currently
+    /// active queries that it has created.
     _active: Weak<()>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,7 +276,7 @@ where
             control_host_and_port,
             controller_tls,
             config.control_backoff_delay,
-            config.max_dst_queries,
+            config.destination_concurrency_limit,
         );
 
         let (drain_tx, drain_rx) = drain::channel();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,7 @@ where
             control_host_and_port,
             controller_tls,
             config.control_backoff_delay,
+            config.max_dst_queries,
         );
 
         let (drain_tx, drain_rx) = drain::channel();

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -10,13 +10,13 @@ use self::support::*;
 macro_rules! generate_outbound_dns_limit_test {
     (server: $make_server:path, client: $make_client:path) => {
         #[test]
-        fn outbound_max_dests_does_not_limit_dns() {
+        fn outbound_dest_limit_does_not_limit_dns() {
             let _ = env_logger::try_init();
             let srv = $make_server().route("/", "hello").run();
             let srv_addr = srv.addr;
 
             let mut env = config::TestEnv::new();
-            env.put(config::ENV_MAX_DESTINATION_QUERIES, "2".to_owned());
+            env.put(config::ENV_DESTINATION_CLIENT_CONCURRENCY_LIMIT, "2".to_owned());
 
             let ctrl = controller::new();
             let _txs = (1..=3).map(|n| {
@@ -85,7 +85,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        fn outbound_max_dests() {
+        fn outbound_dest_concurrency_limit() {
             let _ = env_logger::try_init();
             let srv = $make_server().route("/", "hello").run();
             let srv_addr = srv.addr;
@@ -96,7 +96,7 @@ macro_rules! generate_tests {
             // lower than the total router capacity, so we can reach the
             // maximum number of destinations before we start evicting
             // routes.
-            env.put(config::ENV_MAX_DESTINATION_QUERIES, "10".to_owned());
+            env.put(config::ENV_DESTINATION_CLIENT_CONCURRENCY_LIMIT, "10".to_owned());
             env.put(config::ENV_OUTBOUND_ROUTER_CAPACITY, "11".to_owned());
             env.put(config::ENV_OUTBOUND_ROUTER_MAX_IDLE_AGE, "1s".to_owned());
 


### PR DESCRIPTION
Required for linkerd/linkerd2#1322.

Currently, the proxy places a limit on the number of active routes
in the route cache. This limit defaults to 100 routes, and is intended
to prevent the proxy from requesting more than 100 lookups from the 
Destination service. 

However, in some cases, such as Prometheus scraping a large number of
pods, the proxy hits this limit even though none of those requests 
actually result in requests to service discovery (since Prometheus 
scrapes pods by their IP addresses). 

This branch implements @briansmith's suggestion in 
https://github.com/linkerd/linkerd2/issues/1322#issuecomment-407161829.
It splits the router capacity limit to two separate, configurable 
limits, one that sets an upper bound on the number of concurrently 
active destination lookups, and one that limits the capacity of the
router cache.

I've done some preliminary testing using the `lifecycle` tests, where a
single Prometheus instance is configured to scrape a very large number 
of proxies. In these tests, neither limit is reached. Furthermore, I've added
integration tests in `tests/discovery` to exercise the destination service 
query limit. These tests ensure that query capacity is released when inactive
routes which create queries are evicted from the router cache, and that the
limit does _not_ effect DNS queries.

This branch obsoletes and closes #27, which contained an earlier version of
these changes.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>