### PR TITLE
Remove settings checks from orig-proto module

### DIFF
--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -249,10 +249,7 @@ pub mod orig_proto_upgrade {
         type Error = M::Error;
 
         fn make(&self, endpoint: &Endpoint) -> Result<Self::Value, Self::Error> {
-            if endpoint.can_use_orig_proto()
-                && !endpoint.dst.settings.is_http2()
-                && !endpoint.dst.settings.is_h1_upgrade()
-            {
+            if endpoint.can_use_orig_proto() {
                 let mut upgraded = endpoint.clone();
                 upgraded.dst.settings = Settings::Http2;
                 self.inner.make(&upgraded).map(|i| svc::Either::A(i.into()))

--- a/src/proxy/http/orig_proto.rs
+++ b/src/proxy/http/orig_proto.rs
@@ -48,66 +48,58 @@ where
     }
 
     fn call(&mut self, mut req: Self::Request) -> Self::Future {
-        let mut downgrade_response = false;
+        if req.version() == http::Version::HTTP_2 || h1::wants_upgrade(&req) {
+            // Just passing through...
+            return self.inner.call(req).map(|res| res)
+        }
 
-        if req.version() != http::Version::HTTP_2 {
-            debug!("upgrading {:?} to HTTP2 with orig-proto", req.version());
+        debug!("upgrading {:?} to HTTP2 with orig-proto", req.version());
 
-            // absolute-form is far less common, origin-form is the usual,
-            // so only encode the extra information if it's different than
-            // the normal.
-            let was_absolute_form = h1::is_absolute_form(req.uri());
-            if !was_absolute_form {
-                // Since the version is going to set to HTTP_2, the NormalizeUri
-                // middleware won't normalize the URI automatically, so it
-                // needs to be done now.
-                h1::normalize_our_view_of_uri(&mut req);
+        // absolute-form is far less common, origin-form is the usual,
+        // so only encode the extra information if it's different than
+        // the normal.
+        let was_absolute_form = h1::is_absolute_form(req.uri());
+        if !was_absolute_form {
+            // Since the version is going to set to HTTP_2, the NormalizeUri
+            // middleware won't normalize the URI automatically, so it
+            // needs to be done now.
+            h1::normalize_our_view_of_uri(&mut req);
+        }
+
+        let val = match (req.version(), was_absolute_form) {
+            (http::Version::HTTP_11, false) => "HTTP/1.1",
+            (http::Version::HTTP_11, true) => "HTTP/1.1; absolute-form",
+            (http::Version::HTTP_10, false) => "HTTP/1.0",
+            (http::Version::HTTP_10, true) => "HTTP/1.0; absolute-form",
+            (v, _) => unreachable!("bad orig-proto version: {:?}", v),
+        };
+        req.headers_mut().insert(
+            L5D_ORIG_PROTO,
+            HeaderValue::from_static(val)
+        );
+
+        // transfer-encoding is illegal in HTTP2
+        req.headers_mut().remove(TRANSFER_ENCODING);
+
+        *req.version_mut() = http::Version::HTTP_2;
+
+        self.inner.call(req).map(|mut res| {
+            debug_assert_eq!(res.version(), http::Version::HTTP_2);
+            if let Some(orig_proto) = res.headers().get(L5D_ORIG_PROTO) {
+                debug!("downgrading {} response: {:?}", L5D_ORIG_PROTO, orig_proto);
+                match orig_proto {
+                    "HTTP/1.1" => {
+                        *res.version_mut() = http::Version::HTTP_11;
+                    }
+                    "HTTP/1.0" => {
+                        *res.version_mut() = http::Version::HTTP_10;
+                    }
+                    _ => warn!("unknown {} header value: {:?}", L5D_ORIG_PROTO, orig_proto),
+                }
             }
 
-            let val = match (req.version(), was_absolute_form) {
-                (http::Version::HTTP_11, false) => "HTTP/1.1",
-                (http::Version::HTTP_11, true) => "HTTP/1.1; absolute-form",
-                (http::Version::HTTP_10, false) => "HTTP/1.0",
-                (http::Version::HTTP_10, true) => "HTTP/1.0; absolute-form",
-                (v, _) => unreachable!("bad orig-proto version: {:?}", v),
-            };
-            req.headers_mut().insert(
-                L5D_ORIG_PROTO,
-                HeaderValue::from_static(val)
-            );
-
-            // transfer-encoding is illegal in HTTP2
-            req.headers_mut().remove(TRANSFER_ENCODING);
-
-            *req.version_mut() = http::Version::HTTP_2;
-            downgrade_response = true;
-        }
-
-        let fut = self.inner.call(req);
-
-        if downgrade_response {
-            fut.map(|mut res| {
-                debug_assert_eq!(res.version(), http::Version::HTTP_2);
-                let version = if let Some(orig_proto) = res.headers().get(L5D_ORIG_PROTO) {
-                    debug!("downgrading {} response: {:?}", L5D_ORIG_PROTO, orig_proto);
-                    if orig_proto == "HTTP/1.1" {
-                        http::Version::HTTP_11
-                    } else if orig_proto == "HTTP/1.0" {
-                        http::Version::HTTP_10
-                    } else {
-                        warn!("unknown {} header value: {:?}", L5D_ORIG_PROTO, orig_proto);
-                        res.version()
-                    }
-                } else {
-                    res.version()
-                };
-                *res.version_mut() = version;
-                res
-            })
-        } else {
-            // Just passing through...
-            fut.map(|res| res)
-        }
+            res
+        })
     }
 }
 


### PR DESCRIPTION
When constructing the `outbound::orig_proto_upgrade` module, we check
the endpoint's `settings` to determine the `Upgrade` middleware should
be applied. The `Upgrade` middleware performs a similar, and partially
redundant set of checks on each request.

linkerd/linkerd2#1798 is simplif if we can separate destination-routing
from client settings. Specifically, if the `settings` field will be
removed from `Destination`s and `Endpoint`s, we won't a discovery &
routing stack for each combination of Settings. Instead, a routing layer
will be installed around the client, beneath the profile route stack,
that is responsible for dispatching requests to the appropriate client.

This change does NOT change user-facing behavior. An additional
`h1::wants_upgrade` check is now perormed within the `Upgrade` service
so that HTTP-Upgrade requests can pass through this stack.