### PR TITLE
Reorder endpoint-specific HTTP middlewares

### DIFF
--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -208,10 +208,10 @@ where
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
     type Key = SocketAddr;
-    type Request = http::Request<B>;
-    type Response = bind::HttpResponse;
+    type Request = <Self::Service as tower::Service>::Request;
+    type Response = <Self::Service as tower::Service>::Response;
     type Error = <Self::Service as tower::Service>::Error;
-    type Service = bind::Service<B>;
+    type Service = bind::BoundService<B>;
     type DiscoverError = BindError;
 
     fn poll(&mut self) -> Poll<Change<Self::Key, Self::Service>, Self::DiscoverError> {

--- a/src/svc/mod.rs
+++ b/src/svc/mod.rs
@@ -21,7 +21,11 @@
 //!
 //! * Move HTTP-specific service infrastructure into `svc::http`.
 
-pub use tower_service::Service;
+pub use tower_service::{NewService, Service};
+
+mod reconnect;
+
+pub use self::reconnect::Reconnect;
 
 pub trait NewClient {
 

--- a/src/svc/reconnect.rs
+++ b/src/svc/reconnect.rs
@@ -1,0 +1,122 @@
+use std::fmt;
+
+use futures::{task, Async, Future, Poll};
+use tower_reconnect;
+
+use super::{NewService, Service};
+
+/// Wraps `tower_reconnect`, handling errors.
+///
+/// Ensures that the underlying service is ready and, if the underlying service
+/// fails to become ready, rebuilds the inner stack.
+pub struct Reconnect<T, N>
+where
+    T: fmt::Debug,
+    N: NewService,
+{
+    inner: tower_reconnect::Reconnect<N>,
+
+    /// The target, used for debug logging.
+    target: T,
+
+    /// Prevents logging repeated connect errors.
+    ///
+    /// Set back to false after a connect succeeds, to log about future errors.
+    mute_connect_error_log: bool,
+}
+
+pub struct ResponseFuture<N: NewService> {
+    inner: <tower_reconnect::Reconnect<N> as Service>::Future,
+}
+
+// ===== impl Reconnect =====
+
+impl<T, N> Reconnect<T, N>
+where
+    T: fmt::Debug,
+    N: NewService,
+    N::InitError: fmt::Display,
+{
+    pub fn new(target: T, new_service: N) -> Self {
+        let inner = tower_reconnect::Reconnect::new(new_service);
+        Self {
+            target,
+            inner,
+            mute_connect_error_log: false,
+        }
+    }
+}
+
+impl<T, N> Service for Reconnect<T, N>
+where
+    T: fmt::Debug,
+    N: NewService,
+    N::InitError: fmt::Display,
+{
+    type Request = N::Request;
+    type Response = N::Response;
+    type Error = N::Error;
+    type Future = ResponseFuture<N>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        match self.inner.poll_ready() {
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Ok(ready) => {
+                trace!("poll_ready: ready for business");
+                self.mute_connect_error_log = false;
+                Ok(ready)
+            }
+
+            Err(tower_reconnect::Error::Inner(err)) => {
+                trace!("poll_ready: inner error, debouncing");
+                self.mute_connect_error_log = false;
+                Err(err)
+            }
+
+            Err(tower_reconnect::Error::Connect(err)) => {
+                // A connection could not be established to the target.
+
+                // This is only logged as a warning at most once. Subsequent
+                // errors are logged at debug.
+                if !self.mute_connect_error_log {
+                    self.mute_connect_error_log = true;
+                    warn!("connect error to {:?}: {}", self.target, err);
+                } else {
+                    debug!("connect error to {:?}: {}", self.target, err);
+                }
+
+                // The inner service is now idle and will renew its internal
+                // state on the next poll. Instead of doing this immediately,
+                // the task is scheduled to be polled again only if the caller
+                // decides not to drop it.
+                //
+                // This prevents busy-looping when the connect error is
+                // instantaneous.
+                task::current().notify();
+                Ok(Async::NotReady)
+            }
+
+            Err(tower_reconnect::Error::NotReady) => {
+                unreachable!("poll_ready can't fail with NotReady");
+            }
+        }
+    }
+
+    fn call(&mut self, request: Self::Request) -> Self::Future {
+        ResponseFuture {
+            inner: self.inner.call(request),
+        }
+    }
+}
+
+impl<N: NewService> Future for ResponseFuture<N> {
+    type Item = N::Response;
+    type Error = N::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.inner.poll().map_err(|e| match e {
+            tower_reconnect::Error::Inner(err) => err,
+            _ => unreachable!("response future must fail with inner error"),
+        })
+    }
+}


### PR DESCRIPTION
Currently, the layered service implementations that comprise the HTTP
stack are a mix of `Service` and `NewService` types. In the
endpoint-specific stack. `transparency::Client` is the only layer that
actually needs to be a `NewService` if it is wrapped immediately with a
`Reconnect`.

This allows us to remove several `NewService` implementations.

This extracts a new `svc::Reconnect` middleware from `bind`, handling
connection error logging and hiding `tower_reconnect::Error` from outer
layers.

Furthermore, two HTTP/1-specific middlewares have been moved outside of
the TLS rebinding layer, since they are not dependent on TLS
configuration.

Finally, `bind`'s type aliases have been simplified, removing the
`HttpRequest` and `HttpResponse` aliases. By removing these, and
removing `transparency::Client`'s dependency on the telemetry body
types, it should be easier to change type signatures going forward.