### PR TITLE
Fix compilation warnings in fs-watch

### DIFF
--- a/lib/fs-watch/src/either_stream.rs
+++ b/lib/fs-watch/src/either_stream.rs
@@ -5,6 +5,7 @@ use futures::{Poll, Stream};
 /// Combines two different `Stream`s yielding the same item and error
 /// types into a single type.
 #[derive(Clone, Debug)]
+#[allow(dead_code)]
 pub enum EitherStream<A, B> {
     A(A),
     B(B),

--- a/lib/fs-watch/src/either_stream.rs
+++ b/lib/fs-watch/src/either_stream.rs
@@ -5,7 +5,6 @@ use futures::{Poll, Stream};
 /// Combines two different `Stream`s yielding the same item and error
 /// types into a single type.
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub enum EitherStream<A, B> {
     A(A),
     B(B),

--- a/lib/fs-watch/src/lib.rs
+++ b/lib/fs-watch/src/lib.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate log;
-#[macro_use]
 extern crate futures;
 extern crate futures_watch;
 extern crate ring;

--- a/lib/fs-watch/src/lib.rs
+++ b/lib/fs-watch/src/lib.rs
@@ -1,9 +1,5 @@
 #[macro_use]
 extern crate log;
-#[cfg(target_os = "linux")]
-#[macro_use]
-extern crate futures;
-#[cfg(not(target_os = "linux"))]
 extern crate futures;
 extern crate futures_watch;
 extern crate ring;
@@ -237,7 +233,7 @@ pub mod inotify {
         type Error = io::Error;
         fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
             loop {
-                match try_ready!(self.stream.poll()) {
+                match futures::try_ready!(self.stream.poll()) {
                     Some(Event { mask, name, .. }) => {
                         if mask.contains(EventMask::IGNORED) {
                             // This event fires if we removed a watch. Poll the

--- a/lib/fs-watch/src/lib.rs
+++ b/lib/fs-watch/src/lib.rs
@@ -1,5 +1,9 @@
 #[macro_use]
 extern crate log;
+#[cfg(target_os = "linux")]
+#[macro_use]
+extern crate futures;
+#[cfg(not(target_os = "linux"))]
 extern crate futures;
 extern crate futures_watch;
 extern crate ring;
@@ -17,6 +21,7 @@ use ring::digest::{self, Digest};
 
 use tokio_timer::{clock, Interval};
 
+#[cfg(target_os = "linux")]
 mod either_stream;
 
 /// Stream changes to the files at a group of paths.


### PR DESCRIPTION
fs-watch contains compilation warnings due to an unused macro and a
public enum that is not constructed within the crate. This resolves
these warnings.