### PR TITLE
Allow to disable tap via setting an env var

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -145,6 +145,9 @@ pub struct Config {
     pub dns_canonicalize_timeout: Duration,
 
     pub h2_settings: H2Settings,
+
+    /// When set, tap is not served
+    pub tap_disabled: bool,
 }
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -278,6 +281,7 @@ pub const ENV_DESTINATION_CONTEXT: &str = "LINKERD2_PROXY_DESTINATION_CONTEXT";
 pub const ENV_CONTROL_EXP_BACKOFF_MIN: &str = "LINKERD2_PROXY_CONTROL_EXP_BACKOFF_MIN";
 pub const ENV_CONTROL_EXP_BACKOFF_MAX: &str = "LINKERD2_PROXY_CONTROL_EXP_BACKOFF_MAX";
 pub const ENV_CONTROL_EXP_BACKOFF_JITTER: &str = "LINKERD2_PROXY_CONTROL_EXP_BACKOFF_JITTER";
+pub const ENV_TAP_DISABLED: &str = "LINKERD2_PROXY_TAP_DISABLED";
 const ENV_CONTROL_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_CONTROL_CONNECT_TIMEOUT";
 const ENV_CONTROL_DISPATCH_TIMEOUT: &str = "LINKERD2_PROXY_CONTROL_DISPATCH_TIMEOUT";
 const ENV_RESOLV_CONF: &str = "LINKERD2_PROXY_RESOLV_CONF";
@@ -464,6 +468,11 @@ impl Config {
         let initial_connection_window_size =
             parse(strings, ENV_INITIAL_CONNECTION_WINDOW_SIZE, parse_number);
 
+        let tap_disabled =     strings
+                .get(ENV_TAP_DISABLED)?
+                .map(|d| !d.is_empty())
+                .unwrap_or(false);
+
         Ok(Config {
             outbound_listener: Listener {
                 addr: outbound_listener_addr?
@@ -567,6 +576,8 @@ impl Config {
                 initial_stream_window_size: initial_stream_window_size?,
                 initial_connection_window_size: initial_connection_window_size?,
             },
+
+            tap_disabled,
         })
     }
 }

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -383,9 +383,8 @@ where
                         Admin::new(report, readiness),
                     ));
 
-                    rt.spawn(tap_daemon.map_err(|_| ()));
-
                     if let Some(listener) = control_listener {
+                        rt.spawn(tap_daemon.map_err(|_| ()));
                         rt.spawn(serve_tap(listener, TapServer::new(tap_grpc)));
                     }
 

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -64,7 +64,7 @@ struct ProxyParts<G> {
     start_time: SystemTime,
 
     admin_listener: Listen<identity::Local, ()>,
-    control_listener: Listen<identity::Local, ()>,
+    control_listener: Option<Listen<identity::Local, ()>>,
 
     inbound_listener: Listen<identity::Local, G>,
     outbound_listener: Listen<identity::Local, G>,
@@ -96,8 +96,14 @@ where
         let identity = config.identity_config.as_ref().map(identity::Local::new);
         let local_identity = identity.as_ref().map(|(l, _)| l.clone());
 
-        let control_listener = Listen::bind(config.control_listener.addr, local_identity.clone())
-            .expect("dst_svc listener bind");
+        let control_listener = if config.tap_disabled {
+            None
+        } else {
+            Some(
+                Listen::bind(config.control_listener.addr, local_identity.clone())
+                    .expect("dst_svc listener bind"),
+            )
+        };
 
         let admin_listener = Listen::bind(config.admin_listener.addr, local_identity.clone())
             .expect("metrics listener bind");
@@ -135,8 +141,10 @@ where
         }
     }
 
-    pub fn control_addr(&self) -> SocketAddr {
-        self.proxy_parts.control_listener.local_addr()
+    pub fn control_addr(&self) -> Option<SocketAddr> {
+        self.proxy_parts
+            .control_listener.as_ref()
+            .map(|l| l.local_addr().clone())
     }
 
     pub fn inbound_addr(&self) -> SocketAddr {
@@ -379,7 +387,10 @@ where
                     ));
 
                     rt.spawn(tap_daemon.map_err(|_| ()));
-                    rt.spawn(serve_tap(control_listener, TapServer::new(tap_grpc)));
+
+                    if let Some(listener) = control_listener {
+                        rt.spawn(serve_tap(listener, TapServer::new(tap_grpc)));
+                    }
 
                     rt.spawn(::logging::admin().bg("dns-resolver").future(dns_bg));
 

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -96,14 +96,10 @@ where
         let identity = config.identity_config.as_ref().map(identity::Local::new);
         let local_identity = identity.as_ref().map(|(l, _)| l.clone());
 
-        let control_listener = if config.tap_disabled {
-            None
-        } else {
-            Some(
-                Listen::bind(config.control_listener.addr, local_identity.clone())
-                    .expect("dst_svc listener bind"),
-            )
-        };
+        let control_listener = config
+            .control_listener
+            .as_ref()
+            .map(|l| Listen::bind(l.addr, local_identity.clone()).expect("dst_svc listener bind"));
 
         let admin_listener = Listen::bind(config.admin_listener.addr, local_identity.clone())
             .expect("metrics listener bind");
@@ -143,7 +139,8 @@ where
 
     pub fn control_addr(&self) -> Option<SocketAddr> {
         self.proxy_parts
-            .control_listener.as_ref()
+            .control_listener
+            .as_ref()
             .map(|l| l.local_addr().clone())
     }
 

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -19,7 +19,7 @@ pub struct Proxy {
 }
 
 pub struct Listening {
-    pub control: SocketAddr,
+    pub control: Option<SocketAddr>,
     pub inbound: SocketAddr,
     pub outbound: SocketAddr,
     pub metrics: SocketAddr,
@@ -273,7 +273,10 @@ fn run(proxy: Proxy, mut env: app::config::TestEnv) -> Listening {
     // printlns will show if the test fails...
     println!(
         "proxy running; destination={}, identity={:?}, inbound={}{}, outbound={}{}, metrics={}",
-        control_addr,
+        control_addr
+            .as_ref()
+            .map(|i| format!("{}", i))
+            .unwrap_or_else(String::new),
         identity_addr,
         inbound_addr,
         inbound

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -275,7 +275,7 @@ fn run(proxy: Proxy, mut env: app::config::TestEnv) -> Listening {
         "proxy running; destination={}, identity={:?}, inbound={}{}, outbound={}{}, metrics={}",
         control_addr
             .as_ref()
-            .map(|i| format!("{}", i))
+            .map(SocketAddr::to_string)
             .unwrap_or_else(String::new),
         identity_addr,
         inbound_addr,


### PR DESCRIPTION
This PR aims to fix https://github.com/linkerd/linkerd2/issues/2811. Now if `LINKERD2_PROXY_TAP_DISABLED` is set, the tap is not served at all. The approach taken is that  the `ProxyParts` is changed so the `control_listener` is now an `Option` that will be None if tap is disabled as this control_listener seems to be exclusively used to serve the tap. Feel free to suggest a better approach. 

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>