### PR TITLE
Improve tcp_connect_err test flakiness

### DIFF
--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -820,7 +820,7 @@ mod transport {
         let _ = env_logger::try_init();
         let srv = tcp::server()
             .accept_fut(move |sock| {
-                sock.shutdown(::std::net::Shutdown::Both).unwrap();
+                drop(sock);
                 future::ok(())
             })
             .run();
@@ -850,7 +850,7 @@ mod transport {
         let _ = env_logger::try_init();
         let srv = tcp::server()
             .accept_fut(move |sock| {
-                sock.shutdown(::std::net::Shutdown::Both).unwrap();
+                drop(sock);
                 future::ok(())
             })
             .run();


### PR DESCRIPTION
Both tcp_connect_err tests frequently fail, even during local
development. This seems to happen because the proxy doesn't necessarily
observe the socket closure.

Instead of shutting down the socket gracefully, we can just drop it!
This helps the test pass much more reliably.