### PR TITLE
Remove buffers from endpoint stacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -356,13 +356,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.12.25"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -387,7 +387,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -482,7 +482,7 @@ dependencies = [
  "deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -502,10 +502,10 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mpsc-lossy 0.1.0",
  "futures-watch 0.1.0 (git+https://github.com/carllerche/better-future)",
- "h2 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-balance 0.1.0",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipnet 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -555,7 +555,7 @@ source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.8#5fecc62ee
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1485,7 +1485,7 @@ dependencies = [
  "base64 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1846,12 +1846,12 @@ dependencies = [
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum futures-watch 0.1.0 (git+https://github.com/carllerche/better-future)" = "<none>"
 "checksum gzip-header 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0a9fcfe1c9ee125342355b2467bc29b9dfcb2124fcae27edb9cee6f4cc5ecd40"
-"checksum h2 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "910a5e7be6283a9c91b3982fa5188368c8719cce2a3cf3b86048673bf9d9c36b"
+"checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum hostname 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "58fab6e177434b0bb4cd344a4dabaa5bd6d7a8d792b1885aebcae7af1091d1cb"
 "checksum http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "fe67e3678f2827030e89cc4b9e7ecd16d52f132c0b940ab5005f88e821500f6a"
 "checksum httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b6288d7db100340ca12873fd4d08ad1b8f206a9457798dfb17c018a33fee540"
-"checksum hyper 0.12.25 (registry+https://github.com/rust-lang/crates.io-index)" = "7d5b6658b016965ae301fa995306db965c93677880ea70765a84235a96eae896"
+"checksum hyper 0.12.28 (registry+https://github.com/rust-lang/crates.io-index)" = "e8e4606fed1c162e3a63d408c07584429f49a4f34c7176cb6cbee60e78f2372c"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"

--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use proxy::http::{
     metrics::classify::{CanClassify, Classify, ClassifyEos, ClassifyResponse},
-    profiles, retry, timeout,
+    profiles, retry, settings, timeout,
 };
 use {Addr, NameAddr};
 
@@ -34,6 +34,7 @@ pub struct Retry {
 pub struct DstAddr {
     addr: Addr,
     direction: Direction,
+    pub(super) http_settings: settings::Settings,
 }
 
 // === impl Route ===
@@ -109,17 +110,19 @@ impl AsRef<Addr> for DstAddr {
 }
 
 impl DstAddr {
-    pub fn outbound(addr: Addr) -> Self {
+    pub fn outbound(addr: Addr, http_settings: settings::Settings) -> Self {
         DstAddr {
             addr,
             direction: Direction::Out,
+            http_settings,
         }
     }
 
-    pub fn inbound(addr: Addr) -> Self {
+    pub fn inbound(addr: Addr, http_settings: settings::Settings) -> Self {
         DstAddr {
             addr,
             direction: Direction::In,
+            http_settings,
         }
     }
 

--- a/src/app/inbound.rs
+++ b/src/app/inbound.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use super::classify;
 use super::dst::DstAddr;
 use super::identity;
-use proxy::http::router;
+use proxy::http::{router, settings};
 use proxy::server::Source;
 use tap;
 use transport::{connect, tls};
@@ -17,6 +17,7 @@ use {Conditional, NameAddr};
 pub struct Endpoint {
     pub addr: SocketAddr,
     pub dst_name: Option<NameAddr>,
+    pub http_settings: settings::Settings,
     pub tls_client_id: tls::PeerIdentity,
 }
 
@@ -32,6 +33,7 @@ impl From<SocketAddr> for Endpoint {
         Self {
             addr,
             dst_name: None,
+            http_settings: settings::Settings::NotHttp,
             tls_client_id: Conditional::None(tls::ReasonForNoPeerName::NotHttp.into()),
         }
     }
@@ -46,6 +48,12 @@ impl connect::HasPeerAddr for Endpoint {
 impl tls::HasPeerIdentity for Endpoint {
     fn peer_identity(&self) -> tls::PeerIdentity {
         Conditional::None(tls::ReasonForNoPeerName::Loopback.into())
+    }
+}
+
+impl settings::HasSettings for Endpoint {
+    fn http_settings(&self) -> &settings::Settings {
+        &self.http_settings
     }
 }
 
@@ -126,16 +134,23 @@ impl<A> router::Recognize<http::Request<A>> for RecognizeEndpoint {
             .map(|s| s.tls_peer.clone())
             .unwrap_or_else(|| Conditional::None(tls::ReasonForNoIdentity::Disabled));
 
-        let dst_name = req
+        let dst_addr = req
             .extensions()
             .get::<DstAddr>()
-            .and_then(|a| a.as_ref().name_addr())
-            .cloned();
-        debug!("inbound endpoint: dst={:?}", dst_name);
+            .expect("request extensions should have DstAddr");
+
+        let dst_name = dst_addr.as_ref().name_addr().cloned();
+        let http_settings = dst_addr.http_settings;
+
+        debug!(
+            "inbound endpoint: dst={:?}, proto={:?}",
+            dst_name, http_settings
+        );
 
         Some(Endpoint {
             addr,
             dst_name,
+            http_settings,
             tls_client_id,
         })
     }
@@ -293,18 +308,28 @@ mod tests {
     use std::net;
 
     use super::{Endpoint, RecognizeEndpoint};
-    use proxy::http::router::Recognize;
+    use proxy::http::{router::Recognize, Settings};
     use proxy::server::Source;
     use transport::tls;
     use Conditional;
 
-    fn make_h1_endpoint(addr: net::SocketAddr) -> Endpoint {
+    fn make_test_endpoint(addr: net::SocketAddr) -> Endpoint {
         let tls_client_id = TLS_DISABLED;
         Endpoint {
             addr,
             dst_name: None,
+            http_settings: Settings::Http2,
             tls_client_id,
         }
+    }
+
+    fn dst_addr(req: &mut http::Request<()>) {
+        use app::dst::DstAddr;
+        use Addr;
+        req.extensions_mut().insert(DstAddr::inbound(
+            Addr::Socket(([0, 0, 0, 0], 0).into()),
+            Settings::Http2,
+        ));
     }
 
     const TLS_DISABLED: tls::PeerIdentity = Conditional::None(tls::ReasonForNoIdentity::Disabled);
@@ -316,10 +341,11 @@ mod tests {
             remote: net::SocketAddr
         ) -> bool {
             let src = Source::for_test(remote, local, Some(orig_dst), TLS_DISABLED);
-            let rec = src.orig_dst_if_not_local().map(make_h1_endpoint);
+            let rec = src.orig_dst_if_not_local().map(make_test_endpoint);
 
             let mut req = http::Request::new(());
             req.extensions_mut().insert(src);
+            dst_addr(&mut req);
 
             RecognizeEndpoint::default().recognize(&req) == rec
         }
@@ -332,13 +358,15 @@ mod tests {
             let mut req = http::Request::new(());
             req.extensions_mut()
                 .insert(Source::for_test(remote, local, None, TLS_DISABLED));
+            dst_addr(&mut req);
 
-            RecognizeEndpoint::new(default).recognize(&req) == default.map(make_h1_endpoint)
+            RecognizeEndpoint::new(default).recognize(&req) == default.map(make_test_endpoint)
         }
 
         fn recognize_default_no_ctx(default: Option<net::SocketAddr>) -> bool {
-            let req = http::Request::new(());
-            RecognizeEndpoint::new(default).recognize(&req) == default.map(make_h1_endpoint)
+            let mut req = http::Request::new(());
+            dst_addr(&mut req);
+            RecognizeEndpoint::new(default).recognize(&req) == default.map(make_test_endpoint)
         }
 
         fn recognize_default_no_loop(
@@ -349,8 +377,9 @@ mod tests {
             let mut req = http::Request::new(());
             req.extensions_mut()
                 .insert(Source::for_test(remote, local, Some(local), TLS_DISABLED));
+            dst_addr(&mut req);
 
-            RecognizeEndpoint::new(default).recognize(&req) == default.map(make_h1_endpoint)
+            RecognizeEndpoint::new(default).recognize(&req) == default.map(make_test_endpoint)
         }
     }
 }

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -405,7 +405,6 @@ where
                 //add_remote_ip_on_rsp, add_server_id_on_rsp,
                 discovery::Resolve,
                 orig_proto_upgrade,
-                Endpoint,
             };
             use proxy::{
                 http::{balance, canonicalize, header_from_target, metrics, retry},
@@ -458,9 +457,6 @@ where
                 // disabled on purpose
                 //.layer(add_server_id_on_rsp::layer())
                 //.layer(add_remote_ip_on_rsp::layer())
-                .layer(settings::router::layer::<_, Endpoint>())
-                .layer(buffer::layer(max_in_flight))
-                .layer(pending::layer())
                 .layer(strip_header::response::layer(super::L5D_SERVER_ID))
                 .layer(strip_header::response::layer(super::L5D_REMOTE_IP))
                 .service(client_stack);
@@ -514,11 +510,10 @@ where
             // canonicalize to the same DstAddr use the same dst-stack service.
             let dst_router = svc::builder()
                 .layer(router::layer(|req: &http::Request<_>| {
-                    let addr = req
-                        .extensions()
-                        .get::<Addr>()
-                        .cloned()
-                        .map(DstAddr::outbound);
+                    let addr = req.extensions().get::<Addr>().cloned().map(|addr| {
+                        let settings = settings::Settings::from_request(req);
+                        DstAddr::outbound(addr, settings)
+                    });
                     debug!("outbound dst={:?}", addr);
                     addr
                 }))
@@ -608,7 +603,6 @@ where
             use super::inbound::{
                 orig_proto_downgrade,
                 rewrite_loopback_addr,
-                Endpoint,
                 RecognizeEndpoint,
                 // set_client_id_on_req, set_remote_ip_on_req,
             };
@@ -649,9 +643,6 @@ where
                     endpoint_http_metrics,
                 ))
                 .layer(tap_layer)
-                .layer(settings::router::layer::<_, Endpoint>())
-                .layer(buffer::layer(max_in_flight))
-                .layer(pending::layer())
                 .service(client_stack)
                 .make(&router::Config::new("in endpoint", capacity, max_idle_age));
 
@@ -716,7 +707,10 @@ where
                         .or_else(|| super::http_request_host_addr(req).ok())
                         .or_else(|| super::http_request_orig_dst_addr(req).ok());
                     debug!("inbound dst={:?}", dst);
-                    dst.map(DstAddr::inbound)
+                    dst.map(|addr| {
+                        let settings = settings::Settings::from_request(req);
+                        DstAddr::inbound(addr, settings)
+                    })
                 }))
                 .layer(buffer::layer(max_in_flight))
                 .layer(pending::layer())

--- a/src/dns/name.rs
+++ b/src/dns/name.rs
@@ -27,13 +27,15 @@ impl Name {
 
 impl fmt::Debug for Name {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        fmt::Debug::fmt(&self.0, f)
+        let s: &str = AsRef::<str>::as_ref(&self.0);
+        s.fmt(f)
     }
 }
 
 impl fmt::Display for Name {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        fmt::Display::fmt(self.as_ref(), f)
+        let s: &str = AsRef::<str>::as_ref(&self.0);
+        s.fmt(f)
     }
 }
 

--- a/src/proxy/http/orig_proto.rs
+++ b/src/proxy/http/orig_proto.rs
@@ -44,10 +44,10 @@ where
     }
 
     fn call(&mut self, mut req: http::Request<A>) -> Self::Future {
-        if req.version() == http::Version::HTTP_2 || h1::wants_upgrade(&req) {
-            // Just passing through...
-            return self.inner.call(req).map(|res| res);
-        }
+        debug_assert!(
+            req.version() != http::Version::HTTP_2 && !h1::wants_upgrade(&req),
+            "illegal request routed to orig-proto Upgrade",
+        );
 
         debug!("upgrading {:?} to HTTP2 with orig-proto", req.version());
 

--- a/src/proxy/http/settings.rs
+++ b/src/proxy/http/settings.rs
@@ -1,15 +1,13 @@
 use http::{self, header::HOST};
 
-/// Settings portion of the `Recognize` key for a request.
-///
-/// This marks whether to use HTTP/2 or HTTP/1.x for a request. In
-/// the case of HTTP/1.x requests, it also stores a "host" key to ensure
-/// that each host receives its own connection.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+/// HTTP Client Settings portion of the `Recognize` key for a request.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Settings {
     Http1 {
         /// Indicates whether connections can be reused for each request.
         keep_alive: bool,
+        /// Whether a request has a `CONNECT` method or `Upgrade` header.
+        wants_h1_upgrade: bool,
         /// Whether or not the request URI was in absolute form.
         ///
         /// This is used to configure Hyper's behaviour at the connection
@@ -19,14 +17,19 @@ pub enum Settings {
         was_absolute_form: bool,
     },
     Http2,
+
+    /// Used for types that need to hold a `Settings`, but **WON'T** configure
+    /// an HTTP client. Passing this variant to the `Client` will panic.
+    NotHttp,
+}
+
+pub trait HasSettings {
+    fn http_settings(&self) -> &Settings;
 }
 
 // ===== impl Settings =====
 
 impl Settings {
-    // The router need only have enough capacity for each `Settings` variant.
-    const ROUTER_CAPACITY: usize = 5;
-
     pub fn from_request<B>(req: &http::Request<B>) -> Self {
         if req.version() == http::Version::HTTP_2 {
             return Settings::Http2;
@@ -44,8 +47,11 @@ impl Settings {
             })
             .unwrap_or(true);
 
+        let wants_h1_upgrade = super::h1::wants_upgrade(&req);
+
         Settings::Http1 {
             keep_alive: !is_missing_authority,
+            wants_h1_upgrade,
             was_absolute_form: super::h1::is_absolute_form(req.uri()),
         }
     }
@@ -56,161 +62,14 @@ impl Settings {
             Settings::Http1 {
                 was_absolute_form, ..
             } => *was_absolute_form,
-            Settings::Http2 => false,
+            Settings::Http2 | Settings::NotHttp => false,
         }
     }
 
     pub fn is_http2(&self) -> bool {
         match self {
-            Settings::Http1 { .. } => false,
             Settings::Http2 => true,
-        }
-    }
-}
-
-pub mod router {
-    extern crate linkerd2_router as rt;
-
-    use futures::Poll;
-    use http;
-    use std::fmt;
-    use std::hash::Hash;
-    use std::marker::PhantomData;
-
-    use super::Settings;
-    use proxy::http::client::Config;
-    use svc;
-
-    type Error = Box<dyn std::error::Error + Send + Sync>;
-
-    #[derive(Debug)]
-    pub struct Layer<B, T>(PhantomData<(T, fn(B))>);
-
-    #[derive(Debug)]
-    pub struct MakeSvc<B, T, M>(M, PhantomData<fn(B, T)>);
-
-    pub struct Service<B, T, M>
-    where
-        T: fmt::Debug + Clone + Hash + Eq,
-        M: rt::Make<Config<T>>,
-        M::Value: svc::Service<http::Request<B>>,
-    {
-        router: Router<B, T, M>,
-    }
-
-    pub struct Recognize<T>(T);
-
-    type Router<B, T, M> = rt::Router<http::Request<B>, Recognize<T>, M>;
-
-    pub fn layer<B, T>() -> Layer<B, T>
-    where
-        T: fmt::Debug + Clone + Hash + Eq,
-    {
-        Layer(PhantomData)
-    }
-
-    impl<B, T> Clone for Layer<B, T> {
-        fn clone(&self) -> Self {
-            Layer(PhantomData)
-        }
-    }
-
-    impl<B, T, M, Svc> svc::Layer<M> for Layer<B, T>
-    where
-        MakeSvc<B, T, M>: svc::Service<T>,
-        T: fmt::Debug + Clone + Hash + Eq,
-        M: rt::Make<Config<T>, Value = Svc> + Clone,
-        Svc: svc::Service<http::Request<B>> + Clone,
-        Svc::Error: Into<Error>,
-    {
-        type Service = MakeSvc<B, T, M>;
-
-        fn layer(&self, inner: M) -> Self::Service {
-            MakeSvc(inner, PhantomData)
-        }
-    }
-
-    impl<B, T, M: Clone> Clone for MakeSvc<B, T, M>
-    where
-        T: fmt::Debug + Clone + Hash + Eq,
-    {
-        fn clone(&self) -> Self {
-            MakeSvc(self.0.clone(), PhantomData)
-        }
-    }
-
-    impl<B, T, M, Svc> svc::Service<T> for MakeSvc<B, T, M>
-    where
-        T: fmt::Debug + Clone + Hash + Eq,
-        M: rt::Make<Config<T>, Value = Svc> + Clone,
-        Svc: svc::Service<http::Request<B>> + Clone,
-        Svc::Error: Into<Error>,
-    {
-        type Response = Service<B, T, M>;
-        type Error = never::Never;
-        type Future = futures::future::FutureResult<Self::Response, Self::Error>;
-
-        fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-            Ok(().into()) // always ready to make a Router
-        }
-
-        fn call(&mut self, target: T) -> Self::Future {
-            use std::time::Duration;
-
-            let router = Router::new(
-                Recognize(target),
-                self.0.clone(),
-                Settings::ROUTER_CAPACITY,
-                // Doesn't matter, since we are guaranteed to have enough capacity.
-                Duration::from_secs(0),
-            );
-
-            futures::future::ok(Service { router })
-        }
-    }
-
-    impl<B, T> rt::Recognize<http::Request<B>> for Recognize<T>
-    where
-        T: fmt::Debug + Clone + Hash + Eq,
-    {
-        type Target = Config<T>;
-
-        fn recognize(&self, req: &http::Request<B>) -> Option<Self::Target> {
-            let settings = Settings::from_request(req);
-            Some(Config::new(self.0.clone(), settings))
-        }
-    }
-
-    impl<B, T, M> Clone for Service<B, T, M>
-    where
-        T: fmt::Debug + Clone + Hash + Eq,
-        M: rt::Make<Config<T>>,
-        M::Value: svc::Service<http::Request<B>>,
-    {
-        fn clone(&self) -> Self {
-            Self {
-                router: self.router.clone(),
-            }
-        }
-    }
-
-    impl<B, T, M, Svc> svc::Service<http::Request<B>> for Service<B, T, M>
-    where
-        T: fmt::Debug + Clone + Hash + Eq,
-        M: rt::Make<Config<T>, Value = Svc>,
-        Svc: svc::Service<http::Request<B>> + Clone,
-        Svc::Error: Into<Error>,
-    {
-        type Response = <Router<B, T, M> as svc::Service<http::Request<B>>>::Response;
-        type Error = Error;
-        type Future = rt::ResponseFuture<http::Request<B>, Svc>;
-
-        fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-            self.router.poll_ready()
-        }
-
-        fn call(&mut self, req: http::Request<B>) -> Self::Future {
-            self.router.call(req)
+            Settings::Http1 { .. } | Settings::NotHttp => false,
         }
     }
 }


### PR DESCRIPTION
Due to the `http::settings::router`, a `buffer` was needed in each
endpoint stack. This meant that the service was always ready, even if
the client were falling over (and reconnecting). In turn, this meant
that the balancer would pick one of these endpoint stacks, because it
was always ready!

This change includes a test of a failing endpoint, that the balancer no
longer assumes it is ready, and has the following functional changes:

- Removed `http::settings::router`, instead the client HTTP settings are
  detected as part of the `DstAddr`. This means that each balancer only
  has endpoints with the same HTTP settings.
- Removed `buffer` layer from inside the endpoint stacks.

Closes https://github.com/linkerd/linkerd2/issues/2550