### PR TITLE
Load balancers fall back to ORIG_DST when no endpoints exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
         - export RUSTFLAGS="-C debuginfo=0" RUST_TEST_THREADS=1 RUST_TEST_PATIENCE_MS=200
       script:
         - make check-fmt
-        - travis_wait make test
+        - travis_wait 40 make test
         # If you're debugging disk utilization/caching... This finds the largest files in `target`:
         #- du -sh target && find target -type f |xargs -n 1000 du -s |sort -rn |head |awk '{print $2}' |xargs du -sh
 

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -207,6 +207,7 @@ pub mod discovery {
         fn poll(&mut self) -> Poll<resolve::Update<Self::Endpoint>, Self::Error> {
             match self.resolving {
                 Resolving::Name(ref name, ref mut res) => match try_ready!(res.poll()) {
+                    resolve::Update::NoEndpoints => Ok(Async::Ready(resolve::Update::NoEndpoints)),
                     resolve::Update::Remove(addr) => {
                         debug!("removing {}", addr);
                         Ok(Async::Ready(resolve::Update::Remove(addr)))

--- a/src/control/destination/background/destination_set.rs
+++ b/src/control/destination/background/destination_set.rs
@@ -224,6 +224,10 @@ where
         );
         match self.addrs.take() {
             Exists::Yes(mut cache) => {
+                self.responders.retain(|r| {
+                    let sent = r.update_tx.unbounded_send(Update::NoEndpoints);
+                    sent.is_ok()
+                });
                 cache.clear(&mut |change| {
                     Self::on_change(&mut self.responders, authority_for_logging, change)
                 });

--- a/src/proxy/http/balance.rs
+++ b/src/proxy/http/balance.rs
@@ -166,6 +166,8 @@ where
     }
 
     fn call(&mut self, req: http::Request<A>) -> Self::Future {
+        // The endpoint status is updated by the Discover instance, which is
+        // driven by calling `poll_ready` on the balancer.
         if self.status.is_empty() {
             future::Either::B(future::err(fallback::Error::fallback(req, NoEndpoints)))
         } else {

--- a/src/proxy/http/fallback.rs
+++ b/src/proxy/http/fallback.rs
@@ -15,7 +15,7 @@ pub enum Error<A> {
 
 pub type Layer<P, F, A> = MakeFallback<svc::ServiceBuilder<P>, svc::ServiceBuilder<F>, A>;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct MakeFallback<P, F, A> {
     primary: P,
     fallback: F,
@@ -120,6 +120,20 @@ where
     }
 }
 
+impl<P, F, A> Clone for MakeFallback<P, F, A>
+where
+    P: Clone,
+    F: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            primary: self.primary.clone(),
+            fallback: self.fallback.clone(),
+            _p: PhantomData,
+        }
+    }
+}
+
 impl<P, F, A> Future for MakeFuture<P, F, A>
 where
     P: Future,
@@ -181,7 +195,7 @@ where
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         let primary_ready = self.primary.poll_ready().map_err(|e| match e {
             Error::Fallback(_) => {
-                panic!("service must not return a fallback request in poll_ready")
+                panic!("service must not return a fallback request in poll_ready");
             }
             Error::Error(e) => e,
         });

--- a/src/proxy/http/fallback.rs
+++ b/src/proxy/http/fallback.rs
@@ -241,7 +241,8 @@ where
                 // We've called the primary service and are waiting for its
                 // future to complete.
                 Primary(ref mut f) => match f.poll() {
-                    Ok(r) => return Ok(r),
+                    Ok(Async::NotReady) => return Ok(Async::NotReady),
+                    Ok(Async::Ready(rsp)) => return Ok(Async::Ready(rsp.map(Body::A))),
                     Err(Error {
                         fallback: Some(req),
                         error,

--- a/src/proxy/http/fallback.rs
+++ b/src/proxy/http/fallback.rs
@@ -1,0 +1,291 @@
+use bytes::Buf;
+use futures::{Async, Future, Poll};
+use http;
+use hyper::body::Payload;
+use proxy;
+use svc;
+
+use std::{marker::PhantomData, mem};
+
+#[derive(Debug)]
+pub enum Error<A> {
+    Fallback(http::Request<A>),
+    Error(proxy::Error),
+}
+
+pub type Layer<P, F, A> = MakeFallback<svc::ServiceBuilder<P>, svc::ServiceBuilder<F>, A>;
+
+#[derive(Clone, Debug)]
+pub struct MakeFallback<P, F, A> {
+    primary: P,
+    fallback: F,
+    _p: PhantomData<fn(A)>,
+}
+
+pub struct Service<P, F, A> {
+    primary: P,
+    fallback: F,
+    _p: PhantomData<fn(A)>,
+}
+
+pub struct MakeFuture<P, F, A>
+where
+    P: Future,
+    F: Future,
+{
+    primary: Making<P>,
+    fallback: Making<F>,
+    _p: PhantomData<fn(A)>,
+}
+
+pub struct ResponseFuture<P, F, A>
+where
+    P: Future<Error = Error<A>>,
+    F: svc::Service<http::Request<A>>,
+{
+    fallback: F,
+    state: State<P, F::Future>,
+}
+
+pub enum Body<A, B> {
+    A(A),
+    B(B),
+}
+
+enum State<P, F> {
+    Primary(P),
+    Fallback(F),
+}
+
+enum Making<T: Future> {
+    NotReady(T),
+    Ready(T::Item),
+    Done,
+}
+
+pub fn layer<P, F, A>(
+    primary: svc::ServiceBuilder<P>,
+    fallback: svc::ServiceBuilder<F>,
+) -> Layer<P, F, A> {
+    Layer {
+        primary,
+        fallback,
+        _p: PhantomData,
+    }
+}
+
+impl<P, F, A, M> svc::Layer<M> for Layer<P, F, A>
+where
+    P: svc::Layer<M> + Clone,
+    F: svc::Layer<M> + Clone,
+    M: Clone,
+{
+    type Service = MakeFallback<P::Service, F::Service, A>;
+
+    fn layer(&self, inner: M) -> Self::Service {
+        MakeFallback {
+            primary: self.primary.clone().service(inner.clone()),
+            fallback: self.fallback.clone().service(inner),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<P, F, A, T> svc::Service<T> for MakeFallback<P, F, A>
+where
+    P: svc::Service<T>,
+    P::Error: Into<proxy::Error>,
+    F: svc::Service<T>,
+    F::Error: Into<proxy::Error>,
+    T: Clone,
+{
+    type Response = Service<P::Response, F::Response, A>;
+    type Error = proxy::Error;
+    type Future = MakeFuture<P::Future, F::Future, A>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        let primary_ready = self.primary.poll_ready().map_err(Into::into);
+        let fallback_ready = self.fallback.poll_ready().map_err(Into::into);
+        try_ready!(primary_ready);
+        try_ready!(fallback_ready);
+        Ok(Async::Ready(()))
+    }
+
+    fn call(&mut self, target: T) -> Self::Future {
+        MakeFuture {
+            primary: Making::NotReady(self.primary.call(target.clone())),
+            fallback: Making::NotReady(self.fallback.call(target.clone())),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<P, F, A> Future for MakeFuture<P, F, A>
+where
+    P: Future,
+    P::Error: Into<proxy::Error>,
+    F: Future,
+    F::Error: Into<proxy::Error>,
+{
+    type Item = Service<P::Item, F::Item, A>;
+    type Error = proxy::Error;
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let done =
+            self.primary.poll().map_err(Into::into)? && self.fallback.poll().map_err(Into::into)?;
+        if !done {
+            return Ok(Async::NotReady);
+        }
+
+        Ok(Async::Ready(Service {
+            primary: self.primary.take(),
+            fallback: self.fallback.take(),
+            _p: PhantomData,
+        }))
+    }
+}
+
+impl<T: Future> Making<T> {
+    fn poll(&mut self) -> Result<bool, T::Error> {
+        let res = match *self {
+            Making::NotReady(ref mut fut) => fut.poll()?,
+            Making::Ready(_) => return Ok(true),
+            Making::Done => panic!("polled after ready"),
+        };
+        match res {
+            Async::Ready(res) => {
+                *self = Making::Ready(res);
+                Ok(true)
+            }
+            Async::NotReady => Ok(false),
+        }
+    }
+
+    fn take(&mut self) -> T::Item {
+        match mem::replace(self, Making::Done) {
+            Making::Ready(a) => a,
+            _ => panic!(),
+        }
+    }
+}
+
+impl<P, F, A, B, C> svc::Service<http::Request<A>> for Service<P, F, A>
+where
+    P: svc::Service<http::Request<A>, Response = http::Response<B>, Error = Error<A>>,
+    F: svc::Service<http::Request<A>, Response = http::Response<C>> + Clone,
+    F::Error: Into<proxy::Error>,
+{
+    type Response = http::Response<Body<B, C>>;
+    type Error = proxy::Error;
+    type Future = ResponseFuture<P::Future, F, A>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        let primary_ready = self.primary.poll_ready().map_err(|e| match e {
+            Error::Fallback(_) => {
+                panic!("service must not return a fallback request in poll_ready")
+            }
+            Error::Error(e) => e,
+        });
+        let fallback_ready = self.fallback.poll_ready().map_err(Into::into);
+        try_ready!(primary_ready);
+        try_ready!(fallback_ready);
+        Ok(Async::Ready(()))
+    }
+
+    fn call(&mut self, req: http::Request<A>) -> Self::Future {
+        ResponseFuture {
+            fallback: self.fallback.clone(),
+            state: State::Primary(self.primary.call(req)),
+        }
+    }
+}
+
+impl<P, F, A, B, C> Future for ResponseFuture<P, F, A>
+where
+    P: Future<Item = http::Response<B>, Error = Error<A>>,
+    F: svc::Service<http::Request<A>, Response = http::Response<C>>,
+    F::Error: Into<proxy::Error>,
+{
+    type Item = http::Response<Body<B, C>>;
+    type Error = proxy::Error;
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            self.state = match self.state {
+                State::Primary(ref mut f) => match f.poll() {
+                    Ok(Async::NotReady) => return Ok(Async::NotReady),
+                    Ok(Async::Ready(rsp)) => return Ok(Async::Ready(rsp.map(Body::A))),
+                    Err(Error::Error(e)) => return Err(e),
+                    Err(Error::Fallback(req)) => State::Fallback(self.fallback.call(req)),
+                },
+                State::Fallback(ref mut f) => {
+                    return f
+                        .poll()
+                        .map(|p| p.map(|rsp| rsp.map(Body::B)))
+                        .map_err(Into::into)
+                }
+            }
+        }
+    }
+}
+
+impl<A, B> Payload for Body<A, B>
+where
+    A: Payload,
+    B: Payload<Error = A::Error>,
+{
+    type Data = Body<A::Data, B::Data>;
+    type Error = A::Error;
+
+    fn poll_data(&mut self) -> Poll<Option<Self::Data>, Self::Error> {
+        match self {
+            Body::A(ref mut body) => body.poll_data().map(|r| r.map(|o| o.map(Body::A))),
+            Body::B(ref mut body) => body.poll_data().map(|r| r.map(|o| o.map(Body::B))),
+        }
+    }
+
+    fn poll_trailers(&mut self) -> Poll<Option<http::HeaderMap>, Self::Error> {
+        match self {
+            Body::A(ref mut body) => body.poll_trailers(),
+            Body::B(ref mut body) => body.poll_trailers(),
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        match self {
+            Body::A(ref body) => body.is_end_stream(),
+            Body::B(ref body) => body.is_end_stream(),
+        }
+    }
+}
+
+impl<A, B: Default> Default for Body<A, B> {
+    fn default() -> Self {
+        Body::B(Default::default())
+    }
+}
+
+impl<A, B> Buf for Body<A, B>
+where
+    A: Buf,
+    B: Buf,
+{
+    fn remaining(&self) -> usize {
+        match self {
+            Body::A(ref buf) => buf.remaining(),
+            Body::B(ref buf) => buf.remaining(),
+        }
+    }
+
+    fn bytes(&self) -> &[u8] {
+        match self {
+            Body::A(ref buf) => buf.bytes(),
+            Body::B(ref buf) => buf.bytes(),
+        }
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        match self {
+            Body::A(ref mut buf) => buf.advance(cnt),
+            Body::B(ref mut buf) => buf.advance(cnt),
+        }
+    }
+}

--- a/src/proxy/http/fallback.rs
+++ b/src/proxy/http/fallback.rs
@@ -13,7 +13,7 @@ pub enum Error<A> {
     Error(proxy::Error),
 }
 
-pub type Layer<P, F, A> = MakeFallback<svc::ServiceBuilder<P>, svc::ServiceBuilder<F>, A>;
+pub type Layer<P, F, A> = MakeFallback<svc::Builder<P>, svc::Builder<F>, A>;
 
 #[derive(Debug)]
 pub struct MakeFallback<P, F, A> {
@@ -63,10 +63,7 @@ enum Making<T: Future> {
     Done,
 }
 
-pub fn layer<P, F, A>(
-    primary: svc::ServiceBuilder<P>,
-    fallback: svc::ServiceBuilder<F>,
-) -> Layer<P, F, A> {
+pub fn layer<P, F, A>(primary: svc::Builder<P>, fallback: svc::Builder<F>) -> Layer<P, F, A> {
     Layer {
         primary,
         fallback,

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -2,6 +2,7 @@ pub mod add_header;
 pub mod balance;
 pub mod canonicalize;
 pub mod client;
+pub mod fallback;
 pub(super) mod glue;
 pub mod h1;
 pub mod h2;

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -25,14 +25,14 @@ pub struct Config {
 /// A `Rec`-typed `Recognize` instance is used to produce a target for each
 /// `Req`-typed request. If the router doesn't already have a `Service` for this
 /// target, it uses a `Mk`-typed `Service` stack.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Layer<Req, Rec: Recognize<Req>> {
     config: Config,
     recognize: Rec,
     _p: PhantomData<fn() -> Req>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Stack<Req, Rec: Recognize<Req>, Mk> {
     config: Config,
     recognize: Rec,
@@ -101,6 +101,14 @@ where
     }
 }
 
+impl<Req, Rec> Clone for Layer<Req, Rec>
+where
+    Rec: Recognize<Req> + Clone + Send + Sync + 'static,
+{
+    fn clone(&self) -> Self {
+        layer(self.config.clone(), self.recognize.clone())
+    }
+}
 // === impl Stack ===
 
 impl<Req, Rec, Mk, B> Stack<Req, Rec, Mk>
@@ -143,6 +151,19 @@ where
     }
 }
 
+impl<Req, Rec, Mk> Clone for Stack<Req, Rec, Mk>
+where
+    Rec: Recognize<Req> + Clone,
+    Mk: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            recognize: self.recognize.clone(),
+            inner: self.inner.clone(),
+            _p: PhantomData,
+        }
+    }
+}
 // === impl Service ===
 
 impl<Req, Rec, Mk, B> svc::Service<Req> for Service<Req, Rec, Mk>

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -158,6 +158,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
+            config: self.config.clone(),
             recognize: self.recognize.clone(),
             inner: self.inner.clone(),
             _p: PhantomData,

--- a/src/proxy/resolve.rs
+++ b/src/proxy/resolve.rs
@@ -2,8 +2,14 @@ extern crate linkerd2_router as rt;
 extern crate tower_discover;
 
 use futures::{Async, Poll};
-use std::fmt;
-use std::net::SocketAddr;
+use std::{
+    fmt,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 pub use self::tower_discover::Change;
 use proxy::Error;
@@ -24,6 +30,13 @@ pub trait Resolution {
 
     fn poll(&mut self) -> Poll<Update<Self::Endpoint>, Self::Error>;
 }
+
+pub trait HasEndpointStatus {
+    fn endpoint_status(&self) -> EndpointStatus;
+}
+
+#[derive(Clone, Debug)]
+pub struct EndpointStatus(Arc<AtomicBool>);
 
 #[derive(Clone, Debug)]
 pub enum Update<T> {
@@ -49,7 +62,7 @@ pub struct MakeSvc<R, M> {
 pub struct Discover<R, M> {
     resolution: R,
     make: M,
-    is_empty: bool,
+    is_empty: Arc<AtomicBool>,
 }
 
 // === impl Layer ===
@@ -94,33 +107,22 @@ where
 
     fn call(&mut self, target: T) -> Self::Future {
         let resolution = self.resolve.resolve(&target);
-        futures::future::ok(Discover::new(resolution, self.inner.clone()))
+        futures::future::ok(Discover {
+            resolution,
+            make: self.inner.clone(),
+            is_empty: Arc::new(AtomicBool::new(true)),
+        })
     }
 }
 
-// === impl Discover ===
-impl<R, M> Discover<R, M>
+impl<R, M> HasEndpointStatus for Discover<R, M>
 where
     R: Resolution,
-    R::Endpoint: fmt::Debug,
-    R::Error: Into<Error>,
-    M: rt::Make<R::Endpoint>,
 {
-    /// Returns `true` if there are currently endpoints for this resolution.
-    pub fn is_empty(&self) -> bool {
-        self.is_empty
-    }
-
-    fn new(resolution: R, make: &M) -> Self {
-        Discover {
-            resolution,
-            make: &make.clone(),
-            is_empty: true,
-        }
+    fn endpoint_status(&self) -> EndpointStatus {
+        EndpointStatus(self.is_empty.clone())
     }
 }
-
-
 
 impl<R, M> tower_discover::Discover for Discover<R, M>
 where
@@ -144,16 +146,22 @@ where
                     // insertions of new endpoints and metadata changes for
                     // existing ones can be handled in the same way.
                     let svc = self.make.make(&target);
-                    return Ok(Async::Ready(Change::Insert(addr, svc)))
+                    self.is_empty.store(false, Ordering::Release);
+                    return Ok(Async::Ready(Change::Insert(addr, svc)));
                 }
                 Update::Remove(addr) => return Ok(Async::Ready(Change::Remove(addr))),
                 Update::NoEndpoints => {
-                    self.is_empty = true;
+                    self.is_empty.store(true, Ordering::Release);
                     // Keep polling as we should now start to see removals.
                     continue;
                 }
             }
         }
     }
+}
 
+impl EndpointStatus {
+    pub fn is_empty(&self) -> bool {
+        self.0.load(Ordering::Acquire)
+    }
 }

--- a/src/proxy/resolve.rs
+++ b/src/proxy/resolve.rs
@@ -29,6 +29,7 @@ pub trait Resolution {
 pub enum Update<T> {
     Add(SocketAddr, T),
     Remove(SocketAddr),
+    NoEndpoints,
 }
 
 #[derive(Clone, Debug)]
@@ -48,6 +49,7 @@ pub struct MakeSvc<R, M> {
 pub struct Discover<R, M> {
     resolution: R,
     make: M,
+    is_empty: bool,
 }
 
 // === impl Layer ===
@@ -92,14 +94,33 @@ where
 
     fn call(&mut self, target: T) -> Self::Future {
         let resolution = self.resolve.resolve(&target);
-        futures::future::ok(Discover {
-            resolution,
-            make: self.inner.clone(),
-        })
+        futures::future::ok(Discover::new(resolution, self.inner.clone()))
     }
 }
 
 // === impl Discover ===
+impl<R, M> Discover<R, M>
+where
+    R: Resolution,
+    R::Endpoint: fmt::Debug,
+    R::Error: Into<Error>,
+    M: rt::Make<R::Endpoint>,
+{
+    /// Returns `true` if there are currently endpoints for this resolution.
+    pub fn is_empty(&self) -> bool {
+        self.is_empty
+    }
+
+    fn new(resolution: R, make: &M) -> Self {
+        Discover {
+            resolution,
+            make: &make.clone(),
+            is_empty: true,
+        }
+    }
+}
+
+
 
 impl<R, M> tower_discover::Discover for Discover<R, M>
 where
@@ -113,18 +134,26 @@ where
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Change<Self::Key, Self::Service>, Self::Error> {
-        let up = try_ready!(self.resolution.poll().map_err(Into::into));
-        trace!("watch: {:?}", up);
-        match up {
-            Update::Add(addr, target) => {
-                // We expect the load balancer to handle duplicate inserts
-                // by replacing the old endpoint with the new one, so
-                // insertions of new endpoints and metadata changes for
-                // existing ones can be handled in the same way.
-                let svc = self.make.make(&target);
-                Ok(Async::Ready(Change::Insert(addr, svc)))
+        loop {
+            let up = try_ready!(self.resolution.poll().map_err(Into::into));
+            trace!("watch: {:?}", up);
+            match up {
+                Update::Add(addr, target) => {
+                    // We expect the load balancer to handle duplicate inserts
+                    // by replacing the old endpoint with the new one, so
+                    // insertions of new endpoints and metadata changes for
+                    // existing ones can be handled in the same way.
+                    let svc = self.make.make(&target);
+                    return Ok(Async::Ready(Change::Insert(addr, svc)))
+                }
+                Update::Remove(addr) => return Ok(Async::Ready(Change::Remove(addr))),
+                Update::NoEndpoints => {
+                    self.is_empty = true;
+                    // Keep polling as we should now start to see removals.
+                    continue;
+                }
             }
-            Update::Remove(addr) => Ok(Async::Ready(Change::Remove(addr))),
         }
     }
+
 }


### PR DESCRIPTION
Currently, when no endpoints exist in the load balancer for a
destination, we fail the request. This is because we expect endpoints to
be discovered by both destination service queries _and_ DNS lookups, so
if there are no endpoints for a destination, it is assumed to not exist.

In linkerd/linkerd2#2661, we intend to remove the DNS lookup from the
proxy and instead fall back to routing requests for which no endpoints
exist in the destination service to their SO_ORIGINAL_DST IP address.
This means that the current approach of failing requests when the load
balancer has no endpoints will no longer work.

This branch introduces a generic `fallback` layer, which composes a
primary and secondary service builder into a new layer. The primary 
service can fail requests with an error type that propages the original
request, allowing the fallback middleware to call the fallback service
with the same request. Other errors returned by the primary service are
still propagated upstream.

In contrast to the approach used in #240, this fallback middleware is 
generic and not tied directly to a load balancer or a router, and can
be used for other purposes in the future. It relies on the router cache
eviction added in #247 to drain the router when it is not being used, 
rather than proactively destroying the router when endpoints are
available for the lb, and re-creating it when they exist again.

A new trait, `HasEndpointStatus`, is added in order to allow the
discovery lookup to communicate the "no endpoints" state to the
balancer. In addition, we add a new `Update::NoEndpoints` variant to
`proxy::resolve::Update`, so that when the control plane sends a no
endpoints update, we switch from the balancer to the no endpoints state
_immediately_, rather than waiting for all the endpoints to be
individually removed. When the balancer has no endpoints, it fails all
requests with a fallback error, so that the fallback middleware

A future commit will remove the DNS lookups from the discovery module.

Closes #240.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>