### PR TITLE
refactor: Make `DestinationSet` aware of its own authority

### DIFF
--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -80,6 +80,11 @@ where
         set
     }
 
+    /// Replaces this `DestinationSet`'s current `DestinationServiceQuery`
+    /// with a new one returned by
+    /// `new_query.query_destination_service_if_relevant`.
+    ///
+    /// Returns `true` if the `DestinationSet` was reconnected successfully.
     pub(super) fn reconnect_destination_query(
         &mut self,
         new_query: &super::NewQuery,
@@ -108,6 +113,7 @@ where
         self.dns_query = Some(dns_resolver.resolve_all_ips(deadline, &self.auth.host));
     }
 
+    /// If this `DestinationSet` is currently polling DNS, stop doing so.
     pub(super) fn end_dns_query(&mut self) {
         self.dns_query = None;
     }


### PR DESCRIPTION
This branch makes some changes to the `control::destination::background`
module in order to (hopefully) make this code more understandable. It 
should not cause a functional change.

The primary change here is to make each `DestinationSet` aware of its
own authority, so that code which was previously in methods on the
`Background` struct can be moved to methods on `DestinationSet` which
`Background` invokes. This allows more of `DestinationSet`'s fields to
be made private, and puts a bit more of an API boundary between 
`Background` and `DestinationSet`.

Since the authorities are used as keys in the map of `DestinationSet`s,
and are also sometimes put in the reconnect queue, they are now 
reference counted, so that they can be shared with the `DestinationSet`
without having to clone the string representing those authorities. The
reconnect queue can hold a `Weak` reference, since once the 
`DestinationSet` has been dropped (by `DestinationCache::retain_active`),
the authority is no longer needed and can also be dropped.

In addition, I've added a few more comments on some methods and types.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>