### PR TITLE
Fix linkerd2-metrics test compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "hyper 0.12.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ TEST_FLAGS =
 ifndef TEST_FLAKEY
 	TEST_FLAGS = --no-default-features
 endif
-CARGO_TEST = $(CARGO) test --frozen $(RELEASE) $(TEST_FLAGS)
+CARGO_TEST = $(CARGO) test --all --frozen $(RELEASE) $(TEST_FLAGS)
 
 DOCKER = docker
 DOCKER_BUILD = docker build

--- a/lib/metrics/Cargo.toml
+++ b/lib/metrics/Cargo.toml
@@ -15,3 +15,6 @@ http = "0.1"
 hyper = "0.12.3"
 indexmap = "1.0"
 log = "0.4"
+
+[dev-dependencies]
+quickcheck = { version = "0.6", default-features = false }

--- a/lib/metrics/src/lib.rs
+++ b/lib/metrics/src/lib.rs
@@ -7,6 +7,9 @@ extern crate http;
 extern crate hyper;
 #[macro_use]
 extern crate log;
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck;
 
 mod counter;
 mod gauge;


### PR DESCRIPTION
commit 2a99dd08bda6dc3b9eb271c1f623be50c2707350
Author: Oliver Gould <ver@buoyant.io>
Date:   Tue Sep 18 22:52:51 2018 +0000

    Fix linkerd2-metrics test compilation

    The `quickcheck` dependency was lost when the subcrate was split out.
    This change restores the dependency.

    Fixes linkerd/linker2#1685

commit 80b9fe19434f5703e9fe79bd5de578d81d49f86e (HEAD -> ver/test-fixup, origin/ver/test-fixup)
Author: Oliver Gould <ver@buoyant.io>
Date:   Tue Sep 18 22:54:03 2018 +0000

    Run tests for all packages in `make test`