### PR TITLE
Split proxy infrastructure from `bind`

### DIFF
--- a/src/bind.rs
+++ b/src/bind.rs
@@ -5,30 +5,31 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use futures::Poll;
-use http::{self, uri};
-use tower_service as tower;
 use tower_h2;
 
 use control::destination::Endpoint;
 use ctx;
-use svc::{MakeClient, Reconnect};
 use telemetry;
 use proxy;
+use proxy::http::Dialect;
+use svc;
 use transport;
 use tls;
 use ctx::transport::TlsStatus;
 use watch_service::{WatchService, Rebind};
 
 /// An HTTP `Service` that is created for each `Endpoint` and `Protocol`.
-pub type Stack<B> = proxy::http::orig_proto::Upgrade<NormalizeUri<WatchTls<B>>>;
+pub type Stack<B> = proxy::http::orig_proto::Upgrade<
+    proxy::http::NormalizeUri<WatchTls<B>>
+>;
 
 type WatchTls<B> = WatchService<tls::ConditionalClientConfig, RebindTls<B>>;
 
-/// An HTTP `Service` that is created for each `Endpoint`, `Protocol`, and client
+/// An HTTP `Service` that is created for each `Endpoint`, `Dialect`, and client
 /// TLS configuration.
 pub type TlsStack<B> = telemetry::http::service::Http<HttpService<B>, B, proxy::http::Body>;
 
-type HttpService<B> = Reconnect<
+type HttpService<B> = svc::Reconnect<
     Arc<ctx::transport::Client>,
     proxy::http::Client<
         transport::metrics::Connect<transport::Connect>,
@@ -52,10 +53,10 @@ pub struct Bind<C, B> {
     _p: PhantomData<fn() -> B>,
 }
 
-/// Binds a `Service` from a `SocketAddr` for a pre-determined protocol.
-pub struct BindProtocol<C, B> {
+/// Binds a `Service` from a `SocketAddr` for a pre-determined dialect.
+pub struct BindDialect<C, B> {
     bind: Bind<C, B>,
-    protocol: Protocol,
+    dialect: Dialect,
 }
 
 /// A bound service that can re-bind itself on demand.
@@ -74,7 +75,7 @@ where
     bind: Bind<ctx::Proxy, B>,
     binding: Binding<B>,
     endpoint: Endpoint,
-    protocol: Protocol,
+    dialect: Dialect,
 }
 
 /// A type of service binding.
@@ -98,56 +99,9 @@ where
     },
 }
 
-/// Protocol portion of the `Recognize` key for a request.
-///
-/// This marks whether to use HTTP/2 or HTTP/1.x for a request. In
-/// the case of HTTP/1.x requests, it also stores a "host" key to ensure
-/// that each host receives its own connection.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Protocol {
-    Http1 {
-        host: Host,
-        /// Whether the request wants to use HTTP/1.1's Upgrade mechanism.
-        ///
-        /// Since these cannot be translated into orig-proto, it must be
-        /// tracked here so as to allow those with `is_h1_upgrade: true` to
-        /// use an explicitly HTTP/1 service, instead of one that might
-        /// utilize orig-proto.
-        is_h1_upgrade: bool,
-        /// Whether or not the request URI was in absolute form.
-        ///
-        /// This is used to configure Hyper's behaviour at the connection
-        /// level, so it's necessary that requests with and without
-        /// absolute URIs be bound to separate service stacks. It is also
-        /// used to determine what URI normalization will be necessary.
-        was_absolute_form: bool,
-    },
-    Http2
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Host {
-    Authority(uri::Authority),
-    NoAuthority,
-}
-
-/// Rewrites HTTP/1.x requests so that their URIs are in a canonical form.
-///
-/// The following transformations are applied:
-/// - If an absolute-form URI is received, it must replace
-///   the host header (in accordance with RFC7230#section-5.4)
-/// - If the request URI is not in absolute form, it is rewritten to contain
-///   the authority given in the `Host:` header, or, failing that, from the
-///   request's original destination according to `SO_ORIGINAL_DST`.
-#[derive(Copy, Clone, Debug)]
-pub struct NormalizeUri<S> {
-    inner: S,
-    was_absolute_form: bool,
-}
-
 pub struct RebindTls<B> {
     bind: Bind<ctx::Proxy, B>,
-    protocol: Protocol,
+    dialect: Dialect,
     endpoint: Endpoint,
 }
 
