### PR TITLE
Use the proxy's log formatting in tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub mod convert;
 mod dns;
 mod drain;
 mod identity;
-mod logging;
+pub mod logging;
 mod proxy;
 mod svc;
 mod tap;

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -71,7 +71,10 @@ pub fn env_logger_init() -> Result<(), String> {
     env::set_var("RUST_LOG", &log);
     env::set_var("LINKERD2_PROXY_LOG", &log);
 
-    env_logger::try_init().map_err(|e| e.to_string())
+    self::linkerd2_proxy::logging::formatted_builder()
+        .parse(&log)
+        .try_init()
+        .map_err(|e| e.to_string())
 }
 
 /// Retry an assertion up to a specified number of times, waiting


### PR DESCRIPTION
The proxy implements custom log formatting which includes timestamps and
formatted contexts describing the context in which the log line was
recorded. Currently, however, when running the proxy's integration
tests, the default log formatting from the `env_logger` crate rather
than the proxy's format. There are two main reasons why it would be
preferable to use the proxy's log formatting style instead:

* Information in the log contexts and timestamps can be valuable for
  debugging a failing test. For example, many log lines don't include
  information such as the destination address for a request as they
  assume this will be provided by the log context. This can make
  understanding log output from tests difficult since the log contexts
  are not included.
* In order to debug changes to the log formatting, it may be easier to
  run a test with a log level set, rather than exercise certain
  behaviours manually. This is my original motivation behind this change
  --- I wanted to add a new log context to the background task driving
  destination service discovery, and it takes significantly less work to
  simply run the discovery tests with logging enabled rather than
  actually spinning up a new Kubernetes cluster to test this with a live
  destination service.

This branch changes the integration test support module's
`env_logger_init` function to use the proxy's log formatter rather than
the default.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>