### PR TITLE
config: Make destination service configuration required

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -105,14 +105,7 @@ pub struct Config {
     // Destination Config
     //
     /// Where to talk to the control plane.
-    ///
-    /// When set, DNS is only after the Destination service says that there is
-    /// no service with the given name. When not set, the Destination service
-    /// is completely bypassed for service discovery and DNS is always used.
-    ///
-    /// This is optional to allow the proxy to work without the controller for
-    /// experimental & testing purposes.
-    pub destination_addr: Option<ControlAddr>,
+    pub destination_addr: ControlAddr,
 
     /// The maximum number of queries to the Destination service which may be
     /// active concurrently.
@@ -172,6 +165,7 @@ pub struct Listener {
 #[derive(Clone, Debug)]
 pub enum Error {
     InvalidEnvVar,
+    NoDestinationAddress,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -451,6 +445,7 @@ impl Config {
             .as_ref()
             .map(|c| c.is_none())
             .unwrap_or(false);
+
         let dst_addr = if id_disabled {
             parse_control_addr_disable_identity(strings, ENV_DESTINATION_SVC_BASE)
         } else {
@@ -553,7 +548,7 @@ impl Config {
             destination_profile_suffixes: dst_profile_suffixes?
                 .unwrap_or(parse_dns_suffixes(DEFAULT_DESTINATION_PROFILE_SUFFIXES).unwrap()),
 
-            destination_addr: dst_addr?,
+            destination_addr: dst_addr?.ok_or(Error::NoDestinationAddress)?,
             destination_context: dst_token?.unwrap_or_default(),
 
             identity_config: identity_config?
@@ -1019,7 +1014,8 @@ pub fn parse_identity_config<S: Strings>(strings: &S) -> Result<Option<identity:
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Error::InvalidEnvVar => fmt::Display::fmt("invalid environment variable", f),
+            Error::InvalidEnvVar => write!(f, "invalid environment variable"),
+            Error::NoDestinationAddress => write!(f, "no destination service configured"),
         }
     }
 }

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -300,12 +300,12 @@ where
             }
         };
 
-        let dst_svc = config.destination_addr.as_ref().map(|addr| {
+        let dst_svc = {
             use super::control;
 
             // If the dst_svc is on localhost, use the inbound keepalive.
             // If the dst_svc is remote, use the outbound keepalive.
-            let keepalive = if addr.addr.is_loopback() {
+            let keepalive = if config.destination_addr.addr.is_loopback() {
                 config.inbound_connect_keepalive
             } else {
                 config.outbound_connect_keepalive
@@ -328,8 +328,8 @@ where
                 .layer(keepalive::connect::layer(keepalive))
                 .layer(tls::client::layer(local_identity.clone()))
                 .service(connect::svc())
-                .make(addr.clone())
-        });
+                .make(config.destination_addr.clone())
+        };
 
         let resolver = crate::resolve::Resolver::new(
             dst_svc.clone(),


### PR DESCRIPTION
Practically, we never actually need to start the proxy without a
destination service.

Remove this possibility from the code to simplify logic.