### PR TITLE
Profile Retries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 language: rust
 cache: cargo
+env:
+  - RUSTFLAGS="-C debuginfo=0"
 
 branches:
   only:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ dependencies = [
  "tower-http 0.1.0 (git+https://github.com/tower-rs/tower-http)",
  "tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
+ "tower-retry 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.2.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
  "trust-dns-resolver 0.10.0 (git+https://github.com/bluejekyll/trust-dns?rev=c017c114)",
@@ -1422,6 +1423,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-retry"
+version = "0.1.0"
+source = "git+https://github.com/tower-rs/tower#075ffb372556d05a7db02ce49db34cfb22850dba"
+dependencies = [
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.2.0 (git+https://github.com/tower-rs/tower)",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.2.0"
 source = "git+https://github.com/tower-rs/tower#075ffb372556d05a7db02ce49db34cfb22850dba"
@@ -1790,6 +1801,7 @@ dependencies = [
 "checksum tower-http 0.1.0 (git+https://github.com/tower-rs/tower-http)" = "<none>"
 "checksum tower-in-flight-limit 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
+"checksum tower-retry 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-service 0.2.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum trust-dns-proto 0.5.0 (git+https://github.com/bluejekyll/trust-dns?rev=c017c114)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ tower-buffer          = { git = "https://github.com/tower-rs/tower" }
 tower-discover        = { git = "https://github.com/tower-rs/tower" }
 tower-in-flight-limit = { git = "https://github.com/tower-rs/tower" }
 tower-reconnect       = { git = "https://github.com/tower-rs/tower" }
+tower-retry           = { git = "https://github.com/tower-rs/tower" }
 tower-service         = { git = "https://github.com/tower-rs/tower" }
 tower-util            = { git = "https://github.com/tower-rs/tower" }
 tower-http            = { git = "https://github.com/tower-rs/tower-http" }

--- a/src/app/classify.rs
+++ b/src/app/classify.rs
@@ -188,6 +188,19 @@ fn grpc_class(headers: &http::HeaderMap) -> Option<Class> {
         })
 }
 
+// === impl Class ===
+
+impl Class {
+    pub(super) fn is_failure(&self) -> bool {
+        match self {
+            Class::Default(SuccessOrFailure::Failure) |
+            Class::Grpc(SuccessOrFailure::Failure, _) |
+            Class::Stream(SuccessOrFailure::Failure, _) => true,
+            _ => false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use http::{HeaderMap, Response, StatusCode};

--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -2,8 +2,13 @@ use http;
 use indexmap::IndexMap;
 use std::fmt;
 use std::sync::Arc;
+use tower_retry::budget::Budget;
 
-use proxy::http::{metrics::classify::CanClassify, profiles};
+use proxy::http::{
+    metrics::classify::{CanClassify, Classify, ClassifyResponse, ClassifyEos},
+    profiles,
+    retry,
+};
 use {Addr, NameAddr};
 
 use super::classify;
@@ -20,6 +25,12 @@ pub struct Route {
     pub route: profiles::Route,
 }
 
+#[derive(Clone, Debug)]
+pub struct Retry {
+    budget: Arc<Budget>,
+    response_classes: profiles::ResponseClasses,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DstAddr {
     addr: Addr,
@@ -33,6 +44,51 @@ impl CanClassify for Route {
 
     fn classify(&self) -> classify::Request {
         self.route.response_classes().clone().into()
+    }
+}
+
+impl retry::CanRetry for Route {
+    type Retry = Retry;
+
+    fn can_retry(&self) -> Option<Self::Retry> {
+        self
+            .route
+            .retries()
+            .map(|retries| Retry {
+                budget: retries.budget().clone(),
+                response_classes: self.route.response_classes().clone(),
+            })
+    }
+}
+
+// === impl Retry ===
+
+impl retry::Retry for Retry {
+    fn retry<B1, B2>(&self, req: &http::Request<B1>, res: &http::Response<B2>) -> Result<(), retry::NoRetry> {
+        let class = classify::Request::from(self.response_classes.clone())
+            .classify(req)
+            .start(res)
+            .eos(None);
+
+        if class.is_failure() {
+            return self
+                .budget
+                .withdraw()
+                .map_err(|_overdrawn| retry::NoRetry::Budget);
+        }
+
+        self.budget.deposit();
+        Err(retry::NoRetry::Success)
+    }
+
+    fn clone_request<B: retry::TryClone>(&self, req: &http::Request<B>) -> Option<http::Request<B>> {
+        retry::TryClone::try_clone(req)
+            .map(|mut clone| {
+                if let Some(ext) = req.extensions().get::<classify::Response>() {
+                    clone.extensions_mut().insert(ext.clone());
+                }
+                clone
+            })
     }
 }
 

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -206,12 +206,18 @@ where
             (m, r.with_prefix("route"))
         };
 
+        let (retry_http_metrics, retry_http_report) = {
+            let (m, r) = http_metrics::new::<RouteLabels, Class>(config.metrics_retain_idle);
+            (m, r.with_prefix("route_actual"))
+        };
+
         let (transport_metrics, transport_report) = transport::metrics::new();
 
         let (tls_config_sensor, tls_config_report) = telemetry::tls_config_reload::new();
 
         let report = endpoint_http_report
             .and_then(route_http_report)
+            .and_then(retry_http_report)
             .and_then(transport_report)
             .and_then(tls_config_report)
             .and_then(ctl_http_report)
@@ -289,7 +295,7 @@ where
                 use super::outbound::{discovery::Resolve, orig_proto_upgrade, Endpoint};
                 use proxy::{
                     canonicalize,
-                    http::{balance, header_from_target, metrics},
+                    http::{balance, header_from_target, metrics, retry},
                     resolve,
                 };
 
@@ -340,6 +346,8 @@ where
                 // implementations can use the route-specific configuration.
                 let dst_route_layer = phantom_data::layer()
                     .push(insert_target::layer())
+                    .push(metrics::layer::<_, classify::Response>(retry_http_metrics.clone()))
+                    .push(retry::layer(retry_http_metrics))
                     .push(metrics::layer::<_, classify::Response>(route_http_metrics))
                     .push(classify::layer());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ extern crate tokio;
 extern crate tokio_timer;
 extern crate tower_grpc;
 extern crate tower_http;
+extern crate tower_retry;
 extern crate tower_util;
 extern crate trust_dns_resolver;
 extern crate try_lock;

--- a/src/proxy/http/glue.rs
+++ b/src/proxy/http/glue.rs
@@ -118,6 +118,16 @@ impl Default for HttpBody {
     }
 }
 
+impl super::retry::TryClone for HttpBody {
+    fn try_clone(&self) -> Option<Self> {
+        if self.is_end_stream() {
+            Some(HttpBody::default())
+        } else {
+            None
+        }
+    }
+}
+
 impl Drop for HttpBody {
     fn drop(&mut self) {
         // If an HTTP/1 upgrade was wanted, send the upgrade future.

--- a/src/proxy/http/metrics/service.rs
+++ b/src/proxy/http/metrics/service.rs
@@ -11,7 +11,8 @@ use tokio_timer::clock;
 use tower_grpc;
 
 use super::classify::{ClassifyEos, ClassifyResponse};
-use super::{ClassMetrics, Metrics, Registry, StatusMetrics};
+use super::{ClassMetrics, RequestMetrics, Registry, StatusMetrics};
+use super::super::retry::TryClone;
 use svc;
 
 /// A stack module that wraps services to record metrics.
@@ -46,7 +47,7 @@ where
     C: ClassifyResponse<Error = h2::Error> + Clone,
     C::Class: Hash + Eq,
 {
-    metrics: Option<Arc<Mutex<Metrics<C::Class>>>>,
+    metrics: Option<Arc<Mutex<RequestMetrics<C::Class>>>>,
     inner: S,
     _p: PhantomData<fn() -> C>,
 }
@@ -57,7 +58,7 @@ where
     C::Class: Hash + Eq,
 {
     classify: Option<C>,
-    metrics: Option<Arc<Mutex<Metrics<C::Class>>>>,
+    metrics: Option<Arc<Mutex<RequestMetrics<C::Class>>>>,
     stream_open_at: Instant,
     inner: F,
 }
@@ -68,7 +69,7 @@ where
     B: Payload,
     C: Hash + Eq,
 {
-    metrics: Option<Arc<Mutex<Metrics<C>>>>,
+    metrics: Option<Arc<Mutex<RequestMetrics<C>>>>,
     inner: B,
 }
 
@@ -81,7 +82,7 @@ where
 {
     status: http::StatusCode,
     classify: Option<C>,
-    metrics: Option<Arc<Mutex<Metrics<C::Class>>>>,
+    metrics: Option<Arc<Mutex<RequestMetrics<C::Class>>>>,
     stream_open_at: Instant,
     latency_recorded: bool,
     inner: B,
@@ -173,7 +174,7 @@ where
             Ok(mut r) => Some(
                 r.by_target
                     .entry(target.clone().into())
-                    .or_insert_with(|| Arc::new(Mutex::new(Metrics::default())))
+                    .or_insert_with(|| Arc::new(Mutex::new(RequestMetrics::default())))
                     .clone(),
             ),
             Err(_) => None,
@@ -214,7 +215,7 @@ where
     A: Payload,
     B: Payload,
     C: ClassifyResponse<Error = h2::Error> + Clone + Default + Send + Sync + 'static,
-    C::Class: Hash + Eq,
+    C::Class: Hash + Eq + Send + Sync,
 {
     type Response = http::Response<ResponseBody<B, C::ClassifyEos>>;
     type Error = S::Error;
@@ -262,7 +263,7 @@ where
     F: Future<Item = http::Response<B>>,
     B: Payload,
     C: ClassifyResponse<Error = h2::Error> + Send + Sync + 'static,
-    C::Class: Hash + Eq,
+    C::Class: Hash + Eq + Send + Sync,
 {
     type Item = http::Response<ResponseBody<B, C::ClassifyEos>>;
     type Error = F::Error;
@@ -337,6 +338,24 @@ where
 
     fn poll_metadata(&mut self) -> Poll<Option<http::HeaderMap>, tower_grpc::Error> {
         Payload::poll_trailers(self).map_err(From::from)
+    }
+}
+
+impl<B, C> TryClone for RequestBody<B, C>
+where
+    B: Payload<Error=h2::Error> + TryClone,
+    C: Eq + Hash
+{
+    fn try_clone(&self) -> Option<Self> {
+        self
+            .inner
+            .try_clone()
+            .map(|inner| {
+                RequestBody {
+                    inner,
+                    metrics: self.metrics.clone(),
+                }
+            })
     }
 }
 

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -9,6 +9,7 @@ pub mod metrics;
 pub mod normalize_uri;
 pub mod orig_proto;
 pub mod profiles;
+pub mod retry;
 pub mod router;
 pub mod settings;
 pub mod upgrade;

--- a/src/proxy/http/retry.rs
+++ b/src/proxy/http/retry.rs
@@ -1,0 +1,184 @@
+use std::marker::PhantomData;
+
+use futures::future;
+use http::{Request, Response};
+use tower_retry;
+
+use proxy::http::metrics::{Scoped, Stats};
+use svc;
+
+pub trait CanRetry {
+    type Retry: Retry + Clone;
+    fn can_retry(&self) -> Option<Self::Retry>;
+}
+
+pub trait Retry: Sized {
+    fn retry<B1, B2>(&self, req: &Request<B1>, res: &Response<B2>) -> Result<(), NoRetry>;
+    fn clone_request<B: TryClone>(&self, req: &Request<B>) -> Option<Request<B>>;
+}
+
+pub enum NoRetry {
+    Success,
+    Budget,
+}
+
+pub trait TryClone: Sized {
+    fn try_clone(&self) -> Option<Self>;
+}
+
+pub struct Layer<S, K, A, B> {
+    registry: S,
+    _p: PhantomData<(K, fn(A) -> B)>,
+}
+
+pub struct Stack<M, S, K, A, B> {
+    inner: M,
+    registry: S,
+    _p: PhantomData<(K, fn(A) -> B)>,
+}
+
+pub type Service<R, Svc, St> = tower_retry::Retry<Policy<R, St>, Svc>;
+
+#[derive(Clone)]
+pub struct Policy<R, S>(R, S);
+
+// === impl Layer ===
+
+pub fn layer<S, K, A, B>(registry: S) -> Layer<S, K, A, B> {
+    Layer {
+        registry,
+        _p: PhantomData,
+    }
+}
+
+impl<S: Clone, K, A, B> Clone for Layer<S, K, A, B> {
+    fn clone(&self) -> Self {
+        Layer {
+            registry: self.registry.clone(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T, M, S, K, A, B> svc::Layer<T, T, M> for Layer<S, K, A, B>
+where
+    T: CanRetry + Clone,
+    M: svc::Stack<T>,
+    M::Value: svc::Service<Request<A>, Response = Response<B>> + Clone,
+    S: Scoped<K> + Clone,
+    S::Scope: Clone,
+    K: From<T>,
+    A: TryClone,
+{
+    type Value = <Stack<M, S, K, A, B> as svc::Stack<T>>::Value;
+    type Error = <Stack<M, S, K, A, B> as svc::Stack<T>>::Error;
+    type Stack = Stack<M, S, K, A, B>;
+
+    fn bind(&self, inner: M) -> Self::Stack {
+        Stack {
+            inner,
+            registry: self.registry.clone(),
+            _p: PhantomData,
+        }
+    }
+}
+
+// === impl Stack ===
+
+impl<M: Clone, S: Clone, K, A, B> Clone for Stack<M, S, K, A, B> {
+    fn clone(&self) -> Self {
+        Stack {
+            inner: self.inner.clone(),
+            registry: self.registry.clone(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<T, M, S, K, A, B> svc::Stack<T> for Stack<M, S, K, A, B>
+where
+    T: CanRetry + Clone,
+    M: svc::Stack<T>,
+    M::Value: svc::Service<Request<A>, Response = Response<B>> + Clone,
+    S: Scoped<K>,
+    S::Scope: Clone,
+    K: From<T>,
+    A: TryClone,
+{
+    type Value = svc::Either<Service<T::Retry, M::Value, S::Scope>, M::Value>;
+    type Error = M::Error;
+
+    fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
+        let inner = self.inner.make(target)?;
+        if let Some(retries) = target.can_retry() {
+            trace!("stack is retryable");
+            let stats = self.registry.scoped(target.clone().into());
+            Ok(svc::Either::A(tower_retry::Retry::new(Policy(retries, stats), inner)))
+        } else {
+            Ok(svc::Either::B(inner))
+        }
+    }
+}
+
+// === impl Policy ===
+
+impl<R, S, A, B, E> ::tower_retry::Policy<Request<A>, Response<B>, E> for Policy<R, S>
+where
+    R: Retry + Clone,
+    S: Stats + Clone,
+    A: TryClone,
+{
+    type Future = future::FutureResult<Self, ()>;
+
+    fn retry(&self, req: &Request<A>, result: Result<&Response<B>, &E>) -> Option<Self::Future> {
+        match result {
+            Ok(res) => {
+                match self.0.retry(req, res) {
+                    Ok(()) => {
+                        trace!("retrying request");
+                        Some(future::ok(self.clone()))
+                    },
+                    Err(NoRetry::Budget) => {
+                        self.1.incr_retry_skipped_budget();
+                        None
+                    },
+                    Err(NoRetry::Success) => None,
+                }
+            },
+            Err(_err) => {
+                trace!("cannot retry transport error");
+                None
+            }
+        }
+    }
+
+    fn clone_request(&self, req: &Request<A>) -> Option<Request<A>> {
+        if let Some(clone) = self.0.clone_request(req) {
+            trace!("cloning request");
+            Some(clone)
+        } else {
+            trace!("request could not be cloned");
+            None
+        }
+    }
+}
+
+impl<B: TryClone> TryClone for Request<B> {
+    fn try_clone(&self) -> Option<Self> {
+        if let Some(body) = self.body().try_clone() {
+            let mut clone = Request::new(body);
+            *clone.method_mut() = self.method().clone();
+            *clone.uri_mut() = self.uri().clone();
+            *clone.headers_mut() = self.headers().clone();
+            *clone.version_mut() = self.version();
+
+            if let Some(ext) = self.extensions().get::<::proxy::server::Source>() {
+                clone.extensions_mut().insert(ext.clone());
+            }
+
+            Some(clone)
+        } else {
+            None
+        }
+    }
+}

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -1,0 +1,293 @@
+#![recursion_limit="128"]
+#![deny(warnings)]
+mod support;
+use self::support::*;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+macro_rules! profile_test {
+    (routes: [$($route:expr),+], budget: $budget:expr, with_client: $with_client:expr) => {
+        profile_test! {
+            routes: [$($route),+],
+            budget: $budget,
+            with_client: $with_client,
+            with_metrics: |_m| {}
+        }
+    };
+    (routes: [$($route:expr),+], budget: $budget:expr, with_client: $with_client:expr, with_metrics: $with_metrics:expr) => {
+        profile_test! {
+            http: http1,
+            routes: [$($route),+],
+            budget: $budget,
+            with_client: $with_client,
+            with_metrics: $with_metrics
+        }
+    };
+    (http: $http:ident, routes: [$($route:expr),+], budget: $budget:expr, with_client: $with_client:expr, with_metrics: $with_metrics:expr) => {
+        let _ = env_logger_init();
+
+        let counter = AtomicUsize::new(0);
+        let counter2 = AtomicUsize::new(0);
+        let counter3 = AtomicUsize::new(0);
+        let host = "profiles.test.svc.cluster.local";
+
+        let srv = server::$http()
+            .route_fn("/load-profile", |_| {
+                Response::builder()
+                    .status(201)
+                    .body("".into())
+                    .unwrap()
+            })
+            .route_fn("/0.5",  move |_req| {
+                if counter.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
+                    Response::builder()
+                        .status(533)
+                        .body("nope".into())
+                        .unwrap()
+                } else {
+                    Response::builder()
+                        .status(200)
+                        .body("retried".into())
+                        .unwrap()
+                }
+            })
+            .route_fn("/0.5/sleep",  move |_req| {
+                ::std::thread::sleep(Duration::from_secs(1));
+                if counter2.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
+                    Response::builder()
+                        .status(533)
+                        .body("nope".into())
+                        .unwrap()
+                } else {
+                    Response::builder()
+                        .status(200)
+                        .body("retried".into())
+                        .unwrap()
+                }
+            })
+            .route_fn("/0.5/100KB",  move |_req| {
+                if counter3.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
+                    Response::builder()
+                        .status(533)
+                        .body(vec![b'x'; 1024 * 100].into())
+                        .unwrap()
+                } else {
+                    Response::builder()
+                        .status(200)
+                        .body("retried".into())
+                        .unwrap()
+                }
+            })
+            .run();
+        let ctrl = controller::new();
+
+        let dst_tx = ctrl.destination_tx(host);
+        dst_tx.send_addr(srv.addr);
+
+        let profile_tx = ctrl.profile_tx(host);
+        let routes = vec![$(
+            $route,
+        ),+];
+        profile_tx.send(controller::profile(routes, $budget));
+
+        let ctrl = ctrl.run();
+        let proxy = proxy::new()
+            .controller(ctrl)
+            .outbound(srv)
+            .run();
+
+        let client = client::$http(proxy.outbound, host);
+        assert_eq!(client.get("/load-profile"), "");
+
+        $with_client(client);
+
+        let metrics = client::http1(proxy.metrics, "localhost");
+        $with_metrics(metrics);
+    }
+}
+
+#[test]
+fn retry_if_profile_allows() {
+    profile_test! {
+        routes: [
+            controller::route()
+                .request_any()
+                // use default classifier
+                .retryable(true)
+        ],
+        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
+        with_client: |client: client::Client| {
+            assert_eq!(client.get("/0.5"), "retried");
+        }
+    }
+}
+
+#[test]
+fn retry_uses_budget() {
+    profile_test! {
+        routes: [
+            controller::route()
+                .request_any()
+                .response_failure(500..600)
+                .retryable(true)
+        ],
+        budget: Some(controller::retry_budget(Duration::from_secs(1), 0.1, 1)),
+        with_client: |client: client::Client| {
+            assert_eq!(client.get("/0.5"), "retried");
+            let res = client.request(&mut client.request_builder("/0.5"));
+            assert_eq!(res.status(), 533);
+        },
+        with_metrics: |metrics: client::Client| {
+            assert_eventually_contains!(
+                metrics.get("/metrics"),
+                "route_actual_retry_skipped_total{direction=\"outbound\",dst=\"profiles.test.svc.cluster.local:80\",skipped=\"budget\"} 1"
+            );
+        }
+    }
+}
+
+#[test]
+fn does_not_retry_if_request_does_not_match() {
+    profile_test! {
+        routes: [
+            controller::route()
+                .request_path("/wont/match/anything")
+                .response_failure(..)
+                .retryable(true)
+        ],
+        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
+        with_client: |client: client::Client| {
+            let res = client.request(&mut client.request_builder("/0.5"));
+            assert_eq!(res.status(), 533);
+        }
+    }
+}
+
+#[test]
+fn does_not_retry_if_earlier_response_class_is_success() {
+    profile_test! {
+        routes: [
+            controller::route()
+                .request_any()
+                // prevent 533s from being retried
+                .response_success(533..534)
+                .response_failure(500..600)
+                .retryable(true)
+        ],
+        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
+        with_client: |client: client::Client| {
+            let res = client.request(&mut client.request_builder("/0.5"));
+            assert_eq!(res.status(), 533);
+        }
+    }
+}
+
+#[test]
+fn does_not_retry_if_request_has_body() {
+    profile_test! {
+        routes: [
+            controller::route()
+                .request_any()
+                .response_failure(500..600)
+                .retryable(true)
+        ],
+        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
+        with_client: |client: client::Client| {
+            let req = client.request_builder("/0.5")
+                .method("POST")
+                .body("req has a body".into())
+                .unwrap();
+            let res = client.request_body(req);
+            assert_eq!(res.status(), 533);
+        }
+    }
+}
+
+#[test]
+fn does_not_retry_if_missing_retry_budget() {
+    profile_test! {
+        routes: [
+            controller::route()
+                .request_any()
+                .response_failure(500..600)
+                .retryable(true)
+        ],
+        budget: None,
+        with_client: |client: client::Client| {
+            let res = client.request(&mut client.request_builder("/0.5"));
+            assert_eq!(res.status(), 533);
+        }
+    }
+}
+
+#[test]
+fn ignores_invalid_retry_budget_ttl() {
+    profile_test! {
+        routes: [
+            controller::route()
+                .request_any()
+                .response_failure(500..600)
+                .retryable(true)
+        ],
+        budget: Some(controller::retry_budget(Duration::from_secs(1000), 0.1, 1)),
+        with_client: |client: client::Client| {
+            let res = client.request(&mut client.request_builder("/0.5"));
+            assert_eq!(res.status(), 533);
+        }
+    }
+}
+
+#[test]
+fn ignores_invalid_retry_budget_ratio() {
+    profile_test! {
+        routes: [
+            controller::route()
+                .request_any()
+                .response_failure(500..600)
+                .retryable(true)
+        ],
+        budget: Some(controller::retry_budget(Duration::from_secs(10), 10_000.0, 1)),
+        with_client: |client: client::Client| {
+            let res = client.request(&mut client.request_builder("/0.5"));
+            assert_eq!(res.status(), 533);
+        }
+    }
+}
+
+#[test]
+fn ignores_invalid_retry_budget_negative_ratio() {
+    profile_test! {
+        routes: [
+            controller::route()
+                .request_any()
+                .response_failure(500..600)
+                .retryable(true)
+        ],
+        budget: Some(controller::retry_budget(Duration::from_secs(10), -1.0, 1)),
+        with_client: |client: client::Client| {
+            let res = client.request(&mut client.request_builder("/0.5"));
+            assert_eq!(res.status(), 533);
+        }
+    }
+}
+
+#[test]
+fn http2_failures_dont_leak_connection_window() {
+    profile_test! {
+        http: http2,
+        routes: [
+            controller::route()
+                .request_any()
+                .response_failure(500..600)
+                .retryable(true)
+        ],
+        budget: Some(controller::retry_budget(Duration::from_secs(10), 1.0, 10)),
+        with_client: |client: client::Client| {
+            // Before https://github.com/carllerche/h2/pull/334, this would
+            // hang since the retried failure would have leaked the 100k window
+            // capacity, preventing the successful response from being read.
+            assert_eq!(client.get("/0.5/100KB"), "retried");
+        },
+        with_metrics: |_m| {}
+    }
+}

--- a/tests/support/client.rs
+++ b/tests/support/client.rs
@@ -72,10 +72,9 @@ impl Client {
     pub fn get(&self, path: &str) -> String {
         let mut req = self.request_builder(path);
         let res = self.request(req.method("GET"));
-        assert_eq!(
-            res.status(),
-            StatusCode::OK,
-            "client.get({:?}) expects 200 OK, got \"{}\"",
+        assert!(
+            res.status().is_success(),
+            "client.get({:?}) expects 2xx, got \"{}\"",
             path,
             res.status(),
         );

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -55,16 +55,17 @@ const DEFAULT_LOG: &'static str =
     linkerd2_proxy::proxy::http::router=off,\
     linkerd2_proxy::proxy::tcp=off";
 
-pub fn env_logger_init() {
+pub fn env_logger_init() -> Result<(), String> {
     use std::env;
 
-    let log = env::var("LINKERD2_PROXY_LOG").unwrap_or_else(|_| DEFAULT_LOG.to_owned());
+    let log = env::var("LINKERD2_PROXY_LOG")
+        .or_else(|_| env::var("RUST_LOG"))
+        .unwrap_or_else(|_| DEFAULT_LOG.to_owned());
     env::set_var("RUST_LOG", &log);
     env::set_var("LINKERD2_PROXY_LOG", &log);
 
-    if let Err(e) = env_logger::try_init() {
-        eprintln!("Failed to initialize logger: {}", e);
-    }
+    env_logger::try_init()
+        .map_err(|e| e.to_string())
 }
 
 /// Retry an assertion up to a specified number of times, waiting


### PR DESCRIPTION
This is a WIP that adds request retries if a service profile includes retry instructions, based on https://github.com/linkerd/linkerd2-proxy-api/pull/16.

- [x] Retries requests if a response class from a service profile matches and `is_failure`.
- [x] Uses `retry_budget` per service profile.
- [x] ~~Uses `retry_timeout` per `Route`.~~
- [x] ~~Use `default_retry_timeout` from the service profile if a route doesn't include a `retry_timeout`.~~
- [x] Figure out what metrics should look like.