### PR TITLE
Relax Metric::fmt_scopes' type bounds

### DIFF
--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -134,15 +134,15 @@ impl<'a, M: FmtMetric> Metric<'a, M> {
     }
 
     /// Formats a single metric across labeled scopes.
-    pub fn fmt_scopes<'i, L: 'i, S: 'i, I, F>(
+    pub fn fmt_scopes<'s, L, S: 's, I, F>(
         &self,
         f: &mut fmt::Formatter,
         scopes: I,
         to_metric: F
     ) -> fmt::Result
     where
-        L: Display + Hash + Eq,
-        I: IntoIterator<Item = (&'i L, &'i S)>,
+        L: Display,
+        I: IntoIterator<Item = (L, &'s S)>,
         F: Fn(&S) -> &M
     {
         for (labels, scope) in scopes {
@@ -166,7 +166,6 @@ impl Root {
 
     fn request(&mut self, labels: RequestLabels) -> &mut http::RequestMetrics {
         self.requests.get_or_default(labels).stamped()
-
     }
 
     fn response(&mut self, labels: ResponseLabels) -> &mut http::ResponseMetrics {

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -28,7 +28,6 @@
 //! end of the label set (all of which will make Prometheus angry).
 use std::default::Default;
 use std::fmt::{self, Display};
-use std::hash::Hash;
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};


### PR DESCRIPTION
005d4f1 made `Metric::fmt_scopes` generic over an Iterator, but
maintained some of the unnecessary type bounds inherited from its
initial implementation.

This change relaxes the constraints on the label value so that it need
not be passed as a reference or be hashable--our only requirement is
that it can be rendered.