### PR TITLE
Add test that proxy refreshes its identity

### DIFF
--- a/src/app/identity.rs
+++ b/src/app/identity.rs
@@ -86,7 +86,7 @@ impl Config {
             Some(lifetime) if self.max_refresh < lifetime => self.max_refresh,
             Some(lifetime) => lifetime,
         };
-
+        trace!("will refresh in {:?}", refresh);
         Delay::new(now + refresh)
     }
 }

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -4,7 +4,10 @@
 mod support;
 use self::support::*;
 
-use std::time::{Duration, SystemTime};
+use std::{
+    time::{Duration, SystemTime},
+    sync::{Arc, atomic::{AtomicBool, Ordering}},
+};
 
 #[test]
 fn ready() {
@@ -36,4 +39,47 @@ fn ready() {
 
     // Now, the proxy should be ready.
     assert_eventually!(ready().status() == http::StatusCode::OK);
+}
+
+#[test]
+fn refresh() {
+    let _ = env_logger_init();
+    let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
+    let identity::Identity {
+        mut env,
+        certify_rsp,
+    } = identity::Identity::new("foo-ns1", id.to_string());
+
+    let (expiry_tx, expiry_rx) = oneshot::channel();
+    let refreshed = Arc::new(AtomicBool::new(false));
+
+    let rsp1 = certify_rsp.clone();
+    let rsp2 = certify_rsp.clone();
+    let refreshed2 = refreshed.clone();
+    let id_svc = controller::identity()
+        .certify(move |_| {
+            let mut rsp = rsp1;
+            let expiry = SystemTime::now() + Duration::from_millis(20);
+            rsp.valid_until = Some(expiry.into());
+            expiry_tx.send(expiry).unwrap();
+            rsp
+        })
+        .certify(move |_| {
+            let mut rsp = rsp2;
+            rsp.valid_until = Some((SystemTime::now() + Duration::from_millis(6000)).into());
+            refreshed2.store(true, Ordering::SeqCst);
+            rsp
+        })
+        .run();
+
+    // Disable the minimum bound on when to refresh identity for this test.
+    env.put(app::config::ENV_IDENTITY_MIN_REFRESH, "0ms".into());
+    let _proxy = proxy::new().identity(id_svc).run_with_test_env(env);
+
+    let expiry = expiry_rx.wait().expect("wait for expiry");
+    let how_long = expiry.duration_since(SystemTime::now()).unwrap();
+
+    std::thread::sleep(how_long);
+
+    assert_eventually!(refreshed.load(Ordering::SeqCst) == true);
 }

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -5,8 +5,11 @@ mod support;
 use self::support::*;
 
 use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, SystemTime},
-    sync::{Arc, atomic::{AtomicBool, Ordering}},
 };
 
 #[test]

--- a/tests/support/identity.rs
+++ b/tests/support/identity.rs
@@ -111,7 +111,7 @@ impl Controller {
 
     pub fn certify<F>(self, f: F) -> Self
     where
-        F: Fn(pb::CertifyRequest) -> pb::CertifyResponse + Send + 'static,
+        F: FnOnce(pb::CertifyRequest) -> pb::CertifyResponse + Send + 'static,
     {
         self.certify_async(move |req| Ok::<_, grpc::Status>(f(req)))
     }


### PR DESCRIPTION
Depends on #227 and #228.

This branch adds a new integration test that asserts that a proxy will
refresh its identity before the specified expiration time.

I also added a `trace` log in the `identity` module that logs the actual
duration we will wait before attempting to refresh. This was useful when
debugging why this test was failing (it was because I neglected to set
the LINKERD2_PROXY_IDENTITY_MIN_REFRESH env var, and it defaulted to 10
seconds). I felt like it was useful to log the actual duration we will
wait as well as the `SystemTime` when the cert expires, but I'm happy to
back that commit off if we don't actually want that log line.

Closes linkerd/linkerd2#2505

Signed-off-by: Eliza Weisman <eliza@buoyant.io>