### PR TITLE
Delete ctx::Process

### DIFF
--- a/src/control/pb.rs
+++ b/src/control/pb.rs
@@ -193,10 +193,10 @@ impl ctx::transport::Server {
     }
 
     fn direction(&self) -> tap::tap_event::ProxyDirection {
-        if self.proxy.is_outbound() {
-            tap::tap_event::ProxyDirection::Outbound
-        } else {
-            tap::tap_event::ProxyDirection::Inbound
+        use ctx::Proxy::*;
+        match self.proxy {
+            Outbound => tap::tap_event::ProxyDirection::Outbound,
+            Inbound => tap::tap_event::ProxyDirection::Inbound,
         }
     }
 }

--- a/src/control/pb.rs
+++ b/src/control/pb.rs
@@ -193,10 +193,9 @@ impl ctx::transport::Server {
     }
 
     fn direction(&self) -> tap::tap_event::ProxyDirection {
-        use ctx::Proxy::*;
         match self.proxy {
-            Outbound => tap::tap_event::ProxyDirection::Outbound,
-            Inbound => tap::tap_event::ProxyDirection::Inbound,
+            ctx::Proxy::Outbound => tap::tap_event::ProxyDirection::Outbound,
+            ctx::Proxy::Inbound => tap::tap_event::ProxyDirection::Inbound,
         }
     }
 }

