### PR TITLE
Eagerly drop services from the router cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,6 +592,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linkerd2-never 0.1.0",
  "linkerd2-stack 0.1.0",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,6 +593,8 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-stack 0.1.0",
+ "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,6 +595,7 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-stack 0.1.0",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,6 +594,7 @@ dependencies = [
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-stack 0.1.0",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1265,7 +1266,7 @@ dependencies = [
  "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1382,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-sync"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1506,7 +1507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1586,7 +1587,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2013,7 +2014,7 @@ dependencies = [
 "checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
 "checksum tokio-rustls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7223fa02f4b2d9f3736f13cc3dea3723aaec57ca4b3dded922126ebbb2cb8ce9"
 "checksum tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6a5bf935a0151cc8899aa806ce6a425bdaec79ed4034de1a1e6bfa247e2def"
-"checksum tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5b2f843ffdf8d6e1f90bddd48da43f99ab071660cd92b7ec560ef3cdfd7a409a"
+"checksum tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2162248ff317e2bc713b261f242b69dbb838b85248ed20bb21df56d60ea4cae7"
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
 "checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,12 +396,12 @@ dependencies = [
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -548,7 +548,7 @@ dependencies = [
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -593,7 +593,7 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-stack 0.1.0",
- "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -608,7 +608,7 @@ dependencies = [
  "linkerd2-never 0.1.0",
  "linkerd2-task 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -619,7 +619,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1252,7 +1252,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1265,9 +1265,9 @@ dependencies = [
  "tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1328,7 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-threadpool 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-sync"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-threadpool"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1506,7 +1506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1586,7 +1586,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1701,7 +1701,7 @@ dependencies = [
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-proto 0.6.0 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)",
 ]
 
@@ -2002,7 +2002,7 @@ dependencies = [
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
-"checksum tokio 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "65641e515a437b308ab131a82ce3042ff9795bef5d6c5a9be4eb24195c417fd9"
+"checksum tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "94a1f9396aec29d31bb16c24d155cfa144d1af91c40740125db3131bdaf76da8"
 "checksum tokio-buf 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "473a45a40e558d6d80e9f60e3d934c32488045def2745488a257e472941e9bce"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 "checksum tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)" = "<none>"
@@ -2013,9 +2013,9 @@ dependencies = [
 "checksum tokio-reactor 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3cedc8e5af5131dc3423ffa4f877cce78ad25259a9a62de0613735a13ebc64b"
 "checksum tokio-rustls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7223fa02f4b2d9f3736f13cc3dea3723aaec57ca4b3dded922126ebbb2cb8ce9"
 "checksum tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6a5bf935a0151cc8899aa806ce6a425bdaec79ed4034de1a1e6bfa247e2def"
-"checksum tokio-sync 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1bf2b9dac2a0509b5cfd1df5aa25eafacb616a42a491a13604d6bbeab4486363"
+"checksum tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5b2f843ffdf8d6e1f90bddd48da43f99ab071660cd92b7ec560ef3cdfd7a409a"
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
-"checksum tokio-threadpool 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "ec5759cf26cf9659555f36c431b515e3d05f66831741c85b4b5d5dfb9cf1323c"
+"checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6"
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
 "checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,6 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "linkerd2-never 0.1.0",
  "linkerd2-stack 0.1.0",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/lib/router/Cargo.toml
+++ b/lib/router/Cargo.toml
@@ -12,6 +12,7 @@ publish = false
 futures = "0.1"
 indexmap = "1.0.0"
 linkerd2-stack  = { path = "../stack" }
+log = "0.4"
 tower-load-shed = "0.1"
 tokio = "0.1.20"
 tokio-sync = "0.1.6"

--- a/lib/router/Cargo.toml
+++ b/lib/router/Cargo.toml
@@ -12,6 +12,6 @@ futures = "0.1"
 indexmap = "1.0.0"
 linkerd2-stack  = { path = "../stack" }
 tower-load-shed = "0.1"
-tokio = "0.1.7"
+tokio = "0.1.20"
 tokio-timer = "0.2.4"
 tower-service = "0.2"

--- a/lib/router/Cargo.toml
+++ b/lib/router/Cargo.toml
@@ -13,5 +13,6 @@ indexmap = "1.0.0"
 linkerd2-stack  = { path = "../stack" }
 tower-load-shed = "0.1"
 tokio = "0.1.20"
+tokio-sync = "0.1.6"
 tokio-timer = "0.2.4"
 tower-service = "0.2"

--- a/lib/router/Cargo.toml
+++ b/lib/router/Cargo.toml
@@ -12,4 +12,6 @@ futures = "0.1"
 indexmap = "1.0.0"
 linkerd2-stack  = { path = "../stack" }
 tower-load-shed = "0.1"
+tokio = "0.1.7"
+tokio-timer = "0.2.4"
 tower-service = "0.2"

--- a/lib/router/Cargo.toml
+++ b/lib/router/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 [dependencies]
 futures = "0.1"
 indexmap = "1.0.0"
+linkerd2-never = { path = "../never" }
 linkerd2-stack  = { path = "../stack" }
 tower-load-shed = "0.1"
 tokio = "0.1.20"

--- a/lib/router/Cargo.toml
+++ b/lib/router/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [dependencies]
 futures = "0.1"
 indexmap = "1.0.0"
-linkerd2-never = { path = "../never" }
 linkerd2-stack  = { path = "../stack" }
 tower-load-shed = "0.1"
 tokio = "0.1.20"

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -8,13 +8,13 @@ use tokio_timer::{delay_queue, DelayQueue, Error, Interval};
 /// An LRU cache that can eagerly remove values in a background task.
 ///
 /// Assumptions:
-///     - `access` is common
-///     - `insert` is less common
-///     - Values should have an `expires` span of time greater than 0
+/// - `access` is common
+/// - `insert` is less common
+/// - Values should have an `expires` span of time greater than 0
 ///
 /// Complexity:
-///     - `access` in **O(1)** time (amortized average)
-///     - `insert` in **O(1)** time (average)
+/// - `access` in **O(1)** time (amortized average)
+/// - `insert` in **O(1)** time (average)
 ///
 /// The underlying data structure of Cache is a [`DelayQueue`]. This allows
 /// the background task to remove values by polling for elements that have
@@ -30,7 +30,8 @@ where
 {
     capacity: usize,
     expires: Duration,
-    /// Elements are keys into `values`. As elements become Ready, we can
+    /// A queue of keys into `values` that become ready when the corresponding
+    /// cache entry expires. As elements become ready, we can
     /// remove the key and corresponding value from the cache.
     expirations: DelayQueue<K>,
     /// Cache access is coordinated through `values`. This field represents

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -1,10 +1,7 @@
 use futures::{Async, Future, Poll, Stream};
 use indexmap::IndexMap;
-use std::{
-    hash::Hash,
-    sync::{Arc, Mutex, TryLockError, Weak},
-    time::Duration,
-};
+use std::{hash::Hash, time::Duration};
+use tokio::sync::lock::Lock;
 use tokio_timer::{delay_queue, DelayQueue, Error, Interval};
 
 /// A cache that is internally maintained by a `tokio_timer::DelayQueue`.
@@ -16,7 +13,7 @@ use tokio_timer::{delay_queue, DelayQueue, Error, Interval};
 /// can be polled in the background and remove expired values.
 ///
 /// All values in the cache will expire after a `expires` span of time.
-pub struct Cache<K: Clone + Eq + Hash, V> {
+pub struct Cache<K: Clone + Eq + Hash + Send, V> {
     capacity: usize,
     expires: Duration,
     expirations: DelayQueue<K>,
@@ -28,15 +25,15 @@ pub struct Cache<K: Clone + Eq + Hash, V> {
 ///
 /// This contains a weak reference to a cache so that if use of the cache is
 /// dropped, it will not continue to be polled in the background.
-pub struct PurgeCache<K: Clone + Eq + Hash, V> {
-    cache: Weak<Mutex<Cache<K, V>>>,
+pub struct PurgeCache<K: Clone + Eq + Hash + Send, V> {
+    cache: Lock<Cache<K, V>>,
     interval: Interval,
 }
 
 /// Wraps a cache value so that a lock is held on the entire cache. When the
 /// access is dropped, the associated expiration time of the value in
 /// `expirations` is reset.
-pub struct Access<'a, K: Clone + Eq + Hash, V> {
+pub struct Access<'a, K: Clone + Eq + Hash + Send, V> {
     expires: Duration,
     expirations: &'a mut DelayQueue<K>,
     pub(crate) node: &'a mut Node<V>,
@@ -54,7 +51,7 @@ pub struct CapacityExhausted {
 }
 
 /// A handle to a cache that has capacity for at least one additional value.
-pub struct Reserve<'a, K: Clone + Eq + Hash, V> {
+pub struct Reserve<'a, K: Clone + Eq + Hash + Send, V> {
     expirations: &'a mut DelayQueue<K>,
     expires: Duration,
     vals: &'a mut IndexMap<K, Node<V>>,
@@ -62,17 +59,17 @@ pub struct Reserve<'a, K: Clone + Eq + Hash, V> {
 
 // ===== impl Cache =====
 
-impl<K: Clone + Eq + Hash, V> Cache<K, V> {
-    pub fn new(capacity: usize, expires: Duration) -> (Arc<Mutex<Cache<K, V>>>, PurgeCache<K, V>) {
+impl<K: Clone + Eq + Hash + Send, V> Cache<K, V> {
+    pub fn new(capacity: usize, expires: Duration) -> (Lock<Cache<K, V>>, PurgeCache<K, V>) {
         let cache = Self {
             capacity,
             expires,
             expirations: DelayQueue::with_capacity(capacity),
             vals: IndexMap::default(),
         };
-        let cache = Arc::new(Mutex::new(cache));
+        let cache = Lock::new(cache);
         let bg_purge = PurgeCache {
-            cache: Arc::downgrade(&cache),
+            cache: cache.clone(),
             interval: Interval::new_interval(expires),
         };
 
@@ -137,7 +134,7 @@ impl<K: Clone + Eq + Hash, V> Cache<K, V> {
 
 // ===== impl PurgeCache =====
 
-impl<K: Clone + Eq + Hash, V> Future for PurgeCache<K, V> {
+impl<K: Clone + Eq + Hash + Send, V> Future for PurgeCache<K, V> {
     type Item = ();
     type Error = ();
 
@@ -146,29 +143,17 @@ impl<K: Clone + Eq + Hash, V> Future for PurgeCache<K, V> {
             panic!("PurgeCache.interval Interval::poll must not fail: {}", e);
         }));
 
-        let lock = match self.cache.upgrade() {
-            Some(lock) => lock,
-            // Failing to upgrade the Weak reference means the cache has been
-            // dropped. We can stop trying to purge values.
-            None => return Ok(Async::Ready(())),
-        };
-        let mut cache = match lock.try_lock() {
-            // If we can lock the cache then do so
-            Ok(lock) => lock,
+        // let mut upgraded = match self.cache.upgrade() {
+        //     Some(upgraded) => upgraded,
 
-            // If we were unable to lock the cache, panic if the cause of error
-            // was a poisoned lock
-            Err(TryLockError::Poisoned(e)) => panic!("lock poisoned: {:?}", e),
+        //     // Failing to upgrade the Weak reference means the cache has been
+        //     // dropped. We can stop trying to purge values.
+        //     None => return Ok(Async::Ready(())),
+        // };
 
-            // If the lock is not poisoned, it is being held by another
-            // thread. Schedule this thread to be polled in the near future.
-            Err(_) => {
-                futures::task::current().notify();
-                return Ok(Async::NotReady);
-            }
-        };
+        let mut acquired = try_ready!(Ok(self.cache.poll_lock()));
 
-        cache.poll_purge().map_err(|e| {
+        acquired.poll_purge().map_err(|e| {
             panic!("PurgeCache.cache Cache::poll_purge must not fail: {}", e);
         })
     }
@@ -176,7 +161,7 @@ impl<K: Clone + Eq + Hash, V> Future for PurgeCache<K, V> {
 
 // ===== impl Access =====
 
-impl<'a, K: Clone + Eq + Hash, V> Drop for Access<'a, K, V> {
+impl<'a, K: Clone + Eq + Hash + Send, V> Drop for Access<'a, K, V> {
     fn drop(&mut self) {
         self.expirations.reset(&self.node.key, self.expires);
     }
@@ -192,7 +177,7 @@ impl<T> Node<T> {
 
 // ===== impl Reserve =====
 
-impl<'a, K: Clone + Eq + Hash, V> Reserve<'a, K, V> {
+impl<'a, K: Clone + Eq + Hash + Send, V> Reserve<'a, K, V> {
     pub fn store(self, key: K, val: V) {
         let node = {
             let delay = self.expirations.insert(key.clone(), self.expires);
@@ -202,201 +187,208 @@ impl<'a, K: Clone + Eq + Hash, V> Reserve<'a, K, V> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use futures::future;
-    use tokio::runtime::current_thread::{self, Runtime};
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use futures::future;
+//     use tokio::runtime::current_thread::{self, Runtime};
 
-    #[test]
-    fn reserve_and_store() {
-        current_thread::run(future::lazy(|| {
-            let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
+//     #[test]
+//     fn reserve_and_store() {
+//         current_thread::run(future::lazy(|| {
+//             let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
 
-            let mut cache = cache.lock().unwrap();
+//             let mut cache = loop {
+//                 match self.inner.cache.poll_lock() {
+//                     Async::Ready(acquired) => {
+//                         break acquired;
+//                     }
+//                     Async::NotReady => continue,
+//                 }
+//             };
 
-            cache.poll_reserve().expect("reserve").store(1, 2);
-            assert_eq!(cache.vals.len(), 1);
+//             cache.poll_reserve().expect("reserve").store(1, 2);
+//             assert_eq!(cache.vals.len(), 1);
 
-            cache.poll_reserve().expect("reserve").store(2, 3);
-            assert_eq!(cache.vals.len(), 2);
+//             cache.poll_reserve().expect("reserve").store(2, 3);
+//             assert_eq!(cache.vals.len(), 2);
 
-            assert_eq!(
-                cache.poll_reserve().err(),
-                Some(CapacityExhausted { capacity: 2 })
-            );
-            assert_eq!(cache.vals.len(), 2);
+//             assert_eq!(
+//                 cache.poll_reserve().err(),
+//                 Some(CapacityExhausted { capacity: 2 })
+//             );
+//             assert_eq!(cache.vals.len(), 2);
 
-            Ok(())
-        }))
-    }
+//             Ok(Async::Ready(()))
+//         }))
+//     }
 
-    #[test]
-    fn store_access_value() {
-        current_thread::run(future::lazy(|| {
-            let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
+//     #[test]
+//     fn store_access_value() {
+//         current_thread::run(future::lazy(|| {
+//             let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
 
-            let mut cache = cache.lock().unwrap();
+//             let mut cache = try_ready!(Ok(cache.poll_lock()));
 
-            assert!(cache.access(&1).is_none());
-            assert!(cache.access(&2).is_none());
+//             assert!(cache.access(&1).is_none());
+//             assert!(cache.access(&2).is_none());
 
-            cache.poll_reserve().expect("reserve").store(1, 2);
-            assert!(cache.access(&1).is_some());
-            assert!(cache.access(&2).is_none());
+//             cache.poll_reserve().expect("reserve").store(1, 2);
+//             assert!(cache.access(&1).is_some());
+//             assert!(cache.access(&2).is_none());
 
-            cache.poll_reserve().expect("reserve").store(2, 3);
-            assert!(cache.access(&1).is_some());
-            assert!(cache.access(&2).is_some());
+//             cache.poll_reserve().expect("reserve").store(2, 3);
+//             assert!(cache.access(&1).is_some());
+//             assert!(cache.access(&2).is_some());
 
-            assert_eq!(cache.access(&1).take().unwrap().node.value, 2);
-            assert_eq!(cache.access(&2).take().unwrap().node.value, 3);
+//             assert_eq!(cache.access(&1).take().unwrap().node.value, 2);
+//             assert_eq!(cache.access(&2).take().unwrap().node.value, 3);
 
-            Ok(())
-        }))
-    }
+//             Ok(Async::Ready(()))
+//         }))
+//     }
 
-    #[test]
-    fn reserve_does_nothing_when_capacity_exists() {
-        current_thread::run(futures::future::lazy(|| {
-            let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
+//     #[test]
+//     fn reserve_does_nothing_when_capacity_exists() {
+//         current_thread::run(futures::future::lazy(|| {
+//             let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
 
-            let mut cache = cache.lock().unwrap();
+//             let mut cache = try_ready!(Ok(cache.poll_lock()));
 
-            cache.poll_reserve().expect("capacity").store(1, 2);
-            assert_eq!(cache.vals.len(), 1);
+//             cache.poll_reserve().expect("capacity").store(1, 2);
+//             assert_eq!(cache.vals.len(), 1);
 
-            assert!(cache.poll_reserve().is_ok());
-            assert_eq!(cache.vals.len(), 1);
+//             assert!(cache.poll_reserve().is_ok());
+//             assert_eq!(cache.vals.len(), 1);
 
-            Ok(())
-        }))
-    }
+//             Ok(Async::Ready(()))
+//         }))
+//     }
 
-    #[test]
-    fn store_and_self_purge() {
-        let mut rt = Runtime::new().unwrap();
+//     #[test]
+//     fn store_and_self_purge() {
+//         let mut rt = Runtime::new().unwrap();
 
-        let (cache, _cache_purge) = rt
-            .block_on(future::lazy(|| {
-                Ok::<_, ()>(Cache::new(2, Duration::from_millis(10)))
-            }))
-            .unwrap();
+//         let (cache, _cache_purge) = rt
+//             .block_on(future::lazy(|| {
+//                 Ok::<_, ()>(Cache::new(2, Duration::from_millis(10)))
+//             }))
+//             .unwrap();
 
-        // Fill the cache, but do not spawn a background purge task
-        rt.block_on(future::lazy(|| {
-            let mut cache_1 = cache.lock().unwrap();
+//         // Fill the cache, but do not spawn a background purge task
+//         rt.block_on(future::lazy(|| {
+//             let mut cache_1 = cache.lock().unwrap();
 
-            cache_1.poll_reserve().expect("reserve").store(1, 2);
-            cache_1.poll_reserve().expect("reserve").store(2, 3);
-            assert_eq!(cache_1.vals.len(), 2);
+//             cache_1.poll_reserve().expect("reserve").store(1, 2);
+//             cache_1.poll_reserve().expect("reserve").store(2, 3);
+//             assert_eq!(cache_1.vals.len(), 2);
 
-            Ok::<_, ()>(())
-        }))
-        .unwrap();
+//             Ok::<_, ()>(())
+//         }))
+//         .unwrap();
 
-        // Sleep for enough time that cache values should be expired
-        rt.block_on(tokio_timer::sleep(Duration::from_millis(100)))
-            .unwrap();
+//         // Sleep for enough time that cache values should be expired
+//         rt.block_on(tokio_timer::sleep(Duration::from_millis(100)))
+//             .unwrap();
 
-        // Force `reserve` to purge the cache
-        rt.block_on(future::lazy(|| {
-            let mut cache_2 = cache.lock().unwrap();
+//         // Force `reserve` to purge the cache
+//         rt.block_on(future::lazy(|| {
+//             let mut cache_2 = cache.lock().unwrap();
 
-            cache_2.poll_reserve().expect("reserve").store(3, 4);
-            assert_eq!(cache_2.vals.len(), 2);
-            assert!(cache_2.access(&3).is_some());
+//             cache_2.poll_reserve().expect("reserve").store(3, 4);
+//             assert_eq!(cache_2.vals.len(), 2);
+//             assert!(cache_2.access(&3).is_some());
 
-            Ok::<_, ()>(())
-        }))
-        .unwrap()
-    }
+//             Ok::<_, ()>(())
+//         }))
+//         .unwrap()
+//     }
 
-    #[test]
-    fn store_and_background_purge() {
-        let mut rt = Runtime::new().unwrap();
+//     #[test]
+//     fn store_and_background_purge() {
+//         let mut rt = Runtime::new().unwrap();
 
-        let (cache, cache_purge) = rt
-            .block_on(futures::future::lazy(|| {
-                Ok::<_, ()>(Cache::new(2, Duration::from_millis(10)))
-            }))
-            .unwrap();
+//         let (cache, cache_purge) = rt
+//             .block_on(futures::future::lazy(|| {
+//                 Ok::<_, ()>(Cache::new(2, Duration::from_millis(10)))
+//             }))
+//             .unwrap();
 
-        // Spawn a background purge task on the runtime
-        rt.spawn(cache_purge);
+//         // Spawn a background purge task on the runtime
+//         rt.spawn(cache_purge);
 
-        // Fill the cache
-        rt.block_on(future::lazy(|| {
-            let mut cache = cache.lock().unwrap();
+//         // Fill the cache
+//         rt.block_on(future::lazy(|| {
+//             let mut cache = cache.lock().unwrap();
 
-            cache.poll_reserve().expect("reserve").store(1, 2);
-            cache.poll_reserve().expect("reserve").store(2, 3);
-            assert_eq!(cache.vals.len(), 2);
+//             cache.poll_reserve().expect("reserve").store(1, 2);
+//             cache.poll_reserve().expect("reserve").store(2, 3);
+//             assert_eq!(cache.vals.len(), 2);
 
-            Ok::<_, ()>(())
-        }))
-        .unwrap();
+//             Ok::<_, ()>(())
+//         }))
+//         .unwrap();
 
-        // Sleep for enough time that all cache values expire
-        rt.block_on(tokio_timer::sleep(Duration::from_millis(100)))
-            .unwrap();
+//         // Sleep for enough time that all cache values expire
+//         rt.block_on(tokio_timer::sleep(Duration::from_millis(100)))
+//             .unwrap();
 
-        assert_eq!(cache.lock().unwrap().vals.len(), 0);
-    }
+//         assert_eq!(cache.lock().unwrap().vals.len(), 0);
+//     }
 
-    #[test]
-    fn drop_access_resets_expiration() {
-        let mut rt = current_thread::Runtime::new().unwrap();
+//     #[test]
+//     fn drop_access_resets_expiration() {
+//         let mut rt = current_thread::Runtime::new().unwrap();
 
-        let (cache, cache_purge) = rt
-            .block_on(futures::future::lazy(|| {
-                Ok::<_, ()>(Cache::new(2, Duration::from_millis(10)))
-            }))
-            .unwrap();
+//         let (cache, cache_purge) = rt
+//             .block_on(futures::future::lazy(|| {
+//                 Ok::<_, ()>(Cache::new(2, Duration::from_millis(10)))
+//             }))
+//             .unwrap();
 
-        // Spawn a background purge task on the runtime
-        rt.spawn(cache_purge);
+//         // Spawn a background purge task on the runtime
+//         rt.spawn(cache_purge);
 
-        {
-            let mut cache = cache.lock().unwrap();
+//         {
+//             let mut cache = cache.lock().unwrap();
 
-            // Hold on to an access handle the cache
-            let _access = rt
-                .block_on(future::lazy(|| {
-                    cache.poll_reserve().expect("reserve").store(1, 2);
-                    assert!(cache.access(&1).is_some());
+//             // Hold on to an access handle the cache
+//             let _access = rt
+//                 .block_on(future::lazy(|| {
+//                     cache.poll_reserve().expect("reserve").store(1, 2);
+//                     assert!(cache.access(&1).is_some());
 
-                    Ok::<_, ()>(cache.access(&1))
-                }))
-                .unwrap();
+//                     Ok::<_, ()>(cache.access(&1))
+//                 }))
+//                 .unwrap();
 
-            // Sleep for enough time that the background purge would remove the value
-            rt.block_on(tokio_timer::sleep(Duration::from_millis(100)))
-                .unwrap();
+//             // Sleep for enough time that the background purge would remove the value
+//             rt.block_on(tokio_timer::sleep(Duration::from_millis(100)))
+//                 .unwrap();
 
-            // Drop both the access and cache handles. Dropping the
-            // access handle will reset the expiration on the value in the cache.
-            // Dropping the cache handle will unlock the cache and allow a
-            // background purge to occur.
-        }
+//             // Drop both the access and cache handles. Dropping the
+//             // access handle will reset the expiration on the value in the cache.
+//             // Dropping the cache handle will unlock the cache and allow a
+//             // background purge to occur.
+//         }
 
-        // Ensure a background purge is polled so that it can expire any
-        // values.
-        rt.block_on(future::lazy(|| {
-            tokio_timer::sleep(Duration::from_millis(1))
-        }))
-        .unwrap();
+//         // Ensure a background purge is polled so that it can expire any
+//         // values.
+//         rt.block_on(future::lazy(|| {
+//             tokio_timer::sleep(Duration::from_millis(1))
+//         }))
+//         .unwrap();
 
-        rt.block_on(future::lazy(|| {
-            let mut cache = cache.lock().unwrap();
+//         rt.block_on(future::lazy(|| {
+//             let mut cache = cache.lock().unwrap();
 
-            // The cache value should still be present since it was reset after
-            // the value expiration. We ensured a background purge occurred but
-            // that it did not purge the value.
-            assert!(cache.access(&1).is_some());
+//             // The cache value should still be present since it was reset after
+//             // the value expiration. We ensured a background purge occurred but
+//             // that it did not purge the value.
+//             assert!(cache.access(&1).is_some());
 
-            Ok::<_, ()>(())
-        }))
-        .unwrap()
-    }
-}
+//             Ok::<_, ()>(())
+//         }))
+//         .unwrap()
+//     }
+// }

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -319,25 +319,25 @@ mod tests {
         // Spawn a background purge on the current runtime
         runtime.spawn(cache_purge);
 
-        let mut cache_1 = cache.lock().unwrap();
+        {
+            let mut cache_1 = cache.lock().unwrap();
 
-        cache_1.reserve().expect("reserve").store(1, 2);
-        assert!(cache_1.access(&1).is_some());
-        let access = cache_1.access(&1);
+            cache_1.reserve().expect("reserve").store(1, 2);
+            assert!(cache_1.access(&1).is_some());
+            let _access = cache_1.access(&1);
 
-        // Sleep for an amount of time greater than the expiry duration so
-        // that the background purge would purge the cache iff values can
-        // be expired.
-        runtime
-            .block_on(tokio_timer::sleep(Duration::from_millis(100)))
-            .unwrap();
+            // Sleep for an amount of time greater than the expiry duration so
+            // that the background purge would purge the cache iff values can
+            // be expired.
+            runtime
+                .block_on(tokio_timer::sleep(Duration::from_millis(100)))
+                .unwrap();
 
-        // Explicity drop both the access and cache handles. Dropping the
-        // access handle will reset the expiration on the value in the cache.
-        // Dropping the cache handle will unlock the cache and allow a
-        // background purge to occur.
-        drop(access);
-        drop(cache_1);
+            // Explicity drop both the access and cache handles. Dropping the
+            // access handle will reset the expiration on the value in the cache.
+            // Dropping the cache handle will unlock the cache and allow a
+            // background purge to occur.
+        }
 
         // Ensure a background purge is polled so that it can expire any
         // values.

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -1,6 +1,6 @@
 use std::{hash::Hash, time::Duration};
 
-use futures::{Async, Future, Poll, Stream, try_ready};
+use futures::{try_ready, Async, Future, Poll, Stream};
 use indexmap::IndexMap;
 use tokio::sync::lock::Lock;
 use tokio_timer::{delay_queue, DelayQueue, Error, Interval};

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -1,426 +1,189 @@
+use futures::{Async, Future, Poll, Stream};
 use indexmap::IndexMap;
 use std::{
     hash::Hash,
-    ops::{Deref, DerefMut},
-    time::{Duration, Instant},
+    sync::{Arc, Mutex, TryLockError, Weak},
+    time::Duration,
 };
+use tokio_timer::{delay_queue, DelayQueue, Error, Interval};
 
-// Reexported so IndexMap isn't exposed.
-pub use indexmap::Equivalent;
-
-/// An LRU cache
-///
-/// ## Assumptions
-///
-/// - `access` is common;
-/// - `store` is less common;
-/// - `capacity` is large enough that idle vals need not be removed frequently.
-///
-/// ## Complexity
-///
-/// - `access` computes in O(1) time (amortized average).
-/// - `store` computes in O(1) time (average).
-/// - `reserve` computes in O(n) time (average) when capacity is not available,
-///
-/// ### TODO
-///
-/// The underlying datastructure could be improved somewhat so that `reserve` can evict
-/// unused nodes more efficiently. Given that eviction is intended to be rare, this is
-/// probably not a very high priority.
-pub struct Cache<K: Hash + Eq, V, N: Now = ()> {
-    vals: IndexMap<K, Node<V>>,
+/// An LRU cache that is purged by a background purge task.
+pub struct Cache<K: Clone + Eq + Hash, V> {
     capacity: usize,
-    max_idle_age: Duration,
-
-    /// The time source.
-    now: N,
+    expires: Duration,
+    expirations: DelayQueue<K>,
+    vals: IndexMap<K, Node<V>>,
 }
 
-/// Provides the current time within the module. Useful for testing.
-pub trait Now {
-    fn now(&self) -> Instant;
+/// Purge a cache at a set interval.
+pub struct PurgeCache<K: Clone + Eq + Hash, V> {
+    cache: Weak<Mutex<Cache<K, V>>>,
+    interval: Interval,
 }
 
-/// Wraps cache values so that each tracks its last access time.
-#[derive(Debug, PartialEq)]
+/// Wrap a cache node so that a lock is held on the entire cache. When the
+/// access is dropped, reset the cache node so that it is not purged.
+pub struct Access<'a, K: Clone + Eq + Hash, V> {
+    expires: Duration,
+    expirations: &'a mut DelayQueue<K>,
+    pub(crate) node: &'a mut Node<V>,
+}
+
+/// This is the handle to a cache value.
 pub struct Node<T> {
-    value: T,
-    last_access: Instant,
+    key: delay_queue::Key,
+    pub(crate) value: T,
 }
 
-/// A smart pointer that updates an access time when dropped.
-///
-/// Wraps a mutable reference to a `V`-typed value.
-///
-/// When the guard is dropped, the value's `last_access` time is updated with the provided
-/// time source.
-#[derive(Debug)]
-pub struct Access<'a, T: 'a, N: Now + 'a = ()> {
-    node: &'a mut Node<T>,
-    now: &'a N,
-}
-
-/// A handle to a `Cache` that has capacity for at least one additional value.
-#[derive(Debug)]
-pub struct Reserve<'a, K: Hash + Eq + 'a, V: 'a, N: 'a> {
-    vals: &'a mut IndexMap<K, Node<V>>,
-    now: &'a N,
-}
-
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct CapacityExhausted {
-    pub capacity: usize,
+    pub(crate) capacity: usize,
+}
+
+/// A handle to a cache that has capacity for at least one additional value.
+pub struct Reserve<'a, K: Clone + Eq + Hash, V> {
+    expirations: &'a mut DelayQueue<K>,
+    expires: Duration,
+    vals: &'a mut IndexMap<K, Node<V>>,
 }
 
 // ===== impl Cache =====
 
-impl<K: Hash + Eq, V> Cache<K, V, ()> {
-    pub fn new(capacity: usize, max_idle_age: Duration) -> Self {
-        Self {
+impl<K: Clone + Eq + Hash, V> Cache<K, V> {
+    pub fn new(capacity: usize, expires: Duration) -> (Arc<Mutex<Cache<K, V>>>, PurgeCache<K, V>) {
+        let cache = Self {
             capacity,
+            expires,
+            expirations: DelayQueue::with_capacity(capacity),
             vals: IndexMap::default(),
-            max_idle_age,
-            now: (),
-        }
-    }
-}
+        };
+        let cache = Arc::new(Mutex::new(cache));
+        let bg_purge = PurgeCache {
+            cache: Arc::downgrade(&cache),
+            interval: Interval::new_interval(expires),
+        };
 
-impl<K: Hash + Eq, V, N: Now> Cache<K, V, N> {
-    /// Accesses a route.
-    ///
-    /// A mutable reference to the route is wrapped in the returned `Access` to
-    /// ensure that the access-time is updated when the reference is released.
-    pub fn access<Q>(&mut self, key: &Q) -> Option<Access<V, N>>
-    where
-        Q: Hash + Equivalent<K>,
-    {
-        let v = self.vals.get_mut(key)?;
-        Some(v.access(&self.now))
+        (cache, bg_purge)
     }
 
-    /// Ensures that there is capacity to store an additional route.
-    ///
-    /// Returns a handle that may be used to store an ite,. If there is no available
-    /// capacity, idle entries may be evicted to create capacity.
-    ///
-    /// An error is returned if there is no available capacity.
-    pub fn reserve(&mut self) -> Result<Reserve<K, V, N>, CapacityExhausted> {
+    pub fn access(&mut self, key: &K) -> Option<Access<K, V>> {
+        let node = self.vals.get_mut(key)?;
+        Some(Access {
+            expires: self.expires,
+            expirations: &mut self.expirations,
+            node,
+        })
+    }
+
+    pub fn reserve(&mut self) -> Result<Reserve<K, V>, CapacityExhausted> {
         if self.vals.len() == self.capacity {
-            // Only whole seconds are used to determine whether a node should be retained.
-            // This is intended to prevent the need for repetitive reservations when
-            // entries are clustered in tight time ranges.
-            let max_age = self.max_idle_age.as_secs();
-            let now = self.now.now();
-            self.vals.retain(|_, n| {
-                let age = now - n.last_access();
-                age.as_secs() <= max_age
-            });
+            match self.expirations.poll() {
+                // The cache is at capacity but we are able to remove a value.
+                Ok(Async::Ready(Some(entry))) => {
+                    self.vals.remove(entry.get_ref());
+                }
 
-            if self.vals.len() == self.capacity {
-                return Err(CapacityExhausted {
-                    capacity: self.capacity,
-                });
+                // `Ready(None)` can only be returned when expirations is
+                // empty. We know `expirations` is not empty because `vals` is
+                // not empty.
+                Ok(Async::Ready(None)) => unreachable!(),
+
+                // The cache is at capacity and no values can be removed.
+                Ok(Async::NotReady) => {
+                    return Err(CapacityExhausted {
+                        capacity: self.capacity,
+                    });
+                }
+
+                // `warn!` could be helpful here in an actual use case.
+                Err(_e) => {
+                    return Err(CapacityExhausted {
+                        capacity: self.capacity,
+                    });
+                }
             }
         }
 
         Ok(Reserve {
+            expirations: &mut self.expirations,
+            expires: self.expires,
             vals: &mut self.vals,
-            now: &self.now,
         })
     }
 
-    /// Overrides the time source for tests.
-    #[cfg(test)]
-    fn with_clock<M: Now>(self, now: M) -> Cache<K, V, M> {
-        Cache {
-            now,
-            vals: self.vals,
-            capacity: self.capacity,
-            max_idle_age: self.max_idle_age,
+    fn poll_purge(&mut self) -> Poll<(), Error> {
+        while let Some(entry) = try_ready!(self.expirations.poll()) {
+            self.vals.remove(entry.get_ref());
         }
+
+        Ok(Async::Ready(()))
     }
 }
 
-// ===== impl Reserve =====
+// ===== impl PurgeCache =====
 
-impl<'a, K: Hash + Eq + 'a, V: 'a, N: Now + 'a> Reserve<'a, K, V, N> {
-    /// Stores a route in the cache.
-    pub fn store(self, key: K, val: V) {
-        let node = Node::new(val.into(), self.now.now());
-        self.vals.insert(key, node);
+impl<K: Clone + Eq + Hash, V> Future for PurgeCache<K, V> {
+    type Item = ();
+
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        try_ready!(self.interval.poll().map_err(|e| {
+            println!("error polling purge interval: {:?}", e);
+            ()
+        }));
+
+        let lock = match self.cache.upgrade() {
+            Some(lock) => lock,
+            None => return Ok(Async::Ready(())),
+        };
+        let mut cache = match lock.try_lock() {
+            // If we can lock the cache then do so
+            Ok(lock) => lock,
+
+            // If we were unable to lock the cache, panic if the cause of error
+            // was a poisoned lock
+            Err(TryLockError::Poisoned(e)) => panic!("lock poisoned: {:?}", e),
+
+            // If the lock is not poisoned, it is being held by another
+            // thread. Schedule this thread to be polled in the near future.
+            Err(_) => {
+                futures::task::current().notify();
+                return Ok(Async::NotReady);
+            }
+        };
+
+        cache.poll_purge().map_err(|e| {
+            println!("error purging cache: {:?}", e);
+            ()
+        })
     }
 }
 
 // ===== impl Access =====
 
-impl<'a, T: 'a, N: Now + 'a> Deref for Access<'a, T, N> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.node
-    }
-}
-
-impl<'a, T: 'a, N: Now + 'a> DerefMut for Access<'a, T, N> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.node
-    }
-}
-
-impl<'a, T: 'a, N: Now + 'a> Access<'a, T, N> {
-    #[cfg(test)]
-    fn last_access(&self) -> Instant {
-        self.node.last_access
-    }
-}
-
-impl<'a, T: 'a, N: Now + 'a> Drop for Access<'a, T, N> {
+impl<'a, K: Clone + Eq + Hash, V> Drop for Access<'a, K, V> {
     fn drop(&mut self) {
-        self.node.last_access = self.now.now();
+        self.expirations.reset(&self.node.key, self.expires);
     }
 }
 
 // ===== impl Node =====
 
 impl<T> Node<T> {
-    pub fn new(value: T, last_access: Instant) -> Self {
-        Node { value, last_access }
-    }
-
-    pub fn access<'a, N: Now + 'a>(&'a mut self, now: &'a N) -> Access<'a, T, N> {
-        Access { now, node: self }
-    }
-
-    pub fn last_access(&self) -> Instant {
-        self.last_access
+    pub fn new(key: delay_queue::Key, value: T) -> Self {
+        Node { key, value }
     }
 }
 
-impl<T> Deref for Node<T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
-}
+// ===== impl Reserve =====
 
-impl<T> DerefMut for Node<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.value
-    }
-}
-
-// ===== impl Now =====
-
-/// Default source of time.
-impl Now for () {
-    fn now(&self) -> Instant {
-        Instant::now()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use futures::Future;
-    use std::{
-        cell::RefCell,
-        rc::Rc,
-        time::{Duration, Instant},
-    };
-    use svc::Service;
-    use test_util::MultiplyAndAssign;
-
-    /// A mocked instance of `Now` to drive tests.
-    #[derive(Clone)]
-    pub struct Clock(Rc<RefCell<Instant>>);
-
-    // ===== impl Clock =====
-
-    impl Default for Clock {
-        fn default() -> Clock {
-            Clock(Rc::new(RefCell::new(Instant::now())))
-        }
-    }
-
-    impl Clock {
-        pub fn advance(&mut self, d: Duration) {
-            *self.0.borrow_mut() += d;
-        }
-    }
-
-    impl Now for Clock {
-        fn now(&self) -> Instant {
-            self.0.borrow().clone()
-        }
-    }
-
-    #[test]
-    fn reserve_and_store() {
-        let mut cache = Cache::<_, MultiplyAndAssign>::new(2, Duration::from_secs(1));
-
-        {
-            let r = cache.reserve().expect("reserve");
-            r.store(1, MultiplyAndAssign::default());
-        }
-        assert_eq!(cache.vals.len(), 1);
-
-        {
-            let r = cache.reserve().expect("reserve");
-            r.store(2, MultiplyAndAssign::default());
-        }
-        assert_eq!(cache.vals.len(), 2);
-
-        assert_eq!(
-            cache.reserve().err(),
-            Some(CapacityExhausted { capacity: 2 })
-        );
-        assert_eq!(cache.vals.len(), 2);
-    }
-
-    #[test]
-    fn store_and_access() {
-        let mut cache = Cache::<_, MultiplyAndAssign>::new(2, Duration::from_secs(0));
-
-        assert!(cache.access(&1).is_none());
-        assert!(cache.access(&2).is_none());
-
-        {
-            let r = cache.reserve().expect("reserve");
-            r.store(1, MultiplyAndAssign::default());
-        }
-        assert!(cache.access(&1).is_some());
-        assert!(cache.access(&2).is_none());
-
-        {
-            let r = cache.reserve().expect("reserve");
-            r.store(2, MultiplyAndAssign::default());
-        }
-        assert!(cache.access(&1).is_some());
-        assert!(cache.access(&2).is_some());
-    }
-
-    #[test]
-    fn reserve_does_nothing_when_capacity_exists() {
-        let mut cache = Cache::<_, MultiplyAndAssign, _>::new(2, Duration::from_secs(0));
-
-        // Create a route that goes idle immediately:
-        {
-            let r = cache.reserve().expect("capacity");
-            let mut service = MultiplyAndAssign::default();
-            service.call(1.into()).wait().unwrap();
-            r.store(1, service);
+impl<'a, K: Clone + Eq + Hash, V> Reserve<'a, K, V> {
+    pub fn store(self, key: K, val: V) {
+        let node = {
+            let delay = self.expirations.insert(key.clone(), self.expires);
+            Node::new(delay, val)
         };
-        assert_eq!(cache.vals.len(), 1);
-
-        assert!(cache.reserve().is_ok());
-        assert_eq!(cache.vals.len(), 1);
-    }
-
-    #[test]
-    fn reserve_honors_max_idle_age() {
-        let mut clock = Clock::default();
-        let mut cache = Cache::<_, MultiplyAndAssign, _>::new(1, Duration::from_secs(2))
-            .with_clock(clock.clone());
-
-        // Touch `1` at 0s.
-        cache
-            .reserve()
-            .expect("capacity")
-            .store(1, MultiplyAndAssign::default());
-        assert_eq!(
-            cache.reserve().err(),
-            Some(CapacityExhausted { capacity: 1 })
-        );
-        assert_eq!(cache.vals.len(), 1);
-
-        // No capacity at 1s.
-        clock.advance(Duration::from_secs(1));
-        assert_eq!(
-            cache.reserve().err(),
-            Some(CapacityExhausted { capacity: 1 })
-        );
-        assert_eq!(cache.vals.len(), 1);
-
-        // No capacity at 2s.
-        clock.advance(Duration::from_secs(1));
-        assert_eq!(
-            cache.reserve().err(),
-            Some(CapacityExhausted { capacity: 1 })
-        );
-        assert_eq!(cache.vals.len(), 1);
-
-        // Capacity at 3+s.
-        clock.advance(Duration::from_secs(1));
-        assert!(cache.reserve().is_ok());
-        assert_eq!(cache.vals.len(), 0);
-    }
-
-    #[test]
-    fn last_access() {
-        let mut clock = Clock::default();
-        let mut cache =
-            Cache::<_, MultiplyAndAssign>::new(1, Duration::from_secs(0)).with_clock(clock.clone());
-
-        let t0 = clock.now();
-        cache
-            .reserve()
-            .expect("capacity")
-            .store(333, MultiplyAndAssign::default());
-
-        clock.advance(Duration::from_secs(1));
-        let t1 = clock.now();
-        assert_eq!(cache.access(&333).map(|n| n.last_access()), Some(t0));
-
-        clock.advance(Duration::from_secs(1));
-        assert_eq!(cache.access(&333).map(|n| n.last_access()), Some(t1));
-    }
-
-    #[test]
-    fn last_access_wiped_on_evict() {
-        let mut clock = Clock::default();
-        let mut cache =
-            Cache::<_, MultiplyAndAssign>::new(1, Duration::from_secs(0)).with_clock(clock.clone());
-
-        let t0 = clock.now();
-        cache
-            .reserve()
-            .expect("capacity")
-            .store(333, MultiplyAndAssign::default());
-
-        clock.advance(Duration::from_secs(1));
-        assert_eq!(cache.access(&333).map(|n| n.last_access()), Some(t0));
-
-        // Cause the router to evict the `333` route.
-        clock.advance(Duration::from_secs(1));
-        cache
-            .reserve()
-            .expect("capacity")
-            .store(444, MultiplyAndAssign::default());
-
-        clock.advance(Duration::from_secs(1));
-        let t1 = clock.now();
-        cache
-            .reserve()
-            .expect("capacity")
-            .store(333, MultiplyAndAssign::default());
-
-        clock.advance(Duration::from_secs(1));
-        assert_eq!(cache.access(&333).map(|n| n.last_access()), Some(t1));
-    }
-
-    #[test]
-    fn node_access_updated_on_drop() {
-        let mut clock = Clock::default();
-        let t0 = clock.now();
-        let mut node = Node::new(123, t0);
-
-        clock.advance(Duration::from_secs(1));
-        {
-            let access = node.access(&clock);
-            assert_eq!(access.last_access(), t0);
-        }
-
-        let t1 = clock.now();
-        assert_eq!(node.last_access(), t1);
-        assert_ne!(t0, t1);
+        self.vals.insert(key, node);
     }
 }

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -89,6 +89,13 @@ impl<K: Clone + Eq + Hash, V> Cache<K, V> {
     }
 
     pub fn reserve(&mut self) -> Result<Reserve<K, V>, CapacityExhausted> {
+        // If the cache capacity is zero, then we have no space to reserve a slot
+        if self.capacity == 0 {
+            return Err(CapacityExhausted {
+                capacity: self.capacity,
+            });
+        }
+
         if self.vals.len() == self.capacity {
             match self.expirations.poll() {
                 // The cache is at capacity but we are able to remove a value.
@@ -98,8 +105,8 @@ impl<K: Clone + Eq + Hash, V> Cache<K, V> {
 
                 // `Ready(None)` can only be returned when expirations is
                 // empty. We know `expirations` is not empty because `vals` is
-                // not empty.
-                Ok(Async::Ready(None)) => unreachable!(),
+                // not empty and capacity does not equal zero.
+                Ok(Async::Ready(None)) => unreachable!("cache expirations cannot be empty"),
 
                 // The cache is at capacity and no values can be removed.
                 Ok(Async::NotReady) => {
@@ -108,11 +115,7 @@ impl<K: Clone + Eq + Hash, V> Cache<K, V> {
                     });
                 }
 
-                Err(_e) => {
-                    return Err(CapacityExhausted {
-                        capacity: self.capacity,
-                    });
-                }
+                Err(e) => panic!("Cache.expirations DelayQueue::poll must not fail: {}", e),
             }
         }
 
@@ -140,12 +143,13 @@ impl<K: Clone + Eq + Hash, V> Future for PurgeCache<K, V> {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         try_ready!(self.interval.poll().map_err(|e| {
-            println!("error polling purge interval: {:?}", e);
-            ()
+            panic!("PurgeCache.interval Interval::poll must not fail: {}", e);
         }));
 
         let lock = match self.cache.upgrade() {
             Some(lock) => lock,
+            // Failing to upgrade the Weak reference means the cache has been
+            // dropped. We can stop trying to purge values.
             None => return Ok(Async::Ready(())),
         };
         let mut cache = match lock.try_lock() {
@@ -165,8 +169,7 @@ impl<K: Clone + Eq + Hash, V> Future for PurgeCache<K, V> {
         };
 
         cache.poll_purge().map_err(|e| {
-            println!("error purging cache: {:?}", e);
-            ()
+            panic!("PurgeCache.cache Cache::poll_purge must not fail: {}", e);
         })
     }
 }
@@ -202,150 +205,176 @@ impl<'a, K: Clone + Eq + Hash, V> Reserve<'a, K, V> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::future;
+    use tokio::runtime::current_thread::{self, Runtime};
 
     #[test]
     fn reserve_and_store() {
-        let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
+        current_thread::run(future::lazy(|| {
+            let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
 
-        let mut cache = cache.lock().unwrap();
+            let mut cache = cache.lock().unwrap();
 
-        cache.reserve().expect("reserve").store(1, 2);
-        assert_eq!(cache.vals.len(), 1);
+            cache.reserve().expect("reserve").store(1, 2);
+            assert_eq!(cache.vals.len(), 1);
 
-        cache.reserve().expect("reserve").store(2, 3);
-        assert_eq!(cache.vals.len(), 2);
+            cache.reserve().expect("reserve").store(2, 3);
+            assert_eq!(cache.vals.len(), 2);
 
-        assert_eq!(
-            cache.reserve().err(),
-            Some(CapacityExhausted { capacity: 2 })
-        );
+            assert_eq!(
+                cache.reserve().err(),
+                Some(CapacityExhausted { capacity: 2 })
+            );
+            assert_eq!(cache.vals.len(), 2);
 
-        assert_eq!(cache.vals.len(), 2);
+            Ok(())
+        }))
     }
 
     #[test]
     fn store_access_value() {
-        let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
+        current_thread::run(future::lazy(|| {
+            let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
 
-        let mut cache = cache.lock().unwrap();
+            let mut cache = cache.lock().unwrap();
 
-        assert!(cache.access(&1).is_none());
-        assert!(cache.access(&2).is_none());
+            assert!(cache.access(&1).is_none());
+            assert!(cache.access(&2).is_none());
 
-        cache.reserve().expect("reserve").store(1, 2);
-        assert!(cache.access(&1).is_some());
-        assert!(cache.access(&2).is_none());
+            cache.reserve().expect("reserve").store(1, 2);
+            assert!(cache.access(&1).is_some());
+            assert!(cache.access(&2).is_none());
 
-        cache.reserve().expect("reserve").store(2, 3);
-        assert!(cache.access(&1).is_some());
-        assert!(cache.access(&2).is_some());
+            cache.reserve().expect("reserve").store(2, 3);
+            assert!(cache.access(&1).is_some());
+            assert!(cache.access(&2).is_some());
 
-        assert_eq!(cache.access(&1).take().unwrap().node.value, 2);
-        assert_eq!(cache.access(&2).take().unwrap().node.value, 3);
+            assert_eq!(cache.access(&1).take().unwrap().node.value, 2);
+            assert_eq!(cache.access(&2).take().unwrap().node.value, 3);
+
+            Ok(())
+        }))
     }
 
     #[test]
     fn reserve_does_nothing_when_capacity_exists() {
-        let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
+        current_thread::run(futures::future::lazy(|| {
+            let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
 
-        let mut cache = cache.lock().unwrap();
+            let mut cache = cache.lock().unwrap();
 
-        cache.reserve().expect("capacity").store(1, 2);
-        assert_eq!(cache.vals.len(), 1);
+            cache.reserve().expect("capacity").store(1, 2);
+            assert_eq!(cache.vals.len(), 1);
 
-        assert!(cache.reserve().is_ok());
-        assert_eq!(cache.vals.len(), 1);
+            assert!(cache.reserve().is_ok());
+            assert_eq!(cache.vals.len(), 1);
+
+            Ok(())
+        }))
     }
 
     #[test]
     fn store_and_self_purge() {
-        tokio::run(futures::lazy(|| {
-            let (cache, _cache_purge) = Cache::new(2, Duration::from_millis(10));
+        let mut rt = Runtime::new().unwrap();
 
-            // Do not spawn background purge. Instead, fill the cache and
-            // force a manual purge to occur when a value can be expired.
-            {
-                let mut cache = cache.lock().unwrap();
+        let (cache, _cache_purge) = rt
+            .block_on(future::lazy(|| {
+                Ok::<_, ()>(Cache::new(2, Duration::from_millis(10)))
+            }))
+            .unwrap();
 
-                cache.reserve().expect("reserve").store(1, 2);
-                cache.reserve().expect("reserve").store(2, 3);
-                assert_eq!(cache.vals.len(), 2);
-            }
+        // Fill the cache, but do not spawn a background purge task
+        rt.block_on(future::lazy(|| {
+            let mut cache_1 = cache.lock().unwrap();
 
-            // Sleep for an amount of time greater than expiry duration so
-            // that a value can be purged.
-            tokio::spawn(
-                tokio_timer::sleep(Duration::from_millis(100))
-                    .map(move |_| {
-                        let mut cache = cache.lock().unwrap();
+            cache_1.reserve().expect("reserve").store(1, 2);
+            cache_1.reserve().expect("reserve").store(2, 3);
+            assert_eq!(cache_1.vals.len(), 2);
 
-                        cache.reserve().expect("reserve").store(3, 4);
-                        assert_eq!(cache.vals.len(), 2);
-                        assert!(cache.access(&3).is_some());
-                    })
-                    .map_err(|_| ()),
-            );
-
-            Ok(())
+            Ok::<_, ()>(())
         }))
+        .unwrap();
+
+        // Sleep for enough time that cache values should be expired
+        rt.block_on(tokio_timer::sleep(Duration::from_millis(100)))
+            .unwrap();
+
+        // Force `reserve` to purge the cache
+        rt.block_on(future::lazy(|| {
+            let mut cache_2 = cache.lock().unwrap();
+
+            cache_2.reserve().expect("reserve").store(3, 4);
+            assert_eq!(cache_2.vals.len(), 2);
+            assert!(cache_2.access(&3).is_some());
+
+            Ok::<_, ()>(())
+        }))
+        .unwrap()
     }
 
     #[test]
     fn store_and_background_purge() {
-        tokio::run(futures::lazy(|| {
-            let (cache, cache_purge) = Cache::new(2, Duration::from_millis(10));
+        let mut rt = Runtime::new().unwrap();
 
-            // Spawn a background purge
-            tokio::spawn(cache_purge);
+        let (cache, cache_purge) = rt
+            .block_on(futures::future::lazy(|| {
+                Ok::<_, ()>(Cache::new(2, Duration::from_millis(10)))
+            }))
+            .unwrap();
 
-            {
-                let mut cache = cache.lock().unwrap();
+        // Spawn a background purge task on the runtime
+        rt.spawn(cache_purge);
 
-                cache.reserve().expect("reserve").store(1, 2);
-                cache.reserve().expect("reserve").store(2, 3);
-                assert_eq!(cache.vals.len(), 2);
-            }
+        // Fill the cache
+        rt.block_on(future::lazy(|| {
+            let mut cache = cache.lock().unwrap();
 
-            // Sleep for an amount of time greater than expiry duration so
-            // that the background purge purges the entire cache.
-            tokio::spawn(
-                tokio_timer::sleep(Duration::from_millis(100))
-                    .map(move |_| {
-                        assert_eq!(cache.lock().unwrap().vals.len(), 0);
-                    })
-                    .map_err(|_| ()),
-            );
+            cache.reserve().expect("reserve").store(1, 2);
+            cache.reserve().expect("reserve").store(2, 3);
+            assert_eq!(cache.vals.len(), 2);
 
-            Ok(())
+            Ok::<_, ()>(())
         }))
+        .unwrap();
+
+        // Sleep for enough time that all cache values expire
+        rt.block_on(tokio_timer::sleep(Duration::from_millis(100)))
+            .unwrap();
+
+        assert_eq!(cache.lock().unwrap().vals.len(), 0);
     }
 
     #[test]
     fn drop_access_resets_expiration() {
-        use tokio::runtime::current_thread::Runtime;
+        let mut rt = current_thread::Runtime::new().unwrap();
 
-        let mut runtime = Runtime::new().unwrap();
+        let (cache, cache_purge) = rt
+            .block_on(futures::future::lazy(|| {
+                Ok::<_, ()>(Cache::new(2, Duration::from_millis(10)))
+            }))
+            .unwrap();
 
-        let (cache, cache_purge) = Cache::new(2, Duration::from_millis(10));
-
-        // Spawn a background purge on the current runtime
-        runtime.spawn(cache_purge);
+        // Spawn a background purge task on the runtime
+        rt.spawn(cache_purge);
 
         {
-            let mut cache_1 = cache.lock().unwrap();
+            let mut cache = cache.lock().unwrap();
 
-            cache_1.reserve().expect("reserve").store(1, 2);
-            assert!(cache_1.access(&1).is_some());
-            let _access = cache_1.access(&1);
+            // Hold on to an access handle the cache
+            let _access = rt
+                .block_on(future::lazy(|| {
+                    cache.reserve().expect("reserve").store(1, 2);
+                    assert!(cache.access(&1).is_some());
 
-            // Sleep for an amount of time greater than the expiry duration so
-            // that the background purge would purge the cache iff values can
-            // be expired.
-            runtime
-                .block_on(tokio_timer::sleep(Duration::from_millis(100)))
+                    Ok::<_, ()>(cache.access(&1))
+                }))
                 .unwrap();
 
-            // Explicity drop both the access and cache handles. Dropping the
+            // Sleep for enough time that the background purge would remove the value
+            rt.block_on(tokio_timer::sleep(Duration::from_millis(100)))
+                .unwrap();
+
+            // Drop both the access and cache handles. Dropping the
             // access handle will reset the expiration on the value in the cache.
             // Dropping the cache handle will unlock the cache and allow a
             // background purge to occur.
@@ -353,15 +382,21 @@ mod tests {
 
         // Ensure a background purge is polled so that it can expire any
         // values.
-        runtime
-            .block_on(tokio_timer::sleep(Duration::from_millis(1)))
-            .unwrap();
+        rt.block_on(future::lazy(|| {
+            tokio_timer::sleep(Duration::from_millis(1))
+        }))
+        .unwrap();
 
-        let mut cache_2 = cache.lock().unwrap();
+        rt.block_on(future::lazy(|| {
+            let mut cache = cache.lock().unwrap();
 
-        // The cache value should still be present since it was reset after
-        // the value expiration. We ensured a background purge occurred but
-        // that it did not purge the value.
-        assert!(cache_2.access(&1).is_some());
+            // The cache value should still be present since it was reset after
+            // the value expiration. We ensured a background purge occurred but
+            // that it did not purge the value.
+            assert!(cache.access(&1).is_some());
+
+            Ok::<_, ()>(())
+        }))
+        .unwrap()
     }
 }

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -124,7 +124,6 @@ impl<K: Clone + Eq + Hash, V> Cache<K, V> {
 
 impl<K: Clone + Eq + Hash, V> Future for PurgeCache<K, V> {
     type Item = ();
-
     type Error = ();
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -1,6 +1,5 @@
 use std::{hash::Hash, time::Duration};
 
-use error::NoCapacity;
 use futures::{Async, Future, Poll, Stream};
 use indexmap::IndexMap;
 use tokio::sync::lock::Lock;
@@ -80,12 +79,12 @@ where
         (cache, bg_purge)
     }
 
-    pub fn at_capacity(&self) -> Result<(), NoCapacity> {
-        if self.values.len() == self.capacity {
-            Err(NoCapacity(self.capacity))
-        } else {
-            Ok(())
-        }
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn can_insert(&self) -> bool {
+        self.values.len() < self.capacity
     }
 
     /// Attempts to access an item by key.
@@ -171,7 +170,7 @@ mod tests {
 
             cache.insert(2, 3);
             assert_eq!(cache.values.len(), 2);
-            assert!(cache.at_capacity().is_err());
+            assert!(!cache.can_insert());
 
             Ok::<_, ()>(())
         }))

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -269,6 +269,11 @@ where
                     State::Acquired(Some(req), Some(target), Some(make), cache)
                 }
                 State::Acquired(ref mut req, ref mut target, ref mut make, ref mut cache) => {
+                    // FIXME(kleimkuhler): This match arm is a bit of a hack.
+                    // It is a closure that is immediately executed. The
+                    // reason for this is because of the mutable borrow that
+                    // happens when we check if the target already exists in
+                    // the cache. It should no longer be an issue with NLL.
                     (|| {
                         let req = req.take().expect("polled after ready");
                         let target = target.take().expect("polled after ready");

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -425,18 +425,26 @@ mod tests {
 
     #[test]
     fn cache_limited_by_capacity() {
-        let (mut router, _cache_bg) = Router::new(Recognize, Recognize, 1, Duration::from_secs(1));
+        use futures::future;
+        use tokio::runtime::current_thread;
 
-        let rsp = router.call_ok(2);
-        assert_eq!(rsp, 2);
+        current_thread::run(future::lazy(|| {
+            let (mut router, _cache_bg) =
+                Router::new(Recognize, Recognize, 1, Duration::from_secs(1));
 
-        let rsp = router.call_err(3);
-        assert_eq!(
-            rsp.downcast_ref::<error::NoCapacity>()
-                .expect("error should be NoCapacity")
-                .0,
-            1
-        );
+            let rsp = router.call_ok(2);
+            assert_eq!(rsp, 2);
+
+            let rsp = router.call_err(3);
+            assert_eq!(
+                rsp.downcast_ref::<error::NoCapacity>()
+                    .expect("error should be NoCapacity")
+                    .0,
+                1
+            );
+
+            Ok(())
+        }))
     }
 
     #[test]

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -22,7 +22,7 @@ use self::cache::{Cache, PurgeCache};
 pub struct Router<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send,
-    <Rec as Recognize<Req>>::Target: Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: Make<Rec::Target> + Clone + Send,
     Mk::Value: svc::Service<Req>,
 {
@@ -71,7 +71,7 @@ where
 struct Inner<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send,
-    <Rec as Recognize<Req>>::Target: Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: Make<Rec::Target> + Clone + Send,
     Mk::Value: svc::Service<Req>,
 {
@@ -109,7 +109,7 @@ where
 impl<Req, Rec, Mk> Router<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send,
-    <Rec as Recognize<Req>>::Target: Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: Make<Rec::Target> + Clone + Send,
     Mk::Value: svc::Service<Req> + Clone,
 {
@@ -137,7 +137,7 @@ where
 impl<Req, Rec, Mk, Svc> svc::Service<Req> for Router<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send,
-    <Rec as Recognize<Req>>::Target: Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: Make<Rec::Target, Value = Svc> + Clone + Send,
     Svc: svc::Service<Req> + Clone,
     Svc::Error: Into<error::Error>,
@@ -202,7 +202,7 @@ where
 impl<Req, Rec, Mk> Clone for Router<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send,
-    <Rec as Recognize<Req>>::Target: Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: Make<Rec::Target> + Clone + Send,
     Mk::Value: svc::Service<Req>,
 {
@@ -277,7 +277,7 @@ where
 impl<Req, Rec, Mk> Clone for Inner<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send,
-    <Rec as Recognize<Req>>::Target: Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: Make<Rec::Target> + Clone + Send,
     Mk::Value: svc::Service<Req>,
 {

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -140,6 +140,7 @@ impl<Req, Rec, Mk> Router<Req, Rec, Mk>
 where
     Rec: Recognize<Req>,
     Mk: Make<Rec::Target>,
+    <Mk as Make<Rec::Target>>::Value: Clone,
     Mk::Value: svc::Service<Req>,
 {
     pub fn new(
@@ -307,7 +308,7 @@ where
                         // If the target exists in the cache, get the service
                         // and call it with `request`.
                         if let Some(service) = state.unlocked_cache.access(&target) {
-                            return State::Call(Some(request), Some(service.node.value.clone()));
+                            return State::Call(Some(request), Some(service));
                         }
 
                         // Since there wasn't a cached route, ensure that

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
-use log::trace;
+use log::debug;
 use tokio::sync::lock::Lock;
 use tower_load_shed::LoadShed;
 use tower_service as svc;
@@ -302,14 +302,14 @@ where
                     // If the target is already cached, route the request to
                     // the service; otherwise, try to insert it
                     if let Some(service) = cache.access(&target) {
-                        trace!("target already cached");
+                        debug!("target already cached");
                         State::Call(Some(request), Some(service))
                     } else {
-                        trace!("target not cached");
+                        debug!("target not cached");
 
                         // Ensure that there is capacity for a new slot
                         if !cache.can_insert() {
-                            trace!("not enough capacity to insert target into cache");
+                            debug!("not enough capacity to insert target into cache");
                             return Err(error::NoCapacity(cache.capacity()).into());
                         }
 
@@ -317,7 +317,7 @@ where
                         let make = make.take().expect("polled after ready");
                         let service = LoadShed::new(make.make(&target));
 
-                        trace!("inserting new target into cache");
+                        debug!("inserting new target into cache");
                         cache.insert(target, service.clone());
                         State::Call(Some(request), Some(service))
                     }

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -474,7 +474,7 @@ mod tests {
             Recognize,
             MultiplyAndAssign::never_ready(),
             1,
-            Duration::from_secs(0),
+            Duration::from_secs(1),
         );
 
         let err = router.call_err(2);

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -176,7 +176,7 @@ where
 
         // Since there wasn't a cached route, ensure that there is capacity for a
         // new one.
-        let reserve = match cache.reserve() {
+        let reserve = match cache.poll_reserve() {
             Ok(r) => r,
             Err(cache::CapacityExhausted { capacity }) => {
                 return ResponseFuture::no_capacity(capacity);

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn invalid() {
-        let mut router = Router::new(Recognize, Recognize, 1, Duration::from_secs(60));
+        let (mut router, _cache_bg) = Router::new(Recognize, Recognize, 1, Duration::from_secs(60));
 
         let rsp = router.call_err(Request::NotRecognized);
         assert!(rsp.is::<error::NotRecognized>());
@@ -425,7 +425,7 @@ mod tests {
 
     #[test]
     fn cache_limited_by_capacity() {
-        let mut router = Router::new(Recognize, Recognize, 1, Duration::from_secs(1));
+        let (mut router, _cache_bg) = Router::new(Recognize, Recognize, 1, Duration::from_secs(1));
 
         let rsp = router.call_ok(2);
         assert_eq!(rsp, 2);
@@ -441,7 +441,7 @@ mod tests {
 
     #[test]
     fn services_cached() {
-        let mut router = Router::new(Recognize, Recognize, 1, Duration::from_secs(60));
+        let (mut router, _cache_bg) = Router::new(Recognize, Recognize, 1, Duration::from_secs(60));
 
         let rsp = router.call_ok(2);
         assert_eq!(rsp, 2);
@@ -452,7 +452,7 @@ mod tests {
 
     #[test]
     fn poll_ready_is_called_first() {
-        let mut router = Router::new(
+        let (mut router, _cache_bg) = Router::new(
             Recognize,
             MultiplyAndAssign::new(usize::MAX),
             1,
@@ -470,7 +470,7 @@ mod tests {
     fn load_shed_from_inner_services() {
         use tower_load_shed::error::Overloaded;
 
-        let mut router = Router::new(
+        let (mut router, _cache_bg) = Router::new(
             Recognize,
             MultiplyAndAssign::never_ready(),
             1,

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -340,6 +340,7 @@ mod test_util {
     use std::rc::Rc;
     use svc::Service;
 
+    #[derive(Clone)]
     pub struct Recognize;
 
     #[derive(Clone, Debug)]
@@ -465,13 +466,9 @@ mod tests {
 
     impl<Mk> Router<Request, Recognize, Mk>
     where
-        Recognize: Recognize<Req>,
-        Mk: Make<Recognize::Target>,
-        Mk::Value: svc::Service<Request>,
+        Mk: Make<usize> + Clone,
+        Mk::Value: svc::Service<Request, Response = usize> + Clone,
         <Mk::Value as svc::Service<Request>>::Error: Into<error::Error>,
-        // Mk: Make<usize>,
-        // Mk::Value: svc::Service<Request, Response = usize> + Clone,
-        // <Mk::Value as svc::Service<Request>>::Error: Into<error::Error>,
     {
         fn call_ok(&mut self, req: impl Into<Request>) -> usize {
             let req = req.into();

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
+use log::trace;
 use tokio::sync::lock::Lock;
 use tower_load_shed::LoadShed;
 use tower_service as svc;
@@ -301,10 +302,14 @@ where
                     // If the target is already cached, route the request to
                     // the service; otherwise, try to insert it
                     if let Some(service) = cache.access(&target) {
+                        trace!("target already cached");
                         State::Call(Some(request), Some(service))
                     } else {
+                        trace!("target not cached");
+
                         // Ensure that there is capacity for a new slot
                         if !cache.can_insert() {
+                            trace!("not enough capacity to insert target into cache");
                             return Err(error::NoCapacity(cache.capacity()).into());
                         }
 
@@ -312,6 +317,7 @@ where
                         let make = make.take().expect("polled after ready");
                         let service = LoadShed::new(make.make(&target));
 
+                        trace!("inserting new target into cache");
                         cache.insert(target, service.clone());
                         State::Call(Some(request), Some(service))
                     }

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -416,7 +416,8 @@ pub mod router {
             let inner = self.inner.make(&target);
             let stack = self.route_layer.clone().service(svc::shared(inner));
 
-            let router = Router::new(
+            // We never want to purge routes from the Profile's router cache
+            let (router, _cache_bg) = Router::new(
                 Recognize {
                     target: target.clone(),
                     routes: Vec::new(),
@@ -483,7 +484,9 @@ pub mod router {
     {
         fn update_routes(&mut self, routes: Routes) {
             let slots = routes.len() + 1;
-            self.router = Router::new(
+
+            // We never want to purge routes from the Profile's router cache
+            let (router, _cache_bg) = Router::new(
                 Recognize {
                     target: self.target.clone(),
                     routes,
@@ -494,6 +497,7 @@ pub mod router {
                 // Doesn't matter, since we are guaranteed to have enough capacity.
                 Duration::from_secs(1),
             );
+            self.router = router;
         }
 
         fn poll_route_stream(&mut self) -> Option<Async<Option<Routes>>> {

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -518,7 +518,7 @@ pub mod router {
     {
         type Response = Svc::Response;
         type Error = Error;
-        type Future = rt::ResponseFuture<http::Request<B>, Svc>;
+        type Future = rt::ResponseFuture<http::Request<B>, Recognize<T>, Stk>;
 
         fn poll_ready(&mut self) -> Poll<(), Self::Error> {
             while let Some(Async::Ready(Some(routes))) = self.poll_route_stream() {

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -317,9 +317,9 @@ pub mod router {
 
     pub struct Service<G, T, R, B>
     where
-        T: WithRoute + Clone + Send,
+        T: WithRoute + Clone,
         T::Output: Clone + Eq + Hash,
-        R: rt::Make<T::Output> + Clone + Send,
+        R: rt::Make<T::Output>,
         R::Value: svc::Service<http::Request<B>> + Clone,
     {
         target: T,
@@ -337,20 +337,10 @@ pub mod router {
         default_route: Route,
     }
 
-    impl<T: Clone> Clone for Recognize<T> {
-        fn clone(&self) -> Self {
-            Recognize {
-                target: self.target.clone(),
-                routes: self.routes.clone(),
-                default_route: self.default_route.clone(),
-            }
-        }
-    }
-
     impl<B, T> rt::Recognize<http::Request<B>> for Recognize<T>
     where
         T: WithRoute + Clone,
-        T::Output: Eq + Hash,
+        T::Output: Clone + Eq + Hash,
     {
         type Target = T::Output;
 
@@ -404,13 +394,13 @@ pub mod router {
 
     impl<T, G, M, R, B, RMk, RSvc> svc::Service<T> for MakeSvc<G, M, R, B>
     where
-        T: CanGetDestination + WithRoute + Clone + Send,
+        T: CanGetDestination + WithRoute + Clone,
         <T as WithRoute>::Output: Eq + Hash + Clone,
         M: rt::Make<T>,
         M::Value: Clone,
         G: GetRoutes,
         R: svc::Layer<svc::shared::Shared<M::Value>, Service = RMk> + Clone,
-        RMk: rt::Make<<T as WithRoute>::Output, Value = RSvc> + Clone + Send,
+        RMk: rt::Make<<T as WithRoute>::Output, Value = RSvc> + Clone,
         RSvc: svc::Service<http::Request<B>> + Clone,
         RSvc::Error: Into<Error>,
     {
@@ -487,9 +477,9 @@ pub mod router {
     impl<G, T, R, B> Service<G, T, R, B>
     where
         G: Stream<Item = Routes, Error = Never>,
-        T: WithRoute + Clone + Send,
+        T: WithRoute + Clone,
         T::Output: Clone + Eq + Hash,
-        R: rt::Make<T::Output> + Clone + Send,
+        R: rt::Make<T::Output> + Clone,
         R::Value: svc::Service<http::Request<B>> + Clone,
     {
         fn update_routes(&mut self, routes: Routes) {
@@ -520,9 +510,9 @@ pub mod router {
     impl<G, T, Stk, B, Svc> svc::Service<http::Request<B>> for Service<G, T, Stk, B>
     where
         G: Stream<Item = Routes, Error = Never>,
-        T: WithRoute + Clone + Send,
+        T: WithRoute + Clone,
         T::Output: Clone + Eq + Hash,
-        Stk: rt::Make<T::Output, Value = Svc> + Clone + Send,
+        Stk: rt::Make<T::Output, Value = Svc> + Clone,
         Svc: svc::Service<http::Request<B>> + Clone,
         Svc::Error: Into<Error>,
     {

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -417,7 +417,7 @@ pub mod router {
             let stack = self.route_layer.clone().service(svc::shared(inner));
 
             // We never want to purge routes from the profiles router cache
-            let (router, _) = Router::new(
+            let router = Router::new_lazy(
                 Recognize {
                     target: target.clone(),
                     routes: Vec::new(),
@@ -486,7 +486,7 @@ pub mod router {
             let slots = routes.len() + 1;
 
             // We never want to purge routes from the profiles router cache
-            let (router, _) = Router::new(
+            let router = Router::new_lazy(
                 Recognize {
                     target: self.target.clone(),
                     routes,

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -490,8 +490,8 @@ pub mod router {
             let mut make = IndexMap::with_capacity(capacity);
             make.insert(default_route.clone(), self.stack.make(&default_route));
 
-            for (_, route) in routes.clone().into_iter() {
-                let route = self.target.clone().with_route(route);
+            for (_, route) in &routes {
+                let route = self.target.clone().with_route(route.clone());
                 let service = self.stack.make(&route);
                 make.insert(route, service);
             }

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -416,8 +416,8 @@ pub mod router {
             let inner = self.inner.make(&target);
             let stack = self.route_layer.clone().service(svc::shared(inner));
 
-            // We never want to purge routes from the Profile's router cache
-            let (router, _cache_bg) = Router::new(
+            // We never want to purge routes from the profiles router cache
+            let (router, _) = Router::new(
                 Recognize {
                     target: target.clone(),
                     routes: Vec::new(),
@@ -485,8 +485,8 @@ pub mod router {
         fn update_routes(&mut self, routes: Routes) {
             let slots = routes.len() + 1;
 
-            // We never want to purge routes from the Profile's router cache
-            let (router, _cache_bg) = Router::new(
+            // We never want to purge routes from the profiles router cache
+            let (router, _) = Router::new(
                 Recognize {
                     target: self.target.clone(),
                     routes,

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -417,7 +417,7 @@ pub mod router {
             let stack = self.route_layer.clone().service(svc::shared(inner));
 
             // We never want to purge routes from the profiles router cache
-            let router = Router::new_lazy(
+            let router = Router::new_without_expiry(
                 Recognize {
                     target: target.clone(),
                     routes: Vec::new(),
@@ -426,8 +426,6 @@ pub mod router {
                 stack.clone(),
                 // only need 1 for default_route at first
                 1,
-                // Doesn't matter, since we are guaranteed to have enough capacity.
-                Duration::from_secs(1),
             );
 
             let route_stream = match target.get_destination() {
@@ -486,7 +484,7 @@ pub mod router {
             let slots = routes.len() + 1;
 
             // We never want to purge routes from the profiles router cache
-            let router = Router::new_lazy(
+            let router = Router::new_without_expiry(
                 Recognize {
                     target: self.target.clone(),
                     routes,
@@ -494,8 +492,6 @@ pub mod router {
                 },
                 self.stack.clone(),
                 slots,
-                // Doesn't matter, since we are guaranteed to have enough capacity.
-                Duration::from_secs(1),
             );
             self.router = router;
         }

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -317,9 +317,9 @@ pub mod router {
 
     pub struct Service<G, T, R, B>
     where
-        T: WithRoute + Clone,
-        T::Output: Clone + Eq + Hash,
-        R: rt::Make<T::Output>,
+        T: WithRoute + Clone + Send,
+        T::Output: Clone + Eq + Hash + Send,
+        R: rt::Make<T::Output> + Clone + Send,
         R::Value: svc::Service<http::Request<B>> + Clone,
     {
         target: T,
@@ -335,6 +335,16 @@ pub mod router {
         target: T,
         routes: Routes,
         default_route: Route,
+    }
+
+    impl<T: Clone> Clone for Recognize<T> {
+        fn clone(&self) -> Self {
+            Recognize {
+                target: self.target.clone(),
+                routes: self.routes.clone(),
+                default_route: self.default_route.clone(),
+            }
+        }
     }
 
     impl<B, T> rt::Recognize<http::Request<B>> for Recognize<T>
@@ -394,13 +404,13 @@ pub mod router {
 
     impl<T, G, M, R, B, RMk, RSvc> svc::Service<T> for MakeSvc<G, M, R, B>
     where
-        T: CanGetDestination + WithRoute + Clone,
-        <T as WithRoute>::Output: Eq + Hash + Clone,
+        T: CanGetDestination + WithRoute + Clone + Send,
+        <T as WithRoute>::Output: Eq + Hash + Clone + Send,
         M: rt::Make<T>,
         M::Value: Clone,
         G: GetRoutes,
         R: svc::Layer<svc::shared::Shared<M::Value>, Service = RMk> + Clone,
-        RMk: rt::Make<<T as WithRoute>::Output, Value = RSvc> + Clone,
+        RMk: rt::Make<<T as WithRoute>::Output, Value = RSvc> + Clone + Send,
         RSvc: svc::Service<http::Request<B>> + Clone,
         RSvc::Error: Into<Error>,
     {
@@ -477,9 +487,9 @@ pub mod router {
     impl<G, T, R, B> Service<G, T, R, B>
     where
         G: Stream<Item = Routes, Error = Never>,
-        T: WithRoute + Clone,
-        T::Output: Clone + Eq + Hash,
-        R: rt::Make<T::Output> + Clone,
+        T: WithRoute + Clone + Send,
+        T::Output: Clone + Eq + Hash + Send,
+        R: rt::Make<T::Output> + Clone + Send,
         R::Value: svc::Service<http::Request<B>> + Clone,
     {
         fn update_routes(&mut self, routes: Routes) {
@@ -510,9 +520,9 @@ pub mod router {
     impl<G, T, Stk, B, Svc> svc::Service<http::Request<B>> for Service<G, T, Stk, B>
     where
         G: Stream<Item = Routes, Error = Never>,
-        T: WithRoute + Clone,
-        T::Output: Clone + Eq + Hash,
-        Stk: rt::Make<T::Output, Value = Svc> + Clone,
+        T: WithRoute + Clone + Send,
+        T::Output: Clone + Eq + Hash + Send,
+        Stk: rt::Make<T::Output, Value = Svc> + Clone + Send,
         Svc: svc::Service<http::Request<B>> + Clone,
         Svc::Error: Into<Error>,
     {

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -318,7 +318,7 @@ pub mod router {
     pub struct Service<G, T, R, B>
     where
         T: WithRoute + Clone + Send,
-        T::Output: Clone + Eq + Hash + Send,
+        T::Output: Clone + Eq + Hash,
         R: rt::Make<T::Output> + Clone + Send,
         R::Value: svc::Service<http::Request<B>> + Clone,
     {
@@ -405,7 +405,7 @@ pub mod router {
     impl<T, G, M, R, B, RMk, RSvc> svc::Service<T> for MakeSvc<G, M, R, B>
     where
         T: CanGetDestination + WithRoute + Clone + Send,
-        <T as WithRoute>::Output: Eq + Hash + Clone + Send,
+        <T as WithRoute>::Output: Eq + Hash + Clone,
         M: rt::Make<T>,
         M::Value: Clone,
         G: GetRoutes,
@@ -488,7 +488,7 @@ pub mod router {
     where
         G: Stream<Item = Routes, Error = Never>,
         T: WithRoute + Clone + Send,
-        T::Output: Clone + Eq + Hash + Send,
+        T::Output: Clone + Eq + Hash,
         R: rt::Make<T::Output> + Clone + Send,
         R::Value: svc::Service<http::Request<B>> + Clone,
     {
@@ -521,7 +521,7 @@ pub mod router {
     where
         G: Stream<Item = Routes, Error = Never>,
         T: WithRoute + Clone + Send,
-        T::Output: Clone + Eq + Hash + Send,
+        T::Output: Clone + Eq + Hash,
         Stk: rt::Make<T::Output, Value = Svc> + Clone + Send,
         Svc: svc::Service<http::Request<B>> + Clone,
         Svc::Error: Into<Error>,

--- a/src/proxy/http/profiles.rs
+++ b/src/proxy/http/profiles.rs
@@ -318,7 +318,7 @@ pub mod router {
     pub struct Service<G, T, R, B>
     where
         T: WithRoute + Clone,
-        T::Output: Eq + Hash,
+        T::Output: Clone + Eq + Hash,
         R: rt::Make<T::Output>,
         R::Value: svc::Service<http::Request<B>> + Clone,
     {
@@ -426,7 +426,7 @@ pub mod router {
                 // only need 1 for default_route at first
                 1,
                 // Doesn't matter, since we are guaranteed to have enough capacity.
-                Duration::from_secs(0),
+                Duration::from_secs(1),
             );
 
             let route_stream = match target.get_destination() {
@@ -477,7 +477,7 @@ pub mod router {
     where
         G: Stream<Item = Routes, Error = Never>,
         T: WithRoute + Clone,
-        T::Output: Eq + Hash,
+        T::Output: Clone + Eq + Hash,
         R: rt::Make<T::Output> + Clone,
         R::Value: svc::Service<http::Request<B>> + Clone,
     {
@@ -492,7 +492,7 @@ pub mod router {
                 self.stack.clone(),
                 slots,
                 // Doesn't matter, since we are guaranteed to have enough capacity.
-                Duration::from_secs(0),
+                Duration::from_secs(1),
             );
         }
 
@@ -507,7 +507,7 @@ pub mod router {
     where
         G: Stream<Item = Routes, Error = Never>,
         T: WithRoute + Clone,
-        T::Output: Eq + Hash,
+        T::Output: Clone + Eq + Hash,
         Stk: rt::Make<T::Output, Value = Svc> + Clone,
         Svc: svc::Service<http::Request<B>> + Clone,
         Svc::Error: Into<Error>,

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -43,6 +43,7 @@ pub struct Stack<Req, Rec: Recognize<Req>, Mk> {
 pub struct Service<Req, Rec, Mk>
 where
     Rec: Recognize<Req>,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target>,
     Mk::Value: svc::Service<Req>,
 {
@@ -84,6 +85,7 @@ where
 impl<Req, Rec, Mk, B> svc::Layer<Mk> for Layer<Req, Rec>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
@@ -114,6 +116,7 @@ where
 impl<Req, Rec, Mk, B> Stack<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
@@ -133,6 +136,7 @@ where
 impl<Req, Rec, Mk, B, T> svc::Service<T> for Stack<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
@@ -170,6 +174,7 @@ where
 impl<Req, Rec, Mk, B> svc::Service<Req> for Service<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Send + Sync + 'static,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target> + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
@@ -192,6 +197,7 @@ where
 impl<Req, Rec, Mk> Clone for Service<Req, Rec, Mk>
 where
     Rec: Recognize<Req>,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target>,
     Mk::Value: svc::Service<Req>,
     Router<Req, Rec, Mk>: Clone,

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -43,7 +43,7 @@ pub struct Stack<Req, Rec: Recognize<Req>, Mk> {
 pub struct Service<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send,
-    <Rec as Recognize<Req>>::Target: Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target> + Clone + Send,
     Mk::Value: svc::Service<Req>,
 {
@@ -85,7 +85,7 @@ where
 impl<Req, Rec, Mk, B> svc::Layer<Mk> for Layer<Req, Rec>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
-    <Rec as Recognize<Req>>::Target: Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
@@ -176,7 +176,7 @@ where
 impl<Req, Rec, Mk, B> svc::Service<Req> for Service<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
-    <Rec as Recognize<Req>>::Target: Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
@@ -199,7 +199,7 @@ where
 impl<Req, Rec, Mk> Clone for Service<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send,
-    <Rec as Recognize<Req>>::Target: Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target> + Clone + Send,
     Mk::Value: svc::Service<Req>,
     Router<Req, Rec, Mk>: Clone,

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -42,9 +42,8 @@ pub struct Stack<Req, Rec: Recognize<Req>, Mk> {
 
 pub struct Service<Req, Rec, Mk>
 where
-    Rec: Recognize<Req> + Clone + Send,
-    <Rec as Recognize<Req>>::Target: Clone,
-    Mk: rt::Make<Rec::Target> + Clone + Send,
+    Rec: Recognize<Req>,
+    Mk: rt::Make<Rec::Target>,
     Mk::Value: svc::Service<Req>,
 {
     inner: Router<Req, Rec, Mk>,
@@ -85,7 +84,6 @@ where
 impl<Req, Rec, Mk, B> svc::Layer<Mk> for Layer<Req, Rec>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
-    <Rec as Recognize<Req>>::Target: Clone,
     Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
@@ -116,7 +114,7 @@ where
 impl<Req, Rec, Mk, B> Stack<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
-    <Rec as Recognize<Req>>::Target: Clone + Send + 'static,
+    <Rec as Recognize<Req>>::Target: Send + 'static,
     Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone + Send + 'static,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
@@ -138,7 +136,7 @@ where
 impl<Req, Rec, Mk, B, T> svc::Service<T> for Stack<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
-    <Rec as Recognize<Req>>::Target: Clone + Send + 'static,
+    <Rec as Recognize<Req>>::Target: Send + 'static,
     Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone + Send + 'static,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
@@ -175,9 +173,8 @@ where
 
 impl<Req, Rec, Mk, B> svc::Service<Req> for Service<Req, Rec, Mk>
 where
-    Rec: Recognize<Req> + Clone + Send + Sync + 'static,
-    <Rec as Recognize<Req>>::Target: Clone,
-    Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
+    Rec: Recognize<Req> + Send + Sync + 'static,
+    Mk: rt::Make<Rec::Target> + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
     B: Default + Send + 'static,
@@ -198,9 +195,8 @@ where
 
 impl<Req, Rec, Mk> Clone for Service<Req, Rec, Mk>
 where
-    Rec: Recognize<Req> + Clone + Send,
-    <Rec as Recognize<Req>>::Target: Clone,
-    Mk: rt::Make<Rec::Target> + Clone + Send,
+    Rec: Recognize<Req>,
+    Mk: rt::Make<Rec::Target>,
     Mk::Value: svc::Service<Req>,
     Router<Req, Rec, Mk>: Clone,
 {

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -42,9 +42,9 @@ pub struct Stack<Req, Rec: Recognize<Req>, Mk> {
 
 pub struct Service<Req, Rec, Mk>
 where
-    Rec: Recognize<Req>,
-    <Rec as Recognize<Req>>::Target: Clone,
-    Mk: rt::Make<Rec::Target>,
+    Rec: Recognize<Req> + Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone + Send,
+    Mk: rt::Make<Rec::Target> + Clone + Send,
     Mk::Value: svc::Service<Req>,
 {
     inner: Router<Req, Rec, Mk>,
@@ -85,7 +85,7 @@ where
 impl<Req, Rec, Mk, B> svc::Layer<Mk> for Layer<Req, Rec>
 where
     Rec: Recognize<Req> + Clone + Send + Sync + 'static,
-    <Rec as Recognize<Req>>::Target: Clone,
+    <Rec as Recognize<Req>>::Target: Clone + Send,
     Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
@@ -175,9 +175,9 @@ where
 
 impl<Req, Rec, Mk, B> svc::Service<Req> for Service<Req, Rec, Mk>
 where
-    Rec: Recognize<Req> + Send + Sync + 'static,
-    <Rec as Recognize<Req>>::Target: Clone,
-    Mk: rt::Make<Rec::Target> + Send + Sync + 'static,
+    Rec: Recognize<Req> + Clone + Send + Sync + 'static,
+    <Rec as Recognize<Req>>::Target: Clone + Send,
+    Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
     B: Default + Send + 'static,
@@ -198,9 +198,9 @@ where
 
 impl<Req, Rec, Mk> Clone for Service<Req, Rec, Mk>
 where
-    Rec: Recognize<Req>,
-    <Rec as Recognize<Req>>::Target: Clone,
-    Mk: rt::Make<Rec::Target>,
+    Rec: Recognize<Req> + Clone + Send,
+    <Rec as Recognize<Req>>::Target: Clone + Send,
+    Mk: rt::Make<Rec::Target> + Clone + Send,
     Mk::Value: svc::Service<Req>,
     Router<Req, Rec, Mk>: Clone,
 {

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -174,7 +174,7 @@ where
 impl<Req, Rec, Mk, B> svc::Service<Req> for Service<Req, Rec, Mk>
 where
     Rec: Recognize<Req> + Send + Sync + 'static,
-    Mk: rt::Make<Rec::Target> + Send + Sync + 'static,
+    Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
     Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
     B: Default + Send + 'static,

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::time::Duration;
 
+use logging;
 use never::Never;
 
 use proxy::Error;
@@ -127,7 +128,10 @@ where
             self.config.capacity,
             self.config.max_idle_age,
         );
-        tokio::spawn(cache_bg);
+
+        let ctx = logging::Section::Proxy.bg(self.config.proxy_name);
+        let cache_daemon = ctx.future(cache_bg);
+        tokio::spawn(cache_daemon);
 
         Service { inner }
     }


### PR DESCRIPTION
This change introduces an eviction task for router caches. Few changes were made
in how a router uses a cache; we still use `access` and `reserve` handles for
cache interactions.

### Current issue

The issue this change addresses is that services are only dropped from a router
cache when we have reached that cache's capacity.

We drop a service when it has not received a request within the `max_idle_age`.
When the cache is full, we scan through all the services and check their last
access time. If a service's last access time is longer than `max_idle_age`, then
it is removed.

This strategy is problematic because a service is only removed once the capacity
has been reached. If the capacity of a cache is never reached, then a service's
stack is kept around for the lifetime of that router.

### Proposed solution

When a router is created, we now also create a handle to that router's purge
task (the `PurgeCache` struct). If a router should attempt to purge its services
in the background, it can spawn that handle when the router is created.

A cache's state is now internally maintained by a
[tokio_timer::DelayQueue](https://docs.rs/tokio/0.1.19/tokio/timer/struct.DelayQueue.html).
When `PurgeCache` is able to pop services from the queue, we know that those
services have not received a request within an `expires` span of time -- even if
the cache has not reached it's capacity.

An important thing to note about this strategy is we still rely on locking the
*entire* cache when holding an `access`/`reserve` handle, as well as now purging
it in the background. The purge task will only ever attempt to lock the cache
with `try_lock!`, this ensures we do not cause lock contention with a more
important `access`/`reserve` interaction.

Another important note is that `PurgeCache` only has a weak reference to the
router cache. If the router is dropped and a purge task was previously spawned
on the runtime, then it will not continue to try and purge cache values.

Note: Implementation originally sketched out
[here](https://github.com/kleimkuhler/tec/)

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
