### PR TITLE
Introduce linkerd2-proxy-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "linkerd2-metrics 0.1.0",
  "linkerd2-never 0.1.0",
  "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=ddbc3a4f7f8b0058801f896d27974d19ee98094c)",
+ "linkerd2-proxy-core 0.1.0",
  "linkerd2-router 0.1.0",
  "linkerd2-signal 0.1.0",
  "linkerd2-stack 0.1.0",
@@ -603,6 +604,10 @@ dependencies = [
  "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
  "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
 ]
+
+[[package]]
+name = "linkerd2-proxy-core"
+version = "0.1.0"
 
 [[package]]
 name = "linkerd2-router"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "lib/linkerd2-drain",
     "lib/linkerd2-identity",
     "lib/linkerd2-metrics",
+    "lib/linkerd2-proxy-core",
     "lib/linkerd2-router",
     "lib/linkerd2-signal",
     "lib/linkerd2-stack",
@@ -36,6 +37,7 @@ linkerd2-drain       = { path = "lib/linkerd2-drain" }
 linkerd2-identity    = { path = "lib/linkerd2-identity" }
 linkerd2-metrics     = { path = "lib/linkerd2-metrics" }
 linkerd2-never       = { path = "lib/linkerd2-never" }
+linkerd2-proxy-core  = { path = "lib/linkerd2-proxy-core" }
 linkerd2-router      = { path = "lib/linkerd2-router" }
 linkerd2-signal      = { path = "lib/linkerd2-signal" }
 linkerd2-stack       = { path = "lib/linkerd2-stack" }

--- a/lib/linkerd2-proxy-core/Cargo.toml
+++ b/lib/linkerd2-proxy-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "linkerd2-proxy-core"
+version = "0.1.0"
+authors = ["Oliver Gould <ver@buoyant.io>"]
+edition = "2018"
+publish = false
+
+[dependencies]

--- a/lib/linkerd2-proxy-core/src/lib.rs
+++ b/lib/linkerd2-proxy-core/src/lib.rs
@@ -1,0 +1,4 @@
+#![deny(warnings, rust_2018_idioms)]
+
+/// A dynamic error type.
+pub type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/src/app/admin/mod.rs
+++ b/src/app/admin/mod.rs
@@ -3,10 +3,10 @@
 //! * `/metrics` -- reports prometheus-formatted metrics.
 //! * `/ready` -- returns 200 when the proxy is ready to participate in meshed traffic.
 
+use crate::metrics;
 use futures::future::{self, Future};
 use http::StatusCode;
 use hyper::{service::Service, Body, Request, Response};
-use linkerd2_metrics as metrics;
 use std::io;
 mod readiness;
 mod trace_level;
@@ -82,8 +82,8 @@ fn rsp(status: StatusCode, body: impl Into<Body>) -> Response<Body> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::task::test_util::BlockOnFor;
     use http::method::Method;
-    use linkerd2_task::test_util::BlockOnFor;
     use std::time::Duration;
     use tokio::runtime::current_thread::Runtime;
 

--- a/src/app/classify.rs
+++ b/src/app/classify.rs
@@ -1,10 +1,9 @@
 pub use crate::proxy::http::metrics::classify::{self, layer, CanClassify};
 use crate::proxy::http::{profiles, timeout, HasH2Reason};
+use crate::Error;
 use http;
 use std::borrow::Cow;
 use tracing::trace;
