### PR TITLE
tests: Replace `uimplemented!` with 'unreachable!'

### DIFF
--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -316,7 +316,7 @@ mod test_util {
         type Future = future::FutureResult<usize, ()>;
 
         fn poll_ready(&mut self) -> Poll<(), ()> {
-            unimplemented!()
+            unreachable!("not called in test")
         }
 
         fn call(&mut self, req: Request) -> Self::Future {

--- a/src/transport/io.rs
+++ b/src/transport/io.rs
@@ -110,7 +110,7 @@ mod tests {
 
     impl io::Read for WriteBufDetector {
         fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
-            unimplemented!()
+            unreachable!("not called in test")
         }
     }
 
@@ -119,7 +119,7 @@ mod tests {
             panic!("BoxedIo called wrong write_buf method");
         }
         fn flush(&mut self) -> io::Result<()> {
-            unimplemented!()
+            unreachable!("not called in test")
         }
     }
 
@@ -127,7 +127,7 @@ mod tests {
 
     impl AsyncWrite for WriteBufDetector {
         fn shutdown(&mut self) -> Poll<(), io::Error> {
-            unimplemented!()
+            unreachable!("not called in test")
         }
 
         fn write_buf<B: Buf>(&mut self, _: &mut B) -> Poll<usize, io::Error> {
@@ -137,17 +137,17 @@ mod tests {
 
     impl AddrInfo for WriteBufDetector {
         fn local_addr(&self) -> Result<SocketAddr, io::Error> {
-            unimplemented!()
+            unreachable!("not called in test")
         }
 
         fn get_original_dst(&self) -> Option<SocketAddr> {
-            unimplemented!()
+            unreachable!("not called in test")
         }
     }
 
     impl Io for WriteBufDetector {
         fn shutdown_write(&mut self) -> Result<(), io::Error> {
-            unimplemented!()
+            unreachable!("not called in test")
         }
 
         fn write_buf_erased(&mut self, mut buf: &mut Buf) -> Poll<usize, io::Error> {

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -199,7 +199,7 @@ mod response_classification {
                 let grpc_status = parse_header(headers, REQ_GRPC_STATUS_HEADER);
                 let mut rsp = if let Some(_grpc_status) = grpc_status {
                     // TODO: tests for grpc statuses
-                    unimplemented!()
+                    unreachable!("not called in test")
                 } else {
                     Response::new("".into())
                 };


### PR DESCRIPTION
When developing, it's convenient to use `unimplemented!` as a
placeholder for work that has not yet been done. However, we also use
`unimplemented!` in various tests in stubbed methods; so searching the
project for `unimplemented` produces false positives.

This change replaces these with `unreachable!`, which is functionaly
equivalent, but better indicates that the current usage does not reach
these methods and disambiguates usage of `unimplemented!`.