### PR TITLE
Set proxy_id in calls to Get and GetProfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
  "linkerd2-fs-watch 0.1.0",
  "linkerd2-metrics 0.1.0",
  "linkerd2-never 0.1.0",
- "linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=36f54ad)",
+ "linkerd2-proxy-api 0.1.6 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.6)",
  "linkerd2-router 0.1.0",
  "linkerd2-stack 0.1.0",
  "linkerd2-task 0.1.0",
@@ -586,8 +586,8 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.4"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=36f54ad#36f54ad8354c677b22a768a4c1c9ecc087ff4aa8"
+version = "0.1.6"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.6#ff6064f88ecdcbc6f8a4284f4a0f8c49f184897a"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1804,7 +1804,7 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=36f54ad)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.6 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.6)" = "<none>"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,7 +546,7 @@ dependencies = [
  "linkerd2-fs-watch 0.1.0",
  "linkerd2-metrics 0.1.0",
  "linkerd2-never 0.1.0",
- "linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.5)",
+ "linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=36f54ad)",
  "linkerd2-router 0.1.0",
  "linkerd2-stack 0.1.0",
  "linkerd2-task 0.1.0",
@@ -587,7 +587,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.4"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.5#d0ea16ababae239a9ac7d7d39a1e159e69e3d80e"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=36f54ad#36f54ad8354c677b22a768a4c1c9ecc087ff4aa8"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1804,7 +1804,7 @@ dependencies = [
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.5)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.4 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=36f54ad)" = "<none>"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ linkerd2-stack     = { path = "lib/stack" }
 linkerd2-task      = { path = "lib/task" }
 linkerd2-timeout   = { path = "lib/timeout" }
 
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.5" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "36f54ad" }
 
 bytes = "0.4"
 env_logger = { version = "0.5", default-features = false }
@@ -91,7 +91,7 @@ net2 = "0.2"
 quickcheck = { version = "0.8", default-features = false }
 linkerd2-metrics = { path = "./lib/metrics", features = ["test_util"] }
 linkerd2-task    = { path = "lib/task", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.5" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "36f54ad" }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ linkerd2-stack     = { path = "lib/stack" }
 linkerd2-task      = { path = "lib/task" }
 linkerd2-timeout   = { path = "lib/timeout" }
 
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "36f54ad" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.6" }
 
 bytes = "0.4"
 env_logger = { version = "0.5", default-features = false }
@@ -91,7 +91,7 @@ net2 = "0.2"
 quickcheck = { version = "0.8", default-features = false }
 linkerd2-metrics = { path = "./lib/metrics", features = ["test_util"] }
 linkerd2-task    = { path = "lib/task", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "36f54ad" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.6" }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # This reduces build time and produces binaries with debug symbols, at the expense of
 # runtime performance.
 
-ARG RUST_IMAGE=rust:1.30.0
+ARG RUST_IMAGE=rust:1.32.0
 ARG RUNTIME_IMAGE=gcr.io/linkerd-io/base:2017-10-30.01
 
 ## Builds the proxy as incrementally as possible.

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -549,7 +549,7 @@ impl TestEnv {
         let mut values: HashMap<&'static str, String> = Default::default();
         values.insert(ENV_PROXY_ID, "foo.deployment.default.linkerd-managed.linkerd.svc.cluster.local".into());
         Self {
-            values: values,
+            values,
         }
     }
 

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -93,6 +93,8 @@ pub struct Config {
 
     pub namespaces: Namespaces,
 
+    pub proxy_id: String,
+
     /// Optional minimum TTL for DNS lookups.
     pub dns_min_ttl: Option<Duration>,
 
@@ -239,6 +241,7 @@ pub const ENV_TLS_CONTROLLER_IDENTITY: &str = "LINKERD2_PROXY_TLS_CONTROLLER_IDE
 pub const ENV_CONTROLLER_NAMESPACE: &str = "LINKERD2_PROXY_CONTROLLER_NAMESPACE";
 pub const ENV_POD_NAMESPACE: &str = "LINKERD2_PROXY_POD_NAMESPACE";
 pub const VAR_POD_NAMESPACE: &str = "$LINKERD2_PROXY_POD_NAMESPACE";
+pub const ENV_PROXY_ID: &str = "LINKERD2_PROXY_ID";
 
 pub const ENV_CONTROL_URL: &str = "LINKERD2_PROXY_CONTROL_URL";
 pub const ENV_CONTROL_BACKOFF_DELAY: &str = "LINKERD2_PROXY_CONTROL_BACKOFF_DELAY";
@@ -358,6 +361,7 @@ impl<'a> TryFrom<&'a Strings> for Config {
             })
         });
         let controller_namespace = strings.get(ENV_CONTROLLER_NAMESPACE);
+        let proxy_id = strings.get(ENV_PROXY_ID)?.unwrap_or(String::new());
 
         // There is no default controller URL because a default would make it
         // too easy to connect to the wrong controller, which would be dangerous.
