### PR TITLE
cargo: Set authors to Linkerd Developers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [package]
 name = "linkerd2-proxy"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/hyper-balance/Cargo.toml
+++ b/lib/hyper-balance/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hyper-balance"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/linkerd2-addr/Cargo.toml
+++ b/lib/linkerd2-addr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-addr"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/linkerd2-conditional/Cargo.toml
+++ b/lib/linkerd2-conditional/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-conditional"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 
 [dependencies]

--- a/lib/linkerd2-dns-name/Cargo.toml
+++ b/lib/linkerd2-dns-name/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-dns-name"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/linkerd2-drain/Cargo.toml
+++ b/lib/linkerd2-drain/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-drain"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 
 [dependencies]

--- a/lib/linkerd2-identity/Cargo.toml
+++ b/lib/linkerd2-identity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-identity"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 
 [dependencies]

--- a/lib/linkerd2-metrics/Cargo.toml
+++ b/lib/linkerd2-metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-metrics"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/linkerd2-never/Cargo.toml
+++ b/lib/linkerd2-never/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-never"
 version = "0.1.0"
-authors = ["Sean McArthur <sean@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/linkerd2-proxy-core/Cargo.toml
+++ b/lib/linkerd2-proxy-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-proxy-core"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/linkerd2-proxy-resolve/Cargo.toml
+++ b/lib/linkerd2-proxy-resolve/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-proxy-resolve"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 
 [dependencies]

--- a/lib/linkerd2-router/Cargo.toml
+++ b/lib/linkerd2-router/Cargo.toml
@@ -1,10 +1,7 @@
 [package]
 name = "linkerd2-router"
 version = "0.1.0"
-authors = [
-    "Oliver Gould <ver@buoyant.io>",
-    "Carl Lerche <me@carllerche.com>",
-]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/linkerd2-signal/Cargo.toml
+++ b/lib/linkerd2-signal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-signal"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/linkerd2-stack/Cargo.toml
+++ b/lib/linkerd2-stack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-stack"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/linkerd2-task/Cargo.toml
+++ b/lib/linkerd2-task/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-task"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 

--- a/lib/linkerd2-timeout/Cargo.toml
+++ b/lib/linkerd2-timeout/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd2-timeout"
 version = "0.1.0"
-authors = ["Oliver Gould <ver@buoyant.io>"]
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"
 publish = false
 


### PR DESCRIPTION
Rather than have my name plastered all over the place, let's use the
developer list as the canonical author for this repo.