### PR TITLE
Make outbound router honor `l5d-dst-override` header

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -423,13 +423,18 @@ where
                     .push(limit::layer(MAX_IN_FLIGHT))
                     .push(strip_header::layer(super::DST_OVERRIDE_HEADER))
                     .push(router::layer(|req: &http::Request<_>| {
-                        let addr = super::http_request_l5d_override_dst_addr(req)
-                            .or_else(|_| super::http_request_authority_addr(req))
+                        let addr = super::http_request_authority_addr(req)
                             .or_else(|_| super::http_request_host_addr(req))
                             .or_else(|_| super::http_request_orig_dst_addr(req))
                             .ok();
                         debug!("outbound addr={:?}", addr);
-                        addr
+                        super::http_request_l5d_override_dst_addr(req)
+                            .ok()
+                            .map(|override_addr| {
+                                debug!("outbound dst-override={:?}", override_addr);
+                                override_addr
+                            })
+                            .or(addr)
                     }))
                     .make(&router::Config::new("out addr", capacity, max_idle_age))
                     .map(shared::stack)

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -432,13 +432,11 @@ where
                         super::http_request_l5d_override_dst_addr(req)
                             .ok()
                             .map(|override_addr| {
-                                if log_enabled!(log::Level::Debug) {
-                                    debug!(
-                                        "outbound addr={:?}; dst-override={:?}",
-                                        addr(),
-                                        override_addr
-                                    );
-                                }
+                                debug!(
+                                    "outbound addr={:?}; dst-override={:?}",
+                                    addr(),
+                                    override_addr
+                                );
                                 override_addr
                             })
                             .or_else(|| {

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -423,24 +423,17 @@ where
                     .push(limit::layer(MAX_IN_FLIGHT))
                     .push(strip_header::layer(super::DST_OVERRIDE_HEADER))
                     .push(router::layer(|req: &http::Request<_>| {
-                        let addr = || {
-                            super::http_request_authority_addr(req)
-                                .or_else(|_| super::http_request_host_addr(req))
-                                .or_else(|_| super::http_request_orig_dst_addr(req))
-                                .ok()
-                        };
                         super::http_request_l5d_override_dst_addr(req)
                             .ok()
                             .map(|override_addr| {
-                                debug!(
-                                    "outbound addr={:?}; dst-override={:?}",
-                                    addr(),
-                                    override_addr
-                                );
+                                debug!("outbound addr={:?}; dst-override", override_addr);
                                 override_addr
                             })
                             .or_else(|| {
-                                let addr = addr();
+                                let addr = super::http_request_authority_addr(req)
+                                    .or_else(|_| super::http_request_host_addr(req))
+                                    .or_else(|_| super::http_request_orig_dst_addr(req))
+                                    .ok();
                                 debug!("outbound addr={:?}", addr);
                                 addr
                             })

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -424,19 +424,18 @@ where
                     .push(strip_header::layer(super::DST_OVERRIDE_HEADER))
                     .push(router::layer(|req: &http::Request<_>| {
                         super::http_request_l5d_override_dst_addr(req)
-                            .ok()
                             .map(|override_addr| {
                                 debug!("outbound addr={:?}; dst-override", override_addr);
                                 override_addr
                             })
-                            .or_else(|| {
+                            .or_else(|_| {
                                 let addr = super::http_request_authority_addr(req)
                                     .or_else(|_| super::http_request_host_addr(req))
-                                    .or_else(|_| super::http_request_orig_dst_addr(req))
-                                    .ok();
+                                    .or_else(|_| super::http_request_orig_dst_addr(req));
                                 debug!("outbound addr={:?}", addr);
                                 addr
                             })
+                            .ok()
                     }))
                     .make(&router::Config::new("out addr", capacity, max_idle_age))
                     .map(shared::stack)

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -421,7 +421,8 @@ where
                     .push(timeout::layer(config.bind_timeout))
                     .push(limit::layer(MAX_IN_FLIGHT))
                     .push(router::layer(|req: &http::Request<_>| {
-                        let addr = super::http_request_authority_addr(req)
+                        let addr = super::http_request_l5d_override_dst_addr(req)
+                            .or_else(|_| super::http_request_authority_addr(req))
                             .or_else(|_| super::http_request_host_addr(req))
                             .or_else(|_| super::http_request_orig_dst_addr(req))
                             .ok();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,6 +16,7 @@ pub use self::main::Main;
 use addr::{self, Addr};
 
 const CANONICAL_DST_HEADER: &'static str = "l5d-dst-canonical";
+const DST_OVERRIDE_HEADER: &'static str = "l5d-dst-override";
 
 pub fn init() -> Result<config::Config, config::Error> {
     use convert::TryFrom;
@@ -26,6 +27,14 @@ pub fn init() -> Result<config::Config, config::Error> {
 }
 
 const DEFAULT_PORT: u16 = 80;
+
+fn http_request_l5d_override_dst_addr<B>(req: &http::Request<B>) -> Result<Addr, addr::Error> {
+    use proxy;
+
+    proxy::http::authority_from_header(req, DST_OVERRIDE_HEADER)
+        .ok_or(addr::Error::InvalidHost)
+        .and_then(|a| Addr::from_authority_and_default_port(&a, DEFAULT_PORT))
+}
 
 fn http_request_authority_addr<B>(req: &http::Request<B>) -> Result<Addr, addr::Error> {
     req.uri()

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,7 +16,7 @@ pub use self::main::Main;
 use addr::{self, Addr};
 
 const CANONICAL_DST_HEADER: &'static str = "l5d-dst-canonical";
-const DST_OVERRIDE_HEADER: &'static str = "l5d-dst-override";
+pub const DST_OVERRIDE_HEADER: &'static str = "l5d-dst-override";
 
 pub fn init() -> Result<config::Config, config::Error> {
     use convert::TryFrom;

--- a/src/proxy/http/h1.rs
+++ b/src/proxy/http/h1.rs
@@ -49,17 +49,7 @@ pub fn set_origin_form(uri: &mut Uri) {
 
 /// Returns an Authority from a request's Host header.
 pub fn authority_from_host<B>(req: &http::Request<B>) -> Option<Authority> {
-    req.headers().get(HOST)
-        .and_then(|host| {
-             host.to_str().ok()
-                .and_then(|s| {
-                    if s.is_empty() {
-                        None
-                    } else {
-                        s.parse::<Authority>().ok()
-                    }
-                })
-        })
+    super::authority_from_header(req, HOST)
 }
 
 fn set_authority(uri: &mut http::Uri, auth: Authority) {

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -13,6 +13,7 @@ pub mod retry;
 pub mod router;
 pub mod settings;
 pub mod upgrade;
+pub mod strip_header;
 
 pub use self::client::Client;
 pub use self::glue::{Error, HttpBody as Body, HyperServerSvc};

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -18,6 +18,8 @@ pub use self::client::Client;
 pub use self::glue::{Error, HttpBody as Body, HyperServerSvc};
 pub use self::settings::Settings;
 
+use http::header::AsHeaderName;
+use http::uri::Authority;
 use svc::Either;
 
 pub trait HasH2Reason {
@@ -46,4 +48,20 @@ impl<A: HasH2Reason, B: HasH2Reason> HasH2Reason for Either<A, B> {
             Either::B(b) => b.h2_reason(),
         }
     }
+}
+
+/// Returns an Authority from the value of `header`.
+pub fn authority_from_header<B, K>(req: &http::Request<B>, header: K) -> Option<Authority>
+where
+    K: AsHeaderName,
+{
+    req.headers().get(header).and_then(|value| {
+        value.to_str().ok().and_then(|s| {
+            if s.is_empty() {
+                None
+            } else {
+                s.parse::<Authority>().ok()
+            }
+        })
+    })
 }

--- a/src/proxy/http/strip_header.rs
+++ b/src/proxy/http/strip_header.rs
@@ -1,0 +1,91 @@
+use futures::Poll;
+use http;
+use http::header::AsHeaderName;
+
+use svc;
+
+/// Wraps HTTP `Service` `Stack<T>`s so that a given header is removed from a
+/// request.
+#[derive(Debug, Clone)]
+pub struct Layer<H> {
+    header: H,
+}
+
+/// Wraps an HTTP `Service` so that a given header is removed from each
+/// request.
+#[derive(Clone, Debug)]
+pub struct Stack<H, M> {
+    header: H,
+    inner: M,
+}
+
+#[derive(Clone, Debug)]
+pub struct Service<H, S> {
+    header: H,
+    inner: S,
+}
+
+// === impl Layer ===
+
+pub fn layer<H>(header: H) -> Layer<H>
+where
+    H: AsHeaderName + Clone
+{
+    Layer { header }
+}
+
+impl<H, T, M> svc::Layer<T, T, M> for Layer<H>
+where
+    H: AsHeaderName + Clone,
+    M: svc::Stack<T>,
+{
+    type Value = <Stack<H, M> as svc::Stack<T>>::Value;
+    type Error = <Stack<H, M> as svc::Stack<T>>::Error;
+    type Stack = Stack<H, M>;
+
+    fn bind(&self, inner: M) -> Self::Stack {
+        Stack {
+            header: self.header.clone(),
+            inner,
+        }
+    }
+}
+
+// === impl Stack ===
+
+impl<H, T, M> svc::Stack<T> for Stack<H, M>
+where
+    H: AsHeaderName + Clone,
+    M: svc::Stack<T>,
+{
+    type Value = Service<H, M::Value>;
+    type Error = M::Error;
+
+    fn make(&self, t: &T) -> Result<Self::Value, Self::Error> {
+        let inner = self.inner.make(t)?;
+        let header = self.header.clone();
+        Ok(Service { header, inner })
+    }
+}
+
+// === impl Service ===
+
+impl<H, S, B> svc::Service<http::Request<B>> for Service<H, S>
+where
+    H: AsHeaderName + Clone,
+    S: svc::Service<http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+        let header: H = self.header.clone();
+        req.headers_mut().remove(header);
+        self.inner.call(req)
+    }
+}


### PR DESCRIPTION
# Problem
It is valuable to inject an ingress controller with LD2. As ingress, the host
header tends to be the external host and most controllers just route directly
back to the IP address of an endpoint. Unfortunately, this makes it so that
Linkerd cannot discover the destination (as that works off the host header).

# Solution
The outbound router now recognizes request destinations by preferrentially
choosing the `l5d-dst-override` header if it present. This header takes
precedent over the Host header, original dest, etc.

In addition, both the inbound and outbound routers strip this header. The
outbound router strips it after it has used it to determine the authority.
This is done with the `strip_header` layer that was added to the stack.

# Validation
There are integration tests for this behavior in the discovery tests. There
are tests for http1 and http2. The tests test the following scenarios:
- the outbound router routes based on the header when it is present
- the override header applies to only requests with the override header
- the inbound router never honors the override header
- both routers strip the header before forwarding the request

Fixes linkerd/linkerd2#1998

Co-Authored-By: Eliza Weisman <eliza@buoyant.io>
Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>