### PR TITLE
Replace the metrics server with an admin server (#218)

### DIFF
--- a/lib/metrics/src/prom.rs
+++ b/lib/metrics/src/prom.rs
@@ -167,3 +167,9 @@ impl<A: FmtMetrics, B: FmtMetrics> FmtMetrics for AndThen<A, B> {
         Ok(())
     }
 }
+
+impl FmtMetrics for () {
+    fn fmt_metrics(&self, _: &mut fmt::Formatter) -> fmt::Result {
+        Ok(())
+    }
+}

--- a/src/app/admin/mod.rs
+++ b/src/app/admin/mod.rs
@@ -1,0 +1,112 @@
+//! Serves an HTTP/1.1. admin server.
+//!
+//! * `/metrics` -- reports prometheus-formatted metrics.
+//! * `/ready` -- returns 200 when the proxy is ready to participate in meshed traffic.
+
+use futures::future::{self, FutureResult};
+use http::StatusCode;
+use hyper::{service::Service, Body, Request, Response};
+use std::io;
+
+use metrics;
+
+mod readiness;
+pub use self::readiness::{Latch, Readiness};
+
+#[derive(Debug, Clone)]
+pub struct Admin<M>
+where
+    M: metrics::FmtMetrics,
+{
+    metrics: metrics::Serve<M>,
+    ready: Readiness,
+}
+
+impl<M> Admin<M>
+where
+    M: metrics::FmtMetrics,
+{
+    pub fn new(m: M, ready: Readiness) -> Self {
+        Self {
+            metrics: metrics::Serve::new(m),
+            ready,
+        }
+    }
+
+    fn ready_rsp(&self) -> Response<Body> {
+        if self.ready.is_ready() {
+            Response::builder()
+                .status(StatusCode::OK)
+                .body("ready\n".into())
+                .expect("builder with known status code must not fail")
+        } else {
+            Response::builder()
+                .status(StatusCode::SERVICE_UNAVAILABLE)
+                .body("not ready\n".into())
+                .expect("builder with known status code must not fail")
+        }
+    }
+}
+
+impl<M> Service for Admin<M>
+where
+    M: metrics::FmtMetrics,
+{
+    type ReqBody = Body;
+    type ResBody = Body;
+    type Error = io::Error;
+    type Future = FutureResult<Response<Body>, Self::Error>;
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        match req.uri().path() {
+            "/metrics" => self.metrics.call(req),
+            "/ready" => future::ok(self.ready_rsp()),
+            _ => future::ok(
+                Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Body::empty())
+                    .expect("builder with known status code must not fail"),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+    use task::test_util::BlockOnFor;
+    use tokio::runtime::current_thread::Runtime;
+
+    use super::*;
+    use http::method::Method;
+
+    const TIMEOUT: Duration = Duration::from_secs(1);
+
+    #[test]
+    fn ready_when_latches_dropped() {
+        let (r, l0) = Readiness::new();
+        let l1 = l0.clone();
+
+        let mut rt = Runtime::new().unwrap();
+        let mut srv = Admin::new((), r);
+        macro_rules! call {
+            () => {{
+                let r = Request::builder()
+                    .method(Method::GET)
+                    .uri("http://4.3.2.1:5678/ready")
+                    .body(Body::empty())
+                    .unwrap();
+                let f = srv.call(r);
+                rt.block_on_for(TIMEOUT, f).expect("call")
+            };};
+        }
+
+        assert_eq!(call!().status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        drop(l0);
+        assert_eq!(call!().status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        drop(l1);
+        assert_eq!(call!().status(), StatusCode::OK);
+    }
+}

--- a/src/app/admin/readiness.rs
+++ b/src/app/admin/readiness.rs
@@ -1,0 +1,36 @@
+use std::sync::{Arc, Weak};
+
+/// Tracks the processes's readiness to serve traffic.
+///
+/// Once `is_ready()` returns true, it will never return false.
+#[derive(Clone, Debug)]
+pub struct Readiness(Weak<()>);
+
+/// When all latches are dropped, the process is considered ready.
+#[derive(Clone, Debug)]
+pub struct Latch(Arc<()>);
+
+impl Readiness {
+    pub fn new() -> (Readiness, Latch) {
+        let r = Arc::new(());
+        (Readiness(Arc::downgrade(&r)), Latch(r))
+    }
+
+    pub fn is_ready(&self) -> bool {
+        self.0.upgrade().is_none()
+    }
+}
+
+/// ALways ready.
+impl Default for Readiness {
+    fn default() -> Self {
+        Self::new().0
+    }
+}
+
+impl Latch {
+    /// Releases this readiness latch.
+    pub fn release(self) {
+        drop(self);
+    }
+}

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -28,8 +28,8 @@ pub struct Config {
     /// Where to listen for connections initiated by the control plane.
     pub control_listener: Listener,
 
-    /// Where to serve Prometheus metrics.
-    pub metrics_listener: Listener,
+    /// Where to serve admin HTTP.
+    pub admin_listener: Listener,
 
     /// Where to forward externally received connections.
     pub inbound_forward: Option<SocketAddr>,
@@ -167,7 +167,7 @@ pub const ENV_OUTBOUND_LISTEN_ADDR: &str = "LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR"
 pub const ENV_INBOUND_FORWARD: &str = "LINKERD2_PROXY_INBOUND_FORWARD";
 pub const ENV_INBOUND_LISTEN_ADDR: &str = "LINKERD2_PROXY_INBOUND_LISTEN_ADDR";
 pub const ENV_CONTROL_LISTEN_ADDR: &str = "LINKERD2_PROXY_CONTROL_LISTEN_ADDR";
-pub const ENV_METRICS_LISTEN_ADDR: &str = "LINKERD2_PROXY_METRICS_LISTEN_ADDR";
+pub const ENV_ADMIN_LISTEN_ADDR: &str = "LINKERD2_PROXY_ADMIN_LISTEN_ADDR";
 pub const ENV_METRICS_RETAIN_IDLE: &str = "LINKERD2_PROXY_METRICS_RETAIN_IDLE";
 const ENV_INBOUND_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_INBOUND_CONNECT_TIMEOUT";
 const ENV_OUTBOUND_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT";
@@ -264,7 +264,7 @@ const ENV_DNS_CANONICALIZE_TIMEOUT: &str = "LINKERD2_PROXY_DNS_CANONICALIZE_TIME
 const DEFAULT_OUTBOUND_LISTEN_ADDR: &str = "127.0.0.1:4140";
 const DEFAULT_INBOUND_LISTEN_ADDR: &str = "0.0.0.0:4143";
 const DEFAULT_CONTROL_LISTEN_ADDR: &str = "0.0.0.0:4190";
-const DEFAULT_METRICS_LISTEN_ADDR: &str = "127.0.0.1:4191";
+const DEFAULT_ADMIN_LISTEN_ADDR: &str = "127.0.0.1:4191";
 const DEFAULT_METRICS_RETAIN_IDLE: Duration = Duration::from_secs(10 * 60);
 const DEFAULT_INBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(20);
 const DEFAULT_OUTBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
@@ -320,7 +320,7 @@ impl Config {
         let outbound_listener_addr = parse(strings, ENV_OUTBOUND_LISTEN_ADDR, parse_socket_addr);
         let inbound_listener_addr = parse(strings, ENV_INBOUND_LISTEN_ADDR, parse_socket_addr);
         let control_listener_addr = parse(strings, ENV_CONTROL_LISTEN_ADDR, parse_socket_addr);
-        let metrics_listener_addr = parse(strings, ENV_METRICS_LISTEN_ADDR, parse_socket_addr);
+        let admin_listener_addr = parse(strings, ENV_ADMIN_LISTEN_ADDR, parse_socket_addr);
         let inbound_forward = parse(strings, ENV_INBOUND_FORWARD, parse_socket_addr);
 
         let inbound_connect_timeout = parse(strings, ENV_INBOUND_CONNECT_TIMEOUT, parse_duration);
@@ -409,9 +409,9 @@ impl Config {
                 addr: control_listener_addr?
                     .unwrap_or_else(|| parse_socket_addr(DEFAULT_CONTROL_LISTEN_ADDR).unwrap()),
             },
-            metrics_listener: Listener {
-                addr: metrics_listener_addr?
-                    .unwrap_or_else(|| parse_socket_addr(DEFAULT_METRICS_LISTEN_ADDR).unwrap()),
+            admin_listener: Listener {
+                addr: admin_listener_addr?
+                    .unwrap_or_else(|| parse_socket_addr(DEFAULT_ADMIN_LISTEN_ADDR).unwrap()),
             },
             inbound_forward: inbound_forward?,
 

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -15,7 +15,7 @@ use control;
 use dns;
 use drain;
 use logging;
-use metrics::{self, FmtMetrics};
+use metrics::FmtMetrics;
 use never::Never;
 use proxy::{
     self, buffer,
@@ -36,6 +36,7 @@ use telemetry;
 use transport::{self, connect, keepalive, tls, Connection, GetOriginalDst, Listen};
 use {Addr, Conditional};
 
+use super::admin::{Admin, Readiness};
 use super::config::Config;
 use super::dst::DstAddr;
 use super::identity;
@@ -64,7 +65,7 @@ struct ProxyParts<G> {
 
     start_time: SystemTime,
 
-    metrics_listener: Listen<identity::Local, ()>,
+    admin_listener: Listen<identity::Local, ()>,
     control_listener: Listen<identity::Local, ()>,
 
     inbound_listener: Listen<identity::Local, G>,
@@ -87,7 +88,7 @@ where
         let control_listener = Listen::bind(config.control_listener.addr, local_identity.clone())
             .expect("dst_svc listener bind");
 
-        let metrics_listener = Listen::bind(config.metrics_listener.addr, local_identity.clone())
+        let admin_listener = Listen::bind(config.admin_listener.addr, local_identity.clone())
             .expect("metrics listener bind");
 
         let outbound_listener = Listen::bind(
@@ -116,7 +117,7 @@ where
             inbound_listener,
             outbound_listener,
             control_listener,
-            metrics_listener,
+            admin_listener,
         };
 
         Main {
@@ -138,7 +139,7 @@ where
     }
 
     pub fn metrics_addr(&self) -> SocketAddr {
-        self.proxy_parts.metrics_listener.local_addr()
+        self.proxy_parts.admin_listener.local_addr()
     }
 
     pub fn run_until<F>(self, shutdown_signal: F)
@@ -183,7 +184,7 @@ where
             control_listener,
             inbound_listener,
             outbound_listener,
-            metrics_listener,
+            admin_listener,
         } = self;
 
         const MAX_IN_FLIGHT: usize = 10_000;
@@ -203,8 +204,8 @@ where
             config.inbound_forward
         );
         info!(
-            "serving Prometheus metrics on {:?}",
-            metrics_listener.local_addr(),
+            "serving admin endpoint metrics on {:?}",
+            admin_listener.local_addr(),
         );
         info!(
             "protocol detection disabled for inbound ports {:?}",
@@ -252,8 +253,12 @@ where
             .and_then(telemetry::process::Report::new(start_time));
 
         let mut identity_daemon = None;
+        let (readiness, ready_latch) = Readiness::new();
         let local_identity = match identity {
-            Conditional::None(r) => Conditional::None(r),
+            Conditional::None(r) => {
+                ready_latch.release();
+                Conditional::None(r)
+            }
             Conditional::Some((local_identity, crt_store)) => {
                 use super::control;
 
@@ -298,6 +303,7 @@ where
                         .clone()
                         .await_crt()
                         .map(move |id| {
+                            ready_latch.release();
                             info!("Certified identity: {}", id.name().as_ref());
                         })
                         .map_err(|_| {
@@ -360,16 +366,14 @@ where
                     let mut rt =
                         current_thread::Runtime::new().expect("initialize admin thread runtime");
 
-                    let metrics = control::serve_http(
-                        "metrics",
-                        metrics_listener,
-                        metrics::Serve::new(report),
-                    );
+                    rt.spawn(control::serve_http(
+                        "admin",
+                        admin_listener,
+                        Admin::new(report, readiness),
+                    ));
 
                     rt.spawn(tap_daemon.map_err(|_| ()));
                     rt.spawn(serve_tap(control_listener, TapServer::new(tap_grpc)));
-
-                    rt.spawn(metrics);
 
                     rt.spawn(::logging::admin().bg("dns-resolver").future(dns_bg));
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,7 @@
 
 use http;
 
+mod admin;
 mod classify;
 pub mod config;
 mod control;

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -165,10 +165,7 @@ fn run(proxy: Proxy, mut env: app::config::TestEnv) -> Listening {
         app::config::ENV_CONTROL_LISTEN_ADDR,
         "127.0.0.1:0".to_owned(),
     );
-    env.put(
-        app::config::ENV_METRICS_LISTEN_ADDR,
-        "127.0.0.1:0".to_owned(),
-    );
+    env.put(app::config::ENV_ADMIN_LISTEN_ADDR, "127.0.0.1:0".to_owned());
 
     if let Some(ports) = proxy.inbound_disable_ports_protocol_detection {
         let ports = ports


### PR DESCRIPTION
The so-called "metrics" server need not only serve metrics. It can also
serve other administrative endpoints, especially those that may be used
as readiness and liveness probes.

A /ready endpoint is exposed that responds successfully when identity
has been loaded.

The `METRICS_LISTEN_ADDR` configuration has been renamed as
`ADMIN_LISTEN_ADDR`.