### PR TITLE
Remove the labels::TlsStatus type

### DIFF
--- a/src/telemetry/metrics/labels.rs
+++ b/src/telemetry/metrics/labels.rs
@@ -25,7 +25,7 @@ pub struct RequestLabels {
     authority: Authority,
 
     /// Whether or not the request was made over TLS.
-    tls_status: TlsStatus,
+    tls_status: ctx::transport::TlsStatus,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -56,9 +56,6 @@ pub struct Direction(ctx::Proxy);
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct DstLabels(String);
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct TlsStatus(ctx::transport::TlsStatus);
-
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct Authority(Option<http::uri::Authority>);
 
@@ -84,12 +81,12 @@ impl RequestLabels {
             direction,
             outbound_labels,
             authority: Authority(authority),
-            tls_status: TlsStatus(req.tls_status()),
+            tls_status: req.tls_status(),
         }
     }
 
     #[cfg(test)]
-    pub fn tls_status(&self) -> TlsStatus {
+    pub fn tls_status(&self) -> ctx::transport::TlsStatus {
         self.tls_status
     }
 }
@@ -141,7 +138,7 @@ impl ResponseLabels {
     }
 
     #[cfg(test)]
-    pub fn tls_status(&self) -> TlsStatus {
+    pub fn tls_status(&self) -> ctx::transport::TlsStatus {
         self.request_labels.tls_status
     }
 }
@@ -254,43 +251,12 @@ impl FmtLabels for DstLabels {
 
 // ===== impl TlsStatus =====
 
-impl FmtLabels for TlsStatus {
+impl FmtLabels for ctx::transport::TlsStatus {
     fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.0 {
+        match *self {
             Conditional::None(tls::ReasonForNoTls::NoIdentity(why)) =>
                 write!(f, "tls=\"no_identity\",no_tls_reason=\"{}\"", why),
             status => write!(f, "tls=\"{}\"", status),
-        }
-    }
-}
-
-impl From<ctx::transport::TlsStatus> for TlsStatus {
-    fn from(tls: ctx::transport::TlsStatus) -> Self {
-        TlsStatus(tls)
-    }
-}
-
-#[cfg(test)]
-impl Into<ctx::transport::TlsStatus> for TlsStatus {
-    fn into(self) -> ctx::transport::TlsStatus {
-        self.0
-    }
-}
-
-impl fmt::Display for tls::ReasonForNoIdentity {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            tls::ReasonForNoIdentity::NotHttp => f.pad("not_http"),
-            tls::ReasonForNoIdentity::NoAuthorityInHttpRequest =>
-                f.pad("no_authority_in_http_request"),
-            tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery =>
-                f.pad("not_provided_by_service_discovery"),
-            tls::ReasonForNoIdentity::Loopback => f.pad("loopback"),
-            tls::ReasonForNoIdentity::NotConfigured => f.pad("not_configured"),
-            tls::ReasonForNoIdentity::NotImplementedForTap =>
-                f.pad("not_implemented_for_tap"),
-            tls::ReasonForNoIdentity::NotImplementedForMetrics =>
-                f.pad("not_implemented_for_metrics"),
         }
     }
 }

--- a/src/telemetry/metrics/labels.rs
+++ b/src/telemetry/metrics/labels.rs
@@ -253,7 +253,7 @@ impl FmtLabels for DstLabels {
 
 impl FmtLabels for ctx::transport::TlsStatus {
     fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             Conditional::None(tls::ReasonForNoTls::NoIdentity(why)) =>
                 write!(f, "tls=\"no_identity\",no_tls_reason=\"{}\"", why),
             status => write!(f, "tls=\"{}\"", status),

--- a/src/telemetry/metrics/record.rs
+++ b/src/telemetry/metrics/record.rs
@@ -135,7 +135,7 @@ mod test {
         let ev = Event::StreamResponseEnd(rsp.clone(), end.clone());
         let labels = labels::ResponseLabels::new(&rsp, None);
 
-        assert_eq!(labels.tls_status(), client_tls.into());
+        assert_eq!(labels.tls_status(), client_tls);
 
         assert!(r.metrics.lock()
             .expect("lock")
@@ -231,8 +231,8 @@ mod test {
         let req_labels = RequestLabels::new(&req);
         let rsp_labels = ResponseLabels::new(&rsp, None);
 
-        assert_eq!(client_tls, req_labels.tls_status().into());
-        assert_eq!(client_tls, rsp_labels.tls_status().into());
+        assert_eq!(client_tls, req_labels.tls_status());
+        assert_eq!(client_tls, rsp_labels.tls_status());
 
         {
             let mut lock = r.metrics.lock().expect("lock");

--- a/src/telemetry/metrics/transport.rs
+++ b/src/telemetry/metrics/transport.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use ctx;
 use super::{
-    labels::{Direction, TlsStatus},
+    labels::Direction,
     latency,
     prom::{FmtLabels, FmtMetrics},
     Counter,
@@ -38,7 +38,7 @@ pub struct Transports {
 struct Key {
     direction: Direction,
     peer: Peer,
-    tls_status: TlsStatus,
+    tls_status: ctx::transport::TlsStatus,
 }
 
 /// Holds all of the metrics for a class of transport.

--- a/src/transport/tls/config.rs
+++ b/src/transport/tls/config.rs
@@ -1,5 +1,6 @@
 use std::{
     self,
+    fmt,
     fs::File,
     io::{self, Cursor, Read},
     path::PathBuf,
@@ -151,6 +152,24 @@ pub enum ReasonForNoIdentity {
 impl From<ReasonForNoIdentity> for ReasonForNoTls {
     fn from(r: ReasonForNoIdentity) -> Self {
         ReasonForNoTls::NoIdentity(r)
+    }
+}
+
+impl fmt::Display for ReasonForNoIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ReasonForNoIdentity::NotHttp => f.pad("not_http"),
+            ReasonForNoIdentity::NoAuthorityInHttpRequest =>
+                f.pad("no_authority_in_http_request"),
+            ReasonForNoIdentity::NotProvidedByServiceDiscovery =>
+                f.pad("not_provided_by_service_discovery"),
+            ReasonForNoIdentity::Loopback => f.pad("loopback"),
+            ReasonForNoIdentity::NotConfigured => f.pad("not_configured"),
+            ReasonForNoIdentity::NotImplementedForTap =>
+                f.pad("not_implemented_for_tap"),
+            ReasonForNoIdentity::NotImplementedForMetrics =>
+                f.pad("not_implemented_for_metrics"),
+        }
     }
 }
 


### PR DESCRIPTION
Following #67 and #68, the `labels::TlsStatus` type can be removed in
favor of extending underlying `ctx::transport::TlsStatus` type to
implement `FmtLabels`.

No functional changes.