### PR TITLE
Log discovery updates in the outbound proxy

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -542,13 +542,13 @@ where
                             .get(super::CANONICAL_DST_HEADER)
                             .and_then(|dst| dst.to_str().ok())
                             .and_then(|d| Addr::from_str(d).ok());
-                        info!("inbound canonical={:?}", canonical);
+                        debug!("inbound canonical={:?}", canonical);
 
                         let dst = canonical
                             .or_else(|| super::http_request_authority_addr(req).ok())
                             .or_else(|| super::http_request_host_addr(req).ok())
                             .or_else(|| super::http_request_orig_dst_addr(req).ok());
-                        info!("inbound dst={:?}", dst);
+                        debug!("inbound dst={:?}", dst);
                         dst.map(DstAddr::inbound)
                     }))
                     .make(&router::Config::new("in dst", capacity, max_idle_age))

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -147,11 +147,11 @@ pub mod discovery {
             match self {
                 Resolution::Name(ref name, ref mut res) => match try_ready!(res.poll()) {
                     resolve::Update::Remove(addr) => {
-                        debug!("removing {} from {}", addr, name);
+                        debug!("removing {}", addr);
                         Ok(Async::Ready(resolve::Update::Remove(addr)))
                     }
                     resolve::Update::Add(addr, metadata) => {
-                        debug!("adding {} to {}", addr, name);
+                        debug!("adding {}", addr);
                         // If the endpoint does not have TLS, note the reason.
                         // Otherwise, indicate that we don't (yet) have a TLS
                         // config. This value may be changed by a stack layer that

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -147,9 +147,11 @@ pub mod discovery {
             match self {
                 Resolution::Name(ref name, ref mut res) => match try_ready!(res.poll()) {
                     resolve::Update::Remove(addr) => {
+                        debug!("removing {} from {}", addr, name);
                         Ok(Async::Ready(resolve::Update::Remove(addr)))
                     }
                     resolve::Update::Add(addr, metadata) => {
+                        debug!("adding {} to {}", addr, name);
                         // If the endpoint does not have TLS, note the reason.
                         // Otherwise, indicate that we don't (yet) have a TLS
                         // config. This value may be changed by a stack layer that


### PR DESCRIPTION
When debugging issues that users believe is related to discovery, it's helpful to get a narrow set of logs out to determine whether the proxy is observing discovery updates.

With this change, a user can inject the proxy with `--proxy-log-level='warn,linkerd2_proxy=info,linkerd2_proxy::app::outbound::discovery=debug'` and the proxy's logs will include messages like:

```
DBUG voting-svc.emojivoto.svc.cluster.local:8080 linkerd2_proxy::app::outbound::discovery adding 10.233.70.98:8080 to voting-svc.emojivoto.svc.cluster.local:8080
DBUG voting-svc.emojivoto.svc.cluster.local:8080 linkerd2_proxy::app::outbound::discovery removing 10.233.66.36:8080 from voting-svc.emojivoto.svc.cluster.local:8080
```

This change also turns-down some overly chatty INFO logging in main.