### PR TITLE
rfc: Introduce the FmtPrometheus and FmtLabels traits

### DIFF
--- a/src/telemetry/metrics/counter.rs
+++ b/src/telemetry/metrics/counter.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display};
 use std::num::Wrapping;
 use std::ops;
 
-use super::FmtMetric;
+use super::prom::{FmtMetric, FmtLabels};
 
 /// A Prometheus counter is represented by a `Wrapping` unsigned 64-bit int.
 ///
@@ -77,13 +77,11 @@ impl FmtMetric for Counter {
 
     fn fmt_metric_labeled<N, L>(&self, f: &mut fmt::Formatter, name: N, labels: L) -> fmt::Result
     where
-        L: Display,
+        L: FmtLabels,
         N: Display,
     {
-        writeln!(f, "{name}{{{labels}}} {value}",
-            name = name,
-            labels = labels,
-            value = self.0,
-        )
+        write!(f, "{}{{", name)?;
+        labels.fmt_labels(f)?;
+        writeln!(f, "}} {}", self.0)
     }
 }

--- a/src/telemetry/metrics/gauge.rs
+++ b/src/telemetry/metrics/gauge.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use super::FmtMetric;
+use super::{FmtMetric, FmtLabels};
 
 /// An instaneous metric value.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -47,13 +47,11 @@ impl FmtMetric for Gauge {
 
     fn fmt_metric_labeled<N, L>(&self, f: &mut fmt::Formatter, name: N, labels: L) -> fmt::Result
     where
+        L: FmtLabels,
         N: Display,
-        L: Display,
     {
-        writeln!(f, "{name}{{{labels}}} {value}",
-            name = name,
-            labels = labels,
-            value = self.0,
-        )
+        write!(f, "{}{{", name)?;
+        labels.fmt_labels(f)?;
+        writeln!(f, "}} {}", self.0)
     }
 }

--- a/src/telemetry/metrics/http.rs
+++ b/src/telemetry/metrics/http.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use super::{
     latency,
-    prom::FmtPrometheus,
+    prom::FmtMetrics,
     Counter,
     Histogram,
     RequestLabels,
@@ -35,8 +35,8 @@ impl RequestScopes {
     }
 }
 
