### PR TITLE
refactor: Build stacks from bottom-to-top

### DIFF
--- a/lib/stack/src/either.rs
+++ b/lib/stack/src/either.rs
@@ -4,7 +4,7 @@ use futures::Poll;
 use svc;
 
 /// Describes two alternate `Layer`s, `Stacks`s or `Service`s.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Either<A, B> {
     A(A),
     B(B),

--- a/lib/stack/src/map_err.rs
+++ b/lib/stack/src/map_err.rs
@@ -1,0 +1,72 @@
+pub fn layer<E, M>(map_err: M) -> Layer<M>
+where
+    M: MapErr<E>,
+{
+    Layer(map_err)
+}
+
+pub(super) fn stack<T, S, M>(inner: S, map_err: M) -> Stack<S, M>
+where
+    S: super::Stack<T>,
+    M: MapErr<S::Error>,
+{
+    Stack {
+        inner,
+        map_err,
+    }
+}
+
+pub trait MapErr<Input> {
+    type Output;
+
+    fn map_err(&self, e: Input) -> Self::Output;
+}
+
+#[derive(Clone, Debug)]
+pub struct Layer<M>(M);
+
+#[derive(Clone, Debug)]
+pub struct Stack<S, M> {
+    inner: S,
+    map_err: M,
+}
+
+impl<T, S, M> super::Layer<T, T, S> for Layer<M>
+where
+    S: super::Stack<T>,
+    M: MapErr<S::Error> + Clone,
+{
+    type Value = <Stack<S, M> as super::Stack<T>>::Value;
+    type Error = <Stack<S, M> as super::Stack<T>>::Error;
+    type Stack = Stack<S, M>;
+
+    fn bind(&self, inner: S) -> Self::Stack {
+        Stack {
+            inner,
+            map_err: self.0.clone(),
+        }
+    }
+}
+
+impl<T, S, M> super::Stack<T> for Stack<S, M>
+where
+    S: super::Stack<T>,
+    M: MapErr<S::Error>,
+{
+    type Value = S::Value;
+    type Error = M::Output;
+
+    fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
+        self.inner.make(target).map_err(|e| self.map_err.map_err(e))
+    }
+}
+
+impl<F, I, O> MapErr<I> for F
+where
+    F: Fn(I) -> O,
+{
+    type Output = O;
+    fn map_err(&self, i: I) -> O {
+        (self)(i)
+    }
+}

--- a/lib/stack/src/map_target.rs
+++ b/lib/stack/src/map_target.rs
@@ -1,0 +1,62 @@
+
+pub fn layer<T, M>(map_target: M) -> Layer<M>
+where
+    M: MapTarget<T>,
+{
+    Layer(map_target)
+}
+
+pub trait MapTarget<T> {
+    type Target;
+
+    fn map_target(&self, t: &T) -> Self::Target;
+}
+
+#[derive(Clone, Debug)]
+pub struct Layer<M>(M);
+
+#[derive(Clone, Debug)]
+pub struct Stack<S, M> {
+    inner: S,
+    map_target: M,
+}
+
+impl<T, S, M> super::Layer<T, M::Target, S> for Layer<M>
+where
+    S: super::Stack<M::Target>,
+    M: MapTarget<T> + Clone,
+{
+    type Value = <Stack<S, M> as super::Stack<T>>::Value;
+    type Error = <Stack<S, M> as super::Stack<T>>::Error;
+    type Stack = Stack<S, M>;
+
+    fn bind(&self, inner: S) -> Self::Stack {
+        Stack {
+            inner,
+            map_target: self.0.clone(),
+        }
+    }
+}
+
+impl<T, S, M> super::Stack<T> for Stack<S, M>
+where
+    S: super::Stack<M::Target>,
+    M: MapTarget<T>,
+{
+    type Value = S::Value;
+    type Error = S::Error;
+
+    fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
+        self.inner.make(&self.map_target.map_target(target))
+    }
+}
+
+impl<F, T, U> MapTarget<T> for F
+where
+    F: Fn(&T) -> U,
+{
+    type Target = U;
+    fn map_target(&self, t: &T) -> U {
+        (self)(t)
+    }
+}

