### PR TITLE
Remove destination address from endpoint metric labels

### DIFF
--- a/src/app/metric_labels.rs
+++ b/src/app/metric_labels.rs
@@ -1,6 +1,4 @@
-use std::{
-    fmt::{self, Write},
-};
+use std::fmt::{self, Write};
 
 use metrics::FmtLabels;
 

--- a/src/app/metric_labels.rs
+++ b/src/app/metric_labels.rs
@@ -1,6 +1,5 @@
 use std::{
     fmt::{self, Write},
-    net,
 };
 
 use metrics::FmtLabels;
@@ -18,7 +17,6 @@ pub struct ControlLabels {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EndpointLabels {
-    addr: net::SocketAddr,
     direction: Direction,
     tls_status: tls::Status,
     dst_name: Option<NameAddr>,
@@ -89,7 +87,6 @@ impl FmtLabels for RouteLabels {
 impl From<inbound::Endpoint> for EndpointLabels {
     fn from(ep: inbound::Endpoint) -> Self {
         Self {
-            addr: ep.addr,
             dst_name: ep.dst_name,
             direction: Direction::In,
             tls_status: ep.source_tls_status,
@@ -114,7 +111,6 @@ where
 impl From<outbound::Endpoint> for EndpointLabels {
     fn from(ep: outbound::Endpoint) -> Self {
         Self {
-            addr: ep.connect.addr,
             dst_name: ep.dst_name,
             direction: Direction::Out,
             tls_status: ep.connect.tls_status(),


### PR DESCRIPTION
# Problem
When `EndpointLabels`s are compared for equality, the `SocketAddr` field is considered as part of the `Hash`. However, the `SocketAddr` field is never formatted. When all labels are otherwise equal, this results in metrics that look like they have redundant scopes.

# Solution
Removing the `addr: SocketAddr` field from `EndpointLabels` results in equality between sets of labels that may have differed in their destination address, but are otherwise the same.

# Validation
In reproducing with [booksapp](http://github.com/BuoyantIO/booksapp), there are no longer any redundant metric scopes
```bash
$ kubectl -n linkerd exec -c linkerd-proxy $(kubectl -n linkerd get po | awk '$1 ~ /^linkerd-controller-/ && $3 ~ /^Running$/ { print $1 }' |head -n 1) -- curl -s localhost:4191/metrics   | grep tls= | head
request_total{direction="inbound",tls="disabled"} 853
request_total{authority="linkerd-proxy-api.linkerd.svc.cluster.local:8086",direction="inbound",tls="disabled"} 23
response_latency_ms_bucket{direction="inbound",tls="disabled",status_code="200",le="1"} 563
response_latency_ms_bucket{direction="inbound",tls="disabled",status_code="200",le="2"} 661
response_latency_ms_bucket{direction="inbound",tls="disabled",status_code="200",le="3"} 713
response_latency_ms_bucket{direction="inbound",tls="disabled",status_code="200",le="4"} 752
```

Fixes linkerd/linkerd2#2203

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
Co-authored-by: Eliza Weisman <eliza@buoyant.io>
