### PR TITLE
Replace the metrics server with an admin server

### DIFF
--- a/lib/metrics/src/prom.rs
+++ b/lib/metrics/src/prom.rs
@@ -167,3 +167,9 @@ impl<A: FmtMetrics, B: FmtMetrics> FmtMetrics for AndThen<A, B> {
         Ok(())
     }
 }
+
+impl FmtMetrics for () {
+    fn fmt_metrics(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Ok(())
+    }
+}

--- a/src/app/admin/mod.rs
+++ b/src/app/admin/mod.rs
@@ -101,15 +101,12 @@ mod tests {
             };};
         }
 
-        let rsp = call!();
-        assert_eq!(rsp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(call!().status(), StatusCode::SERVICE_UNAVAILABLE);
 
         drop(l0);
-        let rsp = call!();
-        assert_eq!(rsp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(call!().status(), StatusCode::SERVICE_UNAVAILABLE);
 
         drop(l1);
-        let rsp = call!();
-        assert_eq!(rsp.status(), StatusCode::OK);
+        assert_eq!(call!().status(), StatusCode::OK);
     }
 }

--- a/src/app/admin/mod.rs
+++ b/src/app/admin/mod.rs
@@ -80,7 +80,7 @@ mod tests {
     use super::*;
     use http::method::Method;
 
-        const TIMEOUT: Duration = Duration::from_secs(1);
+    const TIMEOUT: Duration = Duration::from_secs(1);
 
     #[test]
     fn ready_when_latches_dropped() {

--- a/src/app/admin/mod.rs
+++ b/src/app/admin/mod.rs
@@ -34,7 +34,7 @@ where
     }
 
     fn ready_rsp(&self) -> Response<Body> {
-        if self.ready.ready() {
+        if self.ready.is_ready() {
             Response::builder()
                 .status(StatusCode::OK)
                 .body("ready\n".into())

--- a/src/app/admin/mod.rs
+++ b/src/app/admin/mod.rs
@@ -1,0 +1,72 @@
+//! Serves an HTTP/1.1. admin server.
+//!
+//! * `/metrics` -- reports prometheus-formatted metrics.
+//! * `/ready` -- returns 200 when the proxy is ready to participate in meshed traffic.
+
+use futures::future::{self, FutureResult};
+use http::StatusCode;
+use hyper::{service::Service, Body, Request, Response};
+use std::io;
+
+use metrics;
+
+mod readiness;
+pub use self::readiness::{Latch, Readiness};
+
+#[derive(Debug, Clone)]
+pub struct Admin<M>
+where
+    M: metrics::FmtMetrics,
+{
+    metrics: metrics::Serve<M>,
+    ready: Readiness,
+}
+
+impl<M> Admin<M>
+where
+    M: metrics::FmtMetrics,
+{
+    pub fn new(m: M, ready: Readiness) -> Self {
+        Self {
+            metrics: metrics::Serve::new(m),
+            ready,
+        }
+    }
+
+    fn ready_rsp(&self) -> Response<Body> {
+        if self.ready.ready() {
+            Response::builder()
+                .status(StatusCode::OK)
+                .body("ready\n".into())
+                .expect("builder with known status code must not fail")
+        } else {
+            Response::builder()
+                .status(StatusCode::SERVICE_UNAVAILABLE)
+                .body("not ready\n".into())
+                .expect("builder with known status code must not fail")
+        }
+    }
+}
+
+impl<M> Service for Admin<M>
+where
+    M: metrics::FmtMetrics,
+{
+    type ReqBody = Body;
+    type ResBody = Body;
+    type Error = io::Error;
+    type Future = FutureResult<Response<Body>, Self::Error>;
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        match req.uri().path() {
+            "/metrics" => self.metrics.call(req),
+            "/ready" => future::ok(self.ready_rsp()),
+            _ => future::ok(
+                Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Body::empty())
+                    .expect("builder with known status code must not fail"),
+            ),
+        }
+    }
+}

--- a/src/app/admin/readiness.rs
+++ b/src/app/admin/readiness.rs
@@ -1,0 +1,25 @@
+use std::sync::{Arc, Weak};
+
+#[derive(Clone, Debug)]
+pub struct Readiness(Weak<()>);
+
+#[derive(Clone, Debug)]
+pub struct Latch(Arc<()>);
+
+impl Readiness {
+    pub fn new() -> (Readiness, Latch) {
+        let r = Arc::new(());
+        (Readiness(Arc::downgrade(&r)), Latch(r))
+    }
+
+    pub fn ready(&self) -> bool {
+        self.0.upgrade().is_none()
+    }
+}
+
+impl Default for Readiness {
+    fn default() -> Self {
+        // Is immediately ready.
+        Self::new().0
+    }
+}

--- a/src/app/admin/readiness.rs
+++ b/src/app/admin/readiness.rs
@@ -1,8 +1,12 @@
 use std::sync::{Arc, Weak};
 
+/// Tracks the processes's readiness to serve traffic.
+///
+/// Once `is_ready()` returns true, it will never return false.
 #[derive(Clone, Debug)]
 pub struct Readiness(Weak<()>);
 
+/// When all latches are dropped, the process is considered ready.
 #[derive(Clone, Debug)]
 pub struct Latch(Arc<()>);
 
@@ -12,14 +16,21 @@ impl Readiness {
         (Readiness(Arc::downgrade(&r)), Latch(r))
     }
 
-    pub fn ready(&self) -> bool {
+    pub fn is_ready(&self) -> bool {
         self.0.upgrade().is_none()
     }
 }
 
+/// ALways ready.
 impl Default for Readiness {
     fn default() -> Self {
-        // Is immediately ready.
         Self::new().0
+    }
+}
+
+impl Latch {
+    /// Releases this readiness latch.
+    pub fn release(self) {
+        drop(self);
     }
 }

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -28,8 +28,8 @@ pub struct Config {
     /// Where to listen for connections initiated by the control plane.
     pub control_listener: Listener,
 
-    /// Where to serve Prometheus metrics.
-    pub metrics_listener: Listener,
+    /// Where to serve admin HTTP.
+    pub admin_listener: Listener,
 
     /// Where to forward externally received connections.
     pub inbound_forward: Option<SocketAddr>,
@@ -167,7 +167,7 @@ pub const ENV_OUTBOUND_LISTEN_ADDR: &str = "LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR"
 pub const ENV_INBOUND_FORWARD: &str = "LINKERD2_PROXY_INBOUND_FORWARD";
 pub const ENV_INBOUND_LISTEN_ADDR: &str = "LINKERD2_PROXY_INBOUND_LISTEN_ADDR";
 pub const ENV_CONTROL_LISTEN_ADDR: &str = "LINKERD2_PROXY_CONTROL_LISTEN_ADDR";
-pub const ENV_METRICS_LISTEN_ADDR: &str = "LINKERD2_PROXY_METRICS_LISTEN_ADDR";
+pub const ENV_ADMIN_LISTEN_ADDR: &str = "LINKERD2_PROXY_ADMIN_LISTEN_ADDR";
 pub const ENV_METRICS_RETAIN_IDLE: &str = "LINKERD2_PROXY_METRICS_RETAIN_IDLE";
 const ENV_INBOUND_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_INBOUND_CONNECT_TIMEOUT";
 const ENV_OUTBOUND_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT";
@@ -264,7 +264,7 @@ const ENV_DNS_CANONICALIZE_TIMEOUT: &str = "LINKERD2_PROXY_DNS_CANONICALIZE_TIME
 const DEFAULT_OUTBOUND_LISTEN_ADDR: &str = "127.0.0.1:4140";
 const DEFAULT_INBOUND_LISTEN_ADDR: &str = "0.0.0.0:4143";
 const DEFAULT_CONTROL_LISTEN_ADDR: &str = "0.0.0.0:4190";
-const DEFAULT_METRICS_LISTEN_ADDR: &str = "127.0.0.1:4191";
+const DEFAULT_ADMIN_LISTEN_ADDR: &str = "127.0.0.1:4191";
 const DEFAULT_METRICS_RETAIN_IDLE: Duration = Duration::from_secs(10 * 60);
 const DEFAULT_INBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(20);
 const DEFAULT_OUTBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
@@ -320,7 +320,7 @@ impl Config {
         let outbound_listener_addr = parse(strings, ENV_OUTBOUND_LISTEN_ADDR, parse_socket_addr);
         let inbound_listener_addr = parse(strings, ENV_INBOUND_LISTEN_ADDR, parse_socket_addr);
         let control_listener_addr = parse(strings, ENV_CONTROL_LISTEN_ADDR, parse_socket_addr);
-        let metrics_listener_addr = parse(strings, ENV_METRICS_LISTEN_ADDR, parse_socket_addr);
+        let admin_listener_addr = parse(strings, ENV_ADMIN_LISTEN_ADDR, parse_socket_addr);
         let inbound_forward = parse(strings, ENV_INBOUND_FORWARD, parse_socket_addr);
 
         let inbound_connect_timeout = parse(strings, ENV_INBOUND_CONNECT_TIMEOUT, parse_duration);
@@ -409,9 +409,9 @@ impl Config {
                 addr: control_listener_addr?
                     .unwrap_or_else(|| parse_socket_addr(DEFAULT_CONTROL_LISTEN_ADDR).unwrap()),
             },
-            metrics_listener: Listener {
-                addr: metrics_listener_addr?
-                    .unwrap_or_else(|| parse_socket_addr(DEFAULT_METRICS_LISTEN_ADDR).unwrap()),
+            admin_listener: Listener {
+                addr: admin_listener_addr?
+                    .unwrap_or_else(|| parse_socket_addr(DEFAULT_ADMIN_LISTEN_ADDR).unwrap()),
             },
             inbound_forward: inbound_forward?,
 

--- a/src/app/identity.rs
+++ b/src/app/identity.rs
@@ -209,7 +209,7 @@ where
                                 .and_then(|d| Result::<SystemTime, Duration>::from(d).ok())
                             {
                                 None => error!(
-                                    "Identity service did not specify a ceritificate expiration."
+                                    "Identity service did not specify a certificate expiration."
                                 ),
                                 Some(expiry) => {
                                     let key = self.config.key.clone();

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -256,7 +256,7 @@ where
         let (readiness, ready_latch) = Readiness::new();
         let local_identity = match identity {
             Conditional::None(r) => {
-                drop(ready_latch);
+                ready_latch.release();
                 Conditional::None(r)
             }
             Conditional::Some((local_identity, crt_store)) => {
@@ -303,7 +303,7 @@ where
                         .clone()
                         .await_crt()
                         .map(move |id| {
-                            drop(ready_latch);
+                            ready_latch.release();
                             info!("Certified identity: {}", id.name().as_ref());
                         })
                         .map_err(|_| {

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -204,7 +204,7 @@ where
             config.inbound_forward
         );
         info!(
-            "serving Prometheus metrics on {:?}",
+            "serving admin endpoint metrics on {:?}",
             admin_listener.local_addr(),
         );
         info!(

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,7 @@
 
 use http;
 
+mod admin;
 mod classify;
 pub mod config;
 mod control;

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -165,10 +165,7 @@ fn run(proxy: Proxy, mut env: app::config::TestEnv) -> Listening {
         app::config::ENV_CONTROL_LISTEN_ADDR,
         "127.0.0.1:0".to_owned(),
     );
-    env.put(
-        app::config::ENV_ADMIN_LISTEN_ADDR,
-        "127.0.0.1:0".to_owned(),
-    );
+    env.put(app::config::ENV_ADMIN_LISTEN_ADDR, "127.0.0.1:0".to_owned());
 
     if let Some(ports) = proxy.inbound_disable_ports_protocol_detection {
         let ports = ports

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -166,7 +166,7 @@ fn run(proxy: Proxy, mut env: app::config::TestEnv) -> Listening {
         "127.0.0.1:0".to_owned(),
     );
     env.put(
-        app::config::ENV_METRICS_LISTEN_ADDR,
+        app::config::ENV_ADMIN_LISTEN_ADDR,
         "127.0.0.1:0".to_owned(),
     );
 


### PR DESCRIPTION
The so-called "metrics" server need not only serve metrics. It can also
serve other administrative endpoints, especially those that may be used
as readiness and liveness probes.

A /ready endpoint is exposed that responds successfully when identity
has been loaded.

The `METRICS_LISTEN_ADDR` configuration has been renamed as
`ADMIN_LISTEN_ADDR`.