### PR TITLE
Introduce TCP keepalive configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # This reduces build time and produces binaries with debug symbols, at the expense of
 # runtime performance.
 
-ARG RUST_IMAGE=rust:1.30.0
+ARG RUST_IMAGE=rust:1.32.0
 ARG RUNTIME_IMAGE=gcr.io/linkerd-io/base:2017-10-30.01
 
 ## Builds the proxy as incrementally as possible.

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -44,6 +44,18 @@ pub struct Config {
     /// The maximum amount of time to wait for a connection to a remote peer.
     pub outbound_connect_timeout: Duration,
 
+    // TCP Keepalive set on accepted inbound connections.
+    pub inbound_accept_keepalive: Option<Duration>,
+
+    // TCP Keepalive set on accepted outbound connections.
+    pub outbound_accept_keepalive: Option<Duration>,
+
+    // TCP Keepalive set on inbound connections to the local application.
+    pub inbound_connect_keepalive: Option<Duration>,
+
+    // TCP Keepalive set on outbound connections to the remote peers.
+    pub outbound_connect_keepalive: Option<Duration>,
+
     pub inbound_ports_disable_protocol_detection: IndexSet<u16>,
 
     pub outbound_ports_disable_protocol_detection: IndexSet<u16>,
@@ -178,6 +190,12 @@ pub const ENV_METRICS_LISTENER: &str = "LINKERD2_PROXY_METRICS_LISTENER";
 pub const ENV_METRICS_RETAIN_IDLE: &str = "LINKERD2_PROXY_METRICS_RETAIN_IDLE";
 const ENV_INBOUND_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_INBOUND_CONNECT_TIMEOUT";
 const ENV_OUTBOUND_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT";
+
+const ENV_INBOUND_ACCEPT_KEEPALIVE: &str = "LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE";
+const ENV_OUTBOUND_ACCEPT_KEEPALIVE: &str = "LINKERD2_PROXY_OUTBOUND_ACCEPT_KEEPALIVE";
+
+const ENV_INBOUND_CONNECT_KEEPALIVE: &str = "LINKERD2_PROXY_INBOUND_CONNECT_KEEPALIVE";
+const ENV_OUTBOUND_CONNECT_KEEPALIVE: &str = "LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE";
 
 pub const DEPRECATED_ENV_PRIVATE_LISTENER: &str = "LINKERD2_PROXY_PRIVATE_LISTENER";
 pub const DEPRECATED_ENV_PRIVATE_FORWARD: &str = "LINKERD2_PROXY_PRIVATE_FORWARD";
@@ -321,35 +339,53 @@ impl<'a> TryFrom<&'a Strings> for Config {
             strings, ENV_INBOUND_LISTENER, DEPRECATED_ENV_PUBLIC_LISTENER, parse_addr);
         let control_listener_addr = parse(strings, ENV_CONTROL_LISTENER, parse_addr);
         let metrics_listener_addr = parse(strings, ENV_METRICS_LISTENER, parse_addr);
+
         let inbound_forward = parse_deprecated(
             strings, ENV_INBOUND_FORWARD, DEPRECATED_ENV_PRIVATE_FORWARD, parse_addr);
+
         let inbound_connect_timeout = parse_deprecated(
             strings, ENV_INBOUND_CONNECT_TIMEOUT, DEPRECATED_ENV_PRIVATE_CONNECT_TIMEOUT, parse_duration);
         let outbound_connect_timeout = parse_deprecated(
             strings, ENV_OUTBOUND_CONNECT_TIMEOUT, DEPRECATED_ENV_PUBLIC_CONNECT_TIMEOUT, parse_duration);
+
+        let inbound_accept_keepalive = parse(strings, ENV_INBOUND_ACCEPT_KEEPALIVE, parse_duration);
+        let outbound_accept_keepalive = parse(strings, ENV_OUTBOUND_ACCEPT_KEEPALIVE, parse_duration);
+
+        let inbound_connect_keepalive = parse(strings, ENV_INBOUND_CONNECT_KEEPALIVE, parse_duration);
+        let outbound_connect_keepalive = parse(strings, ENV_OUTBOUND_CONNECT_KEEPALIVE, parse_duration);
+
         let inbound_disable_ports = parse(strings, ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION, parse_port_set);
         let outbound_disable_ports = parse(strings, ENV_OUTBOUND_PORTS_DISABLE_PROTOCOL_DETECTION, parse_port_set);
+
         let inbound_router_capacity = parse(strings, ENV_INBOUND_ROUTER_CAPACITY, parse_number);
         let outbound_router_capacity = parse(strings, ENV_OUTBOUND_ROUTER_CAPACITY, parse_number);
+
         let inbound_router_max_idle_age = parse(strings, ENV_INBOUND_ROUTER_MAX_IDLE_AGE, parse_duration);
         let outbound_router_max_idle_age = parse(strings, ENV_OUTBOUND_ROUTER_MAX_IDLE_AGE, parse_duration);
+
         let destination_concurrency_limit =
             parse(strings, ENV_DESTINATION_CLIENT_CONCURRENCY_LIMIT, parse_number);
         let destination_get_suffixes =
             parse(strings, ENV_DESTINATION_GET_SUFFIXES, parse_dns_suffixes);
         let destination_profile_suffixes =
             parse(strings, ENV_DESTINATION_PROFILE_SUFFIXES, parse_dns_suffixes);
+
         let tls_trust_anchors = parse(strings, ENV_TLS_TRUST_ANCHORS, parse_path);
         let tls_end_entity_cert = parse(strings, ENV_TLS_CERT, parse_path);
         let tls_private_key = parse(strings, ENV_TLS_PRIVATE_KEY, parse_path);
         let tls_pod_identity_template = strings.get(ENV_TLS_POD_IDENTITY);
         let tls_controller_identity = strings.get(ENV_TLS_CONTROLLER_IDENTITY);
+
         let resolv_conf_path = strings.get(ENV_RESOLV_CONF);
+
         let metrics_retain_idle = parse(strings, ENV_METRICS_RETAIN_IDLE, parse_duration);
+
         let dns_min_ttl = parse(strings, ENV_DNS_MIN_TTL, parse_duration);
         let dns_max_ttl = parse(strings, ENV_DNS_MAX_TTL, parse_duration);
+
         let dns_canonicalize_timeout = parse(strings, ENV_DNS_CANONICALIZE_TIMEOUT, parse_duration)?
             .unwrap_or(DEFAULT_DNS_CANONICALIZE_TIMEOUT);
+
         let pod_namespace = strings.get(ENV_POD_NAMESPACE).and_then(|maybe_value| {
             // There cannot be a default pod namespace, and the pod namespace is required.
             maybe_value.ok_or_else(|| {
@@ -461,6 +497,12 @@ impl<'a> TryFrom<&'a Strings> for Config {
                 .unwrap_or(DEFAULT_INBOUND_CONNECT_TIMEOUT),
             outbound_connect_timeout: outbound_connect_timeout?
                 .unwrap_or(DEFAULT_OUTBOUND_CONNECT_TIMEOUT),
+
+            inbound_accept_keepalive: inbound_accept_keepalive?,
+            outbound_accept_keepalive: outbound_accept_keepalive?,
+
+            inbound_connect_keepalive: inbound_connect_keepalive?,
+            outbound_connect_keepalive: outbound_connect_keepalive?,
 
             inbound_ports_disable_protocol_detection: inbound_disable_ports?
                 .unwrap_or_else(|| default_disable_ports_protocol_detection()),

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -683,10 +683,10 @@ fn serve<A, C, R, B, G>(
 where
     A: svc::Stack<proxy::server::Source, Error = Never> + Send + Clone + 'static,
     A::Value: proxy::Accept<Connection>,
-    <A::Value as proxy::Accept<Connection>>::Io: Send + transport::Peek + 'static,
+    <A::Value as proxy::Accept<Connection>>::Io: fmt::Debug + Send + transport::Peek + 'static,
     C: svc::Stack<connect::Target, Error = Never> + Send + Clone + 'static,
     C::Value: connect::Connect + Send,
-    <C::Value as connect::Connect>::Connected: Send + 'static,
+    <C::Value as connect::Connect>::Connected: fmt::Debug + Send + 'static,
     <C::Value as connect::Connect>::Future: Send + 'static,
     <C::Value as connect::Connect>::Error: fmt::Debug + 'static,
     R: svc::Stack<proxy::server::Source, Error = Never> + Send + Clone + 'static,

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -4,8 +4,8 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 pub mod buffer;
 pub mod canonicalize;
-pub mod http;
 pub mod grpc;
+pub mod http;
 pub mod limit;
 mod protocol;
 pub mod reconnect;

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -177,10 +177,10 @@ impl<A, C, R, B> Server<A, C, R, B>
 where
     A: Stack<Source, Error = Never> + Clone,
     A::Value: Accept<Connection>,
-    <A::Value as Accept<Connection>>::Io: Send + Peek + 'static,
+    <A::Value as Accept<Connection>>::Io: fmt::Debug + Send + Peek + 'static,
     C: Stack<connect::Target, Error = Never> + Clone,
     C::Value: connect::Connect,
-    <C::Value as connect::Connect>::Connected: Send + 'static,
+    <C::Value as connect::Connect>::Connected: fmt::Debug + Send + 'static,
     <C::Value as connect::Connect>::Future: Send + 'static,
     <C::Value as connect::Connect>::Error: fmt::Debug + 'static,
     R: Stack<Source, Error = Never> + Clone,

--- a/src/proxy/tcp.rs
+++ b/src/proxy/tcp.rs
@@ -18,27 +18,27 @@ pub(super) fn forward<I, C, T>(
 ) -> impl Future<Item=(), Error=()> + Send + 'static
 where
     T: fmt::Debug,
-    I: AsyncRead + AsyncWrite + Send + 'static,
+    I: AsyncRead + AsyncWrite + fmt::Debug + Send + 'static,
     C: svc::Stack<T>,
     C::Value: Connect,
     C::Error: fmt::Debug,
     <C::Value as Connect>::Future: Send + 'static,
     <C::Value as Connect>::Error: fmt::Debug,
-    <C::Value as Connect>::Connected: Send + 'static,
+    <C::Value as Connect>::Connected: fmt::Debug + Send + 'static,
 {
     let connect = match connect.make(&target) {
         Ok(c) => c,
         Err(e) => {
-            error!("forward error: {:?}: {:?}", target, e);
+            error!("forward stack error: {:?}: {:?}", target, e);
             return Either::A(future::ok(()));
         }
     };
 
     let fwd = connect.connect()
-        .map_err(|e| info!("forward connect error: {:?}", e))
+        .map_err(|e| info!("forward connect failure: {:?}", e))
         .and_then(move |io| {
             Duplex::new(server_io, io)
-                .map_err(|e| info!("forward duplex error: {}", e))
+                .map_err(|e| debug!("forward duplex complete: {}", e))
         });
 
     Either::B(fwd)
@@ -72,8 +72,8 @@ struct CopyBuf {
 
 impl<In, Out> Duplex<In, Out>
 where
-    In: AsyncRead + AsyncWrite,
-    Out: AsyncRead + AsyncWrite,
+    In: AsyncRead + AsyncWrite + fmt::Debug,
+    Out: AsyncRead + AsyncWrite + fmt::Debug,
 {
     pub(super) fn new(in_io: In, out_io: Out) -> Self {
         Duplex {
@@ -85,8 +85,8 @@ where
 
 impl<In, Out> Future for Duplex<In, Out>
 where
-    In: AsyncRead + AsyncWrite,
-    Out: AsyncRead + AsyncWrite,
+    In: AsyncRead + AsyncWrite + fmt::Debug,
+    Out: AsyncRead + AsyncWrite + fmt::Debug,
 {
     type Item = ();
     type Error = io::Error;
@@ -95,6 +95,7 @@ where
         // This purposefully ignores the Async part, since we don't want to
         // return early if the first half isn't ready, but the other half
         // could make progress.
+        trace!("poll {:?} <-> {:?}", self.half_in.io, self.half_out.io);
         self.half_in.copy_into(&mut self.half_out)?;
         self.half_out.copy_into(&mut self.half_in)?;
         if self.half_in.is_done() && self.half_out.is_done() {
@@ -107,7 +108,7 @@ where
 
 impl<T> HalfDuplex<T>
 where
-    T: AsyncRead,
+    T: AsyncRead + fmt::Debug,
 {
     fn new(io: T) -> Self {
         Self {
@@ -119,7 +120,7 @@ where
 
     fn copy_into<U>(&mut self, dst: &mut HalfDuplex<U>) -> Poll<(), io::Error>
     where
-        U: AsyncWrite,
+        U: AsyncWrite + fmt::Debug,
     {
         // Since Duplex::poll() intentionally ignores the Async part of our
         // return value, we may be polled again after returning Ready, if the
@@ -133,6 +134,7 @@ where
             try_ready!(self.read());
             try_ready!(self.write_into(dst));
             if self.buf.is_none() {
+                trace!("shutting down {:?} <-> {:?}", self.io, dst.io);
                 debug_assert!(!dst.is_shutdown,
                     "attempted to shut down destination twice");
                 try_ready!(dst.io.shutdown());
@@ -141,8 +143,6 @@ where
                 return Ok(Async::Ready(()));
             }
         }
-
-
     }
 
     fn read(&mut self) -> Poll<(), io::Error> {
@@ -150,13 +150,17 @@ where
         if let Some(ref mut buf) = self.buf {
             if !buf.has_remaining() {
                 buf.reset();
+
+                trace!("reading {:?}", self.io);
                 let n = try_ready!(self.io.read_buf(buf));
+                trace!("read {}B {:?}", n, self.io);
+
                 is_eof = n == 0;
             }
         }
-
         if is_eof {
-            self.buf.take();
+            trace!("eof from {:?}", self.io);
+            self.buf = None;
         }
 
         Ok(Async::Ready(()))
@@ -164,11 +168,13 @@ where
 
     fn write_into<U>(&mut self, dst: &mut HalfDuplex<U>) -> Poll<(), io::Error>
     where
-        U: AsyncWrite,
+        U: AsyncWrite + fmt::Debug,
     {
         if let Some(ref mut buf) = self.buf {
             while buf.has_remaining() {
+                trace!("writing {}B from {:?} -> {:?}", buf.remaining(), self.io, dst.io);
                 let n = try_ready!(dst.io.write_buf(buf));
+                trace!("wrote {}B from {:?} -> {:?}", n, self.io, dst.io);
                 if n == 0 {
                     return Err(write_zero());
                 }
@@ -242,6 +248,7 @@ mod tests {
     use futures::{Async, Poll};
     use super::*;
 
+    #[derive(Debug)]
     struct DoneIo(AtomicBool);
 
     impl<'a> Read for &'a DoneIo {

--- a/src/transport/connect.rs
+++ b/src/transport/connect.rs
@@ -2,8 +2,7 @@ extern crate tokio_connect;
 
 pub use self::tokio_connect::Connect;
 
-use std::net::SocketAddr;
-use std::{hash, io};
+use std::{hash, io, net::SocketAddr};
 
 use never::Never;
 use svc;
@@ -20,14 +19,16 @@ pub struct Stack {}
 pub struct Target {
     pub addr: SocketAddr,
     pub tls: tls::ConditionalConnectionConfig<tls::ClientConfig>,
-    _p: (),
 }
 
 // ===== impl Target =====
 
 impl Target {
     pub fn new(addr: SocketAddr, tls: tls::ConditionalConnectionConfig<tls::ClientConfig>) -> Self {
-        Self { addr, tls, _p: () }
+        Self {
+            addr,
+            tls,
+        }
     }
 
     pub fn tls_status(&self) -> tls::Status {
@@ -54,7 +55,11 @@ impl hash::Hash for Target {
 
 impl PartialEq for Target {
     fn eq(&self, other: &Target) -> bool {
-        self.addr.eq(&other.addr) && self.tls_status().is_some().eq(&other.tls_status().is_some())
+        self.addr.eq(&other.addr)
+            && self
+                .tls_status()
+                .is_some()
+                .eq(&other.tls_status().is_some())
     }
 }
 

--- a/src/transport/connection.rs
+++ b/src/transport/connection.rs
@@ -13,7 +13,7 @@ use tokio::{
 };
 
 use Conditional;
-use transport::{AddrInfo, BoxedIo, GetOriginalDst, tls};
+use transport::{AddrInfo, BoxedIo, GetOriginalDst, SetKeepalive, tls};
 use indexmap::IndexSet;
 
 pub struct BoundPort<G = ()> {
@@ -145,7 +145,6 @@ impl BoundPort {
 }
 
 impl<G> BoundPort<G> {
-
     pub fn without_protocol_detection_for(
         self,
         disable_protocol_detection_ports: IndexSet<u16>,
@@ -408,7 +407,7 @@ impl Future for Connecting {
                         );
                         io::Error::new(e.kind(), details)
                     }));
-                    trace!("Connecting: state=plaintext; tls={:?};",tls);
+                    trace!("Connecting: state=plaintext; tls={:?};", tls);
                     set_nodelay_or_warn(&plaintext_stream);
                     match tls.take().expect("Polled after ready") {
                         Conditional::Some(config) => {
@@ -554,6 +553,16 @@ impl AsyncWrite for Connection {
 
     fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
         self.io.write_buf(buf)
+    }
+}
+
+impl SetKeepalive for Connection {
+    fn keepalive(&self) -> io::Result<Option<::std::time::Duration>> {
+        self.io.keepalive()
+    }
+
+    fn set_keepalive(&mut self, ka: Option<::std::time::Duration>) -> io::Result<()> {
+        self.io.set_keepalive(ka)
     }
 }
 

--- a/src/transport/io.rs
+++ b/src/transport/io.rs
@@ -5,7 +5,7 @@ use bytes::Buf;
 use futures::Poll;
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use super::AddrInfo;
+use super::{AddrInfo, SetKeepalive};
 use self::internal::Io;
 
 /// A public wrapper around a `Box<Io>`.
@@ -72,18 +72,28 @@ impl AddrInfo for BoxedIo {
     }
 }
 
+impl SetKeepalive for BoxedIo {
+    fn keepalive(&self) -> io::Result<Option<::std::time::Duration>> {
+        self.0.keepalive()
+    }
+
+    fn set_keepalive(&mut self, ka: Option<::std::time::Duration>) -> io::Result<()> {
+        self.0.set_keepalive(ka)
+    }
+}
+
 pub(super) mod internal {
     use std::io;
     use tokio::net::TcpStream;
-    use super::{AddrInfo, AsyncRead, AsyncWrite, Buf, Poll, Shutdown};
+    use super::{AddrInfo, AsyncRead, AsyncWrite, Buf, Poll, SetKeepalive, Shutdown};
 
     /// This trait is private, since it's purpose is for creating a dynamic
     /// trait object, but doing so without care can lead not getting vectored
     /// writes.
     ///
     /// Instead, used the concrete `BoxedIo` type.
-    pub trait Io: AddrInfo + AsyncRead + AsyncWrite + Send {
-        fn shutdown_write(&mut self) -> Result<(), io::Error>;
+    pub trait Io: AddrInfo + AsyncRead + AsyncWrite + SetKeepalive + Send {
+        fn shutdown_write(&mut self) -> io::Result<()>;
 
         /// This method is to allow using `Async::write_buf` even through a
         /// trait object.
@@ -91,7 +101,7 @@ pub(super) mod internal {
     }
 
     impl Io for TcpStream {
-        fn shutdown_write(&mut self) -> Result<(), io::Error> {
+        fn shutdown_write(&mut self) -> io::Result<()> {
             TcpStream::shutdown(self, Shutdown::Write)
         }
 
@@ -141,6 +151,16 @@ mod tests {
         }
 
         fn get_original_dst(&self) -> Option<SocketAddr> {
+            unreachable!("not called in test")
+        }
+    }
+
+    impl SetKeepalive for WriteBufDetector {
+        fn keepalive(&self) -> io::Result<Option<::std::time::Duration>> {
+            unreachable!("not called in test")
+        }
+
+        fn set_keepalive(&mut self, _: Option<::std::time::Duration>) -> io::Result<()> {
             unreachable!("not called in test")
         }
     }

--- a/src/transport/keepalive.rs
+++ b/src/transport/keepalive.rs
@@ -1,0 +1,199 @@
+use std::io;
+use std::time::Duration;
+use tokio::net::TcpStream;
+
+pub trait SetKeepalive {
+    fn keepalive(&self) -> io::Result<Option<Duration>>;
+    fn set_keepalive(&mut self, ka: Option<Duration>) -> ::std::io::Result<()>;
+}
+
+impl SetKeepalive for TcpStream {
+    fn keepalive(&self) -> io::Result<Option<Duration>> {
+        TcpStream::keepalive(self)
+    }
+
+    fn set_keepalive(&mut self, ka: Option<Duration>) -> ::std::io::Result<()> {
+        TcpStream::set_keepalive(self, ka)
+    }
+}
+
+pub mod accept {
+    use std::time::Duration;
+    use tokio::io::{AsyncRead, AsyncWrite};
+
+    use super::SetKeepalive;
+    use svc;
+
+    pub fn layer(keepalive: Option<Duration>) -> Layer {
+        Layer { keepalive }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct Layer {
+        keepalive: Option<Duration>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct Stack<M> {
+        keepalive: Option<Duration>,
+        inner: M,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct Accept<T> {
+        keepalive: Option<Duration>,
+        inner: T,
+    }
+
+    impl<T, M> svc::Layer<T, T, M> for Layer
+    where
+        M: svc::Stack<T>,
+    {
+        type Value = <Stack<M> as svc::Stack<T>>::Value;
+        type Error = <Stack<M> as svc::Stack<T>>::Error;
+        type Stack = Stack<M>;
+
+        fn bind(&self, inner: M) -> Self::Stack {
+            Stack {
+                inner,
+                keepalive: self.keepalive,
+            }
+        }
+    }
+
+    impl<T, M> svc::Stack<T> for Stack<M>
+    where
+        M: svc::Stack<T>,
+    {
+        type Value = Accept<M::Value>;
+        type Error = M::Error;
+
+        fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
+            let inner = self.inner.make(target)?;
+            Ok(Accept {
+                inner,
+                keepalive: self.keepalive,
+            })
+        }
+    }
+
+    impl<I, A> ::proxy::Accept<I> for Accept<A>
+    where
+        I: AsyncRead + AsyncWrite + SetKeepalive,
+        A: ::proxy::Accept<I>,
+    {
+        type Io = A::Io;
+
+        fn accept(&self, mut io: I) -> Self::Io {
+            if let Err(e) = io.set_keepalive(self.keepalive) {
+                debug!("failed to set keepalive: {}", e);
+            }
+
+            self.inner.accept(io)
+        }
+    }
+}
+
+pub mod connect {
+    use futures::{Future, Poll};
+    use std::time::Duration;
+
+    use super::SetKeepalive;
+    use svc;
+    use transport::connect;
+
+    pub fn layer(keepalive: Option<Duration>) -> Layer {
+        Layer { keepalive }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct Layer {
+        keepalive: Option<Duration>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct Stack<M> {
+        keepalive: Option<Duration>,
+        inner: M,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct Connect<T> {
+        keepalive: Option<Duration>,
+        inner: T,
+    }
+
+    impl<T, M> svc::Layer<T, T, M> for Layer
+    where
+        M: svc::Stack<T>,
+        M::Value: connect::Connect,
+        <M::Value as connect::Connect>::Connected: SetKeepalive,
+    {
+        type Value = <Stack<M> as svc::Stack<T>>::Value;
+        type Error = <Stack<M> as svc::Stack<T>>::Error;
+        type Stack = Stack<M>;
+
+        fn bind(&self, inner: M) -> Self::Stack {
+            Stack {
+                inner,
+                keepalive: self.keepalive,
+            }
+        }
+    }
+
+    impl<T, M> svc::Stack<T> for Stack<M>
+    where
+        M: svc::Stack<T>,
+        M::Value: connect::Connect,
+        <M::Value as connect::Connect>::Connected: SetKeepalive,
+    {
+        type Value = Connect<M::Value>;
+        type Error = M::Error;
+
+        fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
+            let inner = self.inner.make(target)?;
+            Ok(Connect {
+                inner,
+                keepalive: self.keepalive,
+            })
+        }
+    }
+
+    impl<C> connect::Connect for Connect<C>
+    where
+        C: connect::Connect,
+        C::Connected: SetKeepalive,
+    {
+        type Connected = C::Connected;
+        type Error = C::Error;
+        type Future = Connect<C::Future>;
+
+        fn connect(&self) -> Self::Future {
+            let keepalive = self.keepalive;
+            let inner = self.inner.connect();
+            Connect {
+                keepalive,
+                inner,
+            }
+        }
+    }
+
+    impl<F> Future for Connect<F>
+    where
+        F: Future,
+        F::Item: SetKeepalive,
+    {
+        type Item = F::Item;
+        type Error = F::Error;
+
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+            let mut io = try_ready!(self.inner.poll());
+
+            if let Err(e) = io.set_keepalive(self.keepalive) {
+                debug!("failed to set keepalive: {}", e);
+            }
+
+            Ok(io.into())
+        }
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -2,6 +2,7 @@ pub mod connect;
 mod connection;
 mod addr_info;
 mod io;
+pub mod keepalive;
 pub mod metrics;
 mod prefixed;
 pub mod tls;
@@ -22,4 +23,5 @@ pub use self::{
         Peek,
     },
     io::BoxedIo,
+    keepalive::SetKeepalive,
 };

--- a/src/transport/prefixed.rs
+++ b/src/transport/prefixed.rs
@@ -3,7 +3,7 @@ use std::{cmp, fmt::Debug, io, net::SocketAddr};
 use tokio::prelude::*;
 
 use super::io::internal::Io;
-use transport::AddrInfo;
+use transport::{AddrInfo, SetKeepalive};
 
 /// A TcpStream where the initial reads will be served from `prefix`.
 #[derive(Debug)]
@@ -76,6 +76,16 @@ impl<S> AddrInfo for Prefixed<S> where S: AddrInfo {
 
     fn get_original_dst(&self) -> Option<SocketAddr> {
         self.io.get_original_dst()
+    }
+}
+
+impl<S> SetKeepalive for Prefixed<S> where S: SetKeepalive {
+    fn keepalive(&self) -> io::Result<Option<::std::time::Duration>> {
+        self.io.keepalive()
+    }
+
+    fn set_keepalive(&mut self, ka: Option<::std::time::Duration>) -> io::Result<()> {
+        self.io.set_keepalive(ka)
     }
 }
 

--- a/src/transport/tls/connection.rs
+++ b/src/transport/tls/connection.rs
@@ -6,7 +6,7 @@ use futures::Future;
 use tokio::prelude::*;
 use tokio::net::TcpStream;
 
-use transport::{AddrInfo, io::internal::Io, prefixed::Prefixed};
+use transport::{AddrInfo, io::internal::Io, prefixed::Prefixed, SetKeepalive};
 
 use super::{
     identity::Identity,
@@ -124,6 +124,19 @@ impl<S, C> AddrInfo for Connection<S, C>
 
     fn get_original_dst(&self) -> Option<SocketAddr> {
         self.0.get_ref().0.get_original_dst()
+    }
+}
+
+impl<S, C> SetKeepalive for Connection<S, C>
+    where S: SetKeepalive + Debug,
+          C: Session + Debug,
+{
+    fn keepalive(&self) -> io::Result<Option<::std::time::Duration>> {
+        self.0.get_ref().0.keepalive()
+    }
+
+    fn set_keepalive(&mut self, ka: Option<::std::time::Duration>) -> io::Result<()> {
+        self.0.get_mut().0.set_keepalive(ka)
     }
 }
 


### PR DESCRIPTION
In some network environments, peers may silently drop connections such that the proxy cannot detect that the peer's socket has been closed.

The [TCP keepalive socket options][tcp-keepalive] configures the kernel to actively probe connections to ensure connectivity and prevent idle timeouts.

This change adds stack modules that attempt to configure accept and connect sockets' TCP keepalive socket options. There are four new environment configurations the proxy supports:

    - `LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE`
    - `LINKERD2_PROXY_OUTBOUND_ACCEPT_KEEPALIVE`
    - `LINKERD2_PROXY_INBOUND_CONNECT_KEEPALIVE`
    - `LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE`

When an environment variable is unset, no keepalive is set on the corresponding sockets. Otherwise, its value is parsed as a duration. OSes may or may not understand subsecond values.

It is recommended to only set the inbound-accept and outbound-connect keepalive values, as keepalives shouldn'tbe necessary on localhost.

Addresses linkerd/linkerd2#1949 linkerd/linkerd2#2182

[tcp-keepalive]: http://www.tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html

---

Furthermore, adds trace logging to the TCP forwarder and fixes docker compilation by updating the stable rust version in Dockerfile.