--- a/lib/stack/src/phantom_data.rs
+++ b/lib/stack/src/phantom_data.rs
@@ -13,7 +13,7 @@ pub struct Layer<T, M>(PhantomData<fn() -> (T, M)>);
 #[derive(Clone, Debug)]
 pub struct Stack<T, M> {
     inner: M,
-    _p: PhantomData<fn() -> (T, M)>,
+    _p: PhantomData<fn() -> T>,
 }
 
 impl<T, M: super::Stack<T>> super::Layer<T, T, M> for Layer<T, M> {

--- a/lib/stack/src/phantom_data.rs
+++ b/lib/stack/src/phantom_data.rs
@@ -1,0 +1,39 @@
+use std::marker::PhantomData;
+
+pub fn layer<T, M>() -> Layer<T, M>
+where
+    M: super::Stack<T>,
+{
+    Layer(PhantomData)
+}
+
+#[derive(Clone, Debug)]
+pub struct Layer<T, M>(PhantomData<fn() -> (T, M)>);
+
+#[derive(Clone, Debug)]
+pub struct Stack<T, M> {
+    inner: M,
+    _p: PhantomData<fn() -> (T, M)>,
+}
+
+impl<T, M: super::Stack<T>> super::Layer<T, T, M> for Layer<T, M> {
+    type Value = <Stack<T, M> as super::Stack<T>>::Value;
+    type Error = <Stack<T, M> as super::Stack<T>>::Error;
+    type Stack = Stack<T, M>;
+
+    fn bind(&self, inner: M) -> Self::Stack {
+        Stack {
+            inner,
+            _p: PhantomData
+        }
+    }
+}
+
+impl<T, M: super::Stack<T>> super::Stack<T> for Stack<T, M> {
+    type Value = M::Value;
+    type Error = M::Error;
+
+    fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
+        self.inner.make(target)
+    }
+}

--- a/lib/stack/src/watch.rs
+++ b/lib/stack/src/watch.rs
@@ -3,6 +3,7 @@ extern crate futures_watch;
 use self::futures_watch::Watch;
 use futures::{future::MapErr, Async, Future, Poll, Stream};
 use std::{error, fmt};
+use std::marker::PhantomData;
 
 use svc;
 
@@ -16,14 +17,14 @@ pub trait WithUpdate<U> {
 #[derive(Debug)]
 pub struct Layer<T: WithUpdate<U>, U, M> {
     watch: Watch<U>,
-    _p: ::std::marker::PhantomData<(T, M)>,
+    _p: PhantomData<fn() -> (T, M)>,
 }
 
 #[derive(Debug)]
 pub struct Stack<T: WithUpdate<U>, U, M> {
     watch: Watch<U>,
     inner: M,
-    _p: ::std::marker::PhantomData<T>,
+    _p: PhantomData<fn() -> T>,
 }
 
 /// A Service that updates itself as a Watch updates.
@@ -54,7 +55,7 @@ where
 {
     Layer {
         watch,
-        _p: ::std::marker::PhantomData,
+        _p: PhantomData,
     }
 }
 
@@ -81,7 +82,7 @@ where
         Stack {
             inner,
             watch: self.watch.clone(),
-            _p: ::std::marker::PhantomData,
+            _p: PhantomData,
         }
     }
 }
@@ -93,7 +94,7 @@ impl<T: WithUpdate<U>, U, M: Clone> Clone for Stack<T, U, M> {
         Self {
             inner: self.inner.clone(),
             watch: self.watch.clone(),
-            _p: ::std::marker::PhantomData,
+            _p: PhantomData,
         }
     }
 }

--- a/lib/stack/src/watch.rs
+++ b/lib/stack/src/watch.rs
@@ -14,14 +14,16 @@ pub trait WithUpdate<U> {
 }
 
 #[derive(Debug)]
