### PR TITLE
change Inbound to always use localhost

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -359,7 +359,8 @@ where
                 // Establishes connections to the local application.
                 let connect = connect::Stack::new()
                     .push(proxy::timeout::layer(config.inbound_connect_timeout))
-                    .push(transport_metrics.connect("inbound"));
+                    .push(transport_metrics.connect("inbound"))
+                    .push(inbound::rewrite_loopback_addr::layer());
 
                 // A stack configured by `router::Config`, responsible for building
                 // a router made of route stacks configured by `inbound::Endpoint`.

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -57,6 +57,19 @@ impl Proxy {
         self
     }
 
+    /// Adjust the server's 'addr'. This won't actually re-bind the server,
+    /// it will just affect what the proxy think is the so_original_dst.
+    ///
+    /// This address is bogus, but the proxy should properly ignored the IP
+    /// and only use the port combined with 127.0.0.1 to still connect to
+    /// the server.
+    pub fn inbound_fuzz_addr(self, mut s: server::Listening) -> Self {
+        let old_addr = s.addr;
+        let new_addr = ([10, 1, 2, 3], old_addr.port()).into();
+        s.addr = new_addr;
+        self.inbound(s)
+    }
+
     pub fn outbound(mut self, s: server::Listening) -> Self {
         self.outbound = Some(s);
         self

--- a/tests/transparency.rs
+++ b/tests/transparency.rs
@@ -23,7 +23,7 @@ fn inbound_http1() {
 
     let srv = server::http1().route("/", "hello h1").run();
     let proxy = proxy::new()
-        .inbound(srv)
+        .inbound_fuzz_addr(srv)
         .run();
     let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
@@ -69,7 +69,7 @@ fn inbound_tcp() {
         })
         .run();
     let proxy = proxy::new()
-        .inbound(srv)
+        .inbound_fuzz_addr(srv)
         .run();
 
     let client = client::tcp(proxy.inbound);


### PR DESCRIPTION
This changes the HTTP router and TCP forwarder for **inbound** connections to always replace the destination IP with `127.0.0.1`. The port is still taken from `SO_ORIGINAL_DST`. This change, combined with some new `iptables` rules, should fix https://github.com/linkerd/linkerd2/issues/1585.