### PR TITLE
Move mk_err_enum into errno module

### DIFF
--- a/src/telemetry/metrics/labels/errno.rs
+++ b/src/telemetry/metrics/labels/errno.rs
@@ -1,5 +1,36 @@
 use std::fmt;
 
+macro_rules! mk_err_enum {
+    { $(#[$m:meta])* enum $name:ident from $from_ty:ty {
+         $( $from:pat => $reason:ident ),+
+     } } => {
+        $(#[$m])*
+        pub enum $name {
+            $( $reason ),+
+        }
+
+        impl fmt::Display for $name {
+             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                match self {
+                    $(
+                        $name::$reason => f.pad(stringify!($reason))
+                    ),+
+                }
+             }
+        }
+
+        impl<'a> From<$from_ty> for $name {
+            fn from(err: $from_ty) -> Self {
+                match err {
+                    $(
+                        $from => $name::$reason
+                    ),+
+                }
+            }
+        }
+    }
+}
+
 mk_err_enum! {
     /// Taken from `errno.h`.
     #[cfg(not(target_os="windows"))]

--- a/src/telemetry/metrics/labels/mod.rs
+++ b/src/telemetry/metrics/labels/mod.rs
@@ -12,38 +12,6 @@ use conditional::Conditional;
 use telemetry::event;
 use transport::tls;
 
-macro_rules! mk_err_enum {
-    { $(#[$m:meta])* enum $name:ident from $from_ty:ty {
-         $( $from:pat => $reason:ident ),+
-     } } => {
-        $(#[$m])*
-        pub enum $name {
-            $( $reason ),+
-        }
-
-        impl fmt::Display for $name {
-             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                // use super::$name::*;
-                 match self {
-                    $(
-                        $name::$reason => f.pad(stringify!($reason))
-                    ),+
-                }
-             }
-        }
-
-        impl<'a> From<$from_ty> for $name {
-            fn from(err: $from_ty) -> Self {
-                match err {
-                    $(
-                        $from => $name::$reason
-                    ),+
-                }
-            }
-        }
-    }
-}
-
 mod errno;
 pub use self::errno::Errno;
 


### PR DESCRIPTION
The `mk_err_enum` macro is only used in one place: the `labels::errno` module.

In order to make the main `labels` module simpler, the macro definition
can by moved into the errno module. If this macro is really generally
useful, it can be factored out later.