### PR TITLE
Do not block listener on TLS detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # rather than updating this manually, run update-rust-version.sh
 ARG RUST_IMAGE=rust:1.33.0
-ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-19.3.3
+ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-19.4.3
 
 ## Builds the proxy as incrementally as possible.
 FROM $RUST_IMAGE as build

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -108,8 +108,6 @@ where
 
         let runtime = runtime.into();
 
-        let runtime = runtime.into();
-
         let proxy_parts = ProxyParts {
             config,
             identity,


### PR DESCRIPTION
Currently, the listener task does not multiplex TLS discovery, so one
slow/idle connection can prevent a proxy from transmitting all requests.

This change alters the listener to use buffer_unordered and repurposes
the listener's "connection limit" to control this buffer's capacity
(rather than the total number of connections that may be served).