### PR TITLE
Revert "travis: Avoid caching proxy binaries (#69)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@ jobs:
   include:
     # On PRs and branches, quickly run tests in debug mode.
     - if: type = pull_request
-      script:
-        - make test
+      script: make test
       rust: stable
-      before_cache:
-        - rm -rf target/debug/linkerd2-proxy target/release
 
     # On master, package an artifact and run tests in release mode before
     # publishing the artifact to build.l5d.io/linkerd2-proxy.
@@ -44,8 +41,6 @@ jobs:
         access_key_id: GOOGFSRIR3LDO4FFBFCAZOCN
         secret_access_key:
           secure: bd5YkL1KY0xllwN/1S1gmrtBkJcPFFwVfP79q69ghHfLupSWUPCPs2fnNi7w+N1AqzWbyIKDZlakxNaq+/q/+jrZfpCHqrM/ufrJ9lwgKRdECbVLIChPb6/wBOrFMfBD3IaRlXAEea12VLJzQ4ZOvL4pM+isKAJFC4Zm1uVTOr4f3w08vixShutU61Lmg1fIPTnBMW9CGobQSQB63OW2lOtqtZ+rVseLGB2ZY4HnfCV++XbsYYVpfSMs/8I95yUnIW8rxag9tNlt5qdNjMYB1GjRqz4I/td6PL0H8bAmIgOkdv5261R10IXua0tVbcB3/w8dlKoDOMu0xAeBqar0/8qPGLKepW2BGEoVI9a5GsXuC0IRR89a+OHBU1HZeL7y8s9oNp1T0LUkpE7V46ryaGpsEDQhHd7W77+lZ9CDMJ0agQnKJ7dlX4hrLObJaZnneMPhu1YtEU4xV53RbynFPbPTCwXzAbK+vVTCo/YbmHHIvvPGdw7hrlHDgCai7cRrk+kNPpAb8xYBobDOtCjK14PvD/CQdAGoivjsBLqg2xmB2sD06HdmDWYOTsm+6H3D/EgPXbeFoB8xiYof43S2gz+R1MqioFKYR31YlcyMkopFe7mYpAeDDXoVal3zsYi9XdbP0J7jm6/UF0yQSsDWP7GWHoIE5jaRDSb66HQW7MY=
-      before_cache:
-        - rm -rf target/debug target/release/package target/release/linkerd2-proxy
 
 notifications:
   email:


### PR DESCRIPTION
This reverts commit c64d7aa0e5601228786ca5e968710a68cc62afbd.

The CI change introduced in #69 appears to break the master build.