### PR TITLE
Make telemetry::metrics::labels::DstLabels private

### DIFF
--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use std::{
     collections::HashMap,
     fmt,
@@ -24,7 +25,6 @@ use control::{
     remote_stream::Remote,
 };
 use dns::{self, IpAddrListFuture};
-use telemetry::DstLabels;
 use transport::{tls, DnsNameAndPort};
 use conditional::Conditional;
 
@@ -281,10 +281,19 @@ fn pb_to_addr_meta(
 ) -> Option<(SocketAddr, Metadata)> {
     let addr = pb.addr.and_then(pb_to_sock_addr)?;
 
-    let mut labels = set_labels.iter()
-        .chain(pb.metric_labels.iter())
-        .collect::<Vec<_>>();
-    labels.sort_by(|(k0, _), (k1, _)| k0.cmp(k1));
+    let meta = {
+        let mut t = set_labels.iter()
+            .chain(pb.metric_labels.iter())
+            .collect::<Vec<(&String, &String)>>();
+        t.sort_by(|(k0, _), (k1, _)| k0.cmp(k1));
+
+        let mut m = IndexMap::with_capacity(t.len());
+        for (k, v) in t.into_iter() {
+            m.insert(k.clone(), v.clone());
+        }
+
+        m
+    };
 
     let mut tls_identity =
         Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery);
@@ -315,11 +324,7 @@ fn pb_to_addr_meta(
         }
     }
 
-    let meta = Metadata::new(
-        DstLabels::new(labels.into_iter()),
-        proto_hint,
-        tls_identity,
-    );
+    let meta = Metadata::new(meta, proto_hint, tls_identity);
     Some((addr, meta))
 }
 

--- a/src/control/destination/endpoint.rs
+++ b/src/control/destination/endpoint.rs
@@ -1,6 +1,6 @@
+use indexmap::IndexMap;
 use std::net::SocketAddr;
 
-use telemetry::DstLabels;
 use super::{Metadata, ProtocolHint};
 use tls;
 use conditional::Conditional;
@@ -32,8 +32,8 @@ impl Endpoint {
         &self.metadata
     }
 
