### PR TITLE
Fix syntax for windows-only error labels

### DIFF
--- a/src/telemetry/metrics/labels/mod.rs
+++ b/src/telemetry/metrics/labels/mod.rs
@@ -437,21 +437,19 @@ impl fmt::Display for tls::ReasonForNoIdentity {
     }
 }
 
-
 #[cfg(target_os="windows")]
-pub struct Errno(i32);
+mod errno {
+    pub struct Errno(i32);
 
-#[cfg(target_os="windows")]
-impl From<i32> for Errno {
-    fn from(code: i32) -> Self {
-        Errno(code)
+    impl From<i32> for Errno {
+        fn from(code: i32) -> Self {
+            Errno(code)
+        }
     }
-}
 
-#[cfg(target_os="windows")]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-impl fmt::Display for Errno {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display.fmt(self.0, f)
+    impl fmt::Display for Errno {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            fmt::Display.fmt(self.0, f)
+        }
     }
 }


### PR DESCRIPTION
This should fix linkerd/linkerd2/#1396, although it hasn't actually been
verified on Windows yet. However, it's a fairly simple syntax error, so
I'm pretty confident that this change fixes it.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>