### PR TITLE
Remove the CONTROLLER_NAMESPACE configuration

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -287,7 +287,6 @@ where
             let (resolver, resolver_bg) = control::destination::new(
                 controller.clone(),
                 dns_resolver.clone(),
-                config.namespaces.clone(),
                 config.destination_get_suffixes,
                 config.destination_concurrency_limit,
                 config.proxy_id.clone(),

--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -78,9 +78,10 @@ where
                 Ok(Async::Ready(Some(update))) => match update.update {
                     Some(PbUpdate2::Add(a_set)) => {
                         let set_labels = a_set.metric_labels;
-                        let addrs = a_set.addrs.into_iter().filter_map(|pb| {
-                            pb_to_addr_meta(pb, &set_labels)
-                        });
+                        let addrs = a_set
+                            .addrs
+                            .into_iter()
+                            .filter_map(|pb| pb_to_addr_meta(pb, &set_labels));
                         self.add(auth, addrs)
                     }
                     Some(PbUpdate2::Remove(r_set)) => {

--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -70,7 +70,6 @@ where
         &mut self,
         auth: &NameAddr,
         mut rx: UpdateRx<T>,
-        tls_controller_namespace: Option<&str>,
     ) -> (ActiveQuery<T>, Exists<()>) {
         let mut exists = Exists::Unknown;
 
@@ -80,7 +79,7 @@ where
                     Some(PbUpdate2::Add(a_set)) => {
                         let set_labels = a_set.metric_labels;
                         let addrs = a_set.addrs.into_iter().filter_map(|pb| {
-                            pb_to_addr_meta(pb, &set_labels, tls_controller_namespace)
+                            pb_to_addr_meta(pb, &set_labels)
                         });
                         self.add(auth, addrs)
                     }
@@ -281,7 +280,6 @@ where
 fn pb_to_addr_meta(
     pb: WeightedAddr,
     set_labels: &HashMap<String, String>,
-    tls_controller_namespace: Option<&str>,
 ) -> Option<(SocketAddr, Metadata)> {
     let addr = pb.addr.and_then(pb_to_sock_addr)?;
 
@@ -303,7 +301,7 @@ fn pb_to_addr_meta(
     let mut tls_identity =
         Conditional::None(tls::ReasonForNoIdentity::NotProvidedByServiceDiscovery);
     if let Some(pb) = pb.tls_identity {
-        match tls::Identity::maybe_from_protobuf(tls_controller_namespace, pb) {
+        match tls::Identity::maybe_from_protobuf(pb) {
             Ok(Some(identity)) => {
                 tls_identity = Conditional::Some(identity);
             }

--- a/src/control/destination/background/mod.rs
+++ b/src/control/destination/background/mod.rs
@@ -301,11 +301,7 @@ where
 // ===== impl NewQuery =====
 
 impl NewQuery {
-    fn new(
-        suffixes: Vec<dns::Suffix>,
-        concurrency_limit: usize,
-        proxy_id: String,
-    ) -> Self {
+    fn new(suffixes: Vec<dns::Suffix>, concurrency_limit: usize, proxy_id: String) -> Self {
         Self {
             suffixes,
             concurrency_limit,

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -38,7 +38,6 @@ use transport::tls;
 pub mod background;
 
 use self::background::Background;
-use app::config::Namespaces;
 use {Conditional, NameAddr};
 
 /// A handle to request resolutions from the background discovery task.
@@ -107,7 +106,6 @@ pub enum ProtocolHint {
 pub fn new<T>(
     mut client: Option<T>,
     dns_resolver: dns::Resolver,
-    namespaces: Namespaces,
     suffixes: Vec<dns::Suffix>,
     concurrency_limit: usize,
     proxy_id: String,
@@ -122,7 +120,6 @@ where
     let mut bg = Background::new(
         rx,
         dns_resolver,
-        namespaces,
         suffixes,
         concurrency_limit,
         proxy_id,

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -117,13 +117,7 @@ where
 {
     let (request_tx, rx) = mpsc::unbounded();
     let disco = Resolver { request_tx };
-    let mut bg = Background::new(
-        rx,
-        dns_resolver,
-        suffixes,
-        concurrency_limit,
-        proxy_id,
-    );
+    let mut bg = Background::new(rx, dns_resolver, suffixes, concurrency_limit, proxy_id);
     let task = future::poll_fn(move || bg.poll_rpc(&mut client));
     (disco, task)
 }

--- a/src/transport/tls/identity.rs
+++ b/src/transport/tls/identity.rs
@@ -13,9 +13,7 @@ impl Identity {
     ///
     /// In the event of an error, the error is logged, so no detailed error
     /// information is returned.
-    pub fn maybe_from_protobuf(
-        pb: api::destination::TlsIdentity,
-    ) -> Result<Option<Self>, ()> {
+    pub fn maybe_from_protobuf(pb: api::destination::TlsIdentity) -> Result<Option<Self>, ()> {
         use api::destination::tls_identity::Strategy;
         match pb.strategy {
             Some(Strategy::K8sPodIdentity(i)) => {

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -816,7 +816,6 @@ mod proxy_to_proxy {
             app::config::ENV_TLS_POD_IDENTITY,
             "foo.deployment.ns1.linkerd-managed.linkerd.svc.cluster.local".to_string(),
         );
-        env.put(app::config::ENV_CONTROLLER_NAMESPACE, "linkerd".to_string());
         env.put(app::config::ENV_POD_NAMESPACE, "ns1".to_string());
 
         env

--- a/tests/transparency.rs
+++ b/tests/transparency.rs
@@ -154,7 +154,6 @@ fn tcp_server_first_tls() {
         app::config::ENV_TLS_POD_IDENTITY,
         "foo.deployment.ns1.linkerd-managed.linkerd.svc.cluster.local".to_string(),
     );
-    env.put(app::config::ENV_CONTROLLER_NAMESPACE, "linkerd".to_string());
     env.put(app::config::ENV_POD_NAMESPACE, "ns1".to_string());
 
     test_server_speaks_first(env)


### PR DESCRIPTION
linkerd/linkerd2#2371 removes the need for the proxy to be aware of the
controller namespace by moving the TLS-identity checking logic into the
destination service.

With this change, when the destination service returns an identity, the
proxy will try to establish TLS'd communication to the endpoint if the
proxy has trust anchors.