### PR TITLE
Disable debug symbols for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,3 +94,8 @@ flate2 = { version = "1.0.1", default-features = false, features = ["rust_backen
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.
 tokio-io = "0.1.6"
+
+# Debug symbols end up chewing up several GB of disk space, so better to just
+# disable them.
+[profile.test]
+debug = false


### PR DESCRIPTION
Our test artifacts end up consuming several GB of disk space, largely
due to debug symbols. This can prevent CI from passing, as CI hosts only
have about 9G of real estate.

By disabling debug symbols, we reduce artifact size by >90% (and total
target directory size from 14G to 4G).

Thanks to @hawkw for spotting this.