### PR TITLE
Narrow transport metric's API

### DIFF
--- a/src/telemetry/metrics/labels.rs
+++ b/src/telemetry/metrics/labels.rs
@@ -9,7 +9,6 @@ use http;
 
 use ctx;
 use conditional::Conditional;
-use telemetry::event;
 use transport::tls;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -192,15 +191,6 @@ impl Classification {
         grpc_status.map(Classification::grpc_status)
             .unwrap_or_else(|| Classification::http_status(&rsp.status))
     }
-
-    pub fn transport_close(close: &event::TransportClose) -> Self {
-        if close.clean {
-            Classification::Success
-        } else {
-            Classification::Failure
-        }
-    }
-
 }
 
 impl fmt::Display for Classification {


### PR DESCRIPTION
The `telemetry::metrics::transport` module exposes much of its
implementation details to callers, which makes it difficult to make
changes to how the module is structured. In preparation for further
refactors, this change narrows the module's public API:

All labels and scopes types have been made private. A single, public
`Transports` type has been introduce to describe the entire public
interface of the module. This has been crafted to be free of `event`
types and to have minimal external dependencies.

A new `transport::Eos` type has been introduced to replace the
overloaded `labels::Classification` type -- this type was initially
introduced to model _HTTP response_ classification, but it was
reused for transports. This is an undesirable coupling that will have to
be broken when we start to adddress HTTP response classification
properly.