-pub struct Layer<U> {
+pub struct Layer<T: WithUpdate<U>, U, M> {
     watch: Watch<U>,
+    _p: ::std::marker::PhantomData<(T, M)>,
 }
 
 #[derive(Debug)]
-pub struct Stack<U, M> {
+pub struct Stack<T: WithUpdate<U>, U, M> {
     watch: Watch<U>,
     inner: M,
+    _p: ::std::marker::PhantomData<T>,
 }
 
 /// A Service that updates itself as a Watch updates.
@@ -45,47 +47,58 @@ pub struct CloneUpdate {}
 
 // === impl Layer ===
 
-pub fn layer<U>(watch: Watch<U>) -> Layer<U> {
-    Layer { watch }
-}
-
-impl<U> Clone for Layer<U> {
-    fn clone(&self) -> Self {
-        Self {
-            watch: self.watch.clone(),
-        }
-    }
-}
-
-impl<T, U, M> super::Layer<T, T::Updated, M> for Layer<U>
+pub fn layer<T, U, M>(watch: Watch<U>) -> Layer<T, U, M>
 where
     T: WithUpdate<U> + Clone,
     M: super::Stack<T::Updated> + Clone,
 {
-    type Value = <Stack<U, M> as super::Stack<T>>::Value;
-    type Error = <Stack<U, M> as super::Stack<T>>::Error;
-    type Stack = Stack<U, M>;
+    Layer {
+        watch,
+        _p: ::std::marker::PhantomData,
+    }
+}
+
+impl<T, U, M> Clone for Layer<T, U, M>
+where
+    T: WithUpdate<U> + Clone,
+    M: super::Stack<T::Updated> + Clone,
+{
+    fn clone(&self) -> Self {
+        layer(self.watch.clone())
+    }
+}
+
+impl<T, U, M> super::Layer<T, T::Updated, M> for Layer<T, U, M>
+where
+    T: WithUpdate<U> + Clone,
+    M: super::Stack<T::Updated> + Clone,
+{
+    type Value = <Stack<T, U, M> as super::Stack<T>>::Value;
+    type Error = <Stack<T, U, M> as super::Stack<T>>::Error;
+    type Stack = Stack<T, U, M>;
 
     fn bind(&self, inner: M) -> Self::Stack {
         Stack {
             inner,
             watch: self.watch.clone(),
+            _p: ::std::marker::PhantomData,
         }
     }
 }
 
 // === impl Stack ===
 
-impl<U, M: Clone> Clone for Stack<U, M> {
+impl<T: WithUpdate<U>, U, M: Clone> Clone for Stack<T, U, M> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
             watch: self.watch.clone(),
+            _p: ::std::marker::PhantomData,
         }
     }
 }
 
-impl<T, U, M> super::Stack<T> for Stack<U, M>
+impl<T, U, M> super::Stack<T> for Stack<T, U, M>
 where
     T: WithUpdate<U> + Clone,
     M: super::Stack<T::Updated> + Clone,

