### PR TITLE
Make timeouts for canonicalization DNS queries tuneable

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -309,6 +309,7 @@ where
                 let endpoint_http_metrics = endpoint_http_metrics.clone();
                 let route_http_metrics = route_http_metrics.clone();
                 let profile_suffixes = config.destination_profile_suffixes.clone();
+                let canonicalize_timeout = config.dns_canonicalize_timeout;
 
                 // Establishes connections to remote peers (for both TCP
                 // forwarding and HTTP proxying).
@@ -402,7 +403,7 @@ where
                     .push(map_target::layer(|addr: &Addr| {
                         DstAddr::outbound(addr.clone())
                     }))
-                    .push(canonicalize::layer(dns_resolver));
+                    .push(canonicalize::layer(dns_resolver, canonicalize_timeout));
 
                 // Routes requests to an `Addr`:
                 //

--- a/src/proxy/canonicalize.rs
+++ b/src/proxy/canonicalize.rs
@@ -19,10 +19,6 @@ use dns;
 use svc;
 use {Addr, NameAddr};
 
-/// The amount of time to wait for a DNS query to succeed before falling back to
-/// an uncanonicalized address.
-const DEFAULT_TIMEOUT: Duration = Duration::from_millis(100);
-
 /// Duration to wait before polling DNS again after an error (or a NXDOMAIN
 /// response with no TTL).
 const DNS_ERROR_TTL: Duration = Duration::from_secs(3);
@@ -71,10 +67,10 @@ pub enum Error<M, S> {
 
 // FIXME the resolver should be abstracted to a trait so that this can be tested
 // without a real DNS service.
-pub fn layer(resolver: dns::Resolver) -> Layer {
+pub fn layer(resolver: dns::Resolver, timeout: Duration) -> Layer {
     Layer {
         resolver,
-        timeout: DEFAULT_TIMEOUT,
+        timeout,
     }
 }
 


### PR DESCRIPTION
Currently, the proxy hard-codes a 100ms timeout for DNS queries to
canonicalize a name. In some cases (see linkerd/linkerd2#2069), a DNS
server might be slow enough to respond that a majority of these queries
exceed the timeout. This results in a lot of error messages being
logged, and potentially, a delay or complete failure to update to
changes in DNS, if the DNS server is consistently very slow.

This branch adds a `LINKERD2_PROXY_DNS_CANONICALIZE_TIMEOUT` environment
variable that allows the default 100ms timeout to be overridden. 

See also linkerd/linkerd2#2093

Signed-off-by: Eliza Weisman <eliza@buoyant.io>