### PR TITLE
Remove Destination service query concurrency limit

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -242,14 +242,6 @@ pub const ENV_DESTINATION_GET_SUFFIXES: &str = "LINKERD2_PROXY_DESTINATION_GET_S
 /// If unspecified, a default value is used.
 pub const ENV_DESTINATION_PROFILE_SUFFIXES: &str = "LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES";
 
-/// Limits the buffer capacity of the destination service client.
-///
-/// TODO: This no longer sets a limit on the number of concurrent queries,
-/// just the buffer capacity. Perhaps the environment variable should be
-/// renamed?
-pub const ENV_DESTINATION_CLIENT_CONCURRENCY_LIMIT: &str =
-    "LINKERD2_PROXY_DESTINATION_CLIENT_CONCURRENCY_LIMIT";
-
 // These *disable* our protocol detection for connections whose SO_ORIGINAL_DST
 // has a port in the provided list.
 pub const ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION: &str =
@@ -337,7 +329,7 @@ const DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(60);
 const DEFAULT_INBOUND_MAX_IN_FLIGHT: usize = 10_000;
 const DEFAULT_OUTBOUND_MAX_IN_FLIGHT: usize = 10_000;
 
-const DEFAULT_DESTINATION_CLIENT_CONCURRENCY_LIMIT: usize = 100;
+const DEFAULT_DESTINATION_BUFFER_CAPACITY: usize = 100;
 
 const DEFAULT_DESTINATION_GET_SUFFIXES: &str = "svc.cluster.local.";
 const DEFAULT_DESTINATION_PROFILE_SUFFIXES: &str = "svc.cluster.local.";
