### PR TITLE
Refactor profiles::router on top of linkerd2_router

### DIFF
--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -19,7 +19,7 @@ pub enum Direction {
     Out,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Route {
     pub dst_addr: DstAddr,
     pub route: profiles::Route,

--- a/src/proxy/http/timeout.rs
+++ b/src/proxy/http/timeout.rs
@@ -30,7 +30,7 @@ pub struct Stack<M> {
     inner: M,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Service<S>(Timeout<S>);
 
 /// A marker set in `http::Response::extensions` that *this* process triggered


### PR DESCRIPTION
Follow after #194, the `profiles::router` needs to be updated to call `poll_ready` before `call`. I noticed the `profiles::router` is *very* similar to a regular `Router`. So I've refactored it to use one internally, thus getting the poll-ready-then-call fix automatically.