### PR TITLE
tests: Update to Rust 2018

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,7 @@ dependencies = [
  "linkerd2-dns-name 0.1.0",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.19.1 (git+https://github.com/seanmonstar/webpki?branch=cert-dns-names)",
 ]
@@ -626,7 +626,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -1,7 +1,9 @@
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "128"]
+
 #[macro_use]
 mod support;
+
 use self::support::*;
 
 macro_rules! generate_tests {

--- a/tests/identity.rs
+++ b/tests/identity.rs
@@ -1,9 +1,10 @@
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "128"]
+
 #[macro_use]
 mod support;
-use self::support::*;
 
+use self::support::*;
 use std::{
     sync::{
         atomic::{AtomicBool, Ordering},

--- a/tests/profile_dst_overrides.rs
+++ b/tests/profile_dst_overrides.rs
@@ -1,10 +1,10 @@
+#![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "128"]
-#![deny(warnings)]
+
 mod support;
+
 use self::support::*;
-
 use std::sync::atomic::{AtomicUsize, Ordering};
-
 use linkerd2_proxy_api::destination as pb;
 
 struct Service {

--- a/tests/profile_dst_overrides.rs
+++ b/tests/profile_dst_overrides.rs
@@ -4,8 +4,8 @@
 mod support;
 
 use self::support::*;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use linkerd2_proxy_api::destination as pb;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 struct Service {
     name: &'static str,

--- a/tests/profiles.rs
+++ b/tests/profiles.rs
@@ -1,5 +1,5 @@
+#![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "128"]
-#![deny(warnings)]
 mod support;
 use self::support::*;
 

--- a/tests/shutdown.rs
+++ b/tests/shutdown.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "128"]
 mod support;
 use self::support::*;

--- a/tests/support/client.rs
+++ b/tests/support/client.rs
@@ -1,12 +1,12 @@
 use crate::support::*;
-use std::io;
-use std::sync::Mutex;
+use bytes::IntoBuf;
 use futures::sync::{mpsc, oneshot};
+use rustls::{ClientConfig, ClientSession};
+use std::io;
+use std::sync::Arc;
+use std::sync::Mutex;
 use tokio::net::TcpStream;
 use webpki::{DNSName, DNSNameRef};
-use bytes::IntoBuf;
-use rustls::{ClientConfig, ClientSession};
-use std::sync::Arc;
 
 type ClientError = hyper::Error;
 type Request = http::Request<Bytes>;

--- a/tests/support/controller.rs
+++ b/tests/support/controller.rs
@@ -1,13 +1,10 @@
-use crate::support::bytes::IntoBuf;
-use crate::support::hyper::body::Payload;
+use bytes::IntoBuf;
+use hyper::body::Payload;
 use crate::support::*;
-// use crate::support::tokio::executor::Executor as _TokioExecutor;
-
 use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
 use std::ops::{Bound, DerefMut, RangeBounds};
 use std::sync::{Arc, Mutex};
-
 use linkerd2_proxy_api::destination as pb;
 use linkerd2_proxy_api::net;
 
@@ -291,7 +288,7 @@ impl pb::server::Destination for Controller {
 pub(in crate::support) fn run<T, B>(
     svc: T,
     name: &'static str,
-    delay: Option<Box<Future<Item = (), Error = ()> + Send>>,
+    delay: Option<Box<dyn Future<Item = (), Error = ()> + Send>>,
 ) -> Listening
 where
     T: Service<http::Request<tower_grpc::BoxBody>, Response = http::Response<B>>,

--- a/tests/support/controller.rs
+++ b/tests/support/controller.rs
@@ -1,12 +1,12 @@
+use crate::support::*;
 use bytes::IntoBuf;
 use hyper::body::Payload;
-use crate::support::*;
+use linkerd2_proxy_api::destination as pb;
+use linkerd2_proxy_api::net;
 use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
 use std::ops::{Bound, DerefMut, RangeBounds};
 use std::sync::{Arc, Mutex};
-use linkerd2_proxy_api::destination as pb;
-use linkerd2_proxy_api::net;
 
 pub fn new() -> Controller {
     Controller::new()

--- a/tests/support/identity.rs
+++ b/tests/support/identity.rs
@@ -25,9 +25,9 @@ pub struct Controller {
 type Certify = Box<
     dyn FnMut(
             pb::CertifyRequest,
-        )
-            -> Box<dyn Future<Item = grpc::Response<pb::CertifyResponse>, Error = grpc::Status> + Send>
-        + Send,
+        ) -> Box<
+            dyn Future<Item = grpc::Response<pb::CertifyResponse>, Error = grpc::Status> + Send,
+        > + Send,
 >;
 
 const TLS_VERSIONS: &[rustls::ProtocolVersion] = &[rustls::ProtocolVersion::TLSv1_2];

--- a/tests/support/identity.rs
+++ b/tests/support/identity.rs
@@ -23,10 +23,10 @@ pub struct Controller {
 }
 
 type Certify = Box<
-    FnMut(
+    dyn FnMut(
             pb::CertifyRequest,
         )
-            -> Box<Future<Item = grpc::Response<pb::CertifyResponse>, Error = grpc::Status> + Send>
+            -> Box<dyn Future<Item = grpc::Response<pb::CertifyResponse>, Error = grpc::Status> + Send>
         + Send,
 >;
 
@@ -219,7 +219,7 @@ impl Controller {
 
 impl pb::server::Identity for Controller {
     type CertifyFuture =
-        Box<Future<Item = grpc::Response<pb::CertifyResponse>, Error = grpc::Status> + Send>;
+        Box<dyn Future<Item = grpc::Response<pb::CertifyResponse>, Error = grpc::Status> + Send>;
     fn certify(&mut self, req: grpc::Request<pb::CertifyRequest>) -> Self::CertifyFuture {
         if let Some(mut f) = self.expect_calls.lock().unwrap().pop_front() {
             return f(req.into_inner());

--- a/tests/support/proxy.rs
+++ b/tests/support/proxy.rs
@@ -23,7 +23,7 @@ pub struct Proxy {
     inbound_disable_ports_protocol_detection: Option<Vec<u16>>,
     outbound_disable_ports_protocol_detection: Option<Vec<u16>>,
 
-    shutdown_signal: Option<Box<Future<Item = (), Error = ()> + Send>>,
+    shutdown_signal: Option<Box<dyn Future<Item = (), Error = ()> + Send>>,
 }
 
 pub struct Listening {
@@ -149,7 +149,7 @@ struct DstInner {
 }
 
 impl linkerd2_proxy::transport::GetOriginalDst for MockOriginalDst {
-    fn get_original_dst(&self, sock: &transport::AddrInfo) -> Option<SocketAddr> {
+    fn get_original_dst(&self, sock: &dyn transport::AddrInfo) -> Option<SocketAddr> {
         sock.local_addr().ok().and_then(|local| {
             let inner = self.0.lock().unwrap();
             if inner.inbound_local_addr == Some(local) {

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -1,5 +1,5 @@
-use futures::future::Either;
 use crate::support::*;
+use futures::future::Either;
 use rustls::{ServerConfig, ServerSession};
 use std::collections::HashMap;
 use std::io;

--- a/tests/support/server.rs
+++ b/tests/support/server.rs
@@ -1,7 +1,4 @@
-use self::tokio::net::TcpStream;
-use self::tokio_rustls::TlsAcceptor;
-use self::RunningIo;
-use crate::support::futures::future::Either;
+use futures::future::Either;
 use crate::support::*;
 use rustls::{ServerConfig, ServerSession};
 use std::collections::HashMap;
@@ -9,6 +6,9 @@ use std::io;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
+use tokio::net::TcpStream;
+use tokio_rustls::TlsAcceptor;
+use RunningIo;
 
 pub fn new() -> Server {
     http2()
@@ -137,7 +137,7 @@ impl Server {
         self.run_inner(None)
     }
 
-    fn run_inner(self, delay: Option<Box<Future<Item = (), Error = ()> + Send>>) -> Listening {
+    fn run_inner(self, delay: Option<Box<dyn Future<Item = (), Error = ()> + Send>>) -> Listening {
         let (tx, rx) = shutdown_signal();
         let (listening_tx, listening_rx) = oneshot::channel();
         let mut listening_tx = Some(listening_tx);

--- a/tests/support/tap.rs
+++ b/tests/support/tap.rs
@@ -188,7 +188,7 @@ where
 {
     type Response = http::Response<client::BytesBody>;
     type Error = String;
-    type Future = Box<Future<Item = Self::Response, Error = Self::Error> + Send>;
+    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error> + Send>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         unreachable!("tap SyncSvc poll_ready");

--- a/tests/tap.rs
+++ b/tests/tap.rs
@@ -1,7 +1,8 @@
+#![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "128"]
-#![deny(warnings)]
-#[macro_use]
+
 mod support;
+
 use self::support::*;
 use crate::support::tap::TapEventExt;
 use std::time::SystemTime;

--- a/tests/telemetry.rs
+++ b/tests/telemetry.rs
@@ -1,14 +1,11 @@
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "128"]
-#[macro_use]
-extern crate log;
-extern crate flate2;
-extern crate regex;
 
 #[macro_use]
 mod support;
+
 use self::support::*;
-use crate::support::bytes::IntoBuf;
+use bytes::IntoBuf;
 use std::io::Read;
 
 struct Fixture {
@@ -147,6 +144,7 @@ fn metrics_endpoint_outbound_request_count() {
 mod response_classification {
     use super::support::*;
     use super::Fixture;
+    use tracing::info;
 
     const REQ_STATUS_HEADER: &'static str = "x-test-status-requested";
     const REQ_GRPC_STATUS_HEADER: &'static str = "x-test-grpc-status-requested";

--- a/tests/transparency.rs
+++ b/tests/transparency.rs
@@ -1,4 +1,4 @@
-#![deny(warnings)]
+#![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "128"]
 #[macro_use]
 mod support;


### PR DESCRIPTION
When updating the repo to Rust 2018, some of the test modules were left
without the proper updates.