### PR TITLE
Start instrumenting the proxy's router

### DIFF
--- a/src/control/destination/background/mod.rs
+++ b/src/control/destination/background/mod.rs
@@ -76,11 +76,6 @@ struct DestinationCache<T: HttpService<ResponseBody = RecvBody>> {
 struct NewQuery {
     namespaces: Namespaces,
     /// Used for counting the number of currently-active queries.
-    ///
-    /// Each active query will hold a `Weak` reference back to this `Arc`, and
-    /// `NewQuery` can use `Arc::weak_count` to count the number of queries
-    /// that currently exist. When those queries are dropped, the weak count
-    /// will go down accordingly.
     query_counter: QueryCounter,
     concurrency_limit: usize,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,6 +278,7 @@ where
             controller_tls,
             config.control_backoff_delay,
             config.destination_concurrency_limit,
+            sensors.router().query_counter(),
         );
 
         let (drain_tx, drain_rx) = drain::channel();

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -53,12 +53,18 @@ use self::labels::{
     ResponseLabels,
 };
 use self::transport::{TransportLabels, TransportCloseLabels};
-pub use self::labels::DstLabels;
+pub use self::labels::{
+    DstLabels,
+    Direction,
+};
 pub use self::record::Record;
 pub use self::scopes::Scopes;
 pub use self::serve::Serve;
-use super::process;
-use super::tls_config_reload;
+use super::{
+    process,
+    tls_config_reload,
+    router,
+};
 
 /// Writes a metric in prometheus-formatted output.
 ///
@@ -96,6 +102,7 @@ struct Root {
     transports: transport::OpenScopes,
     transport_closes: transport::CloseScopes,
     tls_config_reload: tls_config_reload::Report,
+    router: router::Report,
     process: process::Report,
 }
 
@@ -111,10 +118,14 @@ struct Stamped<T> {
 /// is a Hyper service which can be used to create the server for the
 /// scrape endpoint, while the `Record` side can receive updates to the
 /// metrics by calling `record_event`.
-pub fn new(process: &Arc<ctx::Process>, idle_retain: Duration, tls: tls_config_reload::Report)
-    -> (Record, Serve)
+pub fn new(
+    process: &Arc<ctx::Process>,
+    idle_retain: Duration,
+    tls: tls_config_reload::Report,
+    router: router::Report
+) -> (Record, Serve)
 {
-    let metrics = Arc::new(Mutex::new(Root::new(process, tls)));
+    let metrics = Arc::new(Mutex::new(Root::new(process, tls, router)));
     (Record::new(&metrics), Serve::new(&metrics, idle_retain))
 }
 
@@ -156,10 +167,15 @@ impl<'a, M: FmtMetric> Metric<'a, M> {
 // ===== impl Root =====
 
 impl Root {
-    pub fn new(process: &Arc<ctx::Process>, tls_config_reload: tls_config_reload::Report) -> Self {
+    pub fn new(
+        process: &Arc<ctx::Process>,
+        tls_config_reload: tls_config_reload::Report,
+        router: router::Report,
+    ) -> Self {
         Self {
             process: process::Report::new(&process),
             tls_config_reload,
+            router,
             .. Root::default()
         }
     }

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -210,6 +210,7 @@ impl fmt::Display for Root {
         self.transports.fmt(f)?;
         self.transport_closes.fmt(f)?;
         self.tls_config_reload.fmt(f)?;
+        self.router.fmt(f)?;
         self.process.fmt(f)?;
 
         Ok(())

--- a/src/telemetry/metrics/record.rs
+++ b/src/telemetry/metrics/record.rs
@@ -128,7 +128,12 @@ mod test {
             frames_sent: 0,
         };
 
-        let (mut r, _) = metrics::new(&process, Duration::from_secs(100), Default::default());
+        let (mut r, _) = metrics::new(
+            &process,
+            Duration::from_secs(100),
+            Default::default(),
+            Default::default(),
+        );
         let ev = Event::StreamResponseEnd(rsp.clone(), end.clone());
         let labels = labels::ResponseLabels::new(&rsp, None);
 
@@ -224,7 +229,12 @@ mod test {
             ),
         ];
 
-        let (mut r, _) = metrics::new(&process, Duration::from_secs(1000), Default::default());
+        let (mut r, _) = metrics::new(
+            &process,
+            Duration::from_secs(1000),
+            Default::default(),
+            Default::default(),
+        );
 
         let req_labels = RequestLabels::new(&req);
         let rsp_labels = ResponseLabels::new(&rsp, None);

--- a/src/telemetry/router.rs
+++ b/src/telemetry/router.rs
@@ -1,0 +1,179 @@
+use std::{
+    default::Default,
+    fmt,
+    sync::{Arc, Mutex, Weak},
+};
+
+use ctx;
+use telemetry::metrics::{Counter, Gauge, Scopes, Direction};
+
+metrics! {
+    router_cache_active_routes: Gauge {
+        "Current number of active routes in the router cache."
+    },
+    router_active_destination_queries: Gauge {
+        "Current number of active Destination service queries."
+    },
+    router_error_total: Counter {
+        "Total number of router errors."
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+enum ErrorKind {
+    Route,
+    Capacity,
+    NotRecognized,
+    Inner,
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct ErrorLabels {
+    direction: Direction,
+    kind: ErrorKind,
+}
+
+/// Sensor for recording error total metrics.
+///
+/// When this type is dropped, its metrics may no longer be formatted for prometheus.
+#[derive(Clone, Debug)]
+pub struct ErrorSensor {
+    inner: Arc<ErrorTotalInner>,
+    direction: Direction,
+}
+
+/// Formats metrics for Prometheus for a corresonding `Sensor`.
+#[derive(Debug, Default)]
+pub struct Report {
+    cache_active_routes: Weak<ActiveRoutesInner>,
+    active_destination_queries: Weak<Mutex<Gauge>>,
+    error_total: Weak<ErrorTotalInner>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Sensors {
+    cache_active_routes: Arc<ActiveRoutesInner>,
+    active_destination_queries: Arc<Mutex<Gauge>>,
+    error_total: Arc<ErrorTotalInner>,
+}
+
+type ErrorTotalInner = Mutex<Scopes<ErrorLabels, Counter>>;
+type ActiveRoutesInner = Mutex<Scopes<Direction, Gauge>>;
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ErrorKind::Route => f.pad("kind=\"route\""),
+            ErrorKind::Capacity => f.pad("kind=\"at_capacity\""),
+            ErrorKind::NotRecognized => f.pad("kind=\"route_not_recognized\""),
+            ErrorKind::Inner => f.pad("kind=\"inner\""),
+        }
+    }
+}
+
+impl fmt::Display for ErrorLabels {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{},{}", self.direction, self.kind)
+    }
+}
+
+// ===== impl Sensors =====
+
+impl Sensors {
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+
+    pub fn error_total(&self, proxy_ctx: &ctx::Proxy) -> ErrorSensor {
+        ErrorSensor {
+            inner: self.error_total.clone(),
+            direction: Direction::from_context(proxy_ctx),
+        }
+    }
+
+    pub fn report(&self) -> Report {
+        Report {
+            cache_active_routes: Arc::downgrade(&self.cache_active_routes),
+            active_destination_queries: Arc::downgrade(&self.active_destination_queries),
+            error_total: Arc::downgrade(&self.error_total),
+        }
+    }
+}
+
+
+// ===== impl ErrorSensor =====
+
+impl ErrorSensor {
+    pub fn route_not_recognized(&self) {
+        if let Ok(mut scopes) = self.inner.lock() {
+            let labels = ErrorLabels {
+                direction: self.direction,
+                kind: ErrorKind::NotRecognized,
+            };
+            scopes.get_or_default(labels).incr();
+        }
+    }
+
+    pub fn at_capacity(&self) {
+        if let Ok(mut scopes) = self.inner.lock() {
+            let labels = ErrorLabels {
+                direction: self.direction,
+                kind: ErrorKind::Capacity,
+            };
+            scopes.get_or_default(labels).incr();
+        }
+    }
+
+    pub fn route_error(&self) {
+        if let Ok(mut scopes) = self.inner.lock() {
+            let labels = ErrorLabels {
+                direction: self.direction,
+                kind: ErrorKind::Route,
+            };
+            scopes.get_or_default(labels).incr();
+        }
+    }
+
+    pub fn inner_error(&self) {
+        if let Ok(mut scopes) = self.inner.lock() {
+            let labels = ErrorLabels {
+                direction: self.direction,
+                kind: ErrorKind::Inner,
+            };
+            scopes.get_or_default(labels).incr();
+        }
+    }
+}
+
+// ===== impl Report =====
+
+impl fmt::Display for Report {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(lock) = self.cache_active_routes.upgrade() {
+            if let Ok(active_routes) = lock.lock() {
+                router_cache_active_routes.fmt_help(f)?;
+                router_cache_active_routes
+                    .fmt_scopes(f, &*active_routes, |s| &s)?;
+            }
+        }
+
+        if let Some(lock) = self.error_total.upgrade() {
+            if let Ok(error_total) = lock.lock() {
+                router_error_total.fmt_help(f)?;
+                router_error_total.fmt_scopes(f, &*error_total, |s| &s)?;
+            }
+        }
+
+        if let Some(lock) = self.active_destination_queries.upgrade() {
+            if let Ok(active_queries) = lock.lock() {
+                router_active_destination_queries.fmt_help(f)?;
+                router_active_destination_queries
+                    .fmt_metric(f, *active_queries)?;
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This branch adds two new metrics to the proxy's Prometheus endpoint,
`router_error_total` and `router_active_destination_queries`. The
`router_error_total` metric is a counter of the total number of router
errors that have occurred, broken down by router and kind, while the
`router_active_destination_queries` metric is a gauge of the number of
currently open queries to the Destination service. Metrics instrumenting
the proxy's router were initially described by @siggy in issue
linkerd/linkerd2#1232.

The design behind how these new metrics were implemented was based 
largely on @olix0r's changes to how TLS config metrics are recorded (in
PR #46). As we continue refactoring the proxy's telemetry code, I felt
like this branch served as a nice test case of how metrics might look 
following the refactor.

I had initially planned to also add a `router_cache_active_routes` gauge
tracking the current number of active routes in the router cache in this
branch as well. However, to keep the diff from being too large, I
decided to implement this in an additional branch.

I've added some integration tests in `tests/telemetry.rs` testing these
metrics.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>