### PR TITLE
Make TLS accept logic compatible with disabled protocol detection

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -669,16 +669,17 @@ where
     let server = proxy::Server::new(
         proxy_name,
         listen_addr,
-        get_orig_dst,
         accept,
         connect,
         router,
-        disable_protocol_detection_ports,
         drain_rx.clone(),
     );
     let log = server.log().clone();
 
     let accept = {
+        let bound_port = bound_port
+            .without_protocol_detection_for(disable_protocol_detection_ports)
+            .with_original_dst(get_orig_dst);
         let fut = bound_port.listen_and_fold((), move |(), (connection, remote_addr)| {
             let s = server.serve(connection, remote_addr);
             // Logging context is configured by the server.

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -249,9 +249,6 @@ where
             Err(never) => match never {},
         };
 
-        // We are using the port from the connection's SO_ORIGINAL_DST to
-        // determine whether to skip protocol detection, not any port that
-        // would be found after doing discovery.
         if disable_protocol_detection {
             trace!("protocol detection disabled for {:?}", orig_dst);
             let fwd = tcp::forward(io, &self.connect, &source);

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -229,7 +229,7 @@ where
         -> impl Future<Item=(), Error=()>
     {
         let orig_dst = connection.original_dst_addr();
-        let disable_protocol_detection = connection.disable_protocol_detection();
+        let disable_protocol_detection = connection.is_protocol_detection_disabled();
 
         let log = self.log.clone()
             .with_remote(remote_addr);
@@ -241,7 +241,6 @@ where
             tls_status: connection.tls_status(),
             _p: (),
         };
-
 
         let io = match self.accept.make(&source) {
             Ok(accept) => accept.accept(connection),

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -229,7 +229,7 @@ where
         -> impl Future<Item=(), Error=()>
     {
         let orig_dst = connection.original_dst_addr();
-        let disable_protocol_detection = connection.is_protocol_detection_disabled();
+        let disable_protocol_detection = !connection.should_detect_protocol();
 
         let log = self.log.clone()
             .with_remote(remote_addr);

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -1,7 +1,6 @@
 use futures::{future::Either, Future};
 use http;
 use hyper;
-use indexmap::IndexSet;
 use std::{error, fmt};
 use std::net::SocketAddr;
 
@@ -9,7 +8,7 @@ use Conditional;
 use drain;
 use never::Never;
 use svc::{Stack, Service};
-use transport::{connect, tls, Connection, GetOriginalDst, Peek};
+use transport::{connect, tls, Connection, Peek};
 use proxy::http::glue::{HttpBody, HyperServerSvc};
 use proxy::protocol::Protocol;
 use proxy::tcp;
@@ -40,7 +39,7 @@ use super::Accept;
 ///
 /// 6. Otherwise, an `R`-typed `Service` `Stack` is used to build a service that
 ///    can routeHTTP  requests for the `Source`.
-pub struct Server<A, C, R, B, G>
+pub struct Server<A, C, R, B>
 where
     // Prepares a server transport, e.g. with telemetry.
     A: Stack<Source, Error = Never> + Clone,
@@ -55,12 +54,8 @@ where
         Response = http::Response<B>,
     >,
     B: hyper::body::Payload,
-    // Determines the original destination of an intercepted server socket.
-    G: GetOriginalDst,
 {
-    disable_protocol_detection_ports: IndexSet<u16>,
     drain_signal: drain::Watch,
-    get_orig_dst: G,
     http: hyper::server::conn::Http,
     listen_addr: SocketAddr,
     accept: A,
@@ -178,7 +173,7 @@ impl Stack<Source> for () {
     }
 }
 
-impl<A, C, R, B, G> Server<A, C, R, B, G>
+impl<A, C, R, B> Server<A, C, R, B>
 where
     A: Stack<Source, Error = Never> + Clone,
     A::Value: Accept<Connection>,
@@ -197,25 +192,20 @@ where
     <R::Value as Service<http::Request<HttpBody>>>::Error: error::Error + Send + Sync + 'static,
     <R::Value as Service<http::Request<HttpBody>>>::Future: Send + 'static,
     B: hyper::body::Payload + Default + Send + 'static,
-    G: GetOriginalDst,
 {
 
     /// Creates a new `Server`.
     pub fn new(
         proxy_name: &'static str,
         listen_addr: SocketAddr,
-        get_orig_dst: G,
         accept: A,
         connect: C,
         route: R,
-        disable_protocol_detection_ports: IndexSet<u16>,
         drain_signal: drain::Watch,
     ) -> Self {
         let log = ::logging::Server::proxy(proxy_name, listen_addr);
         Server {
-            disable_protocol_detection_ports,
             drain_signal,
-            get_orig_dst,
             http: hyper::server::conn::Http::new(),
             listen_addr,
             accept,
@@ -238,7 +228,8 @@ where
     pub fn serve(&self, connection: Connection, remote_addr: SocketAddr)
         -> impl Future<Item=(), Error=()>
     {
-        let orig_dst = connection.original_dst_addr(&self.get_orig_dst);
+        let orig_dst = connection.original_dst_addr();
+        let disable_protocol_detection = connection.disable_protocol_detection();
 
         let log = self.log.clone()
             .with_remote(remote_addr);
@@ -251,6 +242,7 @@ where
             _p: (),
         };
 
+
         let io = match self.accept.make(&source) {
             Ok(accept) => accept.accept(connection),
             // Matching never allows LLVM to eliminate this entirely.
@@ -260,12 +252,6 @@ where
         // We are using the port from the connection's SO_ORIGINAL_DST to
         // determine whether to skip protocol detection, not any port that
         // would be found after doing discovery.
-        let disable_protocol_detection = orig_dst
-            .map(|addr| {
-                self.disable_protocol_detection_ports.contains(&addr.port())
-            })
-            .unwrap_or(false);
-
         if disable_protocol_detection {
             trace!("protocol detection disabled for {:?}", orig_dst);
             let fwd = tcp::forward(io, &self.connect, &source);

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -519,7 +519,7 @@ impl Connection {
         self.tls_status
     }
 
-    pub fn disable_protocol_detection(&self) -> bool {
+    pub fn is_protocol_detection_disabled(&self) -> bool {
         self.disable_protocol_detection
     }
 }

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -84,8 +84,9 @@ pub struct Connection {
     /// Whether or not the connection is secured with TLS.
     tls_status: tls::Status,
 
-    /// If true, protocol detection should be disabled for this connection.
-    disable_protocol_detection: bool,
+    /// If true, the proxy should attempt to detect the protocol for this
+    /// connection. If false, protocol detection should be skipped.
+    detect_protocol: bool,
 
     /// The connection's original destination address, if there was one.
     orig_dst: Option<SocketAddr>,
@@ -473,7 +474,7 @@ impl Connection {
             io: BoxedIo::new(io),
             peek_buf: BytesMut::new(),
             tls_status: Conditional::None(reason),
-            disable_protocol_detection: true,
+            detect_protocol: false,
             orig_dst: None,
         }
     }
@@ -485,7 +486,7 @@ impl Connection {
             io: BoxedIo::new(io),
             peek_buf,
             tls_status: Conditional::None(why_no_tls),
-            disable_protocol_detection: false,
+            detect_protocol: true,
             orig_dst: None,
         }
     }
@@ -495,7 +496,7 @@ impl Connection {
             io: io,
             peek_buf: BytesMut::new(),
             tls_status: Conditional::Some(()),
-            disable_protocol_detection: false,
+            detect_protocol: true,
             orig_dst: None,
         }
     }
@@ -519,8 +520,8 @@ impl Connection {
         self.tls_status
     }
 
-    pub fn is_protocol_detection_disabled(&self) -> bool {
-        self.disable_protocol_detection
+    pub fn should_detect_protocol(&self) -> bool {
+        self.detect_protocol
     }
 }
 


### PR DESCRIPTION
This branch changes the proxy's accept logic so that the proxy will no
longer attempt to terminate TLS on ports which are configured to skip
protocol detection. This means that a Linkerd deployment with 
`--tls optional` will no longer break server-speaks-first protocols like
 MySQL (although that traffic will not be encrypted). 

Since it's necessary to get the connection's original destination to
determine if it's on a port which should skip protocol detection, I've
moved the SO_ORIGINAL_DST call down the stack from `Server` to
`BoundPort`. However, to avoid making an additional unnecessary syscall,
the original destination is propagated to the server, along with the
information about whether or not protocol detection is enabled. This is
the approach described in
https://github.com/linkerd/linkerd2/issues/1270#issuecomment-406124236.

I've also written a new integration test for server-speaks-first
protocols with TLS enabled. This test is essentially the same as the
existing `transparency::tcp_server_first` test, but with TLS enabled for
the test proxy. I've confirmed that this fails against master.
Furthermore, I've validated this change by deploying the `booksapp` demo
with MySQL with TLS enabled, which [previously didn't work](https://github.com/linkerd/linkerd2/issues/1648#issuecomment-432867702).

Closes linkerd/linkerd2#1270

Signed-off-by: Eliza Weisman <eliza@buoyant.io>