### PR TITLE
travis: Allow 60 minutes for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,9 @@ jobs:
       #   - du -sh . && find . -type f |xargs -n 1000 du -s |sort -rn |head |awk '{print $2}' |xargs du -sh
       script:
         - make check-fmt
-        - travis_wait 40 make test clean
+        - travis_wait 40 make test-lib
+        - travis_wait 60 make test-integration
+        - make clean
 
     # On master, package an artifact and run tests in release mode before
     # publishing the artifact to build.l5d.io/linkerd2-proxy.


### PR DESCRIPTION
We've seen frequent timeouts in travis. Until this is ported to actions,
let's increase the timeout.