### PR TITLE
classify: Assume success on missing grpc-status

### DIFF
--- a/src/app/classify.rs
+++ b/src/app/classify.rs
@@ -166,7 +166,7 @@ impl classify::ClassifyEos for Eos {
             Eos::Grpc(GrpcEos::NoBody(class)) => class,
             Eos::Grpc(GrpcEos::Open) => trailers
                 .and_then(grpc_class)
-                .unwrap_or_else(|| Class::Grpc(SuccessOrFailure::Failure, 0)),
+                .unwrap_or_else(|| Class::Grpc(SuccessOrFailure::Success, 0)),
             Eos::Profile(class) => class,
             Eos::Error(msg) => Class::Stream(SuccessOrFailure::Failure, msg.into()),
         }
@@ -289,6 +289,14 @@ mod tests {
 
         let class = super::Response::Grpc.start(&rsp).eos(Some(&trailers));
         assert_eq!(class, Class::Grpc(SuccessOrFailure::Failure, 3));
+    }
+
+    #[test]
+    fn grpc_response_trailer_missing() {
+        let rsp = Response::builder().status(StatusCode::OK).body(()).unwrap();
+        let trailers = HeaderMap::new();
+        let class = super::Response::Grpc.start(&rsp).eos(Some(&trailers));
+        assert_eq!(class, Class::Grpc(SuccessOrFailure::Success, 0));
     }
 
     #[test]


### PR DESCRIPTION
When a request is canceled by a client, the server seems to just drop
the open response in a way that prevents the server code from being
notified of the reset reason, and so our classification code treats this
as if the stream ended without trailers.

This was previously treated as a failure, but this should be handled as
a success so that cancelations are not mistaken for application errors.

Addresses linkerd/linkerd2#3281
See also linkerd/linkerd2#3282