### PR TITLE
Authority label should reflect logical dst

### DIFF
--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -32,8 +32,8 @@ pub struct Retry {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DstAddr {
-    logical_dst: Addr,
-    concrete_dst: Addr,
+    dst_logical: Addr,
+    dst_concrete: Addr,
     direction: Direction,
     pub(super) http_settings: settings::Settings,
 }
@@ -106,15 +106,15 @@ impl retry::Retry for Retry {
 
 impl AsRef<Addr> for DstAddr {
     fn as_ref(&self) -> &Addr {
-        &self.concrete_dst
+        &self.dst_concrete
     }
 }
 
 impl DstAddr {
     pub fn outbound(addr: Addr, http_settings: settings::Settings) -> Self {
         DstAddr {
-            logical_dst: addr.clone(),
-            concrete_dst: addr,
+            dst_logical: addr.clone(),
+            dst_concrete: addr,
             direction: Direction::Out,
             http_settings,
         }
@@ -122,8 +122,8 @@ impl DstAddr {
 
     pub fn inbound(addr: Addr, http_settings: settings::Settings) -> Self {
         DstAddr {
-            logical_dst: addr.clone(),
-            concrete_dst: addr,
+            dst_logical: addr.clone(),
+            dst_concrete: addr,
             direction: Direction::In,
             http_settings,
         }
@@ -133,12 +133,12 @@ impl DstAddr {
         self.direction
     }
 
-    pub fn logical_dst(&self) -> &Addr {
-        &self.logical_dst
+    pub fn dst_logical(&self) -> &Addr {
+        &self.dst_logical
     }
 
-    pub fn concrete_dst(&self) -> &Addr {
-        &self.concrete_dst
+    pub fn dst_concrete(&self) -> &Addr {
+        &self.dst_concrete
     }
 }
 
@@ -150,13 +150,13 @@ impl<'t> From<&'t DstAddr> for http::header::HeaderValue {
 
 impl fmt::Display for DstAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.concrete_dst.fmt(f)
+        self.dst_concrete.fmt(f)
     }
 }
 
 impl profiles::CanGetDestination for DstAddr {
     fn get_destination(&self) -> Option<&NameAddr> {
-        self.logical_dst.name_addr()
+        self.dst_logical.name_addr()
     }
 }
 
@@ -173,7 +173,7 @@ impl profiles::WithRoute for DstAddr {
 
 impl profiles::WithAddr for DstAddr {
     fn with_addr(mut self, addr: NameAddr) -> Self {
-        self.concrete_dst = Addr::Name(addr);
+        self.dst_concrete = Addr::Name(addr);
         self
     }
 }

--- a/src/app/dst.rs
+++ b/src/app/dst.rs
@@ -32,7 +32,8 @@ pub struct Retry {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DstAddr {
-    addr: Addr,
+    logical_dst: Addr,
+    concrete_dst: Addr,
     direction: Direction,
     pub(super) http_settings: settings::Settings,
 }
@@ -105,14 +106,15 @@ impl retry::Retry for Retry {
 
 impl AsRef<Addr> for DstAddr {
     fn as_ref(&self) -> &Addr {
-        &self.addr
+        &self.concrete_dst
     }
 }
 
 impl DstAddr {
     pub fn outbound(addr: Addr, http_settings: settings::Settings) -> Self {
         DstAddr {
-            addr,
+            logical_dst: addr.clone(),
+            concrete_dst: addr,
             direction: Direction::Out,
             http_settings,
         }
@@ -120,7 +122,8 @@ impl DstAddr {
 
     pub fn inbound(addr: Addr, http_settings: settings::Settings) -> Self {
         DstAddr {
-            addr,
+            logical_dst: addr.clone(),
+            concrete_dst: addr,
             direction: Direction::In,
             http_settings,
         }
@@ -128,6 +131,14 @@ impl DstAddr {
 
     pub fn direction(&self) -> Direction {
         self.direction
+    }
+
+    pub fn logical_dst(&self) -> &Addr {
+        &self.logical_dst
+    }
+
+    pub fn concrete_dst(&self) -> &Addr {
+        &self.concrete_dst
     }
 }
 
@@ -139,13 +150,13 @@ impl<'t> From<&'t DstAddr> for http::header::HeaderValue {
 
 impl fmt::Display for DstAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.addr.fmt(f)
+        self.concrete_dst.fmt(f)
     }
 }
 
 impl profiles::CanGetDestination for DstAddr {
     fn get_destination(&self) -> Option<&NameAddr> {
-        self.addr.name_addr()
+        self.logical_dst.name_addr()
     }
 }
 
@@ -162,7 +173,7 @@ impl profiles::WithRoute for DstAddr {
 
 impl profiles::WithAddr for DstAddr {
     fn with_addr(mut self, addr: NameAddr) -> Self {
-        self.addr = Addr::Name(addr);
+        self.concrete_dst = Addr::Name(addr);
         self
     }
 }

--- a/src/app/metric_labels.rs
+++ b/src/app/metric_labels.rs
@@ -18,8 +18,8 @@ pub struct ControlLabels {
 pub struct EndpointLabels {
     direction: Direction,
     tls_id: Conditional<TlsId, tls::ReasonForNoIdentity>,
-    logical_dst: Option<NameAddr>,
-    concrete_dst: Option<NameAddr>,
+    dst_logical: Option<NameAddr>,
+    dst_concrete: Option<NameAddr>,
     labels: Option<String>,
 }
 
@@ -92,8 +92,8 @@ impl FmtLabels for RouteLabels {
 impl From<inbound::Endpoint> for EndpointLabels {
     fn from(ep: inbound::Endpoint) -> Self {
         Self {
-            logical_dst: ep.dst_name.clone(),
-            concrete_dst: ep.dst_name,
+            dst_logical: ep.dst_name.clone(),
+            dst_concrete: ep.dst_name,
             direction: Direction::In,
             tls_id: ep.tls_client_id.map(TlsId::ClientId),
             labels: None,
@@ -117,8 +117,8 @@ where
 impl From<outbound::Endpoint> for EndpointLabels {
     fn from(ep: outbound::Endpoint) -> Self {
         Self {
-            logical_dst: ep.logical_dst,
-            concrete_dst: ep.concrete_dst,
+            dst_logical: ep.dst_logical,
+            dst_concrete: ep.dst_concrete,
             direction: Direction::Out,
             tls_id: ep.identity.as_ref().map(|id| TlsId::ServerId(id.clone())),
             labels: prefix_labels("dst", ep.metadata.labels().into_iter()),
@@ -128,7 +128,7 @@ impl From<outbound::Endpoint> for EndpointLabels {
 
 impl FmtLabels for EndpointLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let authority = self.logical_dst.as_ref().map(Authority);
+        let authority = self.dst_logical.as_ref().map(Authority);
         (authority, &self.direction).fmt_labels(f)?;
 
         if let Some(labels) = self.labels.as_ref() {


### PR DESCRIPTION
Supersedes https://github.com/linkerd/linkerd2-proxy/pull/296

The authority label reflects the concrete dst of the request in the endpoint stack.  In the case of a traffic split, this may be different from the actual authority of the request (i.e. the logical dst).

We add the logical dst as a field on the endpoint target and use this value for the authority label instead of the concrete dst.

The net result is that the authority field reflects the apex service of a traffic split and the `dst_service` label reflects the leaf service.  

E.g.:

```
response_total{authority="authors.default.svc.cluster.local:7001",direction="outbound",dst_control_plane_ns="linkerd",dst_deployment="authors-v2",dst_namespace="default",dst_pod="authors-v2-7cffd4894-crhbw",dst_pod_template_hash="7cffd4894",dst_service="authors-v2",dst_serviceaccount="default",tls="true",server_id="default.default.serviceaccount.identity.linkerd.cluster.local",status_code="201",classification="success"} 5
```

This PR can be tested with the `alex-dst-metrics-4` proxy tag.