### PR TITLE
Replace `log` and `env-logger` with `tracing` and `tracing-fmt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -97,7 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.2"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -148,7 +148,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -168,7 +168,7 @@ name = "crossbeam-utils"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -557,6 +557,7 @@ dependencies = [
  "tokio-rustls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
  "tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -644,7 +645,7 @@ name = "log"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -741,7 +742,7 @@ name = "net2"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1149,7 +1150,7 @@ name = "socket2"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1209,7 +1210,7 @@ name = "tempfile"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1434,8 +1435,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-trace"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tokio#d4adeeef2f30a78b147207738b0fcdc0cc8ac5e7"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-trace-core"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-trace-core"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1696,7 +1715,7 @@ name = "trust-dns-resolver"
 version = "0.10.2"
 source = "git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060#7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060"
 dependencies = [
- "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipconfig 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1889,7 +1908,7 @@ dependencies = [
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
-"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum codegen 0.1.1 (git+https://github.com/carllerche/codegen)" = "<none>"
@@ -2021,7 +2040,9 @@ dependencies = [
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
 "checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6"
+"checksum tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)" = "<none>"
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
+"checksum tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9c8a256d6956f7cb5e2bdfe8b1e8022f1a09206c6c2b1ba00f3b746b260c613"
 "checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b931b40c84f47fd203101b2ef18cd6523e27bb2902129bc3ca2ed1f07fa17695"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,17 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,7 +150,7 @@ dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -158,7 +169,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -462,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -485,7 +496,7 @@ dependencies = [
  "hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
+ "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -534,10 +545,6 @@ dependencies = [
  "tokio-rustls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
- "tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
- "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
- "tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
  "tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -546,6 +553,10 @@ dependencies = [
  "tower-request-modifier 0.1.0 (git+https://github.com/tower-rs/tower-http)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)",
  "trust-dns-resolver 0.10.2 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)",
  "try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -580,9 +591,9 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -607,7 +618,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
+ "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -748,16 +759,24 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "num-traits"
-version = "0.1.43"
+name = "num-integer"
+version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.0"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1056,7 +1075,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1212,7 +1231,7 @@ name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1406,70 +1425,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-trace"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio#aac6998c22b393dd371befbc1aacc0c5f3951c1f"
-dependencies = [
- "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio)",
-]
-
-[[package]]
 name = "tokio-trace-core"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-trace-core"
-version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tokio#aac6998c22b393dd371befbc1aacc0c5f3951c1f"
-dependencies = [
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-trace-fmt"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#8793a974c91e4f363d508c02670fd63632405808"
-dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio)",
-]
-
-[[package]]
-name = "tokio-trace-futures"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#8793a974c91e4f363d508c02670fd63632405808"
-dependencies = [
- "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
-]
-
-[[package]]
-name = "tokio-trace-log"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#8793a974c91e4f363d508c02670fd63632405808"
-dependencies = [
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
- "tokio-trace-subscriber 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
-]
-
-[[package]]
-name = "tokio-trace-subscriber"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#8793a974c91e4f363d508c02670fd63632405808"
-dependencies = [
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1700,6 +1660,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-fmt"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tracing#f4752ff724040aa3aec924059933fdd3b4720890"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tracing#f4752ff724040aa3aec924059933fdd3b4720890"
+dependencies = [
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tracing#f4752ff724040aa3aec924059933fdd3b4720890"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tracing#f4752ff724040aa3aec924059933fdd3b4720890"
+dependencies = [
+ "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "trust-dns-proto"
 version = "0.6.0"
 source = "git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060#7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060"
@@ -1708,7 +1729,7 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1731,7 +1752,7 @@ dependencies = [
  "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "ipconfig 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1913,6 +1934,7 @@ dependencies = [
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+"checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum codegen 0.1.1 (git+https://github.com/carllerche/codegen)" = "<none>"
 "checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"
@@ -1952,7 +1974,7 @@ dependencies = [
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
+"checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.8)" = "<none>"
@@ -1971,8 +1993,9 @@ dependencies = [
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
-"checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
@@ -2041,13 +2064,7 @@ dependencies = [
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
 "checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6"
-"checksum tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)" = "<none>"
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
-"checksum tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio)" = "<none>"
-"checksum tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
-"checksum tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
-"checksum tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
-"checksum tokio-trace-subscriber 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
 "checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b931b40c84f47fd203101b2ef18cd6523e27bb2902129bc3ca2ed1f07fa17695"
@@ -2067,6 +2084,12 @@ dependencies = [
 "checksum tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc0c98637d23732f8de6dfd16494c9f1559c3b9e20b4a46462c8f9b9e827bfa"
 "checksum tower-timeout 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "daa179ec4087589dc67148dc661abce5badc2c3ed4197adc7bd64b39f1f33c31"
 "checksum tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4792342fac093db5d2558655055a89a04ca909663467a4310c7739d9f8b64698"
+"checksum tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9bb7fc03e49466b8388752c8b23856f0ae0782d4bbc0e0320430e9f62933a998"
+"checksum tracing-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "647b17ee356f69ed05528260776c8beccfca65fc19a3b484e95ac0ef9ba68080"
+"checksum tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
 "checksum trust-dns-proto 0.6.0 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)" = "<none>"
 "checksum trust-dns-resolver 0.10.2 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)" = "<none>"
 "checksum try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "119b532a17fbe772d360be65617310164549a07c25a1deab04c84168ce0d4545"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
  "hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
 ]
 
 [[package]]
@@ -534,7 +534,7 @@ dependencies = [
  "tokio-rustls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
  "tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
  "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
  "tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
@@ -580,7 +580,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -607,7 +607,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
 ]
 
 [[package]]
@@ -1408,10 +1408,10 @@ dependencies = [
 [[package]]
 name = "tokio-trace"
 version = "0.1.0"
-source = "git+https://github.com/kazimuth/tokio.git?branch=global_dispatch#58012ddc05009060499c5adecd61d65f23efca7e"
+source = "git+https://github.com/tokio-rs/tokio.git#df2c3cd475be085483d76f619ce2d297fe0b2776"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio.git)",
 ]
 
 [[package]]
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-core"
 version = "0.2.0"
-source = "git+https://github.com/kazimuth/tokio.git?branch=global_dispatch#58012ddc05009060499c5adecd61d65f23efca7e"
+source = "git+https://github.com/tokio-rs/tokio.git#df2c3cd475be085483d76f619ce2d297fe0b2776"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1441,7 +1441,7 @@ dependencies = [
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio.git)",
 ]
 
 [[package]]
@@ -1451,7 +1451,7 @@ source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
 ]
 
 [[package]]
@@ -1460,7 +1460,7 @@ version = "0.0.1"
 source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e607c3997b6af273d4403007e92524b319fb4a93"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
  "tokio-trace-subscriber 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
 ]
 
@@ -1469,7 +1469,7 @@ name = "tokio-trace-subscriber"
 version = "0.0.1"
 source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e607c3997b6af273d4403007e92524b319fb4a93"
 dependencies = [
- "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
 ]
 
 [[package]]
@@ -2041,9 +2041,9 @@ dependencies = [
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
 "checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6"
-"checksum tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)" = "<none>"
+"checksum tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)" = "<none>"
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
-"checksum tokio-trace-core 0.2.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)" = "<none>"
+"checksum tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio.git)" = "<none>"
 "checksum tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
 "checksum tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
 "checksum tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-fmt"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#aaed19e4a286df8e36957825986468201e1f0a87"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#641f0c1d055d7392a8db7acfa6b422af4e4c6f84"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-futures"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#aaed19e4a286df8e36957825986468201e1f0a87"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#641f0c1d055d7392a8db7acfa6b422af4e4c6f84"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-log"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#aaed19e4a286df8e36957825986468201e1f0a87"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#641f0c1d055d7392a8db7acfa6b422af4e4c6f84"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
@@ -1467,7 +1467,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-subscriber"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#aaed19e4a286df8e36957825986468201e1f0a87"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#641f0c1d055d7392a8db7acfa6b422af4e4c6f84"
 dependencies = [
  "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-fmt"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#641f0c1d055d7392a8db7acfa6b422af4e4c6f84"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e607c3997b6af273d4403007e92524b319fb4a93"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1447,7 +1447,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-futures"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#641f0c1d055d7392a8db7acfa6b422af4e4c6f84"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e607c3997b6af273d4403007e92524b319fb4a93"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1457,7 +1457,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-log"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#641f0c1d055d7392a8db7acfa6b422af4e4c6f84"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e607c3997b6af273d4403007e92524b319fb4a93"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
@@ -1467,7 +1467,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-subscriber"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#641f0c1d055d7392a8db7acfa6b422af4e4c6f84"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e607c3997b6af273d4403007e92524b319fb4a93"
 dependencies = [
  "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,8 @@ dependencies = [
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
  "tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
+ "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
+ "tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
  "tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1493,7 +1495,6 @@ version = "0.1.0"
 source = "git+https://github.com/kazimuth/tokio.git?branch=global_dispatch#58012ddc05009060499c5adecd61d65f23efca7e"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-trace-core 0.2.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
 ]
 
@@ -1516,7 +1517,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-fmt"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e3cccf61a6b384f49066b7d4f54d8df4693f11f7"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#3590424144bb9c8110ba8d07f994d8fbda3caf71"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1525,6 +1526,34 @@ dependencies = [
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-trace-core 0.2.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+]
+
+[[package]]
+name = "tokio-trace-futures"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#3590424144bb9c8110ba8d07f994d8fbda3caf71"
+dependencies = [
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+]
+
+[[package]]
+name = "tokio-trace-log"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#3590424144bb9c8110ba8d07f994d8fbda3caf71"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace-subscriber 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
+]
+
+[[package]]
+name = "tokio-trace-subscriber"
+version = "0.0.1"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#3590424144bb9c8110ba8d07f994d8fbda3caf71"
+dependencies = [
+ "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
 ]
 
 [[package]]
@@ -2117,6 +2146,9 @@ dependencies = [
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
 "checksum tokio-trace-core 0.2.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)" = "<none>"
 "checksum tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
+"checksum tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
+"checksum tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
+"checksum tokio-trace-subscriber 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
 "checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b931b40c84f47fd203101b2ef18cd6523e27bb2902129bc3ca2ed1f07fa17695"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,16 +30,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "autocfg"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,15 +97,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "chrono"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "cloudabi"
@@ -201,17 +182,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -527,7 +497,6 @@ name = "linkerd2-proxy"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mpsc-lossy 0.1.0",
@@ -777,33 +746,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "nom"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "num"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "num-traits"
@@ -1072,14 +1014,6 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "redox_termios"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "regex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,24 +1205,6 @@ dependencies = [
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "termcolor"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "termion"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1958,14 +1874,6 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "wincolor"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "winreg"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1995,7 +1903,6 @@ dependencies = [
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
-"checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
@@ -2006,7 +1913,6 @@ dependencies = [
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
-"checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum codegen 0.1.1 (git+https://github.com/carllerche/codegen)" = "<none>"
 "checksum crc 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5d02c0aac6bd68393ed69e00bbc2457f3e89075c6349db7189618dc4ddc1d7"
@@ -2017,7 +1923,6 @@ dependencies = [
 "checksum deflate 0.7.18 (registry+https://github.com/rust-lang/crates.io-index)" = "32c8120d981901a9970a3a1c97cf8b630e0fa8c3ca31e75b6fd6fd5f9f427b31"
 "checksum either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c67353c641dc847124ea1902d69bd753dee9bb3beff9aa3662ecf86c971d1fac"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
-"checksum env_logger 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f15f0b172cb4f52ed5dbf47f774a387cd2315d1bf7894ab5af9b083ae27efa5a"
 "checksum error-chain 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6930e04918388a9a2e41d518c25cf679ccafe26733fb4127dbf21993f2575d46"
 "checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
 "checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
@@ -2066,9 +1971,6 @@ dependencies = [
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum nom 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
-"checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
-"checksum num-integer 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "f8d26da319fb45674985c78f1d1caf99aa4941f785d384a2ae36d0740bc3e2fe"
-"checksum num-iter 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "4b226df12c5a59b63569dd57fafb926d91b385dfce33d8074a412411b689d593"
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
@@ -2099,7 +2001,6 @@ dependencies = [
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
-"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
 "checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
 "checksum remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc5b3ce5d5ea144bb04ebd093a9e14e9765bcfec866aecda9b6dec43b3d1e24"
@@ -2123,8 +2024,6 @@ dependencies = [
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "7e91405c14320e5c79b3d148e1c86f40749a36e490642202a31689cb1a3452b2"
-"checksum termcolor 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "56c456352e44f9f91f774ddeeed27c1ec60a2455ed66d692059acfb1d731bda1"
-"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "94a1f9396aec29d31bb16c24d155cfa144d1af91c40740125db3131bdaf76da8"
@@ -2191,7 +2090,6 @@ dependencies = [
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum wincolor 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb06499a3a4d44302791052df005d5232b927ed1a9658146d842165c4de7767"
 "checksum winreg 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9338067aba07889a38beaad4dbb77fa2e62e87c423b770824b3bdf412874bd2c"
 "checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,7 +515,7 @@ dependencies = [
  "hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
+ "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
 ]
 
 [[package]]
@@ -557,7 +565,8 @@ dependencies = [
  "tokio-rustls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
+ "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
+ "tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
  "tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -600,7 +609,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
+ "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -627,7 +636,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
+ "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
 ]
 
 [[package]]
@@ -639,6 +648,15 @@ dependencies = [
  "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -804,6 +822,35 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "owning_ref"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1162,6 +1209,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "string"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,11 +1490,11 @@ dependencies = [
 [[package]]
 name = "tokio-trace"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio#5925ca772056fba370e2b4524bc4103ec7dd2f56"
+source = "git+https://github.com/kazimuth/tokio.git?branch=global_dispatch#58012ddc05009060499c5adecd61d65f23efca7e"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace-core 0.2.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
 ]
 
 [[package]]
@@ -1456,9 +1508,23 @@ dependencies = [
 [[package]]
 name = "tokio-trace-core"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/kazimuth/tokio.git?branch=global_dispatch#58012ddc05009060499c5adecd61d65f23efca7e"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-trace-fmt"
+version = "0.1.0"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e3cccf61a6b384f49066b7d4f54d8df4693f11f7"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace-core 0.2.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
 ]
 
 [[package]]
@@ -1898,6 +1964,7 @@ dependencies = [
 [metadata]
 "checksum adler32 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6cbd0b9af8587c72beadc9f72d35b9fbb070982c9e6203e46e93f10df25f8f45"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum atty 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8352656fd42c30a0c3c89d26dea01e3b77c0ab2af18230835c15e2e13cd51859"
 "checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
@@ -1955,6 +2022,7 @@ dependencies = [
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.8)" = "<none>"
+"checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
@@ -1975,6 +2043,9 @@ dependencies = [
 "checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
 "checksum num-traits 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e7de20f146db9d920c45ee8ed8f71681fd9ade71909b48c3acbd766aa504cf10"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
+"checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
+"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum petgraph 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7a7e5234c228fbfa874c86a77f685886127f82e0aef602ad1d48333fcac6ad61"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
@@ -2016,6 +2087,7 @@ dependencies = [
 "checksum smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "26df3bb03ca5eac2e64192b723d51f56c1b1e0860e7c766281f4598f181acdc8"
 "checksum socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff606e0486e88f5fc6cfeb3966e434fb409abbc7a3ab495238f70a1ca97f789d"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
+"checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0bbfb8937e38e34c3444ff00afb28b0811d9554f15c5ad64d12b0308d1d1995"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1825685f977249735d510a242a6727b46efe914bb67e38d30c071b1b72b1d5c2"
@@ -2041,9 +2113,10 @@ dependencies = [
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
 "checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6"
-"checksum tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)" = "<none>"
+"checksum tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)" = "<none>"
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
-"checksum tokio-trace-core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9c8a256d6956f7cb5e2bdfe8b1e8022f1a09206c6c2b1ba00f3b746b260c613"
+"checksum tokio-trace-core 0.2.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)" = "<none>"
+"checksum tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
 "checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 "checksum tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b931b40c84f47fd203101b2ef18cd6523e27bb2902129bc3ca2ed1f07fa17695"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
  "hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
 ]
 
 [[package]]
@@ -534,7 +534,7 @@ dependencies = [
  "tokio-rustls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
  "tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
  "tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
  "tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
@@ -580,7 +580,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -607,7 +607,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
 ]
 
 [[package]]
@@ -1408,10 +1408,10 @@ dependencies = [
 [[package]]
 name = "tokio-trace"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio.git#df2c3cd475be085483d76f619ce2d297fe0b2776"
+source = "git+https://github.com/tokio-rs/tokio#aac6998c22b393dd371befbc1aacc0c5f3951c1f"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio.git)",
+ "tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio)",
 ]
 
 [[package]]
@@ -1425,7 +1425,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-core"
 version = "0.2.0"
-source = "git+https://github.com/tokio-rs/tokio.git#df2c3cd475be085483d76f619ce2d297fe0b2776"
+source = "git+https://github.com/tokio-rs/tokio#aac6998c22b393dd371befbc1aacc0c5f3951c1f"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1433,7 +1433,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-fmt"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e607c3997b6af273d4403007e92524b319fb4a93"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#8793a974c91e4f363d508c02670fd63632405808"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1441,35 +1441,35 @@ dependencies = [
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio.git)",
+ "tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio)",
 ]
 
 [[package]]
 name = "tokio-trace-futures"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e607c3997b6af273d4403007e92524b319fb4a93"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#8793a974c91e4f363d508c02670fd63632405808"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
 ]
 
 [[package]]
 name = "tokio-trace-log"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e607c3997b6af273d4403007e92524b319fb4a93"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#8793a974c91e4f363d508c02670fd63632405808"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
  "tokio-trace-subscriber 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)",
 ]
 
 [[package]]
 name = "tokio-trace-subscriber"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#e607c3997b6af273d4403007e92524b319fb4a93"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#8793a974c91e4f363d508c02670fd63632405808"
 dependencies = [
- "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
 ]
 
 [[package]]
@@ -2041,9 +2041,9 @@ dependencies = [
 "checksum tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
 "checksum tokio-threadpool 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "72558af20be886ea124595ea0f806dd5703b8958e4705429dd58b3d8231f72f2"
 "checksum tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2910970404ba6fa78c5539126a9ae2045d62e3713041e447f695f41405a120c6"
-"checksum tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio.git)" = "<none>"
+"checksum tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)" = "<none>"
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
-"checksum tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio.git)" = "<none>"
+"checksum tokio-trace-core 0.2.0 (git+https://github.com/tokio-rs/tokio)" = "<none>"
 "checksum tokio-trace-fmt 0.1.0 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
 "checksum tokio-trace-futures 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"
 "checksum tokio-trace-log 0.0.1 (git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,8 +506,8 @@ dependencies = [
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
 ]
 
 [[package]]
@@ -600,6 +600,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -623,10 +624,10 @@ name = "linkerd2-task"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-trace 0.1.0 (git+https://github.com/tokio-rs/tokio)",
 ]
 
 [[package]]
@@ -1437,7 +1438,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio#d4adeeef2f30a78b147207738b0fcdc0cc8ac5e7"
+source = "git+https://github.com/tokio-rs/tokio#5925ca772056fba370e2b4524bc4103ec7dd2f56"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,7 +1517,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-fmt"
 version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#3590424144bb9c8110ba8d07f994d8fbda3caf71"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#aaed19e4a286df8e36957825986468201e1f0a87"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1531,7 +1531,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-futures"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#3590424144bb9c8110ba8d07f994d8fbda3caf71"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#aaed19e4a286df8e36957825986468201e1f0a87"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1541,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-log"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#3590424144bb9c8110ba8d07f994d8fbda3caf71"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#aaed19e4a286df8e36957825986468201e1f0a87"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
@@ -1551,7 +1551,7 @@ dependencies = [
 [[package]]
 name = "tokio-trace-subscriber"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#3590424144bb9c8110ba8d07f994d8fbda3caf71"
+source = "git+https://github.com/tokio-rs/tokio-trace-nursery?branch=eliza/trace-0.2#aaed19e4a286df8e36957825986468201e1f0a87"
 dependencies = [
  "tokio-trace 0.1.0 (git+https://github.com/kazimuth/tokio.git?branch=global_dispatch)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ tower-discover = "0.1"
 tower-service = "0.2"
 tower-util = "0.1"
 tokio-trace            = { git = "https://github.com/tokio-rs/tokio", features = ["log"]}
+tokio-trace-fmt        = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
 tokio-connect          = { git = "https://github.com/carllerche/tokio-connect" }
 tower-balance          = { git = "https://github.com/tower-rs/tower" }
 tower-reconnect        = { git = "https://github.com/tower-rs/tower" }
@@ -103,3 +104,8 @@ debug = false
 
 [patch.crates-io]
 webpki = { git = "https://github.com/seanmonstar/webpki", branch = "cert-dns-names" }
+tokio-trace-core = { git = "https://github.com/kazimuth/tokio.git", branch = "global_dispatch" }
+
+[patch.'https://github.com/tokio-rs/tokio']
+tokio-trace      = { git = "https://github.com/kazimuth/tokio.git", features = ["log"], branch = "global_dispatch" }
+tokio-trace-core = { git = "https://github.com/kazimuth/tokio.git", branch = "global_dispatch" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ tower = "0.1"
 tower-discover = "0.1"
 tower-service = "0.2"
 tower-util = "0.1"
+tokio-trace            = { git = "https://github.com/tokio-rs/tokio", features = ["log"]}
 tokio-connect          = { git = "https://github.com/carllerche/tokio-connect" }
 tower-balance          = { git = "https://github.com/tower-rs/tower" }
 tower-reconnect        = { git = "https://github.com/tower-rs/tower" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,10 @@ tower = "0.1"
 tower-discover = "0.1"
 tower-service = "0.2"
 tower-util = "0.1"
-tokio-trace            = { git = "https://github.com/tokio-rs/tokio", features = ["log"]}
+tokio-trace            = { git = "https://github.com/tokio-rs/tokio" }
 tokio-trace-fmt        = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
+tokio-trace-futures    = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
+tokio-trace-log        = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
 tokio-connect          = { git = "https://github.com/carllerche/tokio-connect" }
 tower-balance          = { git = "https://github.com/tower-rs/tower" }
 tower-reconnect        = { git = "https://github.com/tower-rs/tower" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,8 +105,4 @@ debug = false
 
 [patch.crates-io]
 webpki = { git = "https://github.com/seanmonstar/webpki", branch = "cert-dns-names" }
-tokio-trace-core = { git = "https://github.com/kazimuth/tokio.git", branch = "global_dispatch" }
-
-[patch.'https://github.com/tokio-rs/tokio']
-tokio-trace      = { git = "https://github.com/kazimuth/tokio.git", branch = "global_dispatch", default-features = false }
-tokio-trace-core = { git = "https://github.com/kazimuth/tokio.git", branch = "global_dispatch" }
+tokio-trace-core = { git = "https://github.com/tokio-rs/tokio.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ linkerd2-timeout   = { path = "lib/timeout" }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.8" }
 
 bytes = "0.4"
-env_logger = { version = "0.5", default-features = false }
 futures = "0.1"
 futures-watch = { git = "https://github.com/carllerche/better-future" }
 h2 = "0.1.15"
@@ -43,7 +42,7 @@ http-body = "0.1"
 httparse = "1.2"
 hyper = "0.12.3"
 ipnet = "1.0"
-log = { version = "0.4.1", features = ["max_level_trace"] }
+log = { version = "0.4.1", features = ["std"] }
 indexmap = "1.0.0"
 prost = "0.5.0"
 prost-types = "0.5.0"
@@ -61,7 +60,7 @@ tower = "0.1"
 tower-discover = "0.1"
 tower-service = "0.2"
 tower-util = "0.1"
-tokio-trace            = { git = "https://github.com/tokio-rs/tokio", default-features = false }
+tokio-trace            = { git = "https://github.com/tokio-rs/tokio" }
 tokio-trace-fmt        = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
 tokio-trace-futures    = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
 tokio-trace-log        = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ http-body = "0.1"
 httparse = "1.2"
 hyper = "0.12.3"
 ipnet = "1.0"
-log = "0.4.1"
+log = { version = "0.4.1", features = ["max_level_trace"] }
 indexmap = "1.0.0"
 prost = "0.5.0"
 prost-types = "0.5.0"
@@ -61,7 +61,7 @@ tower = "0.1"
 tower-discover = "0.1"
 tower-service = "0.2"
 tower-util = "0.1"
-tokio-trace            = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace            = { git = "https://github.com/tokio-rs/tokio", default-features = false }
 tokio-trace-fmt        = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
 tokio-trace-futures    = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
 tokio-trace-log        = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
@@ -109,5 +109,5 @@ webpki = { git = "https://github.com/seanmonstar/webpki", branch = "cert-dns-nam
 tokio-trace-core = { git = "https://github.com/kazimuth/tokio.git", branch = "global_dispatch" }
 
 [patch.'https://github.com/tokio-rs/tokio']
-tokio-trace      = { git = "https://github.com/kazimuth/tokio.git", features = ["log"], branch = "global_dispatch" }
+tokio-trace      = { git = "https://github.com/kazimuth/tokio.git", branch = "global_dispatch", default-features = false }
 tokio-trace-core = { git = "https://github.com/kazimuth/tokio.git", branch = "global_dispatch" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,10 +60,6 @@ tower = "0.1"
 tower-discover = "0.1"
 tower-service = "0.2"
 tower-util = "0.1"
-tokio-trace            = { git = "https://github.com/tokio-rs/tokio" }
-tokio-trace-fmt        = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
-tokio-trace-futures    = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
-tokio-trace-log        = { git = "https://github.com/tokio-rs/tokio-trace-nursery", branch = "eliza/trace-0.2"}
 tokio-connect          = { git = "https://github.com/carllerche/tokio-connect" }
 tower-balance          = { git = "https://github.com/tower-rs/tower" }
 tower-reconnect        = { git = "https://github.com/tower-rs/tower" }
@@ -72,6 +68,11 @@ tower-grpc             = { git = "https://github.com/tower-rs/tower-grpc", defau
 
 # FIXME update to a release when available (>0.11)
 trust-dns-resolver = { git = "https://github.com/bluejekyll/trust-dns", rev = "7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060", default-features = false }
+
+tracing         = "0.1.2"
+tracing-fmt     = { git = "https://github.com/tokio-rs/tracing" }
+tracing-futures = { git = "https://github.com/tokio-rs/tracing" }
+tracing-log     = { git = "https://github.com/tokio-rs/tracing" }
 
 # tls
 ring = "0.14.6"
@@ -105,4 +106,4 @@ debug = false
 
 [patch.crates-io]
 webpki = { git = "https://github.com/seanmonstar/webpki", branch = "cert-dns-names" }
-tokio-trace-core = { git = "https://github.com/tokio-rs/tokio.git" }
+

--- a/lib/metrics/Cargo.toml
+++ b/lib/metrics/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.1"
 http = "0.1"
 hyper = "0.12.3"
 indexmap = "1.0"
-log = "0.4"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
 
 [dev-dependencies]
 quickcheck = { version = "0.8", default-features = false }

--- a/lib/metrics/Cargo.toml
+++ b/lib/metrics/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.1"
 http = "0.1"
 hyper = "0.12.3"
 indexmap = "1.0"
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tracing = "0.1.2"
 
 [dev-dependencies]
 quickcheck = { version = "0.8", default-features = false }

--- a/lib/metrics/src/gauge.rs
+++ b/lib/metrics/src/gauge.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use log::warn;
+use tokio_trace::warn;
 
 use super::{FmtLabels, FmtMetric};
 

--- a/lib/metrics/src/gauge.rs
+++ b/lib/metrics/src/gauge.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use tokio_trace::warn;
+use tracing::warn;
 
 use super::{FmtLabels, FmtMetric};
 

--- a/lib/metrics/src/serve.rs
+++ b/lib/metrics/src/serve.rs
@@ -3,10 +3,10 @@ use deflate::CompressionOptions;
 use futures::future::{self, FutureResult};
 use http::{self, header, StatusCode};
 use hyper::{service::Service, Body, Request, Response};
-use tokio_trace::{error, trace};
 use std::error::Error;
 use std::fmt;
 use std::io::{self, Write};
+use tokio_trace::{error, trace};
 
 use super::FmtMetrics;
 

--- a/lib/metrics/src/serve.rs
+++ b/lib/metrics/src/serve.rs
@@ -6,7 +6,7 @@ use hyper::{service::Service, Body, Request, Response};
 use std::error::Error;
 use std::fmt;
 use std::io::{self, Write};
-use tokio_trace::{error, trace};
+use tracing::{error, trace};
 
 use super::FmtMetrics;
 

--- a/lib/metrics/src/serve.rs
+++ b/lib/metrics/src/serve.rs
@@ -3,7 +3,7 @@ use deflate::CompressionOptions;
 use futures::future::{self, FutureResult};
 use http::{self, header, StatusCode};
 use hyper::{service::Service, Body, Request, Response};
-use log::{error, trace};
+use tokio_trace::{error, trace};
 use std::error::Error;
 use std::fmt;
 use std::io::{self, Write};

--- a/lib/router/Cargo.toml
+++ b/lib/router/Cargo.toml
@@ -18,4 +18,4 @@ tokio = "0.1.20"
 tokio-sync = "0.1.6"
 tokio-timer = "0.2.4"
 tower-service = "0.2"
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tracing = "0.1.2"

--- a/lib/router/Cargo.toml
+++ b/lib/router/Cargo.toml
@@ -18,3 +18,4 @@ tokio = "0.1.20"
 tokio-sync = "0.1.6"
 tokio-timer = "0.2.4"
 tower-service = "0.2"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -2,10 +2,10 @@ use std::{hash::Hash, time::Duration};
 
 use futures::{try_ready, Async, Future, Poll, Stream};
 use indexmap::IndexMap;
-use log::debug;
+
 use tokio::sync::lock::Lock;
 use tokio_timer::{delay_queue, DelayQueue, Error, Interval};
-
+use tokio_trace::debug;
 /// An LRU cache that can eagerly remove values in a background task.
 ///
 /// Assumptions:

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -6,6 +6,7 @@ use indexmap::IndexMap;
 use tokio::sync::lock::Lock;
 use tokio_timer::{delay_queue, DelayQueue, Error, Interval};
 use tokio_trace::debug;
+
 /// An LRU cache that can eagerly remove values in a background task.
 ///
 /// Assumptions:

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 
 use tokio::sync::lock::Lock;
 use tokio_timer::{delay_queue, DelayQueue, Error, Interval};
-use tokio_trace::debug;
+use tracing::debug;
 
 /// An LRU cache that can eagerly remove values in a background task.
 ///

--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -3,9 +3,9 @@ use std::{hash::Hash, time::Duration};
 use futures::{task, try_ready, Async, Future, Poll, Stream};
 use indexmap::IndexMap;
 
-use tracing::trace;
 use tokio::sync::lock::Lock;
 use tokio_timer::{delay_queue, DelayQueue};
+use tracing::trace;
 
 /// An LRU cache that can eagerly remove values in a background task.
 ///

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
-use tokio_trace::debug;
 use tokio::sync::lock::Lock;
+use tokio_trace::debug;
 use tower_load_shed::LoadShed;
 use tower_service as svc;
 

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
-use log::debug;
+use tokio_trace::debug;
 use tokio::sync::lock::Lock;
 use tower_load_shed::LoadShed;
 use tower_service as svc;

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -6,9 +6,9 @@ use std::time::Duration;
 use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
 use tokio::sync::lock::Lock;
-use tracing::debug;
 use tower_load_shed::LoadShed;
 use tower_service as svc;
+use tracing::debug;
 
 mod cache;
 pub mod error;

--- a/lib/router/src/lib.rs
+++ b/lib/router/src/lib.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
 use tokio::sync::lock::Lock;
-use tokio_trace::debug;
+use tracing::debug;
 use tower_load_shed::LoadShed;
 use tower_service as svc;
 

--- a/lib/task/Cargo.toml
+++ b/lib/task/Cargo.toml
@@ -14,4 +14,4 @@ futures = "0.1"
 tokio = "0.1.7"
 tokio-executor = "0.1.7"
 tokio-timer = { version = "0.2", optional = true }
-log = "0.4"
+tokio-trace = { git = "https://github.com/tokio-rs/tokio" }

--- a/lib/task/Cargo.toml
+++ b/lib/task/Cargo.toml
@@ -14,4 +14,4 @@ futures = "0.1"
 tokio = "0.1.7"
 tokio-executor = "0.1.7"
 tokio-timer = { version = "0.2", optional = true }
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tracing = "0.1.2"

--- a/lib/task/src/lib.rs
+++ b/lib/task/src/lib.rs
@@ -3,7 +3,7 @@
 //! Task execution utilities.
 
 use std::{error::Error as StdError, fmt, io, sync::Arc};
-use tokio_trace::{debug, warn};
+use tracing::{debug, warn};
 
 pub use futures::future::Executor;
 use futures::future::{ExecuteError, ExecuteErrorKind, Future};

--- a/lib/task/src/lib.rs
+++ b/lib/task/src/lib.rs
@@ -2,7 +2,7 @@
 
 //! Task execution utilities.
 
-use log::{debug, warn};
+use tokio_trace::{debug, warn};
 use std::{error::Error as StdError, fmt, io, sync::Arc};
 
 pub use futures::future::Executor;

--- a/lib/task/src/lib.rs
+++ b/lib/task/src/lib.rs
@@ -2,8 +2,8 @@
 
 //! Task execution utilities.
 
-use tokio_trace::{debug, warn};
 use std::{error::Error as StdError, fmt, io, sync::Arc};
+use tokio_trace::{debug, warn};
 
 pub use futures::future::Executor;
 use futures::future::{ExecuteError, ExecuteErrorKind, Future};

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::fs;
 use std::iter::FromIterator;
 use std::net::SocketAddr;
@@ -955,6 +956,16 @@ pub fn parse_identity_config<S: Strings>(strings: &S) -> Result<Option<identity:
         }
     }
 }
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Error::InvalidEnvVar => fmt::Display::fmt("invalid environment variable", f),
+        }
+    }
+}
+
+impl ::std::error::Error for Error {}
 
 #[cfg(test)]
 mod tests {

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -10,7 +10,6 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::runtime::current_thread;
 use tokio_timer::clock;
 use tower_grpc as grpc;
-use trace::futures::Instrument;
 
 use app::classify::{self, Class};
 use app::metric_labels::{ControlLabels, EndpointLabels, RouteLabels};

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -886,6 +886,7 @@ where
     let future = log.future(
         bound_port.listen_and_fold((), move |(), (connection, remote)| {
             let s = server.serve(connection, remote, h2_settings);
+            // TODO: use trace spans for log contexts.
             // .instrument(info_span!("conn", %remote));
             // Logging context is configured by the server.
             let r = DefaultExecutor::current()
@@ -894,6 +895,7 @@ where
             future::result(r)
         }),
     );
+    // TODO: use trace spans for log contexts.
     // .instrument(info_span!("proxy", server = %proxy_name, local = %listen_addr));
 
     let accept_until = Cancelable {

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -884,19 +884,18 @@ where
     );
     let log = server.log().clone();
 
-    let future = log.future(bound_port.listen_and_fold(
-        (),
-        move |(), (connection, remote)| {
-            let s = server.serve(connection, remote, h2_settings)
-                .instrument(info_span!("conn", %remote));
+    let future = log.future(
+        bound_port.listen_and_fold((), move |(), (connection, remote)| {
+            let s = server.serve(connection, remote, h2_settings);
+            // .instrument(info_span!("conn", %remote));
             // Logging context is configured by the server.
             let r = DefaultExecutor::current()
                 .spawn(Box::new(s))
                 .map_err(task::Error::into_io);
             future::result(r)
-        },
-    ))
-    .instrument(info_span!("server", server = %proxy_name, local = %listen_addr));
+        }),
+    );
+    // .instrument(info_span!("proxy", server = %proxy_name, local = %listen_addr));
 
     let accept_until = Cancelable {
         future,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -17,6 +17,7 @@ mod profiles;
 
 pub use self::main::Main;
 use addr::{self, Addr};
+use std::error::Error;
 
 const CANONICAL_DST_HEADER: &'static str = "l5d-dst-canonical";
 pub const DST_OVERRIDE_HEADER: &'static str = "l5d-dst-override";
@@ -24,11 +25,11 @@ const L5D_REMOTE_IP: &'static str = "l5d-remote-ip";
 const L5D_SERVER_ID: &'static str = "l5d-server-id";
 const L5D_CLIENT_ID: &'static str = "l5d-client-id";
 
-pub fn init() -> Result<config::Config, config::Error> {
+pub fn init() -> Result<config::Config, Box<Error + Send + Sync + 'static>> {
     use trace;
 
     trace::init()?;
-    config::Config::parse(&config::Env)
+    config::Config::parse(&config::Env).map_err(Into::into)
 }
 
 const DEFAULT_PORT: u16 = 80;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,7 +27,7 @@ const L5D_CLIENT_ID: &'static str = "l5d-client-id";
 pub fn init() -> Result<config::Config, config::Error> {
     use trace;
 
-    trace::init();
+    trace::init()?;
     config::Config::parse(&config::Env)
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25,11 +25,10 @@ const L5D_SERVER_ID: &'static str = "l5d-server-id";
 const L5D_CLIENT_ID: &'static str = "l5d-client-id";
 
 pub fn init() -> Result<config::Config, config::Error> {
-    use logging;
     use trace;
 
     // logging::init();
-    trace::dispatcher::set_global_default(logging::dispatch()).unwrap();
+    trace::init();
     config::Config::parse(&config::Env)
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -26,8 +26,10 @@ const L5D_CLIENT_ID: &'static str = "l5d-client-id";
 
 pub fn init() -> Result<config::Config, config::Error> {
     use logging;
+    use trace;
 
-    logging::init();
+    // logging::init();
+    trace::dispatcher::set_global_default(logging::dispatch()).unwrap();
     config::Config::parse(&config::Env)
 }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -27,7 +27,6 @@ const L5D_CLIENT_ID: &'static str = "l5d-client-id";
 pub fn init() -> Result<config::Config, config::Error> {
     use trace;
 
-    // logging::init();
     trace::init();
     config::Config::parse(&config::Env)
 }

--- a/src/app/profiles.rs
+++ b/src/app/profiles.rs
@@ -197,10 +197,11 @@ where
                             Ok(Async::Ready(())) => svc.as_service(),
                             Ok(Async::NotReady) => return Ok(Async::NotReady),
                             Err(err) => {
+                                let err = err.into();
                                 error!(
                                     "profile service unexpected error (dst = {}): {:?}",
                                     self.dst,
-                                    err.into(),
+                                    err,
                                 );
                                 return Ok(Async::Ready(()));
                             }

--- a/src/app/profiles.rs
+++ b/src/app/profiles.rs
@@ -197,10 +197,10 @@ where
                             Ok(Async::Ready(())) => svc.as_service(),
                             Ok(Async::NotReady) => return Ok(Async::NotReady),
                             Err(err) => {
-                                let err = err.into();
                                 error!(
                                     "profile service unexpected error (dst = {}): {:?}",
-                                    self.dst, err,
+                                    self.dst,
+                                    err.into(),
                                 );
                                 return Ok(Async::Ready(()));
                             }

--- a/src/app/profiles.rs
+++ b/src/app/profiles.rs
@@ -200,8 +200,7 @@ where
                                 let err = err.into();
                                 error!(
                                     "profile service unexpected error (dst = {}): {:?}",
-                                    self.dst,
-                                    err,
+                                    self.dst, err,
                                 );
                                 return Ok(Async::Ready(()));
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,7 @@
-// #![deny(warnings)]
+#![deny(warnings)]
 #![recursion_limit = "128"]
 
 extern crate bytes;
-extern crate env_logger;
 #[macro_use]
 extern crate futures;
 extern crate futures_mpsc_lossy;
@@ -31,7 +30,6 @@ extern crate tokio_timer;
 #[macro_use]
 extern crate tokio_trace;
 extern crate tokio_trace_fmt;
-#[macro_use]
 extern crate tokio_trace_futures;
 extern crate tower;
 extern crate tower_grpc;
@@ -65,5 +63,6 @@ pub mod transport;
 
 use self::addr::{Addr, NameAddr};
 use self::conditional::Conditional;
-pub use self::transport::SoOriginalDst;
+
 pub use self::logging::trace;
+pub use self::transport::SoOriginalDst;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@ extern crate regex;
 extern crate tokio;
 extern crate tokio_timer;
 #[macro_use]
-extern crate tokio_trace;
-extern crate tokio_trace_fmt;
-extern crate tokio_trace_futures;
+extern crate tracing;
+extern crate tracing_fmt;
+extern crate tracing_futures;
 extern crate tower;
 extern crate tower_grpc;
 extern crate tower_util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+// #![deny(warnings)]
 #![recursion_limit = "128"]
 
 extern crate bytes;
@@ -29,7 +29,8 @@ extern crate regex;
 extern crate tokio;
 extern crate tokio_timer;
 #[macro_use]
-extern crate tokio_trace;
+extern crate tokio_trace as trace;
+extern crate tokio_trace_fmt as trace_fmt;
 extern crate tower;
 extern crate tower_grpc;
 extern crate tower_util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ extern crate hyper;
 extern crate ipnet;
 #[cfg(target_os = "linux")]
 extern crate libc;
-#[macro_use]
 extern crate log;
 extern crate indexmap;
 #[cfg(target_os = "linux")]
@@ -29,6 +28,8 @@ extern crate rand;
 extern crate regex;
 extern crate tokio;
 extern crate tokio_timer;
+#[macro_use]
+extern crate tokio_trace;
 extern crate tower;
 extern crate tower_grpc;
 extern crate tower_util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,11 +29,11 @@ extern crate tokio;
 extern crate tokio_timer;
 #[macro_use]
 extern crate tracing;
-extern crate tracing_fmt;
-extern crate tracing_futures;
 extern crate tower;
 extern crate tower_grpc;
 extern crate tower_util;
+extern crate tracing_fmt;
+extern crate tracing_futures;
 extern crate try_lock;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,11 @@ extern crate http;
 extern crate http_body;
 extern crate httparse;
 extern crate hyper;
+extern crate indexmap;
 extern crate ipnet;
 #[cfg(target_os = "linux")]
 extern crate libc;
 extern crate log;
-extern crate indexmap;
 #[cfg(target_os = "linux")]
 extern crate procinfo;
 extern crate prost;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,10 @@ extern crate regex;
 extern crate tokio;
 extern crate tokio_timer;
 #[macro_use]
-extern crate tokio_trace as trace;
-extern crate tokio_trace_fmt as trace_fmt;
+extern crate tokio_trace;
+extern crate tokio_trace_fmt;
+#[macro_use]
+extern crate tokio_trace_futures;
 extern crate tower;
 extern crate tower_grpc;
 extern crate tower_util;
@@ -64,3 +66,4 @@ pub mod transport;
 use self::addr::{Addr, NameAddr};
 use self::conditional::Conditional;
 pub use self::transport::SoOriginalDst;
+pub use self::logging::trace;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -15,11 +15,11 @@ thread_local! {
 }
 
 pub mod trace {
-    extern crate tokio_trace_log;
+    extern crate tracing_log;
     use super::{clock, Context as LegacyContext, CONTEXT as LEGACY_CONTEXT};
     use std::{env, error, fmt, sync::Arc};
-    pub use tokio_trace::*;
-    pub use tokio_trace_fmt::*;
+    pub use tracing::*;
+    pub use tracing_fmt::*;
 
     type SubscriberBuilder = Builder<
         default::NewRecorder,
@@ -48,7 +48,7 @@ pub mod trace {
                 .finish(),
         );
         dispatcher::set_global_default(dispatch)?;
-        let logger = tokio_trace_log::LogTracer::with_filter(log::LevelFilter::max());
+        let logger = tracing_log::LogTracer::with_filter(log::LevelFilter::max());
         log::set_boxed_logger(Box::new(logger))?;
         log::set_max_level(log::LevelFilter::max());
         Ok(())
@@ -114,7 +114,7 @@ pub mod trace {
     }
 
     pub mod futures {
-        pub use tokio_trace_futures::*;
+        pub use tracing_futures::*;
     }
 
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -51,6 +51,7 @@ pub mod trace {
             .map_err(|_| "failed to set global default dispatcher")?;
         let logger = tokio_trace_log::LogTracer::with_filter(log::LevelFilter::max());
         log::set_boxed_logger(Box::new(logger)).map_err(|_| "failed to set global logger")?;
+        log::set_max_level(log::LevelFilter::max());
         Ok(())
     }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -18,6 +18,15 @@ thread_local! {
     static CONTEXT: RefCell<Vec<*const fmt::Display>> = RefCell::new(Vec::new());
 }
 
+pub fn dispatch() -> trace::Dispatch {
+    let s = trace_fmt::FmtSubscriber::builder()
+        // .on_event(fmt_event)
+        .full()
+        .with_filter(trace_fmt::filter::EnvFilter::from_env(ENV_LOG))
+        .finish();
+    trace::Dispatch::new(s)
+}
+
 pub fn formatted_builder() -> env_logger::Builder {
     let start_time = clock::now();
     let mut builder = env_logger::Builder::new();
@@ -385,3 +394,56 @@ impl<T: fmt::Display> fmt::Display for Bg<T> {
         write!(f, "{}={{bg={}}}", self.section, self.name)
     }
 }
+
+// pub fn fmt_event<N>(ctx: &trace_fmt::span::Context<N>, f: &mut fmt::Write, event: &trace::Event) -> fmt::Result
+// where
+//     N: for<'a> trace_fmt::NewVisitor<'a>,
+// {
+//     let meta = event.metadata();
+//     let level = match record.level() {
+//         Level::TRACE => "TRCE",
+//         Level::DEBUG => "DBUG",
+//         Level::INFO => "INFO",
+//         Level::WARN => "WARN",
+//         Level::ERROR => "ERR!",
+//     };
+//     let uptime = clock::now() - start_time;
+//     write!(
+//         f,
+//         "{} [{:>6}.{:06}s] {} {}",
+//         level,
+//         uptime.as_secs(),
+//         uptime.subsec_micros(),
+//         FmtCtx(&ctx),
+//         meta.target()
+//     )?;
+//     {
+//         let mut recorder = ctx.new_visitor(f, true);
+//         event.record(&mut recorder);
+//     }
+//     ctx.with_current(|(_, span)| write!(f, " {}", span.fields()))
+//         .unwrap_or(Ok(()))?;
+//     writeln!(f)
+// }
+
+// struct FmtCtx<'a, N: 'a>(&'a trace_fmt::span::Context<'a, N>);
+
+// impl<'a, N> fmt::Display for FmtCtx<'a, N> {
+//     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+//         let mut seen = false;
+//         self.0.visit_spans(|_, span| {
+//             write!(f, "{}", span.name())?;
+//             seen = true;
+
+//             let fields = span.fields();
+//             if !fields.is_empty() {
+//                 write!(f, "{{{}}}", fields)?;
+//             }
+//             ":".fmt(f)
+//         })?;
+//         if seen {
+//             f.pad(" ")?;
+//         }
+//         Ok(())
+//     }
+// }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -49,8 +49,10 @@ pub mod trace {
         );
         dispatcher::set_global_default(dispatch)
             .map_err(|_| "failed to set global default dispatcher")?;
-        let logger = tokio_trace_log::LogTracer::default();
-        log::set_boxed_logger(Box::new(logger)).map_err(|_| "failed to set global logger")
+        let logger = tokio_trace_log::LogTracer::with_filter(log::LevelFilter::max());
+        log::set_boxed_logger(Box::new(logger)).map_err(|_| "failed to set global logger")?;
+        log::set_max_level(log::LevelFilter::max());
+        Ok(())
     }
 
     fn subscriber_builder() -> SubscriberBuilder {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -17,7 +17,7 @@ thread_local! {
 pub mod trace {
     extern crate tokio_trace_log;
     use super::{clock, Context as LegacyContext, CONTEXT as LEGACY_CONTEXT};
-    use std::{env, fmt, sync::Arc, error};
+    use std::{env, error, fmt, sync::Arc};
     pub use tokio_trace::*;
     pub use tokio_trace_fmt::*;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -21,11 +21,7 @@ pub mod trace {
     pub use tracing::*;
     pub use tracing_fmt::*;
 
-    type SubscriberBuilder = Builder<
-        default::NewRecorder,
-        Format,
-        filter::EnvFilter,
-    >;
+    type SubscriberBuilder = Builder<default::NewRecorder, Format, filter::EnvFilter>;
     pub type Error = Box<error::Error + Send + Sync + 'static>;
 
     /// Initialize tracing and logging with the value of the `ENV_LOG`

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -33,8 +33,12 @@ pub mod trace {
     >;
 
     pub fn init() {
+        try_init().expect("initializing tokio-trace failed");
+    }
+
+    pub fn try_init() -> Result<(), &'static str> {
         let env = env::var(super::ENV_LOG).unwrap_or_default();
-        try_init_with_filter(env).expect("initializing tokio-trace failed");
+        try_init_with_filter(env)
     }
 
     pub fn try_init_with_filter<F: AsRef<str>>(filter: F) -> Result<(), &'static str> {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -53,14 +53,6 @@ pub mod trace {
         log::set_boxed_logger(Box::new(logger)).map_err(|_| "failed to set global logger")
     }
 
-    fn fmt_event<N>(span_ctx: &Context<N>, f: &mut fmt::Write, event: &Event) -> fmt::Result {
-        // lazy_static! {
-        //     static ref START_TIME: Instant = clock::now()
-        // }
-        // TODO: put back start time
-        unimplemented!()
-    }
-
     fn subscriber_builder() -> SubscriberBuilder {
         let start_time = Arc::new(clock::now());
         FmtSubscriber::builder().on_event(Box::new(move |span_ctx, f, event| {
@@ -76,12 +68,10 @@ pub mod trace {
             LEGACY_CONTEXT.with(|old_ctx| {
                 write!(
                     f,
-                    "{} [{:>6}.{:06}s] {} {}{} ",
+                    "{} [{:>6}.{:06}s] {}{}{} ",
                     level,
                     uptime.as_secs(),
                     uptime.subsec_micros(),
-                    // "??",
-                    // "????",
                     LegacyContext(&old_ctx.borrow()),
                     FmtCtx(&span_ctx),
                     meta.target()
@@ -91,8 +81,6 @@ pub mod trace {
                 let mut recorder = span_ctx.new_visitor(f, true);
                 event.record(&mut recorder);
             }
-            // ctx.with_current(|(_, span)| write!(f, " {}", span.fields()))
-            //     .unwrap_or(Ok(()))?;
             writeln!(f)
         }))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,10 @@
 extern crate linkerd2_proxy;
 
 #[macro_use]
-extern crate log;
+extern crate tokio_trace;
+extern crate tokio_trace_fmt;
 extern crate tokio;
+
 
 use std::process;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,9 @@
 extern crate linkerd2_proxy;
 
 #[macro_use]
-extern crate tokio_trace;
+extern crate tracing;
 extern crate tokio;
-extern crate tokio_trace_fmt;
+extern crate tracing_fmt;
 
 use std::process;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,8 @@ extern crate linkerd2_proxy;
 
 #[macro_use]
 extern crate tokio_trace;
-extern crate tokio_trace_fmt;
 extern crate tokio;
-
+extern crate tokio_trace_fmt;
 
 use std::process;
 

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -130,12 +130,7 @@ where
             self.config.capacity,
             self.config.max_idle_age,
         );
-        let span = debug_span!(
-            "router",
-            name = self.config.proxy_name,
-            // config.capacity = self.config.capacity,
-            // config.max_idle_age = ?self.config.max_idle_age,
-        );
+        let span = debug_span!("router", name = self.config.proxy_name);
         let ctx = logging::Section::Proxy.bg(self.config.proxy_name);
         let cache_daemon = ctx.future(cache_bg);
         tokio::spawn(cache_daemon);

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -1,9 +1,9 @@
 use futures::Poll;
 use http;
-use trace;
 use std::fmt;
 use std::marker::PhantomData;
 use std::time::Duration;
+use trace;
 
 use logging;
 use never::Never;

--- a/src/transport/tls/listen_tests.rs
+++ b/src/transport/tls/listen_tests.rs
@@ -109,7 +109,7 @@ where
     SF: Future<Item = SR, Error = io::Error> + Send + 'static,
     SR: Send + 'static,
 {
-    let _ = ::env_logger::try_init();
+    let _ = ::trace::try_init();
 
     // A future that will receive a single connection.
     let (server, server_addr, server_result) = {

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -10,7 +10,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_asks_controller_api() {
-            let _ = env_logger_init();
+            let _ = trace_init();
             let srv = $make_server().route("/", "hello").route("/bye", "bye").run();
 
             let ctrl = controller::new()
@@ -25,7 +25,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_router_capacity() {
-            let _ = env_logger_init();
+            let _ = trace_init();
             let srv = $make_server().route("/", "hello").run();
             let srv_addr = srv.addr;
 
@@ -70,7 +70,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_reconnects_if_controller_stream_ends() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = $make_server().route("/recon", "nect").run();
 
@@ -96,7 +96,7 @@ macro_rules! generate_tests {
 
         fn outbound_fails_fast(up: pb::destination::Update) {
             use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let did_not_fall_back = Arc::new(AtomicBool::new(true));
             let did_not_fall_back2 = did_not_fall_back.clone();
@@ -128,7 +128,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_falls_back_to_orig_dst_when_outside_search_path() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = $make_server().route("/", "hello from my great website").run();
 
@@ -144,7 +144,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_falls_back_to_orig_dst_after_invalid_argument() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = $make_server().route("/", "hello").run();
 
@@ -181,7 +181,7 @@ macro_rules! generate_tests {
         }
 
         fn init_env() -> app::config::TestEnv {
-            let _ = env_logger_init();
+            let _ = trace_init();
             app::config::TestEnv::new()
         }
 
@@ -333,7 +333,7 @@ macro_rules! generate_tests {
 
             #[test]
             fn outbound_should_strip() {
-                let _ = env_logger_init();
+                let _ = trace_init();
                 let header = HeaderValue::from_static(IP_1);
 
                 let srv = $make_server().route_fn("/strip", |_req| {
@@ -351,7 +351,7 @@ macro_rules! generate_tests {
 
             #[test]
             fn inbound_should_strip() {
-                let _ = env_logger_init();
+                let _ = trace_init();
                 let header = HeaderValue::from_static(IP_1);
 
                 let srv = $make_server().route_fn("/strip", move |req| {
@@ -369,7 +369,7 @@ macro_rules! generate_tests {
             #[test]
             #[ignore] // #2597
             fn outbound_should_set() {
-                let _ = env_logger_init();
+                let _ = trace_init();
                 let header = HeaderValue::from_static(IP_2);
 
                 let srv = $make_server().route("/set", "hello").run();
@@ -385,7 +385,7 @@ macro_rules! generate_tests {
             #[test]
             #[ignore] // #2597
             fn inbound_should_set() {
-                let _ = env_logger_init();
+                let _ = trace_init();
 
                 let header = HeaderValue::from_static(IP_2);
 
@@ -421,7 +421,7 @@ macro_rules! generate_tests {
 
             impl Fixture {
                 fn new() -> Fixture {
-                    let _ = env_logger_init();
+                    let _ = trace_init();
 
                     let foo_reqs = Arc::new(AtomicUsize::new(0));
                     let foo_reqs2 = foo_reqs.clone();
@@ -678,7 +678,7 @@ mod http2 {
     #[test]
     fn outbound_balancer_waits_for_ready_endpoint() {
         // See https://github.com/linkerd/linkerd2/issues/2550
-        let _ = env_logger_init();
+        let _ = trace_init();
 
         let srv1 = server::http2()
             .route("/", "hello")
@@ -750,7 +750,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn outbound_http1() {
-        let _ = env_logger_init();
+        let _ = trace_init();
 
         // Instead of a second proxy, this mocked h2 server will be the target.
         let srv = server::http2()
@@ -778,7 +778,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn inbound_http1() {
-        let _ = env_logger_init();
+        let _ = trace_init();
 
         let srv = server::http1()
             .route_fn("/h1", |req| {
@@ -809,7 +809,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn inbound_should_strip_l5d_client_id() {
-        let _ = env_logger_init();
+        let _ = trace_init();
 
         let srv = server::http1()
             .route_fn("/stripped", |req| {
@@ -832,7 +832,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn outbound_should_strip_l5d_client_id() {
-        let _ = env_logger_init();
+        let _ = trace_init();
 
         let srv = server::http1()
             .route_fn("/stripped", |req| {
@@ -858,7 +858,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn inbound_should_strip_l5d_server_id() {
-        let _ = env_logger_init();
+        let _ = trace_init();
 
         let srv = server::http1()
             .route_fn("/strip-me", |_req| {
@@ -880,7 +880,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn outbound_should_strip_l5d_server_id() {
-        let _ = env_logger_init();
+        let _ = trace_init();
 
         let srv = server::http1()
             .route_fn("/strip-me", |_req| {
@@ -905,7 +905,7 @@ mod proxy_to_proxy {
 
     macro_rules! generate_l5d_tls_id_test {
         (server: $make_server:path, client: $make_client:path) => {
-            let _ = env_logger_init();
+            let _ = trace_init();
             let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
             let id_env = identity::Identity::new("foo-ns1", id.to_string());
 

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -14,7 +14,7 @@ use std::{
 
 #[test]
 fn nonblocking_identity_detection() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let identity::Identity {
@@ -50,7 +50,7 @@ fn nonblocking_identity_detection() {
 
 macro_rules! generate_tls_accept_test {
     ( client_non_tls: $make_client_non_tls:path, client_tls: $make_client_tls:path) => {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
         let id_svc = identity::Identity::new("foo-ns1", id.to_string());
         let proxy = proxy::new()
@@ -81,7 +81,7 @@ macro_rules! generate_tls_accept_test {
 
 macro_rules! generate_tls_reject_test {
     ( client: $make_client:path) => {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
         let identity::Identity {
             env,
@@ -140,7 +140,7 @@ fn http2_rejects_tls_before_identity_is_certified() {
 
 macro_rules! generate_outbound_tls_accept_not_cert_identity_test {
     (server: $make_server:path, client: $make_client:path) => {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let proxy_id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
         let app_id = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
 
@@ -192,7 +192,7 @@ fn http2_outbound_tls_works_before_identity_is_certified() {
 
 #[test]
 fn ready() {
-    let _ = env_logger_init();
+    let _ = trace_init();
     let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let identity::Identity {
         env,
@@ -225,7 +225,7 @@ fn ready() {
 
 #[test]
 fn refresh() {
-    let _ = env_logger_init();
+    let _ = trace_init();
     let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let identity::Identity {
         mut env,

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -343,7 +343,7 @@ fn timeout() {
 
 #[test]
 fn traffic_split() {
-    let _ = env_logger_init();
+    let _ = trace_init();
     let apex = "profiles.test.svc.cluster.local";
     let leaf_a = "a.profiles.test.svc.cluster.local";
     let leaf_b = "b.profiles.test.svc.cluster.local";

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -24,7 +24,7 @@ macro_rules! profile_test {
         }
     };
     (http: $http:ident, routes: [$($route:expr),+], budget: $budget:expr, with_client: $with_client:expr, with_metrics: $with_metrics:expr) => {
-        let _ = env_logger_init();
+        let _ = trace_init();
 
         let counter = AtomicUsize::new(0);
         let counter2 = AtomicUsize::new(0);

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -5,7 +5,7 @@ use self::support::*;
 
 #[test]
 fn h2_goaways_connections() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let (shdn, rx) = shutdown_signal();
 
@@ -22,7 +22,7 @@ fn h2_goaways_connections() {
 
 #[test]
 fn h2_exercise_goaways_connections() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     const RESPONSE_SIZE: usize = 1024 * 16;
     const NUM_REQUESTS: usize = 50;
@@ -68,7 +68,7 @@ fn h2_exercise_goaways_connections() {
 #[test]
 fn http1_closes_idle_connections() {
     use std::cell::RefCell;
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let (shdn, rx) = shutdown_signal();
 
@@ -95,7 +95,7 @@ fn http1_closes_idle_connections() {
 
 #[test]
 fn tcp_waits_for_proxies_to_close() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let (shdn, rx) = shutdown_signal();
     let msg1 = "custom tcp hello";

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -62,7 +62,6 @@ const DEFAULT_LOG: &'static str = "error,\
                                    linkerd2_proxy::proxy::tcp=off";
 
 pub fn trace_init() -> Result<(), String> {
-    use self::linkerd2_proxy::trace;
     use std::env;
     let log = env::var("LINKERD2_PROXY_LOG")
         .or_else(|_| env::var("RUST_LOG"))

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -60,7 +60,7 @@ const DEFAULT_LOG: &'static str = "error,\
                                    linkerd2_proxy::proxy::http::router=off,\
                                    linkerd2_proxy::proxy::tcp=off";
 
-pub fn trace_init() -> Result<(), String> {
+pub fn trace_init() -> Result<(), &'static str> {
     use std::env;
     let log = env::var("LINKERD2_PROXY_LOG")
         .or_else(|_| env::var("RUST_LOG"))
@@ -68,7 +68,7 @@ pub fn trace_init() -> Result<(), String> {
     env::set_var("RUST_LOG", &log);
     env::set_var("LINKERD2_PROXY_LOG", &log);
 
-    trace::try_init_with_filter(&log).map_err(ToString::to_string)
+    trace::init_with_filter(&log)
 }
 
 /// Retry an assertion up to a specified number of times, waiting

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -22,7 +22,7 @@ extern crate tokio_connect;
 extern crate tokio_current_thread;
 pub extern crate tokio_io;
 extern crate tokio_rustls;
-extern crate tokio_trace as trace;
+pub extern crate tower_grpc;
 extern crate tower_service;
 extern crate webpki;
 
@@ -61,8 +61,7 @@ const DEFAULT_LOG: &'static str = "error,\
                                    linkerd2_proxy::proxy::http::router=off,\
                                    linkerd2_proxy::proxy::tcp=off";
 
-pub fn env_logger_init() -> Result<(), String> {
-
+pub fn trace_init() -> Result<(), String> {
     use self::linkerd2_proxy::trace;
     use std::env;
     let log = env::var("LINKERD2_PROXY_LOG")

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -27,6 +27,7 @@ extern crate tokio_rustls;
 pub extern crate tower_grpc;
 extern crate tower_service;
 extern crate webpki;
+extern crate tokio_trace as trace;
 
 pub use std::collections::HashMap;
 use std::fmt;
@@ -71,10 +72,12 @@ pub fn env_logger_init() -> Result<(), String> {
     env::set_var("RUST_LOG", &log);
     env::set_var("LINKERD2_PROXY_LOG", &log);
 
-    self::linkerd2_proxy::logging::formatted_builder()
-        .parse(&log)
-        .try_init()
-        .map_err(|e| e.to_string())
+    // self::linkerd2_proxy::logging::formatted_builder()
+    //     .parse(&log)
+    //     .try_init()
+    //     .map_err(|e| e.to_string())
+    let _ = trace::dispatcher::set_global_default(self::linkerd2_proxy::logging::dispatch());
+    Ok(())
 }
 
 /// Retry an assertion up to a specified number of times, waiting

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -6,7 +6,6 @@
 #![allow(dead_code)]
 
 pub extern crate bytes;
-extern crate env_logger;
 extern crate futures;
 extern crate h2;
 pub extern crate http;
@@ -15,7 +14,6 @@ extern crate hyper;
 extern crate linkerd2_proxy;
 pub extern crate linkerd2_proxy_api;
 extern crate linkerd2_task;
-extern crate log;
 pub extern crate net2;
 extern crate prost;
 pub extern crate rustls;
@@ -24,10 +22,10 @@ extern crate tokio_connect;
 extern crate tokio_current_thread;
 pub extern crate tokio_io;
 extern crate tokio_rustls;
-pub extern crate tower_grpc;
+extern crate tokio_trace as trace;
 extern crate tower_service;
 extern crate webpki;
-extern crate tokio_trace as trace;
+
 
 pub use std::collections::HashMap;
 use std::fmt;
@@ -64,9 +62,9 @@ const DEFAULT_LOG: &'static str = "error,\
                                    linkerd2_proxy::proxy::tcp=off";
 
 pub fn env_logger_init() -> Result<(), String> {
-    use std::env;
-    use self::linkerd2_proxy::trace;
 
+    use self::linkerd2_proxy::trace;
+    use std::env;
     let log = env::var("LINKERD2_PROXY_LOG")
         .or_else(|_| env::var("RUST_LOG"))
         .unwrap_or_else(|_| DEFAULT_LOG.to_owned());

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -60,7 +60,7 @@ const DEFAULT_LOG: &'static str = "error,\
                                    linkerd2_proxy::proxy::http::router=off,\
                                    linkerd2_proxy::proxy::tcp=off";
 
-pub fn trace_init() -> Result<(), &'static str> {
+pub fn trace_init() -> Result<(), trace::Error> {
     use std::env;
     let log = env::var("LINKERD2_PROXY_LOG")
         .or_else(|_| env::var("RUST_LOG"))

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -65,6 +65,7 @@ const DEFAULT_LOG: &'static str = "error,\
 
 pub fn env_logger_init() -> Result<(), String> {
     use std::env;
+    use self::linkerd2_proxy::trace;
 
     let log = env::var("LINKERD2_PROXY_LOG")
         .or_else(|_| env::var("RUST_LOG"))
@@ -72,12 +73,7 @@ pub fn env_logger_init() -> Result<(), String> {
     env::set_var("RUST_LOG", &log);
     env::set_var("LINKERD2_PROXY_LOG", &log);
 
-    // self::linkerd2_proxy::logging::formatted_builder()
-    //     .parse(&log)
-    //     .try_init()
-    //     .map_err(|e| e.to_string())
-    let _ = trace::dispatcher::set_global_default(self::linkerd2_proxy::logging::dispatch());
-    Ok(())
+    trace::try_init_with_filter(&log).map_err(ToString::to_string)
 }
 
 /// Retry an assertion up to a specified number of times, waiting

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -26,7 +26,6 @@ pub extern crate tower_grpc;
 extern crate tower_service;
 extern crate webpki;
 
-
 pub use std::collections::HashMap;
 use std::fmt;
 pub use std::net::SocketAddr;

--- a/tests/tap.rs
+++ b/tests/tap.rs
@@ -10,7 +10,7 @@ use support::tap::TapEventExt;
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn inbound_http1() {
-    let _ = env_logger_init();
+    let _ = trace_init();
     let srv = server::http1().route("/", "hello").run();
 
     let proxy = proxy::new().inbound(srv).run();
@@ -42,7 +42,7 @@ fn inbound_http1() {
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn grpc_headers_end() {
-    let _ = env_logger_init();
+    let _ = trace_init();
     let srv = server::http2()
         .route_fn("/", |_req| {
             Response::builder()
@@ -76,7 +76,7 @@ fn grpc_headers_end() {
 
 #[test]
 fn tap_enabled_by_default() {
-    let _ = env_logger_init();
+    let _ = trace_init();
     let proxy = proxy::new().run();
 
     assert!(proxy.control.is_some())
@@ -84,7 +84,7 @@ fn tap_enabled_by_default() {
 
 #[test]
 fn can_disable_tap() {
-    let _ = env_logger_init();
+    let _ = trace_init();
     let mut env = app::config::TestEnv::new();
     env.put(app::config::ENV_TAP_DISABLED, "true".to_owned());
 

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -106,7 +106,7 @@ impl TcpFixture {
 
 #[test]
 fn metrics_endpoint_inbound_request_count() {
-    let _ = env_logger_init();
+    let _ = trace_init();
     let Fixture {
         client,
         metrics,
@@ -126,7 +126,7 @@ fn metrics_endpoint_inbound_request_count() {
 
 #[test]
 fn metrics_endpoint_outbound_request_count() {
-    let _ = env_logger_init();
+    let _ = trace_init();
     let Fixture {
         client,
         metrics,
@@ -210,7 +210,7 @@ mod response_classification {
 
     #[test]
     fn inbound_http() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let Fixture {
             client,
             metrics,
@@ -239,7 +239,7 @@ mod response_classification {
 
     #[test]
     fn outbound_http() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let Fixture {
             client,
             metrics,
@@ -279,7 +279,7 @@ mod response_classification {
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn metrics_endpoint_inbound_response_latency() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     info!("running test server");
     let srv = server::new()
@@ -358,7 +358,7 @@ fn metrics_endpoint_inbound_response_latency() {
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn metrics_endpoint_outbound_response_latency() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     info!("running test server");
     let srv = server::new()
@@ -461,7 +461,7 @@ mod outbound_dst_labels {
 
     #[test]
     fn multiple_addr_labels() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let (
             Fixture {
                 client,
@@ -492,7 +492,7 @@ mod outbound_dst_labels {
 
     #[test]
     fn multiple_addrset_labels() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let (
             Fixture {
                 client,
@@ -523,7 +523,7 @@ mod outbound_dst_labels {
 
     #[test]
     fn labeled_addr_and_addrset() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let (
             Fixture {
                 client,
@@ -559,7 +559,7 @@ mod outbound_dst_labels {
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn controller_updates_addr_labels() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         info!("running test server");
 
         let (
@@ -623,7 +623,7 @@ mod outbound_dst_labels {
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn controller_updates_set_labels() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         info!("running test server");
         let (
             Fixture {
@@ -681,7 +681,7 @@ mod outbound_dst_labels {
 #[test]
 fn metrics_have_no_double_commas() {
     // Test for regressions to linkerd/linkerd2#600.
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     info!("running test server");
     let inbound_srv = server::new().route("/hey", "hello").run();
@@ -734,7 +734,7 @@ mod transport {
 
     #[test]
     fn inbound_http_accept() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let Fixture {
             client,
             metrics,
@@ -773,7 +773,7 @@ mod transport {
 
     #[test]
     fn inbound_http_connect() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let Fixture {
             client,
             metrics,
@@ -801,7 +801,7 @@ mod transport {
 
     #[test]
     fn outbound_http_accept() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let Fixture {
             client,
             metrics,
@@ -838,7 +838,7 @@ mod transport {
 
     #[test]
     fn outbound_http_connect() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let Fixture {
             client,
             metrics,
@@ -862,7 +862,7 @@ mod transport {
 
     #[test]
     fn inbound_tcp_connect() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -880,7 +880,7 @@ mod transport {
     #[test]
     #[cfg(macos)]
     fn inbound_tcp_connect_err() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let srv = tcp::server()
             .accept_fut(move |sock| {
                 drop(sock);
@@ -910,7 +910,7 @@ mod transport {
     #[test]
     #[cfg(macos)]
     fn outbound_tcp_connect_err() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let srv = tcp::server()
             .accept_fut(move |sock| {
                 drop(sock);
@@ -937,7 +937,7 @@ mod transport {
 
     #[test]
     fn inbound_tcp_accept() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -980,7 +980,7 @@ mod transport {
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn inbound_tcp_duration() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1019,7 +1019,7 @@ mod transport {
 
     #[test]
     fn inbound_tcp_write_bytes_total() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1047,7 +1047,7 @@ mod transport {
 
     #[test]
     fn inbound_tcp_read_bytes_total() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1075,7 +1075,7 @@ mod transport {
 
     #[test]
     fn outbound_tcp_connect() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1092,7 +1092,7 @@ mod transport {
 
     #[test]
     fn outbound_tcp_accept() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1130,7 +1130,7 @@ mod transport {
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn outbound_tcp_duration() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1169,7 +1169,7 @@ mod transport {
 
     #[test]
     fn outbound_tcp_write_bytes_total() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1197,7 +1197,7 @@ mod transport {
 
     #[test]
     fn outbound_tcp_read_bytes_total() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1225,7 +1225,7 @@ mod transport {
 
     #[test]
     fn outbound_tcp_open_connections() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1263,7 +1263,7 @@ mod transport {
 
     #[test]
     fn outbound_http_tcp_open_connections() {
-        let _ = env_logger_init();
+        let _ = trace_init();
         let Fixture {
             client,
             metrics,
@@ -1304,7 +1304,7 @@ mod transport {
 // linkerd/linkerd2#613
 #[test]
 fn metrics_compression() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let Fixture {
         client,

--- a/tests/transparency.rs
+++ b/tests/transparency.rs
@@ -1203,7 +1203,7 @@ mod max_in_flight {
 
 #[test]
 fn http2_request_without_authority() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let srv = server::http2()
         .route_fn("/", |req| {

--- a/tests/transparency.rs
+++ b/tests/transparency.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc;
 
 #[test]
 fn outbound_http1() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let srv = server::http1().route("/", "hello h1").run();
     let ctrl = controller::new()
@@ -21,7 +21,7 @@ fn outbound_http1() {
 
 #[test]
 fn inbound_http1() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let srv = server::http1().route("/", "hello h1").run();
     let proxy = proxy::new().inbound_fuzz_addr(srv).run();
@@ -32,7 +32,7 @@ fn inbound_http1() {
 
 #[test]
 fn outbound_tcp() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let msg1 = "custom tcp hello";
     let msg2 = "custom tcp bye";
@@ -55,7 +55,7 @@ fn outbound_tcp() {
 
 #[test]
 fn inbound_tcp() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let msg1 = "custom tcp hello";
     let msg2 = "custom tcp bye";
@@ -79,7 +79,7 @@ fn inbound_tcp() {
 fn test_server_speaks_first(env: app::config::TestEnv) {
     const TIMEOUT: Duration = Duration::from_secs(5);
 
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let msg1 = "custom tcp server starts";
     let msg2 = "custom tcp client second";
@@ -161,7 +161,7 @@ fn tcp_server_first_tls() {
 
 #[test]
 fn tcp_with_no_orig_dst() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let srv = server::tcp().accept(move |_| "don't read me").run();
     let proxy = proxy::new().inbound(srv).run();
@@ -183,7 +183,7 @@ fn tcp_with_no_orig_dst() {
 fn tcp_connections_close_if_client_closes() {
     use std::sync::mpsc;
 
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let msg1 = "custom tcp hello";
     let msg2 = "custom tcp bye";
@@ -229,7 +229,7 @@ macro_rules! http1_tests {
     (proxy: $proxy:expr) => {
         #[test]
         fn inbound_http1() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = server::http1().route("/", "hello h1").run();
             let proxy = $proxy(srv);
@@ -240,7 +240,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_removes_connection_headers() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", |req| {
@@ -278,7 +278,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http10_with_host() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let host = "transparency.test.svc.cluster.local";
             let srv = server::http1()
@@ -307,7 +307,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http11_absolute_uri_differs_from_host() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             // We shouldn't touch the URI or the Host, just pass directly as we got.
             let auth = "transparency.test.svc.cluster.local";
@@ -335,7 +335,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http11_upgrades() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             // To simplify things for this test, we just use the test TCP
             // client and server to do an HTTP upgrade.
@@ -411,7 +411,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn l5d_orig_proto_header_isnt_leaked() {
-            let _ = env_logger::try_init();
+            let _ = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", |req| {
@@ -431,7 +431,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http11_upgrade_h2_stripped() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             // If an `h2` upgrade over HTTP/1.1 were to go by the proxy,
             // and it succeeded, there would an h2 connection, but it would
@@ -470,7 +470,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http11_connect() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             // To simplify things for this test, we just use the test TCP
             // client and server to do an HTTP CONNECT.
@@ -544,7 +544,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http11_connect_bad_requests() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = server::tcp()
                 .accept(move |_sock| -> Vec<u8> {
@@ -604,7 +604,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_request_with_body_content_length() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", |req| {
@@ -628,7 +628,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_request_with_body_chunked() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = server::http1()
                 .route_async("/", |req| {
@@ -662,7 +662,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_requests_without_body_doesnt_add_transfer_encoding() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", |req| {
@@ -692,7 +692,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_content_length_zero_is_preserved() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", |req| {
@@ -728,7 +728,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_bodyless_responses() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let req_status_header = "x-test-status-requested";
 
@@ -790,7 +790,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_head_responses() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", move |req| {
@@ -820,7 +820,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_response_end_of_file() {
-            let _ = env_logger_init();
+            let _ = trace_init();
 
             // test both http/1.0 and 1.1
             let srv = server::tcp()
@@ -926,7 +926,7 @@ mod proxy_to_proxy {
 fn http10_without_host() {
     // Without a host or authority, there's no way to route this test,
     // so its not part of the proxy_to_proxy set.
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let srv = server::http1()
         .route_fn("/", move |req| {
@@ -958,7 +958,7 @@ fn http10_without_host() {
 
 #[test]
 fn http1_one_connection_per_host() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let srv = server::http1()
         .route("/body", "hello hosts")
@@ -1004,7 +1004,7 @@ fn http1_one_connection_per_host() {
 
 #[test]
 fn http1_requests_without_host_have_unique_connections() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let srv = server::http1().route("/", "unique hosts").run();
     let proxy = proxy::new().inbound(srv).run();
@@ -1063,7 +1063,7 @@ fn http1_requests_without_host_have_unique_connections() {
 
 #[test]
 fn retry_reconnect_errors() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     // Used to delay `listen` in the server, to force connection refused errors.
     let (tx, rx) = oneshot::channel();
@@ -1123,7 +1123,7 @@ mod max_in_flight {
     }
 
     fn run_max_in_flight(ver: Ver, dir: Dir) {
-        let _ = env_logger_init();
+        let _ = trace_init();
 
         let host = "transparency.test.svc.cluster.local";
         let srv = match ver {

--- a/tests/transparency.rs
+++ b/tests/transparency.rs
@@ -1250,7 +1250,7 @@ fn http2_request_without_authority() {
 
 #[test]
 fn http2_rst_stream_is_propagated() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     let reason = h2::Reason::ENHANCE_YOUR_CALM;
 
@@ -1276,7 +1276,7 @@ fn http2_rst_stream_is_propagated() {
 
 #[test]
 fn http1_orig_proto_does_not_propagate_rst_stream() {
-    let _ = env_logger_init();
+    let _ = trace_init();
 
     // Use a custom http2 server to "act" as an inbound proxy so we
     // can trigger a RST_STREAM.


### PR DESCRIPTION
Currently, the proxy uses the `log` crate for log records, and formats
them using `env_logger`. However, `tracing` is capable of providing
significantly richer scoped, contextual diagnostics, which are
especially valuable in asynchronous systems like the proxy.

In addition, switching to `tracing` is a prerequisite for
dynamically reloading the log level (see linkerd/linkerd2#2005).

This branch replaces `env_logger` with `tracing-fmt`, and the `log`
crate's macros with `tracing`. Log records emitted by our
dependencies can still be consumed as `tracing` events using the
`tracing-log` adapter. A custom `tracing-fmt` formatter is used
to replicate the previous log line formatting; this currently uses the
proxy's log contexts in addition to `tracing` spans. Our homemade
log contexts will be phased out and replaced with `tracing` spans in
subsequent PRs, and the events emitted in the proxy will be made more
structured.

Closes linkerd/linkerd2#2004.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>