### PR TITLE
Introduce `l5d-require-id` request header

### DIFF
--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 
 use super::classify;
 use http;
-use identity;
 use indexmap::IndexMap;
 use proxy::http::{
     metrics::classify::{CanClassify, Classify, ClassifyEos, ClassifyResponse},
@@ -35,7 +34,6 @@ pub struct DstAddr {
     addr: Addr,
     direction: Direction,
     pub(super) http_settings: settings::Settings,
-    force_identity: Option<identity::Name>,
 }
 
 // === impl Route ===
@@ -114,13 +112,11 @@ impl DstAddr {
     pub fn outbound(
         addr: Addr,
         http_settings: settings::Settings,
-        force_identity: Option<identity::Name>,
     ) -> Self {
         DstAddr {
             addr,
             direction: Direction::Out,
             http_settings,
-            force_identity,
         }
     }
 
@@ -129,7 +125,6 @@ impl DstAddr {
             addr,
             direction: Direction::In,
             http_settings,
-            force_identity: None,
         }
     }
 

--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -1,15 +1,16 @@
+use http;
+use indexmap::IndexMap;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::classify;
-use http;
-use indexmap::IndexMap;
 use proxy::http::{
     metrics::classify::{CanClassify, Classify, ClassifyEos, ClassifyResponse},
     profiles, retry, settings, timeout,
 };
 use {Addr, NameAddr};
+
+use super::classify;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Direction {
@@ -109,10 +110,7 @@ impl AsRef<Addr> for DstAddr {
 }
 
 impl DstAddr {
-    pub fn outbound(
-        addr: Addr,
-        http_settings: settings::Settings,
-    ) -> Self {
+    pub fn outbound(addr: Addr, http_settings: settings::Settings) -> Self {
         DstAddr {
             addr,
             direction: Direction::Out,

--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -12,7 +12,6 @@ use proxy::http::{
 };
 use {Addr, NameAddr};
 
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Direction {
     In,

--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -1,16 +1,17 @@
-use http;
-use indexmap::IndexMap;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
+use super::classify;
+use http;
+use identity;
+use indexmap::IndexMap;
 use proxy::http::{
     metrics::classify::{CanClassify, Classify, ClassifyEos, ClassifyResponse},
     profiles, retry, settings, timeout,
 };
 use {Addr, NameAddr};
 
-use super::classify;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Direction {
@@ -35,6 +36,7 @@ pub struct DstAddr {
     addr: Addr,
     direction: Direction,
     pub(super) http_settings: settings::Settings,
+    force_identity: Option<identity::Name>,
 }
 
 // === impl Route ===
@@ -110,11 +112,16 @@ impl AsRef<Addr> for DstAddr {
 }
 
 impl DstAddr {
-    pub fn outbound(addr: Addr, http_settings: settings::Settings) -> Self {
+    pub fn outbound(
+        addr: Addr,
+        http_settings: settings::Settings,
+        force_identity: Option<identity::Name>,
+    ) -> Self {
         DstAddr {
             addr,
             direction: Direction::Out,
             http_settings,
+            force_identity,
         }
     }
 
@@ -123,6 +130,7 @@ impl DstAddr {
             addr,
             direction: Direction::In,
             http_settings,
+            force_identity: None,
         }
     }
 

--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -127,10 +127,10 @@ fn map_err_to_5xx(e: Error) -> StatusCode {
     } else if let Some(_) = e.downcast_ref::<router::NotRecognized>() {
         error!("could not recognize request");
         http::StatusCode::BAD_GATEWAY
-    } else if let Some(_) =
+    } else if let Some(err) =
         e.downcast_ref::<outbound::require_identity_on_endpoint::RequireIdentityError>()
     {
-        warn!("require identity check failed and downcasted");
+        error!("{}", err);
         http::StatusCode::FORBIDDEN
     } else {
         // we probably should have handled this before?

--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -110,6 +110,7 @@ where
 }
 
 fn map_err_to_5xx(e: Error) -> StatusCode {
+    use app::outbound;
     use proxy::buffer;
     use proxy::http::router::error as router;
     use tower::load_shed::error as shed;
@@ -126,6 +127,11 @@ fn map_err_to_5xx(e: Error) -> StatusCode {
     } else if let Some(_) = e.downcast_ref::<router::NotRecognized>() {
         error!("could not recognize request");
         http::StatusCode::BAD_GATEWAY
+    } else if let Some(_) =
+        e.downcast_ref::<outbound::require_identity_on_endpoint::RequireIdentityError>()
+    {
+        warn!("require identity check failed and downcasted");
+        http::StatusCode::FORBIDDEN
     } else {
         // we probably should have handled this before?
         error!("unexpected error: {}", e);

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -584,7 +584,7 @@ where
                 .layer(router::layer(
                     router::Config::new("out dst", capacity, max_idle_age),
                     |req: &http::Request<_>| {
-                        let addr = req.extensions().get::<Addr>().cloned().map(move |addr| {
+                        let addr = req.extensions().get::<Addr>().cloned().map(|addr| {
                             let settings = settings::Settings::from_request(req);
                             DstAddr::outbound(addr, settings)
                         });

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -434,10 +434,10 @@ where
             use super::outbound::{
                 self,
                 discovery::Resolve,
-
                 orig_proto_upgrade,
-                //add_remote_ip_on_rsp, add_server_id_on_rsp,
                 require_identity_on_endpoint,
+                //add_remote_ip_on_rsp, add_server_id_on_rsp,
+            };
             use proxy::{
                 http::{
                     balance, canonicalize, fallback, header_from_target, identity_from_header,
@@ -528,7 +528,8 @@ where
                     router::Config::new("out ep", capacity, max_idle_age),
                     |req: &http::Request<_>| {
                         let ep = outbound::Endpoint::from_orig_dst(req).and_then(|mut ep| {
-                            if let Some(require_id) = identity_from_header(req, super::L5D_REQUIRE_ID)
+                            if let Some(require_id) =
+                                identity_from_header(req, super::L5D_REQUIRE_ID)
                             {
                                 debug!("outbound ep require id={:?}", require_id);
                                 ep.identity = Conditional::Some(require_id);

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -439,10 +439,7 @@ where
                 //add_remote_ip_on_rsp, add_server_id_on_rsp,
             };
             use proxy::{
-                http::{
-                    balance, canonicalize, fallback, header_from_target, identity_from_header,
-                    metrics, retry,
-                },
+                http::{balance, canonicalize, fallback, header_from_target, metrics, retry},
                 resolve,
             };
 
@@ -527,15 +524,7 @@ where
                 .layer(router::layer(
                     router::Config::new("out ep", capacity, max_idle_age),
                     |req: &http::Request<_>| {
-                        let ep = outbound::Endpoint::from_orig_dst(req).and_then(|mut ep| {
-                            if let Some(require_id) =
-                                identity_from_header(req, super::L5D_REQUIRE_ID)
-                            {
-                                debug!("outbound ep require id={:?}", require_id);
-                                ep.identity = Conditional::Some(require_id);
-                            }
-                            Some(ep)
-                        });
+                        let ep = outbound::Endpoint::from_request(req);
                         debug!("outbound ep={:?}", ep);
                         ep
                     },

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -440,12 +440,8 @@ where
             };
             use proxy::{
                 http::{
-<<<<<<< HEAD
                     balance, canonicalize, fallback, header_from_target, identity_from_header,
                     metrics, retry,
-=======
-                    balance, canonicalize, header_from_target, identity_from_header, metrics, retry,
->>>>>>> Run rustfmt
                 },
                 resolve,
             };
@@ -498,9 +494,9 @@ where
                 // disabled on purpose
                 //.layer(add_server_id_on_rsp::layer())
                 //.layer(add_remote_ip_on_rsp::layer())
+                .layer(strip_header::request::layer(super::L5D_FORCE_ID))
                 .layer(strip_header::response::layer(super::L5D_SERVER_ID))
                 .layer(strip_header::response::layer(super::L5D_REMOTE_IP))
-                .layer(strip_header::request::layer(super::L5D_FORCE_ID))
                 .service(client_stack);
             // A per-`dst::Route` layer that uses profile data to configure
             // a per-route layer.

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -439,8 +439,12 @@ where
             };
             use proxy::{
                 http::{
+<<<<<<< HEAD
                     balance, canonicalize, fallback, header_from_target, identity_from_header,
                     metrics, retry,
+=======
+                    balance, canonicalize, header_from_target, identity_from_header, metrics, retry,
+>>>>>>> Run rustfmt
                 },
                 resolve,
             };
@@ -524,14 +528,13 @@ where
                 .layer(router::layer(
                     router::Config::new("out ep", capacity, max_idle_age),
                     |req: &http::Request<_>| {
-                        let ep = outbound::Endpoint::from_orig_dst(req)
-                            .and_then(|mut ep| {
-                                if let Some(force_id) = identity_from_header(req, super::L5D_FORCE_ID) {
-                                    debug!("outbound ep force identity={:?}", force_id);
-                                    ep.identity = Conditional::Some(force_id);
-                                }
-                                Some(ep)
-                            });
+                        let ep = outbound::Endpoint::from_orig_dst(req).and_then(|mut ep| {
+                            if let Some(force_id) = identity_from_header(req, super::L5D_FORCE_ID) {
+                                debug!("outbound ep force identity={:?}", force_id);
+                                ep.identity = Conditional::Some(force_id);
+                            }
+                            Some(ep)
+                        });
                         debug!("outbound ep={:?}", ep);
                         ep
                     },

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -434,6 +434,7 @@ where
             use super::outbound::{
                 self,
                 discovery::Resolve,
+                force_identity_check,
                 orig_proto_upgrade,
                 //add_remote_ip_on_rsp, add_server_id_on_rsp,
             };
@@ -488,6 +489,7 @@ where
             // 6. Strips any `l5d-server-id` that may have been received from
             //    the server, before we apply our own.
             let endpoint_stack = svc::builder()
+                .layer(force_identity_check::layer())
                 .layer(metrics::layer::<_, classify::Response>(
                     endpoint_http_metrics,
                 ))
@@ -498,6 +500,7 @@ where
                 //.layer(add_remote_ip_on_rsp::layer())
                 .layer(strip_header::response::layer(super::L5D_SERVER_ID))
                 .layer(strip_header::response::layer(super::L5D_REMOTE_IP))
+                .layer(strip_header::request::layer(super::L5D_FORCE_ID))
                 .service(client_stack);
             // A per-`dst::Route` layer that uses profile data to configure
             // a per-route layer.
@@ -530,7 +533,7 @@ where
                     |req: &http::Request<_>| {
                         let ep = outbound::Endpoint::from_orig_dst(req).and_then(|mut ep| {
                             if let Some(force_id) = identity_from_header(req, super::L5D_FORCE_ID) {
-                                debug!("outbound ep server name={:?}; force-id", force_id);
+                                debug!("outbound ep force server id={:?}", force_id);
                                 ep.identity = Conditional::Some(force_id);
                             }
                             Some(ep)
@@ -583,10 +586,9 @@ where
                 .layer(router::layer(
                     router::Config::new("out dst", capacity, max_idle_age),
                     |req: &http::Request<_>| {
-                        let force_identity = identity_from_header(req, super::L5D_FORCE_ID);
                         let addr = req.extensions().get::<Addr>().cloned().map(move |addr| {
                             let settings = settings::Settings::from_request(req);
-                            DstAddr::outbound(addr, settings, force_identity)
+                            DstAddr::outbound(addr, settings)
                         });
                         debug!("outbound dst={:?}", addr);
                         addr

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25,6 +25,7 @@ pub const DST_OVERRIDE_HEADER: &'static str = "l5d-dst-override";
 const L5D_REMOTE_IP: &'static str = "l5d-remote-ip";
 const L5D_SERVER_ID: &'static str = "l5d-server-id";
 const L5D_CLIENT_ID: &'static str = "l5d-client-id";
+pub const L5D_FORCE_ID: &'static str = "l5d-force-id";
 
 pub fn init() -> Result<(config::Config, trace::LevelHandle), Box<Error + Send + Sync + 'static>> {
     let trace_admin = trace::init()?;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -25,7 +25,7 @@ pub const DST_OVERRIDE_HEADER: &'static str = "l5d-dst-override";
 const L5D_REMOTE_IP: &'static str = "l5d-remote-ip";
 const L5D_SERVER_ID: &'static str = "l5d-server-id";
 const L5D_CLIENT_ID: &'static str = "l5d-client-id";
-pub const L5D_FORCE_ID: &'static str = "l5d-force-id";
+pub const L5D_REQUIRE_ID: &'static str = "l5d-require-id";
 
 pub fn init() -> Result<(config::Config, trace::LevelHandle), Box<Error + Send + Sync + 'static>> {
     let trace_admin = trace::init()?;

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -415,7 +415,7 @@ pub mod require_identity_on_endpoint {
     type Error = Box<dyn std::error::Error + Send + Sync>;
 
     #[derive(Debug)]
-    struct RequireIdentityError {
+    pub struct RequireIdentityError {
         require_identity: identity::Name,
         peer_identity: Option<identity::Name>,
     }
@@ -601,7 +601,11 @@ pub mod require_identity_on_endpoint {
     impl std::fmt::Display for RequireIdentityError {
         // TODO(kleimkuhler): Use `require_identity` and `peer_identity` fields?
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            write!(f, "require identity check failed")
+            write!(
+                f,
+                "require identity check failed; required={:?} found={:?}",
+                self.require_identity, self.peer_identity
+            )
         }
     }
 

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -48,11 +48,16 @@ impl Endpoint {
     }
 
     pub fn from_request<B>(req: &http::Request<B>) -> Option<Self> {
-        let addr = req.extensions().get::<proxy::Source>()?.orig_dst_if_not_local()?;
+        let addr = req
+            .extensions()
+            .get::<proxy::Source>()?
+            .orig_dst_if_not_local()?;
         let http_settings = settings::Settings::from_request(req);
         let identity = match identity_from_header(req, super::L5D_REQUIRE_ID) {
             Some(require_id) => Conditional::Some(require_id),
-            None => Conditional::None(tls::ReasonForNoPeerName::NotProvidedByServiceDiscovery.into()),
+            None => {
+                Conditional::None(tls::ReasonForNoPeerName::NotProvidedByServiceDiscovery.into())
+            }
         };
 
         Some(Self {

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -599,18 +599,16 @@ pub mod require_identity_on_endpoint {
     impl std::error::Error for RequireIdentityError {}
 
     impl std::fmt::Display for RequireIdentityError {
-        // TODO(kleimkuhler): Use `require_identity` and `peer_identity` fields?
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
             write!(
                 f,
-                "require identity check failed; required={:?} found={:?}",
+                "require identity check failed; require={:?} found={:?}",
                 self.require_identity, self.peer_identity
             )
         }
     }
 
     impl HasH2Reason for RequireIdentityError {
-        // TODO(kleimkuhler): Properly map the StatusCode
         fn h2_reason(&self) -> Option<h2::Reason> {
             (self as &(dyn std::error::Error + 'static)).h2_reason()
         }

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -563,7 +563,7 @@ pub mod require_identity_on_endpoint {
                                 "require identity check failed; found peer_identity={:?}",
                                 peer_identity
                             );
-                            return Either::A(future::err(identity_check_error(
+                            return Either::A(future::err(RequireIdentityError::new(
                                 require_identity,
                                 Some(peer_identity.clone()),
                             )));
@@ -571,7 +571,7 @@ pub mod require_identity_on_endpoint {
                     }
                     Conditional::None(_) => {
                         warn!("require identity check failed; no peer_identity found");
-                        return Either::A(future::err(identity_check_error(
+                        return Either::A(future::err(RequireIdentityError::new(
                             require_identity,
                             None,
                         )));
@@ -585,16 +585,15 @@ pub mod require_identity_on_endpoint {
 
     // ===== impl RequireIdentityError =====
 
-    fn identity_check_error(
-        require_identity: identity::Name,
-        peer_identity: Option<identity::Name>,
-    ) -> Error {
-        let error = RequireIdentityError {
-            require_identity,
-            peer_identity,
-        };
+    impl RequireIdentityError {
+        fn new(require_identity: identity::Name, peer_identity: Option<identity::Name>) -> Error {
+            let error = RequireIdentityError {
+                require_identity,
+                peer_identity,
+            };
 
-        error.into()
+            error.into()
+        }
     }
 
     impl std::error::Error for RequireIdentityError {}

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -398,6 +398,213 @@ pub mod orig_proto_upgrade {
     }
 }
 
+pub mod force_identity_check {
+    use super::Endpoint;
+    use app::L5D_FORCE_ID;
+    use futures::{
+        future::{self, Either, FutureResult},
+        Async, Future, Poll,
+    };
+    use identity;
+    use proxy::http::{identity_from_header, HasH2Reason};
+    use std::marker::PhantomData;
+    use svc;
+    use transport::tls::{self, HasPeerIdentity};
+    use Conditional;
+
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    #[derive(Debug)]
+    struct IdentityCheckError {
+        force_identity: identity::Name,
+        peer_identity: Option<identity::Name>,
+    }
+
+    pub struct Layer<A, B>(PhantomData<fn(A) -> B>);
+
+    pub struct MakeSvc<M, A, B> {
+        inner: M,
+        _marker: PhantomData<fn(A) -> B>,
+    }
+
+    pub struct MakeFuture<F, A, B> {
+        peer_identity: tls::PeerIdentity,
+        inner: F,
+        _marker: PhantomData<fn(A) -> B>,
+    }
+
+    pub struct IdentityCheck<M, A, B> {
+        peer_identity: tls::PeerIdentity,
+        inner: M,
+        _marker: PhantomData<fn(A) -> B>,
+    }
+
+    // ===== impl Layer =====
+
+    pub fn layer<A, B>() -> Layer<A, B> {
+        Layer(PhantomData)
+    }
+
+    impl<M, A, B> svc::Layer<M> for Layer<A, B>
+    where
+        M: svc::MakeService<Endpoint, http::Request<A>, Response = http::Response<B>>,
+    {
+        type Service = MakeSvc<M, A, B>;
+
+        fn layer(&self, inner: M) -> Self::Service {
+            MakeSvc {
+                inner,
+                _marker: PhantomData,
+            }
+        }
+    }
+
+    impl<A, B> Clone for Layer<A, B> {
+        fn clone(&self) -> Self {
+            Layer(PhantomData)
+        }
+    }
+
+    // ===== impl MakeSvc =====
+
+    impl<M, A, B> svc::Service<Endpoint> for MakeSvc<M, A, B>
+    where
+        M: svc::MakeService<Endpoint, http::Request<A>, Response = http::Response<B>>,
+    {
+        type Response = IdentityCheck<M::Service, A, B>;
+        type Error = M::MakeError;
+        type Future = MakeFuture<M::Future, A, B>;
+
+        fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+            self.inner.poll_ready()
+        }
+
+        fn call(&mut self, target: Endpoint) -> Self::Future {
+            // After the inner service is made, we want to wrap that service
+            // with a filter that compares the target's `peer_identity` and
+            // `l5d-force_id` header if present
+            let peer_identity = target.peer_identity().clone();
+            let inner = self.inner.make_service(target);
+
+            MakeFuture {
+                peer_identity,
+                inner,
+                _marker: PhantomData,
+            }
+        }
+    }
+
+    impl<F, A, B> Future for MakeFuture<F, A, B>
+    where
+        F: Future,
+        F::Item: svc::Service<http::Request<A>, Response = http::Response<B>>,
+    {
+        type Item = IdentityCheck<F::Item, A, B>;
+        type Error = F::Error;
+
+        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+            let inner = try_ready!(self.inner.poll());
+
+            // The inner service is ready and we now create a new service
+            // that filters based off `peer_identity` and `l5d-force-id` header
+            let identity_check = IdentityCheck {
+                peer_identity: self.peer_identity.clone(),
+                inner,
+                _marker: PhantomData,
+            };
+
+            Ok(Async::Ready(identity_check))
+        }
+    }
+
+    impl<M: Clone, A, B> Clone for MakeSvc<M, A, B> {
+        fn clone(&self) -> Self {
+            MakeSvc {
+                inner: self.inner.clone(),
+                _marker: PhantomData,
+            }
+        }
+    }
+
+    // ===== impl IdentityCheck =====
+
+    impl<M, A, B> svc::Service<http::Request<A>> for IdentityCheck<M, A, B>
+    where
+        M: svc::Service<http::Request<A>, Response = http::Response<B>>,
+        M::Error: Into<Error>,
+    {
+        type Response = M::Response;
+        type Error = Error;
+        type Future = Either<
+            FutureResult<Self::Response, Self::Error>,
+            future::MapErr<M::Future, fn(M::Error) -> Error>,
+        >;
+
+        fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+            self.inner.poll_ready().map_err(Into::into)
+        }
+
+        fn call(&mut self, request: http::Request<A>) -> Self::Future {
+            // If the `l5d-force-id` header is present, then we should expect
+            // the target's `peer_identity` to match. If the two values do not
+            // match or there is no `peer_identity`, then we fail the request.
+            if let Some(force_identity) = identity_from_header(&request, L5D_FORCE_ID) {
+                debug!("found l5d-force-id={:?}", force_identity.as_ref());
+                match self.peer_identity {
+                    Conditional::Some(ref peer_identity) => {
+                        if force_identity != *peer_identity {
+                            warn!(
+                                "force identity check failed; found peer_identity={:?}",
+                                peer_identity
+                            );
+                            return Either::A(future::err(identity_check_error(
+                                force_identity,
+                                Some(peer_identity.clone()),
+                            )));
+                        }
+                    }
+                    Conditional::None(_) => {
+                        warn!("force identity check failed; no peer_identity found");
+                        return Either::A(future::err(identity_check_error(force_identity, None)));
+                    }
+                }
+            }
+
+            Either::B(self.inner.call(request).map_err(Into::into))
+        }
+    }
+
+    // ===== impl IdentityCheckError =====
+
+    fn identity_check_error(
+        force_identity: identity::Name,
+        peer_identity: Option<identity::Name>,
+    ) -> Error {
+        let error = IdentityCheckError {
+            force_identity,
+            peer_identity,
+        };
+
+        error.into()
+    }
+
+    impl std::error::Error for IdentityCheckError {}
+
+    impl std::fmt::Display for IdentityCheckError {
+        // TODO(kleimkuhler): Use force_identity and peer_identity fields?
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(f, "force identity check failed")
+        }
+    }
+
+    impl HasH2Reason for IdentityCheckError {
+        // TODO(kleimkuhler): Properly map the StatusCode
+        fn h2_reason(&self) -> Option<h2::Reason> {
+            (self as &(dyn std::error::Error + 'static)).h2_reason()
+        }
+    }
+}
+
 /// Adds `l5d-server-id` headers to http::Responses derived from the
 /// TlsIdentity of an `Endpoint`.
 #[allow(dead_code)] // TODO #2597

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -398,9 +398,9 @@ pub mod orig_proto_upgrade {
     }
 }
 
-pub mod force_identity_check {
+pub mod require_identity_on_endpoint {
     use super::Endpoint;
-    use app::L5D_FORCE_ID;
+    use app::L5D_REQUIRE_ID;
     use futures::{
         future::{self, Either, FutureResult},
         Async, Future, Poll,
@@ -415,8 +415,8 @@ pub mod force_identity_check {
     type Error = Box<dyn std::error::Error + Send + Sync>;
 
     #[derive(Debug)]
-    struct IdentityCheckError {
-        force_identity: identity::Name,
+    struct RequireIdentityError {
+        require_identity: identity::Name,
         peer_identity: Option<identity::Name>,
     }
 
@@ -433,7 +433,7 @@ pub mod force_identity_check {
         _marker: PhantomData<fn(A) -> B>,
     }
 
-    pub struct IdentityCheck<M, A, B> {
+    pub struct RequireIdentity<M, A, B> {
         peer_identity: tls::PeerIdentity,
         inner: M,
         _marker: PhantomData<fn(A) -> B>,
@@ -471,7 +471,7 @@ pub mod force_identity_check {
     where
         M: svc::MakeService<Endpoint, http::Request<A>, Response = http::Response<B>>,
     {
-        type Response = IdentityCheck<M::Service, A, B>;
+        type Response = RequireIdentity<M::Service, A, B>;
         type Error = M::MakeError;
         type Future = MakeFuture<M::Future, A, B>;
 
@@ -482,7 +482,12 @@ pub mod force_identity_check {
         fn call(&mut self, target: Endpoint) -> Self::Future {
             // After the inner service is made, we want to wrap that service
             // with a filter that compares the target's `peer_identity` and
-            // `l5d-force_id` header if present
+            // `l5d_require_id` header if present
+
+            // After the inner service is made, we want to wrap that service
+            // with a service that checks for the presence of the
+            // `l5d-require-id` header. If is present then assert it is the
+            // endpoint identity; otherwise fail the request.
             let peer_identity = target.peer_identity().clone();
             let inner = self.inner.make_service(target);
 
@@ -499,21 +504,22 @@ pub mod force_identity_check {
         F: Future,
         F::Item: svc::Service<http::Request<A>, Response = http::Response<B>>,
     {
-        type Item = IdentityCheck<F::Item, A, B>;
+        type Item = RequireIdentity<F::Item, A, B>;
         type Error = F::Error;
 
         fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
             let inner = try_ready!(self.inner.poll());
 
             // The inner service is ready and we now create a new service
-            // that filters based off `peer_identity` and `l5d-force-id` header
-            let identity_check = IdentityCheck {
+            // that filters based off `peer_identity` and `l5d-require-id`
+            // header
+            let svc = RequireIdentity {
                 peer_identity: self.peer_identity.clone(),
                 inner,
                 _marker: PhantomData,
             };
 
-            Ok(Async::Ready(identity_check))
+            Ok(Async::Ready(svc))
         }
     }
 
@@ -526,9 +532,9 @@ pub mod force_identity_check {
         }
     }
 
-    // ===== impl IdentityCheck =====
+    // ===== impl RequireIdentity =====
 
-    impl<M, A, B> svc::Service<http::Request<A>> for IdentityCheck<M, A, B>
+    impl<M, A, B> svc::Service<http::Request<A>> for RequireIdentity<M, A, B>
     where
         M: svc::Service<http::Request<A>, Response = http::Response<B>>,
         M::Error: Into<Error>,
@@ -545,27 +551,30 @@ pub mod force_identity_check {
         }
 
         fn call(&mut self, request: http::Request<A>) -> Self::Future {
-            // If the `l5d-force-id` header is present, then we should expect
-            // the target's `peer_identity` to match. If the two values do not
-            // match or there is no `peer_identity`, then we fail the request.
-            if let Some(force_identity) = identity_from_header(&request, L5D_FORCE_ID) {
-                debug!("found l5d-force-id={:?}", force_identity.as_ref());
+            // If the `l5d-require-id` header is present, then we should expect
+            // the target's `peer_identity` to match; if the two values do not
+            // match or there is no `peer_identity`, then we fail the request
+            if let Some(require_identity) = identity_from_header(&request, L5D_REQUIRE_ID) {
+                debug!("found l5d-require-id={:?}", require_identity.as_ref());
                 match self.peer_identity {
                     Conditional::Some(ref peer_identity) => {
-                        if force_identity != *peer_identity {
+                        if require_identity != *peer_identity {
                             warn!(
-                                "force identity check failed; found peer_identity={:?}",
+                                "require identity check failed; found peer_identity={:?}",
                                 peer_identity
                             );
                             return Either::A(future::err(identity_check_error(
-                                force_identity,
+                                require_identity,
                                 Some(peer_identity.clone()),
                             )));
                         }
                     }
                     Conditional::None(_) => {
-                        warn!("force identity check failed; no peer_identity found");
-                        return Either::A(future::err(identity_check_error(force_identity, None)));
+                        warn!("require identity check failed; no peer_identity found");
+                        return Either::A(future::err(identity_check_error(
+                            require_identity,
+                            None,
+                        )));
                     }
                 }
             }
@@ -574,30 +583,30 @@ pub mod force_identity_check {
         }
     }
 
-    // ===== impl IdentityCheckError =====
+    // ===== impl RequireIdentityError =====
 
     fn identity_check_error(
-        force_identity: identity::Name,
+        require_identity: identity::Name,
         peer_identity: Option<identity::Name>,
     ) -> Error {
-        let error = IdentityCheckError {
-            force_identity,
+        let error = RequireIdentityError {
+            require_identity,
             peer_identity,
         };
 
         error.into()
     }
 
-    impl std::error::Error for IdentityCheckError {}
+    impl std::error::Error for RequireIdentityError {}
 
-    impl std::fmt::Display for IdentityCheckError {
-        // TODO(kleimkuhler): Use force_identity and peer_identity fields?
+    impl std::fmt::Display for RequireIdentityError {
+        // TODO(kleimkuhler): Use `require_identity` and `peer_identity` fields?
         fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            write!(f, "force identity check failed")
+            write!(f, "require identity check failed")
         }
     }
 
-    impl HasH2Reason for IdentityCheckError {
+    impl HasH2Reason for RequireIdentityError {
         // TODO(kleimkuhler): Properly map the StatusCode
         fn h2_reason(&self) -> Option<h2::Reason> {
             (self as &(dyn std::error::Error + 'static)).h2_reason()

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -23,6 +23,7 @@ pub use self::client::Client;
 pub use self::glue::{ClientUsedTls, HttpBody as Body, HyperServerSvc};
 pub use self::settings::Settings;
 
+use super::super::identity;
 use http::header::AsHeaderName;
 use http::uri::Authority;
 
@@ -63,13 +64,31 @@ pub fn authority_from_header<B, K>(req: &http::Request<B>, header: K) -> Option<
 where
     K: AsHeaderName,
 {
+    header_value_from_request(req, header, |s: &str| s.parse::<Authority>().ok())
+}
+
+pub fn identity_from_header<B, K>(req: &http::Request<B>, header: K) -> Option<identity::Name>
+where
+    K: AsHeaderName,
+{
+    header_value_from_request(req, header, |s: &str| {
+        identity::Name::from_hostname(s.as_bytes()).ok()
+    })
+}
+
+fn header_value_from_request<B, K, F, T>(
+    req: &http::Request<B>,
+    header: K,
+    try_from: F,
+) -> Option<T>
+where
+    K: AsHeaderName,
+    F: FnOnce(&str) -> Option<T>,
+{
     req.headers().get(header).and_then(|value| {
-        value.to_str().ok().and_then(|s| {
-            if s.is_empty() {
-                None
-            } else {
-                s.parse::<Authority>().ok()
-            }
-        })
+        value
+            .to_str()
+            .ok()
+            .and_then(|s| if s.is_empty() { None } else { try_from(s) })
     })
 }

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -85,10 +85,5 @@ where
     K: AsHeaderName,
     F: FnOnce(&str) -> Option<T>,
 {
-    req.headers().get(header).and_then(|value| {
-        value
-            .to_str()
-            .ok()
-            .and_then(|s| if s.is_empty() { None } else { try_from(s) })
-    })
+    req.headers().get(header)?.to_str().ok().and_then(try_from)
 }

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -268,163 +268,185 @@ fn refresh() {
     assert_eventually!(refreshed.load(Ordering::SeqCst) == true);
 }
 
-#[test]
-fn orig_dst_client_can_connect_to_tls_server_with_require_id_header() {
-    let _ = trace_init();
+mod require_id_header {
+    macro_rules! generate_tests {
+        (client: $make_client:path, server: $make_server:path) => {
+            #[test]
+            fn orig_dst_client_connects_to_tls_server() {
+                let _ = trace_init();
 
-    let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
-    let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
+                let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
+                let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
 
-    let app_name = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
-    let app_identity = identity::Identity::new("bar-ns1", app_name.to_string());
+                let app_name = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
+                let app_identity = identity::Identity::new("bar-ns1", app_name.to_string());
 
-    let srv = server::http2_tls(app_identity.server_config)
-        .route("/", "hello")
-        .run();
+                // Make a server that expects `app_identity` identity
+                let srv = $make_server(app_identity.server_config)
+                    .route("/", "hello")
+                    .run();
 
-    // Make a proxy that has `proxy_identity` identity
-    let proxy = proxy::new()
-        .outbound(srv)
-        .identity(proxy_identity.service().run())
-        .run_with_test_env(proxy_identity.env);
+                // Make a proxy that has `proxy_identity` identity
+                let proxy = proxy::new()
+                    .outbound(srv)
+                    .identity(proxy_identity.service().run())
+                    .run_with_test_env(proxy_identity.env);
 
-    // Make a non-TLS client
-    let client = client::http2(proxy.outbound, app_name);
+                // Make a non-TLS client
+                let client = $make_client(proxy.outbound, app_name);
 
-    // Assert a request to `srv` with `l5d-require-id` header succeeds
-    assert_eq!(
-        client
-            .request(
-                client
-                    .request_builder("/")
-                    .header("l5d-require-id", app_name)
-                    .method("GET")
-            )
-            .status(),
-        http::StatusCode::OK
-    );
+                // Assert a request to `srv` with `l5d-require-id` header
+                // succeeds
+                assert_eq!(
+                    client
+                        .request(
+                            client
+                                .request_builder("/")
+                                .header("l5d-require-id", app_name)
+                                .method("GET")
+                        )
+                        .status(),
+                    http::StatusCode::OK
+                );
 
-    // Assert a request to `srv` with no `l5d-require-id` header fails
-    //
-    // Fails because of reconnect backoff; results in status code 502
-    assert_eq!(
-        client
-            .request(
-                client
-                    .request_builder("/")
-                    .header("l5d-require-id", "hey-its-me")
-                    .method("GET")
-            )
-            .status(),
-        http::StatusCode::SERVICE_UNAVAILABLE
-    );
-}
+                // Assert a request to `srv` with incorrect `l5d-require-id`
+                // header fails
+                //
+                // Fails because of reconnect backoff; results in status code
+                // 502
+                assert_eq!(
+                    client
+                        .request(
+                            client
+                                .request_builder("/")
+                                .header("l5d-require-id", "hey-its-me")
+                                .method("GET")
+                        )
+                        .status(),
+                    http::StatusCode::SERVICE_UNAVAILABLE
+                );
+            }
 
-#[test]
-fn discovery_client_can_connect_to_tls_server_with_require_id_header() {
-    let _ = trace_init();
+            #[test]
+            fn disco_client_connects_to_tls_server() {
+                let _ = trace_init();
 
-    let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
-    let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
+                let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
+                let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
 
-    let app_name = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
-    let app_identity = identity::Identity::new("bar-ns1", app_name.to_string());
+                let app_name = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
+                let app_identity = identity::Identity::new("bar-ns1", app_name.to_string());
 
-    // Make a server that expects `app_identity` identity
-    let srv = server::http2_tls(app_identity.server_config)
-        .route("/", "hello")
-        .run();
+                // Make a server that expects `app_identity` identity
+                let srv = $make_server(app_identity.server_config)
+                    .route("/", "hello")
+                    .run();
 
-    // Add `srv` to discovery service
-    let ctrl = controller::new();
-    let dst = ctrl.destination_tx("disco.test.svc.cluster.local");
-    dst.send(controller::destination_add_tls(srv.addr, app_name));
+                // Add `srv` to discovery service
+                let ctrl = controller::new();
+                let dst = ctrl.destination_tx("disco.test.svc.cluster.local");
+                dst.send(controller::destination_add_tls(srv.addr, app_name));
 
-    // Make a proxy that has `proxy_identity` identity and no SO_ORIGINAL_DST
-    // backup
-    let proxy = proxy::new()
-        .controller(ctrl.run())
-        .identity(proxy_identity.service().run())
-        .run_with_test_env(proxy_identity.env);
+                // Make a proxy that has `proxy_identity` identity and no
+                // SO_ORIGINAL_DST backup
+                let proxy = proxy::new()
+                    .controller(ctrl.run())
+                    .identity(proxy_identity.service().run())
+                    .run_with_test_env(proxy_identity.env);
 
-    // Make a non-TLS client
-    let client = client::http2(proxy.outbound, "disco.test.svc.cluster.local");
+                // Make a non-TLS client
+                let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
 
-    // Assert a request to `srv` through discovery succeeds
-    assert_eq!(
-        client
-            .request(client.request_builder("/").method("GET"))
-            .status(),
-        http::StatusCode::OK
-    );
+                // Assert a request to `srv` through discovery succeeds
+                assert_eq!(
+                    client
+                        .request(client.request_builder("/").method("GET"))
+                        .status(),
+                    http::StatusCode::OK
+                );
 
-    // Assert a request to `srv` through discovery with incorrect
-    // `l5d-require-id` fails
-    assert_eq!(
-        client
-            .request(
-                client
-                    .request_builder("/")
-                    .header("l5d-require-id", "hey-its-me")
-                    .method("GET")
-            )
-            .status(),
-        http::StatusCode::FORBIDDEN
-    );
+                // Assert a request to `srv` through discovery with incorrect
+                // `l5d-require-id` fails
+                assert_eq!(
+                    client
+                        .request(
+                            client
+                                .request_builder("/")
+                                .header("l5d-require-id", "hey-its-me")
+                                .method("GET")
+                        )
+                        .status(),
+                    http::StatusCode::FORBIDDEN
+                );
 
-    // Assert a request to `srv` through discovery with `l5d-require-id` succeeds
-    assert_eq!(
-        client
-            .request(
-                client
-                    .request_builder("/")
-                    .header("l5d-require-id", app_name)
-                    .method("GET")
-            )
-            .status(),
-        http::StatusCode::OK
-    );
-}
+                // Assert a request to `srv` through discovery with
+                // `l5d-require-id` succeeds
+                assert_eq!(
+                    client
+                        .request(
+                            client
+                                .request_builder("/")
+                                .header("l5d-require-id", app_name)
+                                .method("GET")
+                        )
+                        .status(),
+                    http::StatusCode::OK
+                );
+            }
 
-#[test]
-fn orig_dst_client_cannot_connect_to_plaintext_server_with_require_id_header() {
-    let _ = trace_init();
+            #[test]
+            fn orig_dst_client_cannot_connect_to_plaintext_server() {
+                let _ = trace_init();
 
-    let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
-    let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
+                let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
+                let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
 
-    // Make a non-TLS server
-    let srv = server::http2().route("/", "hello").run();
+                // Make a non-TLS server
+                let srv = server::http2().route("/", "hello").run();
 
-    // Make a proxy that has `proxy_identity` identity
-    let proxy = proxy::new()
-        .outbound(srv)
-        .identity(proxy_identity.service().run())
-        .run_with_test_env(proxy_identity.env);
+                // Make a proxy that has `proxy_identity` identity
+                let proxy = proxy::new()
+                    .outbound(srv)
+                    .identity(proxy_identity.service().run())
+                    .run_with_test_env(proxy_identity.env);
 
-    // Make a non-TLS client
-    let client = client::http2(proxy.outbound, "localhost");
+                // Make a non-TLS client
+                let client = client::http2(proxy.outbound, "localhost");
 
-    // Assert a request to `srv` with `l5d-require-id` header fails
-    //
-    // Fails because of reconnect backoff; results in status code 502
-    assert_eq!(
-        client
-            .request(
-                client
-                    .request_builder("/")
-                    .header("l5d-require-id", "hey-its-me")
-                    .method("GET")
-            )
-            .status(),
-        http::StatusCode::SERVICE_UNAVAILABLE
-    );
+                // Assert a request to `srv` with `l5d-require-id` header fails
+                assert_eq!(
+                    client
+                        .request(
+                            client
+                                .request_builder("/")
+                                .header("l5d-require-id", "hey-its-me")
+                                .method("GET")
+                        )
+                        .status(),
+                    http::StatusCode::SERVICE_UNAVAILABLE
+                );
 
-    // Assert a request to `srv` succeeds
-    assert_eq!(
-        client
-            .request(client.request_builder("/").method("GET"))
-            .status(),
-        http::StatusCode::OK
-    );
+                // Assert a request to `srv` with no `l5d-require-id` header
+                // succeeds
+                assert_eq!(
+                    client
+                        .request(client.request_builder("/").method("GET"))
+                        .status(),
+                    http::StatusCode::OK
+                );
+            }
+        };
+    }
+
+    mod http1 {
+        use super::super::*;
+
+        generate_tests! { client: client::http1, server: server::http1_tls }
+    }
+
+    mod http2 {
+        use super::super::*;
+
+        generate_tests! { client: client::http2, server: server::http2_tls }
+    }
 }

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -277,48 +277,19 @@ fn orig_dst_client_can_connect_to_tls_server_with_require_id_header() {
 
     let app_name = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
     let app_identity = identity::Identity::new("bar-ns1", app_name.to_string());
-    // let identity::Identity {
-    //     mut certify_rsp,
-    //     server_config,
-    //     env,
-    //     ..
-    // } = identity::Identity::new("bar-ns1", app_name.to_string());
-    // certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
 
-    // Certify the server's identity
-    // let app_identity = controller::identity().certify(move |_| certify_rsp).run();
-
-    // Make a server that expects `app_identity` identity
     let srv = server::http2_tls(app_identity.server_config)
         .route("/", "hello")
         .run();
 
     // Make a proxy that has `proxy_identity` identity
-    let out_proxy = proxy::new()
+    let proxy = proxy::new()
         .outbound(srv)
         .identity(proxy_identity.service().run())
         .run_with_test_env(proxy_identity.env);
 
-    // Wait for `out_proxy` identity to become ready
-    let client = client::http1(out_proxy.metrics, "localhost");
-    let ready = || client.request(client.request_builder("/ready").method("GET"));
-    assert_eventually!(ready().status() == http::StatusCode::OK);
-
     // Make a non-TLS client
-    let client = client::http2(out_proxy.outbound, app_name);
-
-    // Assert a request to `srv` with no `l5d-require-id` header fails
-    assert_eq!(
-        client
-            .request(
-                client
-                    .request_builder("/")
-                    .header("l5d-require-id", proxy_name)
-                    .method("GET")
-            )
-            .status(),
-        http::StatusCode::BAD_GATEWAY
-    );
+    let client = client::http2(proxy.outbound, app_name);
 
     // Assert a request to `srv` with `l5d-require-id` header succeeds
     assert_eq!(
@@ -331,6 +302,21 @@ fn orig_dst_client_can_connect_to_tls_server_with_require_id_header() {
             )
             .status(),
         http::StatusCode::OK
+    );
+
+    // Assert a request to `srv` with no `l5d-require-id` header fails
+    //
+    // Fails because of reconnect backoff; results in status code 502
+    assert_eq!(
+        client
+            .request(
+                client
+                    .request_builder("/")
+                    .header("l5d-require-id", "hey-its-me")
+                    .method("GET")
+            )
+            .status(),
+        http::StatusCode::SERVICE_UNAVAILABLE
     );
 }
 

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -277,6 +277,7 @@ mod require_id_header {
             tls_server: $make_tls_server:path,
         ) => {
             #[test]
+            #[cfg_attr(not(feature = "flaky_tests"), ignore)]
             fn orig_dst_client_connects_to_tls_server() {
                 let _ = trace_init();
 
@@ -333,6 +334,7 @@ mod require_id_header {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "flaky_tests"), ignore)]
             fn disco_client_connects_to_tls_server() {
                 let _ = trace_init();
 
@@ -400,6 +402,7 @@ mod require_id_header {
             }
 
             #[test]
+            #[cfg_attr(not(feature = "flaky_tests"), ignore)]
             fn orig_dst_client_cannot_connect_to_plaintext_server() {
                 let _ = trace_init();
 

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -292,20 +292,13 @@ fn orig_dst_client_can_connect_to_tls_server_with_require_id_header() {
     // Make a non-TLS client
     let client = client::http2(proxy.outbound, app_name);
 
-    // Assert a request to `srv` with incorrect `l5d-require-id` header fails
-    //
-    // Fails because of reconnect backoff; results in status code 502
-    assert_eq!(
-        client
-            .request(
-                client
-                    .request_builder("/")
-                    .header("l5d-require-id", "hey-its-me")
-                    .method("GET")
-            )
-            .status(),
-        http::StatusCode::SERVICE_UNAVAILABLE
-    );
+    // Assert a request to `srv` with no `l5d-require-id` header fails
+    // assert_eq!(
+    //     client
+    //         .request(client.request_builder("/").method("GET"))
+    //         .status(),
+    //     http::StatusCode::BAD_GATEWAY
+    // );
 
     // Assert a request to `srv` with `l5d-require-id` header succeeds
     assert_eq!(

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -269,8 +269,8 @@ fn refresh() {
 }
 
 #[test]
-fn orig_dst_client_can_connect_to_tls_server_with_force_id_header() {
-    let _ = env_logger_init();
+fn orig_dst_client_can_connect_to_tls_server_with_require_id_header() {
+    let _ = trace_init();
 
     let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
@@ -292,7 +292,7 @@ fn orig_dst_client_can_connect_to_tls_server_with_force_id_header() {
     // Make a non-TLS client
     let client = client::http2(proxy.outbound, app_name);
 
-    // Assert a request to `srv` with incorrect `l5d-force-id` header fails
+    // Assert a request to `srv` with incorrect `l5d-require-id` header fails
     //
     // Fails because of reconnect backoff; results in status code 502
     assert_eq!(
@@ -300,20 +300,20 @@ fn orig_dst_client_can_connect_to_tls_server_with_force_id_header() {
             .request(
                 client
                     .request_builder("/")
-                    .header("l5d-force-id", "hey-its-me")
+                    .header("l5d-require-id", "hey-its-me")
                     .method("GET")
             )
             .status(),
         http::StatusCode::SERVICE_UNAVAILABLE
     );
 
-    // Assert a request to `srv` with `l5d-force-id` header succeeds
+    // Assert a request to `srv` with `l5d-require-id` header succeeds
     assert_eq!(
         client
             .request(
                 client
                     .request_builder("/")
-                    .header("l5d-force-id", app_name)
+                    .header("l5d-require-id", app_name)
                     .method("GET")
             )
             .status(),
@@ -322,8 +322,8 @@ fn orig_dst_client_can_connect_to_tls_server_with_force_id_header() {
 }
 
 #[test]
-fn discovery_client_can_connect_to_tls_server_with_force_id_header() {
-    let _ = env_logger_init();
+fn discovery_client_can_connect_to_tls_server_with_require_id_header() {
+    let _ = trace_init();
 
     let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
@@ -360,26 +360,26 @@ fn discovery_client_can_connect_to_tls_server_with_force_id_header() {
     );
 
     // Assert a request to `srv` through discovery with incorrect
-    // `l5d-force-id` fails
+    // `l5d-require-id` fails
     assert_eq!(
         client
             .request(
                 client
                     .request_builder("/")
-                    .header("l5d-force-id", "hey-its-me")
+                    .header("l5d-require-id", "hey-its-me")
                     .method("GET")
             )
             .status(),
         http::StatusCode::BAD_GATEWAY
     );
 
-    // Assert a request to `srv` through discovery with `l5d-force-id` succeeds
+    // Assert a request to `srv` through discovery with `l5d-require-id` succeeds
     assert_eq!(
         client
             .request(
                 client
                     .request_builder("/")
-                    .header("l5d-force-id", app_name)
+                    .header("l5d-require-id", app_name)
                     .method("GET")
             )
             .status(),
@@ -388,8 +388,8 @@ fn discovery_client_can_connect_to_tls_server_with_force_id_header() {
 }
 
 #[test]
-fn orig_dst_client_cannot_connect_to_plaintext_server_with_force_id_header() {
-    let _ = env_logger_init();
+fn orig_dst_client_cannot_connect_to_plaintext_server_with_require_id_header() {
+    let _ = trace_init();
 
     let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
@@ -414,7 +414,7 @@ fn orig_dst_client_cannot_connect_to_plaintext_server_with_force_id_header() {
         http::StatusCode::OK
     );
 
-    // Assert a request to `srv` with `l5d-force-header` fails
+    // Assert a request to `srv` with `l5d-require-id` header fails
     //
     // Fails because of reconnect backoff; results in status code 502
     assert_eq!(
@@ -422,7 +422,7 @@ fn orig_dst_client_cannot_connect_to_plaintext_server_with_force_id_header() {
             .request(
                 client
                     .request_builder("/")
-                    .header("l5d-force-id", "hey-its-me")
+                    .header("l5d-require-id", "hey-its-me")
                     .method("GET")
             )
             .status(),


### PR DESCRIPTION
This was originally implemented in #280, but has since changed enough that a
new PR is being opened

### Motivation

As part of the Tap hardening project, tap should only be served on TLS
connections. Currently, when the Tap service makes an outbound Tap request, the
`Host` header is the Pod IP of the resource. Service discovery is not attempted
and therefore the Tap service initiates a plaintext connection. The introduction
of the `l5d-require-id` header will allow an outbound request to require the
specified identity on the endpoint it connects to.

### Details

The `orig_dst_router` router on outbound requests will set the identity of the
`outbound::Endpoint` to the value of the `l5d-require-id` header if it is
present. This is useful specifically for the case explained above when request
are made with an IP as their `Host` header and need to be TLS connections.

In order for the header to be used in other scenarios, a new layer has been
added to the `endpoint_stack` stack on outbound requests. This layer is
implemented in `outbound::require_identity_on_endpoint`. The purpose of this
layer is to wrap the `MakeService` of `Endpoint`s with a new service that checks
for the presence of required identities, and if present, asserts the identity of
the endpoint is expected.

When constructing an `Endpoint`, if a request has the `l5d-require-id` header
then the endpoint will be constructed if it's identity is the expected identity
of the header value; if not, it will error and return a status code `FORBIDDEN`.

### Tests

Tests have been added for both http1 and http2. The tests cover the
`orig_dst_router` router as well as discovery. In both of those cases, clients
make requests with and without the `l5d-require-id` header, as well as correct
and inccorect `l5d-require-id` header values.

Closes linkerd/linkerd2#2677

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
