### PR TITLE
Split transport metrics into read and write halves

### DIFF
--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -22,6 +22,7 @@ mod process;
 pub mod sensor;
 pub mod tap;
 pub mod tls_config_reload;
+mod transport;
 
 use self::errno::Errno;
 pub use self::event::Event;
@@ -33,8 +34,10 @@ pub fn new(
     metrics_retain_idle: Duration,
     taps: &Arc<Mutex<tap::Taps>>,
 ) -> (Sensors, tls_config_reload::Sensor, ServeMetrics) {
+    let process = process::Report::new(start_time);
     let (tls_config_sensor, tls_config_fmt) = tls_config_reload::new();
-    let (metrics_record, metrics_serve) = metrics::new(start_time, metrics_retain_idle, tls_config_fmt);
-    let s = Sensors::new(metrics_record, taps);
-    (s, tls_config_sensor, metrics_serve)
+
+    let (record, serve) = metrics::new(metrics_retain_idle, process, tls_config_fmt);
+    let s = Sensors::new(record, taps);
+    (s, tls_config_sensor, serve)
 }

--- a/src/telemetry/transport/mod.rs
+++ b/src/telemetry/transport/mod.rs
@@ -6,12 +6,6 @@ use std::time::Duration;
 use ctx;
 use telemetry::Errno;
 use telemetry::metrics::{
-<<<<<<< HEAD
-||||||| parent of 17b17e5... wip
-    labels::{Direction, TlsStatus},
-=======
-    labels::TlsStatus,
->>>>>>> 17b17e5... wip
     latency,
     prom::{FmtLabels, FmtMetrics},
     Counter,
@@ -225,13 +219,7 @@ impl FmtMetrics for Report {
 
 impl FmtLabels for Key {
     fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
-<<<<<<< HEAD
         ((self.proxy, self.peer), self.tls_status).fmt_labels(f)
-||||||| parent of 17b17e5... wip
-        ((self.direction, self.peer), self.tls_status).fmt_labels(f)
-=======
-        ((direction, self.peer), self.tls_status).fmt_labels(f)
->>>>>>> 17b17e5... wip
     }
 }
 

--- a/src/telemetry/transport/mod.rs
+++ b/src/telemetry/transport/mod.rs
@@ -1,16 +1,23 @@
 use indexmap::IndexMap;
 use std::fmt;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use ctx;
-use super::{
+use telemetry::Errno;
+use telemetry::metrics::{
+<<<<<<< HEAD
+||||||| parent of 17b17e5... wip
+    labels::{Direction, TlsStatus},
+=======
+    labels::TlsStatus,
+>>>>>>> 17b17e5... wip
     latency,
     prom::{FmtLabels, FmtMetrics},
     Counter,
     Gauge,
     Histogram,
 };
-use telemetry::Errno;
 
 metrics! {
     tcp_open_total: Counter { "Total count of opened connections" },
@@ -22,13 +29,21 @@ metrics! {
     tcp_connection_duration_ms: Histogram<latency::Ms> { "Connection lifetimes" }
 }
 
-/// Holds all transport stats.
-///
-/// Implements `fmt::Display` to render prometheus-formatted metrics for all transports.
-#[derive(Debug, Default)]
-pub struct Transports {
-    metrics: IndexMap<Key, Metrics>,
+pub fn new() -> (Registry, Report) {
+    let inner = Arc::new(Mutex::new(Inner::default()));
+    (Registry(inner.clone()), Report(inner))
 }
+
+/// Implements `FmtMetrics` to render prometheus-formatted metrics for all transports.
+#[derive(Debug, Default)]
+pub struct Report(Arc<Mutex<Inner>>);
+
+/// Supports recording telemetry metrics.
+#[derive(Clone, Debug)]
+pub struct Registry(Arc<Mutex<Inner>>);
+
+#[derive(Debug, Default)]
+struct Inner(IndexMap<Key, Metrics>);
 
 /// Describes the dimensions across which transport metrics are aggregated.
 ///
@@ -69,11 +84,39 @@ struct EosMetrics {
     connection_duration: Histogram<latency::Ms>,
 }
 
-// ===== impl Transports =====
+impl Inner {
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 
-impl Transports {
+    /// Iterates over all metrics.
+    fn iter(&self) -> impl Iterator<Item = (&Key, &Metrics)> {
+        self.0.iter()
+    }
+
+    /// Iterates over all end-of-stream metrics.
+    fn iter_eos(&self) -> impl Iterator<Item = ((&Key, &Eos), &EosMetrics)> {
+        self.iter()
+            .flat_map(|(k, t)| {
+                t.by_eos.iter().map(move |(e, m)| ((k ,e), m))
+            })
+    }
+
+    fn get_or_default(&mut self, k: Key) -> &mut Metrics {
+        self.0.entry(k).or_insert_with(|| Metrics::default())
+    }
+}
+
+// ===== impl Registry =====
+
+impl Registry {
     pub fn open(&mut self, ctx: &ctx::transport::Ctx) {
-        let metrics = self.metrics.entry(Key::new(ctx)).or_insert_with(|| Default::default());
+        let mut inner = match self.0.lock() {
+            Err(_) => return,
+            Ok(lock) => lock,
+        };
+
+        let metrics = inner.get_or_default(Key::new(ctx));
         metrics.open_total.incr();
         metrics.open_connections.incr();
     }
@@ -86,30 +129,27 @@ impl Transports {
         rx: u64,
         tx: u64,
     ) {
-        let key = Key::new(ctx);
+        let mut inner = match self.0.lock() {
+            Err(_) => return,
+            Ok(lock) => lock,
+        };
 
-        let metrics = self.metrics.entry(key).or_insert_with(|| Default::default());
+        let key = Key::new(ctx);
+        let metrics = inner.get_or_default(key);
         metrics.open_connections.decr();
         metrics.read_bytes_total += rx;
         metrics.write_bytes_total += tx;
 
-        let class = metrics.by_eos.entry(eos).or_insert_with(|| Default::default());
+        let class = metrics.by_eos
+            .entry(eos)
+            .or_insert_with(|| EosMetrics::default());
         class.close_total.incr();
         class.connection_duration.add(duration);
     }
 
-    /// Iterates over all end-of-stream metrics.
-    fn iter_eos(&self) -> impl Iterator<Item = ((&Key, &Eos), &EosMetrics)> {
-        self.metrics
-            .iter()
-            .flat_map(|(k, t)| {
-                t.by_eos.iter().map(move |(e, m)| ((k ,e), m))
-            })
-    }
-
     #[cfg(test)]
     pub fn open_total(&self, ctx: &ctx::transport::Ctx) -> u64 {
-        self.metrics
+        self.0.lock().unwrap().0
             .get(&Key::new(ctx))
             .map(|m| m.open_total.into())
             .unwrap_or(0)
@@ -117,7 +157,7 @@ impl Transports {
 
     // #[cfg(test)]
     // pub fn open_connections(&self, ctx: &ctx::transport::Ctx) -> u64 {
-    //     self.metrics
+    //    self.0.lock().unwrap().0
     //         .get(&Key::new(ctx))
     //         .map(|m| m.open_connections.into())
     //         .unwrap_or(0)
@@ -125,7 +165,7 @@ impl Transports {
 
     #[cfg(test)]
     pub fn rx_tx_bytes_total(&self, ctx: &ctx::transport::Ctx) -> (u64, u64) {
-        self.metrics
+        self.0.lock().unwrap().0
             .get(&Key::new(ctx))
             .map(|m| (m.read_bytes_total.into(), m.write_bytes_total.into()))
             .unwrap_or((0, 0))
@@ -133,7 +173,7 @@ impl Transports {
 
     #[cfg(test)]
     pub fn close_total(&self, ctx: &ctx::transport::Ctx, eos: Eos) -> u64 {
-        self.metrics
+        self.0.lock().unwrap().0
             .get(&Key::new(ctx))
             .and_then(move |m| m.by_eos.get(&eos).map(|m| m.close_total.into()))
             .unwrap_or(0)
@@ -141,36 +181,41 @@ impl Transports {
 
     #[cfg(test)]
     pub fn connection_durations(&self, ctx: &ctx::transport::Ctx, eos: Eos) -> Histogram<latency::Ms> {
-        self.metrics
+        self.0.lock().unwrap().0
             .get(&Key::new(ctx))
             .and_then(move |m| m.by_eos.get(&eos).map(|m| m.connection_duration.clone()))
             .unwrap_or_default()
     }
 }
 
-impl FmtMetrics for Transports {
+impl FmtMetrics for Report {
     fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.metrics.is_empty() {
+        let metrics = match self.0.lock() {
+            Err(_) => return Ok(()),
+            Ok(lock) => lock,
+        };
+
+        if metrics.is_empty() {
             return Ok(());
         }
 
         tcp_open_total.fmt_help(f)?;
-        tcp_open_total.fmt_scopes(f, &self.metrics, |m| &m.open_total)?;
+        tcp_open_total.fmt_scopes(f, metrics.iter(), |m| &m.open_total)?;
 
         tcp_open_connections.fmt_help(f)?;
-        tcp_open_connections.fmt_scopes(f, &self.metrics, |m| &m.open_connections)?;
+        tcp_open_connections.fmt_scopes(f, metrics.iter(), |m| &m.open_connections)?;
 
         tcp_read_bytes_total.fmt_help(f)?;
-        tcp_read_bytes_total.fmt_scopes(f, &self.metrics, |m| &m.read_bytes_total)?;
+        tcp_read_bytes_total.fmt_scopes(f, metrics.iter(), |m| &m.read_bytes_total)?;
 
         tcp_write_bytes_total.fmt_help(f)?;
-        tcp_write_bytes_total.fmt_scopes(f, &self.metrics, |m| &m.write_bytes_total)?;
+        tcp_write_bytes_total.fmt_scopes(f, metrics.iter(), |m| &m.write_bytes_total)?;
 
         tcp_close_total.fmt_help(f)?;
-        tcp_close_total.fmt_scopes(f, self.iter_eos(), |e| &e.close_total)?;
+        tcp_close_total.fmt_scopes(f, metrics.iter_eos(), |e| &e.close_total)?;
 
         tcp_connection_duration_ms.fmt_help(f)?;
-        tcp_connection_duration_ms.fmt_scopes(f, self.iter_eos(), |e| &e.connection_duration)?;
+        tcp_connection_duration_ms.fmt_scopes(f, metrics.iter_eos(), |e| &e.connection_duration)?;
 
         Ok(())
     }
@@ -180,7 +225,13 @@ impl FmtMetrics for Transports {
 
 impl FmtLabels for Key {
     fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
+<<<<<<< HEAD
         ((self.proxy, self.peer), self.tls_status).fmt_labels(f)
+||||||| parent of 17b17e5... wip
+        ((self.direction, self.peer), self.tls_status).fmt_labels(f)
+=======
+        ((direction, self.peer), self.tls_status).fmt_labels(f)
+>>>>>>> 17b17e5... wip
     }
 }
 


### PR DESCRIPTION
In anticipation of removing Transport-related Event types, we want to
separate the concerns of recording transport metrics updates from
reporting them to the metrics endpoint.

The transport module has been split into `Registry` and `Report` types:
`Registry` is responsible for recording updates, and `Report` is
responsible for rendering metrics.

This has the benefit of removing transport metrics from the global metrics
lock.