### PR TITLE
fallback: Split fallback into dedicated crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,7 @@ dependencies = [
  "linkerd2-never 0.1.0",
  "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=ddbc3a4f7f8b0058801f896d27974d19ee98094c)",
  "linkerd2-proxy-core 0.1.0",
+ "linkerd2-proxy-fallback 0.1.0",
  "linkerd2-proxy-resolve 0.1.0",
  "linkerd2-router 0.1.0",
  "linkerd2-signal 0.1.0",
@@ -568,7 +569,7 @@ dependencies = [
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-rustls 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
@@ -611,6 +612,19 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-drain 0.1.0",
+]
+
+[[package]]
+name = "linkerd2-proxy-fallback"
+version = "0.1.0"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linkerd2-proxy-core 0.1.0",
+ "tower 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1536,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2158,7 +2172,7 @@ dependencies = [
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
 "checksum tokio-udp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
-"checksum tower 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b931b40c84f47fd203101b2ef18cd6523e27bb2902129bc3ca2ed1f07fa17695"
+"checksum tower 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc72f33b6a72c75c9df0037afce313018bae845f0ec7fdb9201b8768427a917f"
 "checksum tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-buffer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c98a7784e6c8ba106bc98d44ed1dbb9c018a8e0322e5e894d365f9020967128"
 "checksum tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "lib/linkerd2-identity",
     "lib/linkerd2-metrics",
     "lib/linkerd2-proxy-core",
+    "lib/linkerd2-proxy-fallback",
     "lib/linkerd2-proxy-resolve",
     "lib/linkerd2-router",
     "lib/linkerd2-signal",
@@ -38,6 +39,7 @@ linkerd2-identity      = { path = "lib/linkerd2-identity" }
 linkerd2-metrics       = { path = "lib/linkerd2-metrics" }
 linkerd2-never         = { path = "lib/linkerd2-never" }
 linkerd2-proxy-core    = { path = "lib/linkerd2-proxy-core" }
+linkerd2-proxy-fallback = { path = "lib/linkerd2-proxy-fallback" }
 linkerd2-proxy-resolve = { path = "lib/linkerd2-proxy-resolve" }
 linkerd2-router        = { path = "lib/linkerd2-router" }
 linkerd2-signal        = { path = "lib/linkerd2-signal" }

--- a/lib/linkerd2-proxy-fallback/Cargo.toml
+++ b/lib/linkerd2-proxy-fallback/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "linkerd2-proxy-fallback"
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+edition = "2018"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bytes = "0.4"
+futures = "0.1"
+http = "0.1"
+hyper = "0.12"
+linkerd2-proxy-core = { path = "../linkerd2-proxy-core" }
+tower= "0.1"
+tracing = "0.1"

--- a/src/app/outbound/mod.rs
+++ b/src/app/outbound/mod.rs
@@ -133,7 +133,7 @@ where
     //
     // If the `l5d-require-id` header is present, then that identity is
     // used as the server name when connecting to the endpoint.
-    let orig_dst_router = svc::builder()
+    let orig_dst_router_layer = svc::builder()
         .layer(router::layer(
             router::Config::new("out ep", capacity, max_idle_age),
             |req: &http::Request<_>| {
@@ -142,21 +142,23 @@ where
                 ep
             },
         ))
-        .buffer_pending(max_in_flight, DispatchDeadline::extract);
+        .buffer_pending(max_in_flight, DispatchDeadline::extract)
+        .into_inner();
 
     // Resolves the target via the control plane and balances requests
     // over all endpoints returned from the destination service.
-    let balancer = svc::builder()
+    let balancer_layer = svc::builder()
         .layer(balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
         .layer(resolve::layer(discovery::Resolve::new(resolve)))
-        .spawn_ready();
+        .spawn_ready()
+        .into_inner();
 
     let distributor = svc::builder()
         .layer(
             // Attempt to build a balancer. If the service is
             // unresolvable, fall back to using a router that dispatches
             // request to the application-selected original destination.
-            fallback::layer(balancer, orig_dst_router).on_error::<Unresolvable>(),
+            fallback::layer(balancer_layer, orig_dst_router_layer).on_error::<Unresolvable>(),
         )
         .service(endpoint_stack);
 

--- a/src/proxy/http/mod.rs
+++ b/src/proxy/http/mod.rs
@@ -7,7 +7,6 @@ pub mod add_header;
 pub mod balance;
 pub mod canonicalize;
 pub mod client;
-pub mod fallback;
 pub(super) mod glue;
 pub mod h1;
 pub mod h2;
@@ -27,6 +26,7 @@ pub mod upgrade;
 pub use self::client::Client;
 pub use self::glue::{ClientUsedTls, HttpBody as Body, HyperServerSvc};
 pub use self::settings::Settings;
+pub use linkerd2_proxy_fallback as fallback;
 
 pub trait HasH2Reason {
     fn h2_reason(&self) -> Option<::h2::Reason>;

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -58,6 +58,10 @@ impl<L> Builder<L> {
         Builder(self.0.timeout(timeout))
     }
 
+    pub fn into_inner(self) -> L {
+        self.0.into_inner()
+    }
+
     /// Wrap the service `S` with the layers.
     pub fn service<S>(self, service: S) -> L::Service
     where


### PR DESCRIPTION
The `proxy::http::fallback` module need not be in the main proxy crate.
Furthermore, it shouldn't depend on the `svc::Builder` type, which
really just holds a `Layer`. By upgrading the tower dependency, we can
extract the inner layer from the builder and make the `fallback::Layer`
type implemented in terms of these layers.