### PR TITLE
 Pass router::Config directly to router::Layer

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -540,7 +540,8 @@ where
                     },
                 ))
                 .buffer_pending(max_in_flight, DispatchDeadline::extract)
-                .service(dst_stack);
+                .service(dst_stack)
+                .make();
 
             // Canonicalizes the request-specified `Addr` via DNS, and
             // annotates each request with a refined `Addr` so that it may be
@@ -584,7 +585,8 @@ where
                 .layer(insert::target::layer())
                 .layer(strip_header::request::layer(super::DST_OVERRIDE_HEADER))
                 .layer(strip_header::request::layer(super::L5D_CLIENT_ID))
-                .service(addr_stack);
+                .service(addr_stack)
+                .make();
 
             // Share a single semaphore across all requests to signal when
             // the proxy is overloaded.
@@ -670,7 +672,8 @@ where
                     endpoint_http_metrics,
                 ))
                 .layer(tap_layer)
-                .service(client_stack);
+                .service(client_stack)
+                .make();
 
             // A per-`dst::Route` layer that uses profile data to configure
             // a per-route layer.
@@ -740,7 +743,8 @@ where
                     },
                 ))
                 .buffer_pending(max_in_flight, DispatchDeadline::extract)
-                .service(dst_stack);
+                .service(dst_stack)
+                .make();
 
             // Share a single semaphore across all requests to signal when
             // the proxy is overloaded.

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -540,8 +540,7 @@ where
                     },
                 ))
                 .buffer_pending(max_in_flight, DispatchDeadline::extract)
-                .service(dst_stack)
-                .make();
+                .service(dst_stack);
 
             // Canonicalizes the request-specified `Addr` via DNS, and
             // annotates each request with a refined `Addr` so that it may be
@@ -585,8 +584,7 @@ where
                 .layer(insert::target::layer())
                 .layer(strip_header::request::layer(super::DST_OVERRIDE_HEADER))
                 .layer(strip_header::request::layer(super::L5D_CLIENT_ID))
-                .service(addr_stack)
-                .make();
+                .service(addr_stack);
 
             // Share a single semaphore across all requests to signal when
             // the proxy is overloaded.
@@ -672,8 +670,7 @@ where
                     endpoint_http_metrics,
                 ))
                 .layer(tap_layer)
-                .service(client_stack)
-                .make();
+                .service(client_stack);
 
             // A per-`dst::Route` layer that uses profile data to configure
             // a per-route layer.
@@ -743,8 +740,7 @@ where
                     },
                 ))
                 .buffer_pending(max_in_flight, DispatchDeadline::extract)
-                .service(dst_stack)
-                .make();
+                .service(dst_stack);
 
             // Share a single semaphore across all requests to signal when
             // the proxy is overloaded.

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -4,8 +4,6 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::time::Duration;
 
-use never::Never;
-
 use proxy::Error;
 use svc;
 
@@ -29,14 +27,6 @@ pub struct Config {
 pub struct Layer<Req, Rec: Recognize<Req>> {
     config: Config,
     recognize: Rec,
-    _p: PhantomData<fn() -> Req>,
-}
-
-#[derive(Clone, Debug)]
-pub struct Stack<Req, Rec: Recognize<Req>, Mk> {
-    config: Config,
-    recognize: Rec,
-    inner: Mk,
     _p: PhantomData<fn() -> Req>,
 }
 
@@ -99,48 +89,6 @@ where
             self.config.max_idle_age,
         );
         Service { inner }
-    }
-}
-
-// === impl Stack ===
-
-impl<Req, Rec, Mk, B> Stack<Req, Rec, Mk>
-where
-    Rec: Recognize<Req> + Clone + Send + Sync + 'static,
-    Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
-    Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
-    <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
-    B: Default + Send + 'static,
-{
-    pub fn make(&self) -> Service<Req, Rec, Mk> {
-        let inner = Router::new(
-            self.recognize.clone(),
-            self.inner.clone(),
-            self.config.capacity,
-            self.config.max_idle_age,
-        );
-        Service { inner }
-    }
-}
-
-impl<Req, Rec, Mk, B, T> svc::Service<T> for Stack<Req, Rec, Mk>
-where
-    Rec: Recognize<Req> + Clone + Send + Sync + 'static,
-    Mk: rt::Make<Rec::Target> + Clone + Send + Sync + 'static,
-    Mk::Value: svc::Service<Req, Response = http::Response<B>> + Clone,
-    <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
-    B: Default + Send + 'static,
-{
-    type Response = Service<Req, Rec, Mk>;
-    type Error = Never;
-    type Future = futures::future::FutureResult<Self::Response, Self::Error>;
-
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        Ok(().into()) // always ready to make a Router
-    }
-
-    fn call(&mut self, _: T) -> Self::Future {
-        futures::future::ok(self.make())
     }
 }
 

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -79,16 +79,15 @@ where
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
     B: Default + Send + 'static,
 {
-    type Service = Service<Req, Rec, Mk>;
+    type Service = Stack<Req, Rec, Mk>;
 
     fn layer(&self, inner: Mk) -> Self::Service {
-        let inner = Router::new(
-            self.recognize.clone(),
+        Stack {
             inner,
-            self.config.capacity,
-            self.config.max_idle_age,
-        );
-        Service { inner }
+            config: self.config.clone(),
+            recognize: self.recognize.clone(),
+            _p: PhantomData,
+        }
     }
 }
 

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -89,15 +89,16 @@ where
     <Mk::Value as svc::Service<Req>>::Error: Into<Error>,
     B: Default + Send + 'static,
 {
-    type Service = Stack<Req, Rec, Mk>;
+    type Service = Service<Req, Rec, Mk>;
 
     fn layer(&self, inner: Mk) -> Self::Service {
-        Stack {
+        let inner = Router::new(
+            self.recognize.clone(),
             inner,
-            config: self.config.clone(),
-            recognize: self.recognize.clone(),
-            _p: PhantomData,
-        }
+            self.config.capacity,
+            self.config.max_idle_age,
+        );
+        Service { inner }
     }
 }
 


### PR DESCRIPTION
Currently, router `layer`s are constructed with a single argument, a
type implementing `Recognize`. Then, the entire router stack is built
with a `router::Config`. However, in #248, it became necessary to
provide the config up front when constructing the `router::layer`, as
the layer is used in a fallback layer. Rather than providing a separate
type for a preconfigured layer, @olix0r suggested we simply change all
router layers to accept the `Config` when they're constructed (see
https://github.com/linkerd/linkerd2-proxy/pull/248#discussion_r283575008).

This branch changes `router::Layer` to accept the config up front. The
`router::Stack` types `make` function now requires no arguments, and the
implementation of `Service` for `Stack` can be called with any `T` (as
the target is now ignored).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>