### PR TITLE
Assert that TLS connection is refused if identity is not certified yet

### DIFF
--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -48,66 +48,93 @@ fn nonblocking_identity_detection() {
     assert_eq!(active.read_timeout(Duration::from_secs(2)), msg2.as_bytes());
 }
 
-#[test]
+macro_rules! generate_tls_accept_test {
+    ( client_non_tls: $make_client_non_tls:path, client_tls: $make_client_tls:path) => {
+        let _ = env_logger_init();
+        let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
+        let id_svc = identity::Identity::new("foo-ns1", id.to_string());
+        let proxy = proxy::new()
+            .identity(id_svc.service().run())
+            .run_with_test_env(id_svc.env);
 
-fn accepts_tls_after_identity_is_certified() {
-    let _ = env_logger_init();
-    let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
-    let id_svc = identity::Identity::new("foo-ns1", id.to_string());
-    let proxy = proxy::new()
-        .identity(id_svc.service().run())
-        .run_with_test_env(id_svc.env);
+        let non_tls_client = $make_client_non_tls(proxy.metrics, "localhost");
+        assert_eventually!(
+            non_tls_client
+                .request(non_tls_client.request_builder("/ready").method("GET"))
+                .status()
+                == http::StatusCode::OK
+        );
 
-    let non_tls_client = client::http1(proxy.metrics, "localhost");
-    assert_eventually!(
-        non_tls_client
-            .request(non_tls_client.request_builder("/ready").method("GET"))
-            .status()
-            == http::StatusCode::OK
-    );
+        let tls_client = $make_client_tls(
+            proxy.metrics,
+            "localhost",
+            client::TlsConfig::new(id_svc.client_config, id),
+        );
+        assert_eventually!(
+            tls_client
+                .request(tls_client.request_builder("/ready").method("GET"))
+                .status()
+                == http::StatusCode::OK
+        );
+    };
+}
 
-    let tls_client = client::http1_tls(
-        proxy.metrics,
-        "localhost",
-        client::TlsConfig::new(id_svc.client_config, id),
-    );
-    assert_eventually!(
-        tls_client
-            .request(tls_client.request_builder("/ready").method("GET"))
-            .status()
-            == http::StatusCode::OK
-    );
+macro_rules! generate_tls_reject_test {
+    ( client: $make_client:path) => {
+        let _ = env_logger_init();
+        let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
+        let identity::Identity {
+            env,
+            mut certify_rsp,
+            client_config,
+        } = identity::Identity::new("foo-ns1", id.to_string());
+
+        certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
+
+        let (_tx, rx) = oneshot::channel();
+        let id_svc = controller::identity().certify_async(move |_| rx).run();
+
+        let proxy = proxy::new().identity(id_svc).run_with_test_env(env);
+
+        let client = $make_client(
+            proxy.metrics,
+            "localhost",
+            client::TlsConfig::new(client_config, id),
+        );
+
+        assert!(client
+            .request_async(client.request_builder("/ready").method("GET"))
+            .wait()
+            .err()
+            .unwrap()
+            .is_connect());
+    };
 }
 
 #[test]
-fn rejects_tls_before_identity_is_certified() {
-    let _ = env_logger_init();
-    let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
-    let identity::Identity {
-        env,
-        mut certify_rsp,
-        client_config,
-    } = identity::Identity::new("foo-ns1", id.to_string());
+fn http1_accepts_tls_after_identity_is_certified() {
+    generate_tls_accept_test! {
+       client_non_tls:  client::http1,
+       client_tls: client::http1_tls
+    }
+}
 
-    certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
+#[test]
+fn http1_rejects_tls_before_identity_is_certified() {
+    generate_tls_reject_test! {client: client::http1_tls}
+}
 
-    let (_tx, rx) = oneshot::channel();
-    let id_svc = controller::identity().certify_async(move |_| rx).run();
+#[test]
+fn http2_accepts_tls_after_identity_is_certified() {
+    generate_tls_accept_test! {
+       client_non_tls:  client::http2,
+       client_tls: client::http2_tls
+    }
+}
 
-    let proxy = proxy::new().identity(id_svc).run_with_test_env(env);
-
-    let client = client::http1_tls(
-        proxy.metrics,
-        "localhost",
-        client::TlsConfig::new(client_config, id),
-    );
-
-    assert!(client
-        .request_async(client.request_builder("/ready").method("GET"))
-        .wait()
-        .err()
-        .unwrap()
-        .is_connect());
+#[test]
+fn http2_rejects_tls_before_identity_is_certified() {
+    generate_tls_reject_test! {client: client::http2_tls}
 }
 
 #[test]

--- a/tests/support/identity.rs
+++ b/tests/support/identity.rs
@@ -62,7 +62,6 @@ impl Identity {
 
         let mut c = rustls::ClientConfig::new();
         c.root_store = roots;
-        c.enable_tickets = false;
         Arc::new(c)
     }
 

--- a/tests/support/identity.rs
+++ b/tests/support/identity.rs
@@ -94,20 +94,18 @@ impl Identity {
             (id_dir, token, trust_anchors, rsp)
         };
 
+        let client_config = Identity::from_pem(&trust_anchors);
         let mut env = app::config::TestEnv::new();
 
         env.put(app::config::ENV_IDENTITY_DIR, id_dir);
         env.put(app::config::ENV_IDENTITY_TOKEN_FILE, token);
-        env.put(
-            app::config::ENV_IDENTITY_TRUST_ANCHORS,
-            trust_anchors.clone(),
-        );
+        env.put(app::config::ENV_IDENTITY_TRUST_ANCHORS, trust_anchors);
         env.put(app::config::ENV_IDENTITY_IDENTITY_LOCAL_NAME, local_name);
 
         Self {
             env,
             certify_rsp,
-            client_config: Identity::from_pem(&trust_anchors),
+            client_config,
         }
     }
 

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -22,9 +22,11 @@ extern crate tokio;
 extern crate tokio_connect;
 extern crate tokio_current_thread;
 pub extern crate tokio_io;
+extern crate tokio_rustls;
 extern crate tower_grpc;
 extern crate tower_http_service;
 extern crate tower_service;
+extern crate webpki;
 
 pub use std::collections::HashMap;
 use std::fmt;

--- a/tests/support/tap.rs
+++ b/tests/support/tap.rs
@@ -185,6 +185,10 @@ where
 
             buf.freeze()
         });
-        Box::new(self.0.request_body_async(req))
+        Box::new(
+            self.0
+                .request_body_async(req)
+                .map_err(|err| err.to_string()),
+        )
     }
 }


### PR DESCRIPTION
This branch adds tls capability to the support cient used in tests. In addition to that it adds two tests verifying that a TLS connection is refused in case the identity is not certified yet. This attempts to fix #https://github.com/linkerd/linkerd2/issues/2598 and provide facility to write tests for https://github.com/linkerd/linkerd2/issues/2676. 

As these are still some of my first lines of Rust code, it is advised to approach everything with a healthy dose of doubt :)

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>