### PR TITLE
Fully encapsulate process metrics in `mod process`

### DIFF
--- a/src/telemetry/metrics/process.rs
+++ b/src/telemetry/metrics/process.rs
@@ -187,7 +187,7 @@ mod system {
     pub(super) struct System {}
 
     impl System {
-        pub fn new() -> io::Result<Sensor> {
+        pub fn new() -> io::Result<Self> {
             Err(io::Error::new(
                 io::ErrorKind::Other,
                 "procinfo not supported on this operating system"


### PR DESCRIPTION
The `process` module exposes a `Sensor` type that is different from
other types called `Sensor`. Most `Sensor` types instrument other
types with telemetry. The `process::Sensor` type, on the other hand,
is used to read system metrics from the `/proc` filesystem, returning
a metrics summary.

Furthermore, `telemetry::metrics::Root` owns the process start time
metric.

In the interest of making the telemetry system more modular, this moves
all process-related telemetry concerns into the `process` module.
Instead of exposing a `Sensor` that produces metrics, a single public
`Process` type implements `fmt::Display` directly.

This removes process-related concerns from `telemetry/metrics/mod.rs` to
setup further refactoring along these lines.