### PR TITLE
logging: format log records consistently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -529,9 +529,9 @@ dependencies = [
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-spawn-ready 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)",
- "tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-fmt 0.0.1-alpha.2 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-futures 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)",
  "trust-dns-resolver 0.10.2 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)",
  "try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -569,7 +569,7 @@ dependencies = [
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -593,7 +593,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -630,6 +630,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -787,7 +795,7 @@ dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1014,18 +1022,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "regex-syntax"
-version = "0.6.0"
+name = "regex-automata"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "remove_dir_all"
@@ -1117,11 +1132,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.6.3"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "socket2"
@@ -1641,16 +1653,16 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1658,8 +1670,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-fmt"
-version = "0.1.0"
-source = "git+https://github.com/tokio-rs/tracing#f4752ff724040aa3aec924059933fdd3b4720890"
+version = "0.0.1-alpha.2"
+source = "git+https://github.com/tokio-rs/tracing#acd7713cce2034090c20db8f063bcbad2af6b140"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1668,36 +1680,42 @@ dependencies = [
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
 name = "tracing-futures"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tracing#f4752ff724040aa3aec924059933fdd3b4720890"
+version = "0.0.1-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-log"
 version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tracing#f4752ff724040aa3aec924059933fdd3b4720890"
+source = "git+https://github.com/tokio-rs/tracing#acd7713cce2034090c20db8f063bcbad2af6b140"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.0.1-alpha.2 (git+https://github.com/tokio-rs/tracing)",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tracing#f4752ff724040aa3aec924059933fdd3b4720890"
+version = "0.0.1-alpha.2"
+source = "git+https://github.com/tokio-rs/tracing#acd7713cce2034090c20db8f063bcbad2af6b140"
 dependencies = [
- "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1712,7 +1730,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1736,7 +1754,7 @@ dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-proto 0.6.0 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)",
 ]
@@ -1744,11 +1762,6 @@ dependencies = [
 [[package]]
 name = "try-lock"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "ucd-util"
-version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1959,6 +1972,7 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
+"checksum matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
@@ -2003,7 +2017,8 @@ dependencies = [
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
-"checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
+"checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
+"checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
 "checksum remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc5b3ce5d5ea144bb04ebd093a9e14e9765bcfec866aecda9b6dec43b3d1e24"
 "checksum resolv-conf 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e1b086bb6a2659d6ba66e4aa21bde8a53ec03587cd5c80b83bdc3a330f35cab"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
@@ -2015,7 +2030,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum slab 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f9776d6b986f77b35c6cf846c11ad986ff128fe0b2b63a3628e3755e8d3102d"
-"checksum smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "26df3bb03ca5eac2e64192b723d51f56c1b1e0860e7c766281f4598f181acdc8"
+"checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum socket2 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ff606e0486e88f5fc6cfeb3966e434fb409abbc7a3ab495238f70a1ca97f789d"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
@@ -2062,16 +2077,15 @@ dependencies = [
 "checksum tower-spawn-ready 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-timeout 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "daa179ec4087589dc67148dc661abce5badc2c3ed4197adc7bd64b39f1f33c31"
 "checksum tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4792342fac093db5d2558655055a89a04ca909663467a4310c7739d9f8b64698"
-"checksum tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9bb7fc03e49466b8388752c8b23856f0ae0782d4bbc0e0320430e9f62933a998"
-"checksum tracing-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "647b17ee356f69ed05528260776c8beccfca65fc19a3b484e95ac0ef9ba68080"
-"checksum tracing-fmt 0.1.0 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-futures 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9509c828e884d3289fb843055b1462be5f5b54e4b1f21d39e6cc465fe861f4fc"
+"checksum tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b15b1e1f124b19a23d87d54613077bf5249e5f13a5cd39e2f2a50afef938ca05"
+"checksum tracing-fmt 0.0.1-alpha.2 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-futures 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08c7446f4fb35df7ba2c537b7e2f812f91b20a58aa2b846f028342c4d2429be0"
 "checksum tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-subscriber 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-subscriber 0.0.1-alpha.2 (git+https://github.com/tokio-rs/tracing)" = "<none>"
 "checksum trust-dns-proto 0.6.0 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)" = "<none>"
 "checksum trust-dns-resolver 0.10.2 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)" = "<none>"
 "checksum try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "119b532a17fbe772d360be65617310164549a07c25a1deab04c84168ce0d4545"
-"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
 "checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,6 +451,9 @@ dependencies = [
 name = "lazy_static"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
@@ -472,7 +475,7 @@ dependencies = [
  "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -529,10 +532,10 @@ dependencies = [
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-spawn-ready 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-fmt 0.0.1-alpha.2 (git+https://github.com/tokio-rs/tracing)",
+ "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-fmt 0.0.1-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-futures 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-log 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-resolver 0.10.2 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)",
  "try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -569,7 +572,7 @@ dependencies = [
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -593,7 +596,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1653,25 +1656,38 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-attributes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-fmt"
-version = "0.0.1-alpha.2"
-source = "git+https://github.com/tokio-rs/tracing#acd7713cce2034090c20db8f063bcbad2af6b140"
+version = "0.0.1-alpha.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1680,8 +1696,8 @@ dependencies = [
  "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-log 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1691,31 +1707,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-log"
-version = "0.0.1"
-source = "git+https://github.com/tokio-rs/tracing#acd7713cce2034090c20db8f063bcbad2af6b140"
+version = "0.0.1-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-subscriber 0.0.1-alpha.2 (git+https://github.com/tokio-rs/tracing)",
+ "tracing-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.0.1-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-subscriber"
 version = "0.0.1-alpha.2"
-source = "git+https://github.com/tokio-rs/tracing#acd7713cce2034090c20db8f063bcbad2af6b140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2077,12 +2093,13 @@ dependencies = [
 "checksum tower-spawn-ready 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-timeout 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "daa179ec4087589dc67148dc661abce5badc2c3ed4197adc7bd64b39f1f33c31"
 "checksum tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4792342fac093db5d2558655055a89a04ca909663467a4310c7739d9f8b64698"
-"checksum tracing 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9509c828e884d3289fb843055b1462be5f5b54e4b1f21d39e6cc465fe861f4fc"
-"checksum tracing-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b15b1e1f124b19a23d87d54613077bf5249e5f13a5cd39e2f2a50afef938ca05"
-"checksum tracing-fmt 0.0.1-alpha.2 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b3dd549612b88fd19635628c1e6773f557ac419eece8deaefab1295928324d"
+"checksum tracing-attributes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "af9da7f5256f2d11e322c9f10ba848a3eefae64f0272df5e7100dcda53892801"
+"checksum tracing-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a092e91612f25f6571c7bff934e1157b708f2b09e229fdc7760e791e1d2fd74f"
+"checksum tracing-fmt 0.0.1-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b7dced65cefbb0445d76d28d023be32527d6b96ef02b2db9b65d1632d293cc7"
 "checksum tracing-futures 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08c7446f4fb35df7ba2c537b7e2f812f91b20a58aa2b846f028342c4d2429be0"
-"checksum tracing-log 0.0.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
-"checksum tracing-subscriber 0.0.1-alpha.2 (git+https://github.com/tokio-rs/tracing)" = "<none>"
+"checksum tracing-log 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5e73cad5d3da047803f3714aa0a34b47aee03e1e321e22968783dfc0208b97"
+"checksum tracing-subscriber 0.0.1-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d00a4e1771dca8725b0e1630397d85eff67ac7632c999877562b65304dea04c6"
 "checksum trust-dns-proto 0.6.0 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)" = "<none>"
 "checksum trust-dns-resolver 0.10.2 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)" = "<none>"
 "checksum try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "119b532a17fbe772d360be65617310164549a07c25a1deab04c84168ce0d4545"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,9 @@ trust-dns-resolver = { git = "https://github.com/bluejekyll/trust-dns", rev = "7
 
 # tracing
 tracing         = "0.1.3"
-tracing-fmt     = { git = "https://github.com/tokio-rs/tracing" }
+tracing-fmt     = "0.0.1-alpha.3"
 tracing-futures = "0.0.1-alpha.1"
-tracing-log     = { git = "https://github.com/tokio-rs/tracing" }
+tracing-log     = "0.0.1-alpha.1"
 
 # tls
 ring = "0.14.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,9 +69,10 @@ tower-grpc             = { git = "https://github.com/tower-rs/tower-grpc", defau
 # FIXME update to a release when available (>0.11)
 trust-dns-resolver = { git = "https://github.com/bluejekyll/trust-dns", rev = "7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060", default-features = false }
 
-tracing         = "0.1.2"
+# tracing
+tracing         = "0.1.3"
 tracing-fmt     = { git = "https://github.com/tokio-rs/tracing" }
-tracing-futures = { git = "https://github.com/tokio-rs/tracing" }
+tracing-futures = "0.0.1-alpha.1"
 tracing-log     = { git = "https://github.com/tokio-rs/tracing" }
 
 # tls

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -20,12 +20,12 @@ pub mod trace {
     pub use tracing::*;
     pub use tracing_fmt::*;
 
-    type SubscriberBuilder = Builder<default::NewRecorder, Format, filter::EnvFilter>;
+    type SubscriberBuilder = Builder<format::NewRecorder, Format, filter::EnvFilter>;
     pub type Error = Box<dyn error::Error + Send + Sync + 'static>;
 
     #[derive(Clone)]
     pub struct LevelHandle {
-        inner: filter::reload::Handle<filter::EnvFilter, default::NewRecorder>,
+        inner: filter::reload::Handle<filter::EnvFilter, format::NewRecorder>,
     }
 
     /// Initialize tracing and logging with the value of the `ENV_LOG`
@@ -44,9 +44,7 @@ pub mod trace {
         let handle = builder.reload_handle();
         let dispatch = Dispatch::new(builder.finish());
         dispatcher::set_global_default(dispatch)?;
-        let logger = tracing_log::LogTracer::with_filter(log::LevelFilter::max());
-        log::set_boxed_logger(Box::new(logger))?;
-        log::set_max_level(log::LevelFilter::max());
+        tracing_log::LogTracer::init()?;
 
         Ok(LevelHandle { inner: handle })
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -69,7 +69,12 @@ pub mod trace {
             f: &mut dyn fmt::Write,
             event: &Event<'_>,
         ) -> fmt::Result {
-            let meta = event.metadata();
+            use tracing_log::NormalizeEvent;
+            // If the event was converted from a `log` record, use the
+            // normalized tracing metadata for that log record.
+            let norm_meta = event.normalized_metadata();
+            let meta = norm_meta.as_ref().unwrap_or_else(|| event.metadata());
+
             let level = match meta.level() {
                 &Level::TRACE => "TRCE",
                 &Level::DEBUG => "DBUG",


### PR DESCRIPTION
An upstream change tokio-rs/tracing#108 changed how `tracing` represents
`Event`s that are converted from `log::Record`s, so that metadata is
represented as fields on the event rather than as `tracing::Metadata`
This resulted in log records being formatted differently from `tracing`
events in the proxy's log output, with a format that was much harder to
read than the normal formatting for events.

This branch updates the tracing dependency versions, and uses new APIs
added in tokio-rs/tracing#193 to normalize this metadata so that it is
formatted consistently with other events.

Log records, such as those from `h2`, were previously formatted like this:
```
TRCE [     0.662591s] log schedule_pending_open log.target="h2::proto::streams::prioritize" log.module_path="h2::proto::streams::prioritize" log.file="/Users/eliza/.cargo/registry/src/github.com-1ecc6299db9ec823/h2-0.1.26/src/proto/streams/prioritize.rs" log.line=822
TRCE [     0.662623s] admin={client=control dst=127.0.0.1:51168 remote=127.0.0.1:51168} log   assigning; stream=StreamId(11), capacity=49 log.target="h2::proto::streams::prioritize" log.module_path="h2::proto::streams::prioritize" log.file="/Users/eliza/.cargo/registry/src/github.com-1ecc6299db9ec823/h2-0.1.26/src/proto/streams/prioritize.rs" log.line=421
TRCE [     0.662689s] log pop_frame log.target="h2::proto::streams::prioritize" log.module_path="h2::proto::streams::prioritize" log.file="/Users/eliza/.cargo/registry/src/github.com-1ecc6299db9ec823/h2-0.1.26/src/proto/streams/prioritize.rs" log.line=661
TRCE [     0.662723s] admin={client=control dst=127.0.0.1:51168 remote=127.0.0.1:51168} log   assigned capacity to stream; available=50; buffered=50; id=StreamId(11) log.target="h2::proto::streams::stream" log.module_path="h2::proto::streams::stream" log.file="/Users/eliza/.cargo/registry/src/github.com-1ecc6299db9ec823/h2-0.1.26/src/proto/streams/stream.rs" log.line=249
TRCE [     0.662748s] log flush log.target="h2::codec::framed_write" log.module_path="h2::codec::framed_write" log.file="/Users/eliza/.cargo/registry/src/github.com-1ecc6299db9ec823/h2-0.1.26/src/codec/framed_write.rs" log.line=172
TRCE [     0.662831s] admin={client=control dst=127.0.0.1:51168 remote=127.0.0.1:51168} log try_assign_capacity(2); available=50; requested=50; buffered=50; has_unavailable=true log.target="h2::proto::streams::prioritize" log.module_path="h2::proto::streams::prioritize" log.file="/Users/eliza/.cargo/registry/src/github.com-1ecc6299db9ec823/h2-0.1.26/src/proto/streams/prioritize.rs" log.line=434
```

Now, they look like this:
```
TRCE [     0.258741s] h2::proto::streams::prioritize schedule_pending_open
TRCE [     0.258756s] h2::proto::streams::prioritize pop_frame
TRCE [     0.258753s] admin={client=control dst=127.0.0.1:53876 remote=127.0.0.1:53876} h2::proto::streams::counts transition_after; stream=StreamId(27); state=State { inner: HalfClosedLocal(AwaitingHeaders) }; is_closed=false; pending_send_empty=true; buffered_send_data=0; num_recv=0; num_send=1
TRCE [     0.258769s] h2::codec::framed_write flush
TRCE [     0.258784s] h2::codec::framed_write flushing buffer
````