### PR TITLE
 Add Route timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
  "linkerd2-fs-watch 0.1.0",
  "linkerd2-metrics 0.1.0",
  "linkerd2-never 0.1.0",
- "linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=1ad7018)",
+ "linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.5)",
  "linkerd2-router 0.1.0",
  "linkerd2-stack 0.1.0",
  "linkerd2-task 0.1.0",
@@ -557,8 +557,8 @@ dependencies = [
  "procinfo 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -588,7 +588,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.4"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=1ad7018#1ad70188f9a6d94e2865413713a50390456fa6b6"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.5#d0ea16ababae239a9ac7d7d39a1e159e69e3d80e"
 dependencies = [
  "bytes 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -597,7 +597,8 @@ dependencies = [
  "prost 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
  "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
 ]
@@ -640,6 +641,7 @@ name = "linkerd2-timeout"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linkerd2-stack 0.1.0",
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
  "tokio-timer 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (git+https://github.com/tower-rs/tower)",
@@ -902,6 +904,15 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quickcheck"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1797,7 +1808,7 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=1ad7018)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.5)" = "<none>"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
@@ -1828,6 +1839,7 @@ dependencies = [
 "checksum prost-types 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5644c57d56bc085f9570e113495c1f08d7185beca700dcc296cb4672f380a679"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
 "checksum quickcheck 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13f4460d3daa06eb1c4b9a3c55dffe65cb030dd70cf1bfdd482532f48ab24f74"
+"checksum quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd69f633f796e091acd9a53e093bf01745b2c10ba44d22ea788f5fcbb862b720"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ linkerd2-stack     = { path = "lib/stack" }
 linkerd2-task      = { path = "lib/task" }
 linkerd2-timeout   = { path = "lib/timeout" }
 
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "1ad7018", version = "0.1.4" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.5" }
 
 bytes = "0.4"
 env_logger = { version = "0.5", default-features = false }
@@ -48,7 +48,7 @@ log = "0.4.1"
 indexmap = "1.0.0"
 prost = "0.4.0"
 prost-types = "0.4.0"
-rand = "0.5.1"
+rand = "0.6"
 try-lock = "0.2"
 
 # for config parsing
@@ -88,10 +88,10 @@ procinfo = "0.4.2"
 
 [dev-dependencies]
 net2 = "0.2"
-quickcheck = { version = "0.6", default-features = false }
+quickcheck = { version = "0.8", default-features = false }
 linkerd2-metrics = { path = "./lib/metrics", features = ["test_util"] }
 linkerd2-task    = { path = "lib/task", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "1ad7018", version = "0.1.4", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.5" }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.
@@ -99,5 +99,8 @@ tokio-io = "0.1.6"
 
 # Debug symbols end up chewing up several GB of disk space, so better to just
 # disable them.
+
+[profile.dev]
+debug = false
 [profile.test]
 debug = false

--- a/lib/timeout/Cargo.toml
+++ b/lib/timeout/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 futures = "0.1"
+linkerd2-stack = { path = "../stack" }
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-timer = "0.2.4"
 tower-service = { git = "https://github.com/tower-rs/tower" }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -91,9 +91,6 @@ pub struct Config {
     /// Age after which metrics may be dropped.
     pub metrics_retain_idle: Duration,
 
-    /// Timeout after which to cancel binding a request.
-    pub bind_timeout: Duration,
-
     pub namespaces: Namespaces,
 
     /// Optional minimum TTL for DNS lookups.
@@ -181,7 +178,6 @@ pub const ENV_METRICS_LISTENER: &str = "LINKERD2_PROXY_METRICS_LISTENER";
 pub const ENV_METRICS_RETAIN_IDLE: &str = "LINKERD2_PROXY_METRICS_RETAIN_IDLE";
 const ENV_INBOUND_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_INBOUND_CONNECT_TIMEOUT";
 const ENV_OUTBOUND_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT";
-pub const ENV_BIND_TIMEOUT: &str = "LINKERD2_PROXY_BIND_TIMEOUT";
 
 pub const DEPRECATED_ENV_PRIVATE_LISTENER: &str = "LINKERD2_PROXY_PRIVATE_LISTENER";
 pub const DEPRECATED_ENV_PRIVATE_FORWARD: &str = "LINKERD2_PROXY_PRIVATE_FORWARD";
@@ -270,7 +266,6 @@ const DEFAULT_METRICS_LISTENER: &str = "tcp://127.0.0.1:4191";
 const DEFAULT_METRICS_RETAIN_IDLE: Duration = Duration::from_secs(10 * 60);
 const DEFAULT_INBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(20);
 const DEFAULT_OUTBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
-const DEFAULT_BIND_TIMEOUT: Duration = Duration::from_secs(10); // same as in Linkerd
 const DEFAULT_CONTROL_BACKOFF_DELAY: Duration = Duration::from_secs(5);
 const DEFAULT_CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const DEFAULT_DNS_CANONICALIZE_TIMEOUT: Duration = Duration::from_millis(100);
@@ -349,7 +344,6 @@ impl<'a> TryFrom<&'a Strings> for Config {
         let tls_private_key = parse(strings, ENV_TLS_PRIVATE_KEY, parse_path);
         let tls_pod_identity_template = strings.get(ENV_TLS_POD_IDENTITY);
         let tls_controller_identity = strings.get(ENV_TLS_CONTROLLER_IDENTITY);
-        let bind_timeout = parse(strings, ENV_BIND_TIMEOUT, parse_duration);
         let resolv_conf_path = strings.get(ENV_RESOLV_CONF);
         let metrics_retain_idle = parse(strings, ENV_METRICS_RETAIN_IDLE, parse_duration);
         let dns_min_ttl = parse(strings, ENV_DNS_MIN_TTL, parse_duration);
@@ -502,8 +496,6 @@ impl<'a> TryFrom<&'a Strings> for Config {
             control_connect_timeout,
 
             metrics_retain_idle: metrics_retain_idle?.unwrap_or(DEFAULT_METRICS_RETAIN_IDLE),
-
-            bind_timeout: bind_timeout?.unwrap_or(DEFAULT_BIND_TIMEOUT),
 
             namespaces,
 

--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -2,12 +2,14 @@ use http;
 use indexmap::IndexMap;
 use std::fmt;
 use std::sync::Arc;
+use std::time::Duration;
 use tower_retry::budget::Budget;
 
 use proxy::http::{
     metrics::classify::{CanClassify, Classify, ClassifyResponse, ClassifyEos},
     profiles,
     retry,
+    timeout,
 };
 use {Addr, NameAddr};
 
@@ -39,6 +41,7 @@ pub struct DstAddr {
 
 // === impl Route ===
 
+
 impl CanClassify for Route {
     type Classify = classify::Request;
 
@@ -58,6 +61,12 @@ impl retry::CanRetry for Route {
                 budget: retries.budget().clone(),
                 response_classes: self.route.response_classes().clone(),
             })
+    }
+}
+
+impl timeout::HasTimeout for Route {
+    fn timeout(&self) -> Option<Duration> {
+        self.route.timeout()
     }
 }
 

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -24,7 +24,7 @@ use proxy::{
         client, insert_target, metrics as http_metrics, normalize_uri, profiles, router, settings,
         strip_header,
     },
-    limit, reconnect, timeout,
+    limit, reconnect,
 };
 use svc::{
     self, shared,
@@ -252,7 +252,7 @@ where
                 .push(control::client::layer())
                 .push(control::resolve::layer(dns_resolver.clone()))
                 .push(reconnect::layer().with_fixed_backoff(config.control_backoff_delay))
-                .push(proxy::timeout::layer(config.control_connect_timeout))
+                .push(svc::timeout::layer(config.control_connect_timeout))
                 .push(http_metrics::layer::<_, classify::Response>(
                     ctl_http_metrics,
                 ))
@@ -315,7 +315,7 @@ where
                 // Establishes connections to remote peers (for both TCP
                 // forwarding and HTTP proxying).
                 let connect = connect::Stack::new()
-                    .push(proxy::timeout::layer(config.outbound_connect_timeout))
+                    .push(svc::timeout::layer(config.outbound_connect_timeout))
                     .push(transport_metrics.connect("outbound"));
 
                 // Instantiates an HTTP client for for a `client::Config`
@@ -347,13 +347,19 @@ where
                 // A per-`dst::Route` layer that uses profile data to configure
                 // a per-route layer.
                 //
-                // The `classify` module installs a `classify::Response`
-                // extension into each request so that all lower metrics
-                // implementations can use the route-specific configuration.
+                // 1. The `classify` module installs a `classify::Response`
+                //    extension into each request so that all lower metrics
+                //    implementations can use the route-specific configuration.
+                // 2. A timeout is optionally enabled if the target `dst::Route`
+                //    specifies a timeout. This goes before `retry` to cap
+                //    retries.
+                // 3. Retries are optionally enabled depending on if the route
+                //    is retryable.
                 let dst_route_layer = phantom_data::layer()
                     .push(insert_target::layer())
                     .push(metrics::layer::<_, classify::Response>(retry_http_metrics.clone()))
                     .push(retry::layer(retry_http_metrics))
+                    .push(proxy::http::timeout::layer())
                     .push(metrics::layer::<_, classify::Response>(route_http_metrics))
                     .push(classify::layer());
 
@@ -420,7 +426,6 @@ where
                 // address is used.
                 let addr_router = addr_stack
                     .push(buffer::layer(MAX_IN_FLIGHT))
-                    .push(timeout::layer(config.bind_timeout))
                     .push(limit::layer(MAX_IN_FLIGHT))
                     .push(strip_header::layer(super::DST_OVERRIDE_HEADER))
                     .push(router::layer(|req: &http::Request<_>| {
@@ -478,7 +483,7 @@ where
                 // Establishes connections to the local application (for both
                 // TCP forwarding and HTTP proxying).
                 let connect = connect::Stack::new()
-                    .push(proxy::timeout::layer(config.inbound_connect_timeout))
+                    .push(svc::timeout::layer(config.inbound_connect_timeout))
                     .push(transport_metrics.connect("inbound"))
                     .push(rewrite_loopback_addr::layer());
 

--- a/src/app/metric_labels.rs
+++ b/src/app/metric_labels.rs
@@ -180,7 +180,7 @@ impl FmtLabels for classify::Class {
                 result, status
             ),
             Class::Stream(result, status) => {
-                write!(f, "classification=\"{}\",h2_err=\"{}\"", result, status)
+                write!(f, "classification=\"{}\",error=\"{}\"", result, status)
             }
         }
     }

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -14,6 +14,7 @@ pub mod router;
 pub mod settings;
 pub mod upgrade;
 pub mod strip_header;
+pub mod timeout;
 
 pub use self::client::Client;
 pub use self::glue::{Error, HttpBody as Body, HyperServerSvc};

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -6,6 +6,7 @@ use indexmap::IndexMap;
 use regex::Regex;
 use std::iter::FromIterator;
 use std::sync::Arc;
+use std::time::Duration;
 use tower_retry::budget::Budget;
 
 use never::Never;
@@ -42,6 +43,7 @@ pub struct Route {
     labels: Arc<IndexMap<String, String>>,
     response_classes: ResponseClasses,
     retries: Option<Retries>,
+    timeout: Option<Duration>,
 }
 
 #[derive(Clone, Debug)]
@@ -94,6 +96,7 @@ impl Route {
             labels,
             response_classes: response_classes.into(),
             retries: None,
+            timeout: None,
         }
     }
 
@@ -109,10 +112,18 @@ impl Route {
         self.retries.as_ref()
     }
 
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout
+    }
+
     pub fn set_retries(&mut self, budget: Arc<Budget>) {
         self.retries = Some(Retries {
             budget,
         });
+    }
+
+    pub fn set_timeout(&mut self, timeout: Duration) {
+        self.timeout = Some(timeout);
     }
 }
 

--- a/src/proxy/http/timeout.rs
+++ b/src/proxy/http/timeout.rs
@@ -1,0 +1,117 @@
+use std::time::Duration;
+
+use futures::{future, Future, Poll};
+use http::{Request, Response, StatusCode};
+
+use svc::linkerd2_timeout::{Error as TimeoutError, Timeout};
+use svc;
+
+/// Implement on targets to determine if a service has a timeout.
+pub trait HasTimeout {
+    fn timeout(&self) -> Option<Duration>;
+}
+
+/// An HTTP-specific optional timeout layer.
+///
+/// The stack target must implement `HasTimeout`, and if a duration is
+/// specified for the target, a timeout is applied waiting for HTTP responses.
+///
+/// Timeout errors are translated into `http::Response`s with appropiate
+/// status codes.
+pub fn layer() -> Layer {
+    Layer
+}
+
+#[derive(Clone, Debug)]
+pub struct Layer;
+
+#[derive(Clone, Debug)]
+pub struct Stack<M> {
+    inner: M,
+}
+
+#[derive(Debug)]
+pub struct Service<S>(Timeout<S>);
+
+/// A marker set in `http::Response::extensions` that *this* process triggered
+/// the request timeout.
+#[derive(Debug)]
+pub struct ProxyTimedOut(());
+
+impl<T, M> svc::Layer<T, T, M> for Layer
+where
+    M: svc::Stack<T>,
+    T: HasTimeout,
+{
+    type Value = <Stack<M> as svc::Stack<T>>::Value;
+    type Error = <Stack<M> as svc::Stack<T>>::Error;
+    type Stack = Stack<M>;
+
+    fn bind(&self, inner: M) -> Self::Stack {
+        Stack {
+            inner,
+        }
+    }
+}
+
+impl<T, M> svc::Stack<T> for Stack<M>
+where
+    M: svc::Stack<T>,
+    T: HasTimeout,
+{
+    type Value = svc::Either<Service<M::Value>, M::Value>;
+    type Error = M::Error;
+
+    fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
+        let inner = self.inner.make(target)?;
+        if let Some(timeout) = target.timeout() {
+            Ok(svc::Either::A(Service(Timeout::new(inner, timeout))))
+        } else {
+            Ok(svc::Either::B(inner))
+        }
+    }
+}
+
+impl<S, B1, B2> svc::Service<Request<B1>> for Service<S>
+where
+    S: svc::Service<Request<B1>, Response = Response<B2>>,
+    B2: Default,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = future::OrElse<
+        <Timeout<S> as svc::Service<Request<B1>>>::Future,
+        Result<Response<B2>, S::Error>,
+        fn(TimeoutError<S::Error>) -> Result<Response<B2>, S::Error>,
+    >;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        match self.0.poll_ready() {
+            Ok(ok) => Ok(ok),
+            Err(TimeoutError::Error(err)) => Err(err),
+            Err(TimeoutError::Timeout(_)) |
+            Err(TimeoutError::Timer(_)) => unreachable!("timeout error in poll_ready"),
+        }
+    }
+
+    fn call(&mut self, req: Request<B1>) -> Self::Future {
+        self.0.call(req).or_else(|err| match err {
+            TimeoutError::Error(err) => Err(err),
+            TimeoutError::Timeout(dur) => {
+                debug!("request timed out after {:?}", dur);
+                let mut res = Response::default();
+                *res.status_mut() = StatusCode::GATEWAY_TIMEOUT;
+                res.extensions_mut().insert(ProxyTimedOut(()));
+                Ok(res)
+            },
+            TimeoutError::Timer(err) => {
+                // These are unexpected, and mean the runtime is in a bad place.
+                error!("unexpected runtime timer error: {}", err);
+                let mut res = Response::default();
+                *res.status_mut() = StatusCode::BAD_GATEWAY;
+                Ok(res)
+            }
+        })
+    }
+}
+

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -12,7 +12,6 @@ pub mod reconnect;
 pub mod resolve;
 pub mod server;
 mod tcp;
-pub mod timeout;
 
 pub use self::resolve::{Resolve, Resolution};
 pub use self::server::{Server, Source};

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -1,4 +1,5 @@
 pub extern crate linkerd2_stack as stack;
+pub extern crate linkerd2_timeout;
 extern crate tower_service;
 extern crate tower_util;
 
@@ -13,3 +14,5 @@ pub use self::stack::{
     Layer,
     Stack,
 };
+
+pub use self::linkerd2_timeout::stack as timeout;

--- a/src/tap/grpc/match_.rs
+++ b/src/tap/grpc/match_.rs
@@ -315,6 +315,7 @@ impl TryFrom<observe_request::match_::Http> for HttpMatch {
 mod tests {
     use ipnet::{Contains, Ipv4Net, Ipv6Net};
     use quickcheck::*;
+    use rand::Rng;
     use std::collections::HashMap;
 
     use super::*;


### PR DESCRIPTION
If a service profile specifies a timeout for a given route, this applies
a timeout waiting for responses on that route.

Timeouts show up in proxy metrics like this:

```
route_response_total{direction="outbound",dst="localhost:80",status_code="504",classification="failure",error="timeout"} 1
```