### PR TITLE
OpenCensus tracing WIP PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "linkerd2-stack 0.1.0",
  "linkerd2-task 0.1.0",
  "linkerd2-timeout 0.1.0",
+ "linkerd2-tracing 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "procinfo 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -661,6 +662,17 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-timeout"
+version = "0.1.0"
+dependencies = [
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linkerd2-stack 0.1.0",
+ "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
+ "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.2.0 (git+https://github.com/tower-rs/tower)",
+]
+
+[[package]]
+name = "linkerd2-tracing"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "lib/stack",
     "lib/task",
     "lib/timeout",
+    "lib/tracing"
 ]
 
 [package]
@@ -32,6 +33,7 @@ linkerd2-router    = { path = "lib/router" }
 linkerd2-stack     = { path = "lib/stack" }
 linkerd2-task      = { path = "lib/task" }
 linkerd2-timeout   = { path = "lib/timeout" }
+linkerd2-tracing   = { path = "lib/tracing" }
 
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.6" }
 
@@ -100,7 +102,7 @@ tokio-current-thread = "0.1.4"
 # Debug symbols end up chewing up several GB of disk space, so better to just
 # disable them.
 [profile.dev]
-debug = false
+debug = true
 [profile.test]
 debug = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ tokio-current-thread = "0.1.4"
 # Debug symbols end up chewing up several GB of disk space, so better to just
 # disable them.
 [profile.dev]
-debug = true
+debug = false
 [profile.test]
 debug = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ tokio-current-thread = "0.1.4"
 # Debug symbols end up chewing up several GB of disk space, so better to just
 # disable them.
 [profile.dev]
-debug = false
+debug = true
 [profile.test]
 debug = false
 

--- a/lib/tracing/Cargo.toml
+++ b/lib/tracing/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "linkerd2-tracing"
+version = "0.1.0"
+publish = false
+
+[dependencies]
+futures = "0.1"
+linkerd2-stack = { path = "../stack" }
+tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
+tokio-timer = "0.2.4"
+tower-service = { git = "https://github.com/tower-rs/tower" }

--- a/lib/tracing/src/lib.rs
+++ b/lib/tracing/src/lib.rs
@@ -1,0 +1,122 @@
+extern crate futures;
+extern crate linkerd2_stack;
+extern crate tokio_connect;
+extern crate tower_service as svc;
+
+use futures::{Future, Poll, Async};
+use std::{error, fmt};
+use tokio_connect::Connect;
+
+pub mod stack;
+
+/// A Tracing construct that wraps an underlying operation.
+#[derive(Debug, Clone)]
+pub struct Tracing<T> {
+    inner: T,
+    name: String
+}
+
+/// An error representing a Tracing error.
+#[derive(Debug)]
+pub enum Error<E> {
+    /// Indicates that the underlying operation failed.
+    Error(E),
+}
+
+//===== impl Tracing =====
+
+impl<T> Tracing<T> {
+    /// Construct a new `Tracing` wrapping `inner`.
+    pub fn new(inner: T, name: String) -> Self {
+        Tracing { inner, name }
+    }
+}
+
+impl<S, T, E, Req> svc::Service<Req> for Tracing<S>
+where
+    S: svc::Service<Req, Response = T, Error = E>,
+{
+    type Response = T;
+    type Error = Error<E>;
+    type Future = Tracing<S::Future>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready().map_err(|e| Error::Error(e))
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        let inner = self.inner.call(req);
+        Tracing {
+            inner,
+            name: self.name.clone()
+        }
+    }
+}
+
+impl<C> Connect for Tracing<C>
+where
+    C: Connect,
+{
+    type Connected = C::Connected;
+    type Error = Error<C::Error>;
+    type Future = Tracing<C::Future>;
+
+    fn connect(&self) -> Self::Future {
+        let inner = self.inner.connect();
+        Tracing {
+            inner,
+            name: self.name.clone()
+        }
+    }
+}
+
+impl<F> Future for Tracing<F>
+where
+    F: Future,
+{
+    type Item = F::Item;
+    type Error = Error<F::Error>;
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.inner.poll().map(|value| {
+            match value {
+                // close span on Ready
+                Async::Ready(_) => println!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ready! {}", self.name.clone()),
+                Async::NotReady => println!("================================================== not ready {}", self.name.clone())
+            }
+            value
+        }).map_err(|e| {
+            // close span on error
+            Error::Error(e)
+        })
+    }
+}
+
+//===== impl Error =====
+
+impl<E> fmt::Display for Error<E>
+where
+    E: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Error(ref err) => fmt::Display::fmt(err, f),
+        }
+    }
+}
+
+impl<E> error::Error for Error<E>
+where
+    E: error::Error + 'static,
+{
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match *self {
+            Error::Error(ref err) => Some(err),
+        }
+    }
+
+    fn description(&self) -> &str {
+        match *self {
+            Error::Error(ref err) => err.description(),
+        }
+    }
+}

