### PR TITLE
perf(router): Increase inbound/outbound router cap.

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -299,8 +299,8 @@ const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 
 /// It's assumed that a typical proxy can serve inbound traffic for up to 100 pod-local
 /// HTTP services and may communicate with up to 10K external HTTP domains.
-const DEFAULT_INBOUND_ROUTER_CAPACITY: usize = 100;
-const DEFAULT_OUTBOUND_ROUTER_CAPACITY: usize = 100;
+const DEFAULT_INBOUND_ROUTER_CAPACITY: usize = 10000;
+const DEFAULT_OUTBOUND_ROUTER_CAPACITY: usize = 10000;
 
 const DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(60);
 const DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(60);

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -299,7 +299,7 @@ const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 
 /// It's assumed that a typical proxy can serve inbound traffic for up to 100 pod-local
 /// HTTP services and may communicate with up to 10K external HTTP domains.
-const DEFAULT_INBOUND_ROUTER_CAPACITY: usize = 10000;
+const DEFAULT_INBOUND_ROUTER_CAPACITY: usize = 100;
 const DEFAULT_OUTBOUND_ROUTER_CAPACITY: usize = 10000;
 
 const DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(60);


### PR DESCRIPTION
In both server and client case, the default value of
MAX_CONCURRENT_STREAMS is `u32::MAX`. However, we currently cap the
inbound and outbound router capacity limits to 100.

This change increases the capacity of both to 10_000.

This will close linkerd/linkerd2#2395 and could possibly address the
issue in linkerd/linkerd2#2363.

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>