### PR TITLE
Fix inotify dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "inotify"
 version = "0.6.2-dev"
-source = "git+https://github.com/hawkw/inotify?rev=a2d73d61ba61e993b71053e06b9dfe6bc848ef61#a2d73d61ba61e993b71053e06b9dfe6bc848ef61"
+source = "git+https://github.com/inotify-rs/inotify?rev=f78ed9788d437a78ff253ef3b8fafc61932692d5#f78ed9788d437a78ff253ef3b8fafc61932692d5"
 dependencies = [
  "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -503,7 +503,7 @@ dependencies = [
  "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-watch 0.1.0 (git+https://github.com/carllerche/better-future)",
- "inotify 0.6.2-dev (git+https://github.com/hawkw/inotify?rev=a2d73d61ba61e993b71053e06b9dfe6bc848ef61)",
+ "inotify 0.6.2-dev (git+https://github.com/inotify-rs/inotify?rev=f78ed9788d437a78ff253ef3b8fafc61932692d5)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-task 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -547,7 +547,7 @@ dependencies = [
  "hyper 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-balance 0.1.0",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "inotify 0.6.2-dev (git+https://github.com/hawkw/inotify?rev=a2d73d61ba61e993b71053e06b9dfe6bc848ef61)",
+ "inotify 0.6.2-dev (git+https://github.com/inotify-rs/inotify?rev=f78ed9788d437a78ff253ef3b8fafc61932692d5)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-fs-watch 0.1.0",
@@ -1884,7 +1884,7 @@ dependencies = [
 "checksum hyper 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)" = "5a4149341a6362e4d5c23a7cd96a3e964645642919b14c23b9102462a1ac685f"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
-"checksum inotify 0.6.2-dev (git+https://github.com/hawkw/inotify?rev=a2d73d61ba61e993b71053e06b9dfe6bc848ef61)" = "<none>"
+"checksum inotify 0.6.2-dev (git+https://github.com/inotify-rs/inotify?rev=f78ed9788d437a78ff253ef3b8fafc61932692d5)" = "<none>"
 "checksum inotify-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e74a1aa87c59aeff6ef2cc2fa62d41bc43f54952f55652656b18a02fd5e356c0"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum ipconfig 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "fccb81dd962b29a25de46c4f46e497b75117aa816468b6fff7a63a598a192394"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,6 @@ dependencies = [
  "hyper 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-balance 0.1.0",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "inotify 0.6.2-dev (git+https://github.com/inotify-rs/inotify?rev=f78ed9788d437a78ff253ef3b8fafc61932692d5)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-fs-watch 0.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,6 @@ untrusted = "0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
-inotify = { git = "https://github.com/inotify-rs/inotify", rev = "f78ed9788d437a78ff253ef3b8fafc61932692d5" }
 procinfo = "0.4.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ untrusted = "0.6"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
-inotify = { git = "https://github.com/hawkw/inotify", rev = "a2d73d61ba61e993b71053e06b9dfe6bc848ef61" }
+inotify = { git = "https://github.com/inotify-rs/inotify", rev = "f78ed9788d437a78ff253ef3b8fafc61932692d5" }
 procinfo = "0.4.2"
 
 [dev-dependencies]
@@ -110,4 +110,3 @@ debug = false
 prost = { git = "https://github.com/hawkw/prost", branch = "s/tempdir/tempfile"}
 prost-derive = { git = "https://github.com/hawkw/prost", branch = "s/tempdir/tempfile"}
 prost-build = { git = "https://github.com/hawkw/prost", branch = "s/tempdir/tempfile"}
-inotify = { git = "https://github.com/hawkw/inotify", rev = "a2d73d61ba61e993b71053e06b9dfe6bc848ef61" }

--- a/lib/fs-watch/Cargo.toml
+++ b/lib/fs-watch/Cargo.toml
@@ -16,7 +16,7 @@ tokio-timer = "0.2.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
-inotify = { git = "https://github.com/hawkw/inotify", rev = "a2d73d61ba61e993b71053e06b9dfe6bc848ef61" }
+inotify = { git = "https://github.com/inotify-rs/inotify", rev = "f78ed9788d437a78ff253ef3b8fafc61932692d5" }
 procinfo = "0.4.2"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,6 @@ extern crate h2;
 extern crate http;
 extern crate httparse;
 extern crate hyper;
-#[cfg(target_os = "linux")]
-extern crate inotify;
 extern crate ipnet;
 #[cfg(target_os = "linux")]
 extern crate libc;


### PR DESCRIPTION
Since my PR against `inotify` (inotify-rs/inotify#124) has merged, we can
go back to depending on the upstream version. Also, this updates the SHA
we depend on to one that actually exists, which should fix the build.

I've also removed the `inotify` dependency from the main proxy crate's
`Cargo.toml.` This dependency is not actually used, as the `fs-watch` lib
crate fully encapsulates the dependency. I think that this was overlooked
when factoring out `fs-watch` into its own crate.

It seems better to not specify the same dependency in multiple places,
especially since we're not using one of them.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>