### PR TITLE
Fix load balancer not being ready when it wants to fall back

### DIFF
--- a/src/proxy/http/balance.rs
+++ b/src/proxy/http/balance.rs
@@ -164,6 +164,11 @@ where
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         let ready = self.balance.poll_ready().map_err(fallback::Error::from)?;
         if self.status.is_empty() {
+            // `tower_balance`'s load balancer will return `NotReady` when it
+            // has no ready endpoints. However, if we are in the no endpoints
+            // state, we should accept the request so that we can return the
+            // error indicating that we should fall back to the request's 
+            // original destination.
             Ok(Async::Ready(()))
         } else {
             Ok(ready)

--- a/src/proxy/http/balance.rs
+++ b/src/proxy/http/balance.rs
@@ -162,7 +162,12 @@ where
     >;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.balance.poll_ready().map_err(From::from)
+        let ready = self.balance.poll_ready().map_err(fallback::Error::from)?;
+        if self.status.is_empty() {
+            Ok(Async::Ready(()))
+        } else {
+            Ok(ready)
+        }
     }
 
     fn call(&mut self, req: http::Request<A>) -> Self::Future {

--- a/src/proxy/http/balance.rs
+++ b/src/proxy/http/balance.rs
@@ -167,7 +167,7 @@ where
             // `tower_balance`'s load balancer will return `NotReady` when it
             // has no ready endpoints. However, if we are in the no endpoints
             // state, we should accept the request so that we can return the
-            // error indicating that we should fall back to the request's 
+            // error indicating that we should fall back to the request's
             // original destination.
             Ok(Async::Ready(()))
         } else {


### PR DESCRIPTION
The `tower-balance` load balancer's `poll_ready` function returns
`NotReady` when the load balancer has no ready endpoints. However, our
fallback strategy added in #248 requires the load balancer to accept a
request when it has no endpoints, so that it can return the error
indicating that the fallback router should be used. This branch changes
the proxy's `http::balance::Service`'s `poll_ready` implementation to
return `Ok(Async::Ready(()))` when it is in the no endpoints state, so
that the request will fall back.

This fix was backported from #245.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>