### PR TITLE
Update Router to wait for inner poll_ready before calling inner call

### DIFF
--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -88,7 +88,7 @@ impl<Req, Rec, Stk, B> svc::Layer<Config, Rec::Target, Stk> for Layer<Req, Rec>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
     Stk: svc::Stack<Rec::Target> + Clone + Send + Sync + 'static,
-    Stk::Value: svc::Service<Req, Response = http::Response<B>>,
+    Stk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Stk::Value as svc::Service<Req>>::Error: error::Error,
     Stk::Error: fmt::Debug,
     B: Default + Send + 'static,
@@ -112,7 +112,7 @@ impl<Req, Rec, Stk, B> svc::Stack<Config> for Stack<Req, Rec, Stk>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
     Stk: svc::Stack<Rec::Target> + Clone + Send + Sync + 'static,
-    Stk::Value: svc::Service<Req, Response = http::Response<B>>,
+    Stk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Stk::Value as svc::Service<Req>>::Error: error::Error,
     Stk::Error: fmt::Debug,
     B: Default + Send + 'static,
@@ -164,7 +164,7 @@ impl<Req, Rec, Stk, B> svc::Service<Req> for Service<Req, Rec, Stk>
 where
     Rec: Recognize<Req> + Send + Sync + 'static,
     Stk: svc::Stack<Rec::Target> + Send + Sync + 'static,
-    Stk::Value: svc::Service<Req, Response = http::Response<B>>,
+    Stk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Stk::Value as svc::Service<Req>>::Error: error::Error,
     Stk::Error: fmt::Debug,
     B: Default + Send + 'static,

--- a/src/proxy/http/settings.rs
+++ b/src/proxy/http/settings.rs
@@ -112,7 +112,7 @@ pub mod router {
     pub struct ResponseFuture<B, M>
     where
         M: svc::Stack<Config>,
-        M::Value: svc::Service<http::Request<B>>,
+        M::Value: svc::Service<http::Request<B>> + Clone,
     {
         inner: <Router<B, M> as svc::Service<http::Request<B>>>::Future,
     }
@@ -141,7 +141,7 @@ pub mod router {
     where
         T: HasConnect,
         M: svc::Stack<Config> + Clone,
-        M::Value: svc::Service<http::Request<B>>,
+        M::Value: svc::Service<http::Request<B>> + Clone,
     {
         type Value = <Stack<B, M> as svc::Stack<T>>::Value;
         type Error = <Stack<B, M> as svc::Stack<T>>::Error;
@@ -162,7 +162,7 @@ pub mod router {
     where
         T: HasConnect,
         M: svc::Stack<Config> + Clone,
-        M::Value: svc::Service<http::Request<B>>,
+        M::Value: svc::Service<http::Request<B>> + Clone,
     {
         type Value = Service<B, M>;
         type Error = M::Error;
@@ -206,7 +206,7 @@ pub mod router {
     impl<B, M> svc::Service<http::Request<B>> for Service<B, M>
     where
         M: svc::Stack<Config>,
-        M::Value: svc::Service<http::Request<B>>,
+        M::Value: svc::Service<http::Request<B>> + Clone,
     {
         type Response = <Router<B, M> as svc::Service<http::Request<B>>>::Response;
         type Error = Error<<M::Value as svc::Service<http::Request<B>>>::Error, M::Error>;
@@ -232,7 +232,7 @@ pub mod router {
     impl<B, M> Future for ResponseFuture<B, M>
     where
         M: svc::Stack<Config>,
-        M::Value: svc::Service<http::Request<B>>,
+        M::Value: svc::Service<http::Request<B>> + Clone,
     {
         type Item = <Router<B, M> as svc::Service<http::Request<B>>>::Response;
         type Error = Error<<M::Value as svc::Service<http::Request<B>>>::Error, M::Error>;


### PR DESCRIPTION
The contract to only call `Service::call` after seeing ready from `poll_ready` was just [made strong](https://github.com/tower-rs/tower/pull/161). So, this one step towards making sure we do just that.

Since a router can't call `poll_ready` on all of its inner routes, instead it requires each service be `Clone`, and calls `poll_ready` in its `ResponseFuture`.