-impl FmtPrometheus for RequestScopes {
-    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl FmtMetrics for RequestScopes {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_empty() {
             return Ok(());
         }
@@ -73,8 +73,8 @@ impl ResponseScopes {
     }
 }
 
-impl FmtPrometheus for ResponseScopes {
-    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl FmtMetrics for ResponseScopes {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_empty() {
             return Ok(());
         }

--- a/src/telemetry/metrics/http.rs
+++ b/src/telemetry/metrics/http.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 
 use super::{
     latency,
+    prom::FmtPrometheus,
     Counter,
     Histogram,
     RequestLabels,
@@ -34,8 +35,8 @@ impl RequestScopes {
     }
 }
 
-impl fmt::Display for RequestScopes {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl FmtPrometheus for RequestScopes {
+    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_empty() {
             return Ok(());
         }
@@ -72,8 +73,8 @@ impl ResponseScopes {
     }
 }
 
-impl fmt::Display for ResponseScopes {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl FmtPrometheus for ResponseScopes {
+    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.is_empty() {
             return Ok(());
         }

--- a/src/telemetry/metrics/labels.rs
+++ b/src/telemetry/metrics/labels.rs
@@ -101,11 +101,9 @@ impl RequestLabels {
 
 impl FmtLabels for RequestLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let labels = (((&self.authority,
-            &self.direction),
-            self.outbound_labels.as_ref()),
-            &self.tls_status);
-        labels.fmt_labels(f)
+        let dst = (self.outbound_labels.as_ref(), &self.tls_status);
+
+        ((&self.authority, &self.direction), dst).fmt_labels(f)
     }
 }
 
@@ -155,11 +153,9 @@ impl ResponseLabels {
 
 impl FmtLabels for ResponseLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let l = (((&self.request_labels,
-            &self.classification),
-            &self.status_code),
-            self.grpc_status.as_ref());
-        l.fmt_labels(f)
+        let status = (&self.status_code, self.grpc_status.as_ref());
+        let class = (&self.classification, status);
+        (&self.request_labels, class).fmt_labels(f)
     }
 }
 

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -51,7 +51,7 @@ use self::labels::{
     ResponseLabels,
 };
 pub use self::labels::DstLabels;
-pub use self::prom::{FmtPrometheus, FmtLabels, FmtMetric};
+pub use self::prom::{FmtMetrics, FmtLabels, FmtMetric};
 pub use self::record::Record;
 pub use self::scopes::Scopes;
 pub use self::serve::Serve;
@@ -117,13 +117,13 @@ impl Root {
     }
 }
 
-impl FmtPrometheus for Root {
-    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.requests.fmt_prometheus(f)?;
-        self.responses.fmt_prometheus(f)?;
-        self.transports.fmt_prometheus(f)?;
-        self.tls_config_reload.fmt_prometheus(f)?;
-        self.process.fmt_prometheus(f)?;
+impl FmtMetrics for Root {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.requests.fmt_metrics(f)?;
+        self.responses.fmt_metrics(f)?;
+        self.transports.fmt_metrics(f)?;
+        self.tls_config_reload.fmt_metrics(f)?;
+        self.process.fmt_metrics(f)?;
 
         Ok(())
     }

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -27,8 +27,7 @@
 //! to worry about missing commas, double commas, or trailing commas at the
 //! end of the label set (all of which will make Prometheus angry).
 use std::default::Default;
-use std::fmt::{self, Display};
-use std::marker::PhantomData;
+use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -39,6 +38,7 @@ mod histogram;
 mod http;
 mod labels;
 pub mod latency;
+pub mod prom;
 mod record;
 mod scopes;
 mod serve;
@@ -52,40 +52,13 @@ use self::labels::{
     ResponseLabels,
 };
 pub use self::labels::DstLabels;
+pub use self::prom::{FmtPrometheus, FmtLabels, FmtMetric};
 pub use self::record::Record;
 pub use self::scopes::Scopes;
 pub use self::serve::Serve;
 pub use self::transport::Transports;
 use super::process;
 use super::tls_config_reload;
-
-/// Writes a metric in prometheus-formatted output.
-///
-/// This trait is implemented by `Counter`, `Gauge`, and `Histogram` to account for the
-/// differences in formatting each type of metric. Specifically, `Histogram` formats a
-/// counter for each bucket, as well as a count and total sum.
-pub trait FmtMetric {
-    /// The metric's `TYPE` in help messages.
-    const KIND: &'static str;
-
-    /// Writes a metric with the given name and no labels.
-    fn fmt_metric<N: Display>(&self, f: &mut fmt::Formatter, name: N) -> fmt::Result;
-
-    /// Writes a metric with the given name and labels.
-    fn fmt_metric_labeled<N, L>(&self, f: &mut fmt::Formatter, name: N, labels: L) -> fmt::Result
-    where
-        N: Display,
-        L: Display;
-}
-
-/// Describes a metric statically.
-///
-/// Formats help messages and metric values for prometheus output.
-pub struct Metric<'a, M: FmtMetric> {
-    pub name: &'a str,
-    pub help: &'a str,
-    pub _p: PhantomData<M>,
-}
 
 /// The root scope for all runtime metrics.
 #[derive(Debug, Default)]
@@ -114,41 +87,6 @@ pub fn new(process: &Arc<ctx::Process>, idle_retain: Duration, tls: tls_config_r
 {
     let metrics = Arc::new(Mutex::new(Root::new(process, tls)));
     (Record::new(&metrics), Serve::new(&metrics, idle_retain))
-}
-
-// ===== impl Metric =====
-
-impl<'a, M: FmtMetric> Metric<'a, M> {
-    /// Formats help messages for this metric.
-    pub fn fmt_help(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        writeln!(f, "# HELP {} {}", self.name, self.help)?;
-        writeln!(f, "# TYPE {} {}", self.name, M::KIND)?;
-        Ok(())
-    }
-
-    /// Formats a single metric without labels.
-    pub fn fmt_metric(&self, f: &mut fmt::Formatter, metric: M) -> fmt::Result {
-        metric.fmt_metric(f, self.name)
-    }
-
-    /// Formats a single metric across labeled scopes.
-    pub fn fmt_scopes<'s, L, S: 's, I, F>(
-        &self,
-        f: &mut fmt::Formatter,
-        scopes: I,
-        to_metric: F
-    ) -> fmt::Result
-    where
-        L: Display,
-        I: IntoIterator<Item = (L, &'s S)>,
-        F: Fn(&S) -> &M
-    {
-        for (labels, scope) in scopes {
-            to_metric(scope).fmt_metric_labeled(f, self.name, labels)?;
-        }
-
-        Ok(())
-    }
 }
 
 // ===== impl Root =====
@@ -180,13 +118,13 @@ impl Root {
     }
 }
 
-impl fmt::Display for Root {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.requests.fmt(f)?;
-        self.responses.fmt(f)?;
-        self.transports.fmt(f)?;
-        self.tls_config_reload.fmt(f)?;
-        self.process.fmt(f)?;
+impl FmtPrometheus for Root {
+    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.requests.fmt_prometheus(f)?;
+        self.responses.fmt_prometheus(f)?;
+        self.transports.fmt_prometheus(f)?;
+        self.tls_config_reload.fmt_prometheus(f)?;
+        self.process.fmt_prometheus(f)?;
 
         Ok(())
     }

--- a/src/telemetry/metrics/prom.rs
+++ b/src/telemetry/metrics/prom.rs
@@ -1,9 +1,22 @@
 use std::fmt;
-use std::marker::PhantomData;
+use std::marker::{PhantomData, Sized};
+
+pub struct AsDisplay<F>(F);
 
 /// Writes a block of metrics in prometheus-formatted output.
 pub trait FmtPrometheus {
     fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result;
+
+    /// Allows FmtPrometheus to be used in the context of a fmt::Display.
+    fn as_display(&self) -> AsDisplay<&Self> where Self: Sized {
+        AsDisplay(self)
+    }
+}
+
+impl<F: FmtPrometheus> fmt::Display for AsDisplay<F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt_prometheus(f)
+    }
 }
 
 /// Writes a series of key-quoted-val pairs for use as prometheus labels.

--- a/src/telemetry/metrics/prom.rs
+++ b/src/telemetry/metrics/prom.rs
@@ -1,0 +1,126 @@
+use std::fmt;
+use std::marker::PhantomData;
+
+/// Writes a block of metrics in prometheus-formatted output.
+pub trait FmtPrometheus {
+    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result;
+}
+
+/// Writes a series of key-quoted-val pairs for use as prometheus labels.
+pub trait FmtLabels {
+    fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result;
+}
+
+/// Writes a metric in prometheus-formatted output.
+///
+/// This trait is implemented by `Counter`, `Gauge`, and `Histogram` to account for the
+/// differences in formatting each type of metric. Specifically, `Histogram` formats a
+/// counter for each bucket, as well as a count and total sum.
+pub trait FmtMetric {
+    /// The metric's `TYPE` in help messages.
+    const KIND: &'static str;
+
+    /// Writes a metric with the given name and no labels.
+    fn fmt_metric<N: fmt::Display>(&self, f: &mut fmt::Formatter, name: N) -> fmt::Result;
+
+    /// Writes a metric with the given name and labels.
+    fn fmt_metric_labeled<N, L>(&self, f: &mut fmt::Formatter, name: N, labels: L) -> fmt::Result
+    where
+        N: fmt::Display,
+        L: FmtLabels;
+}
+
+/// Describes a metric statically.
+///
+/// Formats help messages and metric values for prometheus output.
+pub struct Metric<'a, M: FmtMetric> {
+    pub name: &'a str,
+    pub help: &'a str,
+    pub _p: PhantomData<M>,
+}
+
+// ===== impl Metric =====
+
+impl<'a, M: FmtMetric> Metric<'a, M> {
+    /// Formats help messages for this metric.
+    pub fn fmt_help(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "# HELP {} {}", self.name, self.help)?;
+        writeln!(f, "# TYPE {} {}", self.name, M::KIND)?;
+        Ok(())
+    }
+
+    /// Formats a single metric without labels.
+    pub fn fmt_metric(&self, f: &mut fmt::Formatter, metric: M) -> fmt::Result {
+        metric.fmt_metric(f, self.name)
+    }
+
+    /// Formats a single metric across labeled scopes.
+    pub fn fmt_scopes<'s, L, S: 's, I, F>(
+        &self,
+        f: &mut fmt::Formatter,
+        scopes: I,
+        to_metric: F
+    ) -> fmt::Result
+    where
+        L: FmtLabels,
+        I: IntoIterator<Item = (L, &'s S)>,
+        F: Fn(&S) -> &M
+    {
+        for (labels, scope) in scopes {
+            to_metric(scope).fmt_metric_labeled(f, self.name, labels)?;
+        }
+
+        Ok(())
+    }
+}
+
+// ===== impl FmtLabels =====
+
+impl<'a, A: FmtLabels + 'a> FmtLabels for &'a A {
+    fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (*self).fmt_labels(f)
+    }
+}
+
+impl<A: FmtLabels, B: FmtLabels> FmtLabels for (A, B) {
+    fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt_labels(f)?;
+        f.pad(",")?;
+        self.1.fmt_labels(f)?;
+
+        Ok(())
+    }
+}
+
+impl<A: FmtLabels, B: FmtLabels> FmtLabels for (A, Option<B>) {
+    fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt_labels(f)?;
+        if let Some(ref b) = self.1 {
+            f.pad(",")?;
+            b.fmt_labels(f)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<A: FmtLabels, B: FmtLabels> FmtLabels for (Option<A>, B) {
+    fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref a) = self.0 {
+            a.fmt_labels(f)?;
+            f.pad(",")?;
+        }
+        self.1.fmt_labels(f)?;
+
+        Ok(())
+    }
+}
+
+// ===== impl FmtPrometheus =====
+
+impl<'a, A: FmtPrometheus + 'a> FmtPrometheus for &'a A {
+    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (*self).fmt_prometheus(f)
+    }
+}
+

