### PR TITLE
Make `metrics!` visible within `telemetry`

### DIFF
--- a/src/telemetry/metrics/http.rs
+++ b/src/telemetry/metrics/http.rs
@@ -5,7 +5,6 @@ use super::{
     latency,
     Counter,
     Histogram,
-    Metric,
     RequestLabels,
     ResponseLabels,
     Scopes,

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -37,19 +37,6 @@ use indexmap::IndexMap;
 
 use ctx;
 
-macro_rules! metrics {
-    { $( $name:ident : $kind:ty { $help:expr } ),+ } => {
-        $(
-            #[allow(non_upper_case_globals)]
-            const $name: Metric<'static, $kind> = Metric {
-                name: stringify!($name),
-                help: $help,
-                _p: ::std::marker::PhantomData,
-            };
-        )+
-    }
-}
-
 mod counter;
 mod gauge;
 mod histogram;
@@ -80,7 +67,7 @@ pub use self::serve::Serve;
 /// This trait is implemented by `Counter`, `Gauge`, and `Histogram` to account for the
 /// differences in formatting each type of metric. Specifically, `Histogram` formats a
 /// counter for each bucket, as well as a count and total sum.
-trait FmtMetric {
+pub trait FmtMetric {
     /// The metric's `TYPE` in help messages.
     const KIND: &'static str;
 
@@ -97,10 +84,10 @@ trait FmtMetric {
 /// Describes a metric statically.
 ///
 /// Formats help messages and metric values for prometheus output.
-struct Metric<'a, M: FmtMetric> {
-    name: &'a str,
-    help: &'a str,
-    _p: PhantomData<M>,
+pub struct Metric<'a, M: FmtMetric> {
+    pub name: &'a str,
+    pub help: &'a str,
+    pub _p: PhantomData<M>,
 }
 
 /// The root scope for all runtime metrics.
@@ -119,7 +106,7 @@ struct Root {
 ///
 /// An `S` type typically holds one or more metrics.
 #[derive(Debug)]
-struct Scopes<L: Display + Hash + Eq, S> {
+pub struct Scopes<L: Display + Hash + Eq, S> {
     scopes: IndexMap<L, S>,
 }
 

--- a/src/telemetry/metrics/process.rs
+++ b/src/telemetry/metrics/process.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::time::UNIX_EPOCH;
 
 use ctx;
-use super::{Gauge, Metric};
+use super::Gauge;
 
 use self::system::System;
 

--- a/src/telemetry/metrics/tls_config_reload.rs
+++ b/src/telemetry/metrics/tls_config_reload.rs
@@ -5,7 +5,7 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use telemetry::metrics::{labels::Errno, Counter, Gauge, Metric, Scopes};
+use telemetry::metrics::{labels::Errno, Counter, Gauge, Scopes};
 use transport::tls;
 
 metrics! {

--- a/src/telemetry/metrics/transport.rs
+++ b/src/telemetry/metrics/transport.rs
@@ -6,7 +6,6 @@ use super::{
     Counter,
     Gauge,
     Histogram,
-    Metric,
     TransportLabels,
     TransportCloseLabels,
     Scopes,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -3,7 +3,22 @@ use std::time::Duration;
 
 use ctx;
 
+macro_rules! metrics {
+    { $( $name:ident : $kind:ty { $help:expr } ),+ } => {
+        $(
+            #[allow(non_upper_case_globals)]
+            const $name: ::telemetry::metrics::Metric<'static, $kind> =
+                ::telemetry::metrics::Metric {
+                    name: stringify!($name),
+                    help: $help,
+                    _p: ::std::marker::PhantomData,
+                };
+        )+
+    }
+}
+
 pub mod event;
+// TODO this shouldn't need to be public.
 pub mod metrics;
 pub mod sensor;
 pub mod tap;


### PR DESCRIPTION
The `telemetry::metrics` module has a mix of core metrics types and
application-specific code. I'd like to change this module to only
contain core types. All app-specific module will be moved into
`telemetry`.

In order to make these changes, the `metrics!` macro (and related types)
must be visible to to `telemetry`. This change moves the macro
definition into the parent mod.rs, and makes the `Metric`, `FmtMetric`,
and `Scopes` types public.

In subsequent PRs, app-specific logic will be moved from
`telemetry::metrics` to `telemetry`, and the `telemetry::metrics`
module's public API will be minimized.