### PR TITLE
Require identity on tap requests

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -655,18 +655,6 @@ fn parse_control_listener(strings: &Strings, id_disabled: bool) -> Result<Option
         .map(|d| !d.is_empty())
         .unwrap_or(false);
 
-    //     E = Enabled; D = Disabled
-    //     +----------+-----+--------------+
-    //     | Identity | Tap | Result       |
-    //     +----------+-----+--------------+
-    //     | E        | E   | Ok(Some(..)) |
-    //     +----------+-----+--------------+
-    //     | E        | D   | Ok(None)     |
-    //     +----------+-----+--------------+
-    //     | D        | E   | Err(..)      |
-    //     +----------+-----+--------------+
-    //     | D        | D   | Ok(None)     |
-    //     +----------+-----+--------------+
     match (id_disabled, tap_disabled) {
         (_, true) => Ok(None),
         (true, false) => {

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -392,6 +392,10 @@ where
                     ));
 
                     if let Some(listener) = control_listener {
+                        // Since tap is not disabled, a tap service name must
+                        // have been set in the environment
+                        let tap_svc_name = tap_svc_name.value().unwrap().clone();
+
                         rt.spawn(tap_daemon.map_err(|_| ()));
                         rt.spawn(serve_tap(listener, tap_svc_name, TapServer::new(tap_grpc)));
                     }

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -200,8 +200,15 @@ fn run(proxy: Proxy, mut env: app::config::TestEnv) -> Listening {
         Some(identity.addr)
     } else {
         env.put(app::config::ENV_IDENTITY_DISABLED, "test".to_owned());
+        env.put(app::config::ENV_TAP_DISABLED, "test".to_owned());
         None
     };