-
-type Error = Box<dyn std::error::Error + Send + Sync>;
 
 #[derive(Clone, Debug)]
 pub enum Request {

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,10 +1,10 @@
 use super::control::ControlAddr;
 use super::identity;
+use crate::addr::{self, Addr};
 use crate::proxy::reconnect::Backoff;
 use crate::transport::tls;
 use crate::{dns, Conditional};
 use indexmap::IndexSet;
-use linkerd2_addr::{self as addr, Addr};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::iter::FromIterator;

--- a/src/app/control.rs
+++ b/src/app/control.rs
@@ -1,5 +1,4 @@
-use crate::transport::tls;
-use crate::Addr;
+use crate::{transport::tls, Addr};
 use std::fmt;
 
 #[derive(Clone, Debug)]
@@ -18,12 +17,11 @@ impl fmt::Display for ControlAddr {
 pub mod add_origin {
     use super::ControlAddr;
     use crate::svc;
+    use crate::Error;
     use futures::try_ready;
     use futures::{Future, Poll};
     use std::marker::PhantomData;
     use tower_request_modifier::{Builder, RequestModifier};
-
-    type Error = Box<dyn std::error::Error + Send + Sync>;
 
     #[derive(Debug)]
     pub struct Layer<M, B> {
@@ -291,9 +289,8 @@ pub mod resolve {
 /// Creates a client suitable for gRPC.
 pub mod client {
     use super::super::config::H2Settings;
-    use crate::proxy::http;
     use crate::transport::{connect, tls};
-    use crate::{logging, svc, Addr};
+    use crate::{logging, proxy::http, svc, task, Addr};
     use futures::Poll;
     use std::net::SocketAddr;
 
@@ -330,8 +327,7 @@ pub mod client {
         http::h2::Connect<C, B>: svc::Service<Target>,
     {
         svc::layer::mk(|mk_conn| {
-            let inner =
-                http::h2::Connect::new(mk_conn, linkerd2_task::LazyExecutor, H2Settings::default());
+            let inner = http::h2::Connect::new(mk_conn, task::LazyExecutor, H2Settings::default());
             Client { inner }
         })
     }

--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -2,11 +2,10 @@
 
 use crate::proxy::http::HasH2Reason;
 use crate::svc;
+use crate::Error;
 use futures::{Future, Poll};
 use http::{header, Request, Response, StatusCode, Version};
 use tracing::{debug, error, warn};
-
-type Error = Box<dyn std::error::Error + Send + Sync>;
 
 /// Layer to map HTTP service errors into appropriate `http::Response`s.
 pub fn layer() -> Layer {

--- a/src/app/handle_time.rs
+++ b/src/app/handle_time.rs
@@ -1,6 +1,6 @@
 use super::metric_labels::Direction;
+use crate::metrics::{FmtMetrics, Metric};
 use crate::proxy::http::metrics::handle_time;
-use linkerd2_metrics::{FmtMetrics, Metric};
 use std::{fmt, iter};
 
 #[derive(Clone, Debug)]

--- a/src/app/identity.rs
+++ b/src/app/identity.rs
@@ -1,8 +1,8 @@
+use crate::api::identity as api;
 pub use crate::identity::{Crt, CrtKey, Csr, InvalidName, Key, Name, TokenSource, TrustAnchors};
 use crate::transport::tls;
+use crate::Never;
 use futures::{try_ready, Async, Future, Poll};
-use linkerd2_never::Never;
-use linkerd2_proxy_api::identity as api;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;

--- a/src/app/metric_labels.rs
+++ b/src/app/metric_labels.rs
@@ -1,7 +1,4 @@
-use crate::identity;
-use crate::transport::tls;
-use crate::{Addr, Conditional, NameAddr};
-use linkerd2_metrics::FmtLabels;
+use crate::{identity, metrics::FmtLabels, transport::tls, Addr, Conditional, NameAddr};
 use std::fmt::{self, Write};
 
 use super::{classify, control, dst, inbound, outbound};

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -16,9 +16,9 @@ mod profiles;
 mod tap;
 
 pub use self::main::Main;
+use crate::addr::{self, Addr};
 use crate::logging::trace;
 use http;
-use linkerd2_addr::{self as addr, Addr};
 use std::error::Error;
 
 const CANONICAL_DST_HEADER: &'static str = "l5d-dst-canonical";

--- a/src/app/profiles.rs
+++ b/src/app/profiles.rs
@@ -1,10 +1,10 @@
+use crate::api::destination as api;
 use crate::proxy::http::{profiles, retry::Budget};
 use crate::NameAddr;
+use crate::Never;
 use futures::sync::{mpsc, oneshot};
 use futures::{Async, AsyncSink, Future, Poll, Sink, Stream};
 use http;
-use linkerd2_never::Never;
-use linkerd2_proxy_api::destination as api;
 use regex::Regex;
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/app/tap.rs
+++ b/src/app/tap.rs
@@ -1,9 +1,6 @@
 use super::identity;
-use crate::logging;
-use crate::proxy;
-use crate::svc;
 use crate::transport::{tls::HasPeerIdentity, Connection, Listen};
-use crate::Conditional;
+use crate::{logging, proxy, svc, task, Conditional};
 use futures::{future, Future};
 use std::{error, io};
 use tokio::executor;
@@ -37,7 +34,7 @@ where
 
     executor::current_thread::TaskExecutor::current()
         .spawn_local(Box::new(log.future(f)))
-        .map_err(linkerd2_task::Error::into_io)
+        .map_err(task::Error::into_io)
 }
 
 pub fn serve_tap<N, B>(

--- a/src/control/destination/client.rs
+++ b/src/control/destination/client.rs
@@ -1,7 +1,7 @@
+use crate::api::destination::{client::Destination, GetDestination, Update};
 use crate::control::remote_stream::{self, Remote};
 use crate::NameAddr;
 use futures::{Async, Poll, Stream};
-use linkerd2_proxy_api::destination::{client::Destination, GetDestination, Update};
 use std::sync::Arc;
 use tower_grpc::{self as grpc, generic::client::GrpcService, BoxBody};
 use tracing::trace;

--- a/src/control/destination/resolution.rs
+++ b/src/control/destination/resolution.rs
@@ -1,23 +1,19 @@
 use super::client;
-use crate::control::destination::{Metadata, ProtocolHint, Update};
-use crate::identity;
-use crate::logging;
-use crate::proxy::resolve;
-use crate::NameAddr;
-use futures::{
-    future::Future,
-    sync::{mpsc, oneshot},
-    Async, Poll, Stream,
-};
-use indexmap::{IndexMap, IndexSet};
-use linkerd2_never::Never;
-use linkerd2_proxy_api::{
+use crate::api::{
     destination::{
         protocol_hint::Protocol, update::Update as PbUpdate2, TlsIdentity, Update as PbUpdate,
         WeightedAddr,
     },
     net::TcpAddress,
 };
+use crate::control::destination::{Metadata, ProtocolHint, Update};
+use crate::{identity, logging, proxy::resolve, NameAddr, Never};
+use futures::{
+    future::Future,
+    sync::{mpsc, oneshot},
+    Async, Poll, Stream,
+};
+use indexmap::{IndexMap, IndexSet};
 use std::{collections::HashMap, error::Error, fmt, net::SocketAddr};
 use tokio;
 use tower_grpc::{self as grpc, generic::client::GrpcService, Body, BoxBody};
@@ -380,7 +376,7 @@ fn pb_to_addr_meta(
 }
 
 fn pb_to_id(pb: TlsIdentity) -> Option<identity::Name> {
-    use linkerd2_proxy_api::destination::tls_identity::Strategy;
+    use crate::api::destination::tls_identity::Strategy;
 
     let Strategy::DnsLikeIdentity(i) = pb.strategy?;
     match identity::Name::from_hostname(i.name.as_bytes()) {
@@ -393,7 +389,7 @@ fn pb_to_id(pb: TlsIdentity) -> Option<identity::Name> {
 }
 
 fn pb_to_sock_addr(pb: TcpAddress) -> Option<SocketAddr> {
-    use linkerd2_proxy_api::net::ip_address::Ip;
+    use crate::api::net::ip_address::Ip;
     use std::net::{Ipv4Addr, Ipv6Addr};
     /*
     current structure is:

--- a/src/control/serve_http.rs
+++ b/src/control/serve_http.rs
@@ -1,12 +1,11 @@
-use crate::logging;
 use crate::transport::{tls, Listen};
+use crate::{logging, task};
 use futures::{future, Future};
 use hyper::{
     server::conn::Http,
     service::{service_fn, Service},
     Body,
 };
-use linkerd2_task;
 use std::net::SocketAddr;
 use tokio::executor::current_thread::TaskExecutor;
 use tracing::error;
@@ -50,7 +49,7 @@ where
                 let r = TaskExecutor::current()
                     .spawn_local(Box::new(serve))
                     .map(move |()| hyper)
-                    .map_err(linkerd2_task::Error::into_io);
+                    .map_err(task::Error::into_io);
 
                 future::result(r)
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,16 @@
 #![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "128"]
 
+use linkerd2_addr::{self as addr, Addr, NameAddr};
+use linkerd2_conditional::Conditional;
+use linkerd2_drain as drain;
+use linkerd2_identity as identity;
+use linkerd2_metrics as metrics;
+use linkerd2_never::Never;
+use linkerd2_proxy_api as api;
+use linkerd2_proxy_core::Error;
+use linkerd2_task as task;
+
 pub mod app;
 pub mod control;
 mod dns;
@@ -10,10 +20,6 @@ mod svc;
 mod tap;
 pub mod telemetry;
 pub mod transport;
-
-use linkerd2_addr::{Addr, NameAddr};
-use linkerd2_conditional::Conditional;
-use linkerd2_identity as identity;
 
 pub use self::logging::trace;
 pub use self::transport::SoOriginalDst;

--- a/src/proxy/buffer.rs
+++ b/src/proxy/buffer.rs
@@ -1,6 +1,6 @@
 use crate::logging;
-use crate::proxy::Error;
 use crate::svc;
+use crate::Error;
 use futures::{try_ready, Async, Future, Poll};
 use linkerd2_router as rt;
 use std::marker::PhantomData;

--- a/src/proxy/grpc/service.rs
+++ b/src/proxy/grpc/service.rs
@@ -110,8 +110,8 @@ pub mod res_body_as_payload {
 }
 
 pub mod unauthenticated {
+    use crate::api::tap as api;
     use futures::{future, stream};
-    use linkerd2_proxy_api::tap as api;
     use tower_grpc::{Code, Request, Response, Status};
 
     #[derive(Clone)]

--- a/src/proxy/http/canonicalize.rs
+++ b/src/proxy/http/canonicalize.rs
@@ -11,10 +11,10 @@
 
 use crate::dns;
 use crate::svc;
+use crate::Never;
 use crate::{Addr, NameAddr};
 use futures::{try_ready, Async, Future, Poll, Stream};
 use http;
-use linkerd2_never::Never;
 use log::trace;
 use std::time::Duration;
 use tokio;

--- a/src/proxy/http/client.rs
+++ b/src/proxy/http/client.rs
@@ -5,9 +5,9 @@ use super::{
     settings::{HasSettings, Settings},
 };
 use crate::app::config::H2Settings;
-use crate::proxy::Error;
 use crate::svc::{self, ServiceExt};
 use crate::transport::{connect, tls};
+use crate::Error;
 use futures::{try_ready, Async, Future, Poll};
 use http;
 use hyper;

--- a/src/proxy/http/glue.rs
+++ b/src/proxy/http/glue.rs
@@ -133,7 +133,7 @@ impl<S> HyperServerSvc<S> {
 impl<S, B> hyper::service::Service for HyperServerSvc<S>
 where
     S: svc::Service<http::Request<HttpBody>, Response = http::Response<B>>,
-    S::Error: Into<crate::proxy::Error>,
+    S::Error: Into<linkerd2_proxy_core::Error>,
     B: Payload,
 {
     type ReqBody = hyper::Body;
@@ -169,7 +169,7 @@ impl<C, T> hyper_connect::Connect for HyperConnect<C, T>
 where
     C: svc::MakeConnection<T> + Clone + Send + Sync,
     C::Future: Send + 'static,
-    <C::Future as Future>::Error: Into<crate::proxy::Error>,
+    <C::Future as Future>::Error: Into<linkerd2_proxy_core::Error>,
     C::Connection: HasTlsStatus + Send + 'static,
     T: Clone + Send + Sync,
 {
@@ -189,7 +189,7 @@ impl<F> Future for HyperConnectFuture<F>
 where
     F: Future + 'static,
     F::Item: HasTlsStatus,
-    F::Error: Into<crate::proxy::Error>,
+    F::Error: Into<linkerd2_proxy_core::Error>,
 {
     type Item = (F::Item, hyper_connect::Connected);
     type Error = F::Error;

--- a/src/proxy/http/h2.rs
+++ b/src/proxy/http/h2.rs
@@ -1,15 +1,14 @@
 use super::{Body, ClientUsedTls};
 use crate::app::config::H2Settings;
-use crate::proxy::Error;
-use crate::svc;
+use crate::task::{ArcExecutor, BoxSendFuture, Executor};
 use crate::transport::tls::HasStatus as HasTlsStatus;
+use crate::{svc, Error};
 use futures::{try_ready, Future, Poll};
 use http;
 use hyper::{
     body::Payload,
     client::conn::{self, Handshake, SendRequest},
 };
-use linkerd2_task::{ArcExecutor, BoxSendFuture, Executor};
 use std::marker::PhantomData;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::debug;

--- a/src/proxy/http/metrics/classify.rs
+++ b/src/proxy/http/metrics/classify.rs
@@ -1,5 +1,5 @@
-use crate::proxy::Error;
 use crate::svc;
+use crate::Error;
 use futures::{try_ready, Future, Poll};
 use http;
 

--- a/src/proxy/http/metrics/handle_time.rs
+++ b/src/proxy/http/metrics/handle_time.rs
@@ -1,5 +1,5 @@
+use crate::metrics::{latency, FmtLabels, FmtMetric, Histogram};
 use crate::proxy::http::insert;
-use linkerd2_metrics::{latency, FmtLabels, FmtMetric, Histogram};
 use std::{
     fmt,
     sync::{

--- a/src/proxy/http/metrics/mod.rs
+++ b/src/proxy/http/metrics/mod.rs
@@ -1,3 +1,11 @@
+use crate::metrics::{latency, Counter, FmtLabels, Histogram};
+use http;
+use indexmap::IndexMap;
+use std::hash::Hash;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio_timer::clock;
+
 pub mod classify;
 pub mod handle_time;
 mod report;
@@ -5,13 +13,6 @@ mod service;
 
 pub use self::report::Report;
 pub use self::service::layer;
-use http;
-use indexmap::IndexMap;
-use linkerd2_metrics::{latency, Counter, FmtLabels, Histogram};
-use std::hash::Hash;
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
-use tokio_timer::clock;
 
 pub fn new<T, C>(retain_idle: Duration) -> (Arc<Mutex<Registry<T, C>>>, Report<T, C>)
 where
@@ -167,7 +168,7 @@ where
 mod tests {
     #[test]
     fn expiry() {
-        use linkerd2_metrics::FmtLabels;
+        use crate::metrics::FmtLabels;
         use std::fmt;
         use std::time::Duration;
         use tokio_timer::clock;

--- a/src/proxy/http/metrics/report.rs
+++ b/src/proxy/http/metrics/report.rs
@@ -1,6 +1,6 @@
 use super::{ClassMetrics, Registry, RequestMetrics, RetrySkipped, StatusMetrics};
+use crate::metrics::{latency, Counter, FmtLabels, FmtMetric, FmtMetrics, Histogram, Metric};
 use http;
-use linkerd2_metrics::{latency, Counter, FmtLabels, FmtMetric, FmtMetrics, Histogram, Metric};
 use std::fmt;
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};

--- a/src/proxy/http/metrics/service.rs
+++ b/src/proxy/http/metrics/service.rs
@@ -1,8 +1,8 @@
 use super::super::retry::TryClone;
 use super::classify::{ClassifyEos, ClassifyResponse};
 use super::{ClassMetrics, Registry, RequestMetrics, StatusMetrics};
-use crate::proxy::Error;
 use crate::svc;
+use crate::Error;
 use futures::{try_ready, Async, Future, Poll};
 use http;
 use hyper::body::Payload;

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -47,7 +47,7 @@ impl<'a> HasH2Reason for &'a (dyn std::error::Error + 'static) {
     }
 }
 
-impl HasH2Reason for crate::proxy::Error {
+impl HasH2Reason for linkerd2_proxy_core::Error {
     fn h2_reason(&self) -> Option<::h2::Reason> {
         (&**self as &(dyn std::error::Error + 'static)).h2_reason()
     }

--- a/src/proxy/http/profiles/mod.rs
+++ b/src/proxy/http/profiles/mod.rs
@@ -1,9 +1,8 @@
 use super::retry::Budget;
-use crate::NameAddr;
+use crate::{NameAddr, Never};
 use futures::Stream;
 use http;
 use indexmap::IndexMap;
-use linkerd2_never::Never;
 use regex::Regex;
 use std::fmt;
 use std::hash::{Hash, Hasher};

--- a/src/proxy/http/profiles/router.rs
+++ b/src/proxy/http/profiles/router.rs
@@ -1,12 +1,11 @@
 use super::recognize::{ConcreteDstRecognize, RouteRecognize};
 use super::{CanGetDestination, GetRoutes, Route, Routes, WeightedAddr, WithAddr, WithRoute};
 use crate::dns;
-use crate::proxy::Error;
 use crate::svc;
+use crate::{Error, Never};
 use futures::{Async, Poll, Stream};
 use http;
 use indexmap::IndexMap;
-use linkerd2_never::Never;
 use linkerd2_router as rt;
 use std::hash::Hash;
 use tracing::{debug, error};
@@ -152,7 +151,7 @@ where
     RouteSvc::Error: Into<Error>,
 {
     type Response = Service<G::Stream, Target, RouteLayer, RouteMake, Inner, RouteBody, InnerBody>;
-    type Error = linkerd2_never::Never;
+    type Error = Never;
     type Future = futures::future::FutureResult<Self::Response, Self::Error>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {

--- a/src/proxy/http/router.rs
+++ b/src/proxy/http/router.rs
@@ -1,10 +1,9 @@
 use crate::logging;
-use crate::proxy::Error;
 use crate::svc;
 use crate::trace;
+use crate::{Error, Never};
 use futures::Poll;
 use http;
-use linkerd2_never::Never;
 use linkerd2_router as rt;
 pub use linkerd2_router::{error, Recognize, Router};
 use std::fmt;

--- a/src/proxy/http/timeout.rs
+++ b/src/proxy/http/timeout.rs
@@ -1,5 +1,4 @@
-use crate::proxy::Error;
-use crate::svc;
+use crate::{svc, Error};
 use futures::{future, try_ready, Future, Poll};
 use http::{Request, Response, StatusCode};
 use linkerd2_timeout::{error, Timeout};

--- a/src/proxy/http/upgrade.rs
+++ b/src/proxy/http/upgrade.rs
@@ -1,5 +1,6 @@
 //! HTTP/1.1 Upgrades
 use super::{glue::HttpBody, h1};
+use crate::drain;
 use crate::proxy::tcp;
 use crate::svc;
 use futures::{
@@ -7,7 +8,6 @@ use futures::{
     Future, Poll,
 };
 use hyper::upgrade::OnUpgrade;
-use linkerd2_drain as drain;
 use linkerd2_task::{BoxSendFuture, ErasedExecutor, Executor};
 use std::fmt;
 use std::mem;

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -14,5 +14,3 @@ mod tcp;
 pub use self::accept::Accept;
 pub use self::resolve::{Resolution, Resolve};
 pub use self::server::{Server, Source};
-
-type Error = Box<dyn std::error::Error + Send + Sync>;

--- a/src/proxy/pending.rs
+++ b/src/proxy/pending.rs
@@ -1,5 +1,5 @@
-use crate::proxy::Error;
 use crate::svc::{self, ServiceExt};
+use crate::Error;
 use futures::{try_ready, Future, Poll};
 use linkerd2_router as rt;
 

--- a/src/proxy/reconnect.rs
+++ b/src/proxy/reconnect.rs
@@ -1,5 +1,6 @@
-use crate::proxy::Error;
 use crate::svc;
+use crate::Error;
+use crate::Never;
 use futures::{task, Async, Future, Poll};
 use rand;
 use std::fmt;
@@ -139,7 +140,7 @@ where
     Error: From<M::Error> + From<S::Error>,
 {
     type Response = Service<M, T>;
-    type Error = linkerd2_never::Never;
+    type Error = Never;
     type Future = futures::future::FutureResult<Self::Response, Self::Error>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
@@ -262,8 +263,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Never;
     use futures::{future, Future};
-    use linkerd2_never::Never;
     use quickcheck::*;
     use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
     use std::{error, fmt, time};

--- a/src/proxy/resolve.rs
+++ b/src/proxy/resolve.rs
@@ -1,5 +1,5 @@
-use crate::proxy::Error;
 use crate::svc;
+use crate::Error;
 use futures::{stream::FuturesUnordered, try_ready, Async, Future, Poll, Stream};
 use indexmap::IndexMap;
 use std::{fmt, net::SocketAddr};

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -1,23 +1,22 @@
 use super::Accept;
 use crate::app::config::H2Settings;
+use crate::drain;
 use crate::logging;
 use crate::proxy::http::{
     glue::{HttpBody, HyperServerSvc},
     upgrade,
 };
-use crate::proxy::protocol::Protocol;
-use crate::proxy::{tcp, Error};
+use crate::proxy::{protocol::Protocol, tcp};
 use crate::svc::{MakeService, Service};
 use crate::transport::{
     tls::{self, HasPeerIdentity},
     Connection, Peek,
 };
+use crate::{Error, Never};
 use futures::{future, Poll};
 use futures::{future::Either, Future};
 use http;
 use hyper;
-use linkerd2_drain as drain;
-use linkerd2_never::Never;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::{error, fmt};

--- a/src/tap/daemon.rs
+++ b/src/tap/daemon.rs
@@ -1,7 +1,7 @@
 use super::iface::Tap;
+use crate::Never;
 use futures::sync::{mpsc, oneshot};
 use futures::{try_ready, Async, Future, Poll, Stream};
-use linkerd2_never::Never;
 use tracing::{debug, trace, warn};
 
 pub fn new<T>() -> (Daemon<T>, Register<T>, Subscribe<T>) {

--- a/src/tap/grpc/match_.rs
+++ b/src/tap/grpc/match_.rs
@@ -1,9 +1,9 @@
+use crate::api::net::ip_address;
+use crate::api::tap::observe_request;
 use crate::tap::Inspect;
 use http;
 use indexmap::IndexMap;
 use ipnet::{Contains, Ipv4Net, Ipv6Net};
-use linkerd2_proxy_api::net::ip_address;
-use linkerd2_proxy_api::tap::observe_request;
 use std::boxed::Box;
 use std::convert::TryFrom;
 use std::net;
@@ -108,7 +108,7 @@ impl TryFrom<observe_request::r#match::Match> for Match {
 
     #[allow(unconditional_recursion)]
     fn try_from(m: observe_request::r#match::Match) -> Result<Self, Self::Error> {
-        use linkerd2_proxy_api::tap::observe_request::r#match;
+        use crate::api::tap::observe_request::r#match;
 
         match m {
             r#match::Match::All(seq) => Self::from_seq(seq).map(Match::All),
@@ -169,7 +169,7 @@ impl TryFrom<observe_request::r#match::Tcp> for TcpMatch {
     type Error = InvalidMatch;
 
     fn try_from(m: observe_request::r#match::Tcp) -> Result<Self, InvalidMatch> {
-        use linkerd2_proxy_api::tap::observe_request::r#match::tcp;
+        use crate::api::tap::observe_request::r#match::tcp;
 
         m.r#match.ok_or(InvalidMatch::Empty).and_then(|t| match t {
             tcp::Match::Ports(range) => {
@@ -261,7 +261,7 @@ impl HttpMatch {
         string_match: &observe_request::r#match::http::string_match::Match,
         value: &str,
     ) -> bool {
-        use linkerd2_proxy_api::tap::observe_request::r#match::http::string_match::Match::*;
+        use crate::api::tap::observe_request::r#match::http::string_match::Match::*;
 
         match string_match {
             Exact(ref exact) => value == exact,
@@ -273,8 +273,8 @@ impl HttpMatch {
 impl TryFrom<observe_request::r#match::Http> for HttpMatch {
     type Error = InvalidMatch;
     fn try_from(m: observe_request::r#match::Http) -> Result<Self, InvalidMatch> {
-        use linkerd2_proxy_api::http_types::scheme::{Registered, Type};
-        use linkerd2_proxy_api::tap::observe_request::r#match::http::Match as Pb;
+        use crate::api::http_types::scheme::{Registered, Type};
+        use crate::api::tap::observe_request::r#match::http::Match as Pb;
 
         m.r#match.ok_or(InvalidMatch::Empty).and_then(|m| match m {
             Pb::Scheme(s) => s.r#type.ok_or(InvalidMatch::Empty).and_then(|s| match s {
@@ -317,7 +317,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use linkerd2_proxy_api::http_types;
+    use crate::api::http_types;
 
     impl Arbitrary for LabelMatch {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {

--- a/src/tap/grpc/server.rs
+++ b/src/tap/grpc/server.rs
@@ -1,4 +1,5 @@
 use super::match_::Match;
+use crate::api::{http_types, pb_duration, tap as api};
 use crate::proxy::http::HasH2Reason;
 use crate::tap::{iface, Inspect};
 use crate::transport::tls;
@@ -7,7 +8,6 @@ use bytes::Buf;
 use futures::sync::mpsc;
 use futures::{future, Async, Future, Poll, Stream};
 use hyper::body::Payload;
-use linkerd2_proxy_api::{http_types, pb_duration, tap as api};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::Instant;

--- a/src/telemetry/process.rs
+++ b/src/telemetry/process.rs
@@ -1,5 +1,5 @@
 use self::system::System;
-use linkerd2_metrics::{metrics, FmtMetrics, Gauge};
+use crate::metrics::{metrics, FmtMetrics, Gauge};
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
@@ -52,8 +52,8 @@ impl FmtMetrics for Report {
 
 #[cfg(target_os = "linux")]
 mod system {
+    use crate::metrics::{metrics, Counter, FmtMetrics, Gauge};
     use libc::{self, pid_t};
-    use linkerd2_metrics::{metrics, Counter, FmtMetrics, Gauge};
     use procinfo::pid;
     use std::fmt;
     use std::{fs, io};
@@ -168,7 +168,7 @@ mod system {
 
 #[cfg(not(target_os = "linux"))]
 mod system {
-    use linkerd2_metrics::FmtMetrics;
+    use crate::metrics::FmtMetrics;
     use std::{fmt, io};
 
     #[derive(Clone, Debug)]

--- a/src/transport/metrics/mod.rs
+++ b/src/transport/metrics/mod.rs
@@ -1,14 +1,12 @@
 mod io;
 
 pub use self::io::Io;
-use crate::svc;
-use crate::telemetry::Errno;
-use crate::transport::tls;
-use futures::{try_ready, Future, Poll};
-use indexmap::IndexMap;
-use linkerd2_metrics::{
+use crate::metrics::{
     latency, metrics, Counter, FmtLabels, FmtMetric, FmtMetrics, Gauge, Histogram, Metric,
 };
+use crate::{svc, telemetry::Errno, transport::tls};
+use futures::{try_ready, Future, Poll};
+use indexmap::IndexMap;
 use std::fmt;
 use std::marker::PhantomData;
 use std::sync::{Arc, Mutex, MutexGuard};


### PR DESCRIPTION
The linkerd2-proxy-core crate is intended to expose the core types and
interfaces needed to implement linkerd2-proxy so that implementation
pieces may eventually be split into separate sub-crates.

Initially, the crate exposes only `Error`, which is redefined
gratuitously throughout the project; and it re-exports the commonly used
`Never` type.

Additional traits and core types may be added in follow-up changes.

The proxy has been updated to re-export many of the core types and
modules from the root of the `linkerd2-proxy` crate and imports have
been updated accordingly.

No functional changes.