### PR TITLE
Add controller client metrics

### DIFF
--- a/src/app/metric_labels.rs
+++ b/src/app/metric_labels.rs
@@ -6,9 +6,15 @@ use std::{
 use metrics::FmtLabels;
 
 use transport::tls;
-use {Conditional, NameAddr};
+use {Conditional, Addr, NameAddr};
 
-use super::{classify, dst, inbound, outbound};
+use super::{control, classify, dst, inbound, outbound};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ControlLabels {
+    addr: Addr,
+    tls_status: tls::Status,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EndpointLabels {
@@ -33,6 +39,27 @@ enum Direction {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct Authority<'a>(&'a NameAddr);
+
+// === impl CtlLabels ===
+
+impl From<control::Config> for ControlLabels {
+    fn from(c: control::Config) -> Self {
+        ControlLabels {
+            addr: c.addr().clone(),
+            tls_status: c.tls_status()
+        }
+    }
+}
+
+impl FmtLabels for ControlLabels {
+    fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "addr=\"{}\",", self.addr)?;
+        self.tls_status.fmt_labels(f)?;
+
+        Ok(())
+    }
+}
+
 
 // === impl RouteLabels ===
 


### PR DESCRIPTION
There is no telemetry from the controller client currently.

This change adds a new scope (`control_`) of metrics including HTTP
metrics for the client to the proxy-api.

---

```
# HELP control_request_total Total count of HTTP requests.
# TYPE control_request_total counter
control_request_total{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled"} 5
# HELP control_response_latency_ms Elapsed times between a request's headers being received and its response stream completing
# TYPE control_response_latency_ms histogram
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="1"} 2
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="2"} 2
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="3"} 2
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="4"} 2
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="5"} 2
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="10"} 3
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="20"} 4
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="30"} 4
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="40"} 4
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="50"} 4
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="100"} 4
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="200"} 4
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="300"} 4
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="400"} 4
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="500"} 4
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="1000"} 4
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="2000"} 5
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="3000"} 5
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="4000"} 5
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="5000"} 5
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="10000"} 5
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="20000"} 5
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="30000"} 5
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="40000"} 5
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="50000"} 5
control_response_latency_ms_bucket{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200",le="+Inf"} 5
control_response_latency_ms_count{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200"} 5
control_response_latency_ms_sum{addr="proxy-api.ver-linkerd.svc.cluster.local:8086",tls="disabled",status_code="200"} 1040
# HELP control_response_total Total count of HTTP responses.
# TYPE control_response_total counter
```