### PR TITLE
Honor `l5d-override-dst` for inbound service profiles

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -771,7 +771,7 @@ where
                             .or_else(|| super::http_request_authority_addr(req).ok())
                             .or_else(|| super::http_request_host_addr(req).ok())
                             .or_else(|| super::http_request_orig_dst_addr(req).ok());
-                            debug!("inbound dst={:?}", dst);
+                        debug!("inbound dst={:?}", dst);
 
                         dst.map(|addr| {
                             let settings = settings::Settings::from_request(req);

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -573,15 +573,18 @@ where
 
             // Routes requests to an `Addr`:
             //
-            // 1. If the request is HTTP/2 and has an :authority, this value
+            // 1. If the request had an `l5d-override-dst` header, this value
             // is used.
             //
-            // 2. If the request is absolute-form HTTP/1, the URI's
+            // 2. If the request is HTTP/2 and has an :authority, this value
+            // is used.
+            //
+            // 3. If the request is absolute-form HTTP/1, the URI's
             // authority is used.
             //
-            // 3. If the request has an HTTP/1 Host header, it is used.
+            // 4. If the request has an HTTP/1 Host header, it is used.
             //
-            // 4. Finally, if the Source had an SO_ORIGINAL_DST, this TCP
+            // 5. Finally, if the Source had an SO_ORIGINAL_DST, this TCP
             // address is used.
             let addr_router = svc::builder()
                 .layer(router::layer(
@@ -717,6 +720,7 @@ where
             // 2. Annotates the request with the `DstAddr` so that
             //    `RecognizeEndpoint` can use the value.
             let dst_stack = svc::builder()
+                .layer(strip_header::request::layer(super::DST_OVERRIDE_HEADER))
                 .layer(profiles::router::layer(
                     profile_suffixes,
                     profiles_client,
@@ -731,15 +735,18 @@ where
             // 1. If the CANONICAL_DST_HEADER is set by the remote peer,
             // this value is used to construct a DstAddr.
             //
-            // 2. If the request is HTTP/2 and has an :authority, this value
+            // 2. If the OVERRIDE_DST_HEADER is set by the remote peer,
+            // this value is used.
+            //
+            // 3. If the request is HTTP/2 and has an :authority, this value
             // is used.
             //
-            // 3. If the request is absolute-form HTTP/1, the URI's
+            // 4. If the request is absolute-form HTTP/1, the URI's
             // authority is used.
             //
-            // 4. If the request has an HTTP/1 Host header, it is used.
+            // 5. If the request has an HTTP/1 Host header, it is used.
             //
-            // 5. Finally, if the Source had an SO_ORIGINAL_DST, this TCP
+            // 6. Finally, if the Source had an SO_ORIGINAL_DST, this TCP
             // address is used.
             let dst_router = svc::builder()
                 .layer(router::layer(
@@ -753,10 +760,19 @@ where
                         debug!("inbound canonical={:?}", canonical);
 
                         let dst = canonical
+                            .or_else(|| {
+                                super::http_request_l5d_override_dst_addr(req)
+                                    .map(|override_addr| {
+                                        debug!("inbound dst={:?}; dst-override", override_addr);
+                                        override_addr
+                                    })
+                                    .ok()
+                            })
                             .or_else(|| super::http_request_authority_addr(req).ok())
                             .or_else(|| super::http_request_host_addr(req).ok())
                             .or_else(|| super::http_request_orig_dst_addr(req).ok());
-                        debug!("inbound dst={:?}", dst);
+                            debug!("inbound dst={:?}", dst);
+
                         dst.map(|addr| {
                             let settings = settings::Settings::from_request(req);
                             DstAddr::inbound(addr, settings)
@@ -785,7 +801,6 @@ where
                 .layer(insert::layer(move || {
                     DispatchDeadline::after(dispatch_timeout)
                 }))
-                .layer(strip_header::request::layer(super::DST_OVERRIDE_HEADER))
                 .layer(strip_header::response::layer(super::L5D_SERVER_ID))
                 .layer(strip_header::request::layer(super::L5D_CLIENT_ID))
                 .layer(strip_header::request::layer(super::L5D_REMOTE_IP))


### PR DESCRIPTION
When the proxy receives an inbound request, it strips the
`l5d-dst-override` header and ignores its value. Instead, this header
value should be honored in the inbound router as it is in the outbound
router. This will enable service profile discovery from ingresses, for
instance.

This branch changes the inbound router to use the `l5d-override-dst`
header preferentially, with only the `l5d-canonical-dst` header taking
priority over it if it is present. The layer that strips the override
header is moved to under the inbound dst router.

In addition, I've added new tests in the discovery module that assert
that the value of the `l5d-override-dst` header is used for profile
discovery when present, on both the inbound and outbound sides of the
proxy. The inbound tests fail prior to the other changes on this branch.

Closes linkerd/linkerd2#2910.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>