### PR TITLE
Allow routers to be implemented with a closure

### DIFF
--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -75,6 +75,20 @@ where
     Invalid,
 }
 
+// ===== impl Recognize =====
+
+impl<R, T, F> Recognize<R> for F
+where
+    T: Clone + Eq + Hash,
+    F: Fn(&R) -> Option<T>,
+ {
+    type Target = T;
+
+    fn recognize(&self, req: &R) -> Option<T> {
+        (self)(req)
+    }
+}
+
 // ===== impl Router =====
 
 impl<Req, Rec, Stk> Router<Req, Rec, Stk>


### PR DESCRIPTION
The router's `Recognize` trait is now essentially a function.

This change provides an implementation of `Recognize` over a `Fn` so
that it's possible to implement routers without defining 0-point marker
types that implement `Recognize`.