### PR TITLE
update-rust-version: Check usage

### DIFF
--- a/update-rust-version.sh
+++ b/update-rust-version.sh
@@ -1,6 +1,13 @@
-#!/bin/bash
+#!/bin/sh
+
+set -eu
+
+if [ $# -ne 1 ]; then
+    echo "usage: $0 VERSION" >&2
+    exit 64
+fi
 
 VERSION=$1
 
-echo $VERSION > rust-toolchain
-sed -i.bak -e "s/RUST_IMAGE=.*/RUST_IMAGE=rust:$VERSION/" Dockerfile
+echo "$VERSION" > rust-toolchain
+sed -i'' -e "s/RUST_IMAGE=.*/RUST_IMAGE=rust:$VERSION/" Dockerfile


### PR DESCRIPTION
When running the update-rust-version script, it was easy to run it
without an argument, which breaks existing configuration.

This change improves the script to handle errors, with some other
shell lints addressed.