### PR TITLE
Dockerfile: copy all lib crates before fetching dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,26 +16,12 @@ FROM $RUST_IMAGE as build
 WORKDIR /usr/src/linkerd2-proxy
 
 # Fetch external dependencies.
-#
-# Mock out all local code and fetch external dependencies to ensure that
-# external sources are primarily cached on Cargo.lock.
-RUN mkdir -p src && touch src/lib.rs && \
-    for d in fs-watch futures-mpsc-lossy metrics router stack task timeout never; \
-    do mkdir -p "lib/${d}/src" && touch "lib/${d}/src/lib.rs" ; \
-    done
+RUN mkdir -p src && touch src/lib.rs
 COPY Cargo.toml Cargo.lock ./
-COPY lib/fs-watch/Cargo.toml            lib/fs-watch/Cargo.toml
-COPY lib/futures-mpsc-lossy/Cargo.toml  lib/futures-mpsc-lossy/Cargo.toml
-COPY lib/metrics/Cargo.toml             lib/metrics/Cargo.toml
-COPY lib/router/Cargo.toml              lib/router/Cargo.toml
-COPY lib/stack/Cargo.toml               lib/stack/Cargo.toml
-COPY lib/task/Cargo.toml                lib/task/Cargo.toml
-COPY lib/timeout/Cargo.toml             lib/timeout/Cargo.toml
-COPY lib/never/Cargo.toml               lib/never/Cargo.toml
+COPY lib lib
 RUN cargo fetch --locked
 
 # Build libraries, leaving the proxy mocked out.
-COPY lib lib
 ARG PROXY_UNOPTIMIZED
 RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
     then cargo build --frozen ; \


### PR DESCRIPTION
It was [noticed](https://github.com/linkerd/linkerd2-proxy/pull/114#issuecomment-442553879) that `hyper-balance` was forgotten in the `Dockerfile`. This change removes the manual copying of `lib/*` dependencies and just copies the whole `lib` directory.