### PR TITLE
Disable potentially info-leaking headers

### DIFF
--- a/src/app/inbound.rs
+++ b/src/app/inbound.rs
@@ -274,6 +274,7 @@ pub mod rewrite_loopback_addr {
 
 /// Adds `l5d-client-id` headers to http::Requests derived from the
 /// TlsIdentity of a `Source`.
+#[allow(dead_code)] // TODO #2597
 pub mod set_client_id_on_req {
     use super::super::L5D_CLIENT_ID;
     use http::header::HeaderValue;
@@ -305,6 +306,7 @@ pub mod set_client_id_on_req {
 
 /// Adds `l5d-remote-ip` headers to http::Requests derived from the
 /// `remote` of a `Source`.
+#[allow(dead_code)] // TODO #2597
 pub mod set_remote_ip_on_req {
     use super::super::L5D_REMOTE_IP;
     use bytes::Bytes;

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -413,7 +413,9 @@ where
 
         let outbound = {
             use super::outbound::{
-                add_remote_ip_on_rsp, add_server_id_on_rsp, discovery::Resolve, orig_proto_upgrade,
+                //add_remote_ip_on_rsp, add_server_id_on_rsp,
+                discovery::Resolve,
+                orig_proto_upgrade,
                 Endpoint,
             };
             use proxy::{
@@ -464,8 +466,8 @@ where
                 .push(strip_header::response::layer(super::L5D_SERVER_ID))
                 .push(strip_header::response::layer(super::L5D_REMOTE_IP))
                 .push(settings::router::layer::<_, Endpoint>())
-                .push(add_server_id_on_rsp::layer())
-                .push(add_remote_ip_on_rsp::layer())
+                //.push(add_server_id_on_rsp::layer())
+                //.push(add_remote_ip_on_rsp::layer())
                 .push(orig_proto_upgrade::layer())
                 .push(tap_layer.clone())
                 .push(metrics::layer::<_, classify::Response>(
@@ -607,8 +609,11 @@ where
 
         let inbound = {
             use super::inbound::{
-                orig_proto_downgrade, rewrite_loopback_addr, set_client_id_on_req,
-                set_remote_ip_on_req, Endpoint, RecognizeEndpoint,
+                orig_proto_downgrade,
+                rewrite_loopback_addr,
+                Endpoint,
+                RecognizeEndpoint,
+                // set_client_id_on_req, set_remote_ip_on_req,
             };
 
             let capacity = config.inbound_router_capacity;
@@ -728,9 +733,9 @@ where
             let source_stack = dst_router
                 .push(orig_proto_downgrade::layer())
                 .push(insert_target::layer())
-                .push(set_remote_ip_on_req::layer())
+                //.push(set_remote_ip_on_req::layer())
+                //.push(set_client_id_on_req::layer())
                 .push(strip_header::request::layer(super::L5D_REMOTE_IP))
-                .push(set_client_id_on_req::layer())
                 .push(strip_header::request::layer(super::L5D_CLIENT_ID))
                 .push(strip_header::response::layer(super::L5D_SERVER_ID))
                 .push(strip_header::request::layer(super::DST_OVERRIDE_HEADER))

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -290,6 +290,7 @@ pub mod orig_proto_upgrade {
 
 /// Adds `l5d-server-id` headers to http::Responses derived from the
 /// TlsIdentity of an `Endpoint`.
+#[allow(dead_code)] // TODO #2597
 pub mod add_server_id_on_rsp {
     use super::super::L5D_SERVER_ID;
     use super::Endpoint;
@@ -318,6 +319,7 @@ pub mod add_server_id_on_rsp {
 
 /// Adds `l5d-remote-ip` headers to http::Responses derived from the
 /// `remote` of a `Source`.
+#[allow(dead_code)] // TODO #2597
 pub mod add_remote_ip_on_rsp {
     use super::super::L5D_REMOTE_IP;
     use super::Endpoint;

--- a/src/proxy/http/add_header.rs
+++ b/src/proxy/http/add_header.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)] // TODO #2597
+
 use std::{fmt, marker::PhantomData};
 
 use http::header::{AsHeaderName, HeaderValue};

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -419,6 +419,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
+            #[ignore] // #2597
             fn outbound_should_set() {
                 let _ = env_logger_init();
                 let header = HeaderValue::from_static(IP_2);
@@ -434,6 +435,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
+            #[ignore] // #2597
             fn inbound_should_set() {
                 let _ = env_logger_init();
 


### PR DESCRIPTION
The proxy has been instrumented to expose various informational `l5d-`
headers to expose identity and network information that would otherwise
be unaccessible to the application.

However, as described in linkerd/linkerd2#2597, when linkerd is injected
into an ingress pod, its easy to accidentally leak these details to
external applications.

Until we have a better mechanism for flagging external-facing pods,
these headers should be disabled.