### PR TITLE
Add names to timeout error messages

### DIFF
--- a/src/control/destination/background/client.rs
+++ b/src/control/destination/background/client.rs
@@ -27,7 +27,7 @@ use watch_service::Rebind;
 /// Type of the client service stack used to make destination requests.
 pub(super) struct ClientService(AddOrigin<Backoff<LogErrors<Reconnect<
         tower_h2::client::Connect<
-            Timeout<'static, LookupAddressAndConnect>,
+            Timeout<LookupAddressAndConnect>,
             ::logging::ContextualExecutor<
                 ::logging::Client<
                     &'static str,
@@ -72,7 +72,6 @@ type LogError = ReconnectError<
     tower_h2::client::Error,
     tower_h2::client::ConnectError<
         TimeoutError<
-            'static,
             io::Error
         >
     >
@@ -86,7 +85,7 @@ impl Service for ClientService {
     type Error = LogError;
     type Future = ReconnectFuture<
         tower_h2::client::Connect<
-            Timeout<'static, LookupAddressAndConnect>,
+            Timeout<LookupAddressAndConnect>,
             ::logging::ContextualExecutor<
                 ::logging::Client<
                     &'static str,

--- a/src/control/destination/background/client.rs
+++ b/src/control/destination/background/client.rs
@@ -146,7 +146,7 @@ impl Rebind<tls::ConditionalClientConfig> for BindClient {
                                          self.dns_resolver.clone(),
                                          conn_cfg),
             Duration::from_secs(3),
-        );
+        ).named("connecting to control plane");
         let h2_client = tower_h2::client::Connect::new(
             connect,
             h2::client::Builder::default(),

--- a/src/control/destination/background/client.rs
+++ b/src/control/destination/background/client.rs
@@ -27,7 +27,7 @@ use watch_service::Rebind;
 /// Type of the client service stack used to make destination requests.
 pub(super) struct ClientService(AddOrigin<Backoff<LogErrors<Reconnect<
         tower_h2::client::Connect<
-            Timeout<LookupAddressAndConnect>,
+            Timeout<'static, LookupAddressAndConnect>,
             ::logging::ContextualExecutor<
                 ::logging::Client<
                     &'static str,
@@ -72,6 +72,7 @@ type LogError = ReconnectError<
     tower_h2::client::Error,
     tower_h2::client::ConnectError<
         TimeoutError<
+            'static,
             io::Error
         >
     >
@@ -85,7 +86,7 @@ impl Service for ClientService {
     type Error = LogError;
     type Future = ReconnectFuture<
         tower_h2::client::Connect<
-            Timeout<LookupAddressAndConnect>,
+            Timeout<'static, LookupAddressAndConnect>,
             ::logging::ContextualExecutor<
                 ::logging::Client<
                     &'static str,

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -190,7 +190,8 @@ where
         let buffer = Buffer::new(balance, &log.executor())
             .map_err(|_| bind::BufferSpawnError::Outbound)?;
 
-        let timeout = Timeout::new(buffer, self.bind_timeout);
+        let timeout = Timeout::new(buffer, self.bind_timeout)
+            .named("binding outbound client");
 
         Ok(InFlightLimit::new(timeout, MAX_IN_FLIGHT))
     }

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -146,7 +146,7 @@ where
     type Error = <Self::Service as tower::Service>::Error;
     type Key = (Destination, Protocol);
     type RouteError = bind::BufferSpawnError;
-    type Service = InFlightLimit<Timeout<'static, Buffer<Balance<
+    type Service = InFlightLimit<Timeout<Buffer<Balance<
         load::WithPeakEwma<Discovery<B>, PendingUntilFirstData>,
         choose::PowerOfTwoChoices,
     >>>>;

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -146,7 +146,7 @@ where
     type Error = <Self::Service as tower::Service>::Error;
     type Key = (Destination, Protocol);
     type RouteError = bind::BufferSpawnError;
-    type Service = InFlightLimit<Timeout<Buffer<Balance<
+    type Service = InFlightLimit<Timeout<'static, Buffer<Balance<
         load::WithPeakEwma<Discovery<B>, PendingUntilFirstData>,
         choose::PowerOfTwoChoices,
     >>>>;

--- a/src/transparency/tcp.rs
+++ b/src/transparency/tcp.rs
@@ -71,7 +71,8 @@ impl Proxy {
         let c = Timeout::new(
             transport::Connect::new(orig_dst, tls),
             self.connect_timeout,
-        );
+        )
+        .named("TCP connection");
         let connect = self.sensors.connect(c, &client_ctx);
 
         future::Either::A(connect.connect()

--- a/src/transparency/tcp.rs
+++ b/src/transparency/tcp.rs
@@ -71,8 +71,7 @@ impl Proxy {
         let c = Timeout::new(
             transport::Connect::new(orig_dst, tls),
             self.connect_timeout,
-        )
-        .named("TCP connection");
+        ).named("TCP connect");
         let connect = self.sensors.connect(c, &client_ctx);
 
         future::Either::A(connect.connect()


### PR DESCRIPTION
The proxy contains several timeouts which can fail operations.
Currently, when formatting the error types produced by any of these
timeouts in log messages, the timeout error returns "operation timed out
after $DURATION". Since these errors are typically logged in a different
scope from the one where the timeout was created, it's often not
immediately clear _what_ timed out. An experienced user can often
determine what timed out based on the duration of the timeout, but for
new users, the logs are not very informative.

This branch adds an optional `name` field to the `Timeout` and
`TimeoutError` types. If a name is provided, the `TimeoutError` will
format as "$NAME timed out after $DURATION" instead. Otherwise, it will
continue to use the original behaviour. It also names all the current
uses of `Timeout` in the proxy.

Implementation Details 
----------------------

Note that the `name` field on `Timeout` and `TimeoutError` is an `&str`
with a generic lifetime. In practice, since the returned timeout futures
are part of future chains which must be valid for the `'static`
lifetime, this must be an `&'static str`. This means that the name may
not be dynamically formatted, so we can't have messages such as
"building outbound $PROTOCOL client to $DESTINATION timed out".

I considered the alternative approach of making the `name` field a
generic type that implements `Display`, so that it could also be a
`String` or an `Arc<String>` or similar. However, I wasn't sure if the
performance impact of doing so would be worth the more specific error
messages --- even using only string constants as names makes the logged
messages much more descriptive than they were previously. I'd be happy
to change this if we think adding more information to these messages
would be worth the performance impact of heap allocating strings here.

Examples
--------

Before:
```
➜ cargo test --test discovery -- http2::outbound_times_out
   Compiling linkerd2-proxy v0.1.0 (file:///Users/eliza/Code/linkerd2-proxy)
    Finished dev [unoptimized + debuginfo] target(s) in 29.86s
     Running target/debug/deps/discovery-88fd1ee2f3bc7947

running 1 test
ERROR 2018-08-13T17:59:06Z: linkerd2_proxy: turning operation timed out after 100ms into 500
test http2::outbound_times_out ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 32 filtered out
```

After:
```
➜ cargo test --test discovery -- http2::outbound_times_out
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
     Running target/debug/deps/discovery-88fd1ee2f3bc7947

running 1 test
ERROR 2018-08-13T17:57:59Z: linkerd2_proxy: turning binding outbound client timed out after 100ms into 500
test http2::outbound_times_out ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 32 filtered out
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>