### PR TITLE
 make: Optionally include debug symbols with builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ sudo: false
 
 language: rust
 cache: cargo
-env:
-  - RUSTFLAGS="-C debuginfo=0" RUST_TEST_THREADS=1 RUST_TEST_PATIENCE_MS=200
 
 branches:
   only:
@@ -13,26 +11,30 @@ branches:
 
 jobs:
   include:
-    # On PRs and branches, quickly run tests in debug mode.
-    - if: type = pull_request
-      install: rustup component add rustfmt
+    # Quickly run tests in dev mode.
+    - rust: stable
+      install:
+        - rustup component add rustfmt
+        - export RUSTFLAGS="-C debuginfo=0" RUST_TEST_THREADS=1 RUST_TEST_PATIENCE_MS=200
       script:
         - make check-fmt
-        - make test
-      rust: stable
+        - travis_wait make test
+        # If you're debugging disk utilization/caching... This finds the largest files in `target`:
+        #- du -sh target && find target -type f |xargs -n 1000 du -s |sort -rn |head |awk '{print $2}' |xargs du -sh
 
     # On master, package an artifact and run tests in release mode before
     # publishing the artifact to build.l5d.io/linkerd2-proxy.
     #
     # build.l5d.io/linkerd2-proxy/latest.txt is updated to reference the latest
     # uploaded binary.
-    - if: type != pull_request
-      # Verbose is enabled so that the build doesn't timeout.
-      install: export CARGO_RELEASE=1 CARGO_VERBOSE=1
-      script:
-        - make clean-package package
-        - make test
+    - stage: publish
+      if: branch = master && type != pull_request
       rust: stable
+      script:
+        # Set `CARGO_DEBUG` in order to include debug symbols.
+        - CARGO_RELEASE=1 travis_wait make package
+      after_deploy:
+        - make clean-package
       deploy:
         on:
           repo: linkerd/linkerd2-proxy


### PR DESCRIPTION
Per linkerd/linkerd2#2199, we want to be able to include the proxy's debug symbols in auxiliary diagnostic containers. In order to do this, the process that produces the proxy's binaries also should be responsible for producing its debug symbols.

This change adds a new environment variable, `CARGO_DEBUG`, which the Makefile uses to instrument the build to produce debug symbols. If `objcopy` is available on the local system (i.e. on Linux), then the symbols are copied from the binary into a .obj file, and the executable is stripped from 3.3G down to 9.9M before packaging.
    
This increases the size of the compressed package artifact by 76% (from 5.0M to 8.8M). This may have similar impacts on build time. This may have similar impacts on build time. To that end, CARGO_DEBUG is not enabled in CI yet.
    
CI has been changed, however, to use build stages. Now, master will undergo the same test stage as PRs, though packages are only built & published for master.