--- a/src/app/inbound.rs
+++ b/src/app/inbound.rs
@@ -130,10 +130,8 @@ pub mod orig_proto_downgrade {
 
     // === impl Layer ===
 
-    impl Layer {
-        pub fn new() -> Self {
-            Layer
-        }
+    pub fn layer() -> Layer {
+        Layer
     }
 
     impl<M, A, B> svc::Layer<Source, Source, M> for Layer

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -214,12 +214,9 @@ pub mod orig_proto_upgrade {
         inner: M,
     }
 
-    impl Layer {
-        pub fn new() -> Self {
-            Layer
-        }
+    pub fn layer() -> Layer {
+        Layer
     }
-
 
     impl<M, A, B> svc::Layer<Endpoint, Endpoint, M> for Layer
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,6 @@
 #![cfg_attr(feature = "cargo-clippy", allow(new_without_default_derive))]
 #![deny(warnings)]
 
-// Stack type inference requires a deeper recursion limit
-#![recursion_limit="128"]
-
 extern crate bytes;
 extern crate env_logger;
 extern crate linkerd2_fs_watch as fs_watch;

--- a/src/proxy/buffer.rs
+++ b/src/proxy/buffer.rs
@@ -1,15 +1,15 @@
 extern crate tower_buffer;
 
-use std::fmt;
+use std::{error, fmt};
 
-pub use self::tower_buffer::{Buffer, SpawnError};
+pub use self::tower_buffer::{Buffer, Error as ServiceError, SpawnError};
 
 use logging;
 use svc;
 
 /// Wraps `Service` stacks with a `Buffer`.
 #[derive(Debug, Clone)]
-pub struct Layer;
+pub struct Layer();
 
 /// Produces `Service`s wrapped with a `Buffer`
 #[derive(Debug, Clone)]
@@ -24,10 +24,8 @@ pub enum Error<M, S> {
 
 // === impl Layer ===
 
-impl Layer {
-    pub fn new() -> Self {
-        Layer
-    }
+pub fn layer() -> Layer {
+    Layer()
 }
 
 impl<T, M> svc::Layer<T, T, M> for Layer
@@ -43,14 +41,11 @@ where
     type Stack = Stack<M>;
 
     fn bind(&self, inner: M) -> Self::Stack {
-        Stack {
-            inner,
-        }
+        Stack { inner }
     }
 }
 
 // === impl Stack ===
-
 
 impl<T, M> svc::Stack<T> for Stack<M>
 where
@@ -77,6 +72,24 @@ impl<M: fmt::Debug, S> fmt::Debug for Error<M, S> {
         match self {
             Error::Stack(e) => fmt.debug_tuple("buffer::Error::Stack").field(e).finish(),
             Error::Spawn(_) => fmt.debug_tuple("buffer::Error::Spawn").finish(),
+        }
+    }
+}
+
+impl<M: fmt::Display, S> fmt::Display for Error<M, S> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::Stack(e) => fmt::Display::fmt(e, fmt),
+            Error::Spawn(_) => write!(fmt, "Stack built without an executor"),
+        }
+    }
+}
+
+impl<M: error::Error, S> error::Error for Error<M, S> {
+    fn cause(&self) -> Option<&error::Error> {
+        match self {
+            Error::Stack(e) => e.cause(),
+            Error::Spawn(_) => None,
         }
     }
 }

--- a/src/proxy/http/balance.rs
+++ b/src/proxy/http/balance.rs
@@ -2,9 +2,9 @@ extern crate tower_balance;
 extern crate tower_discover;
 extern crate tower_h2_balance;
 
-use self::tower_discover::Discover;
 use http;
 use std::time::Duration;
+use self::tower_discover::Discover;
 use tower_h2::Body;
 
 pub use self::tower_balance::{choose::PowerOfTwoChoices, load::WithPeakEwma, Balance};