+
+    if !env.contains_key(app::config::ENV_TAP_DISABLED)
+        && !env.contains_key(app::config::ENV_TAP_SVC_NAME)
+    {
+        env.put(app::config::ENV_TAP_SVC_NAME, "test-identity".to_owned())
+    }
 
     if let Some(ports) = proxy.inbound_disable_ports_protocol_detection {
         let ports = ports

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -204,6 +204,8 @@ fn run(proxy: Proxy, mut env: app::config::TestEnv) -> Listening {
         None
     };
 
+    // If identity is enabled but the test is not concerned with tap, ensure
+    // there is a tap service name set
     if !env.contains_key(app::config::ENV_TAP_DISABLED)
         && !env.contains_key(app::config::ENV_TAP_SVC_NAME)
     {

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -69,6 +69,11 @@ impl Proxy {
         self
     }
 
+    pub fn disable_identity(mut self) -> Self {
+        self.identity = None;
+        self
+    }
+
     pub fn inbound(mut self, s: server::Listening) -> Self {
         let addr = s.addr.clone();
         self.inbound = Some(addr);

--- a/tests/tap.rs
+++ b/tests/tap.rs
@@ -3,76 +3,8 @@
 #[macro_use]
 mod support;
 use self::support::*;
+use std::time::SystemTime;
 use support::tap::TapEventExt;
-
-// Flaky: sometimes the admin thread hasn't had a chance to register
-// the Taps before the `client.get` is called.
-#[test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
-fn inbound_http1() {
-    let _ = trace_init();
-    let srv = server::http1().route("/", "hello").run();
-
-    let proxy = proxy::new().inbound(srv).run();
-
-    let mut tap = tap::client(proxy.control.unwrap());
-    let events = tap.observe(tap::observe_request());
-
-    let authority = "tap.test.svc.cluster.local";
-    let client = client::http1(proxy.inbound, authority);
-
-    assert_eq!(client.get("/"), "hello");
-
-    let mut events = events.wait().take(3);
-
-    let ev1 = events.next().expect("next1").expect("stream1");
-    assert!(ev1.is_inbound());
-    assert_eq!(ev1.request_init_authority(), authority);
-    assert_eq!(ev1.request_init_path(), "/");
-
-    let ev2 = events.next().expect("next2").expect("stream2");
-    assert!(ev2.is_inbound());
-    assert_eq!(ev2.response_init_status(), 200);
-
-    let ev3 = events.next().expect("next3").expect("stream3");
-    assert!(ev3.is_inbound());
-    assert_eq!(ev3.response_end_bytes(), 5);
-}
-
-#[test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
-fn grpc_headers_end() {
-    let _ = trace_init();
-    let srv = server::http2()
-        .route_fn("/", |_req| {
-            Response::builder()
-                .header("grpc-status", "1")
-                .body(Default::default())
-                .unwrap()
-        })
-        .run();
-
-    let proxy = proxy::new().inbound(srv).run();
-
-    let mut tap = tap::client(proxy.control.unwrap());
-    let events = tap.observe(tap::observe_request());
-
-    let authority = "tap.test.svc.cluster.local";
-    let client = client::http2(proxy.inbound, authority);
-
-    let res = client.request(
-        client
-            .request_builder("/")
-            .header("content-type", "application/grpc+nope"),
-    );
-    assert_eq!(res.status(), 200);
-    assert_eq!(res.headers()["grpc-status"], "1");
-    assert_eq!(res.into_body().concat2().wait().unwrap().len(), 0);
-
-    let ev = events.wait().nth(2).expect("nth").expect("stream");
-
-    assert_eq!(ev.response_end_eos_grpc(), 1);
-}
 
 #[test]
 fn tap_enabled_by_default() {
@@ -93,145 +25,197 @@ fn can_disable_tap() {
     assert!(proxy.control.is_none())
 }
 
-mod expected_identity {
-    use super::*;
-    use std::time::SystemTime;
+#[test]
+fn rejects_no_identity_when_identity_is_not_expected() {
+    let _ = trace_init();
+    let auth = "tap.test.svc.cluster.local";
 
-    #[test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-    fn tap_accepts_no_identity_when_identity_is_not_expected() {
-        let _ = trace_init();
-        let auth = "tap.test.svc.cluster.local";
+    let srv = server::http1().route("/", "hello").run();
 
-        let srv = server::http1().route("/", "hello").run();
+    let proxy = proxy::new().inbound(srv).run();
+    let mut tap = tap::client(proxy.control.unwrap());
+    let events = tap.observe(tap::observe_request());
 
-        let proxy = proxy::new().inbound(srv).run();
-        let mut tap = tap::client(proxy.control.unwrap());
-        let events = tap.observe(tap::observe_request());
+    let client = client::http1(proxy.inbound, auth);
+    assert_eq!(client.get("/"), "hello");
 
-        let client = client::http1(proxy.inbound, auth);
-        assert_eq!(client.get("/"), "hello");
+    let mut events = events.wait().take(1);
+    assert!(events.next().expect("next1").is_err());
+}
 
-        let mut events = events.wait().take(1);
+#[test]
+fn rejects_incorrect_identity_when_identity_is_expected() {
+    let _ = trace_init();
 
-        let ev1 = events.next().expect("next1").expect("stream1");
-        assert!(ev1.is_inbound());
-        assert_eq!(ev1.request_init_authority(), auth);
-        assert_eq!(ev1.request_init_path(), "/");
-    }
+    let identity = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
+    let identity_env = identity::Identity::new("foo-ns1", identity.to_string());
 
-    #[test]
-    fn tap_rejects_no_identity_when_identity_is_expected() {
-        let auth = "tap.test.svc.cluster.local";
-        let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
+    let expected_identity = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
+    let mut expected_identity_env = identity_env.env.clone();
+    expected_identity_env.put(app::config::ENV_TAP_SVC_NAME, expected_identity.to_owned());
 
-        let mut env = init_env();
-        env.put(app::config::ENV_TAP_SVC_NAME, id.to_owned());
+    let srv = server::http1().route("/", "hello").run();
 
-        let srv = server::http1().route("/", "hello").run();
+    let in_proxy = proxy::new()
+        .inbound(srv)
+        .identity(identity_env.service().run())
+        .run_with_test_env(expected_identity_env);
 
-        let proxy = proxy::new().inbound(srv).run_with_test_env(env);
-        let mut tap = tap::client(proxy.control.unwrap());
-        let events = tap.observe(tap::observe_request());
+    let tap_proxy = proxy::new()
+        .outbound_ip(in_proxy.control.unwrap())
+        .identity(identity_env.service().run())
+        .run_with_test_env(identity_env.env.clone());
 
-        let client = client::http1(proxy.inbound, auth);
-        assert_eq!(client.get("/"), "hello");
+    let mut tap = tap::client(tap_proxy.outbound);
+    let events = tap.observe(tap::observe_request());
 
-        let mut events = events.wait().take(1);
-        assert!(events.next().expect("next1").is_err());
-    }
+    let client = client::http1(in_proxy.inbound, "localhost");
+    assert_eq!(client.get("/"), "hello");
 
-    #[test]
-    fn tap_rejects_incorrect_identity_when_identity_is_expected() {
-        let _ = trace_init();
+    let mut events = events.wait().take(1);
+    assert!(events.next().expect("next1").is_err());
+}
 
-        let identity = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
-        let identity_env = identity::Identity::new("foo-ns1", identity.to_string());
+// Flaky: sometimes the admin thread hasn't had a chance to register
+// the Taps before the `client.get` is called.
+#[test]
+#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+fn accepts_expected_identity_when_identity_is_expected() {
+    let _ = trace_init();
 
-        let expected_identity = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
-        let mut expected_identity_env = identity_env.env.clone();
-        expected_identity_env.put(app::config::ENV_TAP_SVC_NAME, expected_identity.to_owned());
+    // Setup server proxy authority and identity
+    let srv_proxy_authority = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
+    let identity::Identity {
+        mut env,
+        mut certify_rsp,
+        ..
+    } = identity::Identity::new("foo-ns1", srv_proxy_authority.to_string());
 
-        let srv = server::http1().route("/", "hello").run();
+    // Setup client proxy authority and identity
+    let client_proxy_authority = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
+    let client_proxy_identity =
+        identity::Identity::new("bar-ns1", client_proxy_authority.to_string());
 
-        let in_proxy = proxy::new()
-            .inbound(srv)
-            .identity(identity_env.service().run())
-            .run_with_test_env(expected_identity_env);
+    // Certify server proxy identity
+    certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
+    let srv_proxy_identity_svc = controller::identity().certify(move |_| certify_rsp).run();
 
-        let tap_proxy = proxy::new()
-            .outbound_ip(in_proxy.control.unwrap())
-            .identity(identity_env.service().run())
-            .run_with_test_env(identity_env.env.clone());
+    // Add expected tap service identity
+    env.put(
+        app::config::ENV_TAP_SVC_NAME,
+        client_proxy_authority.to_owned(),
+    );
 
-        let mut tap = tap::client(tap_proxy.outbound);
-        let events = tap.observe(tap::observe_request());
+    let srv = server::http1().route("/", "hello").run();
 
-        let client = client::http1(in_proxy.inbound, "localhost");
-        assert_eq!(client.get("/"), "hello");
+    // Run server proxy with server proxy identity service
+    let srv_proxy = proxy::new()
+        .inbound(srv)
+        .identity(srv_proxy_identity_svc)
+        .run_with_test_env(env);
 
-        let mut events = events.wait().take(1);
-        assert!(events.next().expect("next1").is_err());
-    }
+    // Run client proxy with client proxy identity service.
+    let client_proxy = proxy::new()
+        .outbound_ip(srv_proxy.control.unwrap())
+        .identity(client_proxy_identity.service().run())
+        .run_with_test_env(client_proxy_identity.env);
 
-    #[test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-    fn tap_accepts_expected_identity_when_identity_is_expected() {
-        let _ = trace_init();
+    // Wait for the server proxy to become ready
+    let client = client::http1(srv_proxy.metrics, "localhost");
+    let ready = || client.request(client.request_builder("/ready").method("GET"));
+    assert_eventually!(ready().status() == http::StatusCode::OK);
 
-        // Setup server proxy authority and identity
-        let srv_proxy_authority = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
-        let identity::Identity {
-            mut env,
-            mut certify_rsp,
-            ..
-        } = identity::Identity::new("foo-ns1", srv_proxy_authority.to_string());
+    let mut tap = tap::client_with_auth(client_proxy.outbound, srv_proxy_authority);
+    let events = tap.observe_with_require_id(tap::observe_request(), srv_proxy_authority);
 
-        // Setup client proxy authority and identity
-        let client_proxy_authority = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
-        let client_proxy_identity =
-            identity::Identity::new("bar-ns1", client_proxy_authority.to_string());
+    // Send a request that will be observed via the tap client
+    let client = client::http1(srv_proxy.inbound, "localhost");
+    assert_eq!(client.get("/"), "hello");
 
-        // Certify server proxy identity
-        certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
-        let srv_proxy_identity_svc = controller::identity().certify(move |_| certify_rsp).run();
+    let mut events = events.wait().take(3);
 
-        // Add expected tap service identity
-        env.put(
-            app::config::ENV_TAP_SVC_NAME,
-            client_proxy_authority.to_owned(),
-        );
+    let ev1 = events.next().expect("next1").expect("stream1");
+    assert!(ev1.is_inbound());
+    assert_eq!(ev1.request_init_authority(), "localhost");
+    assert_eq!(ev1.request_init_path(), "/");
 
-        let srv = server::http1().route("/", "hello").run();
+    let ev2 = events.next().expect("next2").expect("stream2");
+    assert!(ev2.is_inbound());
+    assert_eq!(ev2.response_init_status(), 200);
 
-        // Run server proxy with server proxy identity service
-        let srv_proxy = proxy::new()
-            .inbound(srv)
-            .identity(srv_proxy_identity_svc)
-            .run_with_test_env(env);
+    let ev3 = events.next().expect("next3").expect("stream3");
+    assert!(ev3.is_inbound());
+    assert_eq!(ev3.response_end_bytes(), 5);
+}
 
-        // Run client proxy with client proxy identity service.
-        let client_proxy = proxy::new()
-            .outbound_ip(srv_proxy.control.unwrap())
-            .identity(client_proxy_identity.service().run())
-            .run_with_test_env(client_proxy_identity.env);
+#[test]
+fn grpc_headers_end() {
+    let _ = trace_init();
 
-        // Wait for the server proxy to become ready
-        let client = client::http1(srv_proxy.metrics, "localhost");
-        let ready = || client.request(client.request_builder("/ready").method("GET"));
-        assert_eventually!(ready().status() == http::StatusCode::OK);
+    // Setup server proxy authority and identity
+    let srv_proxy_authority = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
+    let identity::Identity {
+        mut env,
+        mut certify_rsp,
+        ..
+    } = identity::Identity::new("foo-ns1", srv_proxy_authority.to_string());
 
-        let mut tap = tap::client_with_auth(client_proxy.outbound, srv_proxy_authority);
-        let events = tap.observe_with_require_id(tap::observe_request(), srv_proxy_authority);
+    // Setup client proxy authority and identity
+    let client_proxy_authority = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
+    let client_proxy_identity =
+        identity::Identity::new("bar-ns1", client_proxy_authority.to_string());
 
-        // Send a request that will be observed via the tap client
-        let client = client::http1(srv_proxy.inbound, "localhost");
-        assert_eq!(client.get("/"), "hello");
+    // Certify server proxy identity
+    certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
+    let srv_proxy_identity_svc = controller::identity().certify(move |_| certify_rsp).run();
 
-        let mut events = events.wait().take(1);
-        let ev1 = events.next().expect("next1").expect("stream1");
-        assert!(ev1.is_inbound());
-        assert_eq!(ev1.request_init_authority(), "localhost");
-        assert_eq!(ev1.request_init_path(), "/");
-    }
+    // Add expected tap service identity
+    env.put(
+        app::config::ENV_TAP_SVC_NAME,
+        client_proxy_authority.to_owned(),
+    );
+
+    let srv = server::http2()
+        .route_fn("/", |_req| {
+            Response::builder()
+                .header("grpc-status", "1")
+                .body(Default::default())
+                .unwrap()
+        })
+        .run();
+
+    // Run server proxy with server proxy identity service
+    let srv_proxy = proxy::new()
+        .inbound(srv)
+        .identity(srv_proxy_identity_svc)
+        .run_with_test_env(env);
+
+    // Run client proxy with client proxy identity service.
+    let client_proxy = proxy::new()
+        .outbound_ip(srv_proxy.control.unwrap())
+        .identity(client_proxy_identity.service().run())
+        .run_with_test_env(client_proxy_identity.env);
+
+    // Wait for the server proxy to become ready
+    let client = client::http2(srv_proxy.metrics, "localhost");
+    let ready = || client.request(client.request_builder("/ready").method("GET"));
+    assert_eventually!(ready().status() == http::StatusCode::OK);
+
+    let mut tap = tap::client_with_auth(client_proxy.outbound, srv_proxy_authority);
+    let events = tap.observe_with_require_id(tap::observe_request(), srv_proxy_authority);
+
+    // Send a request that will be observed via the tap client
+    let client = client::http2(srv_proxy.inbound, "localhost");
+    let res = client.request(
+        client
+            .request_builder("/")
+            .header("content-type", "application/grpc+nope"),
+    );
+    assert_eq!(res.status(), 200);
+    assert_eq!(res.headers()["grpc-status"], "1");
+    assert_eq!(res.into_body().concat2().wait().unwrap().len(), 0);
+
+    let event = events.wait().nth(2).expect("nth").expect("stream");
+
+    assert_eq!(event.response_end_eos_grpc(), 1);
 }

--- a/tests/tap.rs
+++ b/tests/tap.rs
@@ -23,7 +23,7 @@ fn tap_enabled_when_identity_enabled() {
 #[test]
 fn tap_disabled_when_identity_disabled() {
     let _ = trace_init();
-    let proxy = proxy::new().run();
+    let proxy = proxy::new().disable_identity().run();
 
     assert!(proxy.control.is_none())
 }
@@ -76,7 +76,7 @@ fn rejects_incorrect_identity_when_identity_is_expected() {
 // the Taps before the `client.get` is called.
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-fn accepts_expected_identity_when_identity_is_expected() {
+fn inbound_http1() {
     let _ = trace_init();
 
     // Setup server proxy authority and identity


### PR DESCRIPTION
### Motivation

With linkerd/linkerd2#3155 merging, proxy containers will now always have the `LINKERD2_PROXY_TAP_SVC_NAME` variable in their environment. This variable can now be reliably used to check that the client names of incoming tap requests match this value.

If the values do not match, we will always return the gRPC Unauthenticated status code. If the values do match, we will accept the connection.

If there is no client identity, we will similarly return the gRPC Unauthenticated status code.

Closes linkerd/linkerd2#3157
Closes linkerd/linkerd2#3163

Signed-off by: Kevin Leimkuhler <kleimkuhler@icloud.com>
