### PR TITLE
Consolidate labels into metrics::transport

### DIFF
--- a/src/telemetry/metrics/labels.rs
+++ b/src/telemetry/metrics/labels.rs
@@ -71,7 +71,7 @@ pub struct TlsStatus(ctx::transport::TlsStatus);
 
 impl RequestLabels {
     pub fn new(req: &ctx::http::Request) -> Self {
-        let direction = req.server.proxy.as_ref().into();
+        let direction = Direction::from_context(req.server.proxy.as_ref());
 
         let outbound_labels = req.dst_labels().cloned();
 
@@ -214,11 +214,11 @@ impl fmt::Display for Classification {
 
 // ===== impl Direction =====
 
-impl<'a> From<&'a ctx::Proxy> for Direction {
-    fn from(c: &'a ctx::Proxy) -> Self {
-        match *c {
-            ctx::Proxy::Inbound(_) => Direction::Inbound,
-            ctx::Proxy::Outbound(_) => Direction::Outbound,
+impl Direction {
+    pub fn from_context(context: &ctx::Proxy) -> Self {
+        match context {
+            &ctx::Proxy::Inbound(_) => Direction::Inbound,
+            &ctx::Proxy::Outbound(_) => Direction::Outbound,
         }
     }
 }

--- a/src/telemetry/metrics/labels.rs
+++ b/src/telemetry/metrics/labels.rs
@@ -9,7 +9,7 @@ use http;
 
 use ctx;
 use conditional::Conditional;
-use telemetry::{event, Errno};
+use telemetry::event;
 use transport::tls;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -46,44 +46,14 @@ pub struct ResponseLabels {
     classification: Classification,
 }
 
-/// Labels describing a TCP connection
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct TransportLabels {
-    /// Was the transport opened in the inbound or outbound direction?
-    direction: Direction,
-
-    peer: Peer,
-
-    /// Was the transport secured with TLS?
-    tls_status: TlsStatus,
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub enum Peer { Src, Dst }
-
-/// Labels describing the end of a TCP connection
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct TransportCloseLabels {
-    /// Labels describing the TCP connection that closed.
-    pub(super) transport: TransportLabels,
-
-    /// Was the transport closed successfully?
-    classification: Classification,
-
-    /// If `classification` == `Failure`, this may be set with the
-    /// OS error number describing the error, if there was one.
-    /// Otherwise, it should be `None`.
-    errno: Option<Errno>,
-}
-
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-enum Classification {
+pub enum Classification {
     Success,
     Failure,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-enum Direction {
+pub enum Direction {
     Inbound,
     Outbound,
 }
@@ -101,7 +71,7 @@ pub struct TlsStatus(ctx::transport::TlsStatus);
 
 impl RequestLabels {
     pub fn new(req: &ctx::http::Request) -> Self {
-        let direction = Direction::from_context(req.server.proxy.as_ref());
+        let direction = req.server.proxy.as_ref().into();
 
         let outbound_labels = req.dst_labels().cloned();
 
@@ -223,7 +193,7 @@ impl Classification {
             .unwrap_or_else(|| Classification::http_status(&rsp.status))
     }
 
-    fn transport_close(close: &event::TransportClose) -> Self {
+    pub fn transport_close(close: &event::TransportClose) -> Self {
         if close.clean {
             Classification::Success
         } else {
@@ -244,11 +214,11 @@ impl fmt::Display for Classification {
 
 // ===== impl Direction =====
 
-impl Direction {
-    fn from_context(context: &ctx::Proxy) -> Self {
-        match context {
-            &ctx::Proxy::Inbound(_) => Direction::Inbound,
-            &ctx::Proxy::Outbound(_) => Direction::Outbound,
+impl<'a> From<&'a ctx::Proxy> for Direction {
+    fn from(c: &'a ctx::Proxy) -> Self {
+        match *c {
+            ctx::Proxy::Inbound(_) => Direction::Inbound,
+            ctx::Proxy::Outbound(_) => Direction::Outbound,
         }
     }
 }
@@ -317,78 +287,6 @@ impl hash::Hash for DstLabels {
 impl fmt::Display for DstLabels {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.formatted.fmt(f)
-    }
-}
-
-
-// ===== impl TransportLabels =====
-
-impl TransportLabels {
-    pub fn new(ctx: &ctx::transport::Ctx) -> Self {
-        TransportLabels {
-            direction: Direction::from_context(&ctx.proxy()),
-            peer: match *ctx {
-                ctx::transport::Ctx::Server(_) => Peer::Src,
-                ctx::transport::Ctx::Client(_) => Peer::Dst,
-            },
-            tls_status: TlsStatus(ctx.tls_status()),
-        }
-    }
-
-    #[cfg(test)]
-    pub fn tls_status(&self) -> TlsStatus {
-        self.tls_status
-    }
-}
-
-impl fmt::Display for TransportLabels {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{},{},{}", self.direction, self.peer, self.tls_status)
-    }
-}
-
-impl fmt::Display for Peer {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Peer::Src => f.pad("peer=\"src\""),
-            Peer::Dst => f.pad("peer=\"dst\""),
-        }
-    }
-}
-
-// ===== impl TransportCloseLabels =====
-
-impl TransportCloseLabels {
-    pub fn new(ctx: &ctx::transport::Ctx,
-               close: &event::TransportClose)
-               -> Self {
-        let classification = Classification::transport_close(close);
-        let errno = close.errno.map(|code| {
-            // If the error code is set, this should be classified
-            // as a failure!
-            debug_assert!(classification == Classification::Failure);
-            Errno::from(code)
-        });
-        TransportCloseLabels {
-            transport: TransportLabels::new(ctx),
-            classification,
-            errno,
-        }
-    }
-
-    #[cfg(test)]
-    pub fn tls_status(&self) -> TlsStatus  {
-        self.transport.tls_status()
-    }
-}
-
-impl fmt::Display for TransportCloseLabels {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{},{}", self.transport, self.classification)?;
-        if let Some(errno) = self.errno {
-            write!(f, ",errno=\"{}\"", errno)?;
-        }
-        Ok(())
     }
 }
 

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -51,9 +51,8 @@ pub use self::histogram::Histogram;
 use self::labels::{
     RequestLabels,
     ResponseLabels,
-    TransportLabels,
-    TransportCloseLabels,
 };
+use self::transport::{TransportLabels, TransportCloseLabels};
 pub use self::labels::DstLabels;
 pub use self::record::Record;
 pub use self::scopes::Scopes;

--- a/src/telemetry/metrics/record.rs
+++ b/src/telemetry/metrics/record.rs
@@ -5,9 +5,8 @@ use super::Root;
 use super::labels::{
     RequestLabels,
     ResponseLabels,
-    TransportLabels,
-    TransportCloseLabels,
 };
+use super::transport::{TransportLabels, TransportCloseLabels};
 
 /// Tracks Prometheus metrics
 #[derive(Clone, Debug)]
@@ -90,7 +89,7 @@ impl Record {
 mod test {
     use telemetry::{
         event,
-        metrics::{self, labels},
+        metrics::{self, labels, transport::{TransportLabels, TransportCloseLabels}},
         Event,
     };
     use ctx::{self, test_util::*, transport::TlsStatus};

--- a/src/telemetry/metrics/transport.rs
+++ b/src/telemetry/metrics/transport.rs
@@ -173,7 +173,7 @@ impl CloseMetrics {
 impl TransportLabels {
     pub fn new(ctx: &ctx::transport::Ctx) -> Self {
         TransportLabels {
-            direction: ctx.proxy().as_ref().into(),
+            direction: Direction::from_context(ctx.proxy().as_ref()),
             peer: match *ctx {
                 ctx::transport::Ctx::Server(_) => Peer::Src,
                 ctx::transport::Ctx::Client(_) => Peer::Dst,


### PR DESCRIPTION
Various transport-specific labels are defined in the common
`metrics::labels` module.

In preparation to refactor transport metrics into Sensor and Report
halves, this change moves all transport-specific labels into the
transport metrics module.