### PR TITLE
ci: Only test libraries on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,14 @@ jobs:
       #   - du -sh . && find . -type f |xargs -n 1000 du -s |sort -rn |head |awk '{print $2}' |xargs du -sh
       script:
         - make check-fmt
-        - travis_wait 40 make test clean
+        - travis_wait 20 make test-lib clean
+
+    # On master, run the (much longer) set of integration tests.
+    - stage: publish
+      if: branch = master && type != pull_request
+      rust: stable
+      script:
+        - travis_wait 40 make test-integration clean
 
     # On master, package an artifact and run tests in release mode before
     # publishing the artifact to build.l5d.io/linkerd2-proxy.

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,17 @@ check-fmt:
 fmt:
 	$(CARGO_FMT)
 
+
+.PHONY: test-lib
+test-lib:: fetch
+	$(CARGO_TEST) --lib --no-default-features
+
+.PHONY: test-integration
+test-integration: fetch
+	$(CARGO_TEST) --tests --no-default-features
+
 .PHONY: test
-test: fetch
-	$(CARGO_TEST) --no-default-features
+test: test-lib test-integration
 
 .PHONY: test-flakey
 test-flakey: fetch


### PR DESCRIPTION
Building the integration tests takes 2-3x the time as building tests for
the raw libs.

Split `make test-lib` and `make test-integration`, and change the Travis
config to only run `test-lib` on PRs.