@@ -441,11 +433,6 @@ impl Config {
 
         let dst_token = strings.get(ENV_DESTINATION_CONTEXT);
 
-        let dst_concurrency_limit = parse(
-            strings,
-            ENV_DESTINATION_CLIENT_CONCURRENCY_LIMIT,
-            parse_number,
-        );
         let dst_get_suffixes = parse(strings, ENV_DESTINATION_GET_SUFFIXES, parse_dns_suffixes);
         let dst_profile_suffixes = parse(
             strings,
@@ -520,8 +507,7 @@ impl Config {
             outbound_max_requests_in_flight: outbound_max_in_flight?
                 .unwrap_or(DEFAULT_OUTBOUND_MAX_IN_FLIGHT),
 
-            destination_buffer_capacity: dst_concurrency_limit?
-                .unwrap_or(DEFAULT_DESTINATION_CLIENT_CONCURRENCY_LIMIT),
+            destination_buffer_capacity: DEFAULT_DESTINATION_BUFFER_CAPACITY,
 
             destination_get_suffixes: dst_get_suffixes?
                 .unwrap_or(parse_dns_suffixes(DEFAULT_DESTINATION_GET_SUFFIXES).unwrap()),

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -108,7 +108,7 @@ pub struct Config {
 
     /// The maximum number of queries to the Destination service which may be
     /// active concurrently.
-    pub destination_concurrency_limit: usize,
+    pub destination_buffer_capacity: usize,
 
     /// Configured by `ENV_DESTINATION_GET_SUFFIXES`.
     pub destination_get_suffixes: Vec<dns::Suffix>,
@@ -242,11 +242,11 @@ pub const ENV_DESTINATION_GET_SUFFIXES: &str = "LINKERD2_PROXY_DESTINATION_GET_S
 /// If unspecified, a default value is used.
 pub const ENV_DESTINATION_PROFILE_SUFFIXES: &str = "LINKERD2_PROXY_DESTINATION_PROFILE_SUFFIXES";
 
-/// Limits the maximum number of outbound Destination service queries.
+/// Limits the buffer capacity of the destination service client.
 ///
-/// Routes which do not result in service discovery lookups will not be capped
-/// by this limit. This will have no effect if it is greater than the total
-/// router capacity (as configured by `ENV_OUTBOUND_ROUTER_CAPACITY`).
+/// TODO: This no longer sets a limit on the number of concurrent queries,
+/// just the buffer capacity. Perhaps the environment variable should be
+/// renamed?
 pub const ENV_DESTINATION_CLIENT_CONCURRENCY_LIMIT: &str =
     "LINKERD2_PROXY_DESTINATION_CLIENT_CONCURRENCY_LIMIT";
 
@@ -520,7 +520,7 @@ impl Config {
             outbound_max_requests_in_flight: outbound_max_in_flight?
                 .unwrap_or(DEFAULT_OUTBOUND_MAX_IN_FLIGHT),
 
-            destination_concurrency_limit: dst_concurrency_limit?
+            destination_buffer_capacity: dst_concurrency_limit?
                 .unwrap_or(DEFAULT_DESTINATION_CLIENT_CONCURRENCY_LIMIT),
 
             destination_get_suffixes: dst_get_suffixes?

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -340,7 +340,6 @@ where
             dst_svc.clone(),
             dns_resolver.clone(),
             config.destination_get_suffixes,
-            config.destination_concurrency_limit,
             config.destination_context.clone(),
         );
 

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -269,7 +269,7 @@ where
                 };
 
                 let svc = svc::builder()
-                    .layer(buffer::layer(config.destination_concurrency_limit))
+                    .layer(buffer::layer(config.destination_buffer_capacity))
                     .layer(pending::layer())
                     .layer(control::add_origin::layer())
                     .layer(proxy::grpc::req_body_as_payload::layer().per_make())
@@ -319,7 +319,7 @@ where
             };
 
             svc::builder()
-                .layer(buffer::layer(config.destination_concurrency_limit))
+                .layer(buffer::layer(config.destination_buffer_capacity))
                 .layer(pending::layer())
                 .layer(control::add_origin::layer())
                 .layer(proxy::grpc::req_body_as_payload::layer().per_make())

--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -177,12 +177,6 @@ impl<T> DestinationSet<T>
 where
     T: GrpcService<BoxBody>,
 {
-    /// Returns `true` if the authority that created this query _should_ query
-    /// the Destination service, but was unable to due to insufficient capaacity.
-    pub(super) fn needs_query_capacity(&self) -> bool {
-        self.query.needs_query_capacity()
-    }
-
     pub(super) fn reset_on_next_modification(&mut self) {
         match self.addrs {
             Exists::Yes(ref mut cache) => {

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -118,7 +118,6 @@ pub fn new<T>(
     mut client: Option<T>,
     dns_resolver: dns::Resolver,
     suffixes: Vec<dns::Suffix>,
-    concurrency_limit: usize,
     proxy_id: String,
 ) -> (Resolver, impl Future<Item = (), Error = ()>)
 where
@@ -126,7 +125,7 @@ where
 {
     let (request_tx, rx) = mpsc::unbounded();
     let disco = Resolver { request_tx };
-    let mut bg = Background::new(rx, dns_resolver, suffixes, concurrency_limit, proxy_id);
+    let mut bg = Background::new(rx, dns_resolver, suffixes, proxy_id);
     let task = future::poll_fn(move || bg.poll_rpc(&mut client));
     (disco, task)
 }

--- a/src/control/remote_stream.rs
+++ b/src/control/remote_stream.rs
@@ -1,6 +1,5 @@
 use futures::{Future, Poll, Stream};
 use prost::Message;
-use std::sync::Weak;
 use tower_grpc::{
     self as grpc, client::server_streaming::ResponseFuture, generic::client::GrpcService, BoxBody,
     Streaming,
@@ -28,10 +27,6 @@ where
     S: GrpcService<BoxBody>,
 {
     rx: Rx<M, S>,
-
-    /// Used by `background::NewQuery` for counting the number of currently
-    /// active queries that it has created.
-    _active: Weak<()>,
 }
 
 enum Rx<M, S>
@@ -45,10 +40,9 @@ where
 // ===== impl Receiver =====
 
 impl<M: Message + Default, S: GrpcService<BoxBody>> Receiver<M, S> {
-    pub fn new(future: ResponseFuture<M, S::Future>, active: Weak<()>) -> Self {
+    pub fn new(future: ResponseFuture<M, S::Future>) -> Self {
         Receiver {
             rx: Rx::Waiting(future),
-            _active: active,
         }
     }
 }

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -4,76 +4,6 @@
 mod support;
 use self::support::*;
 
-// This test has to be generated separately, since we want it to run for
-// HTTP/1, but not for HTTP/2. This is because the test uses httpbin.org
-// as an external DNS name, and it will 500 our H2 requests because it
-// requires prior knowledge.
-macro_rules! generate_outbound_dns_limit_test {
-    (server: $make_server:path, client: $make_client:path) => {
-        //Flaky: Any test that contacts httpbin.org is inherently flaky
-        #[test]
-        #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-        fn outbound_dest_limit_does_not_limit_dns() {
-            let _ = env_logger_init();
-            let srv = $make_server().route("/", "hello").run();
-            let srv_addr = srv.addr;
-
-            let mut env = app::config::TestEnv::new();
-            env.put(
-                app::config::ENV_DESTINATION_CLIENT_CONCURRENCY_LIMIT,
-                "2".to_owned(),
-            );
-
-            let ctrl = controller::new();
-            let _txs = (1..=3)
-                .map(|n| {
-                    let disco_n = format!("disco{}.test.svc.cluster.local", n);
-                    let tx = ctrl.destination_tx(&disco_n);
-                    tx.send_addr(srv_addr);
-                    tx // This will go into a vec, to keep the stream open.
-                })
-                .collect::<Vec<_>>();
-
-            let proxy = proxy::new()
-                .controller(ctrl.run())
-                .outbound(srv)
-                .run_with_test_env(env);
-
-            // Make two requests that go through service discovery, to reach the
-            // maximum number of Destination resolutions.
-            for n in 1..=2 {
-                let route = format!("disco{}.test.svc.cluster.local", n);
-                let client = $make_client(proxy.outbound, route);
-                println!("trying {}th destination...", n);
-                assert_eq!(client.get("/"), "hello");
-            }
-
-            // The next request will fail, because we have reached the
-            // Destination resolution limit, but we have _not_ reached the
-            // route cache capacity, so we won't start evicting inactive
-            // routes yet, and their Destination resolutions will remain
-            // active.
-            let client = $make_client(proxy.outbound, "disco3.test.svc.cluster.local");
-            println!("trying 3rd destination...");
-            let mut req = client.request_builder("/");
-            client
-                .request_async(req.method("GET"))
-                .wait_timeout(Duration::from_secs(1))
-                .expect_timedout("request should wait for destination capacity");
-
-            // However, a request for a DNS name that _doesn't_ go through the
-            // Destination service should not be affected by the limit.
-            // TODO: The controller should also assert the proxy doesn't make
-            // requests when it has hit the maximum number of resolutions.
-            let client = $make_client(proxy.outbound, "httpbin.org");
-            println!("trying httpbin.org...");
-            let mut req = client.request_builder("/");
-            let rsp = client.request(req.method("GET"));
-            assert_eq!(rsp.status(), http::StatusCode::OK);
-        }
-    };
-}
-
 macro_rules! generate_tests {
     (server: $make_server:path, client: $make_client:path) => {
         use linkerd2_proxy_api as pb;
@@ -91,81 +21,6 @@ macro_rules! generate_tests {
 
             assert_eq!(client.get("/"), "hello");
             assert_eq!(client.get("/bye"), "bye");
-        }
-
-        #[test]
-        fn outbound_dest_concurrency_limit() {
-            let _ = env_logger_init();
-            let srv = $make_server().route("/", "hello").run();
-            let srv_addr = srv.addr;
-
-            let mut env = app::config::TestEnv::new();
-
-            // Set the maximum number of Destination service resolutions
-            // lower than the total router capacity, so we can reach the
-            // maximum number of destinations before we start evicting
-            // routes.
-            let num_dests = 4;
-            env.put(app::config::ENV_DESTINATION_CLIENT_CONCURRENCY_LIMIT, (num_dests - 1).to_string());
-            env.put(app::config::ENV_OUTBOUND_ROUTER_CAPACITY, num_dests.to_string());
-            env.put(app::config::ENV_OUTBOUND_ROUTER_MAX_IDLE_AGE, "1s".to_owned());
-
-            let ctrl = controller::new();
-            let _txs = (1..=num_dests).map(|n| {
-                let disco_n = format!("disco{}.test.svc.cluster.local", n);
-                let tx = ctrl.destination_tx(&disco_n);
-                tx.send_addr(srv_addr);
-                tx // This will go into a vec, to keep the stream open.
-            }).collect::<Vec<_>>();
-
-            let proxy = proxy::new()
-                .controller(ctrl.run())
-                .outbound(srv)
-                .run_with_test_env(env);
-
-            // Make requests that go through service discovery, to reach the
-            // maximum number of Destination resolutions.
-            for n in 1..num_dests {
-                let route = format!("disco{}.test.svc.cluster.local", n);
-                let client = $make_client(proxy.outbound, &*route);
-                println!("expecting GET {} to be OK", route);
-                assert_eq!(client.get("/"), "hello");
-            }
-
-            // The next request will fail, because we have reached the
-            // Destination resolution limit, but we have _not_ reached the
-            // route cache capacity, so we won't start evicting inactive
-            // routes yet, and their Destination resolutions will remain
-            // active.
-            let nth_host = format!("disco{}.test.svc.cluster.local", num_dests);
-            let client = $make_client(proxy.outbound, &*nth_host);
-            println!("expecting GET {} destination to HANG...", nth_host);
-            let mut req = client.request_builder("/");
-            client
-                .request_async(req.method("GET"))
-                .wait_timeout(Duration::from_secs(1))
-                .expect_timedout("request should wait for destination capacity");
-
-            // TODO: The controller should also assert the proxy doesn't make
-            // requests when it has hit the maximum number of resolutions.
-
-            // Sleep for longer than the router cache's max idle age, so that
-            //  at least one old route will be considered inactive.
-            ::std::thread::sleep(Duration::from_secs(2));
-
-            // Next, make a request that _won't_ trigger a Destination lookup,
-            // so that we can reach the router's capacity as well.
-            let addr_client = $make_client(proxy.outbound, format!("{}", srv_addr));
-            println!("trying {} directly...", srv_addr);
-            assert_eq!(addr_client.get("/"), "hello");
-
-            // Now that the router cache capacity has been reached, subsequent
-            // requests that add a new route will evict an inactive route. This
-            // should drop their Destination resolutions, so we should now be
-            // able to open a new one.
-            println!("expecting GET {} destination to be OK", nth_host);
-            let client = $make_client(proxy.outbound, &*nth_host);
-            assert_eq!(client.get("/"), "hello");
         }
 
         #[test]
@@ -721,19 +576,11 @@ mod http1 {
     generate_tests! {
         server: server::http1, client: client::http1
     }
-    generate_outbound_dns_limit_test! {
-        server: server::http1, client: client::http1
-    }
 
     mod absolute_uris {
         use super::super::support::*;
 
         generate_tests! {
-            server: server::http1,
-            client: client::http1_absolute_uris
-        }
-
-        generate_outbound_dns_limit_test! {
             server: server::http1,
             client: client::http1_absolute_uris
         }


### PR DESCRIPTION
Currently, the proxy enforces a limit on the number of concurrent
queries (i.e., the number of gRPC streams) to the Destination service.
This limit was added based on information about the behaviour of the
Destination service that is now known to be incorrect.

This branch removes the limit on concurrent queries from the proxy's
`control::destination` module. Although it should now be possible to
simplify this code as a result of this change, I've refrained from doing
any major refactoring in this branch --- my intention is to do this
after the DNS fallback behaviour has also been removed, as together with
this change, that will result in a _significant_ simplification of the
module. Additionally, I've removed the tests for the concurrency limit,
as they are no longer relevant.

The `LINKERD2_PROXY_DESTINATION_CLIENT_CONCURRENCY_LIMIT` 
environment variable was also removed; this is not a breaking change as
neither the CLI nor the proxy injector will currently set this env var.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>