### PR TITLE
Actually fix the master CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,11 @@ jobs:
     # build.l5d.io/linkerd2-proxy/latest.txt is updated to reference the latest
     # uploaded binary.
     - if: type != pull_request
-      install: export CARGO_RELEASE=1
+      # Verbose is enabled so that the build doesn't timeout.
+      install: export CARGO_RELEASE=1 CARGO_VERBOSE=1
       script:
-        # travis-wait is used so that the build doesn't timeout.
-        - travis_wait 30 make clean-package package
-        - travis_wait 30 make test
+        - make clean-package package
+        - make test
       rust: stable
       deploy:
         on:

--- a/tests/tap.rs
+++ b/tests/tap.rs
@@ -1,3 +1,4 @@
+#![recursion_limit="128"]
 #![deny(warnings)]
 #[macro_use]
 mod support;


### PR DESCRIPTION
It turns out that increasing the recursion limit for the `tap` test
crate _actually_ fixes the compiler error that's broken the last several
builds on master. 

Since I'm now able to locally reproduce the error (which occurs only
when running the tests in release mode), I've verified that this
actually does fix the issue. Thus, I've also reverted the previous
commit (7c35f27ad3e86614c05a2a409c3a8b459cf023ac) which claimed to fix
this issue, as it turns out that was not actually necessary.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>