### PR TITLE
replace Error::cause with Error::source (#2370)

### DIFF
--- a/lib/metrics/src/serve.rs
+++ b/lib/metrics/src/serve.rs
@@ -113,7 +113,7 @@ impl fmt::Display for ServeError {
             f,
             "{}: {}",
             self.description(),
-            self.cause().expect("ServeError must have cause")
+            self.source().expect("ServeError must have cause")
         )
     }
 }
@@ -126,10 +126,10 @@ impl Error for ServeError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
-            ServeError::Http(ref cause) => Some(cause),
-            ServeError::Io(ref cause) => Some(cause),
+            ServeError::Http(ref source) => Some(source),
+            ServeError::Io(ref source) => Some(source),
         }
     }
 }

--- a/lib/metrics/src/serve.rs
+++ b/lib/metrics/src/serve.rs
@@ -113,7 +113,7 @@ impl fmt::Display for ServeError {
             f,
             "{}: {}",
             self.description(),
-            self.source().expect("ServeError must have cause")
+            self.source().expect("ServeError must have source")
         )
     }
 }

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -262,10 +262,10 @@ where
 
 impl<T, U> error::Error for Error<T, U>
 where
-    T: error::Error,
-    U: error::Error,
+    T: error::Error + 'static,
+    U: error::Error + 'static,
 {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             Error::Inner(ref why) => Some(why),
             Error::Route(ref why) => Some(why),

--- a/lib/stack/src/either.rs
+++ b/lib/stack/src/either.rs
@@ -81,10 +81,10 @@ impl<A: fmt::Display, B: fmt::Display> fmt::Display for Either<A, B> {
 }
 
 impl<A: error::Error, B: error::Error> error::Error for Either<A, B> {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
-            Either::A(a) => a.cause(),
-            Either::B(b) => b.cause(),
+            Either::A(a) => a.source(),
+            Either::B(b) => b.source(),
         }
     }
 }

--- a/lib/timeout/src/lib.rs
+++ b/lib/timeout/src/lib.rs
@@ -130,9 +130,9 @@ where
 
 impl<E> error::Error for Error<E>
 where
-    E: error::Error,
+    E: error::Error + 'static,
 {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match *self {
             Error::Error(ref err) => Some(err),
             Error::Timer(ref err) => Some(err),

--- a/src/proxy/buffer.rs
+++ b/src/proxy/buffer.rs
@@ -117,9 +117,9 @@ impl<M: fmt::Display, S> fmt::Display for Error<M, S> {
 }
 
 impl<M: error::Error, S> error::Error for Error<M, S> {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
-            Error::Stack(e) => e.cause(),
+            Error::Stack(e) => e.source(),
             Error::Spawn(_) => None,
         }
     }

--- a/src/proxy/canonicalize.rs
+++ b/src/proxy/canonicalize.rs
@@ -304,10 +304,10 @@ impl<M: fmt::Display, S: fmt::Display> fmt::Display for Error<M, S> {
 }
 
 impl<M: error::Error, S: error::Error> error::Error for Error<M, S> {
-    fn cause(&self) -> Option<&error::Error> {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
-            Error::Stack(e) => e.cause(),
-            Error::Service(e) => e.cause(),
+            Error::Stack(e) => e.source(),
+            Error::Service(e) => e.source(),
         }
     }
 }

--- a/src/proxy/http/glue.rs
+++ b/src/proxy/http/glue.rs
@@ -251,7 +251,7 @@ impl fmt::Display for Error {
 }
 
 impl StdError for Error {
-    fn cause(&self) -> Option<&StdError> {
-        self.0.cause()
+    fn source(&self) -> Option<&(StdError + 'static)> {
+        self.0.source()
     }
 }

--- a/src/proxy/http/settings.rs
+++ b/src/proxy/http/settings.rs
@@ -259,10 +259,10 @@ pub mod router {
     }
 
     impl<E: error::Error, M: error::Error> error::Error for Error<E, M> {
-        fn cause(&self) -> Option<&error::Error> {
+        fn source(&self) -> Option<&(dyn error::Error + 'static)> {
             match self {
-                Error::Service(e) => e.cause(),
-                Error::Stack(e) => e.cause(),
+                Error::Service(e) => e.source(),
+                Error::Stack(e) => e.source(),
             }
         }
     }


### PR DESCRIPTION
proxy: replace `Error::cause` with `Error::source`

Currently, linkerd2-proxy uses and implements `Error::cause`
for error handling.

This branch removes the use of the deprecated
`Error::cause` method and implements and uses the
`Error::source` method, as [recommended by the
documentation](https://doc.rust-lang.org/std/error/trait.Error.html#method.cause). To implement `Error::source`, there are
static lifetimes added to the `Error` traits. However, this
doesn't remove the [use of `cause2`](https://github.com/DebugSteven/linkerd2-proxy/blob/231cb67b1a2178627bbb304055d408cee1007fd9/src/proxy/http/glue.rs#L226) because
`hyper::Error` doesn't provide a `source` yet:
https://docs.rs/hyper/0.12.24/src/hyper/error.rs.html#289-333.
A separate issue could be opened to use `source` for
`hyper::Error` when it becomes available.

Fixes: https://github.com/linkerd/linkerd2/issues/2370