### PR TITLE
fallback: Clarify fallback layering

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -525,7 +525,7 @@ where
 
             let distributor = svc::builder()
                 .layer(
-                    // Attempt to build a balancer. If the serviec is
+                    // Attempt to build a balancer. If the service is
                     // unresolvable, fall back to using a router that dispatches
                     // request to the application-selected original destination.
                     fallback::layer(balancer, orig_dst_router)

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -429,7 +429,7 @@ where
                 //add_remote_ip_on_rsp, add_server_id_on_rsp,
             };
             use proxy::{
-                http::{balance, canonicalize, header_from_target, metrics, retry},
+                http::{balance, canonicalize, fallback, header_from_target, metrics, retry},
                 resolve,
             };
 
@@ -517,14 +517,20 @@ where
                 ))
                 .layer(buffer::layer(max_in_flight, DispatchDeadline::extract));
 
+            // Resolves the target via the control plane and balances requests
+            // over all endpoints returned from the destination service.
             let balancer = svc::builder()
                 .layer(balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
-                .layer(resolve::layer(Resolve::new(resolver)))
-                .fallback_to(orig_dst_router)
-                .on_error::<control::destination::Unresolvable>();
+                .layer(resolve::layer(Resolve::new(resolver)));
 
-            let balancer_stack = svc::builder()
-                .layer(balancer)
+            let distributor = svc::builder()
+                .layer(
+                    // Attempt to build a balancer. If the serviec is
+                    // unresolvable, fall back to using a router that dispatches
+                    // request to the application-selected original destination.
+                    fallback::layer(balancer, orig_dst_router)
+                        .on_error::<control::destination::Unresolvable>(),
+                )
                 .layer(pending::layer())
                 .layer(balance::weight::layer())
                 .service(endpoint_stack);
@@ -544,7 +550,7 @@ where
                     dst_route_layer,
                 ))
                 .buffer_pending(max_in_flight, DispatchDeadline::extract)
-                .service(balancer_stack);
+                .service(distributor);
 
             // Routes request using the `DstAddr` extension.
             //

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -14,7 +14,7 @@ use tower::limit::concurrency::ConcurrencyLimitLayer;
 use tower::load_shed::LoadShedLayer;
 use tower::timeout::TimeoutLayer;
 
-use proxy::{buffer, http::fallback, pending};
+use proxy::{buffer, pending};
 
 #[derive(Clone, Debug)]
 pub struct Builder<L>(ServiceBuilder<L>);
@@ -51,12 +51,6 @@ impl<L> Builder<L> {
 
     pub fn timeout(self, timeout: Duration) -> Builder<Stack<TimeoutLayer, L>> {
         Builder(self.0.timeout(timeout))
-    }
-
-    /// Returns a `Layer` that tries to build a service using `self`, falling
-    /// back to `other` if `self` fails.
-    pub fn fallback_to<B>(self, other: Builder<B>) -> fallback::Layer<L, B> {
-        fallback::layer(self, other)
     }
 
     /// Wrap the service `S` with the layers.


### PR DESCRIPTION
Our `svc::Builder::fallback_on` combinator was a bit surprising, in that
it worked differently from all other combinators, returning a Layer
instead of a Builder.

This change removes this combinator in an attempt to make the fallback
layering logic more explicit in the stack.