### PR TITLE
Expose route labels via tap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
  "linkerd2-fs-watch 0.1.0",
  "linkerd2-metrics 0.1.0",
  "linkerd2-never 0.1.0",
- "linkerd2-proxy-api 0.1.3 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=ver/tap-routes)",
+ "linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.4)",
  "linkerd2-router 0.1.0",
  "linkerd2-stack 0.1.0",
  "linkerd2-task 0.1.0",
@@ -582,8 +582,8 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.3"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=ver/tap-routes#de20a798ba70fcc27f91054088786b68fe0d9dcc"
+version = "0.1.4"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.4#bb4861389d504dfea7b616df8cf6329b1c6f5e50"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1707,7 +1707,7 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.3 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=ver/tap-routes)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.4)" = "<none>"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,7 +542,7 @@ dependencies = [
  "linkerd2-fs-watch 0.1.0",
  "linkerd2-metrics 0.1.0",
  "linkerd2-never 0.1.0",
- "linkerd2-proxy-api 0.1.3 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.3)",
+ "linkerd2-proxy-api 0.1.3 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=ver/tap-routes)",
  "linkerd2-router 0.1.0",
  "linkerd2-stack 0.1.0",
  "linkerd2-task 0.1.0",
@@ -583,7 +583,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.3"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.3#4fe4a6294fc68d1ed83948ddbc5d4f86aec6c5ef"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=ver/tap-routes#de20a798ba70fcc27f91054088786b68fe0d9dcc"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1707,7 +1707,7 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.3 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.3)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.3 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=ver/tap-routes)" = "<none>"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ linkerd2-stack     = { path = "lib/stack" }
 linkerd2-task      = { path = "lib/task" }
 linkerd2-timeout   = { path = "lib/timeout" }
 
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/tap-routes" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.4", version = "0.1.4" }
 
 bytes = "0.4"
 env_logger = { version = "0.5", default-features = false }
@@ -91,7 +91,7 @@ net2 = "0.2"
 quickcheck = { version = "0.6", default-features = false }
 linkerd2-metrics = { path = "./lib/metrics", features = ["test_util"] }
 linkerd2-task    = { path = "lib/task", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/tap-routes", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.4", version = "0.1.4", features = ["arbitrary"] }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ linkerd2-stack     = { path = "lib/stack" }
 linkerd2-task      = { path = "lib/task" }
 linkerd2-timeout   = { path = "lib/timeout" }
 
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.3", version = "0.1.3" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/tap-routes" }
 
 bytes = "0.4"
 env_logger = { version = "0.5", default-features = false }
@@ -91,7 +91,7 @@ net2 = "0.2"
 quickcheck = { version = "0.6", default-features = false }
 linkerd2-metrics = { path = "./lib/metrics", features = ["test_util"] }
 linkerd2-task    = { path = "lib/task", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.3", version = "0.1.3", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/tap-routes", features = ["arbitrary"] }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.

--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -1,5 +1,7 @@
 use http;
+use indexmap::IndexMap;
 use std::fmt;
+use std::sync::Arc;
 
 use proxy::http::{metrics::classify::CanClassify, profiles};
 use {Addr, NameAddr};
@@ -83,5 +85,13 @@ impl profiles::WithRoute for DstAddr {
             dst_addr: self,
             route,
         }
+    }
+}
+
+// === impl Route ===
+
+impl Route {
+    pub fn labels(&self) -> &Arc<IndexMap<String, String>> {
+        self.route.labels()
     }
 }

--- a/src/app/inbound.rs
+++ b/src/app/inbound.rs
@@ -2,6 +2,7 @@ use http;
 use indexmap::IndexMap;
 use std::fmt;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use super::classify;
 use super::dst::DstAddr;
