### PR TITLE
 discovery: Only fall back on InvalidArgument

### DIFF
--- a/src/control/destination/resolution.rs
+++ b/src/control/destination/resolution.rs
@@ -180,7 +180,7 @@ where
                         // requested name should *not* query the destination
                         // service. In this case, do not attempt to reconnect.
                         debug!("Destination.Get stream ended with Invalid Argument",);
-                        let _ = self.updater.does_not_exist();
+                        let _ = self.updater.unresolvable();
                         return Ok(Async::Ready(()));
                     }
                     Err(err) => {
@@ -288,9 +288,9 @@ impl Updater {
         Ok(())
     }
 
-    fn does_not_exist(&mut self) -> Result<(), ()> {
+    fn unresolvable(&mut self) -> Result<(), ()> {
         self.send(Update::NoEndpoints)?;
-        self.remove_all("nonexistent")
+        self.remove_all("unresolvable")
     }
 }
 
@@ -299,7 +299,7 @@ impl<'a> fmt::Display for DisplayUpdate<'a> {
         match self.0 {
             Update::Remove(ref addr) => write!(f, "remove {}", addr),
             Update::Add(ref addr, ..) => write!(f, "add {}", addr),
-            Update::NoEndpoints => "does not exist in service discovery".fmt(f),
+            Update::NoEndpoints => "should not be resolved by the Destination service".fmt(f),
         }
     }
 }

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -212,13 +212,9 @@ macro_rules! generate_tests {
             // Wait for the reconnect to happen. TODO: Replace this flaky logic.
             thread::sleep(Duration::from_millis(1000));
 
+            let rsp = initially_exists.request(&mut initially_exists.request_builder("/"));
+            assert_eq!(rsp.status(), http::StatusCode::SERVICE_UNAVAILABLE);
 
-            // This would wait since there are no endpoints.
-            let mut req = initially_exists.request_builder("/");
-            initially_exists
-                .request_async(req.method("GET"))
-                .wait_timeout(Duration::from_secs(1))
-                .expect_timedout("request should wait for destination capacity");
         }
 
         #[test]


### PR DESCRIPTION
When the Destination service returns a `NoEndpoints` response, a field
`exists` is set if the destination _does_ exist in service discovery
but has no endpoints. The API spec states that:

> `no_endpoints{exists: false}` indicates that the service does not exist
> and the client MAY try an alternate service discovery method (e.g. DNS).
>
> `no_endpoints(exists: true)` indicates that the service does exist and
> the client MUST NOT fall back to an alternate service discovery
> method.

When the DNS fallback behavior was removed from the proxy in #259, this
field was overlooked, and the proxy was changed to fall back to original
destination routing _any_ time the control plane indicates that no
endpoints exist for a destination. This is incorrect, as the proxy
should always treat the destination service as authoritative.
Additionally, this means that requests to endpoints which are known to
not exist will construct an unnecessary client service, and eventually
fail with a 502 error when the upstream client connection  to the
non-existent endpoint ultimately fails.

This branch changes the `control::destination::resolution::Daemon`
future to only send `Update::NoEndpoints` (which indicates that the load
balancer should fall back) to the load balancer when the Destination
service response has `exists: false`, or on `InvalidArgument` errors,
and _not_ when a `no_endpoints{exists: true}` response is received.
These requests will now fail fast with a 503 error rather than
attempting an ultimately futile fallback request.

Previously, one of the discovery tests expected the incorrect behavior.
I've changed this test to now expect that destinations known to not
exist do _not_ fall back, and renamed it from
`outbound_falls_back_to_orig_dst_when_destination_has_no_endpoints` to
`outbound_fails_fast_when_destination_has_no_endpoints`. I've also
confirmed that the updated test fails against master and passes after
this change.

Fixes linkerd/linkerd2#2880

Signed-off-by: Eliza Weisman <eliza@buoyant.io>