### PR TITLE
Set `l5d-remote-ip` on inbound requests and outbound responses

### DIFF
--- a/src/app/inbound.rs
+++ b/src/app/inbound.rs
@@ -261,7 +261,7 @@ pub mod rewrite_loopback_addr {
 
 /// Adds `l5d-client-id` headers to http::Requests derived from the
 /// TlsIdentity of a `Source`.
-pub mod client_id {
+pub mod set_client_id_on_req {
     use super::super::L5D_CLIENT_ID;
     use http::header::HeaderValue;
 
@@ -292,7 +292,7 @@ pub mod client_id {
 
 /// Adds `l5d-remote-ip` headers to http::Requests derived from the
 /// `remote` of a `Source`.
-pub mod remote_ip {
+pub mod set_remote_ip_on_req {
     use super::super::L5D_REMOTE_IP;
     use bytes::Bytes;
     use http::header::HeaderValue;

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -302,7 +302,8 @@ where
 
             let outbound = {
                 use super::outbound::{
-                    discovery::Resolve, orig_proto_upgrade, remote_ip, server_id, Endpoint,
+                    add_remote_ip_on_rsp, add_server_id_on_rsp, discovery::Resolve,
+                    orig_proto_upgrade, Endpoint,
                 };
                 use proxy::{
                     canonicalize,
@@ -350,8 +351,8 @@ where
                     .push(strip_header::response::layer(super::L5D_SERVER_ID))
                     .push(strip_header::response::layer(super::L5D_REMOTE_IP))
                     .push(settings::router::layer::<Endpoint, _>())
-                    .push(server_id::layer())
-                    .push(remote_ip::layer())
+                    .push(add_server_id_on_rsp::layer())
+                    .push(add_remote_ip_on_rsp::layer())
                     .push(orig_proto_upgrade::layer())
                     .push(tap_layer.clone())
                     .push(metrics::layer::<_, classify::Response>(
@@ -492,8 +493,8 @@ where
 
             let inbound = {
                 use super::inbound::{
-                    client_id, orig_proto_downgrade, remote_ip, rewrite_loopback_addr, Endpoint,
-                    RecognizeEndpoint,
+                    orig_proto_downgrade, rewrite_loopback_addr, set_client_id_on_req,
+                    set_remote_ip_on_req, Endpoint, RecognizeEndpoint,
                 };
 
                 let capacity = config.inbound_router_capacity;
@@ -611,9 +612,9 @@ where
                 let source_stack = dst_router
                     .push(orig_proto_downgrade::layer())
                     .push(insert_target::layer())
-                    .push(remote_ip::layer())
+                    .push(set_remote_ip_on_req::layer())
                     .push(strip_header::request::layer(super::L5D_REMOTE_IP))
-                    .push(client_id::layer())
+                    .push(set_client_id_on_req::layer())
                     .push(strip_header::request::layer(super::L5D_CLIENT_ID))
                     .push(strip_header::response::layer(super::L5D_SERVER_ID))
                     .push(strip_header::request::layer(super::DST_OVERRIDE_HEADER));

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,6 +17,7 @@ use addr::{self, Addr};
 
 const CANONICAL_DST_HEADER: &'static str = "l5d-dst-canonical";
 pub const DST_OVERRIDE_HEADER: &'static str = "l5d-dst-override";
+const L5D_REMOTE_IP: &'static str = "l5d-remote-ip";
 const L5D_SERVER_ID: &'static str = "l5d-server-id";
 const L5D_CLIENT_ID: &'static str = "l5d-client-id";
 

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -272,291 +272,41 @@ pub mod orig_proto_upgrade {
 /// Adds `l5d-server-id` headers to http::Responses derived from the
 /// TlsIdentity of an `Endpoint`.
 pub mod server_id {
-    use std::marker::PhantomData;
-
-    use futures::{Future, Poll};
-    use http::{self, header::HeaderValue};
-
     use super::Endpoint;
-    use proxy::http::ClientUsedTls;
-    use svc;
+    use http::header::HeaderValue;
+    use proxy::http::add_header::{self, response::ResHeader, Layer};
     use Conditional;
 
-    #[derive(Debug)]
-    pub struct Layer<B>(PhantomData<fn() -> B>);
-
-    #[derive(Debug)]
-    pub struct Stack<M, B> {
-        inner: M,
-        _marker: PhantomData<fn() -> B>,
-    }
-
-    #[derive(Debug)]
-    pub struct Service<S, B> {
-        inner: S,
-        value: HeaderValue,
-        _marker: PhantomData<fn() -> B>,
-    }
-
-    pub struct ResponseFuture<F> {
-        inner: F,
-        value: HeaderValue,
-    }
-
-    pub fn layer<B>() -> Layer<B> {
-        Layer(PhantomData)
-    }
-
-    impl<B> Clone for Layer<B> {
-        fn clone(&self) -> Self {
-            Layer(PhantomData)
-        }
-    }
-
-    impl<M, B> svc::Layer<Endpoint, Endpoint, M> for Layer<B>
-    where
-        M: svc::Stack<Endpoint>,
-    {
-        type Value = <Stack<M, B> as svc::Stack<Endpoint>>::Value;
-        type Error = <Stack<M, B> as svc::Stack<Endpoint>>::Error;
-        type Stack = Stack<M, B>;
-
-        fn bind(&self, inner: M) -> Self::Stack {
-            Stack {
-                inner,
-                _marker: PhantomData,
-            }
-        }
-    }
-
-    // === impl Stack ===
-
-    impl<M: Clone, B> Clone for Stack<M, B> {
-        fn clone(&self) -> Self {
-            Stack {
-                inner: self.inner.clone(),
-                _marker: PhantomData,
-            }
-        }
-    }
-
-    impl<M, B> svc::Stack<Endpoint> for Stack<M, B>
-    where
-        M: svc::Stack<Endpoint>,
-    {
-        type Value = svc::Either<Service<M::Value, B>, M::Value>;
-        type Error = M::Error;
-
-        fn make(&self, endpoint: &Endpoint) -> Result<Self::Value, Self::Error> {
-            let svc = self.inner.make(endpoint)?;
-
+    pub fn layer() -> Layer<&'static str, Endpoint, ResHeader> {
+        add_header::response::layer(super::super::L5D_SERVER_ID, |endpoint: &Endpoint| {
             if let Conditional::Some(id) = endpoint.connect.tls_server_identity() {
-                match HeaderValue::from_str(id.as_ref()) {
+                return match HeaderValue::from_str(id.as_ref()) {
                     Ok(value) => {
                         debug!("l5d-server-id enabled for {:?}", endpoint);
-                        return Ok(svc::Either::A(Service {
-                            inner: svc,
-                            value,
-                            _marker: PhantomData,
-                        }));
+                        Some(value)
                     }
                     Err(_err) => {
                         warn!("l5d-server-id identity header is invalid: {:?}", endpoint);
+                        None
                     }
-                }
+                };
             }
 
-            trace!("l5d-server-id not enabled for {:?}", endpoint);
-            Ok(svc::Either::B(svc))
-        }
-    }
-
-    // === impl Service ===
-
-    impl<S: Clone, B> Clone for Service<S, B> {
-        fn clone(&self) -> Self {
-            Service {
-                inner: self.inner.clone(),
-                value: self.value.clone(),
-                _marker: PhantomData,
-            }
-        }
-    }
-
-    impl<S, B, Req> svc::Service<Req> for Service<S, B>
-    where
-        S: svc::Service<Req, Response = http::Response<B>>,
-    {
-        type Response = S::Response;
-        type Error = S::Error;
-        type Future = ResponseFuture<S::Future>;
-
-        fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-            self.inner.poll_ready()
-        }
-
-        fn call(&mut self, req: Req) -> Self::Future {
-            let fut = self.inner.call(req);
-
-            ResponseFuture {
-                inner: fut,
-                value: self.value.clone(),
-            }
-        }
-    }
-
-    impl<F, B> Future for ResponseFuture<F>
-    where
-        F: Future<Item = http::Response<B>>,
-    {
-        type Item = F::Item;
-        type Error = F::Error;
-
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            let mut res = try_ready!(self.inner.poll());
-            if res.extensions().get::<ClientUsedTls>().is_some() {
-                res.headers_mut()
-                    .insert(super::super::L5D_SERVER_ID, self.value.clone());
-            }
-            Ok(res.into())
-        }
+            None
+        })
     }
 }
 
 /// Adds `l5d-remote-ip` headers to http::Responses derived from the
 /// `remote` of a `Source`.
 pub mod remote_ip {
-    use std::marker::PhantomData;
-
-    use futures::{Future, Poll};
-    use http::{self, header::HeaderValue};
-
     use super::Endpoint;
-    use svc;
+    use http::header::HeaderValue;
+    use proxy::http::add_header::{self, response::ResHeader, Layer};
 
-    #[derive(Debug)]
-    pub struct Layer<B>(PhantomData<fn() -> B>);
-
-    #[derive(Debug)]
-    pub struct Stack<M, B> {
-        inner: M,
-        _marker: PhantomData<fn() -> B>,
-    }
-
-    #[derive(Debug)]
-    pub struct Service<S, B> {
-        inner: S,
-        value: HeaderValue,
-        _marker: PhantomData<fn() -> B>,
-    }
-
-    pub struct ResponseFuture<F> {
-        inner: F,
-        value: HeaderValue,
-    }
-
-    pub fn layer<B>() -> Layer<B> {
-        Layer(PhantomData)
-    }
-
-    impl<B> Clone for Layer<B> {
-        fn clone(&self) -> Self {
-            Layer(PhantomData)
-        }
-    }
-
-    impl<M, B> svc::Layer<Endpoint, Endpoint, M> for Layer<B>
-    where
-        M: svc::Stack<Endpoint>,
-    {
-        type Value = <Stack<M, B> as svc::Stack<Endpoint>>::Value;
-        type Error = <Stack<M, B> as svc::Stack<Endpoint>>::Error;
-        type Stack = Stack<M, B>;
-
-        fn bind(&self, inner: M) -> Self::Stack {
-            Stack {
-                inner,
-                _marker: PhantomData,
-            }
-        }
-    }
-
-    // === impl Stack ===
-
-    impl<M: Clone, B> Clone for Stack<M, B> {
-        fn clone(&self) -> Self {
-            Stack {
-                inner: self.inner.clone(),
-                _marker: PhantomData,
-            }
-        }
-    }
-
-    impl<M, B> svc::Stack<Endpoint> for Stack<M, B>
-    where
-        M: svc::Stack<Endpoint>,
-    {
-        type Value = Service<M::Value, B>;
-        type Error = M::Error;
-
-        fn make(&self, endpoint: &Endpoint) -> Result<Self::Value, Self::Error> {
-            let svc = self.inner.make(endpoint)?;
-            let value = HeaderValue::from_str(&endpoint.connect.addr.ip().to_string()).unwrap();
-
-            return Ok(Service {
-                inner: svc,
-                value,
-                _marker: PhantomData,
-            });
-        }
-    }
-
-    // === impl Service ===
-
-    impl<S: Clone, B> Clone for Service<S, B> {
-        fn clone(&self) -> Self {
-            Service {
-                inner: self.inner.clone(),
-                value: self.value.clone(),
-                _marker: PhantomData,
-            }
-        }
-    }
-
-    impl<S, B, Req> svc::Service<Req> for Service<S, B>
-    where
-        S: svc::Service<Req, Response = http::Response<B>>,
-    {
-        type Response = S::Response;
-        type Error = S::Error;
-        type Future = ResponseFuture<S::Future>;
-
-        fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-            self.inner.poll_ready()
-        }
-
-        fn call(&mut self, req: Req) -> Self::Future {
-            let fut = self.inner.call(req);
-
-            ResponseFuture {
-                inner: fut,
-                value: self.value.clone(),
-            }
-        }
-    }
-
-    impl<F, B> Future for ResponseFuture<F>
-    where
-        F: Future<Item = http::Response<B>>,
-    {
-        type Item = F::Item;
-        type Error = F::Error;
-
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            let mut res = try_ready!(self.inner.poll());
-            res.headers_mut()
-                .insert(super::super::L5D_REMOTE_IP, self.value.clone());
-            Ok(res.into())
-        }
+    pub fn layer() -> Layer<&'static str, Endpoint, ResHeader> {
+        add_header::response::layer(super::super::L5D_REMOTE_IP, |endpoint: &Endpoint| {
+            HeaderValue::from_str(&endpoint.connect.addr.ip().to_string()).ok()
+        })
     }
 }

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -271,7 +271,7 @@ pub mod orig_proto_upgrade {
 
 /// Adds `l5d-server-id` headers to http::Responses derived from the
 /// TlsIdentity of an `Endpoint`.
-pub mod server_id {
+pub mod add_server_id_on_rsp {
     use super::super::L5D_SERVER_ID;
     use super::Endpoint;
     use http::header::HeaderValue;
@@ -299,7 +299,7 @@ pub mod server_id {
 
 /// Adds `l5d-remote-ip` headers to http::Responses derived from the
 /// `remote` of a `Source`.
-pub mod remote_ip {
+pub mod add_remote_ip_on_rsp {
     use super::super::L5D_REMOTE_IP;
     use super::Endpoint;
     use bytes::Bytes;

--- a/src/proxy/http/add_header.rs
+++ b/src/proxy/http/add_header.rs
@@ -1,0 +1,201 @@
+use std::{fmt, marker::PhantomData};
+
+use http::header::{AsHeaderName, HeaderValue};
+
+use svc;
+
+type Ret<T> = fn(&T) -> Option<HeaderValue>;
+
+/// Wraps HTTP `Service` `Stack<T>`s so that a given header is removed from a
+/// request or response.
+#[derive(Clone)]
+pub struct Layer<H, T, R> {
+    header: H,
+    retrieve: Ret<T>,
+    _req_or_res: PhantomData<fn(R)>,
+}
+
+/// Wraps an HTTP `Service` so that a given header is added from each request
+/// or response.
+#[derive(Clone)]
+pub struct Stack<H, T, M, R> {
+    header: H,
+    retrieve: Ret<T>,
+    inner: M,
+    _req_or_res: PhantomData<fn(R)>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Service<H, S, R> {
+    header: H,
+    value: HeaderValue,
+    inner: S,
+    _req_or_res: PhantomData<fn(R)>,
+}
+
+// === impl Layer ===
+
+/// Call `request::layer(header)` or `response::layer(header)`.
+fn layer<H, T, R>(header: H, retrieve: Ret<T>) -> Layer<H, T, R>
+where
+    H: AsHeaderName + Clone,
+    R: Clone,
+{
+    Layer {
+        header,
+        retrieve,
+        _req_or_res: PhantomData,
+    }
+}
+
+impl<H, T, M, R> svc::Layer<T, T, M> for Layer<H, T, R>
+where
+    H: AsHeaderName + Clone + fmt::Debug,
+    T: fmt::Debug,
+    M: svc::Stack<T>,
+{
+    type Value = <Stack<H, T, M, R> as svc::Stack<T>>::Value;
+    type Error = <Stack<H, T, M, R> as svc::Stack<T>>::Error;
+    type Stack = Stack<H, T, M, R>;
+
+    fn bind(&self, inner: M) -> Self::Stack {
+        Stack {
+            header: self.header.clone(),
+            retrieve: self.retrieve,
+            inner,
+            _req_or_res: PhantomData,
+        }
+    }
+}
+
+// === impl Stack ===
+
+impl<H, T, M, R> svc::Stack<T> for Stack<H, T, M, R>
+where
+    H: AsHeaderName + Clone + fmt::Debug,
+    T: fmt::Debug,
+    M: svc::Stack<T>,
+{
+    type Value = svc::Either<Service<H, M::Value, R>, M::Value>;
+    type Error = M::Error;
+
+    fn make(&self, t: &T) -> Result<Self::Value, Self::Error> {
+        let inner = self.inner.make(t)?;
+
+        if let Some(value) = (self.retrieve)(t) {
+            return Ok(svc::Either::A(Service {
+                header: self.header.clone(),
+                value,
+                inner,
+                _req_or_res: PhantomData,
+            }));
+        }
+
+        trace!("{:?} not enabled for {:?}", self.header, t);
+        Ok(svc::Either::B(inner))
+    }
+}
+
+pub mod request {
+    use futures::Poll;
+    use http;
+    use http::header::{AsHeaderName, IntoHeaderName};
+
+    use svc;
+
+    pub fn layer<H, T>(header: H, retrieve: super::Ret<T>) -> super::Layer<H, T, ReqHeader>
+    where
+        H: AsHeaderName + Clone,
+    {
+        super::layer(header, retrieve)
+    }
+
+    /// Marker type used to specify that the `Request` headers should be added.
+    #[derive(Clone, Debug)]
+    pub enum ReqHeader {}
+
+    impl<H, S, B> svc::Service<http::Request<B>> for super::Service<H, S, ReqHeader>
+    where
+        H: IntoHeaderName + Clone,
+        S: svc::Service<http::Request<B>>,
+    {
+        type Response = S::Response;
+        type Error = S::Error;
+        type Future = S::Future;
+
+        fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+            self.inner.poll_ready()
+        }
+
+        fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+            req.headers_mut()
+                .insert(self.header.clone(), self.value.clone());
+            self.inner.call(req)
+        }
+    }
+}
+
+pub mod response {
+    use futures::{Future, Poll};
+    use http;
+    use http::header::{AsHeaderName, HeaderValue, IntoHeaderName};
+
+    use svc;
+
+    pub fn layer<H, T>(header: H, retrieve: super::Ret<T>) -> super::Layer<H, T, ResHeader>
+    where
+        H: AsHeaderName + Clone,
+    {
+        super::layer(header, retrieve)
+    }
+
+    /// Marker type used to specify that the `Response` headers should be added.
+    #[derive(Clone, Debug)]
+    pub enum ResHeader {}
+
+    pub struct ResponseFuture<F, H> {
+        inner: F,
+        header: H,
+        value: HeaderValue,
+    }
+
+    impl<H, S, B, Req> svc::Service<Req> for super::Service<H, S, ResHeader>
+    where
+        H: IntoHeaderName + Clone,
+        S: svc::Service<Req, Response = http::Response<B>>,
+    {
+        type Response = S::Response;
+        type Error = S::Error;
+        type Future = ResponseFuture<S::Future, H>;
+
+        fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+            self.inner.poll_ready()
+        }
+
+        fn call(&mut self, req: Req) -> Self::Future {
+            let fut = self.inner.call(req);
+
+            ResponseFuture {
+                inner: fut,
+                header: self.header.clone(),
+                value: self.value.clone(),
+            }
+        }
+    }
+
+    impl<F, H, B> Future for ResponseFuture<F, H>
+    where
+        H: IntoHeaderName + Clone,
+        F: Future<Item = http::Response<B>>,
+    {
+        type Item = F::Item;
+        type Error = F::Error;
+
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+            let mut res = try_ready!(self.inner.poll());
+            res.headers_mut()
+                .insert(self.header.clone(), self.value.clone());
+            Ok(res.into())
+        }
+    }
+}

--- a/src/proxy/http/add_header.rs
+++ b/src/proxy/http/add_header.rs
@@ -68,6 +68,19 @@ where
     }
 }
 
+impl<H, T, R> fmt::Debug for Layer<H, T, R>
+where
+    H: fmt::Debug,
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Layer")
+            .field("header", &self.header)
+            .field("retrieve", &format_args!("{}", "..."))
+            .finish()
+    }
+}
+
 // === impl Stack ===
 
 impl<H, T, M, R> svc::Stack<T> for Stack<H, T, M, R>
@@ -93,6 +106,21 @@ where
 
         trace!("{:?} not enabled for {:?}", self.header, t);
         Ok(svc::Either::B(inner))
+    }
+}
+
+impl<H, T, M, R> fmt::Debug for Stack<H, T, M, R>
+where
+    H: fmt::Debug,
+    T: fmt::Debug,
+    M: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Stack")
+            .field("header", &self.header)
+            .field("retrieve", &format_args!("{}", "..."))
+            .field("inner", &self.inner)
+            .finish()
     }
 }
 

--- a/src/proxy/http/add_header.rs
+++ b/src/proxy/http/add_header.rs
@@ -4,14 +4,15 @@ use http::header::{AsHeaderName, HeaderValue};
 
 use svc;
 
-type Ret<T> = fn(&T) -> Option<HeaderValue>;
+/// A function used to retrieve the value for a given Stack target.
+type RetrieveHeader<T> = fn(&T) -> Option<HeaderValue>;
 
 /// Wraps HTTP `Service` `Stack<T>`s so that a given header is removed from a
 /// request or response.
 #[derive(Clone)]
 pub struct Layer<H, T, R> {
     header: H,
-    retrieve: Ret<T>,
+    retrieve: RetrieveHeader<T>,
     _req_or_res: PhantomData<fn(R)>,
 }
 
@@ -20,7 +21,7 @@ pub struct Layer<H, T, R> {
 #[derive(Clone)]
 pub struct Stack<H, T, M, R> {
     header: H,
-    retrieve: Ret<T>,
+    retrieve: RetrieveHeader<T>,
     inner: M,
     _req_or_res: PhantomData<fn(R)>,
 }
@@ -36,7 +37,7 @@ pub struct Service<H, S, R> {
 // === impl Layer ===
 
 /// Call `request::layer(header)` or `response::layer(header)`.
-fn layer<H, T, R>(header: H, retrieve: Ret<T>) -> Layer<H, T, R>
+fn layer<H, T, R>(header: H, retrieve: RetrieveHeader<T>) -> Layer<H, T, R>
 where
     H: AsHeaderName + Clone,
     R: Clone,
@@ -131,7 +132,10 @@ pub mod request {
 
     use svc;
 
-    pub fn layer<H, T>(header: H, retrieve: super::Ret<T>) -> super::Layer<H, T, ReqHeader>
+    pub fn layer<H, T>(
+        header: H,
+        retrieve: super::RetrieveHeader<T>,
+    ) -> super::Layer<H, T, ReqHeader>
     where
         H: AsHeaderName + Clone,
     {
@@ -170,7 +174,10 @@ pub mod response {
 
     use svc;
 
-    pub fn layer<H, T>(header: H, retrieve: super::Ret<T>) -> super::Layer<H, T, ResHeader>
+    pub fn layer<H, T>(
+        header: H,
+        retrieve: super::RetrieveHeader<T>,
+    ) -> super::Layer<H, T, ResHeader>
     where
         H: AsHeaderName + Clone,
     {

--- a/src/proxy/http/add_header.rs
+++ b/src/proxy/http/add_header.rs
@@ -69,19 +69,6 @@ where
     }
 }
 
-impl<H, T, R> fmt::Debug for Layer<H, T, R>
-where
-    H: fmt::Debug,
-    T: fmt::Debug,
-{
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Layer")
-            .field("header", &self.header)
-            .field("get_header", &format_args!("{}", "..."))
-            .finish()
-    }
-}
-
 // === impl Stack ===
 
 impl<H, T, M, R> svc::Stack<T> for Stack<H, T, M, R>

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -1,3 +1,4 @@
+pub mod add_header;
 pub mod balance;
 pub mod client;
 pub(super) mod glue;

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -333,16 +333,16 @@ macro_rules! generate_tests {
             use super::super::*;
 
             const REMOTE_IP_HEADER: &'static str = "l5d-remote-ip";
-            const FOO: &'static str = "0.0.0.0";
-            const BAR: &'static str = "127.0.0.1";
+            const IP_1: &'static str = "0.0.0.0";
+            const IP_2: &'static str = "127.0.0.1";
 
             #[test]
             fn outbound_should_strip() {
                 let _ = env_logger_init();
-                let header = HeaderValue::from_static(FOO);
+                let header = HeaderValue::from_static(IP_1);
 
                 let srv = $make_server().route_fn("/strip", |_req| {
-                    Response::builder().header(REMOTE_IP_HEADER, FOO).body(Default::default()).unwrap()
+                    Response::builder().header(REMOTE_IP_HEADER, IP_1).body(Default::default()).unwrap()
                 }).run();
 
                 let ctrl = controller::new().destination_and_close("disco.test.svc.cluster.local", srv.addr);
@@ -357,7 +357,7 @@ macro_rules! generate_tests {
             #[test]
             fn inbound_should_strip() {
                 let _ = env_logger_init();
-                let header = HeaderValue::from_static(FOO);
+                let header = HeaderValue::from_static(IP_1);
 
                 let srv = $make_server().route_fn("/strip", move |req| {
                     assert_ne!(req.headers().get(REMOTE_IP_HEADER), Some(&header));
@@ -366,7 +366,7 @@ macro_rules! generate_tests {
 
                 let proxy = proxy::new().inbound(srv).run();
                 let client = $make_client(proxy.inbound, "disco.test.svc.cluster.local");
-                let rsp = client.request(client.request_builder("/strip").header(REMOTE_IP_HEADER, FOO));
+                let rsp = client.request(client.request_builder("/strip").header(REMOTE_IP_HEADER, IP_1));
 
                 assert_eq!(rsp.status(), 200);
             }
@@ -374,7 +374,7 @@ macro_rules! generate_tests {
             #[test]
             fn outbound_should_set() {
                 let _ = env_logger_init();
-                let header = HeaderValue::from_static(BAR);
+                let header = HeaderValue::from_static(IP_2);
 
                 let srv = $make_server().route("/set", "hello").run();
                 let ctrl = controller::new().destination_and_close("disco.test.svc.cluster.local", srv.addr);
@@ -390,7 +390,7 @@ macro_rules! generate_tests {
             fn inbound_should_set() {
                 let _ = env_logger_init();
 
-                let header = HeaderValue::from_static(BAR);
+                let header = HeaderValue::from_static(IP_2);
 
                 let srv = $make_server().route_fn("/set", move |req| {
                     assert_eq!(req.headers().get(REMOTE_IP_HEADER), Some(&header));


### PR DESCRIPTION
## Problem

[Context](https://github.com/linkerd/linkerd2/issues/2310)

## Solution

We now add the `l5d-remote-ip` header to all inbound requests and outbound responses. We also make sure to strip the header before setting so that clients may not set this header.

We were already adding a header in similar style, so in order to deduplicate code, `add_header.rs` holds the generic logic for adding a header to a `http::Request` or `http::Response`. `l5d-client-id` and `l5d-server-id` now also use the same logic in order to add their respective headers.

## Validation

An additional test module was added to `tests/discovery.rs` that tests the following:
- outbound responses strip `l5d-remote-ip`
- inbound requests strip `l5d-remote-ip`
- outbound responses set `l5d-remote-ip` to the endpoint IP
- inbound requests set `l5d-remote-ip` to the source IP

Closes linkerd/linkerd2#2310

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>
