### PR TITLE
discovery: Fall back only on InvalidArgument, in MakeService

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -522,7 +522,10 @@ where
                 .layer(buffer::layer(max_in_flight, DispatchDeadline::extract));
 
             let balancer_stack = svc::builder()
-                .layer(fallback::layer(balancer, orig_dst_router))
+                .layer(
+                    fallback::layer(balancer, orig_dst_router)
+                        .on_error::<control::destination::Unresolvable>(),
+                )
                 .layer(pending::layer())
                 .layer(balance::weight::layer())
                 .service(endpoint_stack);

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -250,7 +250,6 @@ pub mod discovery {
         fn poll(&mut self) -> Poll<resolve::Update<Self::Endpoint>, Self::Error> {
             match self.resolving {
                 Resolving::Name(ref name, ref mut res) => match try_ready!(res.poll()) {
-                    resolve::Update::NoEndpoints => Ok(Async::Ready(resolve::Update::NoEndpoints)),
                     resolve::Update::Remove(addr) => {
                         debug!("removing {}", addr);
                         Ok(Async::Ready(resolve::Update::Remove(addr)))

--- a/src/control/destination/client.rs
+++ b/src/control/destination/client.rs
@@ -49,7 +49,7 @@ where
     }
 
     /// Returns a destination service query for the given `dst`.
-    pub fn connect(self, dst: &NameAddr) -> Query<T> {
+    pub fn connect(mut self, dst: &NameAddr) -> Query<T> {
         let query = self.query(dst, "connect");
         Query {
             auth: dst.clone(),

--- a/src/control/destination/client.rs
+++ b/src/control/destination/client.rs
@@ -1,4 +1,4 @@
-use futures::{future::Future, Async, Poll, Stream};
+use futures::{Async, Poll, Stream};
 
 use tower_grpc::{self as grpc, generic::client::GrpcService, BoxBody};
 
@@ -78,7 +78,7 @@ where
         self.query = Remote::NeedsReconnect;
     }
 
-    pub fn poll(&mut self) -> Poll<Update, grpc::Status> {
+    pub fn poll(&mut self) -> Poll<Option<Update>, grpc::Status> {
         loop {
             self.query = match self.query {
                 Remote::ConnectedOrConnecting { ref mut rx } => return rx.poll(),

--- a/src/control/destination/client.rs
+++ b/src/control/destination/client.rs
@@ -1,0 +1,92 @@
+use futures::{future::Future, Async, Poll, Stream};
+
+use tower_grpc::{self as grpc, generic::client::GrpcService, BoxBody};
+
+use api::destination::{client::Destination, GetDestination, Update};
+
+use control::remote_stream::{self, Remote};
+use std::sync::Arc;
+
+use NameAddr;
+
+#[derive(Clone)]
+pub struct Client<T> {
+    client: T,
+    context_token: Arc<String>,
+}
+
+pub struct Query<T>
+where
+    T: GrpcService<BoxBody>,
+{
+    auth: NameAddr,
+    client: Client<T>,
+    query: remote_stream::Remote<Update, T>,
+}
+
+// ===== impl Client =====
+
+impl<T> Client<T>
+where
+    T: GrpcService<BoxBody>,
+{
+    fn query(&mut self, dst: &NameAddr, kind: &str) -> Remote<Update, T> {
+        trace!("{}ing destination service query for {}", kind, dst);
+        if let Ok(Async::Ready(())) = self.client.poll_ready() {
+            let req = GetDestination {
+                scheme: "k8s".into(),
+                path: format!("{}", dst),
+                context_token: self.context_token.as_ref().clone(),
+            };
+            let mut svc = Destination::new(self.client.as_service());
+            let response = svc.get(grpc::Request::new(req));
+            let rx = remote_stream::Receiver::new(response);
+            Remote::ConnectedOrConnecting { rx }
+        } else {
+            trace!("destination client not yet ready");
+            Remote::NeedsReconnect
+        }
+    }
+
+    /// Returns a destination service query for the given `dst`.
+    pub fn connect(self, dst: &NameAddr) -> Query<T> {
+        let query = self.query(dst, "connect");
+        Query {
+            auth: dst.clone(),
+            client: self,
+            query,
+        }
+    }
+
+    pub fn new(client: T, proxy_id: String) -> Self {
+        Self {
+            client,
+            context_token: Arc::new(proxy_id),
+        }
+    }
+}
+
+impl<T> Query<T>
+where
+    T: GrpcService<BoxBody>,
+{
+    pub fn authority(&self) -> &NameAddr {
+        &self.auth
+    }
+
+    pub fn reconnect(&mut self) {
+        self.query = Remote::NeedsReconnect;
+    }
+
+    pub fn poll(&mut self) -> Poll<Update, grpc::Status> {
+        loop {
+            self.query = match self.query {
+                Remote::ConnectedOrConnecting { ref mut rx } => return rx.poll(),
+                Remote::NeedsReconnect => match self.client.query(&self.auth, "reconnect") {
+                    Remote::NeedsReconnect => return Ok(Async::NotReady),
+                    query => query,
+                },
+            }
+        }
+    }
+}

--- a/src/control/destination/client.rs
+++ b/src/control/destination/client.rs
@@ -9,12 +9,16 @@ use std::sync::Arc;
 
 use NameAddr;
 
+/// A client for making service discovery requests to the destination service.
 #[derive(Clone)]
 pub struct Client<T> {
     client: T,
     context_token: Arc<String>,
 }
 
+/// A destination service query for a particular name.
+///
+/// A `Query` manages the underlying gRPC request and can reconnect itself as necessary.
 pub struct Query<T>
 where
     T: GrpcService<BoxBody>,
@@ -74,10 +78,12 @@ where
         &self.auth
     }
 
+    /// Indicates that this query should be reconnected.
     pub fn reconnect(&mut self) {
         self.query = Remote::NeedsReconnect;
     }
 
+    /// Polls the destination service query for updates, reconnecting if necessary.
     pub fn poll(&mut self) -> Poll<Option<Update>, grpc::Status> {
         loop {
             self.query = match self.query {

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -38,7 +38,7 @@ pub use self::resolution::{Resolution, ResolveFuture, Unresolvable};
 use proxy::http::balance::Weight;
 use NameAddr;
 
-/// A handle to request resolutions from the background discovery task.
+/// A handle to request resolutions from the destination service.
 #[derive(Clone)]
 pub struct Resolver<T> {
     client: Option<Client<T>>,

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -31,8 +31,10 @@ use dns;
 use identity;
 use proxy::resolve::{Resolve, Update};
 
+mod client;
 mod resolution;
-pub use self::resolution::Resolution;
+use self::client::Client;
+pub use self::resolution::{Resolution, ResolveFuture};
 use proxy::http::balance::Weight;
 use NameAddr;
 
@@ -77,12 +79,6 @@ pub enum ProtocolHint {
     Http2,
 }
 
-#[derive(Clone)]
-struct Client<T> {
-    client: T,
-    context_token: Arc<String>,
-}
-
 // ==== impl Resolver =====
 
 impl<T> Resolver<T>
@@ -94,10 +90,7 @@ where
 {
     /// Returns a `Resolver` for requesting destination resolutions.
     pub fn new(client: Option<T>, suffixes: Vec<dns::Suffix>, proxy_id: String) -> Resolver<T> {
-        let client = client.map(|client| Client {
-            context_token: Arc::new(proxy_id),
-            client,
-        });
+        let client = client.map(|client| Client::new(client, proxy_id));
         Resolver {
             suffixes: Arc::new(suffixes),
             client,
@@ -114,21 +107,22 @@ where
 {
     type Endpoint = Metadata;
     type Resolution = Resolution;
+    type Future = ResolveFuture<T>;
 
     /// Start watching for address changes for a certain authority.
-    fn resolve(&self, authority: &NameAddr) -> Resolution {
+    fn resolve(&self, authority: &NameAddr) -> Self::Future {
         trace!("resolve; authority={:?}", authority);
 
         if self.suffixes.iter().any(|s| s.contains(authority.name())) {
             if let Some(client) = self.client.as_ref().cloned() {
-                return Resolution::new(authority.clone(), client);
+                return ResolveFuture::new(authority.clone(), client);
             } else {
                 trace!("-> control plane client disabled");
             }
         } else {
             trace!("-> authority {} not in search suffixes", authority);
         }
-        Resolution::none()
+        ResolveFuture::unresolvable()
     }
 }
 

--- a/src/control/destination/mod.rs
+++ b/src/control/destination/mod.rs
@@ -34,7 +34,7 @@ use proxy::resolve::{Resolve, Update};
 mod client;
 mod resolution;
 use self::client::Client;
-pub use self::resolution::{Resolution, ResolveFuture};
+pub use self::resolution::{Resolution, ResolveFuture, Unresolvable};
 use proxy::http::balance::Weight;
 use NameAddr;
 
@@ -115,7 +115,7 @@ where
 
         if self.suffixes.iter().any(|s| s.contains(authority.name())) {
             if let Some(client) = self.client.as_ref().cloned() {
-                return ResolveFuture::new(authority.clone(), client);
+                return ResolveFuture::new(authority, client);
             } else {
                 trace!("-> control plane client disabled");
             }

--- a/src/control/destination/resolution.rs
+++ b/src/control/destination/resolution.rs
@@ -242,13 +242,16 @@ impl Updater {
         self.tx.unbounded_send(update).map_err(|_| ())
     }
 
-    /// Indicates that the resolution should be reset on the next update
-    /// received after a reconnect.
+    /// Indicates that the resolution should reset any previously discovered
+    /// endpoints on the next update received after a reconnect.
     fn should_reset(&mut self) {
         self.reset = true;
     }
 
-    /// If the
+    /// Removes any previously discovered endpoints if they are stale.
+    /// Otherwise, does nothing.
+    ///
+    /// This is called when processing a new update.
     fn reset_if_needed(&mut self) -> Result<(), ()> {
         if self.reset {
             trace!("query reconnected; removing stale endpoints");

--- a/src/control/destination/resolution.rs
+++ b/src/control/destination/resolution.rs
@@ -3,32 +3,41 @@ use indexmap::{IndexMap, IndexSet};
 use std::{collections::HashMap, fmt, net::SocketAddr};
 
 use tokio;
-use tower_grpc::{self as grpc, generic::client::GrpcService, Body, BoxBody};
+use tower_grpc::{self as grpc, generic::client::GrpcService, BoxBody};
 
 use api::{
     destination::{
-        client::Destination, protocol_hint::Protocol, update::Update as PbUpdate2, GetDestination,
-        TlsIdentity, Update as PbUpdate, WeightedAddr,
+        protocol_hint::Protocol, update::Update as PbUpdate2, TlsIdentity, Update as PbUpdate,
+        WeightedAddr,
     },
     net::TcpAddress,
 };
 
-use control::{
-    destination::{Metadata, ProtocolHint, Update},
-    remote_stream::{self, Remote},
-};
+use control::destination::{Metadata, ProtocolHint, Update};
 
+use super::client;
 use identity;
 use logging;
 use never::Never;
 use proxy::resolve;
 use NameAddr;
 
-use super::Client;
-
 /// A resolution for a single authority.
 pub struct Resolution {
     rx: mpsc::UnboundedReceiver<Update<Metadata>>,
+}
+
+pub struct ResolveFuture<T>
+where
+    T: GrpcService<BoxBody>,
+{
+    query: Option<client::Query<T>>,
+}
+
+/// An error indicating that the Destination service cannot resolve the
+/// requested name.
+pub struct Unresolvable {
+    _p: (),
 }
 
 /// Drives the query associated with a `Resolution`.
@@ -41,9 +50,7 @@ struct Daemon<T>
 where
     T: GrpcService<BoxBody>,
 {
-    auth: NameAddr,
-    client: Client<T>,
-    query: Query<T>,
+    query: client::Query<T>,
     updater: Updater,
 }
 
@@ -65,8 +72,6 @@ struct LogCtx(NameAddr);
 
 struct DisplayUpdate<'a>(&'a Update<Metadata>);
 
-type Query<T> = remote_stream::Remote<PbUpdate, T>;
-
 impl resolve::Resolution for Resolution {
     type Endpoint = Metadata;
     type Error = Never;
@@ -83,48 +88,84 @@ impl resolve::Resolution for Resolution {
     }
 }
 
-impl Resolution {
-    pub(super) fn new<T>(auth: NameAddr, client: Client<T>) -> Self
-    where
-        T: GrpcService<BoxBody> + Send + 'static,
-        T::ResponseBody: Send,
-        <T::ResponseBody as Body>::Data: Send,
-        T::Future: Send,
-    {
+impl<T> Resolution<T>
+where
+    T: GrpcService<BoxBody> + Send,
+{
+    fn new() -> (Self, Updater) {
         let (tx, rx) = mpsc::unbounded();
-        let daemon = Daemon::new(auth.clone(), client, tx);
-        let daemon = logging::Section::Proxy.bg(LogCtx(auth)).future(daemon);
-        tokio::spawn(Box::new(daemon));
-        Self { rx }
+        (Self { rx }, Updater::new(tx))
+    }
+}
+
+// ===== impl ResolveFuture =====
+
+impl<T> ResolveFuture<T>
+where
+    T: GrpcService<BoxBody> + Send,
+{
+    pub(super) fn new(authority: NameAddr, client: client::Client<T>) -> (Self, Updater) {
+        Self {
+            query: Some(client.connect(authority)),
+        }
     }
 
-    pub(super) fn none() -> Self {
-        let (tx, rx) = mpsc::unbounded();
-        let _ = tx.unbounded_send(Update::NoEndpoints);
-        Self { rx }
+    pub(super) fn unresolvable() -> Self {
+        Self { query: None }
+    }
+}
+
+impl<T> Future for ResolveFuture<T>
+where
+    T: GrpcService<BoxBody> + Send,
+{
+    type Item = Resolution;
+    type Error = Unresolvable;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        loop {
+            let update = match self.query {
+                Some(ref mut query) => match query.poll() {
+                    Ok(Async::Ready(Some(up))) => up,
+                    Ok(Async::Ready(None)) => {
+                        warn!("Destination.Get stream ended immediately, must reconnect");
+                        query.reconnect();
+                        continue;
+                    }
+                    Ok(Async::NotReady) => return Ok(Async::NotReady),
+                    Err(ref status) if status.code() == grpc::Code::InvalidArgument => {
+                        trace!("{} is unresolvable", query.authority());
+                        return Err(Unresolvable { _p: () });
+                    }
+                    Err(err) => {
+                        warn!("Destination.Get stream error {}, must reconnect", err);
+                        query.reconnect();
+                        continue;
+                    }
+                },
+                None => {
+                    trace!("{} is not in search suffixes", self.query.authority());
+                    return Err(Unresolvable { _p: () });
+                }
+            };
+
+            let (res, updater) = Resolution::new();
+            updater
+                .send(update)
+                .expect("resolution should not have been dropped");
+
+            let query = self.query.take().expect("invalid state");
+            let ctx = logging::Section::Proxy.bg(LogCtx(query.authority.clone()));
+
+            let daemon = ctx.future(Daemon { updater, query });
+            tokio::spawn(Box::new(daemon));
+
+            return Ok(res);
+        }
     }
 }
 
 // ===== impl Daemon =====
-
-impl<T> Daemon<T>
-where
-    T: GrpcService<BoxBody> + Send,
-{
-    fn new(
-        auth: NameAddr,
-        mut client: Client<T>,
-        tx: mpsc::UnboundedSender<Update<Metadata>>,
-    ) -> Self {
-        let query = client.query(&auth, "connect");
-        Self {
-            query,
-            auth,
-            client,
-            updater: Updater::new(tx),
-        }
-    }
-}
 
 impl<T> Future for Daemon<T>
 where
@@ -134,96 +175,26 @@ where
     type Error = ();
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        // Try to send an update to the `Resolution`, ending the background task
-        // if the resolution is no longer needed.
-        macro_rules! try_send {
-            ($send:expr) => {
-                if let Err(_) = $send {
-                    trace!("resolution dropped, daemon terminating...");
-                    return Ok(Async::Ready(()));
-                }
-            };
-        }
         loop {
-            self.query = match self.query {
-                Remote::ConnectedOrConnecting { ref mut rx } => match rx.poll() {
-                    Ok(Async::Ready(Some(update))) => {
-                        match update.update {
-                            Some(PbUpdate2::Add(a_set)) => {
-                                let set_labels = a_set.metric_labels;
-                                let addrs = a_set
-                                    .addrs
-                                    .into_iter()
-                                    .filter_map(|pb| pb_to_addr_meta(pb, &set_labels));
-                                try_send!(self.updater.add(addrs));
-                            }
-                            Some(PbUpdate2::Remove(r_set)) => {
-                                let addrs = r_set.addrs.into_iter().filter_map(pb_to_sock_addr);
-                                try_send!(self.updater.remove(addrs));
-                            }
-                            Some(PbUpdate2::NoEndpoints(_)) => {
-                                trace!("has no endpoints");
-                                try_send!(self.updater.remove_all("no endpoints"));
-                            }
-                            None => (),
-                        };
-                        continue;
-                    }
-                    Ok(Async::Ready(None)) => {
-                        trace!("Destination.Get stream ended, must reconnect");
-                        self.updater.should_reset();
-                        Remote::NeedsReconnect
-                    }
-                    Ok(Async::NotReady) => return Ok(Async::NotReady),
-                    Err(ref status) if status.code() == tower_grpc::Code::InvalidArgument => {
-                        // Invalid Argument is returned to indicate that the
-                        // requested name should *not* query the destination
-                        // service. In this case, do not attempt to reconnect.
-                        debug!("Destination.Get stream ended with Invalid Argument",);
-                        let _ = self.updater.unresolvable();
+            match self.query.poll() {
+                Ok(Async::NotReady) => return Ok(Async::NotReady),
+                Ok(Async::Ready(Some(update))) => {
+                    if let Err(_) = self.updater.update(update) {
+                        trace!("resolution dropped, daemon terminating...");
                         return Ok(Async::Ready(()));
                     }
-                    Err(err) => {
-                        warn!("Destination.Get stream error: {}", err);
-                        self.updater.should_reset();
-                        Remote::NeedsReconnect
-                    }
-                },
-                Remote::NeedsReconnect => match self.client.query(&self.auth, "reconnect") {
-                    Remote::NeedsReconnect => return Ok(Async::NotReady),
-                    query => query,
-                },
-            };
-        }
-    }
-}
-
-// ===== impl Client =====
-
-impl<T> Client<T>
-where
-    T: GrpcService<BoxBody>,
-{
-    /// Returns a new destination service query for the given `dst`.
-    fn query(&mut self, dst: &NameAddr, connect_or_reconnect: &str) -> Query<T> {
-        trace!(
-            "{}ing destination service query for {}",
-            connect_or_reconnect,
-            dst
-        );
-        if let Ok(Async::Ready(())) = self.client.poll_ready() {
-            let req = GetDestination {
-                scheme: "k8s".into(),
-                path: format!("{}", dst),
-                context_token: self.context_token.as_ref().clone(),
-            };
-            let mut svc = Destination::new(self.client.as_service());
-            let response = svc.get(grpc::Request::new(req));
-            let rx = remote_stream::Receiver::new(response);
-            Remote::ConnectedOrConnecting { rx }
-        } else {
-            trace!("destination client not yet ready");
-            Remote::NeedsReconnect
+                }
+                Ok(Async::Ready(None)) => {
+                    trace!("Destination.Get stream ended, must reconnect");
+                    self.updater.should_reset();
+                    self.query.reconnect();
+                }
+                Err(err) => {
+                    warn!("Destination.Get stream error: {}", err);
+                    self.updater.should_reset();
+                    self.query.reconnect();
+                }
+            }
         }
     }
 }
@@ -237,6 +208,29 @@ impl Updater {
             seen: IndexSet::new(),
             reset: false,
         }
+    }
+
+    fn update(&mut self, update: PbUpdate) -> Result<(), ()> {
+        match update.update {
+            Some(PbUpdate2::Add(a_set)) => {
+                let set_labels = a_set.metric_labels;
+                let addrs = a_set
+                    .addrs
+                    .into_iter()
+                    .filter_map(|pb| pb_to_addr_meta(pb, &set_labels));
+                self.add(addrs)?;
+            }
+            Some(PbUpdate2::Remove(r_set)) => {
+                let addrs = r_set.addrs.into_iter().filter_map(pb_to_sock_addr);
+                self.remove(addrs)?;
+            }
+            Some(PbUpdate2::NoEndpoints(_)) => {
+                trace!("has no endpoints");
+                self.remove_all("no endpoints")?;
+            }
+            None => (),
+        }
+        Ok(())
     }
 
     fn send(&mut self, update: Update<Metadata>) -> Result<(), ()> {
@@ -287,11 +281,6 @@ impl Updater {
         }
         Ok(())
     }
-
-    fn unresolvable(&mut self) -> Result<(), ()> {
-        self.send(Update::NoEndpoints)?;
-        self.remove_all("unresolvable")
-    }
 }
 
 impl<'a> fmt::Display for DisplayUpdate<'a> {
@@ -299,7 +288,6 @@ impl<'a> fmt::Display for DisplayUpdate<'a> {
         match self.0 {
             Update::Remove(ref addr) => write!(f, "remove {}", addr),
             Update::Add(ref addr, ..) => write!(f, "add {}", addr),
-            Update::NoEndpoints => "should not be resolved by the Destination service".fmt(f),
         }
     }
 }

--- a/src/control/destination/resolution.rs
+++ b/src/control/destination/resolution.rs
@@ -153,7 +153,7 @@ where
                 }
             };
 
-            let (res, updater) = Resolution::new();
+            let (res, mut updater) = Resolution::new();
             updater
                 .update(update)
                 .expect("resolution should not have been dropped");

--- a/src/control/destination/resolution.rs
+++ b/src/control/destination/resolution.rs
@@ -145,10 +145,7 @@ where
                     }
                 },
                 None => {
-                    trace!(
-                        "{} is not in search suffixes",
-                        self.query.as_ref().expect("invalid state").authority()
-                    );
+                    trace!("name is unresolvable");
                     return Err(Unresolvable { _p: () });
                 }
             };

--- a/src/control/destination/resolution.rs
+++ b/src/control/destination/resolution.rs
@@ -180,7 +180,7 @@ where
                         // requested name should *not* query the destination
                         // service. In this case, do not attempt to reconnect.
                         debug!("Destination.Get stream ended with Invalid Argument",);
-                        let _ = self.updater.does_not_exist();
+                        let _ = self.updater.unresolvable();
                         return Ok(Async::Ready(()));
                     }
                     Err(err) => {
@@ -288,9 +288,9 @@ impl Updater {
         Ok(())
     }
 
-    fn does_not_exist(&mut self) -> Result<(), ()> {
+    fn unresolvable(&mut self) -> Result<(), ()> {
         self.send(Update::NoEndpoints)?;
-        self.remove_all("nonexistent")
+        self.remove_all("unresolvable")
     }
 }
 
@@ -299,7 +299,7 @@ impl<'a> fmt::Display for DisplayUpdate<'a> {
         match self.0 {
             Update::Remove(ref addr) => write!(f, "remove {}", addr),
             Update::Add(ref addr, ..) => write!(f, "add {}", addr),
-            Update::NoEndpoints => "does not exist in service discovery".fmt(f),
+            Update::NoEndpoints => "should not be resolved by the Destination service".fmt(f),
         }
     }
 }

--- a/src/proxy/http/balance.rs
+++ b/src/proxy/http/balance.rs
@@ -2,9 +2,9 @@ extern crate hyper_balance;
 extern crate tower_balance;
 extern crate tower_discover;
 
-use std::{error::Error, fmt, marker::PhantomData, time::Duration};
+use std::{marker::PhantomData, time::Duration};
 
-use futures::{future, Async, Future, Poll};
+use futures::{Async, Future, Poll};
 use hyper::body::Payload;
 
 use self::tower_discover::Discover;
@@ -15,11 +15,6 @@ pub use self::tower_balance::{
 };
 
 use http;
-use proxy::{
-    self,
-    http::fallback,
-    resolve::{EndpointStatus, HasEndpointStatus},
-};
 use svc;
 
 /// Configures a stack to resolve `T` typed targets to balance requests over
@@ -39,15 +34,6 @@ pub struct MakeSvc<M, A, B> {
     inner: M,
     _marker: PhantomData<fn(A) -> B>,
 }
-
-#[derive(Debug)]
-pub struct Service<S> {
-    balance: S,
-    status: EndpointStatus,
-}
-
-#[derive(Debug)]
-pub struct NoEndpoints;
 
 // === impl Layer ===
 
@@ -102,14 +88,13 @@ impl<M: Clone, A, B> Clone for MakeSvc<M, A, B> {
 impl<T, M, A, B> svc::Service<T> for MakeSvc<M, A, B>
 where
     M: svc::Service<T>,
-    M::Response: Discover + HasEndpointStatus,
+    M::Response: Discover,
     <M::Response as Discover>::Service:
         svc::Service<http::Request<A>, Response = http::Response<B>>,
     A: Payload,
     B: Payload,
 {
-    type Response =
-        Service<Balance<WithPeakEwma<M::Response, PendingUntilFirstData>, PowerOfTwoChoices>>;
+    type Response = Balance<WithPeakEwma<M::Response, PendingUntilFirstData>, PowerOfTwoChoices>;
     type Error = M::Error;
     type Future = MakeSvc<M::Future, A, B>;
 
@@ -132,53 +117,20 @@ where
 impl<F, A, B> Future for MakeSvc<F, A, B>
 where
     F: Future,
-    F::Item: Discover + HasEndpointStatus,
+    F::Item: Discover,
     <F::Item as Discover>::Service: svc::Service<http::Request<A>, Response = http::Response<B>>,
     A: Payload,
     B: Payload,
 {
-    type Item = Service<Balance<WithPeakEwma<F::Item, PendingUntilFirstData>, PowerOfTwoChoices>>;
+    type Item = Balance<WithPeakEwma<F::Item, PendingUntilFirstData>, PowerOfTwoChoices>;
     type Error = F::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let discover = try_ready!(self.inner.poll());
-        let status = discover.endpoint_status();
         let instrument = PendingUntilFirstData::default();
         let loaded = WithPeakEwma::new(discover, self.default_rtt, self.decay, instrument);
         let balance = Balance::p2c(loaded);
-        Ok(Async::Ready(Service { balance, status }))
-    }
-}
-
-impl<S, A, B> svc::Service<http::Request<A>> for Service<S>
-where
-    S: svc::Service<http::Request<A>, Response = http::Response<B>, Error = proxy::Error>,
-{
-    type Response = http::Response<B>;
-    type Error = fallback::Error<A>;
-    type Future = future::Either<
-        future::MapErr<S::Future, fn(proxy::Error) -> Self::Error>,
-        future::FutureResult<http::Response<B>, fallback::Error<A>>,
-    >;
-
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        let ready = self.balance.poll_ready().map_err(fallback::Error::from)?;
-        if self.status.is_empty() {
-            Ok(Async::Ready(()))
-        } else {
-            Ok(ready)
-        }
-    }
-
-    fn call(&mut self, req: http::Request<A>) -> Self::Future {
-        // The endpoint status is updated by the Discover instance, which is
-        // driven by calling `poll_ready` on the balancer.
-        if self.status.is_empty() {
-            trace!("no endpoints for {}", req.uri());
-            future::Either::B(future::err(fallback::Error::fallback(req, NoEndpoints)))
-        } else {
-            future::Either::A(self.balance.call(req).map_err(From::from))
-        }
+        Ok(Async::Ready(balance))
     }
 }
 
@@ -236,13 +188,3 @@ pub mod weight {
         }
     }
 }
-
-// === impl NoEndpoints ===
-
-impl fmt::Display for NoEndpoints {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt("load balancer has no endpoints", f)
-    }
-}
-
-impl Error for NoEndpoints {}

--- a/src/proxy/http/fallback.rs
+++ b/src/proxy/http/fallback.rs
@@ -10,14 +10,14 @@ use svc;
 /// If the future returned by the primary builder's `MakeService` fails with
 /// an error matching a given predicate, the fallback future will attempt
 /// to call the secondary `MakeService`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Layer<A, B, P = fn(&proxy::Error) -> bool> {
     primary: svc::Builder<A>,
     fallback: svc::Builder<B>,
     predicate: P,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct MakeSvc<A, B, P> {
     primary: A,
     fallback: B,
@@ -100,23 +100,6 @@ where
             primary: self.primary.clone().service(inner.clone()),
             fallback: self.fallback.clone().service(inner),
             predicate: self.predicate.clone(),
-            // _p: PhantomData,
-        }
-    }
-}
-
-impl<A, B, P> Clone for Layer<A, B, P>
-where
-    A: Clone,
-    B: Clone,
-    P: Clone,
-{
-    fn clone(&self) -> Self {
-        Layer {
-            primary: self.primary.clone(),
-            fallback: self.fallback.clone(),
-            predicate: self.predicate.clone(),
-            // _p: PhantomData,
         }
     }
 }

--- a/src/proxy/http/fallback.rs
+++ b/src/proxy/http/fallback.rs
@@ -1,370 +1,327 @@
 use bytes::Buf;
-use futures::{Async, Future, Poll};
+use futures::{Future, Poll};
 use http;
 use hyper::body::Payload;
 use proxy;
 use svc;
 
-use std::{fmt, marker::PhantomData, mem};
+// use std::marker::PhantomData;
 
+/// A fallback layer composing two service builders.
+///
+/// If the future returned by the primary builder's `MakeService` fails with
+/// an error matching a given predicate, the fallback future will attempt
+/// to call the secondary `MakeService`.
 #[derive(Debug)]
-pub struct Error<A> {
-    error: proxy::Error,
-    fallback: Option<http::Request<A>>,
+pub struct Layer<A, B, P = fn(&proxy::Error) -> bool> {
+    primary: svc::Builder<A>,
+    fallback: svc::Builder<B>,
+    predicate: P,
+    // _p: PhantomData<fn(R)>,
 }
 
-#[derive(Debug)]
-pub struct Layer<P, F, A> {
-    primary: svc::Builder<P>,
-    fallback: svc::Builder<F>,
-    _p: PhantomData<fn(A)>,
+#[derive(Debug, Clone)]
+pub struct MakeSvc<A, B, P> {
+    primary: A,
+    fallback: B,
+    predicate: P,
+    // _p: PhantomData<fn(R)>,
 }
 
-#[derive(Debug)]
-pub struct MakeSvc<P, F, A> {
-    primary: P,
-    fallback: F,
-    _p: PhantomData<fn(A)>,
-}
-
-pub struct Service<P, F, A> {
-    primary: P,
-    fallback: F,
-    _p: PhantomData<fn(A)>,
-}
-
-pub struct MakeFuture<P, F, A>
+pub struct MakeFuture<A, B, P, T>
 where
-    P: Future,
-    F: Future,
+    A: Future,
+    A::Error: Into<proxy::Error>,
+    B: svc::Service<T>,
 {
-    primary: Making<P>,
-    fallback: Making<F>,
-    _p: PhantomData<fn(A)>,
+    fallback: B,
+    target: Option<T>,
+    predicate: P,
+    state: FallbackState<A, B::Future, T>,
 }
 
-pub struct ResponseFuture<P, F, A>
-where
-    P: Future<Error = Error<A>>,
-    F: svc::Service<http::Request<A>>,
-{
-    fallback: F,
-    state: ResponseState<P, F::Future, A>,
-}
-
-pub enum Body<A, B> {
+#[derive(Clone)]
+pub enum Either<A, B> {
     A(A),
     B(B),
 }
 
-enum ResponseState<P, F, A> {
+enum FallbackState<A, B, T> {
     /// Waiting for the primary service's future to complete.
-    Primary(P),
-    /// Request buffered, waiting for the fallback service to become ready.
-    Waiting(Option<http::Request<A>>),
+    Primary(A),
+    ///W aiting for the fallback service to become ready.
+    Waiting(Option<T>),
     /// Waiting for the fallback service's future to complete.
-    Fallback(F),
+    Fallback(B),
 }
 
-enum Making<T: Future> {
-    NotReady(T),
-    Ready(T::Item),
-    Done,
-}
-
-pub fn layer<P, F, A>(primary: svc::Builder<P>, fallback: svc::Builder<F>) -> Layer<P, F, A> {
+pub fn layer<A, B>(primary: svc::Builder<A>, fallback: svc::Builder<B>) -> Layer<A, B> {
+    let predicate: fn(&proxy::Error) -> bool = |_| true;
     Layer {
         primary,
         fallback,
-        _p: PhantomData,
+        predicate,
+        // _p: PhantomData,
     }
 }
 
 // === impl Layer ===
 
-impl<P, F, A, M> svc::Layer<M> for Layer<P, F, A>
+impl<A, B> Layer<A, B> {
+    /// Returns a `Layer` that uses the given `predicate` to determine whether
+    /// to fall back.
+    pub fn with_predicate<P>(self, predicate: P) -> Layer<A, B, P>
+    where
+        P: Fn(&proxy::Error) -> bool + Clone,
+    {
+        Layer {
+            primary: self.primary,
+            fallback: self.fallback,
+            predicate,
+            // _p: PhantomData,
+        }
+    }
+
+    /// Returns a `Layer` that falls back if the error or its cause is of the given type.
+    pub fn on_error<E>(self) -> Layer<A, B>
+    where
+        E: std::error::Error + 'static,
+    {
+        let predicate: fn(&proxy::Error) -> bool =
+            |e| e.is::<E>() || e.source().map(|s| s.is::<E>()).unwrap_or(false);
+        Layer { predicate, ..self }
+    }
+}
+
+impl<A, B, P, M> svc::Layer<M> for Layer<A, B, P>
 where
-    P: svc::Layer<M> + Clone,
-    F: svc::Layer<M> + Clone,
+    A: svc::Layer<M> + Clone,
+    B: svc::Layer<M> + Clone,
     M: Clone,
+    P: Fn(&proxy::Error) -> bool + Clone,
 {
-    type Service = MakeSvc<P::Service, F::Service, A>;
+    type Service = MakeSvc<A::Service, B::Service, P>;
 
     fn layer(&self, inner: M) -> Self::Service {
         MakeSvc {
             primary: self.primary.clone().service(inner.clone()),
             fallback: self.fallback.clone().service(inner),
-            _p: PhantomData,
+            predicate: self.predicate.clone(),
+            // _p: PhantomData,
         }
     }
 }
 
-impl<P, F, A> Clone for Layer<P, F, A>
+impl<A, B, P> Clone for Layer<A, B, P>
 where
+    A: Clone,
+    B: Clone,
     P: Clone,
-    F: Clone,
 {
     fn clone(&self) -> Self {
-        layer(self.primary.clone(), self.fallback.clone())
+        Layer {
+            primary: self.primary.clone(),
+            fallback: self.fallback.clone(),
+            predicate: self.predicate.clone(),
+            // _p: PhantomData,
+        }
     }
 }
 
 // === impl MakeSvc ===
 
-impl<P, F, A, T> svc::Service<T> for MakeSvc<P, F, A>
+impl<A, B, P, T> svc::Service<T> for MakeSvc<A, B, P>
 where
-    P: svc::Service<T>,
-    P::Error: Into<proxy::Error>,
-    F: svc::Service<T>,
-    F::Error: Into<proxy::Error>,
+    A: svc::Service<T>,
+    A::Error: Into<proxy::Error>,
+    B: svc::Service<T> + Clone,
+    B::Error: Into<proxy::Error>,
+    P: Fn(&proxy::Error) -> bool + Clone,
     T: Clone,
 {
-    type Response = Service<P::Response, F::Response, A>;
+    type Response = Either<A::Response, B::Response>;
     type Error = proxy::Error;
-    type Future = MakeFuture<P::Future, F::Future, A>;
+    type Future = MakeFuture<A::Future, B, P, T>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        let primary_ready = self.primary.poll_ready().map_err(Into::into);
-        let fallback_ready = self.fallback.poll_ready().map_err(Into::into);
-        try_ready!(fallback_ready);
-        primary_ready
+        self.primary.poll_ready().map_err(Into::into)
     }
 
     fn call(&mut self, target: T) -> Self::Future {
         MakeFuture {
-            primary: Making::NotReady(self.primary.call(target.clone())),
-            fallback: Making::NotReady(self.fallback.call(target.clone())),
-            _p: PhantomData,
-        }
-    }
-}
-
-impl<P, F, A> Clone for MakeSvc<P, F, A>
-where
-    P: Clone,
-    F: Clone,
-{
-    fn clone(&self) -> Self {
-        Self {
-            primary: self.primary.clone(),
             fallback: self.fallback.clone(),
-            _p: PhantomData,
+            predicate: self.predicate.clone(),
+            target: Some(target.clone()),
+            state: FallbackState::Primary(self.primary.call(target)),
         }
     }
 }
 
-// === impl MakeFuture ===
-
-impl<P, F, A> Future for MakeFuture<P, F, A>
+impl<A, B, P, T> Future for MakeFuture<A, B, P, T>
 where
-    P: Future,
-    P::Error: Into<proxy::Error>,
-    F: Future,
-    F::Error: Into<proxy::Error>,
+    A: Future,
+    A::Error: Into<proxy::Error>,
+    B: svc::Service<T>,
+    B::Error: Into<proxy::Error>,
+    P: Fn(&proxy::Error) -> bool,
 {
-    type Item = Service<P::Item, F::Item, A>;
-    type Error = proxy::Error;
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        // Are both the primary and fallback futures finished?
-        try_ready!(self.primary.poll().map_err(Into::into));
-        try_ready!(self.fallback.poll().map_err(Into::into));
-
-        Ok(Async::Ready(Service {
-            primary: self.primary.take(),
-            fallback: self.fallback.take(),
-            _p: PhantomData,
-        }))
-    }
-}
-
-impl<T: Future> Making<T> {
-    fn poll(&mut self) -> Poll<(), T::Error> {
-        *self = match self {
-            Making::NotReady(ref mut fut) => {
-                let res = try_ready!(fut.poll());
-                Making::Ready(res)
-            }
-            Making::Ready(_) => return Ok(Async::Ready(())),
-            Making::Done => panic!("polled after ready"),
-        };
-        Ok(Async::Ready(()))
-    }
-
-    fn take(&mut self) -> T::Item {
-        match mem::replace(self, Making::Done) {
-            Making::Ready(a) => a,
-            _ => panic!("tried to take service twice"),
-        }
-    }
-}
-
-// === impl Service ===
-
-impl<P, F, A, B, C> svc::Service<http::Request<A>> for Service<P, F, A>
-where
-    P: svc::Service<http::Request<A>, Response = http::Response<B>, Error = Error<A>>,
-    F: svc::Service<http::Request<A>, Response = http::Response<C>> + Clone,
-    F::Error: Into<proxy::Error>,
-{
-    type Response = http::Response<Body<B, C>>;
-    type Error = proxy::Error;
-    type Future = ResponseFuture<P::Future, F, A>;
-
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        // We're ready as long as the primary service is ready. If we have to
-        // call the fallback service, the response future will buffer the
-        // request until the fallback service is ready.
-        self.primary.poll_ready().map_err(|e| e.error)
-    }
-
-    fn call(&mut self, req: http::Request<A>) -> Self::Future {
-        ResponseFuture {
-            fallback: self.fallback.clone(),
-            state: ResponseState::Primary(self.primary.call(req)),
-        }
-    }
-}
-
-impl<P, F, A, B, C> Future for ResponseFuture<P, F, A>
-where
-    P: Future<Item = http::Response<B>, Error = Error<A>>,
-    F: svc::Service<http::Request<A>, Response = http::Response<C>>,
-    F::Error: Into<proxy::Error>,
-{
-    type Item = http::Response<Body<B, C>>;
+    type Item = Either<A::Item, B::Response>;
     type Error = proxy::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        use self::ResponseState::*;
         loop {
             self.state = match self.state {
                 // We've called the primary service and are waiting for its
                 // future to complete.
-                Primary(ref mut f) => match f.poll() {
-                    Ok(Async::NotReady) => return Ok(Async::NotReady),
-                    Ok(Async::Ready(rsp)) => return Ok(Async::Ready(rsp.map(Body::A))),
-                    Err(Error {
-                        fallback: Some(req),
-                        error,
-                    }) => {
-                        trace!("{}; trying to fall back", error);
-                        Waiting(Some(req))
+                FallbackState::Primary(ref mut f) => match f.poll() {
+                    Ok(r) => return Ok(r.map(Either::A)),
+                    Err(error) => {
+                        let error = error.into();
+                        if (self.predicate)(&error) {
+                            trace!("{} matches; trying to fall back", error);
+                            FallbackState::Waiting(self.target.take())
+                        } else {
+                            trace!("{} does not match; not falling back", error);
+                            return Err(error);
+                        }
                     }
-                    Err(e) => return Err(e.into()),
                 },
                 // The primary service has returned a fallback error, so we are
                 // waiting for the fallback service to be ready.
-                Waiting(ref mut req) => {
+                FallbackState::Waiting(ref mut target) => {
                     try_ready!(self.fallback.poll_ready().map_err(Into::into));
-                    let req = req.take().expect("request should only be taken once");
-                    Fallback(self.fallback.call(req))
+                    let target = target.take().expect("target should only be taken once");
+                    FallbackState::Fallback(self.fallback.call(target))
                 }
                 // We've called the fallback service and are waiting for its
                 // future to complete.
-                Fallback(ref mut f) => {
-                    return f
-                        .poll()
-                        .map(|p| p.map(|rsp| rsp.map(Body::B)))
-                        .map_err(Into::into)
+                FallbackState::Fallback(ref mut f) => {
+                    return f.poll().map(|a| a.map(Either::B)).map_err(Into::into)
                 }
             }
         }
     }
 }
 
-// === impl Body ===
+// === impl Either ===
 
-impl<A, B> Payload for Body<A, B>
+impl<A, B, B1, B2, R> svc::Service<R> for Either<A, B>
+where
+    A: svc::Service<R, Response = http::Response<B1>>,
+    A::Error: Into<proxy::Error>,
+    B: svc::Service<R, Response = http::Response<B2>>,
+    B::Error: Into<proxy::Error>,
+{
+    type Response = http::Response<Either<B1, B2>>;
+    type Future = Either<A::Future, B::Future>;
+    type Error = proxy::Error;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        match self {
+            Either::A(ref mut inner) => inner.poll_ready().map_err(Into::into),
+            Either::B(ref mut inner) => inner.poll_ready().map_err(Into::into),
+        }
+    }
+
+    fn call(&mut self, req: R) -> Self::Future {
+        match self {
+            Either::A(ref mut inner) => Either::A(inner.call(req)),
+            Either::B(ref mut inner) => Either::B(inner.call(req)),
+        }
+    }
+}
+
+impl<A, B, B1, B2> Future for Either<A, B>
+where
+    A: Future<Item = http::Response<B1>>,
+    A::Error: Into<proxy::Error>,
+    B: Future<Item = http::Response<B2>>,
+    B::Error: Into<proxy::Error>,
+{
+    type Item = http::Response<Either<B1, B2>>;
+    type Error = proxy::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self {
+            Either::A(ref mut inner) => inner
+                .poll()
+                .map_err(Into::into)
+                .map(|ready| ready.map(|rsp| rsp.map(Either::A))),
+            Either::B(ref mut inner) => inner
+                .poll()
+                .map_err(Into::into)
+                .map(|ready| ready.map(|rsp| rsp.map(Either::B))),
+        }
+    }
+}
+
+impl<A, B> Payload for Either<A, B>
 where
     A: Payload,
-    B: Payload<Error = A::Error>,
+    A::Error: Into<proxy::Error>,
+    B: Payload,
+    B::Error: Into<proxy::Error>,
 {
-    type Data = Body<A::Data, B::Data>;
-    type Error = A::Error;
+    type Data = Either<A::Data, B::Data>;
+    type Error = proxy::Error;
 
     fn poll_data(&mut self) -> Poll<Option<Self::Data>, Self::Error> {
         match self {
-            Body::A(ref mut body) => body.poll_data().map(|r| r.map(|o| o.map(Body::A))),
-            Body::B(ref mut body) => body.poll_data().map(|r| r.map(|o| o.map(Body::B))),
+            Either::A(ref mut body) => body
+                .poll_data()
+                .map(|r| r.map(|o| o.map(Either::A)))
+                .map_err(Into::into),
+            Either::B(ref mut body) => body
+                .poll_data()
+                .map(|r| r.map(|o| o.map(Either::B)))
+                .map_err(Into::into),
         }
     }
 
     fn poll_trailers(&mut self) -> Poll<Option<http::HeaderMap>, Self::Error> {
         match self {
-            Body::A(ref mut body) => body.poll_trailers(),
-            Body::B(ref mut body) => body.poll_trailers(),
+            Either::A(ref mut body) => body.poll_trailers().map_err(Into::into),
+            Either::B(ref mut body) => body.poll_trailers().map_err(Into::into),
         }
     }
 
     fn is_end_stream(&self) -> bool {
         match self {
-            Body::A(ref body) => body.is_end_stream(),
-            Body::B(ref body) => body.is_end_stream(),
+            Either::A(ref body) => body.is_end_stream(),
+            Either::B(ref body) => body.is_end_stream(),
         }
     }
 }
 
-impl<A, B: Default> Default for Body<A, B> {
+impl<A, B: Default> Default for Either<A, B> {
     fn default() -> Self {
-        Body::B(Default::default())
+        Either::B(Default::default())
     }
 }
 
-impl<A, B> Buf for Body<A, B>
+impl<A, B> Buf for Either<A, B>
 where
     A: Buf,
     B: Buf,
 {
     fn remaining(&self) -> usize {
         match self {
-            Body::A(ref buf) => buf.remaining(),
-            Body::B(ref buf) => buf.remaining(),
+            Either::A(ref buf) => buf.remaining(),
+            Either::B(ref buf) => buf.remaining(),
         }
     }
 
     fn bytes(&self) -> &[u8] {
         match self {
-            Body::A(ref buf) => buf.bytes(),
-            Body::B(ref buf) => buf.bytes(),
+            Either::A(ref buf) => buf.bytes(),
+            Either::B(ref buf) => buf.bytes(),
         }
     }
 
     fn advance(&mut self, cnt: usize) {
         match self {
-            Body::A(ref mut buf) => buf.advance(cnt),
-            Body::B(ref mut buf) => buf.advance(cnt),
-        }
-    }
-}
-
-// === impl Error ===
-
-impl<A> fmt::Display for Error<A> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.error, f)
-    }
-}
-
-impl<A> Into<proxy::Error> for Error<A> {
-    fn into(self) -> proxy::Error {
-        self.error
-    }
-}
-
-impl<A> From<proxy::Error> for Error<A> {
-    fn from(error: proxy::Error) -> Self {
-        Error {
-            error,
-            fallback: None,
-        }
-    }
-}
-
-impl<A> Error<A> {
-    pub fn fallback(req: http::Request<A>, error: impl Into<proxy::Error>) -> Self {
-        Error {
-            fallback: Some(req),
-            error: error.into(),
+            Either::A(ref mut buf) => buf.advance(cnt),
+            Either::B(ref mut buf) => buf.advance(cnt),
         }
     }
 }

--- a/src/proxy/http/fallback.rs
+++ b/src/proxy/http/fallback.rs
@@ -179,8 +179,8 @@ where
                         }
                     }
                 },
-                // The primary service has returned a fallback error, so we are
-                // waiting for the fallback service to be ready.
+                // The primary service has returned an error matching the
+                // predicate, and we are waiting for the fallback service to be ready.
                 FallbackState::Waiting(ref mut target) => {
                     try_ready!(self.fallback.poll_ready().map_err(Into::into));
                     let target = target.take().expect("target should only be taken once");

--- a/src/proxy/resolve.rs
+++ b/src/proxy/resolve.rs
@@ -2,10 +2,7 @@ extern crate linkerd2_router as rt;
 extern crate tower_discover;
 
 use futures::{Async, Future, Poll};
-use std::{
-    fmt,
-    net::SocketAddr,
-};
+use std::{fmt, net::SocketAddr};
 
 pub use self::tower_discover::Change;
 use proxy::Error;

--- a/src/proxy/resolve.rs
+++ b/src/proxy/resolve.rs
@@ -1,7 +1,7 @@
 extern crate linkerd2_router as rt;
 extern crate tower_discover;
 
-use futures::{Async, Poll};
+use futures::{Async, Future, Poll};
 use std::{
     fmt,
     net::SocketAddr,
@@ -19,8 +19,9 @@ use svc;
 pub trait Resolve<T> {
     type Endpoint;
     type Resolution: Resolution<Endpoint = Self::Endpoint>;
+    type Future: Future<Item = Self::Resolution>;
 
-    fn resolve(&self, target: &T) -> Self::Resolution;
+    fn resolve(&self, target: &T) -> Self::Future;
 }
 
 /// An infinite stream of endpoint updates.

--- a/src/proxy/resolve.rs
+++ b/src/proxy/resolve.rs
@@ -21,6 +21,12 @@ pub trait Resolve<T> {
     type Resolution: Resolution<Endpoint = Self::Endpoint>;
     type Future: Future<Item = Self::Resolution>;
 
+    /// Asynchronously returns a `Resolution` for the given `target`.
+    ///
+    /// The returned future will complete with a `Resolution` if this resolver
+    /// was able to successfully resolve `target`. Otherwise, if it completes
+    /// with an error, that name or address should not be resolved by this
+    /// resolver.
     fn resolve(&self, target: &T) -> Self::Future;
 }
 

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -14,7 +14,7 @@ use tower::limit::concurrency::ConcurrencyLimitLayer;
 use tower::load_shed::LoadShedLayer;
 use tower::timeout::TimeoutLayer;
 
-use proxy::{buffer, pending};
+use proxy::{buffer, http::fallback, pending};
 
 #[derive(Clone, Debug)]
 pub struct Builder<L>(ServiceBuilder<L>);
@@ -51,6 +51,12 @@ impl<L> Builder<L> {
 
     pub fn timeout(self, timeout: Duration) -> Builder<Stack<TimeoutLayer, L>> {
         Builder(self.0.timeout(timeout))
+    }
+
+    /// Returns a `Layer` that tries to build a service using `self`, falling
+    /// back to `other` if `self` fails.
+    pub fn fallback_to<B>(self, other: Builder<B>) -> fallback::Layer<L, B> {
+        fallback::layer(self, other)
     }
 
     /// Wrap the service `S` with the layers.

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -212,13 +212,9 @@ macro_rules! generate_tests {
             // Wait for the reconnect to happen. TODO: Replace this flaky logic.
             thread::sleep(Duration::from_millis(1000));
 
+            let rsp = initially_exists.request(&mut initially_exists.request_builder("/"));
+            assert_eq!(rsp.status(), http::StatusCode::SERVICE_UNAVAILABLE);
 
-            // This would wait since there are no endpoints.
-            let mut req = initially_exists.request_builder("/");
-            initially_exists
-                .request_async(req.method("GET"))
-                .wait_timeout(Duration::from_secs(1))
-                .expect_timedout("request should wait for destination capacity");
         }
 
         #[test]


### PR DESCRIPTION
When the DNS fallback behavior was removed from the proxy in #259, the
proxy was changed to fall back to original destination routing _any_
time the control plane indicates that no endpoints exist for a
destination. This is incorrect, as the proxy should always treat the
destination service as authoritative. Additionally, this means that
requests to endpoints which are known to not exist will construct an
unnecessary client service, and eventually fail with a 502 error when
the upstream client connection to the non-existent endpoint ultimately
fails. Instead, the proxy should only fall back when the destination is
outside the search suffixes or the Destination service returns an
`InvalidArgument` response.

This is a much larger change than #263. In particular, the fallback
behavior has been moved from when the the actual client service is 
called to when the client service is _constructed_, as we do not expect
to recieve an `InvalidArgument` response on a Destination query that
has previously recieved updates. 

This was implemented by changing the `Resolve` trait to return a
`Future` whose `Item` type is a `Resolution`, rather than returning a
`Resolution`. When the Destination query returns `InvalidArgument`, the
future will fail. The `proxy::http::fallback` middleware has been
changed so that rather than making both the primary and fallback service
and falling back on a per-request basis, it tries to make the primary
service, and falls back if the primary `MakeService` future fails. 

Although this is a large change, I think the resulting code is simpler
and more elegant than the previous approach.

Previously, one of the discovery tests expected the incorrect behavior.
I've changed this test to now expect that destinations known to not
exist do _not_ fall back, and renamed it from
`outbound_falls_back_to_orig_dst_when_destination_has_no_endpoints` to
`outbound_fails_fast_when_destination_has_no_endpoints`. I've also
confirmed that the updated test fails against master and passes after
this change.

Fixes linkerd/linkerd2#2880
Closes #263 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>