--- a/lib/tracing/src/span.rs
+++ b/lib/tracing/src/span.rs
@@ -1,0 +1,100 @@
+use std::time::{Duration, Instant};
+use std::fmt;
+
+pub trait Sampler {
+  fn should_sample(&self, req: String) -> bool;
+}
+
+pub struct NeverSample;
+
+impl Sampler for NeverSample {
+  fn should_sample(&self, _req: String) -> bool {
+    false
+  }
+}
+
+pub struct AlwaysSample;
+
+impl Sampler for AlwaysSample {
+  fn should_sample(&self, _req: String) -> bool {
+    true
+  }
+}
+
+impl Clone for AlwaysSample {
+   fn clone(&self) -> Self {
+     AlwaysSample {}
+   }
+}
+
+pub struct SpanContext {
+  sampler: Box<AlwaysSample>
+}
+
+impl SpanContext {
+  pub fn new() -> Self {
+    SpanContext {
+      sampler: Box::new(AlwaysSample{})
+    }
+  }
+
+  pub fn span_from_request(&self, name: String, _req: String) -> Option<Span> {
+    if (*self.sampler).should_sample(String::from("request_place_holder")) {
+      Some(Span::new(name))
+    }
+    else {
+      None
+    }
+  }
+}
+
+impl fmt::Debug for SpanContext {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+      write!(f, "SpanContext debug place holder")
+    }
+}
+
+impl Clone for SpanContext {
+   fn clone(&self) -> Self {
+     SpanContext {
+       sampler: Box::new((*self.sampler).clone())
+     }
+   }
+}
+
+#[derive(Clone)]
+pub struct Span {
+  name: String, 
+  start_time: Option<Instant>, 
+  duration: Option<Duration>
+}
+
+impl fmt::Debug for Span {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+      write!(f, "Hi: {}", 123)
+    }
+}
+
+impl Span {
+  pub fn new(name: String) -> Self {
+    let mut res = Span {
+      name,
+      start_time: None,
+      duration: None
+    };
+    res.start_span();
+    res
+  } 
+
+  pub fn start_span(&mut self) {
+    self.start_time = Some(Instant::now());
+  }
+
+  pub fn finish_span(&mut self) {
+     if let Some(start) = self.start_time {
+       let raw_duration = Instant::now().duration_since(start);
+       self.duration = Some(raw_duration);
+       println!("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Closed span with duration {}", raw_duration.as_millis());
+     }
+  }
+}

--- a/lib/tracing/src/stack.rs
+++ b/lib/tracing/src/stack.rs
@@ -1,6 +1,8 @@
 use super::Tracing;
 use linkerd2_stack as svc;
 
+use span;
+
 /// Creates a layer that handles Tracing start and finish events
 ///
 /// The tracer layer is responsible for applying tracing
@@ -43,8 +45,8 @@ where
     type Error = M::Error;
 
     fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
-        // create span here and pass to tracing instance?
+        let span: Option<span::Span> = span::SpanContext::new().span_from_request(String::from("spanName"), String::from("request_place_holder"));
         let inner = self.inner.make(target)?;
