### PR TITLE
Add support for mocking DNS refinement

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -54,12 +54,12 @@ use super::profiles::Client as ProfilesClient;
 ///
 /// The private listener routes requests to service-discovery-aware load-balancer.
 ///
-pub struct Main<G, R=dns::DefaultRefine> {
+pub struct Main<G, R = dns::DefaultRefine> {
     proxy_parts: ProxyParts<G, R>,
     runtime: task::MainRuntime,
 }
 
-struct ProxyParts<G, R=dns::DefaultRefine> {
+struct ProxyParts<G, R = dns::DefaultRefine> {
     config: Config,
     identity: tls::Conditional<(identity::Local, identity::CrtKeyStore)>,
 

--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -22,7 +22,7 @@ use control::{
     destination::{Metadata, ProtocolHint, Responder, Update},
     remote_stream::Remote,
 };
-use dns;
+use dns::{self, IpList};
 use identity;
 use NameAddr;
 

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -101,15 +101,16 @@ pub enum ProtocolHint {
 /// The `Resolver` is used by a listener to request resolutions, while
 /// the background future is executed on the controller thread's executor
 /// to drive the background task.
-pub fn new<T>(
+pub fn new<T, R>(
     mut client: Option<T>,
-    dns_resolver: dns::Resolver,
+    dns_resolver: R,
     suffixes: Vec<dns::Suffix>,
     concurrency_limit: usize,
     proxy_id: String,
 ) -> (Resolver, impl Future<Item = (), Error = ()>)
 where
     T: GrpcService<BoxBody>,
+    R: dns::Resolve + Clone,
 {
     let (request_tx, rx) = mpsc::unbounded();
     let disco = Resolver { request_tx };

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -176,7 +176,7 @@ impl NewResolver for Resolver {
         opts.cache_size = 0;
         let (resolver, background) = AsyncResolver::new(config, opts);
         let resolver = Resolver { resolver };
-        (resolver, background)
+        (resolver, Box::new(background))
     }
 }
 

--- a/src/dns/mod.rs
+++ b/src/dns/mod.rs
@@ -38,6 +38,14 @@ pub trait Refine {
     fn refine(&self, name: &Name) -> Self::Future;
 }
 
+pub trait MakeRefine: Send + 'static {
+    type Refine: Refine + Clone + Send + Sync + 'static;
+    fn make(self, resolver: &Resolver) -> Self::Refine;
+}
+
+#[derive(Debug)]
+pub struct DefaultRefine;
+
 #[derive(Debug)]
 pub enum Error {
     NoAddressesFound,
@@ -203,6 +211,13 @@ impl Refine for Resolver {
     fn refine(&self, name: &Name) -> Self::Future {
         let f = self.resolver.lookup_ip(name.as_ref());
         RefineFuture(::logging::context_future(Ctx(name.clone()), f))
+    }
+}
+
+impl MakeRefine for DefaultRefine {
+    type Refine = Resolver;
+    fn make(self, resolver: &Resolver) -> Self::Refine {
+        resolver.clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub mod app;
 mod conditional;
 pub mod control;
 pub mod convert;
-mod dns;
+pub mod dns;
 mod drain;
 mod identity;
 mod logging;

--- a/src/proxy/canonicalize.rs
+++ b/src/proxy/canonicalize.rs
@@ -144,12 +144,7 @@ impl<R> Task<R>
 where
     R: dns::Refine,
 {
-    fn new(
-        original: NameAddr,
-        resolver: R,
-        timeout: Duration,
-        tx: mpsc::Sender<NameAddr>,
-    ) -> Self {
+    fn new(original: NameAddr, resolver: R, timeout: Duration, tx: mpsc::Sender<NameAddr>) -> Self {
         Self {
             original,
             resolved: Cache::AwaitingInitial,

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -117,9 +117,13 @@ macro_rules! profile_test {
         profile_tx.send(controller::profile(routes, $budget));
 
         let ctrl = ctrl.run();
+        let dns = dns::new()
+            .refine("profiles.test.svc.cluster.local", "profiles.test.svc.cluster.local")
+            .resolve("profiles.test.svc.cluster.local", srv.addr.ip());
         let proxy = proxy::new()
             .controller(ctrl)
             .outbound(srv)
+            .dns(dns)
             .run_with_test_env($env);
 
         let client = client::$http(proxy.outbound, host);

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -120,13 +120,6 @@ macro_rules! profile_test {
         let proxy = proxy::new()
             .controller(ctrl)
             .outbound(srv)
-            .refine(|_| {
-                use std::time::{Instant, Duration};
-                let name = support::dns_name(b"profiles.test.svc.cluster.local");
-                linkerd2_proxy::dns::RefinedName {
-                    name, valid_until: Instant::now() + Duration::from_secs(666)
-                }
-            })
             .run_with_test_env($env);
 
         let client = client::$http(proxy.outbound, host);

--- a/tests/support/dns.rs
+++ b/tests/support/dns.rs
@@ -1,0 +1,65 @@
+pub use support::linkerd2_proxy::dns::*;
+use support::tokio::prelude::future;
+
+use std::{
+    collections::{VecDeque, HashMap},
+    net::IpAddr,
+    sync::{Arc, Mutex},
+    time::{Instant, Duration}
+};
+
+#[derive(Clone)]
+pub struct MockDns {
+    inner: Arc<Mutex<Inner>>,
+}
+
+struct Inner {
+    resolvutions: HashMap<String, VecDeque<IpAddr>>,
+    refines: HashMap<String, VecDeque<Name>>,
+}
+
+impl NewResolver for MockDns {
+    type Resolver = Self;
+    type Background = future::FutureResult<(), ()>;
+
+    /// NOTE: It would be nice to be able to return a named type rather than
+    ///       `impl Future` for the background future; it would be called
+    ///       `Background` or `ResolverBackground` if that were possible.
+    fn new_resolver(
+        &self,
+        _: ResolverConfig,
+        _: ResolverOpts,
+    ) -> (Self, Self::Background) {
+        (self.clone(), future::ok(()))
+    }
+}
+
+
+impl Refine for MockDns {
+    type Future = future::FutureResult<RefinedName, ResolveError>;
+
+    fn refine(&self, name: &Name) -> Self::Future {
+        let mut lock = self.inner.lock().unwrap();
+        if let Some(name) = lock.refines.get_mut(name.without_trailing_dot()).and_then(|names| names.pop_front()) {
+            return future::ok(RefinedName {
+                name,
+                // TODO: customize?
+                valid_until: Instant::now() + Duration::from_secs(6000)
+            });
+        } else {
+            // FIXME(eliza): make good
+            future::err(ResolveError::from("fake nxdomain".to_string()))
+        }
+    }
+}
+
+impl Resolve for MockDns {
+    type Future = future::FutureResult<IpAddr, Error>;
+    type ListFuture = future::FutureResult<Response, ResolveError>;
+    fn resolve_one_ip(&self, _: &Name) -> Self::Future {
+        unimplemented!()
+    }
+    fn resolve_all_ips(&self, _: Instant, _: &Name) -> Self::ListFuture {
+        unimplemented!()
+    }
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -155,6 +155,7 @@ macro_rules! assert_eventually_contains {
 
 pub mod client;
 pub mod controller;
+pub mod dns;
 pub mod identity;
 pub mod proxy;
 pub mod server;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -299,3 +299,7 @@ impl<T: fmt::Debug, E: fmt::Debug> ResultWaitedExt for Result<T, Waited<E>> {
         }
     }
 }
+
+pub fn dns_name(name: &[u8]) -> dns::Name {
+    linkerd2_proxy::convert::TryFrom::try_from(name).expect("invalid dns name")
+}

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -72,6 +72,26 @@ where
         self
     }
 
+    pub fn dns<R2>(self, dns: R2) -> Proxy<R2>
+    where
+        R2: dns::NewResolver + Send + 'static,
+        R2::Resolver: Clone + Send + Sync + 'static,
+    {
+        Proxy {
+            controller: self.controller,
+            identity: self.identity,
+            inbound: self.inbound,
+            outbound: self.outbound,
+
+            inbound_disable_ports_protocol_detection: self.inbound_disable_ports_protocol_detection,
+            outbound_disable_ports_protocol_detection: self.outbound_disable_ports_protocol_detection,
+
+            shutdown_signal: self.shutdown_signal,
+
+            dns,
+        }
+    }
+
     /// Adjust the server's 'addr'. This won't actually re-bind the server,
     /// it will just affect what the proxy think is the so_original_dst.
     ///


### PR DESCRIPTION
This branch adds support for mocking the source of DNS name refinement
used by the proxy. A new trait, `dns::Refine`, is added, which is
implemented by the `dns::resolver` type, and the appropriate plumbing is
added to the test support code.

Fixes linkerd/linkerd2##2706

Signed-off-by: Eliza Weisman <eliza@buoyant.io>