### PR TITLE
Ensure l5d-orig-proto header is removed before returning responses

### DIFF
--- a/src/proxy/http/orig_proto.rs
+++ b/src/proxy/http/orig_proto.rs
@@ -84,7 +84,7 @@ where
 
         self.inner.call(req).map(|mut res| {
             debug_assert_eq!(res.version(), http::Version::HTTP_2);
-            let version = if let Some(orig_proto) = res.headers().get(L5D_ORIG_PROTO) {
+            let version = if let Some(orig_proto) = res.headers_mut().remove(L5D_ORIG_PROTO) {
                 debug!("downgrading {} response: {:?}", L5D_ORIG_PROTO, orig_proto);
                 if orig_proto == "HTTP/1.1" {
                     http::Version::HTTP_11


### PR DESCRIPTION
I noticed a pod was seeing this response header, it should be removed before the pod gets it.