@@ -68,6 +69,10 @@ impl tap::Inspect for Endpoint {
 
     fn dst_tls<B>(&self, _: &http::Request<B>) -> tls::Status {
         Conditional::None(tls::ReasonForNoTls::InternalTraffic)
+    }
+
+    fn route_labels<B>(&self, req: &http::Request<B>) -> Option<Arc<IndexMap<String, String>>> {
+        req.extensions().get::<super::dst::Route>().map(|r| r.labels().clone())
     }
 
     fn is_outbound<B>(&self, _: &http::Request<B>) -> bool {

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -341,6 +341,7 @@ where
                 // extension into each request so that all lower metrics
                 // implementations can use the route-specific configuration.
                 let dst_route_layer = phantom_data::layer()
+                    .push(insert_target::layer())
                     .push(metrics::layer::<_, classify::Response>(route_http_metrics))
                     .push(classify::layer());
 
@@ -495,6 +496,7 @@ where
                 // extension into each request so that all lower metrics
                 // implementations can use the route-specific configuration.
                 let dst_route_stack = phantom_data::layer()
+                    .push(insert_target::layer())
                     .push(http_metrics::layer::<_, classify::Response>(
                         route_http_metrics,
                     ))

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -1,5 +1,6 @@
 use indexmap::IndexMap;
 use std::{fmt, net};
+use std::sync::Arc;
 
 use control::destination::{Metadata, ProtocolHint};
 use proxy::http::settings;
@@ -75,6 +76,10 @@ impl tap::Inspect for Endpoint {
 
     fn dst_tls<B>(&self, _: &http::Request<B>) -> tls::Status {
         self.metadata.tls_status()
+    }
+
+    fn route_labels<B>(&self, req: &http::Request<B>) -> Option<Arc<IndexMap<String, String>>> {
+        req.extensions().get::<super::dst::Route>().map(|r| r.labels().clone())
     }
 
     fn is_outbound<B>(&self, _: &http::Request<B>) -> bool {

--- a/src/tap/grpc/match_.rs
+++ b/src/tap/grpc/match_.rs
@@ -19,6 +19,7 @@ pub enum Match {
     Source(TcpMatch),
     Destination(TcpMatch),
     DestinationLabel(LabelMatch),
+    RouteLabel(LabelMatch),
     Http(HttpMatch),
 }
 
@@ -87,6 +88,10 @@ impl Match {
                 .dst_labels(req)
                 .map(|l| lbl.matches(l))
                 .unwrap_or(false),
+            Match::RouteLabel(ref lbl) => inspect
+                .route_labels(req)
+                .map(|l| lbl.matches(l.as_ref()))
+                .unwrap_or(false),
             Match::Http(ref http) => http.matches(req, inspect),
         }
     }
@@ -120,6 +125,7 @@ impl TryFrom<observe_request::match_::Match> for Match {
             match_::Match::DestinationLabel(l) => {
                 LabelMatch::try_from(l).map(Match::DestinationLabel)
             }
+            match_::Match::RouteLabel(l) => LabelMatch::try_from(l).map(Match::RouteLabel),
             match_::Match::Http(http) => HttpMatch::try_from(http).map(Match::Http),
         }
     }

--- a/src/tap/grpc/server.rs
+++ b/src/tap/grpc/server.rs
@@ -539,14 +539,14 @@ fn base_event<B, I: Inspect>(req: &http::Request<B>, inspect: &I) -> api::TapEve
         destination: inspect.dst_addr(req).as_ref().map(|a| a.into()),
         destination_meta: inspect.dst_labels(req).map(|labels| {
             let mut m = api::tap_event::EndpointMeta::default();
-            m.labels.extend(labels.clone());
+            m.labels.extend(labels.iter().map(|(k, v)| (k.clone(), v.clone())));
             let tls = format!("{}", inspect.dst_tls(req));
             m.labels.insert("tls".to_owned(), tls);
             m
         }),
         route_meta: inspect.route_labels(req).map(|labels| {
             let mut m = api::tap_event::RouteMeta::default();
-            m.labels.extend(labels.as_ref().clone());
+            m.labels.extend(labels.as_ref().iter().map(|(k, v)| (k.clone(), v.clone())));
             m
         }),
         event: None,

--- a/src/tap/grpc/server.rs
+++ b/src/tap/grpc/server.rs
@@ -544,6 +544,11 @@ fn base_event<B, I: Inspect>(req: &http::Request<B>, inspect: &I) -> api::TapEve
             m.labels.insert("tls".to_owned(), tls);
             m
         }),
+        route_meta: inspect.route_labels(req).map(|labels| {
+            let mut m = api::tap_event::RouteMeta::default();
+            m.labels.extend(labels.as_ref().clone());
+            m
+        }),
         event: None,
     }
 }

--- a/src/tap/mod.rs
+++ b/src/tap/mod.rs
@@ -1,6 +1,7 @@
 use http;
 use indexmap::IndexMap;
 use std::net;
+use std::sync::Arc;
 
 use transport::tls;
 
@@ -46,6 +47,8 @@ pub trait Inspect {
     fn dst_addr<B>(&self, req: &http::Request<B>) -> Option<net::SocketAddr>;
     fn dst_labels<B>(&self, req: &http::Request<B>) -> Option<&IndexMap<String, String>>;
     fn dst_tls<B>(&self, req: &http::Request<B>) -> tls::Status;
+
+    fn route_labels<B>(&self, req: &http::Request<B>) -> Option<Arc<IndexMap<String, String>>>;
 
     fn is_outbound<B>(&self, req: &http::Request<B>) -> bool;
 


### PR DESCRIPTION
Route labels are not queryable by tap, nor are they exposed to in tap
events.

This change adds route label matching and adds route labels to events.

Depends on linkerd/linkerd2-proxy-api#17