### PR TITLE
Fix connect timeouts

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -268,8 +268,8 @@ const DEFAULT_METRICS_LISTEN_ADDR: &str = "127.0.0.1:4191";
 const DEFAULT_METRICS_RETAIN_IDLE: Duration = Duration::from_secs(10 * 60);
 const DEFAULT_INBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(20);
 const DEFAULT_OUTBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
-const DEFAULT_CONTROL_BACKOFF_DELAY: Duration = Duration::from_secs(5);
-const DEFAULT_CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const DEFAULT_CONTROL_BACKOFF_DELAY: Duration = Duration::from_secs(3);
+const DEFAULT_CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_DNS_CANONICALIZE_TIMEOUT: Duration = Duration::from_millis(100);
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -266,10 +266,10 @@ const DEFAULT_INBOUND_LISTEN_ADDR: &str = "0.0.0.0:4143";
 const DEFAULT_CONTROL_LISTEN_ADDR: &str = "0.0.0.0:4190";
 const DEFAULT_METRICS_LISTEN_ADDR: &str = "127.0.0.1:4191";
 const DEFAULT_METRICS_RETAIN_IDLE: Duration = Duration::from_secs(10 * 60);
-const DEFAULT_INBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(20);
-const DEFAULT_OUTBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
-const DEFAULT_CONTROL_BACKOFF_DELAY: Duration = Duration::from_secs(3);
-const DEFAULT_CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+const DEFAULT_INBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(100);
+const DEFAULT_OUTBOUND_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+const DEFAULT_CONTROL_BACKOFF_DELAY: Duration = Duration::from_secs(1);
+const DEFAULT_CONTROL_CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
 const DEFAULT_DNS_CANONICALIZE_TIMEOUT: Duration = Duration::from_millis(100);
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 

--- a/src/app/control.rs
+++ b/src/app/control.rs
@@ -302,6 +302,7 @@ pub mod resolve {
 /// Creates a client suitable for gRPC.
 pub mod client {
     use hyper::body::Payload;
+    use std::error;
     use std::marker::PhantomData;
     use std::net::SocketAddr;
 
@@ -350,7 +351,7 @@ pub mod client {
         C::Value: connect::Connect + Clone + Send + Sync + 'static,
         <C::Value as connect::Connect>::Connected: Send + 'static,
         <C::Value as connect::Connect>::Future: Send + 'static,
-        <C::Value as connect::Connect>::Error: ::std::error::Error + Send + Sync + 'static,
+        <C::Value as connect::Connect>::Error: Into<Box<dyn error::Error + Send + Sync + 'static>>,
         B: Payload,
     {
         Layer { _p: PhantomData }
@@ -368,7 +369,7 @@ pub mod client {
         C::Value: connect::Connect + Clone + Send + Sync + 'static,
         <C::Value as connect::Connect>::Connected: Send + 'static,
         <C::Value as connect::Connect>::Future: Send + 'static,
-        <C::Value as connect::Connect>::Error: ::std::error::Error + Send + Sync + 'static,
+        <C::Value as connect::Connect>::Error: Into<Box<dyn error::Error + Send + Sync + 'static>>,
         B: Payload,
     {
         type Value = <Stack<C, B> as svc::Stack<Target>>::Value;
@@ -403,7 +404,7 @@ pub mod client {
         C::Value: connect::Connect + Clone + Send + Sync + 'static,
         <C::Value as connect::Connect>::Connected: Send + 'static,
         <C::Value as connect::Connect>::Future: Send + 'static,
-        <C::Value as connect::Connect>::Error: ::std::error::Error + Send + Sync + 'static,
+        <C::Value as connect::Connect>::Error: Into<Box<dyn error::Error + Send + Sync + 'static>>,
         B: Payload,
     {
         type Value = http::h2::Connect<C::Value, B>;

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -277,10 +277,10 @@ where
                         id_config.trust_anchors.clone(),
                     )))
                     .push(keepalive::connect::layer(keepalive))
+                    .push(svc::timeout::layer(config.control_connect_timeout))
                     .push(control::client::layer())
                     .push(control::resolve::layer(dns_resolver.clone()))
                     .push(reconnect::layer().with_fixed_backoff(config.control_backoff_delay))
-                    .push(svc::timeout::layer(config.control_connect_timeout))
                     .push(http_metrics::layer::<_, classify::Response>(
                         ctl_http_metrics.clone(),
                     ))
@@ -316,10 +316,10 @@ where
                 .push(phantom_data::layer())
                 .push(tls::client::layer(local_identity.clone()))
                 .push(keepalive::connect::layer(keepalive))
+                .push(svc::timeout::layer(config.control_connect_timeout))
                 .push(control::client::layer())
                 .push(control::resolve::layer(dns_resolver.clone()))
                 .push(reconnect::layer().with_fixed_backoff(config.control_backoff_delay))
-                .push(svc::timeout::layer(config.control_connect_timeout))
                 .push(http_metrics::layer::<_, classify::Response>(
                     ctl_http_metrics,
                 ))


### PR DESCRIPTION
The controller client's connect timeout setting doesn't actually 
ontrol the connect timeout: it configures the _request_ timeout.

This change fixes the controller by moving the timeout layer
into the connect stack.

Furthermore, the connect timeout and backoff settings have been
updated to be more aggressive in the case of controller communication
and less aggressive when communicating with applications.