### PR TITLE
Relax the default outbound dispatch timeout to 3s

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -316,7 +316,7 @@ const DEFAULT_INBOUND_CONNECT_BACKOFF: Backoff = Backoff::Exponential {
     max: Duration::from_millis(500),
     jitter: 0.1,
 };
-const DEFAULT_OUTBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(1);
+const DEFAULT_OUTBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(3);
 const DEFAULT_OUTBOUND_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_OUTBOUND_CONNECT_BACKOFF: Backoff = Backoff::Exponential {
     min: Duration::from_millis(100),


### PR DESCRIPTION
Given that the first request to a service incurs a DNS lookup and 2
discovery lookups, a 1s timeout can be too aggressive for some
environments.

Let's relax this to 3s to allow for more slowness during initialization.