### PR TITLE
Reduce log level for orig-proto-downgrade

### DIFF
--- a/src/app/inbound.rs
+++ b/src/app/inbound.rs
@@ -167,7 +167,7 @@ pub mod orig_proto_downgrade {
         type Error = M::Error;
 
         fn make(&self, target: &Source) -> Result<Self::Value, Self::Error> {
-            info!("downgrading requests; source={:?}", target);
+            debug!("downgrading requests; source={:?}", target);
             self
                 .inner
                 .make(&target)


### PR DESCRIPTION
Using a downgrade stack is not sufficiently important to log at the INFO
level. Log it at DEBUG.