### PR TITLE
Replace futures_watch with tokio::sync::watch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,15 +282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-watch"
-version = "0.1.0"
-source = "git+https://github.com/carllerche/better-future#07baa13e91fefe7a51533dfde7b4e69e109ebe14"
-dependencies = [
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "gzip-header"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,7 +494,6 @@ dependencies = [
  "flate2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-mpsc-lossy 0.1.0",
- "futures-watch 0.1.0 (git+https://github.com/carllerche/better-future)",
  "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -595,7 +585,6 @@ name = "linkerd2-stack"
 version = "0.1.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures-watch 0.1.0 (git+https://github.com/carllerche/better-future)",
  "linkerd2-never 0.1.0",
  "linkerd2-task 0.1.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1955,7 +1944,6 @@ dependencies = [
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "62941eff9507c8177d448bd83a44d9b9760856e184081d8cd79ba9f03dd24981"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum futures-watch 0.1.0 (git+https://github.com/carllerche/better-future)" = "<none>"
 "checksum gzip-header 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0a9fcfe1c9ee125342355b2467bc29b9dfcb2124fcae27edb9cee6f4cc5ecd40"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", re
 
 bytes = "0.4"
 futures = "0.1"
-futures-watch = { git = "https://github.com/carllerche/better-future" }
 h2 = "0.1.15"
 http = "0.1"
 http-body = "0.1"

--- a/lib/stack/Cargo.toml
+++ b/lib/stack/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 log = "0.4.1"
 futures = "0.1"
-futures-watch = { git = "https://github.com/carllerche/better-future" }
 linkerd2-never = { path = "../never" }
 tower-layer = "0.1"
 tower-service = "0.2"

--- a/src/app/identity.rs
+++ b/src/app/identity.rs
@@ -1,14 +1,12 @@
+use api::identity as api;
 use futures::{Async, Future, Poll};
-use futures_watch::{Store, Watch};
+pub use identity::{Crt, CrtKey, Csr, InvalidName, Key, Name, TokenSource, TrustAnchors};
+use never::Never;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::sync::watch;
 use tokio_timer::{clock, Delay};
 use tower_grpc::{self as grpc, generic::client::GrpcService, BoxBody};
-
-use api::identity as api;
-use never::Never;
-
-pub use identity::{Crt, CrtKey, Csr, InvalidName, Key, Name, TokenSource, TrustAnchors};
 use transport::tls;
 
 /// Configures the Identity service and local identity.
@@ -31,7 +29,7 @@ pub struct Config {
 pub struct Local {
     trust_anchors: TrustAnchors,
     name: Name,
-    crt_key: Watch<Option<CrtKey>>,
+    crt_key: watch::Receiver<Option<CrtKey>>,
 }
 
 /// Produces a `Local` identity once a certificate is available.
@@ -41,7 +39,7 @@ pub struct AwaitCrt(Option<Local>);
 #[derive(Copy, Clone, Debug)]
 pub struct LostDaemon;
 
-pub type CrtKeyStore = Store<Option<CrtKey>>;
+pub type CrtKeySender = watch::Sender<Option<CrtKey>>;
 
 /// Drives updates.
 pub struct Daemon<T>
@@ -51,7 +49,7 @@ where
 {
     config: Config,
     client: api::client::Identity<T>,
-    crt_key: Store<Option<CrtKey>>,
+    crt_key: watch::Sender<Option<CrtKey>>,
     expiry: SystemTime,
     inner: Inner<T>,
 }
@@ -94,8 +92,8 @@ impl Config {
 // === impl Local ===
 
 impl Local {
-    pub fn new(config: &Config) -> (Self, CrtKeyStore) {
-        let (w, s) = Watch::new(None);
+    pub fn new(config: &Config) -> (Self, CrtKeySender) {
+        let (s, w) = watch::channel(None);
         let l = Local {
             name: config.local_name.clone(),
             trust_anchors: config.trust_anchors.clone(),
@@ -115,7 +113,7 @@ impl Local {
 
 impl tls::client::HasConfig for Local {
     fn tls_client_config(&self) -> Arc<tls::client::Config> {
-        if let Some(ref c) = *self.crt_key.borrow() {
+        if let Some(ref c) = *self.crt_key.get_ref() {
             return c.tls_client_config();
         }
 
@@ -129,7 +127,7 @@ impl tls::listen::HasConfig for Local {
     }
 
     fn tls_server_config(&self) -> Arc<tls::listen::Config> {
-        if let Some(ref c) = *self.crt_key.borrow() {
+        if let Some(ref c) = *self.crt_key.get_ref() {
             return c.tls_server_config();
         }
 
@@ -143,7 +141,7 @@ impl<T> Daemon<T>
 where
     T: GrpcService<BoxBody> + Clone,
 {
-    pub fn new(config: Config, crt_key: CrtKeyStore, client: T) -> Self {
+    pub fn new(config: Config, crt_key: CrtKeySender, client: T) -> Self {
         Self {
             config,
             crt_key,
@@ -226,7 +224,7 @@ where
                                         }
                                         Ok(crt_key) => {
                                             debug!("daemon certified until {:?}", expiry);
-                                            if self.crt_key.store(Some(crt_key)).is_err() {
+                                            if self.crt_key.broadcast(Some(crt_key)).is_err() {
                                                 // If we can't store a value, than all observations
                                                 // have been dropped and we can stop refreshing.
                                                 return Ok(Async::Ready(()));
@@ -258,20 +256,19 @@ impl Future for AwaitCrt {
     type Error = LostDaemon;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        use futures::Stream;
-
         let mut local = self.0.take().expect("polled after ready");
         loop {
-            if (*local.crt_key.borrow()).is_some() {
+            if (*local.crt_key.get_ref()).is_some() {
                 return Ok(Async::Ready(local));
             }
 
-            match local.crt_key.poll() {
+            let poll = local.crt_key.poll_ref().map(|a| a.map(|v| v.map(|_| ())));
+            match poll {
+                Ok(Async::Ready(Some(()))) => {} // continue
                 Ok(Async::NotReady) => {
                     self.0 = Some(local);
                     return Ok(Async::NotReady);
                 }
-                Ok(Async::Ready(Some(()))) => {} // continue
                 Err(_) | Ok(Async::Ready(None)) => return Err(LostDaemon),
             }
         }

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -59,7 +59,7 @@ pub struct Main<G> {
 
 struct ProxyParts<G> {
     config: Config,
-    identity: tls::Conditional<(identity::Local, identity::CrtKeyStore)>,
+    identity: tls::Conditional<(identity::Local, identity::CrtKeySender)>,
 
     start_time: SystemTime,
     trace_level: trace::LevelHandle,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ extern crate bytes;
 #[macro_use]
 extern crate futures;
 extern crate futures_mpsc_lossy;
-extern crate futures_watch;
 extern crate h2;
 extern crate http;
 extern crate http_body;


### PR DESCRIPTION
The `futures_watch` crate is superceded by `tokio::sync::watch`.

This change replaces our single usage of a watch.