### PR TITLE
Stop tracking transport metrics for eviction

### DIFF
--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -197,21 +197,17 @@ impl Root {
 
     fn transport(&mut self, labels: TransportLabels) -> &mut transport::OpenMetrics {
         self.transports.scopes.entry(labels)
-            .or_insert_with(|| transport::OpenMetrics::default().into())
-            .stamped()
+            .or_insert_with(|| transport::OpenMetrics::default())
     }
 
     fn transport_close(&mut self, labels: TransportCloseLabels) -> &mut transport::CloseMetrics {
         self.transport_closes.scopes.entry(labels)
-            .or_insert_with(|| transport::CloseMetrics::default().into())
-            .stamped()
+            .or_insert_with(|| transport::CloseMetrics::default())
     }
 
     fn retain_since(&mut self, epoch: Instant) {
         self.requests.retain_since(epoch);
         self.responses.retain_since(epoch);
-        self.transports.retain_since(epoch);
-        self.transport_closes.retain_since(epoch);
     }
 }
 
@@ -338,13 +334,13 @@ mod tests {
         root.retain_since(t1);
         assert_eq!(root.requests.scopes.len(), 1);
         assert_eq!(root.responses.scopes.len(), 1);
-        assert_eq!(root.transports.scopes.len(), 1);
+        assert_eq!(root.transports.scopes.len(), 2);
         assert_eq!(root.transport_closes.scopes.len(), 1);
 
         root.retain_since(t2);
         assert_eq!(root.requests.scopes.len(), 0);
         assert_eq!(root.responses.scopes.len(), 0);
-        assert_eq!(root.transports.scopes.len(), 0);
-        assert_eq!(root.transport_closes.scopes.len(), 0);
+        assert_eq!(root.transports.scopes.len(), 2);
+        assert_eq!(root.transport_closes.scopes.len(), 1);
     }
 }

--- a/src/telemetry/metrics/transport.rs
+++ b/src/telemetry/metrics/transport.rs
@@ -10,10 +10,9 @@ use super::{
     TransportLabels,
     TransportCloseLabels,
     Scopes,
-    Stamped,
 };
 
-pub(super) type OpenScopes = Scopes<TransportLabels, Stamped<OpenMetrics>>;
+pub(super) type OpenScopes = Scopes<TransportLabels, OpenMetrics>;
 
 #[derive(Debug, Default)]
 pub(super) struct OpenMetrics {
@@ -23,7 +22,7 @@ pub(super) struct OpenMetrics {
     read_bytes_total: Counter,
 }
 
-pub(super) type CloseScopes = Scopes<TransportCloseLabels, Stamped<CloseMetrics>>;
+pub(super) type CloseScopes = Scopes<TransportCloseLabels, CloseMetrics>;
 
 #[derive(Debug, Default)]
 pub(super) struct CloseMetrics {


### PR DESCRIPTION
Metric eviction was introduced to protect against the situation where,
over time, the proxy addresses an effectively unbounded number of
endpoints. Metrics with endpoint-specific dimensions must be removed
over time to prevent a form of memory leak.

Eviction is implemented for transport stats. However, transport stats do
not yet contain per-endpoint dimensions. The eviction logic is
superfluous because transport metrics are bounded and small.

In preparation of changes to transport telemetry, this disables tracking
of transport metrics for eviction. This logic will be restored when we
support per-endpoint transport metrics.