### PR TITLE
canonicalize: Only log errors at the WARN level when falling back

### DIFF
--- a/src/proxy/canonicalize.rs
+++ b/src/proxy/canonicalize.rs
@@ -183,8 +183,8 @@ impl Future for Task {
                             State::ValidUntil(Delay::new(refine.valid_until))
                         }
                         Err(e) => {
-                            error!("failed to refine {}: {}", self.original.name(), e);
                             if self.resolved.is_none() {
+                                error!("failed to refine {}: {}", self.original.name(), e);
                                 let err = self.tx.try_send(self.original.clone()).err();
                                 if err.map(|e| e.is_disconnected()).unwrap_or(false) {
                                     return Ok(().into());
@@ -193,6 +193,8 @@ impl Future for Task {
                                 // Pretend the original name was resolved so
                                 // that we don't re-publish on subsequent errors.
                                 self.resolved = Some(self.original.clone());
+                            } else {
+                                warn!("failed to refine {}: {}, falling back", self.original.name(), e);
                             }
 
                             let valid_until = e


### PR DESCRIPTION
Previously, whenever the `canonicalize::Task` future encounters an
error, it logs that error at the error level. However, in many cases,
these errors are transient, and we are able to successfully fall back to
a previously canonicalized name.

This branch changes `canonicalize::Task` to only log at the error level
when there's no previously successful result to fall back to, and log at
the warning level otherwise. In addition, the log message on fallbacks
now indicates that we fell back to a previous canonicalization.

Hopefully, this should make transient errors, such as a slow DNS server,
a little less scary.

Fixes linkerd/linkerd2#2094

Signed-off-by: Eliza Weisman <eliza@buoyant.io>