### PR TITLE
Convert several Stack unit errors into Never

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkerd2-never"
+version = "0.1.0"
+
+[[package]]
 name = "linkerd2-proxy"
 version = "0.1.0"
 dependencies = [
@@ -525,6 +529,7 @@ dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-fs-watch 0.1.0",
  "linkerd2-metrics 0.1.0",
+ "linkerd2-never 0.1.0",
  "linkerd2-proxy-api 0.1.3 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.3)",
  "linkerd2-router 0.1.0",
  "linkerd2-stack 0.1.0",
@@ -597,6 +602,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-watch 0.1.0 (git+https://github.com/carllerche/better-future)",
+ "linkerd2-never 0.1.0",
  "linkerd2-task 0.1.0",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ flaky_tests = []
 futures-mpsc-lossy = { path = "lib/futures-mpsc-lossy" }
 linkerd2-fs-watch  = { path = "lib/fs-watch" }
 linkerd2-metrics   = { path = "lib/metrics" }
+linkerd2-never     = { path = "lib/never" }
 linkerd2-router    = { path = "lib/router" }
 linkerd2-stack     = { path = "lib/stack" }
 linkerd2-task      = { path = "lib/task" }

--- a/lib/never/Cargo.toml
+++ b/lib/never/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "linkerd2-never"
+version = "0.1.0"
+authors = ["Sean McArthur <sean@buoyant.io>"]
+publish = false
+
+[dependencies]

--- a/lib/never/src/lib.rs
+++ b/lib/never/src/lib.rs
@@ -1,0 +1,15 @@
+use std::{error::Error, fmt};
+
+/// A type representing a value that can never materialize.
+///
+/// This would be `!`, but it isn't stable yet.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Never {}
+
+impl fmt::Display for Never {
+    fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        match *self {}
+    }
+}
+
+impl Error for Never {}

--- a/lib/stack/Cargo.toml
+++ b/lib/stack/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 log = "0.4.1"
 futures = "0.1"
 futures-watch = { git = "https://github.com/carllerche/better-future" }
+linkerd2-never = { path = "../never" }
 tower-service = { git = "https://github.com/tower-rs/tower" }
 
 [dev-dependencies]

--- a/lib/stack/src/lib.rs
+++ b/lib/stack/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate futures;
 #[macro_use]
 extern crate log;
+extern crate linkerd2_never as never;
 extern crate tower_service as svc;
 
 pub mod either;
@@ -53,7 +54,7 @@ pub trait Stack<T> {
 
 /// Implements `Stack<T>` for any `T` by cloning a `V`-typed value.
 pub mod shared {
-    use std::{error, fmt};
+    use never::Never;
 
     pub fn stack<V: Clone>(v: V) -> Stack<V> {
         Stack(v)
@@ -62,23 +63,12 @@ pub mod shared {
     #[derive(Clone, Debug)]
     pub struct Stack<V: Clone>(V);
 
-    #[derive(Debug)]
-    pub enum Error {}
-
     impl<T, V: Clone> super::Stack<T> for Stack<V> {
         type Value = V;
-        type Error = Error;
+        type Error = Never;
 
-        fn make(&self, _: &T) -> Result<V, Error> {
+        fn make(&self, _: &T) -> Result<V, Never> {
             Ok(self.0.clone())
         }
     }
-
-    impl fmt::Display for Error {
-        fn fmt(&self, _: &mut fmt::Formatter) -> fmt::Result {
-            unreachable!()
-        }
-    }
-
-    impl error::Error for Error {}
 }

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -4,6 +4,8 @@ use futures::{Async, Future, Poll, Stream};
 use futures::future::Shared;
 use futures::sync::{mpsc, oneshot};
 
+use never::Never;
+
 /// Creates a drain channel.
 ///
 /// The `Signal` is used to start a drain, and the `Watch` will be notified
@@ -55,10 +57,6 @@ enum State<F> {
     Watch(F),
     Draining,
 }
-
-//TODO: in Rust 1.26, replace this with `!`.
-#[derive(Debug)]
-enum Never {}
 
 /// A future that resolves when all `Watch`ers have been dropped (drained).
 pub struct Drained {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ extern crate try_lock;
 
 #[macro_use]
 extern crate linkerd2_metrics;
+extern crate linkerd2_never as never;
 extern crate linkerd2_proxy_api as api;
 extern crate linkerd2_task as task;
 extern crate linkerd2_timeout as timeout;

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -6,6 +6,7 @@ use std::marker::PhantomData;
 use std::time::Duration;
 use std::{error, fmt};
 
+use never::Never;
 use svc;
 
 extern crate linkerd2_router;
@@ -117,7 +118,7 @@ where
     B: Default + Send + 'static,
 {
     type Value = Service<Req, Rec, Stk>;
-    type Error = ();
+    type Error = Never;
 
     fn make(&self, config: &Config) -> Result<Self::Value, Self::Error> {
         let inner = Router::new(

--- a/src/transport/connect.rs
+++ b/src/transport/connect.rs
@@ -2,9 +2,10 @@ extern crate tokio_connect;
 
 pub use self::tokio_connect::Connect;
 
-use std::{error, fmt, io};
+use std::io;
 use std::net::SocketAddr;
 
+use never::Never;
 use svc;
 use transport::{connection, tls};
 
@@ -17,10 +18,6 @@ pub struct Target {
     pub tls: tls::ConditionalConnectionConfig<tls::ClientConfig>,
     _p: (),
 }
-
-/// Note: this isn't actually used, but is needed to satisfy Error.
-#[derive(Debug)]
-pub struct InvalidTarget;
 
 // ===== impl Target =====
 
@@ -61,17 +58,9 @@ where
     Target: From<T>,
 {
     type Value = Target;
-    type Error = InvalidTarget;
+    type Error = Never;
 
     fn make(&self, t: &T) -> Result<Self::Value, Self::Error> {
         Ok(t.clone().into())
     }
 }
-
-impl fmt::Display for InvalidTarget {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Invalid target")
-    }
-}
-
-impl error::Error for InvalidTarget {}


### PR DESCRIPTION
Since this stack pieces will never error, we can mark their
`Error`s with a type that can "never" be created. When seeing an `Error
= ()`, it can either mean the error never happens, or that the detailed
error is dealt with elsewhere and only a unit is passed on. When seeing
`Error = Never`, it is clearer that the error case never happens.
Besides helping humans, LLVM can also remove the error branchs entirely.