### PR TITLE
Extract metrics::Scopes into its own module

### DIFF
--- a/src/telemetry/metrics/http.rs
+++ b/src/telemetry/metrics/http.rs
@@ -36,7 +36,7 @@ impl RequestScopes {
 
 impl fmt::Display for RequestScopes {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.scopes.is_empty() {
+        if self.is_empty() {
             return Ok(());
         }
 
@@ -74,7 +74,7 @@ impl ResponseScopes {
 
 impl fmt::Display for ResponseScopes {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.scopes.is_empty() {
+        if self.is_empty() {
             return Ok(());
         }
 

--- a/src/telemetry/metrics/record.rs
+++ b/src/telemetry/metrics/record.rs
@@ -137,7 +137,7 @@ mod test {
 
         assert!(r.metrics.lock()
             .expect("lock")
-            .responses.scopes
+            .responses
             .get(&labels)
             .is_none()
         );
@@ -146,7 +146,8 @@ mod test {
         {
             let lock = r.metrics.lock()
                 .expect("lock");
-            let scope = lock.responses.scopes
+            let scope = lock
+                .responses
                 .get(&labels)
                 .expect("scope should be some after event");
 
@@ -249,12 +250,12 @@ mod test {
         {
             let lock = r.metrics.lock()
                 .expect("lock");
-            assert!(lock.requests.scopes.get(&req_labels).is_none());
-            assert!(lock.responses.scopes.get(&rsp_labels).is_none());
-            assert!(lock.transports.scopes.get(&srv_open_labels).is_none());
-            assert!(lock.transports.scopes.get(&client_open_labels).is_none());
-            assert!(lock.transport_closes.scopes.get(&srv_close_labels).is_none());
-            assert!(lock.transport_closes.scopes.get(&client_close_labels).is_none());
+            assert!(lock.requests.get(&req_labels).is_none());
+            assert!(lock.responses.get(&rsp_labels).is_none());
+            assert!(lock.transports.get(&srv_open_labels).is_none());
+            assert!(lock.transports.get(&client_open_labels).is_none());
+            assert!(lock.transport_closes.get(&srv_close_labels).is_none());
+            assert!(lock.transport_closes.get(&client_close_labels).is_none());
         }
 
         for e in &events {
@@ -267,7 +268,7 @@ mod test {
 
             // === request scope ====================================
             assert_eq!(
-                lock.requests.scopes
+                lock.requests
                     .get(&req_labels)
                     .map(|scope| scope.total()),
                 Some(1)
@@ -275,7 +276,7 @@ mod test {
 
             // === response scope ===================================
             let response_scope = lock
-                .responses.scopes
+                .responses
                 .get(&rsp_labels)
                 .expect("response scope missing");
             assert_eq!(response_scope.total(), 1);
@@ -287,7 +288,7 @@ mod test {
 
             // === server transport open scope ======================
             let srv_transport_scope = lock
-                .transports.scopes
+                .transports
                 .get(&srv_open_labels)
                 .expect("server transport scope missing");
             assert_eq!(srv_transport_scope.open_total(), 1);
@@ -296,7 +297,7 @@ mod test {
 
             // === client transport open scope ======================
             let client_transport_scope = lock
-                .transports.scopes
+                .transports
                 .get(&client_open_labels)
                 .expect("client transport scope missing");
             assert_eq!(client_transport_scope.open_total(), 1);
@@ -307,7 +308,7 @@ mod test {
 
             // === server transport close scope =====================
             let srv_transport_close_scope = lock
-                .transport_closes.scopes
+                .transport_closes
                 .get(&srv_close_labels)
                 .expect("server transport close scope missing");
             assert_eq!(srv_transport_close_scope.close_total(), 1);
@@ -318,7 +319,7 @@ mod test {
 
             // === client transport close scope =====================
             let client_transport_close_scope = lock
-                .transport_closes.scopes
+                .transport_closes
                 .get(&client_close_labels)
                 .expect("client transport close scope missing");
             assert_eq!(client_transport_close_scope.close_total(), 1);

--- a/src/telemetry/metrics/scopes.rs
+++ b/src/telemetry/metrics/scopes.rs
@@ -1,0 +1,50 @@
+use indexmap::IndexMap;
+use std::{fmt::Display, hash::Hash};
+
+/// Holds an `S`-typed scope for each `L`-typed label set.
+///
+/// An `S` type typically holds one or more metrics.
+#[derive(Debug)]
+pub struct Scopes<L: Display + Hash + Eq, S>(IndexMap<L, S>);
+
+impl<L: Display + Hash + Eq, S> Default for Scopes<L, S> {
+    fn default() -> Self {
+        Scopes(IndexMap::default())
+    }
+}
+
+impl<L: Display + Hash + Eq, S> Scopes<L, S> {
+    pub fn get(&self, key: &L) -> Option<&S> {
+        self.0.get(key)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&L, &mut S) -> bool,
+    {
+        self.0.retain(f)
+    }
+}
+
+impl<L: Display + Hash + Eq, S: Default> Scopes<L, S> {
+    pub fn get_or_default(&mut self, key: L) -> &mut S {
+        self.0.entry(key).or_insert_with(|| S::default())
+    }
+}
+
+impl<'a, L: Display + Hash + Eq, S> IntoIterator for &'a Scopes<L, S> {
+    type Item = <&'a IndexMap<L, S> as IntoIterator>::Item;
+    type IntoIter = <&'a IndexMap<L, S> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}

--- a/src/telemetry/metrics/transport.rs
+++ b/src/telemetry/metrics/transport.rs
@@ -42,7 +42,7 @@ impl OpenScopes {
 
 impl fmt::Display for OpenScopes {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.scopes.is_empty() {
+        if self.is_empty() {
             return Ok(());
         }
 
@@ -103,7 +103,7 @@ impl CloseScopes {
 
 impl fmt::Display for CloseScopes {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.scopes.is_empty() {
+        if self.is_empty() {
             return Ok(());
         }
 


### PR DESCRIPTION
The metrics::Scopes type exposes its internal implementation to many of
its uses.

By extracting the type into its own module, we are forced to provide an
explicit public interface, hiding its IndexMap implementation details.