### PR TITLE
Configure HTTP/2 window size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.12.24"
+version = "0.12.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -385,6 +385,7 @@ dependencies = [
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -402,7 +403,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -539,7 +540,7 @@ dependencies = [
  "deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -562,7 +563,7 @@ dependencies = [
  "h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-balance 0.1.0",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1914,7 +1915,7 @@ dependencies = [
 "checksum hostname 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "58fab6e177434b0bb4cd344a4dabaa5bd6d7a8d792b1885aebcae7af1091d1cb"
 "checksum http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fe67e3678f2827030e89cc4b9e7ecd16d52f132c0b940ab5005f88e821500f6a"
 "checksum httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b6288d7db100340ca12873fd4d08ad1b8f206a9457798dfb17c018a33fee540"
-"checksum hyper 0.12.24 (registry+https://github.com/rust-lang/crates.io-index)" = "fdfa9b401ef6c4229745bb6e9b2529192d07b920eed624cdee2a82348cd550af"
+"checksum hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5b6658b016965ae301fa995306db965c93677880ea70765a84235a96eae896"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum inotify 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24e40d6fd5d64e2082e0c796495c8ef5ad667a96d03e5aaa0becfd9d47bcbfb8"

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -123,7 +123,13 @@ pub struct Config {
 
     pub dns_canonicalize_timeout: Duration,
 
-    pub h2_settings: H2Config,
+    pub h2_settings: H2Settings,
+}
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct H2Settings {
+    pub initial_stream_window_size: Option<u32>,
+    pub initial_connection_window_size: Option<u32>,
 }
 
 /// Configuration settings for binding a listener.
@@ -273,8 +279,9 @@ const ENV_DNS_CANONICALIZE_TIMEOUT: &str = "LINKERD2_PROXY_DNS_CANONICALIZE_TIME
 /// Configure the stream or connection level flow control setting for HTTP2.
 ///
 /// If unspecified, the default value of 65,535 is used.
-const ENV_INITIAL_STREAM_WINDOW_SIZE: &str = "LINKERD2_PROXY_INITIAL_STREAM_WINDOW_SIZE";
-const ENV_INITIAL_CONNECTION_WINDOW_SIZE: &str = "LINKERD2_PROXY_INITIAL_CONNECTION_WINDOW_SIZE";
+const ENV_INITIAL_STREAM_WINDOW_SIZE: &str = "LINKERD2_PROXY_HTTP2_INITIAL_STREAM_WINDOW_SIZE";
+const ENV_INITIAL_CONNECTION_WINDOW_SIZE: &str =
+    "LINKERD2_PROXY_HTTP2_INITIAL_CONNECTION_WINDOW_SIZE";
 
 // Default values for various configuration fields
 const DEFAULT_OUTBOUND_LISTEN_ADDR: &str = "127.0.0.1:4140";
@@ -417,6 +424,11 @@ impl Config {
             parse_dns_suffixes,
         );
 
+        let initial_stream_window_size =
+            parse(strings, ENV_INITIAL_STREAM_WINDOW_SIZE, parse_number);
+        let initial_connection_window_size =
+            parse(strings, ENV_INITIAL_CONNECTION_WINDOW_SIZE, parse_number);
+
         Ok(Config {
             outbound_listener: Listener {
                 addr: outbound_listener_addr?
@@ -497,6 +509,11 @@ impl Config {
 
             dns_canonicalize_timeout: dns_canonicalize_timeout?
                 .unwrap_or(DEFAULT_DNS_CANONICALIZE_TIMEOUT),
+
+            h2_settings: H2Settings {
+                initial_stream_window_size: initial_stream_window_size?,
+                initial_connection_window_size: initial_connection_window_size?,
+            },
         })
     }
 }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -122,6 +122,8 @@ pub struct Config {
     pub dns_max_ttl: Option<Duration>,
 
     pub dns_canonicalize_timeout: Duration,
+
+    pub h2_settings: H2Config,
 }
 
 /// Configuration settings for binding a listener.
@@ -267,6 +269,12 @@ const ENV_DNS_MAX_TTL: &str = "LINKERD2_PROXY_DNS_MAX_TTL";
 /// The amount of time to wait for a DNS query to succeed before falling back to
 /// an uncanonicalized address.
 const ENV_DNS_CANONICALIZE_TIMEOUT: &str = "LINKERD2_PROXY_DNS_CANONICALIZE_TIMEOUT";
+
+/// Configure the stream or connection level flow control setting for HTTP2.
+///
+/// If unspecified, the default value of 65,535 is used.
+const ENV_INITIAL_STREAM_WINDOW_SIZE: &str = "LINKERD2_PROXY_INITIAL_STREAM_WINDOW_SIZE";
+const ENV_INITIAL_CONNECTION_WINDOW_SIZE: &str = "LINKERD2_PROXY_INITIAL_CONNECTION_WINDOW_SIZE";
 
 // Default values for various configuration fields
 const DEFAULT_OUTBOUND_LISTEN_ADDR: &str = "127.0.0.1:4140";

--- a/src/app/control.rs
+++ b/src/app/control.rs
@@ -306,6 +306,7 @@ pub mod client {
     use std::marker::PhantomData;
     use std::net::SocketAddr;
 
+    use super::super::config::H2Config;
     use proxy::http;
     use svc;
     use transport::{connect, tls};

--- a/src/app/control.rs
+++ b/src/app/control.rs
@@ -306,7 +306,7 @@ pub mod client {
     use std::marker::PhantomData;
     use std::net::SocketAddr;
 
-    use super::super::config::H2Config;
+    use super::super::config::H2Settings;
     use proxy::http;
     use svc;
     use transport::{connect, tls};
@@ -414,7 +414,7 @@ pub mod client {
         fn make(&self, target: &Target) -> Result<Self::Value, Self::Error> {
             let c = self.connect.make(&target)?;
             let e = target.log_ctx.clone().with_remote(target.addr).executor();
-            Ok(http::h2::Connect::new(c, e))
+            Ok(http::h2::Connect::new(c, e, H2Settings::default()))
         }
     }
 }

--- a/src/proxy/http/h2.rs
+++ b/src/proxy/http/h2.rs
@@ -9,6 +9,7 @@ use hyper::{
 };
 
 use super::{Body, ClientUsedTls, Error};
+use app::config::H2Config;
 use svc;
 use task::{ArcExecutor, BoxSendFuture, Executor};
 use transport::{connect, tls::HasStatus as HasTlsStatus};
@@ -17,6 +18,7 @@ use transport::{connect, tls::HasStatus as HasTlsStatus};
 pub struct Connect<C, B> {
     connect: C,
     executor: ArcExecutor,
+    h2_settings: H2Config,
     _marker: PhantomData<fn() -> B>,
 }
 
@@ -29,6 +31,7 @@ pub struct Connection<B> {
 pub struct ConnectFuture<C: connect::Connect, B> {
     executor: ArcExecutor,
     state: ConnectState<C, B>,
+    h2_settings: H2Config,
 }
 
 enum ConnectState<C: connect::Connect, B> {
@@ -53,13 +56,14 @@ pub enum ConnectError<E> {
 // ===== impl Connect =====
 
 impl<C, B> Connect<C, B> {
-    pub fn new<E>(connect: C, executor: E) -> Self
+    pub fn new<E>(connect: C, executor: E, h2_settings: H2Config) -> Self
     where
         E: Executor<BoxSendFuture> + Clone + Send + Sync + 'static,
     {
         Connect {
             connect,
             executor: ArcExecutor::new(executor),
+            h2_settings,
             _marker: PhantomData,
         }
     }
@@ -83,6 +87,7 @@ where
         ConnectFuture {
             executor: self.executor.clone(),
             state: ConnectState::Connect(self.connect.connect()),
+            h2_settings: self.h2_settings,
         }
     }
 }
@@ -127,6 +132,10 @@ where
             let hs = conn::Builder::new()
                 .executor(self.executor.clone())
                 .http2_only(true)
+                .http2_initial_stream_window_size(self.h2_settings.initial_stream_window_size)
+                .http2_initial_connection_window_size(
+                    self.h2_settings.initial_connection_window_size,
+                )
                 .handshake(io);
             self.state = ConnectState::Handshake {
                 client_used_tls,

--- a/src/proxy/http/h2.rs
+++ b/src/proxy/http/h2.rs
@@ -9,7 +9,7 @@ use hyper::{
 };
 
 use super::{Body, ClientUsedTls, Error};
-use app::config::H2Config;
+use app::config::H2Settings;
 use svc;
 use task::{ArcExecutor, BoxSendFuture, Executor};
 use transport::{connect, tls::HasStatus as HasTlsStatus};
@@ -18,7 +18,7 @@ use transport::{connect, tls::HasStatus as HasTlsStatus};
 pub struct Connect<C, B> {
     connect: C,
     executor: ArcExecutor,
-    h2_settings: H2Config,
+    h2_settings: H2Settings,
     _marker: PhantomData<fn() -> B>,
 }
 
@@ -31,7 +31,7 @@ pub struct Connection<B> {
 pub struct ConnectFuture<C: connect::Connect, B> {
     executor: ArcExecutor,
     state: ConnectState<C, B>,
-    h2_settings: H2Config,
+    h2_settings: H2Settings,
 }
 
 enum ConnectState<C: connect::Connect, B> {
@@ -56,7 +56,7 @@ pub enum ConnectError<E> {
 // ===== impl Connect =====
 
 impl<C, B> Connect<C, B> {
-    pub fn new<E>(connect: C, executor: E, h2_settings: H2Config) -> Self
+    pub fn new<E>(connect: C, executor: E, h2_settings: H2Settings) -> Self
     where
         E: Executor<BoxSendFuture> + Clone + Send + Sync + 'static,
     {

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -6,7 +6,7 @@ use std::net::SocketAddr;
 use std::{error, fmt};
 
 use super::Accept;
-use app::config::H2Config;
+use app::config::H2Settings;
 use drain;
 use never::Never;
 use proxy::http::{
@@ -46,7 +46,7 @@ use transport::{
 ///    instrumented with telemetry, etc).
 ///
 /// 6. Otherwise, an `R`-typed `Service` `Stack` is used to build a service that
-///    can routeHTTP  requests for the `Source`.
+///    can route HTTP  requests for the `Source`.
 pub struct Server<A, T, C, R, B>
 where
     // Prepares a server transport, e.g. with telemetry.
@@ -248,7 +248,7 @@ where
         &self,
         connection: Connection,
         remote_addr: SocketAddr,
-        h2_settings: H2Config,
+        h2_settings: H2Settings,
     ) -> impl Future<Item = (), Error = ()> {
         let orig_dst = connection.original_dst_addr();
         let disable_protocol_detection = !connection.should_detect_protocol();


### PR DESCRIPTION
Expose an environment configuration to override the default stream or
connection level window size of 65,535.

This allows us to test alternate values without having to recompile.

Closes linkerd/linkerd2#2396

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>