### PR TITLE
Decouple reconnect & connect layers from proxy::http::client

### DIFF
--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -6,13 +6,12 @@ pub mod buffer;
 pub mod http;
 pub mod limit;
 mod protocol;
-mod reconnect;
+pub mod reconnect;
 pub mod resolve;
 pub mod server;
 mod tcp;
 pub mod timeout;
 
-pub use self::reconnect::Reconnect;
 pub use self::resolve::{Resolve, Resolution};
 pub use self::server::{Server, Source};
 

--- a/src/proxy/reconnect.rs
+++ b/src/proxy/reconnect.rs
@@ -1,15 +1,26 @@
-use std::fmt;
-
 use futures::{task, Async, Future, Poll};
+use std::fmt;
+use std::marker::PhantomData;
 use tower_reconnect;
 
 use svc;
+
+#[derive(Debug)]
+pub struct Layer<T, M> {
+    _p: PhantomData<fn() -> (T, M)>,
+}
+
+#[derive(Debug)]
+pub struct Stack<T, M> {
+    inner: M,
+    _p: PhantomData<fn() -> T>,
+}
 
 /// Wraps `tower_reconnect`, handling errors.
 ///
 /// Ensures that the underlying service is ready and, if the underlying service
 /// fails to become ready, rebuilds the inner stack.
-pub struct Reconnect<T, N>
+pub struct Service<T, N>
 where
     T: fmt::Debug,
     N: svc::NewService,
@@ -29,26 +40,80 @@ pub struct ResponseFuture<N: svc::NewService> {
     inner: <tower_reconnect::Reconnect<N> as svc::Service>::Future,
 }
 
-// ===== impl Reconnect =====
+// === impl Layer ===
 
-
-impl<T, N> Reconnect<T, N>
+impl<T, M> Layer<T, M>
 where
     T: fmt::Debug,
-    N: svc::NewService,
-    N::InitError: fmt::Display,
+    M: svc::Stack<T>,
+    M::Value: svc::NewService,
 {
-    pub fn new(target: T, new_service: N) -> Self {
-        let inner = tower_reconnect::Reconnect::new(new_service);
+    pub fn new() -> Self {
         Self {
-            target,
-            inner,
-            mute_connect_error_log: false,
+            _p: PhantomData,
         }
     }
 }
 
-impl<T, N> svc::Service for Reconnect<T, N>
+impl<T, M> Clone for Layer<T, M> {
+    fn clone(&self) -> Self {
+        Self {
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T, M> svc::Layer<T, T, M> for Layer<T, M>
+where
+    T: Clone + fmt::Debug,
+    M: svc::Stack<T>,
+    M::Value: svc::NewService,
+{
+    type Value = <Stack<T, M> as svc::Stack<T>>::Value;
+    type Error = <Stack<T, M> as svc::Stack<T>>::Error;
+    type Stack = Stack<T, M>;
+
+    fn bind(&self, inner: M) -> Self::Stack {
+        Stack {
+            inner,
+            _p: PhantomData,
+        }
+    }
+}
+
+// === impl Stack ===
+
+impl<T, M: Clone> Clone for Stack<T, M> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T, M> svc::Stack<T> for Stack<T, M>
+where
+    T: Clone + fmt::Debug,
+    M: svc::Stack<T>,
+    M::Value: svc::NewService,
+{
+    type Value = Service<T, M::Value>;
+    type Error = M::Error;
+
+    fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
+        let new_service = self.inner.make(target)?;
+        Ok(Service {
+            inner: tower_reconnect::Reconnect::new(new_service),
+            target: target.clone(),
+            mute_connect_error_log: false,
+        })
+    }
+}
+
+// === impl Service ===
+
+impl<T, N> svc::Service for Service<T, N>
 where
     T: fmt::Debug,
     N: svc::NewService,
@@ -63,13 +128,11 @@ where
         match self.inner.poll_ready() {
             Ok(Async::NotReady) => Ok(Async::NotReady),
             Ok(ready) => {
-                trace!("poll_ready: ready for business");
                 self.mute_connect_error_log = false;
                 Ok(ready)
             }
 
             Err(tower_reconnect::Error::Inner(err)) => {
-                trace!("poll_ready: inner error, debouncing");
                 self.mute_connect_error_log = false;
                 Err(err)
             }
@@ -110,7 +173,7 @@ where
     }
 }
 
-impl<T: fmt::Debug, N: svc::NewService> fmt::Debug for Reconnect<T, N> {
+impl<T: fmt::Debug, N: svc::NewService> fmt::Debug for Service<T, N> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Reconnect")
             .field("target", &self.target)


### PR DESCRIPTION
Previously, the `client` module was responsible for instrument reconnects. Now, the reconnect module becomes its own stack layer that composes over NewService stacks.

Additionally, the `proxy::http::client` module can now layer over an underlying Connect stack.

---
This sets up the controller client to become a Stack.