### PR TITLE
Stop using a Builder in the profile router

### DIFF
--- a/src/app/inbound/mod.rs
+++ b/src/app/inbound/mod.rs
@@ -104,7 +104,7 @@ where
         .layer(profiles::router::layer(
             profile_suffixes,
             profiles_client,
-            dst_route_stack,
+            dst_route_stack.into_inner(),
         ))
         .buffer_pending(max_in_flight, DispatchDeadline::extract)
         .layer(insert::target::layer())

--- a/src/app/outbound/mod.rs
+++ b/src/app/outbound/mod.rs
@@ -126,7 +126,8 @@ where
         .layer(http_metrics::layer::<_, classify::Response>(
             retry_http_metrics,
         ))
-        .layer(insert::target::layer());
+        .layer(insert::target::layer())
+        .into_inner();
 
     // Routes requests to their original destination endpoints. Used as
     // a fallback when service discovery has no endpoints for a destination.

--- a/src/proxy/http/profiles/router.rs
+++ b/src/proxy/http/profiles/router.rs
@@ -22,7 +22,7 @@ type RouteRouter<Target, RouteTarget, Svc, Body> =
 pub fn layer<G, Inner, RouteLayer, RouteBody, InnerBody>(
     suffixes: Vec<dns::Suffix>,
     get_routes: G,
-    route_layer: svc::Builder<RouteLayer>,
+    route_layer: RouteLayer,
 ) -> Layer<G, Inner, RouteLayer, RouteBody, InnerBody>
 where
     G: GetRoutes + Clone,
@@ -40,7 +40,7 @@ where
 #[derive(Debug)]
 pub struct Layer<G, Inner, RouteLayer, RouteBody, InnerBody> {
     get_routes: G,
-    route_layer: svc::Builder<RouteLayer>,
+    route_layer: RouteLayer,
     suffixes: Vec<dns::Suffix>,
     /// This is saved into a field so that the same `Arc`s are used and
     /// cloned, instead of calling `Route::default()` every time.
@@ -52,7 +52,7 @@ pub struct Layer<G, Inner, RouteLayer, RouteBody, InnerBody> {
 pub struct MakeSvc<G, Inner, RouteLayer, RouteBody, InnerBody> {
     inner: Inner,
     get_routes: G,
-    route_layer: svc::Builder<RouteLayer>,
+    route_layer: RouteLayer,
     suffixes: Vec<dns::Suffix>,
     default_route: Route,
     _p: ::std::marker::PhantomData<fn(RouteBody, InnerBody)>,
@@ -89,7 +89,7 @@ where
 {
     target: Target,
     inner: Inner,
-    route_layer: svc::Builder<RouteLayer>,
+    route_layer: RouteLayer,
     route_stream: Option<RouteStream>,
     concrete_router: Option<ConcreteRouter<Target, Inner::Value, InnerBody>>,
     router: RouteRouter<Target, Target::Output, RouteMake::Value, RouteBody>,
@@ -171,8 +171,7 @@ where
 
         let stack = self
             .route_layer
-            .clone()
-            .service(svc::shared(concrete_router.clone()));
+            .layer(svc::shared(concrete_router.clone()));
 
         // Initially there are no routes, so build a route router with only
         // the default route.
@@ -290,8 +289,7 @@ where
 
         let stack = self
             .route_layer
-            .clone()
-            .service(svc::shared(concrete_router));
+            .layer(svc::shared(concrete_router));
 
         let default_route = self.target.clone().with_route(self.default_route.clone());
 

--- a/src/proxy/http/profiles/router.rs
+++ b/src/proxy/http/profiles/router.rs
@@ -169,9 +169,7 @@ where
             rt::Router::new_fixed(rec, make)
         };
 
-        let stack = self
-            .route_layer
-            .layer(svc::shared(concrete_router.clone()));
+        let stack = self.route_layer.layer(svc::shared(concrete_router.clone()));
 
         // Initially there are no routes, so build a route router with only
         // the default route.
@@ -287,9 +285,7 @@ where
         // new concrete router.
         self.concrete_router = Some(concrete_router.clone());
 
-        let stack = self
-            .route_layer
-            .layer(svc::shared(concrete_router));
+        let stack = self.route_layer.layer(svc::shared(concrete_router));
 
         let default_route = self.target.clone().with_route(self.default_route.clone());
 


### PR DESCRIPTION
The builder type should only be used when composing layers. Now that we
have `Builder::into_inner`, we need not store a builder in the profile
router.

No functional changes.