### PR TITLE
Split the `timeout` module into its own subcrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "linkerd2-metrics 0.1.0",
  "linkerd2-proxy-api 0.1.1 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.1)",
  "linkerd2-proxy-router 0.1.0",
+ "linkerd2-timeout 0.1.0",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "procinfo 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -560,6 +561,16 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
+]
+
+[[package]]
+name = "linkerd2-timeout"
+version = "0.1.0"
+dependencies = [
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
+ "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.1.0 (git+https://github.com/tower-rs/tower)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "futures-mpsc-lossy",
     "metrics",
     "router",
+    "timeout",
 ]
 
 [package]
@@ -21,6 +22,7 @@ flaky_tests = []
 futures-mpsc-lossy    = { path = "./futures-mpsc-lossy" }
 linkerd2-metrics      = { path = "./metrics" }
 linkerd2-proxy-router = { path = "./router" }
+linkerd2-timeout      = { path = "./timeout" }
 
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.1", version = "0.1.1" }
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,19 +19,21 @@ WORKDIR /usr/src/linkerd2-proxy
 #
 # Mock out all local code and fetch external dependencies to ensure that
 # external sources are primarily cached on Cargo.lock.
-RUN for d in . futures-mpsc-lossy router metrics ; \
+RUN for d in . futures-mpsc-lossy router metrics timeout ; \
     do mkdir -p "${d}/src" && touch "${d}/src/lib.rs" ; \
     done
 COPY Cargo.toml Cargo.lock          ./
 COPY futures-mpsc-lossy/Cargo.toml  futures-mpsc-lossy/Cargo.toml
-COPY router/Cargo.toml              router/Cargo.toml
 COPY metrics/Cargo.toml             metrics/Cargo.toml
+COPY router/Cargo.toml              router/Cargo.toml
+COPY timeout/Cargo.toml             timeout/Cargo.toml
 RUN cargo fetch --locked
 
 # Build libraries, leaving the proxy mocked out.
 COPY futures-mpsc-lossy futures-mpsc-lossy
 COPY router router
 COPY metrics metrics
+COPY timeout timeout
 ARG PROXY_UNOPTIMIZED
 RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
     then cargo build --frozen ; \

--- a/src/control/destination/background/client.rs
+++ b/src/control/destination/background/client.rs
@@ -20,7 +20,7 @@ use tower_reconnect::{
 };
 use conditional::Conditional;
 use dns;
-use timeout::{Timeout, TimeoutError};
+use timeout::{Timeout, Error as TimeoutError};
 use transport::{tls, HostAndPort, LookupAddressAndConnect};
 use watch_service::Rebind;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ extern crate try_lock;
 #[macro_use]
 extern crate linkerd2_metrics;
 extern crate linkerd2_proxy_api;
+extern crate linkerd2_timeout as timeout;
 
 use futures::*;
 
@@ -88,7 +89,6 @@ pub mod task;
 pub mod telemetry;
 mod proxy;
 mod transport;
-pub mod timeout;
 mod watch_service; // TODO: move to tower
 
 use bind::Bind;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -23,6 +23,7 @@ extern crate tower_service;
 extern crate log;
 pub extern crate env_logger;
 
+use std::fmt;
 pub use std::collections::HashMap;
 pub use std::net::SocketAddr;
 pub use std::time::Duration;