--- a/src/ctx/http.rs
+++ b/src/ctx/http.rs
@@ -83,14 +83,11 @@ impl Request {
 
     /// Returns a `TlsStatus` indicating if the request was sent was over TLS.
     pub fn tls_status(&self) -> ctx::transport::TlsStatus {
-        if self.server.proxy.is_outbound() {
-            // If the request is in the outbound direction, then we opened the
-            // client connection, so check if it was secured.
-            self.client.tls_status
-        } else {
-            // Otherwise, the request is inbound, so check if we accepted it
-            // over TLS.
-            self.server.tls_status
+        use ctx::Proxy::*;
+        // The proxy only handles TLS on one side of each proxy.
+        match self.server.proxy {
+            Outbound => self.client.tls_status,
+            Inbound => self.server.tls_status,
         }
     }
 

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -14,6 +14,15 @@ pub enum Proxy {
     Outbound,
 }
 
+impl Proxy {
+    pub fn as_str(&self) -> &'static str {
+        match *self {
+            Proxy::Inbound => "in",
+            Proxy::Outbound => "out",
+        }
+    }
+}
+
 #[cfg(test)]
 pub mod test_util {
     use http;

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -1,27 +1,5 @@
-//! Describes proxy traffic.
-//!
-//! Contexts are primarily intended to describe traffic contexts for the purposes of
-//! telemetry. They may also be useful for, for instance,
-//! routing/rate-limiting/policy/etc.
-//!
-//! As a rule, context types should implement `Clone + Send + Sync`. This allows them to
-//! be stored in `http::Extensions`, for instance. Furthermore, because these contexts
-//! will be sent to a telemetry processing thread, we want to avoid excessive cloning.
-use config;
-use std::time::SystemTime;
-use std::sync::Arc;
-
 pub mod http;
 pub mod transport;
-
-/// Describes a single running proxy instance.
-#[derive(Clone, Debug)]
-pub struct Process {
-    /// Identifies the Kubernetes namespace in which this proxy is process.
-    pub scheduled_namespace: String,
-
-    pub start_time: SystemTime,
-}
 
 /// Indicates the orientation of traffic, relative to a sidecar proxy.
 ///
@@ -30,51 +8,10 @@ pub struct Process {
 ///   local instance.
 /// - The  _outbound_ proxy receives traffic from the local instance and forwards it to a
 ///   remove service.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum Proxy {
-    Inbound(Arc<Process>),
-    Outbound(Arc<Process>),
-}
-
-impl Process {
-    // Test-only, but we can't use `#[cfg(test)]` because it is used by the
-    // benchmarks
-    pub fn test(ns: &str) -> Arc<Self> {
-        Arc::new(Self {
-            scheduled_namespace: ns.into(),
-            start_time: SystemTime::now(),
-        })
-    }
-
-    /// Construct a new `Process` from environment variables.
-    pub fn new(config: &config::Config) -> Arc<Self> {
-        let start_time = SystemTime::now();
-        Arc::new(Self {
-            scheduled_namespace: config.namespaces.pod.clone(),
-            start_time,
-        })
-    }
-}
-
-impl Proxy {
-    pub fn inbound(p: &Arc<Process>) -> Arc<Self> {
-        Arc::new(Proxy::Inbound(Arc::clone(p)))
-    }
-
-    pub fn outbound(p: &Arc<Process>) -> Arc<Self> {
-        Arc::new(Proxy::Outbound(Arc::clone(p)))
-    }
-
-    pub fn is_inbound(&self) -> bool {
-        match *self {
-            Proxy::Inbound(_) => true,
-            Proxy::Outbound(_) => false,
-        }
-    }
-
-    pub fn is_outbound(&self) -> bool {
-        !self.is_inbound()
-    }
+    Inbound,
+    Outbound,
 }
 
 #[cfg(test)]
@@ -96,19 +33,15 @@ pub mod test_util {
         ([1, 2, 3, 4], 5678).into()
     }
 
-    pub fn process() -> Arc<ctx::Process> {
-        ctx::Process::test("test")
-    }
-
     pub fn server(
-        proxy: &Arc<ctx::Proxy>,
+        proxy: ctx::Proxy,
         tls: ctx::transport::TlsStatus
     ) -> Arc<ctx::transport::Server> {
-        ctx::transport::Server::new(&proxy, &addr(), &addr(), &Some(addr()), tls)
+        ctx::transport::Server::new(proxy, &addr(), &addr(), &Some(addr()), tls)
     }
 
     pub fn client<L, S>(
-        proxy: &Arc<ctx::Proxy>,
+        proxy: ctx::Proxy,
         labels: L,
         tls: ctx::transport::TlsStatus,
     ) -> Arc<ctx::transport::Client>
@@ -119,7 +52,7 @@ pub mod test_util {
         let meta = destination::Metadata::new(DstLabels::new(labels),
             destination::ProtocolHint::Unknown,
             Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery));
-        ctx::transport::Client::new(&proxy, &addr(), meta, tls)
+        ctx::transport::Client::new(proxy, &addr(), meta, tls)
     }
 
     pub fn request(

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -7,7 +7,7 @@ pub mod transport;
 /// - The _inbound_ proxy receives traffic from another services forwards it to within the
 ///   local instance.
 /// - The  _outbound_ proxy receives traffic from the local instance and forwards it to a
-///   remove service.
+///   remote service.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum Proxy {
     Inbound,

--- a/src/ctx/transport.rs
+++ b/src/ctx/transport.rs
@@ -19,7 +19,7 @@ pub enum Ctx {
 /// Identifies a connection from another process to a proxy listener.
 #[derive(Debug)]
 pub struct Server {
-    pub proxy: Arc<ctx::Proxy>,
+    pub proxy: ctx::Proxy,
     pub remote: SocketAddr,
     pub local: SocketAddr,
     pub orig_dst: Option<SocketAddr>,
@@ -29,7 +29,7 @@ pub struct Server {
 /// Identifies a connection from the proxy to another process.
 #[derive(Debug)]
 pub struct Client {
-    pub proxy: Arc<ctx::Proxy>,
+    pub proxy: ctx::Proxy,
     pub remote: SocketAddr,
     pub metadata: destination::Metadata,
     pub tls_status: TlsStatus,
@@ -63,16 +63,16 @@ impl fmt::Display for TlsStatus {
 
 
 impl Ctx {
-    pub fn proxy(&self) -> &Arc<ctx::Proxy> {
+    pub fn proxy(&self) -> ctx::Proxy {
         match *self {
-            Ctx::Client(ref ctx) => &ctx.proxy,
-            Ctx::Server(ref ctx) => &ctx.proxy,
+            Ctx::Client(ref ctx) => ctx.proxy,
+            Ctx::Server(ref ctx) => ctx.proxy,
         }
     }
 
     pub fn tls_status(&self) -> TlsStatus {
         match self {
-            Ctx::Client(ctx)  => ctx.tls_status,
+            Ctx::Client(ctx) => ctx.tls_status,
             Ctx::Server(ctx) => ctx.tls_status,
         }
     }
@@ -80,14 +80,14 @@ impl Ctx {
 
 impl Server {
     pub fn new(
-        proxy: &Arc<ctx::Proxy>,
+        proxy: ctx::Proxy,
         local: &SocketAddr,
         remote: &SocketAddr,
         orig_dst: &Option<SocketAddr>,
         tls_status: TlsStatus,
     ) -> Arc<Server> {
         let s = Server {
-            proxy: Arc::clone(proxy),
+            proxy,
             local: *local,
             remote: *remote,
             orig_dst: *orig_dst,
@@ -123,13 +123,13 @@ fn same_addr(a0: &SocketAddr, a1: &SocketAddr) -> bool {
 
 impl Client {
     pub fn new(
-        proxy: &Arc<ctx::Proxy>,
+        proxy: ctx::Proxy,
         remote: &SocketAddr,
         metadata: destination::Metadata,
         tls_status: TlsStatus,
     ) -> Arc<Client> {
         let c = Client {
-            proxy: Arc::clone(proxy),
+            proxy,
             remote: *remote,
             metadata,
             tls_status,

--- a/src/inbound.rs
+++ b/src/inbound.rs
@@ -12,7 +12,7 @@ use bind;
 use ctx;
 use transparency::orig_proto;
 
-type Bind<B> = bind::Bind<Arc<ctx::Proxy>, B>;
+type Bind<B> = bind::Bind<ctx::Proxy, B>;
 
 pub struct Inbound<B> {
     default_addr: Option<SocketAddr>,
@@ -103,7 +103,6 @@ where
 #[cfg(test)]
 mod tests {
     use std::net;
-    use std::sync::Arc;
 
     use http;
     use linkerd2_proxy_router::Recognize;
@@ -114,8 +113,8 @@ mod tests {
     use conditional::Conditional;
     use tls;
 
-    fn new_inbound(default: Option<net::SocketAddr>, ctx: &Arc<ctx::Proxy>) -> Inbound<()> {
-        let bind = Bind::new(tls::ClientConfig::no_tls()).with_ctx(ctx.clone());
+    fn new_inbound(default: Option<net::SocketAddr>, ctx: ctx::Proxy) -> Inbound<()> {
+        let bind = Bind::new(tls::ClientConfig::no_tls()).with_ctx(ctx);
         Inbound::new(default, bind)
     }
 
@@ -137,12 +136,12 @@ mod tests {
             local: net::SocketAddr,
             remote: net::SocketAddr
         ) -> bool {
-            let ctx = ctx::Proxy::inbound(&ctx::Process::test("test"));
+            let ctx = ctx::Proxy::Inbound;
 
-            let inbound = new_inbound(None, &ctx);
+            let inbound = new_inbound(None, ctx);
 
             let srv_ctx = ctx::transport::Server::new(
-                &ctx, &local, &remote, &Some(orig_dst), TLS_DISABLED);
+                ctx, &local, &remote, &Some(orig_dst), TLS_DISABLED);
 
             let rec = srv_ctx.orig_dst_if_not_local().map(make_key_http1);
 
@@ -158,14 +157,14 @@ mod tests {
             local: net::SocketAddr,
             remote: net::SocketAddr
         ) -> bool {
-            let ctx = ctx::Proxy::inbound(&ctx::Process::test("test"));
+            let ctx = ctx::Proxy::Inbound;
 
-            let inbound = new_inbound(default, &ctx);
+            let inbound = new_inbound(default, ctx);
 
             let mut req = http::Request::new(());
             req.extensions_mut()
                 .insert(ctx::transport::Server::new(
-                    &ctx,
+                    ctx,
                     &local,
                     &remote,
                     &None,
@@ -176,9 +175,9 @@ mod tests {
         }
 
         fn recognize_default_no_ctx(default: Option<net::SocketAddr>) -> bool {
-            let ctx = ctx::Proxy::inbound(&ctx::Process::test("test"));
+            let ctx = ctx::Proxy::Inbound;
 
-            let inbound = new_inbound(default, &ctx);
+            let inbound = new_inbound(default, ctx);
 
             let req = http::Request::new(());
 
@@ -190,14 +189,14 @@ mod tests {
             local: net::SocketAddr,
             remote: net::SocketAddr
         ) -> bool {
-            let ctx = ctx::Proxy::inbound(&ctx::Process::test("test"));
+            let ctx = ctx::Proxy::Inbound;
 
-            let inbound = new_inbound(default, &ctx);
+            let inbound = new_inbound(default, ctx);
 
             let mut req = http::Request::new(());
             req.extensions_mut()
                 .insert(ctx::transport::Server::new(
-                    &ctx,
+                    ctx,
                     &local,
                     &remote,
                     &Some(local),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ where
         // to the managed application (private destination).
         let inbound = {
             let ctx = ctx::Proxy::Inbound;
-            let bind = bind.clone().with_ctx(ctx.clone());
+            let bind = bind.clone().with_ctx(ctx);
             let default_addr = config.private_forward.map(|a| a.into());
 
             let router = Router::new(

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -277,12 +277,7 @@ pub type ServerFuture<F> = ContextualFuture<Server, F>;
 
 impl Server {
     pub fn proxy(ctx: ::ctx::Proxy, listen: SocketAddr) -> Self {
-        use ::ctx::Proxy::*;
-        let name = match ctx {
-            Inbound => "in",
-            Outbound => "out",
-        };
-        Section::Proxy.server(name, listen)
+        Section::Proxy.server(ctx.as_str(), listen)
     }
 
     pub fn with_remote(self, remote: SocketAddr) -> Self {
@@ -313,12 +308,7 @@ impl fmt::Display for Server {
 
 impl<D: fmt::Display> Client<&'static str, D> {
     pub fn proxy(ctx: ::ctx::Proxy, dst: D) -> Self {
-        use ::ctx::Proxy::*;
-        let name = match ctx {
-            Inbound => "in",
-            Outbound => "out",
-        };
-        Section::Proxy.client(name, dst)
+        Section::Proxy.client(ctx.as_str(), dst)
     }
 }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -276,11 +276,11 @@ pub type ServerExecutor = ContextualExecutor<Server>;
 pub type ServerFuture<F> = ContextualFuture<Server, F>;
 
 impl Server {
-    pub fn proxy(ctx: &::ctx::Proxy, listen: SocketAddr) -> Self {
-        let name = if ctx.is_inbound() {
-            "in"
-        } else {
-            "out"
+    pub fn proxy(ctx: ::ctx::Proxy, listen: SocketAddr) -> Self {
+        use ::ctx::Proxy::*;
+        let name = match ctx {
+            Inbound => "in",
+            Outbound => "out",
         };
         Section::Proxy.server(name, listen)
     }
@@ -312,11 +312,11 @@ impl fmt::Display for Server {
 }
 
 impl<D: fmt::Display> Client<&'static str, D> {
-    pub fn proxy(ctx: &::ctx::Proxy, dst: D) -> Self {
-        let name = if ctx.is_inbound() {
-            "in"
-        } else {
-            "out"
+    pub fn proxy(ctx: ::ctx::Proxy, dst: D) -> Self {
+        use ::ctx::Proxy::*;
+        let name = match ctx {
+            Inbound => "in",
+            Outbound => "out",
         };
         Section::Proxy.client(name, dst)
     }

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -22,10 +22,10 @@ use timeout::Timeout;
 use transparency::{h1, HttpBody};
 use transport::{DnsNameAndPort, Host, HostAndPort};
 
-type BindProtocol<B> = bind::BindProtocol<Arc<ctx::Proxy>, B>;
+type BindProtocol<B> = bind::BindProtocol<ctx::Proxy, B>;
 
 pub struct Outbound<B> {
-    bind: Bind<Arc<ctx::Proxy>, B>,
+    bind: Bind<ctx::Proxy, B>,
     discovery: destination::Resolver,
     bind_timeout: Duration,
 }
@@ -48,7 +48,7 @@ pub enum Destination {
 // ===== impl Outbound =====
 
 impl<B> Outbound<B> {
-    pub fn new(bind: Bind<Arc<ctx::Proxy>, B>,
+    pub fn new(bind: Bind<ctx::Proxy, B>,
                discovery: destination::Resolver,
                bind_timeout: Duration)
                -> Outbound<B> {

--- a/src/telemetry/metrics/labels.rs
+++ b/src/telemetry/metrics/labels.rs
@@ -52,10 +52,7 @@ pub enum Classification {
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub enum Direction {
-    Inbound,
-    Outbound,
-}
+pub struct Direction(ctx::Proxy);
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DstLabels {
@@ -70,7 +67,7 @@ pub struct TlsStatus(ctx::transport::TlsStatus);
 
 impl RequestLabels {
     pub fn new(req: &ctx::http::Request) -> Self {
-        let direction = Direction::from_context(req.server.proxy.as_ref());
+        let direction = Direction::new(req.server.proxy);
 
         let outbound_labels = req.dst_labels().cloned();
 
@@ -205,19 +202,17 @@ impl fmt::Display for Classification {
 // ===== impl Direction =====
 
 impl Direction {
-    pub fn from_context(context: &ctx::Proxy) -> Self {
-        match context {
-            &ctx::Proxy::Inbound(_) => Direction::Inbound,
-            &ctx::Proxy::Outbound(_) => Direction::Outbound,
-        }
+    pub fn new(ctx: ctx::Proxy) -> Self {
+        Direction(ctx)
     }
 }
 
 impl fmt::Display for Direction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &Direction::Inbound => f.pad("direction=\"inbound\""),
-            &Direction::Outbound => f.pad("direction=\"outbound\""),
+        use ctx::Proxy::*;
+        match self.0 {
+            Inbound => f.pad("direction=\"inbound\""),
+            Outbound => f.pad("direction=\"outbound\""),
         }
     }
 }

--- a/src/telemetry/metrics/labels.rs
+++ b/src/telemetry/metrics/labels.rs
@@ -209,10 +209,9 @@ impl Direction {
 
 impl fmt::Display for Direction {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use ctx::Proxy::*;
         match self.0 {
-            Inbound => f.pad("direction=\"inbound\""),
-            Outbound => f.pad("direction=\"outbound\""),
+            ctx::Proxy::Inbound => f.pad("direction=\"inbound\""),
+            ctx::Proxy::Outbound => f.pad("direction=\"outbound\""),
         }
     }
 }

--- a/src/telemetry/metrics/record.rs
+++ b/src/telemetry/metrics/record.rs
@@ -97,7 +97,7 @@ mod test {
         Event,
     };
     use ctx::{self, test_util::*, transport::TlsStatus};
-    use std::time::{Duration, Instant};
+    use std::time::{Duration, Instant, SystemTime};
     use conditional::Conditional;
     use tls;
 
@@ -106,11 +106,10 @@ mod test {
         Conditional::None(tls::ReasonForNoTls::Disabled);
 
     fn test_record_response_end_outbound(client_tls: TlsStatus, server_tls: TlsStatus) {
-        let process = process();
-        let proxy = ctx::Proxy::outbound(&process);
-        let server = server(&proxy, server_tls);
+        let proxy = ctx::Proxy::Outbound;
+        let server = server(proxy, server_tls);
 
-        let client = client(&proxy, vec![
+        let client = client(proxy, vec![
             ("service", "draymond"),
             ("deployment", "durant"),
             ("pod", "klay"),
@@ -132,7 +131,7 @@ mod test {
             frames_sent: 0,
         };
 
-        let (mut r, _) = metrics::new(&process, Duration::from_secs(100), Default::default());
+        let (mut r, _) = metrics::new(SystemTime::now(), Duration::from_secs(100), Default::default());
         let ev = Event::StreamResponseEnd(rsp.clone(), end.clone());
         let labels = labels::ResponseLabels::new(&rsp, None);
 
@@ -168,11 +167,10 @@ mod test {
         use self::labels::*;
         use std::sync::Arc;
 
-        let process = process();
-        let proxy = ctx::Proxy::outbound(&process);
-        let server = server(&proxy, server_tls);
+        let proxy = ctx::Proxy::Outbound;
+        let server = server(proxy, server_tls);
 
-        let client = client(&proxy, vec![
+        let client = client(proxy, vec![
             ("service", "draymond"),
             ("deployment", "durant"),
             ("pod", "klay"),
@@ -228,7 +226,7 @@ mod test {
             ),
         ];
 
-        let (mut r, _) = metrics::new(&process, Duration::from_secs(1000), Default::default());
+        let (mut r, _) = metrics::new(SystemTime::now(), Duration::from_secs(1000), Default::default());
 
         let req_labels = RequestLabels::new(&req);
         let rsp_labels = ResponseLabels::new(&rsp, None);

--- a/src/telemetry/metrics/transport.rs
+++ b/src/telemetry/metrics/transport.rs
@@ -189,7 +189,7 @@ impl fmt::Display for Key {
 impl Key {
     fn new(ctx: &ctx::transport::Ctx) -> Self {
         Self {
-            direction: Direction::from_context(ctx.proxy().as_ref()),
+            direction: Direction::new(ctx.proxy()),
             peer: match *ctx {
                 ctx::transport::Ctx::Server(_) => Peer::Src,
                 ctx::transport::Ctx::Client(_) => Peer::Dst,

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,7 +1,5 @@
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
-
-use ctx;
+use std::time::{Duration, SystemTime};
 
 macro_rules! metrics {
     { $( $name:ident : $kind:ty { $help:expr } ),+ } => {
@@ -31,12 +29,12 @@ pub use self::metrics::{DstLabels, Serve as ServeMetrics};
 pub use self::sensor::Sensors;
 
 pub fn new(
-    process: &Arc<ctx::Process>,
+    start_time: SystemTime,
     metrics_retain_idle: Duration,
     taps: &Arc<Mutex<tap::Taps>>,
 ) -> (Sensors, tls_config_reload::Sensor, ServeMetrics) {
     let (tls_config_sensor, tls_config_fmt) = tls_config_reload::new();
-    let (metrics_record, metrics_serve) = metrics::new(process, metrics_retain_idle, tls_config_fmt);
+    let (metrics_record, metrics_serve) = metrics::new(start_time, metrics_retain_idle, tls_config_fmt);
     let s = Sensors::new(metrics_record, taps);
     (s, tls_config_sensor, metrics_serve)
 }

--- a/src/telemetry/process.rs
+++ b/src/telemetry/process.rs
@@ -1,7 +1,6 @@
 use std::fmt;
-use std::time::UNIX_EPOCH;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use ctx;
 use super::metrics::Gauge;
 
 use self::system::System;
@@ -19,8 +18,8 @@ pub struct Report {
 }
 
 impl Report {
-    pub fn new(process: &ctx::Process) -> Self {
-        let t0 = process.start_time
+    pub fn new(start_time: SystemTime) -> Self {
+        let t0 = start_time
             .duration_since(UNIX_EPOCH)
             .expect("process start time")
             .as_secs();

--- a/src/telemetry/sensor/transport.rs
+++ b/src/telemetry/sensor/transport.rs
@@ -240,7 +240,7 @@ where
         let io = try_ready!(self.underlying.poll());
         debug!("client connection open");
         let ctx = ctx::transport::Client::new(
-            &self.ctx.proxy,
+            self.ctx.proxy,
             &self.ctx.remote,
             self.ctx.metadata.clone(),
             io.tls_status(),

--- a/src/transparency/server.rs
+++ b/src/transparency/server.rs
@@ -46,7 +46,7 @@ where
     >,
     listen_addr: SocketAddr,
     new_service: S,
-    proxy_ctx: Arc<ProxyCtx>,
+    proxy_ctx: ProxyCtx,
     sensors: Sensors,
     tcp: tcp::Proxy,
     log: ::logging::Server,
@@ -75,7 +75,7 @@ where
    /// Creates a new `Server`.
     pub fn new(
         listen_addr: SocketAddr,
-        proxy_ctx: Arc<ProxyCtx>,
+        proxy_ctx: ProxyCtx,
         sensors: Sensors,
         get_orig_dst: G,
         stack: S,
@@ -85,7 +85,7 @@ where
     ) -> Self {
         let recv_body_svc = HttpBodyNewSvc::new(stack.clone());
         let tcp = tcp::Proxy::new(tcp_connect_timeout, sensors.clone());
-        let log = ::logging::Server::proxy(&proxy_ctx, listen_addr);
+        let log = ::logging::Server::proxy(proxy_ctx, listen_addr);
         Server {
             disable_protocol_detection_ports,
             drain_signal,
@@ -124,7 +124,7 @@ where
         let orig_dst = connection.original_dst_addr(&self.get_orig_dst);
         let local_addr = connection.local_addr().unwrap_or(self.listen_addr);
         let srv_ctx = ServerCtx::new(
-            &self.proxy_ctx,
+            self.proxy_ctx,
             &local_addr,
             &remote_addr,
             &orig_dst,

--- a/src/transparency/tcp.rs
+++ b/src/transparency/tcp.rs
@@ -63,7 +63,7 @@ impl Proxy {
         let tls = Conditional::None(tls::ReasonForNoIdentity::NotHttp.into()); // TODO
 
         let client_ctx = ClientCtx::new(
-            &srv_ctx.proxy,
+            srv_ctx.proxy,
             &orig_dst,
             destination::Metadata::no_metadata(),
             TlsStatus::from(&tls),


### PR DESCRIPTION
In order to start dismantling the monolithic ctx structures, this change
removes the root `ctx::Process` type. This simplifies `ctx::Proxy` such
that is copyable and need not be `Arc`ed.

`telemetry::metrics::labels::Direction` has been updated to decorate
`ctx::Proxy` instead of modeling the same variants directly as an enum.