### PR TITLE
Share a common TlsConfigReload metrics object

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ where
         );
 
         let tls_client_config = tls_config_watch.client.clone();
-        let tls_cfg_bg = tls_config_watch.start(sensors.tls_config());
+        let tls_cfg_bg = tls_config_watch.start(sensors.tls_config_reload().clone());
 
         let controller_tls = config.tls_settings.as_ref().and_then(|settings| {
             settings.controller_identity.as_ref().map(|controller_identity| {

--- a/src/telemetry/event.rs
+++ b/src/telemetry/event.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, Instant};
 
 use h2;
 
@@ -17,9 +17,6 @@ pub enum Event {
     StreamResponseOpen(Arc<ctx::http::Response>, StreamResponseOpen),
     StreamResponseFail(Arc<ctx::http::Response>, StreamResponseFail),
     StreamResponseEnd(Arc<ctx::http::Response>, StreamResponseEnd),
-
-    TlsConfigReloaded(SystemTime),
-    TlsConfigReloadFailed(::transport::tls::ConfigError),
 }
 
 #[derive(Clone, Debug)]

--- a/src/telemetry/metrics/record.rs
+++ b/src/telemetry/metrics/record.rs
@@ -82,12 +82,6 @@ impl Record {
                         .close(close.duration);
                 })
             },
-
-            Event::TlsConfigReloaded(ref when) =>
-                self.update(|m| m.tls_config().success(when)),
-
-            Event::TlsConfigReloadFailed(ref err) =>
-                self.update(|m| m.tls_config().error(err.clone())),
         };
     }
 }
@@ -135,7 +129,7 @@ mod test {
             frames_sent: 0,
         };
 
-        let (mut r, _) = metrics::new(&process, Duration::from_secs(100));
+        let (mut r, _, _) = metrics::new(&process, Duration::from_secs(100));
         let ev = Event::StreamResponseEnd(rsp.clone(), end.clone());
         let labels = labels::ResponseLabels::new(&rsp, None);
 
@@ -230,7 +224,7 @@ mod test {
             ),
         ];
 
-        let (mut r, _) = metrics::new(&process, Duration::from_secs(1000));
+        let (mut r, _, _) = metrics::new(&process, Duration::from_secs(1000));
 
         let req_labels = RequestLabels::new(&req);
         let rsp_labels = ResponseLabels::new(&rsp, None);

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -16,7 +16,7 @@ pub fn new(
     metrics_retain_idle: Duration,
     taps: &Arc<Mutex<tap::Taps>>,
 ) -> (Sensors, metrics::Serve) {
-    let (metrics_record, metrics_serve) = metrics::new(process, metrics_retain_idle);
-    let s = Sensors::new(metrics_record, taps);
+    let (metrics_record, tls_config_reload, metrics_serve) = metrics::new(process, metrics_retain_idle);
+    let s = Sensors::new(metrics_record, tls_config_reload, taps);
     (s, metrics_serve)
 }

--- a/src/telemetry/sensor/mod.rs
+++ b/src/telemetry/sensor/mod.rs
@@ -9,7 +9,7 @@ use tower_h2::Body;
 
 use ctx;
 use telemetry::{event, metrics, tap};
-use transport::{Connection, tls};
+use transport::Connection;
 use transparency::ClientError;
 
 pub mod http;
