### PR TITLE
Add dst and route labels to request and response metrics

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -36,9 +36,9 @@ use {Addr, Conditional};
 
 use super::admin::{Admin, Readiness};
 use super::config::{Config, H2Settings};
-use super::{dst, dst::DstAddr};
 use super::identity;
 use super::profiles::Client as ProfilesClient;
+use super::{dst, dst::DstAddr};
 
 /// Runs a sidecar proxy.
 ///
@@ -243,7 +243,8 @@ where
             });
 
         let (ctl_http_metrics, ctl_http_report) = {
-            let (m, r) = http_metrics::new::<ControlLabels, dst::Route, Class>(config.metrics_retain_idle);
+            let (m, r) =
+                http_metrics::new::<ControlLabels, dst::Route, Class>(config.metrics_retain_idle);
             (m, r.with_prefix("control"))
         };
 
@@ -251,12 +252,14 @@ where
             http_metrics::new::<EndpointLabels, dst::Route, Class>(config.metrics_retain_idle);
 
         let (route_http_metrics, route_http_report) = {
-            let (m, r) = http_metrics::new::<RouteLabels, dst::Route, Class>(config.metrics_retain_idle);
+            let (m, r) =
+                http_metrics::new::<RouteLabels, dst::Route, Class>(config.metrics_retain_idle);
             (m, r.with_prefix("route"))
         };
 
         let (retry_http_metrics, retry_http_report) = {
-            let (m, r) = http_metrics::new::<RouteLabels, dst::Route, Class>(config.metrics_retain_idle);
+            let (m, r) =
+                http_metrics::new::<RouteLabels, dst::Route, Class>(config.metrics_retain_idle);
             (m, r.with_prefix("route_actual"))
         };
 
@@ -509,10 +512,14 @@ where
             let dst_route_layer = svc::builder()
                 .buffer_pending(max_in_flight, DispatchDeadline::extract)
                 .layer(classify::layer())
-                .layer(metrics::layer::<_, dst::Route, classify::Response>(route_http_metrics))
+                .layer(metrics::layer::<_, dst::Route, classify::Response>(
+                    route_http_metrics,
+                ))
                 .layer(proxy::http::timeout::layer())
                 .layer(retry::layer(retry_http_metrics.clone()))
-                .layer(metrics::layer::<_, dst::Route, classify::Response>(retry_http_metrics))
+                .layer(metrics::layer::<_, dst::Route, classify::Response>(
+                    retry_http_metrics,
+                ))
                 .layer(insert::target::layer());
 
             // Routes requests to their original destination endpoints. Used as

--- a/src/app/metric_labels.rs
+++ b/src/app/metric_labels.rs
@@ -74,6 +74,17 @@ impl From<dst::Route> for RouteLabels {
     }
 }
 
+impl FmtLabels for dst::Route {
+    fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let labels = prefix_labels("rt", self.labels().as_ref().into_iter());
+        if let Some(labels) = labels.as_ref() {
+            write!(f, "{}", labels)?;
+        }
+
+        Ok(())
+    }
+}
+
 impl FmtLabels for RouteLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.dst.fmt_labels(f)?;
@@ -171,6 +182,12 @@ impl FmtLabels for dst::DstAddr {
         }
 
         write!(f, ",dst=\"{}\"", self.as_ref())
+    }
+}
+
+impl FmtLabels for Addr {
+    fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "dst=\"{}\"", self)
     }
 }
 

--- a/src/proxy/http/metrics/mod.rs
+++ b/src/proxy/http/metrics/mod.rs
@@ -123,7 +123,7 @@ where
 impl<T, R, C> Scoped<T> for Arc<Mutex<Registry<T, R, C>>>
 where
     T: Hash + Eq,
-    R: Hash + Eq,    
+    R: Hash + Eq,
     C: Hash + Eq,
 {
     type Scope = Arc<Mutex<RequestMetrics<R, C>>>;

--- a/src/proxy/http/metrics/report.rs
+++ b/src/proxy/http/metrics/report.rs
@@ -134,7 +134,6 @@ where
         Ok(())
     }
 
-
     fn fmt_by_route<M, F>(
         &self,
         f: &mut fmt::Formatter,

--- a/src/proxy/http/metrics/report.rs
+++ b/src/proxy/http/metrics/report.rs
@@ -158,7 +158,6 @@ where
         Ok(())
     }
 
