### PR TITLE
metrics: Classify response errors

### DIFF
--- a/src/proxy/http/metrics/classify.rs
+++ b/src/proxy/http/metrics/classify.rs
@@ -1,6 +1,7 @@
 use futures::{Future, Poll};
 use http;
 
+use proxy::Error;
 use svc;
 
 /// Determines how a request's response should be classified.
@@ -32,7 +33,7 @@ pub trait ClassifyResponse {
     fn start<B>(self, headers: &http::Response<B>) -> Self::ClassifyEos;
 
     /// Classifies the given error.
-    fn error(self, error: &(dyn std::error::Error + 'static)) -> Self::Class;
+    fn error(self, error: &Error) -> Self::Class;
 }
 
 pub trait ClassifyEos {
@@ -47,7 +48,7 @@ pub trait ClassifyEos {
     ///
     /// Because errors indicate an end-of-stream, a classification must be
     /// returned.
-    fn error(self, error: &(dyn std::error::Error + 'static)) -> Self::Class;
+    fn error(self, error: &Error) -> Self::Class;
 }
 
 // Used for stack targets that can produce a `Classify` implementation.

--- a/src/proxy/http/metrics/mod.rs
+++ b/src/proxy/http/metrics/mod.rs
@@ -49,7 +49,7 @@ where
     last_update: Instant,
     total: Counter,
     by_retry_skipped: IndexMap<RetrySkipped, Counter>,
-    by_status: IndexMap<http::StatusCode, StatusMetrics<C>>,
+    by_status: IndexMap<Option<http::StatusCode>, StatusMetrics<C>>,
 }
 
 #[derive(Debug)]

--- a/src/proxy/http/metrics/report.rs
+++ b/src/proxy/http/metrics/report.rs
@@ -162,7 +162,8 @@ where
         for (tgt, tm) in &self.by_target {
             if let Ok(tm) = tm.lock() {
                 for (status, m) in &tm.by_status {
-                    let labels = (tgt, Status(*status));
+                    let status = status.as_ref().map(|s| Status(*s));
+                    let labels = (tgt, status);
                     get_metric(&*m).fmt_metric_labeled(f, metric.name, labels)?;
                 }
             }
@@ -185,7 +186,8 @@ where
             if let Ok(tm) = tm.lock() {
                 for (status, sm) in &tm.by_status {
                     for (cls, m) in &sm.by_class {
-                        let labels = (tgt, (Status(*status), cls));
+                        let status = status.as_ref().map(|s| Status(*s));
+                        let labels = (tgt, (status, cls));
                         get_metric(&*m).fmt_metric_labeled(f, metric.name, labels)?;
                     }
                 }

--- a/src/proxy/http/metrics/service.rs
+++ b/src/proxy/http/metrics/service.rs
@@ -241,17 +241,18 @@ where
 impl<C, S, A, B> svc::Service<http::Request<A>> for Service<S, C>
 where
     S: svc::Service<http::Request<RequestBody<A, C::Class>>, Response = http::Response<B>>,
+    S::Error: Into<Error>,
     A: Payload,
     B: Payload,
     C: ClassifyResponse + Clone + Default + Send + Sync + 'static,
     C::Class: Hash + Eq + Send + Sync,
 {
     type Response = http::Response<ResponseBody<B, C::ClassifyEos>>;
-    type Error = S::Error;
+    type Error = Error;
     type Future = ResponseFuture<S::Future, C>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.inner.poll_ready()
+        self.inner.poll_ready().map_err(Into::into)
     }
 
     fn call(&mut self, req: http::Request<A>) -> Self::Future {
@@ -290,32 +291,48 @@ where
 impl<C, F, B> Future for ResponseFuture<F, C>
 where
     F: Future<Item = http::Response<B>>,
+    F::Error: Into<Error>,
     B: Payload,
     C: ClassifyResponse + Send + Sync + 'static,
     C::Class: Hash + Eq + Send + Sync,
 {
     type Item = http::Response<ResponseBody<B, C::ClassifyEos>>;
-    type Error = F::Error;
+    type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let rsp = try_ready!(self.inner.poll());
-
-        let classify = self.classify.take().map(|c| c.start(&rsp));
-
-        let rsp = {
-            let (head, inner) = rsp.into_parts();
-            let body = ResponseBody {
-                status: head.status,
-                classify,
-                metrics: self.metrics.clone(),
-                stream_open_at: self.stream_open_at,
-                latency_recorded: false,
-                inner,
-            };
-            http::Response::from_parts(head, body)
+        let rsp = match self.inner.poll() {
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Ok(Async::Ready(rsp)) => Ok(rsp),
+            Err(e) => Err(e),
         };
 
-        Ok(rsp.into())
+        let classify = self.classify.take();
+        let metrics = self.metrics.take();
+        match rsp {
+            Ok(rsp) => {
+                let classify = classify.map(|c| c.start(&rsp));
+                let (head, inner) = rsp.into_parts();
+                let body = ResponseBody {
+                    status: head.status,
+                    classify,
+                    metrics,
+                    stream_open_at: self.stream_open_at,
+                    latency_recorded: false,
+                    inner,
+                };
+                Ok(http::Response::from_parts(head, body).into())
+            }
+            Err(e) => {
+                let e = e.into();
+                if let Some(lock) = metrics {
+                    if let Some(classify) = classify {
+                        let class = classify.error(&e);
+                        measure_class(&lock, class, None);
+                    }
+                }
+                Err(e)
+            }
+        }
     }
 }
 
@@ -424,7 +441,7 @@ where
 
         let status_metrics = metrics
             .by_status
-            .entry(self.status)
+            .entry(Some(self.status))
             .or_insert_with(|| StatusMetrics::default());
 
         status_metrics.latency.add(now - self.stream_open_at);
@@ -433,37 +450,43 @@ where
     }
 
     fn record_class(&mut self, class: C::Class) {
-        let now = clock::now();
-        let lock = match self.metrics.take() {
-            Some(lock) => lock,
-            None => return,
-        };
-        let mut metrics = match lock.lock() {
-            Ok(m) => m,
-            Err(_) => return,
-        };
-
-        (*metrics).last_update = now;
-
-        let status_metrics = metrics
-            .by_status
-            .entry(self.status)
-            .or_insert_with(|| StatusMetrics::default());
-
-        let class_metrics = status_metrics
-            .by_class
-            .entry(class)
-            .or_insert_with(|| ClassMetrics::default());
-
-        class_metrics.total.incr();
+        if let Some(lock) = self.metrics.take() {
+            measure_class(&lock, class, Some(self.status));
+        }
     }
 
     fn measure_err(&mut self, err: Error) -> Error {
-        if let Some(c) = self.classify.take().map(|c| c.error(&*err)) {
+        if let Some(c) = self.classify.take().map(|c| c.error(&err)) {
             self.record_class(c);
         }
         err
     }
+}
+
+fn measure_class<C: Hash + Eq>(
+    lock: &Arc<Mutex<RequestMetrics<C>>>,
+    class: C,
+    status: Option<http::StatusCode>,
+) {
+    let now = clock::now();
+    let mut metrics = match lock.lock() {
+        Ok(m) => m,
+        Err(_) => return,
+    };
+
+    (*metrics).last_update = now;
+
+    let status_metrics = metrics
+        .by_status
+        .entry(status)
+        .or_insert_with(|| StatusMetrics::default());
+
+    let class_metrics = status_metrics
+        .by_class
+        .entry(class)
+        .or_insert_with(|| ClassMetrics::default());
+
+    class_metrics.total.incr();
 }
 
 impl<B, C> Payload for ResponseBody<B, C>


### PR DESCRIPTION
The metrics layer did not properly count response errors.

This change makes a response status code optional so that response
errors may be counted when no status code is present.

Fixes linkerd/linkerd2#2934