### PR TITLE
ci: Use 'xenial' travis build hosts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
-dist: trusty
-sudo: false
+dist: xenial
 
 language: rust
 cache: cargo


### PR DESCRIPTION
Our travis builds are running out of disk space. Full debug builds for
all tests require about 14GB of disk space. The travis 'trusty'
container hosts only offer about 9GB of disk. The 'xenial' hosts support
about 18GB of disk.

https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system