### PR TITLE
Make `metrics` private to `telemetry`

### DIFF
--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -24,7 +24,7 @@ use control::{
     remote_stream::Remote,
 };
 use dns::{self, IpAddrListFuture};
-use telemetry::metrics::DstLabels;
+use telemetry::DstLabels;
 use transport::{tls, DnsNameAndPort};
 use conditional::Conditional;
 

--- a/src/control/destination/endpoint.rs
+++ b/src/control/destination/endpoint.rs
@@ -1,6 +1,6 @@
 use std::net::SocketAddr;
 
-use telemetry::metrics::DstLabels;
+use telemetry::DstLabels;
 use super::{Metadata, ProtocolHint};
 use tls;
 use conditional::Conditional;

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -41,7 +41,7 @@ use tower_discover::{Change, Discover};
 use tower_service::Service;
 
 use dns;
-use telemetry::metrics::DstLabels;
+use telemetry::DstLabels;
 use transport::{DnsNameAndPort, HostAndPort};
 
 pub mod background;

--- a/src/ctx/http.rs
+++ b/src/ctx/http.rs
@@ -2,7 +2,7 @@ use http;
 use std::sync::{Arc, atomic::AtomicUsize};
 
 use ctx;
-use telemetry::metrics::DstLabels;
+use telemetry::DstLabels;
 use std::sync::atomic::Ordering;
 use transport::tls;
 use conditional::Conditional;

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -88,7 +88,7 @@ pub mod test_util {
 
     use ctx;
     use control::destination;
-    use telemetry::metrics::DstLabels;
+    use telemetry::DstLabels;
     use tls;
     use conditional::Conditional;
 

--- a/src/ctx/transport.rs
+++ b/src/ctx/transport.rs
@@ -6,7 +6,7 @@ use std::{
 };
 use ctx;
 use control::destination;
-use telemetry::metrics::DstLabels;
+use telemetry::DstLabels;
 use transport::tls;
 use conditional::Conditional;
 

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -19,8 +19,7 @@ macro_rules! metrics {
 
 mod errno;
 pub mod event;
-// TODO this shouldn't need to be public.
-pub mod metrics;
+mod metrics;
 mod process;
 pub mod sensor;
 pub mod tap;
@@ -28,13 +27,14 @@ pub mod tls_config_reload;
 
 use self::errno::Errno;
 pub use self::event::Event;
+pub use self::metrics::{DstLabels, Serve as ServeMetrics};
 pub use self::sensor::Sensors;
 
 pub fn new(
     process: &Arc<ctx::Process>,
     metrics_retain_idle: Duration,
     taps: &Arc<Mutex<tap::Taps>>,
-) -> (Sensors, tls_config_reload::Sensor, metrics::Serve) {
+) -> (Sensors, tls_config_reload::Sensor, ServeMetrics) {
     let (tls_config_sensor, tls_config_fmt) = tls_config_reload::new();
     let (metrics_record, metrics_serve) = metrics::new(process, metrics_retain_idle, tls_config_fmt);
     let s = Sensors::new(metrics_record, taps);


### PR DESCRIPTION
Only the `DstLabels` and `Serve` types in `metrics` are used outside of
`telemetry`.

This change narrows visibility so that `metrics` is not referenced
outside of `telemetry`.