### PR TITLE
Instrument identity with logging

### DIFF
--- a/src/app/identity.rs
+++ b/src/app/identity.rs
@@ -104,6 +104,10 @@ impl Local {
         (l, s)
     }
 
+    pub fn name(&self) -> &Name {
+        &self.name
+    }
+
     pub fn await_crt(self) -> AwaitCrt {
         AwaitCrt(Some(self))
     }

--- a/src/app/identity.rs
+++ b/src/app/identity.rs
@@ -209,7 +209,7 @@ where
                                 .and_then(|d| Result::<SystemTime, Duration>::from(d).ok())
                             {
                                 None => error!(
-                                    "Identity service did not specify a ceritificate expiration."
+                                    "Identity service did not specify a certificate expiration."
                                 ),
                                 Some(expiry) => {
                                     let key = self.config.key.clone();

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -3,7 +3,7 @@ use http;
 use hyper;
 use std::net::SocketAddr;
 use std::thread;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::{Duration, SystemTime};
 use std::{error, fmt, io};
 use tokio::executor::{self, DefaultExecutor, Executor};
 use tokio::runtime::current_thread;
@@ -297,15 +297,13 @@ where
                         .map_err(|_| error!("identity task failed")),
                 );
 
-                let t0 = Instant::now();
                 task::spawn(
                     local_identity
                         .clone()
                         .await_crt()
                         .map(move |id| {
                             info!(
-                                "Certified identity in {}s: {}",
-                                t0.elapsed().as_secs(),
+                                "Certified identity: {}",
                                 id.name().as_ref()
                             );
                         })

--- a/src/transport/connect.rs
+++ b/src/transport/connect.rs
@@ -65,6 +65,7 @@ impl Connect for ConnectSocketAddr {
     type Future = ConnectFuture;
 
     fn connect(&self) -> Self::Future {
+        debug!("connecting to {}", self.0);
         ConnectFuture {
             addr: self.0,
             future: TcpStream::connect(&self.0),
@@ -83,6 +84,7 @@ impl Future for ConnectFuture {
             let details = format!("{} (address: {})", e, self.addr);
             io::Error::new(e.kind(), details)
         }));
+        debug!("connection established to {}", self.addr);
         super::set_nodelay_or_warn(&io);
         Ok(io.into())
     }


### PR DESCRIPTION
This changes initialization logic so that a task is spawn that logs when
identity is provisioned (as observed by stacks). Identity's daemon task is
now spawned on the admin thread with context logging.

Furthermore, the processes's uptime is now logged in log messages so that the
relative time between events is easily observeable. This is borrowed from the
Linux kernel's behavior (i.e. in /var/log/kern.log).