@@ -29,12 +29,11 @@ struct Inner {
 struct Handle(Option<Inner>);
 
 /// Supports the creation of telemetry scopes.
-#[derive(Clone, Debug)]
-pub struct Sensors(Option<Inner>);
-
-/// Given to the TLS config watch to generate events on reloads.
-#[derive(Clone, Debug)]
-pub struct TlsConfig(Handle);
+#[derive(Clone, Debug, Default)]
+pub struct Sensors {
+    inner: Option<Inner>,
+    tls_config_reload: Arc<metrics::TlsConfigReload>,
+}
 
 impl Handle {
     fn send<F>(&mut self, mk: F)
@@ -55,15 +54,22 @@ impl Handle {
 }
 
 impl Sensors {
-    pub(super) fn new(metrics: metrics::Record, taps: &Arc<Mutex<tap::Taps>>) -> Self {
-        Sensors(Some(Inner {
-            metrics,
-            taps: taps.clone(),
-        }))
+    pub(super) fn new(
+        metrics: metrics::Record,
+        tls_config_reload: Arc<metrics::TlsConfigReload>,
+        taps: &Arc<Mutex<tap::Taps>>
+    ) -> Self {
+        Sensors {
+            tls_config_reload,
+            inner: Some(Inner {
+                metrics,
+                taps: taps.clone(),
+            })
+        }
     }
 
     pub fn null() -> Sensors {
-        Sensors(None)
+        Sensors::default()
     }
 
     pub fn accept<T>(
@@ -77,14 +83,14 @@ impl Sensors {
     {
         debug!("server connection open");
         let ctx = Arc::new(ctx::transport::Ctx::Server(Arc::clone(ctx)));
-        Transport::open(io, opened_at, Handle(self.0.clone()), ctx)
+        Transport::open(io, opened_at, Handle(self.inner.clone()), ctx)
     }
 
     pub fn connect<C>(&self, connect: C, ctx: &Arc<ctx::transport::Client>) -> Connect<C>
     where
         C: tokio_connect::Connect<Connected = Connection>,
     {
-        Connect::new(connect, Handle(self.0.clone()), ctx)
+        Connect::new(connect, Handle(self.inner.clone()), ctx)
     }
 
     pub fn http<N, A, B>(
@@ -102,22 +108,10 @@ impl Sensors {
         >
             + 'static,
     {
-        NewHttp::new(new_service, Handle(self.0.clone()), client_ctx)
+        NewHttp::new(new_service, Handle(self.inner.clone()), client_ctx)
     }
 
-    pub fn tls_config(&self) -> TlsConfig {
-        TlsConfig(Handle(self.0.clone()))
-    }
-}
-
-impl TlsConfig {
-
-    pub fn reloaded(&mut self) {
-        use std::time::SystemTime;
-        self.0.send(|| event::Event::TlsConfigReloaded(SystemTime::now()))
-    }
-
-    pub fn failed(&mut self, err: tls::ConfigError) {
-        self.0.send(|| event::Event::TlsConfigReloadFailed(err.into()))
+    pub fn tls_config_reload(&self) -> &Arc<metrics::TlsConfigReload> {
+        &self.tls_config_reload
     }
 }

--- a/src/transport/tls/config.rs
+++ b/src/transport/tls/config.rs
@@ -16,7 +16,7 @@ use super::{
     webpki,
 };
 use conditional::Conditional;
-use telemetry::sensor;
+use telemetry::metrics::TlsConfigReload;
 
 use futures::{future, stream, Future, Stream};
 use futures_watch::{Store, Watch};
@@ -182,7 +182,7 @@ impl CommonSettings {
     fn stream_changes(
         self,
         interval: Duration,
-        mut sensor: sensor::TlsConfig,
+        metrics: Arc<TlsConfigReload>,
     ) -> impl Stream<Item = CommonConfig, Error = ()>
     {
         let paths = self.paths().iter()
@@ -196,11 +196,11 @@ impl CommonSettings {
                 match CommonConfig::load_from_disk(&self) {
                     Err(e) => {
                         warn!("error reloading TLS config: {:?}, falling back", e);
-                        sensor.failed(e);
+                        metrics.failed(e);
                         None
                     },
                     Ok(cfg) => {
-                        sensor.reloaded();
+                        metrics.reloaded();
                         Some(cfg)
                     }
                 }
@@ -337,7 +337,7 @@ impl ConfigWatch {
     ///
     /// The returned task Future is expected to never complete. If TLS is
     /// disabled then an empty future is returned.
-    pub fn start(self, sensor: sensor::TlsConfig) -> PublishConfigs {
+    pub fn start(self, metrics: Arc<TlsConfigReload>) -> PublishConfigs {
         let settings = match self.settings {
             Conditional::Some(settings) => settings,
             Conditional::None(_) => {
@@ -347,7 +347,7 @@ impl ConfigWatch {
 
         let (client_store, server_store) = (self.client_store, self.server_store);
 
-        let changes = settings.stream_changes(Duration::from_secs(1), sensor);
+        let changes = settings.stream_changes(Duration::from_secs(1), metrics);
 
         // `Store::store` will return an error iff all watchers have been dropped,
         // so we'll use `fold` to cancel the forwarding future. Eventually, we can


### PR DESCRIPTION
The current implementation of TLS config reload telemetry has several
layers: a sensor emits events into a dispatcher that updates a metrics
object.

This can be simplified by sharing a common TlsConfigReload struct
directly from the metrics registry into the config module.