### PR TITLE
Hangup destination resolutions when dropped

### DIFF
--- a/src/control/destination/resolution.rs
+++ b/src/control/destination/resolution.rs
@@ -190,12 +190,12 @@ where
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         match self.updater.hangup.poll() {
             Ok(Async::Ready(never)) => match never {}, // unreachable!
-            Ok(Async::NotReady) => {},
+            Ok(Async::NotReady) => {}
             Err(_) => {
                 // Hangup tx has been dropped.
                 debug!("resolution cancelled");
                 return Ok(Async::Ready(()));
-            },
+            }
         };
 
         loop {


### PR DESCRIPTION
When destinations idle out of the router cache, the corresponding destination lookup is not cancelled.  This can lead to a build-up of many subscriptions as entries idle out of the cache and are later re-added.  As these subscriptions accumulate, memory usage of the destination service grows, manifesting as a memory leak.

We use a hangup oneshot so that when the resolution is dropped, the daemon will be notified and will terminate.

Signed-off-by: Alex Leong <alex@buoyant.io>