-        Ok(Tracing::new(inner, self.name.clone()))
+        Ok(Tracing::new(inner, self.name.clone(), span))
     }
 }

--- a/lib/tracing/src/stack.rs
+++ b/lib/tracing/src/stack.rs
@@ -1,0 +1,50 @@
+use super::Tracing;
+use linkerd2_stack as svc;
+
+/// Creates a layer that handles Tracing start and finish events
+///
+/// The tracer layer is responsible for applying tracing
+pub fn layer(name: String) -> Layer {
+    Layer { name: name.clone() }
+}
+
+#[derive(Clone, Debug)]
+pub struct Layer {
+    name: String
+}
+
+#[derive(Clone, Debug)]
+pub struct Stack<M> {
+    inner: M,
+    name: String
+}
+
+impl<T, M> svc::Layer<T, T, M> for Layer
+where
+    M: svc::Stack<T>,
+{
+    type Value = <Stack<M> as svc::Stack<T>>::Value;
+    type Error = <Stack<M> as svc::Stack<T>>::Error;
+    type Stack = Stack<M>;
+
+    fn bind(&self, inner: M) -> Self::Stack {
+        Stack {
+            inner,
+            name: self.name.clone()
+        }
+    }
+}
+
+impl<T, M> svc::Stack<T> for Stack<M>
+where
+    M: svc::Stack<T>,
+{
+    type Value = Tracing<M::Value>;
+    type Error = M::Error;
+
+    fn make(&self, target: &T) -> Result<Self::Value, Self::Error> {
+        // create span here and pass to tracing instance?
+        let inner = self.inner.make(target)?;
+        Ok(Tracing::new(inner, self.name.clone()))
+    }
+}

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -322,6 +322,7 @@ where
                 // Establishes connections to remote peers (for both TCP
                 // forwarding and HTTP proxying).
                 let connect = connect::Stack::new()
+                    .push(svc::tracing::layer(String::from("outbound")))
                     .push(keepalive::connect::layer(config.outbound_connect_keepalive))
                     .push(svc::timeout::layer(config.outbound_connect_timeout))
                     .push(transport_metrics.connect("outbound"));
@@ -465,7 +466,8 @@ where
                     .make(&router::Config::new("out addr", capacity, max_idle_age))
                     .map(shared::stack)
                     .expect("outbound addr router")
-                    .push(phantom_data::layer());
+                    .push(phantom_data::layer())
+                    .push(svc::tracing::layer(String::from("inbound")));
 
                 // Instantiates an HTTP service for each `Source` using the
                 // shared `addr_router`. The `Source` is stored in the request's

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -1,5 +1,6 @@
 pub extern crate linkerd2_stack as stack;
 pub extern crate linkerd2_timeout;
+pub extern crate linkerd2_tracing;
 extern crate tower_service;
 extern crate tower_util;
 
@@ -9,3 +10,4 @@ pub use self::tower_util::MakeService;
 pub use self::stack::{shared, stack_per_request, watch, Either, Layer, Stack};
 
 pub use self::linkerd2_timeout::stack as timeout;
+pub use self::linkerd2_tracing::stack as tracing;


### PR DESCRIPTION
This PR is a draft / conversation starter so that we can discuss the details around adding OpenCensus tracing and to make sure we have alignment on direction and strategy. 

Some open questions:

- Should we assemble a Layer and place it in the request response pipeline?
(This draft PR assumes this approach adding a scaffolding "layer cake" `Layer, Stack, Service <- Tracer`)
- Or should we use some of the existing metrics mechanisms rather than adding a pipeline layer?

This change set is the scaffolding of such a Layer. Eventually, the layer would provide an implementation of a Sampler and Tracer which would employ an Async Exporter. Perhaps the sample could be an enum with associated values eg:
Never,
Always,
Rate(rps),
Percentage(value)

Next would come the evolution of the control plane configuring tracing TBD.