### PR TITLE
tap: remove need to clone Services

### DIFF
--- a/src/tap/service.rs
+++ b/src/tap/service.rs
@@ -1,9 +1,9 @@
 use bytes::IntoBuf;
-use futures::{future, Async, Future, Poll, Stream};
+use futures::{Async, Future, Poll, Stream};
 use http;
 use hyper::body::Payload as HyperPayload;
 
-use super::iface::{Register, Tap, TapPayload, TapRequest, TapResponse};
+use super::iface::{Register, Tap, TapPayload, TapResponse};
 use super::Inspect;
 use proxy::http::HasH2Reason;
 use svc;
@@ -36,37 +36,9 @@ pub struct Service<I, R, T, S> {
     inspect: I,
 }
 
-/// Fetches `TapRequest`s, instruments messages to be tapped, and executes a
-/// request.
-pub struct ResponseFuture<I, T, A, S>
-where
-    I: Inspect,
-    T: Tap,
-    A: HyperPayload,
-    A::Error: HasH2Reason,
-    S: svc::Service<http::Request<Payload<A, T::TapRequestPayload>>>,
-{
-    state: FutState<I, T, A, S>,
-}
-
-enum FutState<I, T, A, S>
-where
-    I: Inspect,
-    T: Tap,
-    A: HyperPayload,
-    A::Error: HasH2Reason,
-    S: svc::Service<http::Request<Payload<A, T::TapRequestPayload>>>,
-{
-    Taps {
-        taps: future::JoinAll<Vec<T::Future>>,
-        inspect: I,
-        request: Option<http::Request<A>>,
-        service: S,
-    },
-    Call {
-        taps: Vec<T::TapResponse>,
-        call: S::Future,
-    },
+pub struct ResponseFuture<F, T> {
+    inner: F,
+    taps: Vec<T>,
 }
 
 // A `Payload` instrumented with taps.
@@ -160,13 +132,12 @@ where
 
 impl<I, R, S, T, A, B> svc::Service<http::Request<A>> for Service<I, R, T, S>
 where
-    I: Inspect + Clone,
+    I: Inspect,
     R: Stream<Item = T>,
     T: Tap,
     T::TapRequestPayload: Send + 'static,
     T::TapResponsePayload: Send + 'static,
-    S: svc::Service<http::Request<Payload<A, T::TapRequestPayload>>, Response = http::Response<B>>
-        + Clone,
+    S: svc::Service<http::Request<Payload<A, T::TapRequestPayload>>, Response = http::Response<B>>,
     S::Error: HasH2Reason,
     A: HyperPayload,
     A::Error: HasH2Reason,
@@ -175,7 +146,7 @@ where
 {
     type Response = http::Response<Payload<B, T::TapResponsePayload>>;
     type Error = S::Error;
-    type Future = ResponseFuture<I, T, A, S>;
+    type Future = ResponseFuture<S::Future, T::TapResponse>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         // Load new taps from the tap server.
@@ -189,115 +160,66 @@ where
     }
 
     fn call(&mut self, req: http::Request<A>) -> Self::Future {
-        // Determine which active taps match the request and collect all of the
-        // futures requesting TapRequests from the tap server.
-        let mut tap_futs = Vec::new();
-        for t in self.taps.iter_mut() {
-            if t.should_tap(&req, &self.inspect) {
-                tap_futs.push(t.tap());
+        // Record the request and obtain request-body and response taps.
+        let mut req_taps = Vec::new();
+        let mut rsp_taps = Vec::new();
+
+        for t in &mut self.taps {
+            if let Some((req_tap, rsp_tap)) = t.tap(&req, &self.inspect) {
+                req_taps.push(req_tap);
+                rsp_taps.push(rsp_tap);
             }
         }
 
+        // Install the request taps into the request body.
+        let req = req.map(move |inner| Payload {
+            inner,
+            taps: req_taps,
+        });
+
+        let inner = self.inner.call(req);
+
         ResponseFuture {
-            state: FutState::Taps {
-                taps: future::join_all(tap_futs),
-                request: Some(req),
-                service: self.inner.clone(),
-                inspect: self.inspect.clone(),
-            },
+            inner,
+            taps: rsp_taps,
         }
     }
 }
 
-impl<A, B, I, T, S> Future for ResponseFuture<I, T, A, S>
+impl<F, T, B> Future for ResponseFuture<F, T>
 where
-    I: Inspect,
-    T: Tap,
-    T::TapRequestPayload: Send + 'static,
-    T::TapResponsePayload: Send + 'static,
-    S: svc::Service<http::Request<Payload<A, T::TapRequestPayload>>, Response = http::Response<B>>,
-    S::Error: HasH2Reason,
-    A: HyperPayload,
-    A::Error: HasH2Reason,
+    F: Future<Item = http::Response<B>>,
+    F::Error: HasH2Reason,
+    T: TapResponse,
+    T::TapPayload: Send + 'static,
     B: HyperPayload,
     B::Error: HasH2Reason,
 {
-    type Item = http::Response<Payload<B, T::TapResponsePayload>>;
-    type Error = S::Error;
+    type Item = http::Response<Payload<B, T::TapPayload>>;
+    type Error = F::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        // Drive the state machine from FutState::Taps to FutState::Call to Ready.
-        loop {
-            self.state = match self.state {
-                FutState::Taps {
-                    ref mut request,
-                    ref mut service,
-                    ref mut taps,
-                    ref inspect,
-                } => {
-                    // Get all the tap requests. If there's any sort of error,
-                    // continue without taps.
-                    let mut taps = match taps.poll() {
-                        Ok(Async::NotReady) => return Ok(Async::NotReady),
-                        Ok(Async::Ready(taps)) => taps,
-                        Err(_) => Vec::new(),
-                    };
-
-                    let req = request.take().expect("request must be set");
-
-                    // Record the request and obtain request-body and response taps.
-                    let mut req_taps = Vec::with_capacity(taps.len());
-                    let mut rsp_taps = Vec::with_capacity(taps.len());
-                    for tap in taps.drain(..).filter_map(|t| t) {
-                        let (req_tap, rsp_tap) = tap.open(&req, inspect);
-                        req_taps.push(req_tap);
-                        rsp_taps.push(rsp_tap);
+        match self.inner.poll() {
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Ok(Async::Ready(rsp)) => {
+                // Tap the response headers and use the response
+                // body taps to decorate the response body.
+                let taps = self.taps.drain(..).map(|t| t.tap(&rsp)).collect();
+                let rsp = rsp.map(move |inner| {
+                    let mut body = Payload { inner, taps };
+                    if body.is_end_stream() {
+                        body.eos(None);
                     }
-
-                    // Install the request taps into the request body.
-                    let req = {
-                        let (head, inner) = req.into_parts();
-                        let body = Payload {
-                            inner,
-                            taps: req_taps,
-                        };
-                        http::Request::from_parts(head, body)
-                    };
-
-                    // Call the service with the decorated request and save the
-                    // response taps for when the call completes.
-                    let call = service.call(req);
-                    FutState::Call {
-                        call,
-                        taps: rsp_taps,
-                    }
+                    body
+                });
+                Ok(Async::Ready(rsp))
+            }
+            Err(e) => {
+                for tap in self.taps.drain(..) {
+                    tap.fail(&e);
                 }
-                FutState::Call {
-                    ref mut call,
-                    ref mut taps,
-                } => {
-                    return match call.poll() {
-                        Ok(Async::NotReady) => Ok(Async::NotReady),
-                        Ok(Async::Ready(rsp)) => {
-                            // Tap the response headers and use the response
-                            // body taps to decorate the response body.
-                            let taps = taps.drain(..).map(|t| t.tap(&rsp)).collect();
-                            let (head, inner) = rsp.into_parts();
-                            let mut body = Payload { inner, taps };
-                            if body.is_end_stream() {
-                                body.eos(None);
-                            }
-                            Ok(Async::Ready(http::Response::from_parts(head, body)))
-                        }
-                        Err(e) => {
-                            for tap in taps.drain(..) {
-                                tap.fail(&e);
-                            }
-                            Err(e)
-                        }
-                    };
-                }
-            };
+                Err(e)
+            }
         }
     }
 }


### PR DESCRIPTION
This refactors the tap system to not require intermediary channels to
register matches and taps when a request comes through. The Dispatcher
that used to exist in order to prevent tapping more requests than the
limit asked for has been removed. In its place is a shared atomic
counter to keep the count under the limit.

The resulting behavior should be the same. There should be improved
performance as tap registration doesn't need go through a second
channel, and requests don't need to be delayed waiting for the
dispatcher to be able to process its queue.

----

I noticed this because of the need for `S: Service + Clone` on the tap layer, which I'm trying to remove for another reason. However, this seems orthogonal enough to be a separate PR.