--- a/src/proxy/http/insert_target.rs
+++ b/src/proxy/http/insert_target.rs
@@ -21,10 +21,8 @@ pub struct Service<T, S> {
 
 // === impl Layer ===
 
-impl Layer {
-    pub fn new() -> Self {
-        Layer
-    }
+pub fn layer() -> Layer {
+    Layer
 }
 
 impl<T, M, B> svc::Layer<T, T, M> for Layer

--- a/src/proxy/http/metrics/mod.rs
+++ b/src/proxy/http/metrics/mod.rs
@@ -12,7 +12,7 @@ mod service;
 pub mod timestamp_request_open;
 
 pub use self::report::Report;
-pub use self::service::Layer;
+pub use self::service::layer;
 
 pub fn new<T, C>(retain_idle: Duration) -> (Arc<Mutex<Registry<T, C>>>, Report<T, C>)
 where

--- a/src/proxy/http/metrics/service.rs
+++ b/src/proxy/http/metrics/service.rs
@@ -91,30 +91,27 @@ where
 
 // ===== impl Stack =====
 
-impl<M, K, C> Layer<M, K, C>
+pub fn layer<M, K, C, T, A, B>(registry: Arc<Mutex<Registry<K, C::Class>>>, classify: C)
+    -> Layer<M, K, C>
 where
     K: Clone + Hash + Eq,
     C: Classify<Error = h2::Error> + Clone,
     C::Class: Hash + Eq,
     C::ClassifyResponse: Send + Sync + 'static,
+    T: Clone + Debug,
+    K: From<T>,
+    M: svc::Stack<T>,
+    M::Value: svc::Service<
+        Request = http::Request<RequestBody<A, C::Class>>,
+        Response = http::Response<B>,
+    >,
+    A: tower_h2::Body,
+    B: tower_h2::Body,
 {
-    pub fn new<T, A, B>(registry: Arc<Mutex<Registry<K, C::Class>>>, classify: C) -> Self
-    where
-        T: Clone + Debug,
-        K: From<T>,
-        M: svc::Stack<T>,
-        M::Value: svc::Service<
-            Request = http::Request<RequestBody<A, C::Class>>,
-            Response = http::Response<B>,
-        >,
-        A: tower_h2::Body,
-        B: tower_h2::Body,
-    {
-        Self {
-            classify,
-            registry,
-            _p: PhantomData,
-        }
+    Layer {
+        classify,
+        registry,
+        _p: PhantomData,
     }
 }
 

--- a/src/proxy/http/metrics/timestamp_request_open.rs
+++ b/src/proxy/http/metrics/timestamp_request_open.rs
@@ -24,8 +24,8 @@ pub struct TimestampRequestOpen<S> {
 }
 
 /// Layers a `TimestampRequestOpen` middleware on an HTTP client.
-#[derive(Debug)]
-pub struct Layer<M>(::std::marker::PhantomData<fn() -> (M)>);
+#[derive(Clone, Debug)]
+pub struct Layer();
 
 /// Uses an `M`-typed `Stack` to build a `TimestampRequestOpen` service.
 #[derive(Clone, Debug)]
@@ -54,19 +54,11 @@ where
 
 // === impl Layer ===
 
-impl<M> Layer<M> {
-    pub fn new() -> Self {
-        Layer(::std::marker::PhantomData)
-    }
+pub fn layer() -> Layer {
+    Layer()
 }
 
-impl<M> Clone for Layer<M> {
-    fn clone(&self) -> Self {
-        Self::new()
-    }
-}
-
-impl<T, B, M> svc::Layer<T, T, M> for Layer<M>
+impl<T, B, M> svc::Layer<T, T, M> for Layer
 where
     M: svc::Stack<T>,
     M::Value: svc::Service<Request = http::Request<B>>,

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -4,10 +4,10 @@ extern crate tower_service;
 pub use self::tower_service::{NewService, Service};
 
 pub use self::stack::{
+    shared,
     stack_per_request,
     watch,
     Either,
     Layer,
     Stack,
-    Shared,
 };

--- a/src/tap/mod.rs
+++ b/src/tap/mod.rs
@@ -11,7 +11,7 @@ mod service;
 pub use self::event::{Direction, Endpoint, Event};
 pub use self::match_::InvalidMatch;
 use self::match_::*;
-pub use self::service::{Layer, Stack, RequestBody, Service};
+pub use self::service::layer;
 
 #[derive(Clone, Debug, Default)]
 pub struct NextId(Arc<AtomicUsize>);

--- a/src/tap/service.rs
+++ b/src/tap/service.rs
@@ -82,7 +82,7 @@ pub struct ResponseBody<B> {
 
 // === Layer ===
 
-impl<T, M, A, B> Layer<T, M>
+pub fn layer<T, M, A, B>(next_id: NextId, taps: Arc<Mutex<Taps>>) -> Layer<T, M>
 where
     T: Clone + Into<event::Endpoint>,
     M: svc::Stack<T>,
@@ -94,12 +94,10 @@ where
     A: Body,
     B: Body,
 {
-    pub fn new(next_id: NextId, taps: Arc<Mutex<Taps>>) -> Self {
-        Self {
-            next_id,
-            taps,
-            _p: PhantomData,
-        }
+    Layer {
+        next_id,
+        taps,
+        _p: PhantomData,
     }
 }
 


### PR DESCRIPTION
Previously, stacks were built with `Layer::and_then`. This pattern
severely impacts compile-times as stack complexity grows.

In order to ameliorate this, `app::main` has been changed to build
stacks from the "bottom" (endpoint client) to "top" (serverside
connection) by _push_-ing Layers onto a concrete stack, i.e. and not
composing layers for an abstract stack.

While doing this, we take the oppportunity to remove a ton of
now-unnecessary `PhantomData`. A new, dedicated `phantom_data` stack
module can be used to aid type inference as needed.

Other stack utilities like `map_target` and `map_err` have been
introduced to assist this transition.

Furthermore, all instances of `Layer::new` have been changed to a free
`fn layer` to improve readability.

This change sets up two upcoming changes: a stack-oriented `controller`
client and, subsequently, service-profile-based routing. There are no functional
changes.