### PR TITLE
Make `Metric::fmt_scopes` generic over an Iterator

### DIFF
--- a/src/telemetry/metrics/http.rs
+++ b/src/telemetry/metrics/http.rs
@@ -41,7 +41,7 @@ impl fmt::Display for RequestScopes {
         }
 
         Self::request_total.fmt_help(f)?;
-        Self::request_total.fmt_scopes(f, &self, |s| &s.total)?;
+        Self::request_total.fmt_scopes(f, self, |s| &s.total)?;
 
         Ok(())
     }
@@ -79,10 +79,10 @@ impl fmt::Display for ResponseScopes {
         }
 
         Self::response_total.fmt_help(f)?;
-        Self::response_total.fmt_scopes(f, &self, |s| &s.total)?;
+        Self::response_total.fmt_scopes(f, self, |s| &s.total)?;
 
         Self::response_latency_ms.fmt_help(f)?;
-        Self::response_latency_ms.fmt_scopes(f, &self, |s| &s.latency)?;
+        Self::response_latency_ms.fmt_scopes(f, self, |s| &s.latency)?;
 
         Ok(())
     }

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -135,12 +135,17 @@ impl<'a, M: FmtMetric> Metric<'a, M> {
     }
 
     /// Formats a single metric across labeled scopes.
-    pub fn fmt_scopes<L: Display + Hash + Eq, S, F: Fn(&S) -> &M>(
+    pub fn fmt_scopes<'i, L: 'i, S: 'i, I, F>(
         &self,
         f: &mut fmt::Formatter,
-        scopes: &Scopes<L, S>,
+        scopes: I,
         to_metric: F
-    )-> fmt::Result {
+    ) -> fmt::Result
+    where
+        L: Display + Hash + Eq,
+        I: IntoIterator<Item = (&'i L, &'i S)>,
+        F: Fn(&S) -> &M
+    {
         for (labels, scope) in scopes {
             to_metric(scope).fmt_metric_labeled(f, self.name, labels)?;
         }

--- a/src/telemetry/metrics/transport.rs
+++ b/src/telemetry/metrics/transport.rs
@@ -47,16 +47,16 @@ impl fmt::Display for OpenScopes {
         }
 
         Self::tcp_open_total.fmt_help(f)?;
-        Self::tcp_open_total.fmt_scopes(f, &self, |s| &s.open_total)?;
+        Self::tcp_open_total.fmt_scopes(f, self, |s| &s.open_total)?;
 
         Self::tcp_open_connections.fmt_help(f)?;
-        Self::tcp_open_connections.fmt_scopes(f, &self, |s| &s.open_connections)?;
+        Self::tcp_open_connections.fmt_scopes(f, self, |s| &s.open_connections)?;
 
         Self::tcp_read_bytes_total.fmt_help(f)?;
-        Self::tcp_read_bytes_total.fmt_scopes(f, &self, |s| &s.read_bytes_total)?;
+        Self::tcp_read_bytes_total.fmt_scopes(f, self, |s| &s.read_bytes_total)?;
 
         Self::tcp_write_bytes_total.fmt_help(f)?;
-        Self::tcp_write_bytes_total.fmt_scopes(f, &self, |s| &s.write_bytes_total)?;
+        Self::tcp_write_bytes_total.fmt_scopes(f, self, |s| &s.write_bytes_total)?;
 
         Ok(())
     }
@@ -108,10 +108,10 @@ impl fmt::Display for CloseScopes {
         }
 
         Self::tcp_close_total.fmt_help(f)?;
-        Self::tcp_close_total.fmt_scopes(f, &self, |s| &s.close_total)?;
+        Self::tcp_close_total.fmt_scopes(f, self, |s| &s.close_total)?;
 
         Self::tcp_connection_duration_ms.fmt_help(f)?;
-        Self::tcp_connection_duration_ms.fmt_scopes(f, &self, |s| &s.connection_duration)?;
+        Self::tcp_connection_duration_ms.fmt_scopes(f, self, |s| &s.connection_duration)?;
 
         Ok(())
     }


### PR DESCRIPTION
The `Scopes` type shouldn't be critical to metrics formatting.

This change makes the `Metric` type unaware of `Scopes` so that other
labeling mechanisms can be used if appropriate.

Redux of https://github.com/linkerd/linkerd2-proxy/pull/56