### PR TITLE
Log canonicalization warnings on only the first error

### DIFF
--- a/src/proxy/canonicalize.rs
+++ b/src/proxy/canonicalize.rs
@@ -191,9 +191,8 @@ impl Future for Task {
                         }
                         Err(e) => {
                             if self.resolved == Cache::AwaitingInitial {
-                                // The service needs a value in order to
-                                // continue, so we need to publish the original
-                                // name so it can proceed.
+                                // The service needs a value, so we need to
+                                // publish the original name so it can proceed.
                                 warn!(
                                     "failed to refine {}: {}; using original name",
                                     self.original.name(),


### PR DESCRIPTION
When a canonicalization task fails to resolve a name, our logging is not
particularly clear about the current state of the stack. Specifically,
it's difficult to know whether the stack has resolved the name
successfully before.

With this change, canonicalization failures are logged (at warning, not
error) only when the task has not previously resolved a name.
Subsequent errors are now logged at the debug level (instead of
warning).