### PR TITLE
fix orig-proto translation with HTTP1 chunked bodies

### DIFF
--- a/src/transparency/orig_proto.rs
+++ b/src/transparency/orig_proto.rs
@@ -1,6 +1,6 @@
 use futures::{future, Future, Poll};
 use http;
-use http::header::HeaderValue;
+use http::header::{TRANSFER_ENCODING, HeaderValue};
 use tower_service::{Service, NewService};
 
 use bind;
@@ -98,6 +98,8 @@ where
                 HeaderValue::from_static(val)
             );
 
+            // transfer-encoding is illegal in HTTP2
+            req.headers_mut().remove(TRANSFER_ENCODING);
 
             *req.version_mut() = http::Version::HTTP_2;
             downgrade_response = true;
@@ -228,6 +230,10 @@ where
                     L5D_ORIG_PROTO,
                     HeaderValue::from_static(orig_proto)
                 );
+
+                // transfer-encoding is illegal in HTTP2
+                res.headers_mut().remove(TRANSFER_ENCODING);
+
                 *res.version_mut() = http::Version::HTTP_2;
                 res
             })


### PR DESCRIPTION
The `transfer-encoding` header was not being removed before translating to HTTP2, which was causing protocol errors. This removes them. hyper will automatically add them when translating back to HTTP/1.1 (and won't add if it was HTTP/1.0). Tests added to ensure this behavior.

Closes https://github.com/linkerd/linkerd2/issues/1404