@@ -223,20 +177,20 @@ where
     /// Binds the innermost layers of the stack with a TLS configuration.
     ///
     /// A reconnecting HTTP client is established with the given endpont,
-    /// protocol, and TLS configuration.
+    /// dialect, and TLS configuration.
     ///
     /// This client is instrumented with metrics.
     fn bind_with_tls(
         &self,
         ep: &Endpoint,
-        protocol: &Protocol,
+        dialect: &Dialect,
         tls_client_config: &tls::ConditionalClientConfig,
     ) -> TlsStack<B> {
-        debug!("bind_with_tls endpoint={:?}, protocol={:?}", ep, protocol);
+        debug!("bind_with_tls endpoint={:?}, dialect={:?}", ep, dialect);
         let addr = ep.address();
 
         let log = ::logging::Client::proxy(self.ctx, addr)
-            .with_protocol(protocol.clone());
+            .with_dialect(dialect.clone());
 
         let tls = ep.tls_identity().and_then(|identity| {
             tls_client_config.as_ref().map(|config| {
@@ -261,59 +215,57 @@ where
         // TODO: Add some sort of backoff logic between reconnects.
         self.sensors.http(
             client_ctx.clone(),
-            Reconnect::new(
+            svc::Reconnect::new(
                 client_ctx.clone(),
-                proxy::http::Client::new(protocol, connect, log.executor())
+                proxy::http::Client::new(dialect, connect, log.executor())
             )
         )
    }
 
-    /// Build a `Service` for the given endpoint and `Protocol`.
+    /// Build a `Service` for the given endpoint and `Dialect`.
     ///
     /// The service attempts to upgrade HTTP/1 requests to HTTP/2 (if it's known
     /// with prior knowledge that the endpoint supports HTTP/2).
     ///
     /// As `tls_client_config` updates, `bind_with_tls` is called to rebuild the
     /// client with the appropriate TLS configuraiton.
-    fn bind_stack(&self, ep: &Endpoint, protocol: &Protocol) -> Stack<B> {
-        debug!("bind_stack: endpoint={:?}, protocol={:?}", ep, protocol);
+    fn bind_stack(&self, ep: &Endpoint, dialect: &Dialect) -> Stack<B> {
+        debug!("bind_stack: endpoint={:?}, dialect={:?}", ep, dialect);
         let rebind = RebindTls {
             bind: self.clone(),
             endpoint: ep.clone(),
-            protocol: protocol.clone(),
+            dialect: dialect.clone(),
         };
         let watch_tls = WatchService::new(self.tls_client_config.clone(), rebind);
 
         // HTTP/1.1 middlewares
         //
-        // TODO make this conditional based on `protocol`
+        // TODO make this conditional based on `dialect`
         // TODO extract HTTP/1 rebinding logic up here
 
         // Rewrite the HTTP/1 URI, if the authorities in the Host header
         // and request URI are not in agreement, or are not present.
-        //
-        // TODO move this into proxy::Client?
-        let normalize_uri = NormalizeUri::new(watch_tls, protocol.was_absolute_form());
+        let normalize_uri = proxy::http::NormalizeUri::new(watch_tls, dialect.was_absolute_form());
 
         // Upgrade HTTP/1.1 requests to be HTTP/2 if the endpoint supports HTTP/2.
-        proxy::http::orig_proto::Upgrade::new(normalize_uri, protocol.is_http2())
+        proxy::http::orig_proto::Upgrade::new(normalize_uri, dialect.is_http2())
     }
 
-    pub fn bind_service(&self, ep: &Endpoint, protocol: &Protocol) -> BoundService<B> {
+    pub fn bind_service(&self, ep: &Endpoint, dialect: &Dialect) -> BoundService<B> {
         // If the endpoint is another instance of this proxy, AND the usage
         // of HTTP/1.1 Upgrades are not needed, then bind to an HTTP2 service
         // instead.
         //
         // The related `orig_proto` middleware will automatically translate
-        // if the protocol was originally HTTP/1.
-        let protocol = if ep.can_use_orig_proto() && !protocol.is_h1_upgrade() {
-            &Protocol::Http2
+        // if the dialect was originally HTTP/1.
+        let dialect = if ep.can_use_orig_proto() && !dialect.is_h1_upgrade() {
+            &Dialect::Http2
         } else {
-            protocol
+            dialect
         };
 
-        let binding = if protocol.can_reuse_clients() {
-            Binding::Bound(self.bind_stack(ep, protocol))
+        let binding = if dialect.can_reuse_clients() {
+            Binding::Bound(self.bind_stack(ep, dialect))
         } else {
             Binding::BindsPerRequest {
                 next: None
@@ -324,26 +276,26 @@ where
             bind: self.clone(),
             binding,
             endpoint: ep.clone(),
-            protocol: protocol.clone(),
+            dialect: dialect.clone(),
         }
     }
 }
 
-// ===== impl BindProtocol =====
+// ===== impl BindDialect =====
 
 
 impl<C, B> Bind<C, B> {
-    pub fn with_protocol(self, protocol: Protocol)
-        -> BindProtocol<C, B>
+    pub fn with_dialect(self, dialect: Dialect)
+        -> BindDialect<C, B>
     {
-        BindProtocol {
+        BindDialect {
             bind: self,
-            protocol,
+            dialect,
         }
     }
 }
 
-impl<B> MakeClient<Endpoint> for BindProtocol<ctx::Proxy, B>
+impl<B> svc::MakeClient<Endpoint> for BindDialect<ctx::Proxy, B>
 where
     B: tower_h2::Body + Send + 'static,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
@@ -352,54 +304,21 @@ where
     type Client = BoundService<B>;
 
     fn make_client(&self, ep: &Endpoint) -> Result<Self::Client, ()> {
-        Ok(self.bind.bind_service(ep, &self.protocol))
+        Ok(self.bind.bind_service(ep, &self.dialect))
     }
 }
 
-
-// ===== impl NormalizeUri =====
-
-impl<S> NormalizeUri<S> {
-    fn new(inner: S, was_absolute_form: bool) -> Self {
-        Self { inner, was_absolute_form }
-    }
-}
-
-impl<S, B> tower::Service for NormalizeUri<S>
-where
-    S: tower::Service<Request = http::Request<B>>,
-{
-    type Request = S::Request;
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
-
-    fn poll_ready(&mut self) -> Poll<(), S::Error> {
-        self.inner.poll_ready()
-    }
-
-    fn call(&mut self, mut request: S::Request) -> Self::Future {
-        if request.version() != http::Version::HTTP_2 &&
-            // Skip normalizing the URI if it was received in
-            // absolute form.
-            !self.was_absolute_form
-        {
-            proxy::http::h1::normalize_our_view_of_uri(&mut request);
-        }
-        self.inner.call(request)
-    }
-}
 // ===== impl Binding =====
 
-impl<B> tower::Service for BoundService<B>
+impl<B> svc::Service for BoundService<B>
 where
     B: tower_h2::Body + Send + 'static,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
 {
-    type Request = <Stack<B> as tower::Service>::Request;
-    type Response = <Stack<B> as tower::Service>::Response;
-    type Error = <Stack<B> as tower::Service>::Error;
-    type Future = <Stack<B> as tower::Service>::Future;
+    type Request = <Stack<B> as svc::Service>::Request;
+    type Response = <Stack<B> as svc::Service>::Response;
+    type Error = <Stack<B> as svc::Service>::Error;
+    type Future = <Stack<B> as svc::Service>::Future;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         match self.binding {
@@ -414,7 +333,7 @@ where
             // checked. Store it so it can be consumed to dispatch the next request.
             Binding::BindsPerRequest { ref mut next } => {
                 trace!("poll_ready: binding stack");
-                let mut svc = self.bind.bind_stack(&self.endpoint, &self.protocol);
+                let mut svc = self.bind.bind_stack(&self.endpoint, &self.dialect);
                 let ready = svc.poll_ready();
                 *next = Some(svc);
                 ready
@@ -432,76 +351,6 @@ where
         }
     }
 }
-
-// ===== impl Protocol =====
-
-
-impl Protocol {
-    pub fn detect<B>(req: &http::Request<B>) -> Self {
-        if req.version() == http::Version::HTTP_2 {
-            return Protocol::Http2;
-        }
-
-        let was_absolute_form = proxy::http::h1::is_absolute_form(req.uri());
-        trace!(
-            "Protocol::detect(); req.uri='{:?}'; was_absolute_form={:?};",
-            req.uri(), was_absolute_form
-        );
-        // If the request has an authority part, use that as the host part of
-        // the key for an HTTP/1.x request.
-        let host = Host::detect(req);
-
-        let is_h1_upgrade = proxy::http::h1::wants_upgrade(req);
-
-        Protocol::Http1 {
-            host,
-            is_h1_upgrade,
-            was_absolute_form,
-        }
-    }
-
-    /// Returns true if the request was originally received in absolute form.
-    pub fn was_absolute_form(&self) -> bool {
-        match self {
-            &Protocol::Http1 { was_absolute_form, .. } => was_absolute_form,
-            _ => false,
-        }
-    }
-
-    pub fn can_reuse_clients(&self) -> bool {
-        match *self {
-            Protocol::Http2 | Protocol::Http1 { host: Host::Authority(_), .. } => true,
-            _ => false,
-        }
-    }
-
-    pub fn is_h1_upgrade(&self) -> bool {
-        match *self {
-            Protocol::Http1 { is_h1_upgrade: true, .. } => true,
-            _ => false,
-        }
-    }
-
-    pub fn is_http2(&self) -> bool {
-        match *self {
-            Protocol::Http2 => true,
-            _ => false,
-        }
-    }
-}
-
-impl Host {
-    pub fn detect<B>(req: &http::Request<B>) -> Host {
-        req
-            .uri()
-            .authority_part()
-            .cloned()
-            .or_else(|| proxy::http::h1::authority_from_host(req))
-            .map(Host::Authority)
-            .unwrap_or_else(|| Host::NoAuthority)
-    }
-}
-
 // ===== impl RebindTls =====
 
 impl<B> Rebind<tls::ConditionalClientConfig> for RebindTls<B>
@@ -513,8 +362,8 @@ where
     fn rebind(&mut self, tls: &tls::ConditionalClientConfig) -> Self::Service {
         debug!(
             "rebinding endpoint stack for {:?}:{:?} on TLS config change",
-            self.endpoint, self.protocol,
+            self.endpoint, self.dialect,
         );
-        self.bind.bind_with_tls(&self.endpoint, &self.protocol, tls)
+        self.bind.bind_with_tls(&self.endpoint, &self.dialect, tls)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ use bind::Bind;
 use conditional::Conditional;
 use inbound::Inbound;
 use task::MainRuntime;
-use proxy::http::router::{Router, Recognize};
+use proxy::http::router::{self, Router, Recognize};
 use svc::Layer;
 use telemetry::http::timestamp_request_open;
 use transport::{BoundPort, Connection};
@@ -428,8 +428,6 @@ where
     Router<R>: Send,
     G: GetOriginalDst + Send + 'static,
 {
-
-
     // Install the request open timestamp module at the very top of the
     // stack, in order to take the timestamp as close as possible to the
     // beginning of the request's lifetime.
@@ -437,7 +435,7 @@ where
     // TODO replace with a metrics module that is registered to the server
     // transport.
     let stack = timestamp_request_open::Layer::new()
-        .bind(proxy::http::router::Make::new(router));
+        .bind(router::Make::new(router));
 
     let listen_addr = bound_port.local_addr();
     let server = proxy::Server::new(

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -222,7 +222,7 @@ pub struct Client<C: fmt::Display, D: fmt::Display> {
     section: Section,
     client: C,
     dst: D,
-    protocol: Option<::bind::Protocol>,
+    dialect: Option<::proxy::http::Dialect>,
     remote: Option<SocketAddr>,
 }
 
@@ -255,7 +255,7 @@ impl Section {
             section: *self,
             client,
             dst,
-            protocol: None,
+            dialect: None,
             remote: None,
         }
     }
@@ -313,9 +313,9 @@ impl<D: fmt::Display> Client<&'static str, D> {
 }
 
 impl<C: fmt::Display, D: fmt::Display> Client<C, D> {
-    pub fn with_protocol(self, p: ::bind::Protocol) -> Self {
+    pub fn with_dialect(self, p: ::proxy::http::Dialect) -> Self {
         Self {
-            protocol: Some(p),
+            dialect: Some(p),
             .. self
         }
     }
@@ -335,7 +335,7 @@ impl<C: fmt::Display, D: fmt::Display> Client<C, D> {
 impl<C: fmt::Display, D: fmt::Display> fmt::Display for Client<C, D> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}={{client={} dst={}", self.section, self.client, self.dst)?;
-        if let Some(ref proto) = self.protocol {
+        if let Some(ref proto) = self.dialect {
             write!(f, " proto={:?}", proto)?;
         }
         if let Some(remote) = self.remote {

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -13,20 +13,19 @@ use tower_in_flight_limit::InFlightLimit;
 use tower_h2;
 use tower_h2_balance::{PendingUntilFirstData, PendingUntilFirstDataBody};
 
-use bind::{self, Bind, Protocol};
+use bind;
 use control::destination::{self, Resolution};
 use ctx;
-use proxy::{self, http::h1};
-use proxy::http::router::Recognize;
+use proxy;
 use svc::MakeClient;
 use telemetry::http::service::{ResponseBody as SensorBody};
 use timeout::Timeout;
 use transport::{DnsNameAndPort, Host, HostAndPort};
 
-type BindProtocol<B> = bind::BindProtocol<ctx::Proxy, B>;
+type BindDialect<B> = bind::BindDialect<ctx::Proxy, B>;
 
 pub struct Outbound<B> {
-    bind: Bind<ctx::Proxy, B>,
+    bind: bind::Bind<ctx::Proxy, B>,
     discovery: destination::Resolver,
     bind_timeout: Duration,
 }
@@ -49,7 +48,7 @@ pub enum Destination {
 // ===== impl Outbound =====
 
 impl<B> Outbound<B> {
-    pub fn new(bind: Bind<ctx::Proxy, B>,
+    pub fn new(bind: bind::Bind<ctx::Proxy, B>,
                discovery: destination::Resolver,
                bind_timeout: Duration)
                -> Outbound<B> {
@@ -80,7 +79,7 @@ impl<B> Outbound<B> {
             .authority_part()
             .and_then(Self::normalize)
             .or_else(|| {
-                h1::authority_from_host(req)
+                proxy::http::h1::authority_from_host(req)
                     .and_then(|h| Self::normalize(&h))
             })
     }
@@ -134,7 +133,7 @@ where
     }
 }
 
-impl<B> Recognize for Outbound<B>
+impl<B> proxy::http::router::Recognize for Outbound<B>
 where
     B: tower_h2::Body + Send + 'static,
     <B::Data as ::bytes::IntoBuf>::Buf: Send,
@@ -145,7 +144,7 @@ where
         SensorBody<proxy::http::Body>,
     >>;
     type Error = <Self::Service as tower::Service>::Error;
-    type Key = (Destination, Protocol);
+    type Key = (Destination, proxy::http::Dialect);
     type RouteError = bind::BufferSpawnError;
     type Service = InFlightLimit<Timeout<Buffer<Balance<
         load::WithPeakEwma<Discovery<B>, PendingUntilFirstData>,
@@ -156,8 +155,8 @@ where
     // requests from being routed to HTTP/2 servers, and vice versa.
     fn recognize(&self, req: &Self::Request) -> Option<Self::Key> {
         let dest = Self::destination(req)?;
-        let proto = bind::Protocol::detect(req);
-        Some((dest, proto))
+        let dialect = proxy::http::Dialect::detect(req);
+        Some((dest, dialect))
     }
 
     /// Builds a dynamic, load balancing service.
@@ -168,11 +167,11 @@ where
         &self,
         key: &Self::Key,
     ) -> Result<Self::Service, Self::RouteError> {
-        let &(ref dest, ref protocol) = key;
-        debug!("building outbound {:?} client to {:?}", protocol, dest);
+        let &(ref dest, ref dialect) = key;
+        debug!("building outbound {:?} client to {:?}", dialect, dest);
 
         let resolve = {
-            let proto = self.bind.clone().with_protocol(protocol.clone());
+            let proto = self.bind.clone().with_dialect(dialect.clone());
             match *dest {
                 Destination::Name(ref authority) =>
                     Discovery::Name(self.discovery.resolve(authority, proto)),
@@ -187,7 +186,7 @@ where
         };
 
         let log = ::logging::proxy().client("out", Dst(dest.clone()))
-            .with_protocol(protocol.clone());
+            .with_dialect(dialect.clone());
         let buffer = Buffer::new(balance, &log.executor())
             .map_err(|_| bind::BufferSpawnError::Outbound)?;
 
@@ -198,8 +197,8 @@ where
 }
 
 pub enum Discovery<B> {
-    Name(Resolution<BindProtocol<B>>),
-    Addr(Option<(SocketAddr, BindProtocol<B>)>),
+    Name(Resolution<BindDialect<B>>),
+    Addr(Option<(SocketAddr, BindDialect<B>)>),
 }
 
 impl<B> Discover for Discovery<B>

--- a/src/proxy/http/dialect.rs
+++ b/src/proxy/http/dialect.rs
@@ -1,0 +1,115 @@
+use http;
+
+use proxy::http::h1;
+
+/// Describes the required HTTP "dialect".
+///
+/// This marks whether to use HTTP/2 or HTTP/1.x for a request. In
+/// the case of HTTP/1.x requests, it also stores a "host" key to ensure
+/// that each host receives its own connection.
+///
+/// TODO HTTP2 should indicate whether the requester supports PUSH_PROMISE.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Dialect {
+    Http1 {
+        host: Host,
+        /// Whether the request wants to use HTTP/1.1's Upgrade mechanism.
+        ///
+        /// Since these cannot be translated into orig-proto, it must be
+        /// tracked here so as to allow those with `is_h1_upgrade: true` to
+        /// use an explicitly HTTP/1 service, instead of one that might
+        /// utilize orig-proto.
+        is_h1_upgrade: bool,
+        /// Whether or not the request URI was in absolute form.
+        ///
+        /// This is used to configure Hyper's behaviour at the connection
+        /// level, so it's necessary that requests with and without
+        /// absolute URIs be bound to separate service stacks. It is also
+        /// used to determine what URI normalization will be necessary.
+        was_absolute_form: bool,
+    },
+    Http2,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Host {
+    Authority(http::uri::Authority),
+    NoAuthority,
+}
+
+// ===== impl Dialect =====
+
+impl Dialect {
+    pub fn detect<B>(req: &http::Request<B>) -> Self {
+        if req.version() == http::Version::HTTP_2 {
+            return Dialect::Http2;
+        }
+
+        let was_absolute_form = h1::is_absolute_form(req.uri());
+        trace!(
+            "detect; uri='{:?}'; was_absolute_form={:?};",
+            req.uri(),
+            was_absolute_form
+        );
+        // If the request has an authority part, use that as the host part of
+        // the key for an HTTP/1.x request.
+        let host = Host::detect(req);
+
+        let is_h1_upgrade = h1::wants_upgrade(req);
+
+        Dialect::Http1 {
+            host,
+            is_h1_upgrade,
+            was_absolute_form,
+        }
+    }
+
+    /// Returns true if the request was originally received in absolute form.
+    pub fn was_absolute_form(&self) -> bool {
+        match self {
+            &Dialect::Http1 {
+                was_absolute_form, ..
+            } => was_absolute_form,
+            _ => false,
+        }
+    }
+
+    pub fn can_reuse_clients(&self) -> bool {
+        match *self {
+            Dialect::Http2
+            | Dialect::Http1 {
+                host: Host::Authority(_),
+                ..
+            } => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_h1_upgrade(&self) -> bool {
+        match *self {
+            Dialect::Http1 {
+                is_h1_upgrade: true,
+                ..
+            } => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_http2(&self) -> bool {
+        match *self {
+            Dialect::Http2 => true,
+            _ => false,
+        }
+    }
+}
+
+impl Host {
+    pub fn detect<B>(req: &http::Request<B>) -> Host {
+        req.uri()
+            .authority_part()
+            .cloned()
+            .or_else(|| h1::authority_from_host(req))
+            .map(Host::Authority)
+            .unwrap_or_else(|| Host::NoAuthority)
+    }
+}

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -1,9 +1,13 @@
 pub mod client;
+pub mod dialect;
 pub(super) mod glue;
 pub mod h1;
+pub mod normalize_uri;
+pub mod orig_proto;
 pub mod router;
 pub mod upgrade;
-pub mod orig_proto;
 
 pub use self::client::{Client, Error as ClientError};
+pub use self::dialect::Dialect;
 pub use self::glue::HttpBody as Body;
+pub use self::normalize_uri::NormalizeUri;

--- a/src/proxy/http/normalize_uri.rs
+++ b/src/proxy/http/normalize_uri.rs
@@ -1,0 +1,52 @@
+use http;
+use futures::Poll;
+
+use super::h1::normalize_our_view_of_uri;
+use svc;
+
+/// Rewrites HTTP/1.x requests so that their URIs are in a canonical form.
+///
+/// The following transformations are applied:
+/// - If an absolute-form URI is received, it must replace
+///   the host header (in accordance with RFC7230#section-5.4)
+/// - If the request URI is not in absolute form, it is rewritten to contain
+///   the authority given in the `Host:` header, or, failing that, from the
+///   request's original destination according to `SO_ORIGINAL_DST`.
+#[derive(Copy, Clone, Debug)]
+pub struct NormalizeUri<S> {
+    inner: S,
+    was_absolute_form: bool,
+}
+
+// ===== impl NormalizeUri =====
+
+impl<S> NormalizeUri<S> {
+    pub fn new(inner: S, was_absolute_form: bool) -> Self {
+        Self { inner, was_absolute_form }
+    }
+}
+
+impl<S, B> svc::Service for NormalizeUri<S>
+where
+    S: svc::Service<Request = http::Request<B>>,
+{
+    type Request = S::Request;
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), S::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, mut request: S::Request) -> Self::Future {
+        if request.version() != http::Version::HTTP_2 &&
+            // Skip normalizing the URI if it was received in
+            // absolute form.
+            !self.was_absolute_form
+        {
+            normalize_our_view_of_uri(&mut request);
+        }
+        self.inner.call(request)
+    }
+}

--- a/src/proxy/http/orig_proto.rs
+++ b/src/proxy/http/orig_proto.rs
@@ -3,8 +3,7 @@ use http;
 use http::header::{TRANSFER_ENCODING, HeaderValue};
 use tower_service::Service;
 
-use bind;
-use super::h1;
+use super::{dialect::{Dialect, Host}, h1};
 
 const L5D_ORIG_PROTO: &str = "l5d-orig-proto";
 
@@ -22,15 +21,15 @@ pub struct Downgrade<S> {
     inner: S,
 }
 
-pub fn detect<B>(req: &http::Request<B>) -> bind::Protocol {
+pub fn detect<B>(req: &http::Request<B>) -> Dialect {
     if req.version() == http::Version::HTTP_2 {
         if let Some(orig_proto) = req.headers().get(L5D_ORIG_PROTO) {
             trace!("detected orig-proto: {:?}", orig_proto);
             let val = orig_proto.as_bytes();
             let was_absolute_form = was_absolute_form(val);
-            let host = bind::Host::detect(req);
+            let host = Host::detect(req);
 
-            return bind::Protocol::Http1 {
+            return Dialect::Http1 {
                 host,
                 is_h1_upgrade: false, // orig-proto is never used with upgrades
                 was_absolute_form,
@@ -38,7 +37,7 @@ pub fn detect<B>(req: &http::Request<B>) -> bind::Protocol {
         }
     }
 
-    bind::Protocol::detect(req)
+    Dialect::detect(req)
 }
 
 


### PR DESCRIPTION
The `bind` module includes core types that are used throughout the proxy
module, like `bind::Protocol`. Furthermore, this "protocol" is not really
related to the protocol detection that occurs in `proxy`.

In order to simplify `bind` and set up for further refactoring (adopting
`MakeClient`), this change reorganizes the module structure as follows:

- `bind::Protocol` is now `proxy::http::Dialect`. This change is made to
   distinguish this concept from protocol detection and, furthermore, to
   separate this logic from endpoint-construction implemented in `bind`.

- HTTP proxying utilities have been moved into the `proxy::http` module.

- `bind::NormalizeUri` is now `proxy::http::NormalizeUri`

- `proxy::h2_router` is now `proxy::http::router`