@@ -498,6 +502,8 @@ impl<'a> TryFrom<&'a Strings> for Config {
             metrics_retain_idle: metrics_retain_idle?.unwrap_or(DEFAULT_METRICS_RETAIN_IDLE),
 
             namespaces,
+
+            proxy_id,
 
             dns_min_ttl: dns_min_ttl?,
 

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -546,7 +546,7 @@ impl Strings for Env {
 
 impl TestEnv {
     pub fn new() -> Self {
-        let mut values: HashMap<&'static str, String> = Default::default();
+        let mut values = HashMap::new();
         values.insert(ENV_PROXY_ID, "foo.deployment.default.linkerd-managed.linkerd.svc.cluster.local".into());
         Self {
             values,

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -361,7 +361,6 @@ impl<'a> TryFrom<&'a Strings> for Config {
             })
         });
         let controller_namespace = strings.get(ENV_CONTROLLER_NAMESPACE);
-        let proxy_id = strings.get(ENV_PROXY_ID)?.unwrap_or(String::new());
 
         // There is no default controller URL because a default would make it
         // too easy to connect to the wrong controller, which would be dangerous.
@@ -376,6 +375,9 @@ impl<'a> TryFrom<&'a Strings> for Config {
             pod: pod_namespace?,
             tls_controller: controller_namespace?,
         };
+
+        let proxy_id_template = strings.get(ENV_PROXY_ID)?.unwrap_or(String::new());
+        let proxy_id = proxy_id_template.replace(VAR_POD_NAMESPACE, &namespaces.pod);
 
         let tls_controller_identity = tls_controller_identity?;
         let control_host_and_port = control_host_and_port?;

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -546,8 +546,10 @@ impl Strings for Env {
 
 impl TestEnv {
     pub fn new() -> Self {
+        let mut values: HashMap<&'static str, String> = Default::default();
+        values.insert(ENV_PROXY_ID, "foo.deployment.default.linkerd-managed.linkerd.svc.cluster.local".into());
         Self {
-            values: Default::default(),
+            values: values,
         }
     }
 

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -280,11 +280,6 @@ where
         // This channel is used to move the task.
         let (resolver_bg_tx, resolver_bg_rx) = futures::sync::oneshot::channel();
 
-        let proxy_id = match config.tls_settings {
-            Conditional::Some(ref settings) => settings.pod_identity.as_ref().to_string(),
-            Conditional::None(_) => String::new(),
-        };
-
         // Build the outbound and inbound proxies using the controller client.
         let main_fut = controller_fut.and_then(move |controller| {
             let (resolver, resolver_bg) = control::destination::new(
@@ -293,7 +288,7 @@ where
                 config.namespaces.clone(),
                 config.destination_get_suffixes,
                 config.destination_concurrency_limit,
-                proxy_id.clone(),
+                config.proxy_id.clone(),
             );
             resolver_bg_tx
                 .send(resolver_bg)
@@ -301,7 +296,7 @@ where
                 .expect("admin thread must receive resolver task");
 
 
-            let profiles_client = ProfilesClient::new(controller, Duration::from_secs(3), proxy_id);
+            let profiles_client = ProfilesClient::new(controller, Duration::from_secs(3), config.proxy_id);
 
             let outbound = {
                 use super::outbound::{discovery::Resolve, orig_proto_upgrade, server_id, Endpoint};

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -117,6 +117,7 @@ pub fn new<T>(
     namespaces: Namespaces,
     suffixes: Vec<dns::Suffix>,
     concurrency_limit: usize,
+    proxy_id: String,
 ) -> (Resolver, impl Future<Item = (), Error = ()>)
 where
     T: HttpService<BoxBody>,
@@ -131,6 +132,7 @@ where
         namespaces,
         suffixes,
         concurrency_limit,
+        proxy_id,
     );
     let task = future::poll_fn(move || bg.poll_rpc(&mut client));
     (disco, task)

--- a/tests/support/controller.rs
+++ b/tests/support/controller.rs
@@ -62,6 +62,7 @@ impl Controller {
         let dst = pb::GetDestination {
             scheme: "k8s".into(),
             path,
+            proxy_id: "foo.deployment.default.linkerd-managed.linkerd.svc.cluster.local".into(),
         };
         self.expect_dst_calls
             .lock()
@@ -97,6 +98,7 @@ impl Controller {
         let dst = pb::GetDestination {
             scheme: "k8s".into(),
             path,
+            proxy_id: "foo.deployment.default.linkerd-managed.linkerd.svc.cluster.local".into(),
         };
         self.expect_profile_calls
             .lock()


### PR DESCRIPTION
Pick up API changes to the proxy-api where Get and GetProfiles now accept a proxy_id parameter.  We set this parameter to be equal to the proxy's TLS pod identity, which is configured through an environment variable.  Sending this value to the proxy-api allows it to return more tailored results, for example, by looking for service profiles in the proxy's namespace.

Signed-off-by: Alex Leong <alex@buoyant.io>