-
     fn fmt_by_status<M, F>(
         &self,
         f: &mut fmt::Formatter,

--- a/src/proxy/http/metrics/service.rs
+++ b/src/proxy/http/metrics/service.rs
@@ -144,7 +144,7 @@ where
 impl<M, K, R, C> svc::Layer<M> for Layer<K, R, C>
 where
     K: Clone + Hash + Eq,
-    R: Hash + Eq,    
+    R: Hash + Eq,
     C: ClassifyResponse + Clone + Default + Send + Sync + 'static,
     C::Class: Hash + Eq,
 {
@@ -288,7 +288,7 @@ where
                 let now = clock::now();
                 if let Ok(mut metrics) = lock.lock() {
                     (*metrics).last_update = now;
-                    
+
                     let dst_metrics = (*metrics).by_dst
                         .entry(dst.clone())
                         .or_insert_with(|| DstMetrics::default());
@@ -296,7 +296,7 @@ where
                     let route_metrics = dst_metrics.by_route
                         .entry(route.clone())
                         .or_insert_with(|| RouteMetrics::default());
-                    
+
                     route_metrics.total.incr();
 
                 }
@@ -568,7 +568,7 @@ fn measure_class<R: Hash + Eq, C: Hash + Eq>(
 impl<B, R, C> Payload for ResponseBody<B, R, C>
 where
     B: Payload,
-    R: Hash + Eq + Send + Clone + 'static, 
+    R: Hash + Eq + Send + Clone + 'static,
     C: ClassifyEos + Send + 'static,
     C::Class: Hash + Eq + Send,
 {

--- a/src/proxy/http/metrics/service.rs
+++ b/src/proxy/http/metrics/service.rs
@@ -8,10 +8,10 @@ use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio_timer::clock;
 
-use addr::Addr;
 use super::super::retry::TryClone;
 use super::classify::{ClassifyEos, ClassifyResponse};
 use super::{ClassMetrics, DstMetrics, Registry, RequestMetrics, RouteMetrics, StatusMetrics};
+use addr::Addr;
 use proxy::Error;
 use svc;
 
@@ -289,16 +289,17 @@ where
                 if let Ok(mut metrics) = lock.lock() {
                     (*metrics).last_update = now;
 
-                    let dst_metrics = (*metrics).by_dst
+                    let dst_metrics = (*metrics)
+                        .by_dst
                         .entry(dst.clone())
                         .or_insert_with(|| DstMetrics::default());
 
-                    let route_metrics = dst_metrics.by_route
+                    let route_metrics = dst_metrics
+                        .by_route
                         .entry(route.clone())
                         .or_insert_with(|| RouteMetrics::default());
 
                     route_metrics.total.incr();
-
                 }
             }
         }
@@ -399,11 +400,13 @@ where
             if let Ok(mut metrics) = lock.lock() {
                 (*metrics).last_update = now;
 
-                let dst_metrics = (*metrics).by_dst
+                let dst_metrics = (*metrics)
+                    .by_dst
                     .entry(self.dst.clone())
                     .or_insert_with(|| DstMetrics::default());
 
-                let route_metrics = dst_metrics.by_route
+                let route_metrics = dst_metrics
+                    .by_route
                     .entry(self.route.clone())
                     .or_insert_with(|| RouteMetrics::default());
 
@@ -499,11 +502,13 @@ where
 
         (*metrics).last_update = now;
 
-        let dst_metrics = metrics.by_dst
+        let dst_metrics = metrics
+            .by_dst
             .entry(self.dst.clone())
             .or_insert_with(|| DstMetrics::default());
 
-        let route_metrics = dst_metrics.by_route
+        let route_metrics = dst_metrics
+            .by_route
             .entry(self.route.clone())
             .or_insert_with(|| RouteMetrics::default());
 
@@ -519,7 +524,13 @@ where
 
     fn record_class(&mut self, class: C::Class) {
         if let Some(lock) = self.metrics.take() {
-            measure_class(&lock, class, Some(self.status), self.dst.take(), self.route.take());
+            measure_class(
+                &lock,
+                class,
+                Some(self.status),
+                self.dst.take(),
+                self.route.take(),
+            );
         }
     }
 
@@ -546,19 +557,23 @@ fn measure_class<R: Hash + Eq, C: Hash + Eq>(
 
     (*metrics).last_update = now;
 
-    let dst_metrics = metrics.by_dst
+    let dst_metrics = metrics
+        .by_dst
         .entry(dst)
         .or_insert_with(|| DstMetrics::default());
 
-    let route_metrics = dst_metrics.by_route
+    let route_metrics = dst_metrics
+        .by_route
         .entry(route)
         .or_insert_with(|| RouteMetrics::default());
 
-    let status_metrics = route_metrics.by_status
+    let status_metrics = route_metrics
+        .by_status
         .entry(status)
         .or_insert_with(|| StatusMetrics::default());
 
-    let class_metrics = status_metrics.by_class
+    let class_metrics = status_metrics
+        .by_class
         .entry(class)
         .or_insert_with(|| ClassMetrics::default());
 

--- a/src/proxy/http/profiles/mod.rs
+++ b/src/proxy/http/profiles/mod.rs
@@ -113,7 +113,7 @@ pub struct Retries {
     budget: Arc<Budget>,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 struct Labels(Arc<IndexMap<String, String>>);
 
 // === impl Route ===
@@ -278,5 +278,13 @@ impl Hash for Labels {
 impl fmt::Debug for Labels {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
+    }
+}
+
+impl Default for Labels {
+    fn default() -> Self {
+        let mut labels = IndexMap::with_capacity(1);
+        labels.insert("route".to_string(), "".to_string());
+        Self(Arc::new(labels))
     }
 }


### PR DESCRIPTION
The `request_total` and `response_total` metrics are measured in the endpoint stack and do not include a label which indicates the dst of the request.  These metrics do have an `authority` label, but this label's value is taken from the target of the endpoint stack.  In the case of a traffic-split, the `authority` label corresponds to the overridden (concrete) dst, and not to the authority of the request itself.  In order to know the logical dst of the request, a new label is needed.

We add a `dst` label by recording the target of the dst stack into the request extensions.  We then extract this value in the endpoint stack and use it as a label value.  Similarly, we also record the route (the target of the route stack) into the request extensions and then use this as a label in the endpoint stat metrics as well.  The route label is not related to traffic-splits, but seems like useful information anyway.

## Labels
```
authority: the concrete dst (authors-v1.default.svc.cluster.local:7001)
dst_service: the concrete service (authors-v1)
dst: the logical dst (authors.default.svc.cluster.local:7001) [NEW!]
rt_rotue: the logical route (GET /authors.json) [NEW!]
```

One side-effect of this change is that the default route now has a route label with an empty value.  This means that proxy metrics for requests without a route will now include the `rt_route=""` label.  Prometheus seems to filter out these empty value labels and these are not present in Prometheus.