### PR TITLE
canonicalize: stop resolving when the receiver is dropped

### DIFF
--- a/src/proxy/http/canonicalize.rs
+++ b/src/proxy/http/canonicalize.rs
@@ -47,6 +47,7 @@ pub struct Service<S> {
     canonicalized: Option<Addr>,
     inner: S,
     rx: mpsc::Receiver<NameAddr>,
+    /// Notifies the daemon `Task` on drop.
     _tx_stop: oneshot::Sender<()>,
 }
 

--- a/src/proxy/http/canonicalize.rs
+++ b/src/proxy/http/canonicalize.rs
@@ -269,11 +269,7 @@ impl Future for Task {
                 }
 
                 State::ValidUntil(ref mut f) => {
-                    trace!(
-                        "task idle; name={:?}; ttl={}s",
-                        self.original,
-                        f.deadline().duration_since(clock::now()).as_secs(),
-                    );
+                    trace!("task idle; name={:?}", self.original);
 
                     match f.poll().expect("timer must not fail") {
                         Async::NotReady => return Ok(Async::NotReady),

--- a/src/proxy/http/canonicalize.rs
+++ b/src/proxy/http/canonicalize.rs
@@ -137,7 +137,7 @@ where
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let inner = try_ready!(self.inner.poll());
         let svc = if let Some((na, resolver, timeout)) = self.task.take() {
-            let (tx, rx) = mpsc::channel(2);
+            let (tx, rx) = mpsc::channel(1);
 
             tokio::spawn(Task::new(na, resolver, timeout, tx));
 

--- a/src/proxy/http/canonicalize.rs
+++ b/src/proxy/http/canonicalize.rs
@@ -178,13 +178,13 @@ impl Future for Task {
     type Error = ();
 
     fn poll(&mut self) -> Poll<(), ()> {
-        // If the receiver has been dropped, stop watching for updates.
-        let tx_ready = match self.tx.poll_ready() {
-            Err(_) => return Ok(Async::Ready(())),
-            Ok(r) => r,
-        };
-
         loop {
+            // If the receiver has been dropped, stop watching for updates.
+            let tx_ready = match self.tx.poll_ready() {
+                Err(_) => return Ok(Async::Ready(())),
+                Ok(r) => r,
+            };
+
             self.state = match self.state {
                 State::Init => {
                     let f = self.resolver.refine(self.original.name());

--- a/src/proxy/http/canonicalize.rs
+++ b/src/proxy/http/canonicalize.rs
@@ -6,12 +6,13 @@
 //! this module may build its inner stack with either `web.example.com.:8080`,
 //! `web.example.net.:8080`, or `web:8080`, depending on the state of DNS.
 //!
-//! DNS TTLs are honored and, if the resolution changes, the inner stack is
-//! rebuilt with the updated value.
+//! DNS TTLs are honored and the most recent value is added to each request's
+//! extensions.
 
 use futures::{Async, Future, Poll, Stream};
 use http;
 use log::trace;
+use never::Never;
 use std::time::Duration;
 use tokio;
 use tokio::sync::{mpsc, oneshot};
@@ -48,7 +49,7 @@ pub struct Service<S> {
     inner: S,
     rx: mpsc::Receiver<NameAddr>,
     /// Notifies the daemon `Task` on drop.
-    _tx_stop: oneshot::Sender<()>,
+    _tx_stop: oneshot::Sender<Never>,
 }
 
 struct Task {
@@ -58,7 +59,7 @@ struct Task {
     state: State,
     timeout: Duration,
     tx: mpsc::Sender<NameAddr>,
-    rx_stop: oneshot::Receiver<()>,
+    rx_stop: oneshot::Receiver<Never>,
 }
 
 /// Tracks the state of the last resolution.
@@ -168,7 +169,7 @@ impl Task {
         resolver: dns::Resolver,
         timeout: Duration,
         tx: mpsc::Sender<NameAddr>,
-        rx_stop: oneshot::Receiver<()>,
+        rx_stop: oneshot::Receiver<Never>,
     ) -> Self {
         Self {
             original,


### PR DESCRIPTION
The proxy's canonicalization queries can persist after the observing
service is dropped.

This change modifies the background resolution task to use tokio-sync so
that it can eagerly cease polling for updates when corresponding service
is dropped.