--- a/src/telemetry/metrics/prom.rs
+++ b/src/telemetry/metrics/prom.rs
@@ -4,24 +4,29 @@ use std::marker::{PhantomData, Sized};
 pub struct AsDisplay<F>(F);
 
 /// Writes a block of metrics in prometheus-formatted output.
-pub trait FmtPrometheus {
-    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result;
+pub trait FmtMetrics {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result;
 
-    /// Allows FmtPrometheus to be used in the context of a fmt::Display.
     fn as_display(&self) -> AsDisplay<&Self> where Self: Sized {
         AsDisplay(self)
     }
 }
 
-impl<F: FmtPrometheus> fmt::Display for AsDisplay<F> {
+impl<F: FmtMetrics> fmt::Display for AsDisplay<F> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt_prometheus(f)
+        self.0.fmt_metrics(f)
     }
 }
 
 /// Writes a series of key-quoted-val pairs for use as prometheus labels.
 pub trait FmtLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result;
+}
+
+impl<F: FmtMetrics> fmt::Display for AsDisplay<F> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt_labels(f)
+    }
 }
 
 /// Writes a metric in prometheus-formatted output.
@@ -129,11 +134,11 @@ impl<A: FmtLabels, B: FmtLabels> FmtLabels for (Option<A>, B) {
     }
 }
 