@@ -90,7 +91,7 @@ macro_rules! assert_eventually {
                 } else if i == $retries {
                     panic!(
                         "assertion failed after {} (retried {} times): {}",
-                        timeout::HumanDuration(start_t.elapsed()),
+                        ::support::HumanDuration(start_t.elapsed()),
                         i,
                         format_args!($($arg)+)
                     )
@@ -188,4 +189,20 @@ pub fn thread_name() -> String {
 #[should_panic]
 fn assert_eventually() {
     assert_eventually!(false)
+}
+
+/// A duration which pretty-prints as fractional seconds.
+#[derive(Copy, Clone, Debug)]
+pub struct HumanDuration(pub Duration);
+
+impl fmt::Display for HumanDuration {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let secs = self.0.as_secs();
+        let subsec_ms = self.0.subsec_nanos() as f64 / 1_000_000f64;
+        if secs == 0 {
+            write!(fmt, "{}ms", subsec_ms)
+        } else {
+            write!(fmt, "{}s", secs as f64 + subsec_ms)
+        }
+    }
 }

--- a/timeout/Cargo.toml
+++ b/timeout/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "linkerd2-timeout"
+version = "0.1.0"
+authors = ["Oliver Gould <ver@buoyant.io>"]
+
+[dependencies]
+futures = "0.1"
+tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
+tokio-timer = "0.2.4"
+tower-service = { git = "https://github.com/tower-rs/tower" }

--- a/timeout/src/lib.rs
+++ b/timeout/src/lib.rs
@@ -1,14 +1,14 @@
-// #![deny(missing_docs)]
+extern crate futures;
+extern crate tokio_connect;
+extern crate tokio_timer;
+extern crate tower_service;
+
 use futures::{Future, Poll};
-
-use std::error::Error;
-use std::{fmt, io};
-use std::time::{Duration, Instant};
-
 use tokio_connect::Connect;
-use tokio::timer::{self, Deadline, DeadlineError};
-use tokio::io::{AsyncRead, AsyncWrite};
+use tokio_timer::{self as timer, clock, Deadline, DeadlineError};
 use tower_service::Service;
+use std::{error, fmt};
+use std::time::Duration;
 
 /// A timeout that wraps an underlying operation.
 #[derive(Debug, Clone)]
@@ -20,12 +20,12 @@ pub struct Timeout<T> {
 
 /// An error representing that an operation timed out.
 #[derive(Debug)]
-pub struct TimeoutError<E> {
-    kind: TimeoutErrorKind<E>,
+pub struct Error<E> {
+    kind: ErrorKind<E>,
 }
 
 #[derive(Debug)]
-enum TimeoutErrorKind<E> {
+enum ErrorKind<E> {
     /// Indicates the underlying operation timed out.
     Timeout (Duration),
     /// Indicates that the underlying operation failed.
@@ -36,11 +36,8 @@ enum TimeoutErrorKind<E> {
 
 
 /// A duration which pretty-prints as fractional seconds.
-///
-/// This may not be the ideal display format for _all_ duration values,
-/// but should be sufficient for most timeouts.
 #[derive(Copy, Clone, Debug)]
-pub struct HumanDuration(pub Duration);
+struct HumanDuration(pub Duration);
 
 //===== impl Timeout =====
 
@@ -53,23 +50,23 @@ impl<T> Timeout<T> {
         }
     }
 
-    fn error<E>(&self, error: E) -> TimeoutError<E> {
-        TimeoutError {
-            kind: TimeoutErrorKind::Error(error),
+    fn error<E>(&self, error: E) -> Error<E> {
+        Error {
+            kind: ErrorKind::Error(error),
         }
     }
 
-    fn deadline_error<E>(&self, error: DeadlineError<E>) -> TimeoutError<E> {
+    fn deadline_error<E>(&self, error: DeadlineError<E>) -> Error<E> {
         let kind = match error {
             _ if error.is_timer() =>
-                TimeoutErrorKind::Timer(error.into_timer()
+                ErrorKind::Timer(error.into_timer()
                     .expect("error.into_timer() must succeed if error.is_timer()")),
             _ if error.is_elapsed() =>
-                TimeoutErrorKind::Timeout(self.duration),
-            _ => TimeoutErrorKind::Error(error.into_inner()
+                ErrorKind::Timeout(self.duration),
+            _ => ErrorKind::Error(error.into_inner()
                 .expect("if error is not elapsed or timer, must be inner")),
         };
-        TimeoutError { kind }
+        Error { kind }
     }
 }
 
@@ -79,7 +76,7 @@ where
 {
     type Request = S::Request;
     type Response = T;
-    type Error = TimeoutError<E>;
+    type Error = Error<E>;
     type Future = Timeout<Deadline<S::Future>>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
@@ -88,7 +85,7 @@ where
 
     fn call(&mut self, req: Self::Request) -> Self::Future {
         let duration = self.duration;
-        let deadline = Instant::now() + duration;
+        let deadline = clock::now() + duration;
         let inner = Deadline::new(self.inner.call(req), deadline);
         Timeout {
             inner,
@@ -103,11 +100,11 @@ where
     C: Connect,
 {
     type Connected = C::Connected;
-    type Error = TimeoutError<C::Error>;
+    type Error = Error<C::Error>;
     type Future = Timeout<Deadline<C::Future>>;
 
     fn connect(&self) -> Self::Future {
-        let deadline = Instant::now() + self.duration;
+        let deadline = clock::now() + self.duration;
         let inner = Deadline::new(self.inner.connect(), deadline);
         Timeout {
             inner,
@@ -122,86 +119,45 @@ where
     // F::Error: Error,
 {
     type Item = F::Item;
-    type Error = TimeoutError<F::Error>;
+    type Error = Error<F::Error>;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         self.inner.poll().map_err(|e| self.deadline_error(e))
     }
 }
 
+//===== impl Error =====
 
-impl<C> io::Read for Timeout<C>
-where
-    C: io::Read,
-{
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.inner.read(buf)
-    }
-}
-
-impl<C> io::Write for Timeout<C>
-where
-    C: io::Write,
-{
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.inner.write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.inner.flush()
-    }
-}
-
-impl<C> AsyncRead for Timeout<C>
-where
-    C: AsyncRead,
-{
-    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
-        self.inner.prepare_uninitialized_buffer(buf)
-    }
-}
-
-impl<C> AsyncWrite for Timeout<C>
-where
-    C: AsyncWrite,
-{
-    fn shutdown(&mut self) -> Poll<(), io::Error> {
-        self.inner.shutdown()
-    }
-}
-
-//===== impl TimeoutError =====
-
-impl<E> fmt::Display for TimeoutError<E>
+impl<E> fmt::Display for Error<E>
 where
     E: fmt::Display
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.kind {
-            TimeoutErrorKind::Timeout(ref d) =>
+            ErrorKind::Timeout(ref d) =>
                 write!(f, "operation timed out after {}", HumanDuration(*d)),
-            TimeoutErrorKind::Timer(ref err) => write!(f, "timer failed: {}", err),
-            TimeoutErrorKind::Error(ref err) => fmt::Display::fmt(err, f),
+            ErrorKind::Timer(ref err) => write!(f, "timer failed: {}", err),
+            ErrorKind::Error(ref err) => fmt::Display::fmt(err, f),
         }
     }
 }
 
-impl<E> Error for TimeoutError<E>
+impl<E> error::Error for Error<E>
 where
-    E: Error
+    E: error::Error
 {
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&error::Error> {
         match self.kind {
-            TimeoutErrorKind::Error(ref err) => Some(err),
-            TimeoutErrorKind::Timer(ref err) => Some(err),
+            ErrorKind::Error(ref err) => Some(err),
+            ErrorKind::Timer(ref err) => Some(err),
             _ => None,
         }
     }
 
     fn description(&self) -> &str {
         match self.kind {
-            TimeoutErrorKind::Timeout(_) => "operation timed out",
-            TimeoutErrorKind::Error(ref err) => err.description(),
-            TimeoutErrorKind::Timer(ref err) => err.description(),
+            ErrorKind::Timeout(_) => "operation timed out",
+            ErrorKind::Error(ref err) => err.description(),
+            ErrorKind::Timer(ref err) => err.description(),
         }
     }
 }


### PR DESCRIPTION
The `timeout` module has very little to do with the proxy, specifically.

This change moves it into a dedicated subcrate. This helps to clarify
dependencies and to minimize generic logic in the main proxy crate.

In doing this, an unused implementation of AsyncRead/AsyncWrite for
Timeout was deleted.

Furthermore, the `HumanDuration` type has been copied into
tests/support/mod.rs so that this type need not be part of the timeout
module's public API.