### PR TITLE
Improve load balancer configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,7 +1323,7 @@ dependencies = [
 [[package]]
 name = "tower-balance"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#075ffb372556d05a7db02ce49db34cfb22850dba"
+source = "git+https://github.com/tower-rs/tower#bdecb3377543e00e445c4dd7177e8041e942eb5e"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1338,7 +1338,7 @@ dependencies = [
 [[package]]
 name = "tower-buffer"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#075ffb372556d05a7db02ce49db34cfb22850dba"
+source = "git+https://github.com/tower-rs/tower#bdecb3377543e00e445c4dd7177e8041e942eb5e"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1349,7 +1349,7 @@ dependencies = [
 [[package]]
 name = "tower-direct-service"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#075ffb372556d05a7db02ce49db34cfb22850dba"
+source = "git+https://github.com/tower-rs/tower#bdecb3377543e00e445c4dd7177e8041e942eb5e"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "tower-discover"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#075ffb372556d05a7db02ce49db34cfb22850dba"
+source = "git+https://github.com/tower-rs/tower#bdecb3377543e00e445c4dd7177e8041e942eb5e"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (git+https://github.com/tower-rs/tower)",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "tower-in-flight-limit"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#075ffb372556d05a7db02ce49db34cfb22850dba"
+source = "git+https://github.com/tower-rs/tower#bdecb3377543e00e445c4dd7177e8041e942eb5e"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (git+https://github.com/tower-rs/tower)",
@@ -1413,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "tower-reconnect"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#075ffb372556d05a7db02ce49db34cfb22850dba"
+source = "git+https://github.com/tower-rs/tower#bdecb3377543e00e445c4dd7177e8041e942eb5e"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1424,7 +1424,7 @@ dependencies = [
 [[package]]
 name = "tower-service"
 version = "0.2.0"
-source = "git+https://github.com/tower-rs/tower#075ffb372556d05a7db02ce49db34cfb22850dba"
+source = "git+https://github.com/tower-rs/tower#bdecb3377543e00e445c4dd7177e8041e942eb5e"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "tower-util"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#075ffb372556d05a7db02ce49db34cfb22850dba"
+source = "git+https://github.com/tower-rs/tower#bdecb3377543e00e445c4dd7177e8041e942eb5e"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-direct-service 0.1.0 (git+https://github.com/tower-rs/tower)",

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -161,6 +161,10 @@ where
         } = self;
 
         const MAX_IN_FLIGHT: usize = 10_000;
+
+        const EWMA_DEFAULT_RTT: Duration = Duration::from_millis(30);
+        const EWMA_DECAY: Duration = Duration::from_secs(10);
+
         let control_host_and_port = config.control_host_and_port.clone();
 
         info!("using controller at {:?}", control_host_and_port);
@@ -352,7 +356,7 @@ where
                 //   `DstAddr` with a resolver.
                 let dst_stack = endpoint_stack
                     .push(resolve::layer(Resolve::new(resolver)))
-                    .push(balance::layer())
+                    .push(balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
                     .push(buffer::layer(MAX_IN_FLIGHT))
                     .push(profiles::router::layer(
                         profile_suffixes,


### PR DESCRIPTION
Adopts changes from https://github.com/tower-rs/tower/pull/134

> balance: Consider new nodes more readily
>
> When a PeakEwma Balancer discovers a single new endpoint, it will not
> dispatch requests to the new endpoint until the RTT estimate for an
> existing endpoint exceeds _one second_. This misconfiguration leads to
> unexpected behavior.
>
> When more than one endpoint is discovered, the balancer may eventually
> dispatch traffic to some of--but not all of--the new enpoints.
>
> This change alters the PeakEwma balancer in two ways:
>
> First, the previous DEFAULT_RTT_ESTIMATE of 1s has been changed to be
> configurable (and required). The library should not hard code a default
> here.
>
> Second, the initial RTT value is now decayed over time so that new
> endpoints will eventually be considered, even when other endpoints are
> less loaded than the default RTT estimate.