### PR TITLE
Deprecate PRIVATE/PUBLIC config variables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,12 +163,12 @@ where
                     }
                 })
             });
-            BoundPort::new(config.public_listener.addr, tls)
+            BoundPort::new(config.inbound_listener.addr, tls)
                 .expect("public listener bind")
         };
 
         let outbound_listener = BoundPort::new(
-            config.private_listener.addr,
+            config.outbound_listener.addr,
             Conditional::None(tls::ReasonForNoTls::InternalTraffic))
             .expect("private listener bind");
 
@@ -233,7 +233,7 @@ where
         info!(
             "proxying on {:?} to {:?}",
             inbound_listener.local_addr(),
-            config.private_forward
+            config.inbound_forward
         );
         info!(
             "serving Prometheus metrics on {:?}",
@@ -303,7 +303,7 @@ where
         let inbound = {
             let ctx = ctx::Proxy::Inbound;
             let bind = bind.clone().with_ctx(ctx);
-            let default_addr = config.private_forward.map(|a| a.into());
+            let default_addr = config.inbound_forward.map(|a| a.into());
 
             let router = Router::new(
                 Inbound::new(default_addr, bind),
@@ -313,7 +313,7 @@ where
             serve(
                 inbound_listener,
                 router,
-                config.private_connect_timeout,
+                config.inbound_connect_timeout,
                 config.inbound_ports_disable_protocol_detection,
                 ctx,
                 transport_registry.clone(),
@@ -336,7 +336,7 @@ where
             serve(
                 outbound_listener,
                 router,
-                config.public_connect_timeout,
+                config.outbound_connect_timeout,
                 config.outbound_ports_disable_protocol_detection,
                 ctx,
                 transport_registry,

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -131,15 +131,15 @@ fn run(proxy: Proxy, mut env: config::TestEnv) -> Listening {
     let mut mock_orig_dst = DstInner::default();
 
     env.put(config::ENV_CONTROL_URL, format!("tcp://{}", controller.addr));
-    env.put(config::ENV_PRIVATE_LISTENER, "tcp://127.0.0.1:0".to_owned());
+    env.put(config::ENV_OUTBOUND_LISTENER, "tcp://127.0.0.1:0".to_owned());
     if let Some(ref inbound) = inbound {
-        env.put(config::ENV_PRIVATE_FORWARD, format!("tcp://{}", inbound.addr));
+        env.put(config::ENV_INBOUND_FORWARD, format!("tcp://{}", inbound.addr));
         mock_orig_dst.inbound_orig_addr = Some(inbound.addr);
     }
     if let Some(ref outbound) = outbound {
         mock_orig_dst.outbound_orig_addr = Some(outbound.addr);
     }
-    env.put(config::ENV_PUBLIC_LISTENER, "tcp://127.0.0.1:0".to_owned());
+    env.put(config::ENV_INBOUND_LISTENER, "tcp://127.0.0.1:0".to_owned());
     env.put(config::ENV_CONTROL_LISTENER, "tcp://127.0.0.1:0".to_owned());
     env.put(config::ENV_METRICS_LISTENER, "tcp://127.0.0.1:0".to_owned());
     env.put(config::ENV_POD_NAMESPACE, "test".to_owned());


### PR DESCRIPTION
There are a few crufty remaining references to the `private` and
`public` proxy interfaces. `private` referred to the pod-local side of
the proxy; and `public` the external side.

These terms have been replaced by `inbound` and `outbound` proxies.

The "private forward address" is now the "inbound forward address".
The "private listener" is now the "outbound listener".
The "public listener" is now the "inbound listener".

This change adds new environment variables to support configuration:
- `LINKERD2_PROXY_INBOUND_CONNECT_TIMEOUT`
- `LINKERD2_PROXY_INBOUND_FORWARD`
- `LINKERD2_PROXY_INBOUND_LISTENER`
- `LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT`
- `LINKERD2_PROXY_OUTBOUND_LISTENER`

The old configuration variables have not been removed. Instead, a
warning is logged when such a variable is used to configure the proxy.