### PR TITLE
Workaround for Rust 1.31 crash with verbose mode enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ jobs:
     # build.l5d.io/linkerd2-proxy/latest.txt is updated to reference the latest
     # uploaded binary.
     - if: type != pull_request
-      # Verbose is enabled so that the build doesn't timeout.
-      install: export CARGO_RELEASE=1 CARGO_VERBOSE=1
+      install: export CARGO_RELEASE=1
       script:
-        - make clean-package package
-        - make test
+        # travis-wait is used so that the build doesn't timeout.
+        - travis_wait 30 make clean-package package
+        - travis_wait 30 make test
       rust: stable
       deploy:
         on:


### PR DESCRIPTION
This branch replaces the `export CARGO_VERBOSE=1` on CI release-mode
builds with the `travis_wait` script. Verbose mode was previously being
set to prevent long release-mode builds from timing out. However, there
appears to be a bug in `rustc` 1.31.0, which causes the compiler to
crash when building the proxy with verbose mode enabled. Hopefully, this
will fix the build on master.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

