### PR TITLE
router: Remove interval from router eviction

### DIFF
--- a/lib/router/src/cache.rs
+++ b/lib/router/src/cache.rs
@@ -142,11 +142,6 @@ where
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let mut cache = try_ready!(Ok(self.0.poll_lock()));
-        trace!("purge: locked and purging");
-
-        // If poll_purge is not ready, we cannot expire any values and
-        // wait for the next interval. If poll_purge is ready, we have
-        // expired all values and wait for the next interval
         cache.poll_purge()
     }
 }


### PR DESCRIPTION
The router only purges its cache only once per `max_idle_age`, which
means that a route may be idle for ~2x `max_idle_age`.

By removing the interval completely, we can ensure that routes are
evicted in a timely fashion.