### PR TITLE
core: Formalize the listen/serve API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -541,7 +541,6 @@ dependencies = [
  "linkerd2-addr 0.1.0",
  "linkerd2-conditional 0.1.0",
  "linkerd2-dns-name 0.1.0",
- "linkerd2-drain 0.1.0",
  "linkerd2-identity 0.1.0",
  "linkerd2-metrics 0.1.0",
  "linkerd2-never 0.1.0",
@@ -608,6 +607,10 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-core"
 version = "0.1.0"
+dependencies = [
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linkerd2-drain 0.1.0",
+]
 
 [[package]]
 name = "linkerd2-router"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ hyper-balance = { path = "lib/hyper-balance" }
 linkerd2-addr        = { path = "lib/linkerd2-addr" }
 linkerd2-conditional = { path = "lib/linkerd2-conditional" }
 linkerd2-dns-name    = { path = "lib/linkerd2-dns-name" }
-linkerd2-drain       = { path = "lib/linkerd2-drain" }
 linkerd2-identity    = { path = "lib/linkerd2-identity" }
 linkerd2-metrics     = { path = "lib/linkerd2-metrics" }
 linkerd2-never       = { path = "lib/linkerd2-never" }

--- a/lib/linkerd2-proxy-core/Cargo.toml
+++ b/lib/linkerd2-proxy-core/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
+futures = "0.1"
+linkerd2-drain = { path = "../linkerd2-drain" }

--- a/lib/linkerd2-proxy-core/src/lib.rs
+++ b/lib/linkerd2-proxy-core/src/lib.rs
@@ -1,4 +1,30 @@
 #![deny(warnings, rust_2018_idioms)]
 
-/// A dynamic error type.
+use futures::Future;
+pub use linkerd2_drain as drain;
+
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
+
+pub trait ListenAndSpawn {
+    type Connection;
+
+    /// Accept connections, spawning a task for each.
+    fn listen_and_spawn<S>(
+        self,
+        serve: S,
+        drain: drain::Watch,
+    ) -> Box<dyn Future<Item = (), Error = Error> + Send + 'static>
+    where
+        S: ServeConnection<Self::Connection> + Send + 'static;
+}
+
+pub trait ServeConnection<C> {
+    /// Handles an accepted connection.
+    ///
+    /// The connection may be notified for graceful shutdown via `drain`.
+    fn serve_connection(
+        &mut self,
+        connection: C,
+        drain: drain::Watch,
+    ) -> Box<dyn Future<Item = (), Error = ()> + Send + 'static>;
+}

--- a/src/app/control.rs
+++ b/src/app/control.rs
@@ -16,8 +16,7 @@ impl fmt::Display for ControlAddr {
 /// Sets the request's URI from `Config`.
 pub mod add_origin {
     use super::ControlAddr;
-    use crate::svc;
-    use crate::Error;
+    use crate::{svc, Error};
     use futures::try_ready;
     use futures::{Future, Poll};
     use std::marker::PhantomData;

--- a/src/app/errors.rs
+++ b/src/app/errors.rs
@@ -1,8 +1,6 @@
 //! Layer to map HTTP service errors into appropriate `http::Response`s.
 
-use crate::proxy::http::HasH2Reason;
-use crate::svc;
-use crate::Error;
+use crate::{proxy::http::HasH2Reason, svc, Error};
 use futures::{Future, Poll};
 use http::{header, Request, Response, StatusCode, Version};
 use tracing::{debug, error, warn};

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -1,7 +1,7 @@
 use super::admin::{Admin, Readiness};
 use super::config::{Config, H2Settings};
 use super::profiles::Client as ProfilesClient;
-use super::{DispatchDeadline, dst::DstAddr, identity};
+use super::{dst::DstAddr, identity, DispatchDeadline};
 use crate::app::classify::{self, Class};
 use crate::app::handle_time;
 use crate::app::metric_labels::{ControlLabels, EndpointLabels, RouteLabels};
@@ -23,10 +23,10 @@ use crate::{
 use futures::{self, future, Future};
 use http;
 use hyper;
+use std::fmt;
 use std::net::SocketAddr;
 use std::thread;
 use std::time::{Duration, SystemTime};
-use std::fmt;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::runtime::current_thread;
 use tracing::{debug, error, info, trace};
@@ -847,8 +847,7 @@ fn spawn_server<A, T, C, R, B, G>(
     router: R,
     h2_settings: H2Settings,
     drain_rx: drain::Watch,
-)
-where
+) where
     A: proxy::Accept<Connection> + Send + 'static,
     A::Io: transport::Peek + fmt::Debug + Send + 'static,
 

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -1,7 +1,7 @@
 use super::admin::{Admin, Readiness};
 use super::config::{Config, H2Settings};
 use super::profiles::Client as ProfilesClient;
-use super::{dst::DstAddr, identity};
+use super::{DispatchDeadline, dst::DstAddr, identity};
 use crate::app::classify::{self, Class};
 use crate::app::handle_time;
 use crate::app::metric_labels::{ControlLabels, EndpointLabels, RouteLabels};
@@ -20,17 +20,15 @@ use crate::{
     control, dns, drain, logging, metrics::FmtMetrics, tap, task, telemetry, trace, Addr,
     Conditional, Never,
 };
-use futures::{self, future, Future, Poll};
+use futures::{self, future, Future};
 use http;
 use hyper;
 use std::net::SocketAddr;
 use std::thread;
-use std::time::{Duration, Instant, SystemTime};
-use std::{fmt, io};
-use tokio::executor::{DefaultExecutor, Executor};
+use std::time::{Duration, SystemTime};
+use std::fmt;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::runtime::current_thread;
-use tokio_timer::clock;
 use tracing::{debug, error, info, trace};
 
 /// Runs a sidecar proxy.
@@ -62,19 +60,6 @@ struct ProxyParts<G> {
 
     inbound_listener: Listen<identity::Local, G>,
     outbound_listener: Listen<identity::Local, G>,
-}
-
-#[derive(Copy, Clone, Debug)]
-struct DispatchDeadline(Instant);
-
-impl DispatchDeadline {
-    fn after(allowance: Duration) -> DispatchDeadline {
-        DispatchDeadline(clock::now() + allowance)
-    }
-
-    fn extract<A>(req: &http::Request<A>) -> Option<Instant> {
-        req.extensions().get::<DispatchDeadline>().map(|d| d.0)
-    }
 }
 
 impl<G> Main<G>
@@ -429,7 +414,8 @@ where
         let profiles_client =
             ProfilesClient::new(dst_svc, Duration::from_secs(3), config.destination_context);
 
-        let outbound = {
+        // Outbound
+        {
             use super::outbound::{
                 self,
                 discovery::Resolve,
@@ -657,7 +643,7 @@ where
                 .layer(transport_metrics.accept("outbound"))
                 .layer(keepalive::accept::layer(config.outbound_accept_keepalive));
 
-            serve(
+            spawn_server(
                 "out",
                 outbound_listener,
                 accept,
@@ -665,12 +651,11 @@ where
                 server_stack,
                 config.h2_settings,
                 drain_rx.clone(),
-            )
-            .map_err(|e| error!("outbound proxy background task failed: {}", e))
+            );
         };
-        task::spawn(outbound);
 
-        let inbound = {
+        // Inbound
+        {
             use super::inbound::{
                 orig_proto_downgrade,
                 rewrite_loopback_addr,
@@ -839,7 +824,7 @@ where
                 .layer(transport_metrics.accept("inbound"))
                 .layer(keepalive::accept::layer(config.inbound_accept_keepalive));
 
-            serve(
+            spawn_server(
                 "in",
                 inbound_listener,
                 accept,
@@ -847,16 +832,14 @@ where
                 source_stack,
                 config.h2_settings,
                 drain_rx.clone(),
-            )
-            .map_err(|e| error!("inbound proxy background task failed: {}", e))
+            );
         };
-        task::spawn(inbound);
     }
 }
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 
-fn serve<A, T, C, R, B, G>(
+fn spawn_server<A, T, C, R, B, G>(
     proxy_name: &'static str,
     bound_port: Listen<identity::Local, G>,
     accept: A,
@@ -864,7 +847,7 @@ fn serve<A, T, C, R, B, G>(
     router: R,
     h2_settings: H2Settings,
     drain_rx: drain::Watch,
-) -> impl Future<Item = (), Error = io::Error> + Send + 'static
+)
 where
     A: proxy::Accept<Connection> + Send + 'static,
     A::Io: transport::Peek + fmt::Debug + Send + 'static,
@@ -892,65 +875,13 @@ where
     B: hyper::body::Payload + Default + Send + 'static,
     G: GetOriginalDst + Send + 'static,
 {
-    let listen_addr = bound_port.local_addr();
     let server = proxy::Server::new(
         proxy_name,
-        listen_addr,
+        bound_port.local_addr(),
         accept,
         connect,
         router,
-        drain_rx.clone(),
+        h2_settings,
     );
-    let log = server.log().clone();
-
-    let future = log.future(
-        bound_port.listen_and_fold((), move |(), (connection, remote)| {
-            let s = server.serve(connection, remote, h2_settings);
-            // TODO: use trace spans for log contexts.
-            // .instrument(info_span!("conn", %remote));
-            // Logging context is configured by the server.
-            let r = DefaultExecutor::current()
-                .spawn(Box::new(s))
-                .map_err(task::Error::into_io);
-            future::result(r)
-        }),
-    );
-    // TODO: use trace spans for log contexts.
-    // .instrument(info_span!("proxy", server = %proxy_name, local = %listen_addr));
-
-    let accept_until = Cancelable {
-        future,
-        canceled: false,
-    };
-
-    // As soon as we get a shutdown signal, the listener
-    // is canceled immediately.
-    drain_rx.watch(accept_until, |accept| {
-        accept.canceled = true;
-    })
-}
-
-/// Can cancel a future by setting a flag.
-///
-/// Used to 'watch' the accept futures, and close the listeners
-/// as soon as the shutdown signal starts.
-struct Cancelable<F> {
-    future: F,
-    canceled: bool,
-}
-
-impl<F> Future for Cancelable<F>
-where
-    F: Future<Item = ()>,
-{
-    type Item = ();
-    type Error = F::Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        if self.canceled {
-            Ok(().into())
-        } else {
-            self.future.poll()
-        }
-    }
+    super::proxy::spawn(bound_port, server, drain_rx)
 }

--- a/src/app/outbound/discovery.rs
+++ b/src/app/outbound/discovery.rs
@@ -71,7 +71,6 @@ where
 {
     type Item = Resolution<F::Item>;
     type Error = F::Error;
-
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let resolving = match self.resolving {
             Resolving::Name {

--- a/src/app/outbound/require_identity_on_endpoint.rs
+++ b/src/app/outbound/require_identity_on_endpoint.rs
@@ -1,8 +1,8 @@
 use super::super::L5D_REQUIRE_ID;
 use super::Endpoint;
 use crate::proxy::http::{identity_from_header, HasH2Reason};
-use crate::{identity, svc, Conditional, Error};
 use crate::transport::tls::{self, HasPeerIdentity};
+use crate::{identity, svc, Conditional, Error};
 use futures::{
     future::{self, Either, FutureResult},
     try_ready, Async, Future, Poll,

--- a/src/app/outbound/require_identity_on_endpoint.rs
+++ b/src/app/outbound/require_identity_on_endpoint.rs
@@ -1,18 +1,14 @@
 use super::super::L5D_REQUIRE_ID;
 use super::Endpoint;
-use crate::identity;
 use crate::proxy::http::{identity_from_header, HasH2Reason};
-use crate::svc;
+use crate::{identity, svc, Conditional, Error};
 use crate::transport::tls::{self, HasPeerIdentity};
-use crate::Conditional;
 use futures::{
     future::{self, Either, FutureResult},
     try_ready, Async, Future, Poll,
 };
 use std::marker::PhantomData;
 use tracing::{debug, warn};
-
-type Error = Box<dyn std::error::Error + Send + Sync>;
 
 #[derive(Debug)]
 pub struct RequireIdentityError {

--- a/src/app/proxy.rs
+++ b/src/app/proxy.rs
@@ -1,0 +1,55 @@
+use crate::core::{drain, ListenAndSpawn, ServeConnection};
+use futures::{self, Future, Poll};
+use tracing::error;
+
+/// Spawns a task that binds an `S`-typed server with an `L`-typed listener until
+/// a drain is signaled.
+pub fn spawn<L, S>(listen: L, server: S, drain: drain::Watch)
+where
+    L: ListenAndSpawn + Send + 'static,
+    S: ServeConnection<L::Connection> + Send + 'static,
+{
+    let serve = listen
+        .listen_and_spawn(server, drain.clone())
+        .map_err(|e| error!("failed to listen for connection: {}", e));
+
+    // As soon as we get a shutdown signal, the listener task completes and
+    // stops accepting new connections.
+    let fut = drain.watch(Cancelable::new(serve), |c| c.cancel());
+    linkerd2_task::spawn(fut);
+}
+
+/// Can cancel a future by setting a flag.
+///
+/// Used to 'watch' the accept futures, and close the listeners
+/// as soon as the shutdown signal starts.
+struct Cancelable<F> {
+    future: F,
+    canceled: bool,
+}
+
+impl<F: Future<Item = ()>> Cancelable<F> {
+    fn new(future: F) -> Self {
+        Self {
+            future,
+            canceled: false,
+        }
+    }
+
+    fn cancel(&mut self) {
+        self.canceled = true;
+    }
+}
+
+impl<F: Future<Item = ()>> Future for Cancelable<F> {
+    type Item = ();
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        if self.canceled {
+            Ok(().into())
+        } else {
+            self.future.poll()
+        }
+    }
+}

--- a/src/app/tap.rs
+++ b/src/app/tap.rs
@@ -57,8 +57,8 @@ where
     let fut = {
         let log = log.clone();
         bound_port
-            .listen_and_fold(new_service, move |mut new_service, (session, remote)| {
-                let log = log.clone().with_remote(remote);
+            .listen_and_fold(new_service, move |mut new_service, session| {
+                let log = log.clone().with_remote(session.remote_addr());
                 trace!("expecting Tap client name: {:?}", tap_svc_name);
 
                 let is_tap_service = match session.peer_identity() {

--- a/src/control/serve_http.rs
+++ b/src/control/serve_http.rs
@@ -28,10 +28,11 @@ where
     let fut = {
         let log = log.clone();
         bound_port
-            .listen_and_fold(Http::new(), move |hyper, (conn, remote)| {
+            .listen_and_fold(Http::new(), move |hyper, conn| {
                 // Since the `/proxy-log-level` controls access based on the
                 // client's IP address, we wrap the service with a new service
                 // that adds the remote IP as a request extension.
+                let remote = conn.remote_addr();
                 let svc = service.clone();
                 let svc = service_fn(move |mut req| {
                     let mut svc = svc.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,12 +3,11 @@
 
 use linkerd2_addr::{self as addr, Addr, NameAddr};
 use linkerd2_conditional::Conditional;
-use linkerd2_drain as drain;
 use linkerd2_identity as identity;
 use linkerd2_metrics as metrics;
 use linkerd2_never::Never;
 use linkerd2_proxy_api as api;
-use linkerd2_proxy_core::Error;
+use linkerd2_proxy_core::{self as core, drain, Error};
 use linkerd2_task as task;
 
 pub mod app;

--- a/src/proxy/buffer.rs
+++ b/src/proxy/buffer.rs
@@ -1,6 +1,4 @@
-use crate::logging;
-use crate::svc;
-use crate::Error;
+use crate::{logging, svc, Error};
 use futures::{try_ready, Async, Future, Poll};
 use linkerd2_router as rt;
 use std::marker::PhantomData;

--- a/src/proxy/http/fallback.rs
+++ b/src/proxy/http/fallback.rs
@@ -1,5 +1,4 @@
-use crate::svc;
-use crate::Error;
+use crate::{svc, Error};
 use bytes::Buf;
 use futures::{try_ready, Future, Poll};
 use http;

--- a/src/proxy/http/glue.rs
+++ b/src/proxy/http/glue.rs
@@ -1,5 +1,5 @@
 use crate::proxy::http::{upgrade::Http11Upgrade, HasH2Reason};
-use crate::svc;
+use crate::{Error, svc};
 use crate::transport::tls::HasStatus as HasTlsStatus;
 use futures::{try_ready, Async, Future, Poll};
 use http;
@@ -133,7 +133,7 @@ impl<S> HyperServerSvc<S> {
 impl<S, B> hyper::service::Service for HyperServerSvc<S>
 where
     S: svc::Service<http::Request<HttpBody>, Response = http::Response<B>>,
-    S::Error: Into<linkerd2_proxy_core::Error>,
+    S::Error: Into<Error>,
     B: Payload,
 {
     type ReqBody = hyper::Body;
@@ -169,7 +169,7 @@ impl<C, T> hyper_connect::Connect for HyperConnect<C, T>
 where
     C: svc::MakeConnection<T> + Clone + Send + Sync,
     C::Future: Send + 'static,
-    <C::Future as Future>::Error: Into<linkerd2_proxy_core::Error>,
+    <C::Future as Future>::Error: Into<Error>,
     C::Connection: HasTlsStatus + Send + 'static,
     T: Clone + Send + Sync,
 {
@@ -189,7 +189,7 @@ impl<F> Future for HyperConnectFuture<F>
 where
     F: Future + 'static,
     F::Item: HasTlsStatus,
-    F::Error: Into<linkerd2_proxy_core::Error>,
+    F::Error: Into<Error>,
 {
     type Item = (F::Item, hyper_connect::Connected);
     type Error = F::Error;

--- a/src/proxy/http/glue.rs
+++ b/src/proxy/http/glue.rs
@@ -1,6 +1,6 @@
 use crate::proxy::http::{upgrade::Http11Upgrade, HasH2Reason};
-use crate::{Error, svc};
 use crate::transport::tls::HasStatus as HasTlsStatus;
+use crate::{svc, Error};
 use futures::{try_ready, Async, Future, Poll};
 use http;
 use hyper::client::connect as hyper_connect;

--- a/src/proxy/http/h2.rs
+++ b/src/proxy/http/h2.rs
@@ -1,8 +1,7 @@
 use super::{Body, ClientUsedTls};
-use crate::app::config::H2Settings;
 use crate::task::{ArcExecutor, BoxSendFuture, Executor};
 use crate::transport::tls::HasStatus as HasTlsStatus;
-use crate::{svc, Error};
+use crate::{app::config::H2Settings, svc, Error};
 use futures::{try_ready, Future, Poll};
 use http;
 use hyper::{

--- a/src/proxy/http/metrics/classify.rs
+++ b/src/proxy/http/metrics/classify.rs
@@ -1,5 +1,4 @@
-use crate::svc;
-use crate::Error;
+use crate::{svc, Error};
 use futures::{try_ready, Future, Poll};
 use http;
 

--- a/src/proxy/http/metrics/mod.rs
+++ b/src/proxy/http/metrics/mod.rs
@@ -14,7 +14,9 @@ mod service;
 pub use self::report::Report;
 pub use self::service::layer;
 
-pub fn new<T, C>(retain_idle: Duration) -> (Arc<Mutex<Registry<T, C>>>, Report<T, C>)
+pub type SharedRegistry<T, C> = Arc<Mutex<Registry<T, C>>>;
+
+pub fn new<T, C>(retain_idle: Duration) -> (SharedRegistry<T, C>, Report<T, C>)
 where
     T: FmtLabels + Clone + Hash + Eq,
     C: FmtLabels + Hash + Eq,

--- a/src/proxy/http/metrics/service.rs
+++ b/src/proxy/http/metrics/service.rs
@@ -1,8 +1,7 @@
 use super::super::retry::TryClone;
 use super::classify::{ClassifyEos, ClassifyResponse};
 use super::{ClassMetrics, Registry, RequestMetrics, StatusMetrics};
-use crate::svc;
-use crate::Error;
+use crate::{svc, Error};
 use futures::{try_ready, Async, Future, Poll};
 use http;
 use hyper::body::Payload;

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -1,3 +1,8 @@
+use super::super::identity;
+use crate::Error;
+use http::header::AsHeaderName;
+use http::uri::Authority;
+
 pub mod add_header;
 pub mod balance;
 pub mod canonicalize;
@@ -23,10 +28,6 @@ pub use self::client::Client;
 pub use self::glue::{ClientUsedTls, HttpBody as Body, HyperServerSvc};
 pub use self::settings::Settings;
 
-use super::super::identity;
-use http::header::AsHeaderName;
-use http::uri::Authority;
-
 pub trait HasH2Reason {
     fn h2_reason(&self) -> Option<::h2::Reason>;
 }
@@ -47,7 +48,7 @@ impl<'a> HasH2Reason for &'a (dyn std::error::Error + 'static) {
     }
 }
 
-impl HasH2Reason for linkerd2_proxy_core::Error {
+impl HasH2Reason for Error {
     fn h2_reason(&self) -> Option<::h2::Reason> {
         (&**self as &(dyn std::error::Error + 'static)).h2_reason()
     }

--- a/src/proxy/reconnect.rs
+++ b/src/proxy/reconnect.rs
@@ -1,6 +1,4 @@
-use crate::svc;
-use crate::Error;
-use crate::Never;
+use crate::{svc, Error, Never};
 use futures::{task, Async, Future, Poll};
 use rand;
 use std::fmt;

--- a/src/proxy/resolve.rs
+++ b/src/proxy/resolve.rs
@@ -1,5 +1,4 @@
-use crate::svc;
-use crate::Error;
+use crate::{svc, Error};
 use futures::{stream::FuturesUnordered, try_ready, Async, Future, Poll, Stream};
 use indexmap::IndexMap;
 use std::{fmt, net::SocketAddr};

--- a/src/proxy/server.rs
+++ b/src/proxy/server.rs
@@ -1,5 +1,4 @@
 use super::Accept;
-use crate::{app::config::H2Settings, drain, logging, Error, Never};
 use crate::core::ServeConnection;
 use crate::proxy::http::{
     glue::{HttpBody, HyperServerSvc},
@@ -11,6 +10,7 @@ use crate::transport::{
     tls::{self, HasPeerIdentity},
     Connection, Peek,
 };
+use crate::{app::config::H2Settings, drain, logging, Error, Never};
 use futures::future::{self, Either};
 use futures::{Future, Poll};
 use http;

--- a/src/transport/addr_info.rs
+++ b/src/transport/addr_info.rs
@@ -6,10 +6,15 @@ use tracing::trace;
 
 pub trait AddrInfo: Debug {
     fn local_addr(&self) -> Result<SocketAddr, io::Error>;
+    fn remote_addr(&self) -> Result<SocketAddr, io::Error>;
     fn get_original_dst(&self) -> Option<SocketAddr>;
 }
 
 impl<T: AddrInfo + ?Sized> AddrInfo for Box<T> {
+    fn remote_addr(&self) -> Result<SocketAddr, io::Error> {
+        self.as_ref().remote_addr()
+    }
+
     fn local_addr(&self) -> Result<SocketAddr, io::Error> {
         self.as_ref().local_addr()
     }
@@ -20,6 +25,10 @@ impl<T: AddrInfo + ?Sized> AddrInfo for Box<T> {
 }
 
 impl AddrInfo for TcpStream {
+    fn remote_addr(&self) -> Result<SocketAddr, io::Error> {
+        TcpStream::peer_addr(&self)
+    }
+
     fn local_addr(&self) -> Result<SocketAddr, io::Error> {
         TcpStream::local_addr(&self)
     }

--- a/src/transport/io.rs
+++ b/src/transport/io.rs
@@ -63,6 +63,10 @@ impl AsyncWrite for BoxedIo {
 }
 
 impl AddrInfo for BoxedIo {
+    fn remote_addr(&self) -> Result<SocketAddr, io::Error> {
+        self.0.remote_addr()
+    }
+
     fn local_addr(&self) -> Result<SocketAddr, io::Error> {
         self.0.local_addr()
     }
@@ -146,6 +150,10 @@ mod tests {
     }
 
     impl AddrInfo for WriteBufDetector {
+        fn remote_addr(&self) -> Result<SocketAddr, io::Error> {
+            unreachable!("not called in test")
+        }
+
         fn local_addr(&self) -> Result<SocketAddr, io::Error> {
             unreachable!("not called in test")
         }

--- a/src/transport/prefixed.rs
+++ b/src/transport/prefixed.rs
@@ -85,6 +85,10 @@ impl<S> AddrInfo for Prefixed<S>
 where
     S: AddrInfo,
 {
+    fn remote_addr(&self) -> Result<SocketAddr, io::Error> {
+        self.io.remote_addr()
+    }
+
     fn local_addr(&self) -> Result<SocketAddr, io::Error> {
         self.io.local_addr()
     }

--- a/src/transport/tls/io.rs
+++ b/src/transport/tls/io.rs
@@ -80,6 +80,10 @@ where
     S: AddrInfo + Debug,
     C: Session + Debug,
 {
+    fn remote_addr(&self) -> Result<SocketAddr, io::Error> {
+        self.0.get_ref().0.remote_addr()
+    }
+
     fn local_addr(&self) -> Result<SocketAddr, io::Error> {
         self.0.get_ref().0.local_addr()
     }


### PR DESCRIPTION
The `transport::tls::Listen` and `proxy::Server` types together formed a
sort of interface that facilitiates serving connections from tasks.

This change formalizes these interfaces so that the concrete
implementations can move/change more easily.

In pursuing this change, the remote `SocketAddr` is no longer passed
around in a tuple and is, instead, wired into the `Connection` type. The
`AddrInfo` trait has been updated to account for existince of the remote
socket addr on a socket.

No functional changes intended.