-    pub fn dst_labels(&self) -> Option<&DstLabels> {
-        self.metadata.dst_labels()
+    pub fn labels(&self) -> &IndexMap<String, String> {
+        self.metadata.labels()
     }
 
     pub fn can_use_orig_proto(&self) -> bool {

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -24,10 +24,10 @@
 //! - We need some means to limit the number of endpoints that can be returned for a
 //!   single resolution so that `control::Cache` is not effectively unbounded.
 
+use indexmap::IndexMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Weak};
 use std::time::Duration;
-use tls;
 
 use futures::{
     sync::mpsc,
@@ -41,7 +41,7 @@ use tower_discover::{Change, Discover};
 use tower_service::Service;
 
 use dns;
-use telemetry::DstLabels;
+use tls;
 use transport::{DnsNameAndPort, HostAndPort};
 
 pub mod background;
@@ -93,8 +93,8 @@ pub struct Resolution<B> {
 /// Metadata describing an endpoint.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Metadata {
-    /// A set of Prometheus metric labels describing the destination.
-    dst_labels: Option<DstLabels>,
+    /// Arbitrary endpoint labels. Useful for telemetry, especially.
+    labels: IndexMap<String, String>,
 
     /// A hint from the controller about what protocol (HTTP1, HTTP2, etc) the
     /// destination understands.
@@ -257,8 +257,8 @@ impl Responder {
 impl Metadata {
     /// Construct a Metadata struct representing an endpoint with no metadata.
     pub fn no_metadata() -> Self {
-        Metadata {
-            dst_labels: None,
+        Self {
+            labels: IndexMap::default(),
             protocol_hint: ProtocolHint::Unknown,
             // If we have no metadata on an endpoint, assume it does not support TLS.
             tls_identity:
@@ -267,20 +267,20 @@ impl Metadata {
     }
 
     pub fn new(
-        dst_labels: Option<DstLabels>,
+        labels: IndexMap<String, String>,
         protocol_hint: ProtocolHint,
         tls_identity: Conditional<tls::Identity, tls::ReasonForNoIdentity>
     ) -> Self {
-        Metadata {
-            dst_labels,
+        Self {
+            labels,
             protocol_hint,
             tls_identity,
         }
     }
 
     /// Returns the endpoint's labels from the destination service, if it has them.
-    pub fn dst_labels(&self) -> Option<&DstLabels> {
-        self.dst_labels.as_ref()
+    pub fn labels(&self) -> &IndexMap<String, String> {
+        &self.labels
     }
 
     pub fn protocol_hint(&self) -> ProtocolHint {

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -93,7 +93,7 @@ pub struct Resolution<B> {
 /// Metadata describing an endpoint.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Metadata {
-    /// Arbitrary endpoint labels. Useful for telemetry, especially.
+    /// Arbitrary endpoint labels. Primarily used for telemetry.
     labels: IndexMap<String, String>,
 
     /// A hint from the controller about what protocol (HTTP1, HTTP2, etc) the

--- a/src/control/pb.rs
+++ b/src/control/pb.rs
@@ -204,10 +204,8 @@ impl ctx::transport::Client {
     fn dst_meta(&self) -> tap::tap_event::EndpointMeta {
         let mut meta = tap::tap_event::EndpointMeta::default();
 
-        if let Some(ref d) = self.dst_labels() {
-            for (k, v) in d.as_map() {
-                meta.labels.insert(k.clone(), v.clone());
-            }
+        for (k, v) in self.labels() {
+            meta.labels.insert(k.clone(), v.clone());
         }
 
         meta.labels.insert("tls".to_owned(), format!("{}", self.tls_status));

--- a/src/control/pb.rs
+++ b/src/control/pb.rs
@@ -203,13 +203,8 @@ impl ctx::transport::Server {
 impl ctx::transport::Client {
     fn dst_meta(&self) -> tap::tap_event::EndpointMeta {
         let mut meta = tap::tap_event::EndpointMeta::default();
-
-        for (k, v) in self.labels() {
-            meta.labels.insert(k.clone(), v.clone());
-        }
-
+        meta.labels.extend(self.labels().clone());
         meta.labels.insert("tls".to_owned(), format!("{}", self.tls_status));
-
         meta
     }
 }

--- a/src/ctx/http.rs
+++ b/src/ctx/http.rs
@@ -1,9 +1,9 @@
+use indexmap::IndexMap;
 use http;
 use std::sync::{Arc, atomic::AtomicUsize};
+use std::sync::atomic::Ordering;
 
 use ctx;
-use telemetry::DstLabels;
-use std::sync::atomic::Ordering;
 use transport::tls;
 use conditional::Conditional;
 
@@ -91,8 +91,8 @@ impl Request {
         }
     }
 
-    pub fn dst_labels(&self) -> Option<&DstLabels> {
-        self.client.dst_labels()
+    pub fn labels(&self) -> &IndexMap<String, String> {
+        self.client.labels()
     }
 }
 
@@ -111,7 +111,7 @@ impl Response {
         self.request.tls_status()
     }
 
-    pub fn dst_labels(&self) -> Option<&DstLabels> {
-        self.request.dst_labels()
+    pub fn labels(&self) -> &IndexMap<String, String> {
+        self.request.labels()
     }
 }

--- a/src/ctx/mod.rs
+++ b/src/ctx/mod.rs
@@ -26,15 +26,14 @@ impl Proxy {
 #[cfg(test)]
 pub mod test_util {
     use http;
+    use indexmap::IndexMap;
     use std::{
-        fmt,
         net::SocketAddr,
         sync::Arc,
     };
 
     use ctx;
     use control::destination;
-    use telemetry::DstLabels;
     use tls;
     use conditional::Conditional;
 
@@ -49,18 +48,16 @@ pub mod test_util {
         ctx::transport::Server::new(proxy, &addr(), &addr(), &Some(addr()), tls)
     }
 
-    pub fn client<L, S>(
+    pub fn client(
         proxy: ctx::Proxy,
-        labels: L,
+        labels: IndexMap<String, String>,
         tls: ctx::transport::TlsStatus,
-    ) -> Arc<ctx::transport::Client>
-    where
-        L: IntoIterator<Item=(S, S)>,
-        S: fmt::Display,
-    {
-        let meta = destination::Metadata::new(DstLabels::new(labels),
+    ) -> Arc<ctx::transport::Client> {
+        let meta = destination::Metadata::new(
+            labels,
             destination::ProtocolHint::Unknown,
-            Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery));
+            Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery)
+        );
         ctx::transport::Client::new(proxy, &addr(), meta, tls)
     }
 

--- a/src/ctx/transport.rs
+++ b/src/ctx/transport.rs
@@ -1,12 +1,13 @@
+use indexmap::IndexMap;
 use std::{
     self,
     fmt,
     net::{IpAddr, SocketAddr},
     sync::Arc,
 };
+
 use ctx;
 use control::destination;
-use telemetry::DstLabels;
 use transport::tls;
 use conditional::Conditional;
 
@@ -142,10 +143,11 @@ impl Client {
         self.metadata.tls_identity()
     }
 
-    pub fn dst_labels(&self) -> Option<&DstLabels> {
-        self.metadata.dst_labels()
+    pub fn labels(&self) -> &IndexMap<String, String> {
+        self.metadata.labels()
     }
 }
+
 impl From<Arc<Client>> for Ctx {
     fn from(c: Arc<Client>) -> Self {
         Ctx::Client(c)

--- a/src/telemetry/metrics/mod.rs
+++ b/src/telemetry/metrics/mod.rs
@@ -50,7 +50,6 @@ use self::labels::{
     RequestLabels,
     ResponseLabels,
 };
-pub use self::labels::DstLabels;
 pub use self::prom::{FmtMetrics, FmtLabels, FmtMetric};
 pub use self::record::Record;
 pub use self::scopes::Scopes;
@@ -177,7 +176,7 @@ mod tests {
         server: &Arc<ctx::transport::Server>,
         team: &str
     ) {
-        let client = client(proxy, vec![("team", team)], TLS_DISABLED);
+        let client = client(proxy, indexmap!["team".into() => team.into(),], TLS_DISABLED);
         let (req, rsp) = request("http://nba.com", &server, &client);
 
         let client_transport = Arc::new(ctx::transport::Ctx::Client(client));

--- a/src/telemetry/metrics/record.rs
+++ b/src/telemetry/metrics/record.rs
@@ -109,10 +109,10 @@ mod test {
         let proxy = ctx::Proxy::Outbound;
         let server = server(proxy, server_tls);
 
-        let client = client(proxy, vec![
-            ("service", "draymond"),
-            ("deployment", "durant"),
-            ("pod", "klay"),
+        let client = client(proxy, indexmap![
+            "service".into() => "draymond".into(),
+            "deployment".into() => "durant".into(),
+            "pod".into() => "klay".into(),
         ], client_tls);
 
         let (_, rsp) = request("http://buoyant.io", &server, &client);
@@ -170,10 +170,10 @@ mod test {
         let proxy = ctx::Proxy::Outbound;
         let server = server(proxy, server_tls);
 
-        let client = client(proxy, vec![
-            ("service", "draymond"),
-            ("deployment", "durant"),
-            ("pod", "klay"),
+        let client = client(proxy, indexmap![
+            "service".into() => "draymond".into(),
+            "deployment".into() => "durant".into(),
+            "pod".into() => "klay".into(),
         ], client_tls);
 
         let (req, rsp) = request("http://buoyant.io", &server, &client);

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -25,7 +25,7 @@ pub mod tls_config_reload;
 
 use self::errno::Errno;
 pub use self::event::Event;
-pub use self::metrics::{DstLabels, Serve as ServeMetrics};
+pub use self::metrics::{Serve as ServeMetrics};
 pub use self::sensor::Sensors;
 
 pub fn new(


### PR DESCRIPTION
The `DstLabels` type has a large and undefined scope. Over time, it's
become critical in a variety of contexts, even outside of the scope of
prometheus endpoint labels.

This change makes `DstLabels` private to the
`telemetry::metrics::labels` module. This more clearly separates the
concerns of prometheus labeling from discovery, etc.

Now, destination metadata includes an index map of arbitrary metadata
labels.

Previously, dst label strings would be formatted eagerly at
service-discovery-time. This change moves this string formatting into
the data path(!). I think this is an acceptable tradeoff temporarily,
while we work to stop constructing RequestLabels in the data path
altogether.