### PR TITLE
travis: Avoid caching proxy binaries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ jobs:
     - if: type = pull_request
       script: make test
       rust: stable
+      before_cache:
+        - rm -rf target/debug/linkerd2-proxy
 
     # On master, package an artifact and run tests in release mode before
     # publishing the artifact to build.l5d.io/linkerd2-proxy.
@@ -41,6 +43,8 @@ jobs:
         access_key_id: GOOGFSRIR3LDO4FFBFCAZOCN
         secret_access_key:
           secure: bd5YkL1KY0xllwN/1S1gmrtBkJcPFFwVfP79q69ghHfLupSWUPCPs2fnNi7w+N1AqzWbyIKDZlakxNaq+/q/+jrZfpCHqrM/ufrJ9lwgKRdECbVLIChPb6/wBOrFMfBD3IaRlXAEea12VLJzQ4ZOvL4pM+isKAJFC4Zm1uVTOr4f3w08vixShutU61Lmg1fIPTnBMW9CGobQSQB63OW2lOtqtZ+rVseLGB2ZY4HnfCV++XbsYYVpfSMs/8I95yUnIW8rxag9tNlt5qdNjMYB1GjRqz4I/td6PL0H8bAmIgOkdv5261R10IXua0tVbcB3/w8dlKoDOMu0xAeBqar0/8qPGLKepW2BGEoVI9a5GsXuC0IRR89a+OHBU1HZeL7y8s9oNp1T0LUkpE7V46ryaGpsEDQhHd7W77+lZ9CDMJ0agQnKJ7dlX4hrLObJaZnneMPhu1YtEU4xV53RbynFPbPTCwXzAbK+vVTCo/YbmHHIvvPGdw7hrlHDgCai7cRrk+kNPpAb8xYBobDOtCjK14PvD/CQdAGoivjsBLqg2xmB2sD06HdmDWYOTsm+6H3D/EgPXbeFoB8xiYof43S2gz+R1MqioFKYR31YlcyMkopFe7mYpAeDDXoVal3zsYi9XdbP0J7jm6/UF0yQSsDWP7GWHoIE5jaRDSb66HQW7MY=
+      before_cache:
+        - rm -rf target/release/package target/release/linkerd2-proxy
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ jobs:
   include:
     # On PRs and branches, quickly run tests in debug mode.
     - if: type = pull_request
-      script: make test
+      script:
+        - find target -type f -ls
+        - make test
       rust: stable
       before_cache:
         - rm -rf target/debug/linkerd2-proxy

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,10 @@ jobs:
     # On PRs and branches, quickly run tests in debug mode.
     - if: type = pull_request
       script:
-        - find target -type f -ls
         - make test
       rust: stable
       before_cache:
-        - rm -rf target/debug/linkerd2-proxy
+        - rm -rf target/debug/linkerd2-proxy target/release
 
     # On master, package an artifact and run tests in release mode before
     # publishing the artifact to build.l5d.io/linkerd2-proxy.
@@ -46,7 +45,7 @@ jobs:
         secret_access_key:
           secure: bd5YkL1KY0xllwN/1S1gmrtBkJcPFFwVfP79q69ghHfLupSWUPCPs2fnNi7w+N1AqzWbyIKDZlakxNaq+/q/+jrZfpCHqrM/ufrJ9lwgKRdECbVLIChPb6/wBOrFMfBD3IaRlXAEea12VLJzQ4ZOvL4pM+isKAJFC4Zm1uVTOr4f3w08vixShutU61Lmg1fIPTnBMW9CGobQSQB63OW2lOtqtZ+rVseLGB2ZY4HnfCV++XbsYYVpfSMs/8I95yUnIW8rxag9tNlt5qdNjMYB1GjRqz4I/td6PL0H8bAmIgOkdv5261R10IXua0tVbcB3/w8dlKoDOMu0xAeBqar0/8qPGLKepW2BGEoVI9a5GsXuC0IRR89a+OHBU1HZeL7y8s9oNp1T0LUkpE7V46ryaGpsEDQhHd7W77+lZ9CDMJ0agQnKJ7dlX4hrLObJaZnneMPhu1YtEU4xV53RbynFPbPTCwXzAbK+vVTCo/YbmHHIvvPGdw7hrlHDgCai7cRrk+kNPpAb8xYBobDOtCjK14PvD/CQdAGoivjsBLqg2xmB2sD06HdmDWYOTsm+6H3D/EgPXbeFoB8xiYof43S2gz+R1MqioFKYR31YlcyMkopFe7mYpAeDDXoVal3zsYi9XdbP0J7jm6/UF0yQSsDWP7GWHoIE5jaRDSb66HQW7MY=
       before_cache:
-        - rm -rf target/release/package target/release/linkerd2-proxy
+        - rm -rf target/debug target/release/package target/release/linkerd2-proxy
 
 notifications:
   email:


### PR DESCRIPTION
There's no reason that we should ever need to cache proxy binaries
between CI runs.

However, for each pull request build we appear to cache a ~125M
binary in target/debug/linkerd2-proxy.

Cache interactions seem to account for much of our CI times, so any
reduction here may be helpful.