### PR TITLE
Consolidate telemetry::metrics::tls_config_reload

### DIFF
--- a/src/telemetry/metrics/record.rs
+++ b/src/telemetry/metrics/record.rs
@@ -7,9 +7,7 @@ use super::labels::{
     ResponseLabels,
     TransportLabels,
     TransportCloseLabels,
-    TlsConfigLabels,
 };
-use std::time::UNIX_EPOCH;
 
 /// Tracks Prometheus metrics
 #[derive(Clone, Debug)]
@@ -86,20 +84,10 @@ impl Record {
             },
 
             Event::TlsConfigReloaded(ref when) =>
-                self.update(|metrics| {
-                    let timestamp_secs = when
-                        .duration_since(UNIX_EPOCH)
-                        .expect("SystemTime before UNIX_EPOCH!")
-                        .as_secs()
-                        .into();
-                    metrics.tls_config_last_reload_seconds = Some(timestamp_secs);
-                    metrics.tls_config(TlsConfigLabels::success()).incr();
-                }),
+                self.update(|m| m.tls_config().success(when)),
 
             Event::TlsConfigReloadFailed(ref err) =>
-                self.update(|metrics| {
-                    metrics.tls_config(err.clone().into()).incr();
-                }),
+                self.update(|m| m.tls_config().error(err.clone())),
         };
     }
 }

--- a/src/telemetry/metrics/tls_config_reload.rs
+++ b/src/telemetry/metrics/tls_config_reload.rs
@@ -1,0 +1,112 @@
+use std::{fmt, path::PathBuf, time::{SystemTime, UNIX_EPOCH}};
+
+use telemetry::metrics::{Counter, Gauge, Metric, Scopes, labels::Errno};
+use transport::tls;
+
+metrics! {
+    tls_config_last_reload_seconds: Gauge {
+        "Timestamp of the last successful TLS configuration reload \
+         (in seconds since the UNIX epoch)"
+    },
+    tls_config_reload_total: Counter {
+        "Total number of TLS configuration reloads"
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct TlsConfigReload {
+    last_reload: Option<Gauge>,
+    by_status: Scopes<Status, Counter>,
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+enum Status {
+    Reloaded,
+    InvalidTrustAnchors,
+    InvalidPrivateKey,
+    InvalidEndEntityCert,
+    Io { path: PathBuf, errno: Option<Errno>, },
+}
+
+// ===== impl TlsConfigReload =====
+
+impl TlsConfigReload {
+    pub fn success(&mut self, when: &SystemTime) {
+        let t = when
+            .duration_since(UNIX_EPOCH)
+            .expect("times must be after UNIX epoch")
+            .as_secs();
+        self.last_reload = Some(t.into());
+
+        self.by_status.scopes
+            .entry(Status::Reloaded)
+            .or_insert_with(|| Counter::default())
+            .incr()
+    }
+
+    pub fn error(&mut self, e: tls::ConfigError) {
+        self.by_status.scopes
+            .entry(e.into())
+            .or_insert_with(|| Counter::default())
+            .incr()
+    }
+}
+
+impl fmt::Display for TlsConfigReload {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if !self.by_status.scopes.is_empty() {
+            tls_config_reload_total.fmt_help(f)?;
+            tls_config_reload_total.fmt_scopes(f, &self.by_status, |s| &s)?;
+        }
+
+        if let Some(timestamp) = self.last_reload {
+            tls_config_last_reload_seconds.fmt_help(f)?;
+            tls_config_last_reload_seconds.fmt_metric(f, timestamp)?;
+        }
+
+        Ok(())
+    }
+}
+
+// ===== impl Status =====
+
+impl From<tls::ConfigError> for Status {
+    fn from(err: tls::ConfigError) -> Self {
+        match err {
+            tls::ConfigError::Io(path, error_code) =>
+                Status::Io { path, errno: error_code.map(Errno::from) },
+            tls::ConfigError::FailedToParseTrustAnchors(_) =>
+                Status::InvalidTrustAnchors,
+            tls::ConfigError::EndEntityCertIsNotValid(_) =>
+                Status::InvalidEndEntityCert,
+            tls::ConfigError::InvalidPrivateKey =>
+                Status::InvalidPrivateKey,
+        }
+    }
+}
+
+impl fmt::Display for Status {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Status::Reloaded =>
+                f.pad("status=\"reloaded\""),
+            Status::Io { ref path, errno: Some(errno) } =>
+                write!(f,
+                    "status=\"io_error\",path=\"{}\",errno=\"{}\"",
+                    path.display(), errno
+                ),
+            Status::Io { ref path, errno: None } =>
+                write!(f,
+                    "status=\"io_error\",path=\"{}\",errno=\"UNKNOWN\"",
+                    path.display(),
+                ),
+            Status::InvalidPrivateKey =>
+                f.pad("status=\"invalid_private_key\""),
+            Status::InvalidEndEntityCert =>
+                f.pad("status=\"invalid_end_entity_cert\""),
+            Status::InvalidTrustAnchors =>
+                f.pad("status=\"invalid_trust_anchors\""),
+        }
+    }
+}
+


### PR DESCRIPTION
Details of TLS configuration reload metrics span several modules.

This change consolidates all of this logic into a single
module with a single public type, `TlsConfigReload`, that supports
recording successful reloads, recording errors, and formatting its
current state.

This sets up further simplifications, eventually leading to the removal
of the `Event` API.