### PR TITLE
Revise several log levels and messages

### DIFF
--- a/src/app/inbound.rs
+++ b/src/app/inbound.rs
@@ -188,7 +188,11 @@ pub mod orig_proto_downgrade {
         type Error = M::Error;
 
         fn make(&self, target: &Source) -> Result<Self::Value, Self::Error> {
-            debug!("downgrading requests; source={:?}", target);
+            trace!(
+                "supporting {} downgrades for source={:?}",
+                orig_proto::L5D_ORIG_PROTO,
+                target,
+            );
             self.inner.make(&target).map(orig_proto::Downgrade::new)
         }
     }

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -251,6 +251,11 @@ pub mod orig_proto_upgrade {
 
         fn make(&self, endpoint: &Endpoint) -> Result<Self::Value, Self::Error> {
             if endpoint.can_use_orig_proto() {
+                trace!(
+                    "supporting {} upgrades for endpoint={:?}",
+                    orig_proto::L5D_ORIG_PROTO,
+                    endpoint,
+                );
                 self.inner.make(&endpoint).map(|i| svc::Either::A(orig_proto::Upgrade::new(i)))
             } else {
                 self.inner.make(&endpoint).map(svc::Either::B)

--- a/src/proxy/http/metrics/report.rs
+++ b/src/proxy/http/metrics/report.rs
@@ -64,7 +64,7 @@ where
     C: FmtLabels + Hash + Eq,
 {
     fn fmt_metrics(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        debug!("fmt_metrics");
+        trace!("fmt_metrics");
         let mut registry = match self.registry.lock() {
             Err(_) => return Ok(()),
             Ok(r) => r,
@@ -72,11 +72,11 @@ where
 
         let now = clock::now();
         let since = now - self.retain_idle;
-        debug!("fmt_metrics: retain_since: now={:?} since={:?}", now, since);
+        trace!("fmt_metrics: retain_since: now={:?} since={:?}", now, since);
         registry.retain_since(since);
 
         let registry = registry;
-        debug!("fmt_metrics: by_target={}", registry.by_target.len());
+        trace!("fmt_metrics: by_target={}", registry.by_target.len());
         if registry.by_target.is_empty() {
             return Ok(());
         }

--- a/src/proxy/http/metrics/service.rs
+++ b/src/proxy/http/metrics/service.rs
@@ -167,7 +167,7 @@ where
     type Error = M::Error;
 
     fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
-        debug!("make: target={:?}", target);
+        trace!("make: target={:?}", target);
         let inner = self.inner.make(target)?;
 
         let metrics = match self.registry.lock() {
@@ -180,7 +180,7 @@ where
             Err(_) => None,
         };
 
-        debug!("make: metrics={}", metrics.is_some());
+        trace!("make: metrics={}", metrics.is_some());
         Ok(Service {
             metrics,
             inner,

--- a/src/proxy/http/orig_proto.rs
+++ b/src/proxy/http/orig_proto.rs
@@ -5,7 +5,7 @@ use http::header::{TRANSFER_ENCODING, HeaderValue};
 use super::h1;
 use svc;
 
-const L5D_ORIG_PROTO: &str = "l5d-orig-proto";
+pub const L5D_ORIG_PROTO: &str = "l5d-orig-proto";
 
 /// Upgrades HTTP requests from their original protocol to HTTP2.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
- Change wording of orig-proto upgrade and downgrade `Stack` logs, and
  make them `trace` level.
- Make `fmt_metrics` logs `trace` level.
- Make metrics `Stack` logs `trace` level.

-----

I've noticed some of these logs may confuse people (or just be noisy), so I've clarified them and adjusted their log level.