### PR TITLE
Properly fall back in the dst_router

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -433,7 +433,7 @@ where
         let outbound = {
             use super::outbound::{
                 self,
-                discovery::Resolve,
+                discovery::Resolver,
                 orig_proto_upgrade,
                 require_identity_on_endpoint,
                 //add_remote_ip_on_rsp, add_server_id_on_rsp,
@@ -535,7 +535,7 @@ where
             // over all endpoints returned from the destination service.
             let balancer = svc::builder()
                 .layer(balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
-                .layer(resolve::layer(Resolve::new(resolver)))
+                .layer(resolve::layer(Resolver::new(resolver)))
                 .spawn_ready();
 
             let distributor = svc::builder()

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -433,7 +433,7 @@ where
         let outbound = {
             use super::outbound::{
                 self,
-                discovery::Resolver,
+                discovery::Resolve,
                 orig_proto_upgrade,
                 require_identity_on_endpoint,
                 //add_remote_ip_on_rsp, add_server_id_on_rsp,
@@ -535,7 +535,7 @@ where
             // over all endpoints returned from the destination service.
             let balancer = svc::builder()
                 .layer(balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
-                .layer(resolve::layer(Resolver::new(resolver)))
+                .layer(resolve::layer(Resolve::new(resolver)))
                 .spawn_ready();
 
             let distributor = svc::builder()

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -165,13 +165,15 @@ pub mod discovery {
     use transport::tls;
     use {Addr, Conditional, NameAddr};
 
-    #[derive(Clone)]
+    #[derive(Clone, Debug)]
     pub struct Resolve<R: resolve::Resolve<NameAddr>>(R);
 
+    #[derive(Debug)]
     pub struct ResolveFuture<F> {
         resolving: Option<Resolution<F>>,
     }
 
+    #[derive(Debug)]
     pub struct Resolution<R> {
         http_settings: settings::Settings,
         name: NameAddr,
@@ -184,8 +186,8 @@ pub mod discovery {
     where
         R: resolve::Resolve<NameAddr, Endpoint = Metadata>,
     {
-        pub fn new(resolver: R) -> Self {
-            Resolve(resolver)
+        pub fn new(resolve: R) -> Self {
+            Resolve(resolve)
         }
     }
 

--- a/src/app/outbound.rs
+++ b/src/app/outbound.rs
@@ -180,7 +180,7 @@ pub mod discovery {
         resolution: R,
     }
 
-    // ===== impl Resolver =====
+    // ===== impl Resolve =====
 
     impl<R> Resolve<R>
     where

--- a/src/control/destination/resolution.rs
+++ b/src/control/destination/resolution.rs
@@ -304,6 +304,12 @@ impl fmt::Display for LogCtx {
 
 // === impl Unresolvable ===
 
+impl Unresolvable {
+    pub fn new() -> Self {
+        Self { _p: () }
+    }
+}
+
 impl fmt::Display for Unresolvable {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         "this name cannot be resolved by the destination service".fmt(f)

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -95,11 +95,19 @@ pub struct NoOriginalDst;
 impl Source {
     pub fn orig_dst_if_not_local(&self) -> Option<SocketAddr> {
         match self.orig_dst {
-            None => None,
+            None => {
+                trace!("no SO_ORIGINAL_DST on source");
+                None
+            }
             Some(orig_dst) => {
                 // If the original destination is actually the listening socket,
                 // we don't want to create a loop.
                 if Self::same_addr(orig_dst, self.local) {
+                    trace!(
+                        "SO_ORIGINAL_DST={}; local={}; avoiding loop",
+                        orig_dst,
+                        self.local
+                    );
                     None
                 } else {
                     Some(orig_dst)

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -264,26 +264,6 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        fn outbound_skips_controller_if_destination_is_address() {
-            let _ = init_env();
-
-            let srv = $make_server()
-                .route("/", "hello")
-                .route("/bye", "bye")
-                .run();
-
-            let host = srv.addr.to_string();
-
-            // don't set outbound() or controller()
-            let proxy = proxy::new()
-                .run();
-            let client = $make_client(proxy.outbound, &*host);
-
-            assert_eq!(client.get("/"), "hello");
-            assert_eq!(client.get("/bye"), "bye");
-        }
-
-        #[test]
         fn outbound_error_reconnects_after_backoff() {
             let mut env = init_env();
 


### PR DESCRIPTION
### Motivation

TLDR: Requests whose target authority is a socket address do not properly fall
back. Requests to unresolvable authorities which are DNS names do fall back as
expected.

In a control plane branch, I have the tap controller properly adding the header
metadata to tap requests, and the pod proxy’s expecting the tap identity the
requests would be coming from. After installing a local build of this control
plane and the proxy that supports `l5d-require-id`, I noticed that the tap
controller’s proxy was still not setting identity on `outbound::Endpoint`s when
the header was there.

I began looking for the `debug!` lines that would be hit in the
`orig_dst_router` because I would expect to be hitting that router, and did not
see them—indicating those requests were still going through the balancer.

It turns out that requests with an authority that we cannot resolve still get a
single slot in the balancer, and therefore do not fallback because they do not
return the `Unresolvable` error. We match on `Socket` [here](https://github.com/linkerd/linkerd2-proxy/blob/master/src/app/outbound.rs#L207) and make a new
slot in the balancer [here](https://github.com/linkerd/linkerd2-proxy/blob/master/src/app/outbound.rs#L276)

This is an issue because if these requests contain the `l5d-require-id` header,
the `Endpoint` `identity` is not set because we do not go through the
`orig_dst_router` and therefore do not have a TLS connection

### Solution

In `outbound::discover`, `Resolve` will now only attempt to resolve
`Addr::Name`, and return a `Unresolvable` error on `Addr::Socket`. For requests
that are `Addr::Socket`, we rely on getting the original dst of the request and
therefore routes through `orig_dst_router`.

### Tests

The tests that specifically test SO_ORIGINAL_DST have been removed because those
tests now result in errors which is the expected behavior now.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>