-// ===== impl FmtPrometheus =====
+// ===== impl FmtMetrics =====
 
-impl<'a, A: FmtPrometheus + 'a> FmtPrometheus for &'a A {
-    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        (*self).fmt_prometheus(f)
+impl<'a, A: FmtMetrics + 'a> FmtMetrics for &'a A {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        (*self).fmt_metrics(f)
     }
 }
 

--- a/src/telemetry/metrics/prom.rs
+++ b/src/telemetry/metrics/prom.rs
@@ -1,18 +1,19 @@
 use std::fmt;
 use std::marker::{PhantomData, Sized};
 
-pub struct AsDisplay<F>(F);
-
 /// Writes a block of metrics in prometheus-formatted output.
 pub trait FmtMetrics {
     fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result;
 
-    fn as_display(&self) -> AsDisplay<&Self> where Self: Sized {
-        AsDisplay(self)
+    fn as_display(&self) -> DisplayMetrics<&Self> where Self: Sized {
+        DisplayMetrics(self)
     }
 }
 
-impl<F: FmtMetrics> fmt::Display for AsDisplay<F> {
+/// Adapts `FmtMetrics` to `fmt::Display`.
+pub struct DisplayMetrics<F>(F);
+
+impl<F: FmtMetrics> fmt::Display for DisplayMetrics<F> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt_metrics(f)
     }
@@ -21,12 +22,6 @@ impl<F: FmtMetrics> fmt::Display for AsDisplay<F> {
 /// Writes a series of key-quoted-val pairs for use as prometheus labels.
 pub trait FmtLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result;
-}
-
-impl<F: FmtMetrics> fmt::Display for AsDisplay<F> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt_labels(f)
-    }
 }
 
 /// Writes a metric in prometheus-formatted output.

--- a/src/telemetry/metrics/scopes.rs
+++ b/src/telemetry/metrics/scopes.rs
@@ -1,19 +1,20 @@
 use indexmap::IndexMap;
-use std::{fmt::Display, hash::Hash};
+use super::prom::FmtLabels;
+use std::hash::Hash;
 
 /// Holds an `S`-typed scope for each `L`-typed label set.
 ///
 /// An `S` type typically holds one or more metrics.
 #[derive(Debug)]
