### PR TITLE
Refactor control::destination::background::client module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,7 @@ dependencies = [
  "tokio-rustls 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-add-origin 0.1.0 (git+https://github.com/tower-rs/tower-http)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
@@ -1219,6 +1220,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-add-origin"
+version = "0.1.0"
+source = "git+https://github.com/tower-rs/tower-http#c9e13f641a681b3ef01e96910789586e39aee2e2"
+dependencies = [
+ "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+]
+
+[[package]]
 name = "tower-balance"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#679dcbe3272785277081acd4b6671e2bf69fcc52"
@@ -1679,6 +1690,7 @@ dependencies = [
 "checksum tokio-threadpool 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c3873a6d8d0b636e024e77b9a82eaab6739578a06189ecd0e731c7308fbc5d"
 "checksum tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "028b94314065b90f026a21826cffd62a4e40a92cda3e5c069cc7b02e5945f5e9"
 "checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
+"checksum tower-add-origin 0.1.0 (git+https://github.com/tower-rs/tower-http)" = "<none>"
 "checksum tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tokio = "0.1.7"
 tokio-signal = "0.2"
 tokio-timer = "0.2.4"   # for tokio_timer::clock
 tokio-connect         = { git = "https://github.com/carllerche/tokio-connect" }
+tower-add-origin      = { git = "https://github.com/tower-rs/tower-http" }
 tower-balance         = { git = "https://github.com/tower-rs/tower" }
 tower-buffer          = { git = "https://github.com/tower-rs/tower" }
 tower-discover        = { git = "https://github.com/tower-rs/tower" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ extern crate tempdir;
 extern crate tokio;
 extern crate tokio_connect;
 extern crate tokio_timer;
+extern crate tower_add_origin;
 extern crate tower_balance;
 extern crate tower_buffer;
 extern crate tower_discover;


### PR DESCRIPTION
This branch should not make any functional changes.

This branch makes two minor refactorings to the `client` module in 
`control::destination::background`:

 1. Remove the `AddOrigin` middleware and replace it with the 
    `tower-add-origin` crate from `tower-http`. These middlewares are
    functionally identical, but the Tower version has tests.
 2. Change `ClientService` from a type alias to a tuple struct. This
    means that some of the middleware that are used only in this module
    (`LogErrors` and `Backoff`) are no longer part of a publicly visible
    type and can be made private to the module.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>