-pub struct Scopes<L: Display + Hash + Eq, S>(IndexMap<L, S>);
+pub struct Scopes<L: FmtLabels + Hash + Eq, S>(IndexMap<L, S>);
 
-impl<L: Display + Hash + Eq, S> Default for Scopes<L, S> {
+impl<L: FmtLabels + Hash + Eq, S> Default for Scopes<L, S> {
     fn default() -> Self {
         Scopes(IndexMap::default())
     }
 }
 
-impl<L: Display + Hash + Eq, S> Scopes<L, S> {
+impl<L: FmtLabels + Hash + Eq, S> Scopes<L, S> {
     pub fn get(&self, key: &L) -> Option<&S> {
         self.0.get(key)
     }
@@ -34,13 +35,13 @@ impl<L: Display + Hash + Eq, S> Scopes<L, S> {
     }
 }
 
-impl<L: Display + Hash + Eq, S: Default> Scopes<L, S> {
+impl<L: FmtLabels + Hash + Eq, S: Default> Scopes<L, S> {
     pub fn get_or_default(&mut self, key: L) -> &mut S {
         self.0.entry(key).or_insert_with(|| S::default())
     }
 }
 
-impl<'a, L: Display + Hash + Eq, S> IntoIterator for &'a Scopes<L, S> {
+impl<'a, L: FmtLabels + Hash + Eq, S> IntoIterator for &'a Scopes<L, S> {
     type Item = <&'a IndexMap<L, S> as IntoIterator>::Item;
     type IntoIter = <&'a IndexMap<L, S> as IntoIterator>::IntoIter;
 

--- a/src/telemetry/metrics/serve.rs
+++ b/src/telemetry/metrics/serve.rs
@@ -15,7 +15,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::executor::current_thread::TaskExecutor;
 
-use super::{prom::FmtPrometheus, Root};
+use super::{prom::FmtMetrics, Root};
 use task;
 use transport::BoundPort;
 

--- a/src/telemetry/metrics/transport.rs
+++ b/src/telemetry/metrics/transport.rs
@@ -6,7 +6,7 @@ use ctx;
 use super::{
     labels::{Direction, TlsStatus},
     latency,
-    prom::{FmtLabels, FmtPrometheus},
+    prom::{FmtLabels, FmtMetrics},
     Counter,
     Gauge,
     Histogram,
@@ -149,8 +149,8 @@ impl Transports {
     }
 }
 
-impl FmtPrometheus for Transports {
-    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl FmtMetrics for Transports {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if self.metrics.is_empty() {
             return Ok(());
         }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -7,8 +7,8 @@ macro_rules! metrics {
     { $( $name:ident : $kind:ty { $help:expr } ),+ } => {
         $(
             #[allow(non_upper_case_globals)]
-            const $name: ::telemetry::metrics::Metric<'static, $kind> =
-                ::telemetry::metrics::Metric {
+            const $name: ::telemetry::metrics::prom::Metric<'static, $kind> =
+                ::telemetry::metrics::prom::Metric {
                     name: stringify!($name),
                     help: $help,
                     _p: ::std::marker::PhantomData,

--- a/src/telemetry/process.rs
+++ b/src/telemetry/process.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::time::UNIX_EPOCH;
 
 use ctx;
-use super::metrics::Gauge;
+use super::metrics::{Gauge, prom::FmtPrometheus};
 
 use self::system::System;
 
@@ -39,13 +39,13 @@ impl Report {
     }
 }
 
-impl fmt::Display for Report {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl FmtPrometheus for Report {
+    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
         process_start_time_seconds.fmt_help(f)?;
         process_start_time_seconds.fmt_metric(f, self.start_time)?;
 
         if let Some(ref sys) = self.system {
-            sys.fmt(f)?;
+            sys.fmt_prometheus(f)?;
         }
 
         Ok(())
@@ -59,7 +59,7 @@ mod system {
     use std::{io, fs};
 
     use super::*;
-    use super::super::metrics::{Counter, Gauge};
+    use super::super::metrics::{Counter, Gauge, FmtPrometheus};
 
     metrics! {
         process_cpu_seconds_total: Counter {
@@ -120,8 +120,8 @@ mod system {
         }
     }
 
-    impl fmt::Display for System {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    impl FmtPrometheus for System {
+        fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
             // XXX potentially blocking call
             let stat = match pid::stat_self() {
                 Ok(stat) => stat,
@@ -192,8 +192,8 @@ mod system {
         }
     }
 
-    impl fmt::Display for System {
-        fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+    impl FmtPrometheus for System {
+        fn fmt_prometheus(&self, _: &mut fmt::Formatter) -> fmt::Result {
             Ok(())
         }
     }

--- a/src/telemetry/process.rs
+++ b/src/telemetry/process.rs
@@ -179,6 +179,8 @@ mod system {
 mod system {
     use std::{fmt, io};
 
+    use super::super::metrics::FmtPrometheus;
+
     #[derive(Debug)]
     pub(super) struct System {}
 

--- a/src/telemetry/process.rs
+++ b/src/telemetry/process.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use super::metrics::{Gauge, prom::FmtPrometheus};
+use super::metrics::{Gauge, prom::FmtMetrics};
 
 use self::system::System;
 
@@ -38,13 +38,13 @@ impl Report {
     }
 }
 
-impl FmtPrometheus for Report {
-    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl FmtMetrics for Report {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
         process_start_time_seconds.fmt_help(f)?;
         process_start_time_seconds.fmt_metric(f, self.start_time)?;
 
         if let Some(ref sys) = self.system {
-            sys.fmt_prometheus(f)?;
+            sys.fmt_metrics(f)?;
         }
 
         Ok(())
@@ -58,7 +58,7 @@ mod system {
     use std::{io, fs};
 
     use super::*;
-    use super::super::metrics::{Counter, Gauge, FmtPrometheus};
+    use super::super::metrics::{Counter, Gauge, FmtMetrics};
 
     metrics! {
         process_cpu_seconds_total: Counter {
@@ -119,8 +119,8 @@ mod system {
         }
     }
 
-    impl FmtPrometheus for System {
-        fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    impl FmtMetrics for System {
+        fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
             // XXX potentially blocking call
             let stat = match pid::stat_self() {
                 Ok(stat) => stat,
@@ -179,7 +179,7 @@ mod system {
 mod system {
     use std::{fmt, io};
 
-    use super::super::metrics::FmtPrometheus;
+    use super::super::metrics::FmtMetrics;
 
     #[derive(Debug)]
     pub(super) struct System {}
@@ -193,8 +193,8 @@ mod system {
         }
     }
 
-    impl FmtPrometheus for System {
-        fn fmt_prometheus(&self, _: &mut fmt::Formatter) -> fmt::Result {
+    impl FmtMetrics for System {
+        fn fmt_metrics(&self, _: &mut fmt::Formatter) -> fmt::Result {
             Ok(())
         }
     }

--- a/src/telemetry/tls_config_reload.rs
+++ b/src/telemetry/tls_config_reload.rs
@@ -5,7 +5,15 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use telemetry::{Errno, metrics::{Counter, Gauge, Scopes}};
+use telemetry::{
+    metrics::{
+        prom::{FmtLabels, FmtPrometheus},
+        Counter,
+        Gauge,
+        Scopes,
+    },
+    Errno,
+};
 use transport::tls;
 
 metrics! {
@@ -74,8 +82,8 @@ impl Sensor {
 
 // ===== impl Report =====
 
-impl fmt::Display for Report {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl FmtPrometheus for Report {
+    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let lock = match self.0.upgrade() {
             None => return Ok(()),
             Some(lock) => lock,
@@ -115,8 +123,8 @@ impl From<tls::ConfigError> for Status {
     }
 }
 
-impl fmt::Display for Status {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl FmtLabels for Status {
+    fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Status::Reloaded => f.pad("status=\"reloaded\""),
             Status::Io {

--- a/src/telemetry/tls_config_reload.rs
+++ b/src/telemetry/tls_config_reload.rs
@@ -7,7 +7,7 @@ use std::{
 
 use telemetry::{
     metrics::{
-        prom::{FmtLabels, FmtPrometheus},
+        prom::{FmtLabels, FmtMetrics},
         Counter,
         Gauge,
         Scopes,
@@ -82,8 +82,8 @@ impl Sensor {
 
 // ===== impl Report =====
 
-impl FmtPrometheus for Report {
-    fn fmt_prometheus(&self, f: &mut fmt::Formatter) -> fmt::Result {
+impl FmtMetrics for Report {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let lock = match self.0.upgrade() {
             None => return Ok(()),
             Some(lock) => lock,


### PR DESCRIPTION
There are many different types of things that implement `fmt::Display`
in the metrics library: lists of key-value labels, individial label keys
or values, groups of metrics output, etc. While modifying metrics code,
it can be very easy to use something that's not a label in the context
of a label.