### PR TITLE
Improve stack-related compiler error messages

### DIFF
--- a/src/app/inbound/mod.rs
+++ b/src/app/inbound/mod.rs
@@ -84,12 +84,12 @@ where
     // extension into each request so that all lower metrics
     // implementations can use the route-specific configuration.
     let dst_route_layer = svc::layers()
-        .buffer_pending(max_in_flight, DispatchDeadline::extract)
-        .layer(classify::layer())
-        .layer(http_metrics::layer::<_, classify::Response>(
+        .and_then_buffer_pending(max_in_flight, DispatchDeadline::extract)
+        .and_then(classify::layer())
+        .and_then(http_metrics::layer::<_, classify::Response>(
             route_http_metrics,
         ))
-        .layer(insert::target::layer())
+        .and_then(insert::target::layer())
         .into_inner();
 
     // A per-`DstAddr` stack that does the following:
@@ -188,8 +188,8 @@ where
     // As the inbound proxy accepts connections, we don't do any
     // special transport-level handling.
     let accept = accept::builder()
-        .layer(transport_metrics.accept("inbound"))
-        .layer(keepalive::accept::layer(config.inbound_accept_keepalive));
+        .and_then(transport_metrics.accept("inbound"))
+        .and_then(keepalive::accept::layer(config.inbound_accept_keepalive));
 
     Server::new(
         "out",

--- a/src/app/inbound/mod.rs
+++ b/src/app/inbound/mod.rs
@@ -175,6 +175,9 @@ where
     let source_stack = svc::stack(svc::shared(admission_control))
         .push(orig_proto_downgrade::layer())
         .push(insert::target::layer())
+        // disabled due to information leagkage
+        //.push(set_remote_ip_on_req::layer())
+        //.push(set_client_id_on_req::layer())
         .push(strip_header::request::layer(super::L5D_REMOTE_IP))
         .push(strip_header::request::layer(super::L5D_CLIENT_ID))
         .push(strip_header::response::layer(super::L5D_SERVER_ID))

--- a/src/app/inbound/mod.rs
+++ b/src/app/inbound/mod.rs
@@ -54,7 +54,7 @@ where
         .push(rewrite_loopback_addr::layer());
 
     // Instantiates an HTTP client for a `client::Config`
-    let client_stack = svc::stack(connect.clone())
+    let client_stack = connect.clone()
         .push(client::layer("in", config.h2_settings))
         .push(reconnect::layer().with_backoff(config.inbound_connect_backoff.clone()))
         .push(normalize_uri::layer());
@@ -64,7 +64,7 @@ where
     //
     // If there is no `SO_ORIGINAL_DST` for an inbound socket,
     // `default_fwd_addr` may be used.
-    let endpoint_router = svc::stack(client_stack)
+    let endpoint_router = client_stack
         .push(tap_layer)
         .push(http_metrics::layer::<_, classify::Response>(
             endpoint_http_metrics,
@@ -125,7 +125,7 @@ where
     //
     // 6. Finally, if the Source had an SO_ORIGINAL_DST, this TCP
     // address is used.
-    let dst_router = svc::stack(dst_stack)
+    let dst_router = dst_stack
         .push_buffer_pending(max_in_flight, DispatchDeadline::extract)
         .push(router::layer(
             router::Config::new("in dst", capacity, max_idle_age),

--- a/src/app/inbound/mod.rs
+++ b/src/app/inbound/mod.rs
@@ -46,37 +46,35 @@ where
 
     // Establishes connections to the local application (for both
     // TCP forwarding and HTTP proxying).
-    let connect = svc::builder()
-        .layer(rewrite_loopback_addr::layer())
-        .layer(transport_metrics.connect("inbound"))
-        .timeout(config.inbound_connect_timeout)
-        .layer(keepalive::connect::layer(config.inbound_connect_keepalive))
-        .layer(tls::client::layer(local_identity))
-        .service(connect::svc());
+    let connect = svc::stack(connect::svc())
+        .push(tls::client::layer(local_identity))
+        .push(keepalive::connect::layer(config.inbound_connect_keepalive))
+        .push_timeout(config.inbound_connect_timeout)
+        .push(transport_metrics.connect("inbound"))
+        .push(rewrite_loopback_addr::layer());
 
     // Instantiates an HTTP client for a `client::Config`
-    let client_stack = svc::builder()
-        .layer(normalize_uri::layer())
-        .layer(reconnect::layer().with_backoff(config.inbound_connect_backoff.clone()))
-        .layer(client::layer("in", config.h2_settings))
-        .service(connect.clone());
+    let client_stack = svc::stack(connect.clone())
+        .push(client::layer("in", config.h2_settings))
+        .push(reconnect::layer().with_backoff(config.inbound_connect_backoff.clone()))
+        .push(normalize_uri::layer());
 
     // A stack configured by `router::Config`, responsible for building
     // a router made of route stacks configured by `inbound::Endpoint`.
     //
     // If there is no `SO_ORIGINAL_DST` for an inbound socket,
     // `default_fwd_addr` may be used.
-    let endpoint_router = svc::builder()
-        .layer(router::layer(
+    let endpoint_router = svc::stack(client_stack)
+        .push(tap_layer)
+        .push(http_metrics::layer::<_, classify::Response>(
+            endpoint_http_metrics,
+        ))
+        .push_buffer_pending(max_in_flight, DispatchDeadline::extract)
+        .push(router::layer(
             router::Config::new("in endpoint", capacity, max_idle_age),
             RecognizeEndpoint::new(default_fwd_addr),
         ))
-        .buffer_pending(max_in_flight, DispatchDeadline::extract)
-        .layer(http_metrics::layer::<_, classify::Response>(
-            endpoint_http_metrics,
-        ))
-        .layer(tap_layer)
-        .service(client_stack)
+        .into_inner()
         .make();
 
     // A per-`dst::Route` layer that uses profile data to configure
@@ -85,13 +83,14 @@ where
     // The `classify` module installs a `classify::Response`
     // extension into each request so that all lower metrics
     // implementations can use the route-specific configuration.
-    let dst_route_stack = svc::builder()
+    let dst_route_layer = svc::layers()
         .buffer_pending(max_in_flight, DispatchDeadline::extract)
         .layer(classify::layer())
         .layer(http_metrics::layer::<_, classify::Response>(
             route_http_metrics,
         ))
-        .layer(insert::target::layer());
+        .layer(insert::target::layer())
+        .into_inner();
 
     // A per-`DstAddr` stack that does the following:
     //
@@ -99,16 +98,15 @@ where
     //    per-route policy.
     // 2. Annotates the request with the `DstAddr` so that
     //    `RecognizeEndpoint` can use the value.
-    let dst_stack = svc::builder()
-        .layer(strip_header::request::layer(super::DST_OVERRIDE_HEADER))
-        .layer(profiles::router::layer(
+    let dst_stack = svc::stack(svc::shared(endpoint_router))
+        .push(insert::target::layer())
+        .push_buffer_pending(max_in_flight, DispatchDeadline::extract)
+        .push(profiles::router::layer(
             profile_suffixes,
             profiles_client,
-            dst_route_stack.into_inner(),
+            dst_route_layer,
         ))
-        .buffer_pending(max_in_flight, DispatchDeadline::extract)
-        .layer(insert::target::layer())
-        .service(svc::shared(endpoint_router));
+        .push(strip_header::request::layer(super::DST_OVERRIDE_HEADER));
 
     // Routes requests to a `DstAddr`.
     //
@@ -128,8 +126,9 @@ where
     //
     // 6. Finally, if the Source had an SO_ORIGINAL_DST, this TCP
     // address is used.
-    let dst_router = svc::builder()
-        .layer(router::layer(
+    let dst_router = svc::stack(dst_stack)
+        .push_buffer_pending(max_in_flight, DispatchDeadline::extract)
+        .push(router::layer(
             router::Config::new("in dst", capacity, max_idle_age),
             |req: &http::Request<_>| {
                 let canonical = req
@@ -159,16 +158,14 @@ where
                 })
             },
         ))
-        .buffer_pending(max_in_flight, DispatchDeadline::extract)
-        .service(dst_stack)
+        .into_inner()
         .make();
 
     // Share a single semaphore across all requests to signal when
     // the proxy is overloaded.
-    let admission_control = svc::builder()
-        .load_shed()
-        .concurrency_limit(max_in_flight)
-        .service(dst_router);
+    let admission_control = svc::stack(dst_router)
+        .push_concurrency_limit(max_in_flight)
+        .push_load_shed();
 
     // As HTTP requests are accepted, the `Source` connection
     // metadata is stored on each request's extensions.
@@ -176,21 +173,17 @@ where
     // Furthermore, HTTP/2 requests may be downgraded to HTTP/1.1 per
     // `orig-proto` headers. This happens in the source stack so that
     // the router need not detect whether a request _will be_ downgraded.
-    let source_stack = svc::builder()
-        .layer(handle_time.layer())
-        .layer(super::errors::layer())
-        .layer(insert::layer(move || {
+    let source_stack = svc::stack(svc::shared(admission_control))
+        .push(orig_proto_downgrade::layer())
+        .push(insert::target::layer())
+        .push(strip_header::request::layer(super::L5D_REMOTE_IP))
+        .push(strip_header::request::layer(super::L5D_CLIENT_ID))
+        .push(strip_header::response::layer(super::L5D_SERVER_ID))
+        .push(insert::layer(move || {
             DispatchDeadline::after(dispatch_timeout)
         }))
-        .layer(strip_header::response::layer(super::L5D_SERVER_ID))
-        .layer(strip_header::request::layer(super::L5D_CLIENT_ID))
-        .layer(strip_header::request::layer(super::L5D_REMOTE_IP))
-        .layer(insert::target::layer())
-        .layer(orig_proto_downgrade::layer())
-        // disabled on purpose
-        //.push(set_remote_ip_on_req::layer())
-        //.push(set_client_id_on_req::layer())
-        .service(svc::shared(admission_control));
+        .push(super::errors::layer())
+        .push(handle_time.layer());
 
     // As the inbound proxy accepts connections, we don't do any
     // special transport-level handling.

--- a/src/app/inbound/mod.rs
+++ b/src/app/inbound/mod.rs
@@ -104,7 +104,7 @@ where
         .layer(profiles::router::layer(
             profile_suffixes,
             profiles_client,
-            dst_route_stack,
+            dst_route_stack.into_inner(),
         ))
         .buffer_pending(max_in_flight, DispatchDeadline::extract)
         .layer(insert::target::layer())

--- a/src/app/inbound/mod.rs
+++ b/src/app/inbound/mod.rs
@@ -54,7 +54,8 @@ where
         .push(rewrite_loopback_addr::layer());
 
     // Instantiates an HTTP client for a `client::Config`
-    let client_stack = connect.clone()
+    let client_stack = connect
+        .clone()
         .push(client::layer("in", config.h2_settings))
         .push(reconnect::layer().with_backoff(config.inbound_connect_backoff.clone()))
         .push(normalize_uri::layer());

--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -259,25 +259,25 @@ where
                     config.outbound_connect_keepalive
                 };
 
-                let svc = svc::builder()
-                    .buffer_pending(
+                let svc = svc::stack(connect::svc())
+                    .push(tls::client::layer(Conditional::Some(
+                        id_config.trust_anchors.clone(),
+                    )))
+                    .push(keepalive::connect::layer(keepalive))
+                    .push_timeout(config.control_connect_timeout)
+                    .push(control::client::layer())
+                    .push(control::resolve::layer(dns_resolver.clone()))
+                    .push(reconnect::layer().with_backoff(config.control_backoff.clone()))
+                    .push(http_metrics::layer::<_, classify::Response>(
+                        ctl_http_metrics.clone(),
+                    ))
+                    .push(proxy::grpc::req_body_as_payload::layer().per_make())
+                    .push(control::add_origin::layer())
+                    .push_buffer_pending(
                         config.destination_buffer_capacity,
                         config.control_dispatch_timeout,
                     )
-                    .layer(control::add_origin::layer())
-                    .layer(proxy::grpc::req_body_as_payload::layer().per_make())
-                    .layer(http_metrics::layer::<_, classify::Response>(
-                        ctl_http_metrics.clone(),
-                    ))
-                    .layer(reconnect::layer().with_backoff(config.control_backoff.clone()))
-                    .layer(control::resolve::layer(dns_resolver.clone()))
-                    .layer(control::client::layer())
-                    .timeout(config.control_connect_timeout)
-                    .layer(keepalive::connect::layer(keepalive))
-                    .layer(tls::client::layer(Conditional::Some(
-                        id_config.trust_anchors.clone(),
-                    )))
-                    .service(connect::svc())
+                    .into_inner()
                     .make(id_config.svc.clone());
 
                 identity_daemon = Some(identity::Daemon::new(id_config, crt_store, svc));
@@ -311,23 +311,23 @@ where
                 config.outbound_connect_keepalive
             };
 
-            svc::builder()
-                .buffer_pending(
+            svc::stack(connect::svc())
+                .push(tls::client::layer(local_identity.clone()))
+                .push(keepalive::connect::layer(keepalive))
+                .push_timeout(config.control_connect_timeout)
+                .push(control::client::layer())
+                .push(control::resolve::layer(dns_resolver.clone()))
+                .push(reconnect::layer().with_backoff(config.control_backoff.clone()))
+                .push(http_metrics::layer::<_, classify::Response>(
+                    ctl_http_metrics.clone(),
+                ))
+                .push(proxy::grpc::req_body_as_payload::layer().per_make())
+                .push(control::add_origin::layer())
+                .push_buffer_pending(
                     config.destination_buffer_capacity,
                     config.control_dispatch_timeout,
                 )
-                .layer(control::add_origin::layer())
-                .layer(proxy::grpc::req_body_as_payload::layer().per_make())
-                .layer(http_metrics::layer::<_, classify::Response>(
-                    ctl_http_metrics.clone(),
-                ))
-                .layer(reconnect::layer().with_backoff(config.control_backoff.clone()))
-                .layer(control::resolve::layer(dns_resolver.clone()))
-                .layer(control::client::layer())
-                .timeout(config.control_connect_timeout)
-                .layer(keepalive::connect::layer(keepalive))
-                .layer(tls::client::layer(local_identity.clone()))
-                .service(connect::svc())
+                .into_inner()
                 .make(config.destination_addr.clone())
         };
 

--- a/src/app/outbound/mod.rs
+++ b/src/app/outbound/mod.rs
@@ -91,7 +91,7 @@ where
         .push(strip_header::response::layer(super::L5D_REMOTE_IP))
         .push(strip_header::response::layer(super::L5D_SERVER_ID))
         .push(strip_header::request::layer(super::L5D_REQUIRE_ID))
-        // disabled on purpose
+        // disabled due to information leagkage
         //.push(add_remote_ip_on_rsp::layer())
         //.push(add_server_id_on_rsp::layer())
         .push(orig_proto_upgrade::layer())

--- a/src/app/outbound/mod.rs
+++ b/src/app/outbound/mod.rs
@@ -126,7 +126,8 @@ where
         .layer(http_metrics::layer::<_, classify::Response>(
             retry_http_metrics,
         ))
-        .layer(insert::target::layer());
+        .layer(insert::target::layer())
+        .into_inner();
 
     // Routes requests to their original destination endpoints. Used as
     // a fallback when service discovery has no endpoints for a destination.

--- a/src/app/outbound/mod.rs
+++ b/src/app/outbound/mod.rs
@@ -70,7 +70,8 @@ where
         .push(transport_metrics.connect("outbound"));
 
     // Instantiates an HTTP client for for a `client::Config`
-    let client_stack = connect.clone()
+    let client_stack = connect
+        .clone()
         .push(client::layer("out", config.h2_settings))
         .push(reconnect::layer().with_backoff(config.outbound_connect_backoff.clone()))
         .push(normalize_uri::layer());

--- a/src/app/outbound/mod.rs
+++ b/src/app/outbound/mod.rs
@@ -70,7 +70,7 @@ where
         .push(transport_metrics.connect("outbound"));
 
     // Instantiates an HTTP client for for a `client::Config`
-    let client_stack = svc::stack(connect.clone())
+    let client_stack = connect.clone()
         .push(client::layer("out", config.h2_settings))
         .push(reconnect::layer().with_backoff(config.outbound_connect_backoff.clone()))
         .push(normalize_uri::layer());
@@ -87,7 +87,7 @@ where
     //    request version and headers).
     // 6. Strips any `l5d-server-id` that may have been received from
     //    the server, before we apply our own.
-    let endpoint_stack = svc::stack(client_stack)
+    let endpoint_stack = client_stack
         .push(strip_header::response::layer(super::L5D_REMOTE_IP))
         .push(strip_header::response::layer(super::L5D_SERVER_ID))
         .push(strip_header::request::layer(super::L5D_REQUIRE_ID))
@@ -149,7 +149,7 @@ where
         .push(resolve::layer(discovery::Resolve::new(resolve)))
         .push(balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY));
 
-    let distributor = svc::stack(endpoint_stack)
+    let distributor = endpoint_stack
         .push(
             // Attempt to build a balancer. If the service is
             // unresolvable, fall back to using a router that dispatches
@@ -165,7 +165,7 @@ where
     //    per-route policy.
     // 3. Creates a load balancer , configured by resolving the
     //   `DstAddr` with a resolver.
-    let dst_stack = svc::stack(distributor)
+    let dst_stack = distributor
         .push_buffer_pending(max_in_flight, DispatchDeadline::extract)
         .push(profiles::router::layer(
             profile_suffixes,
@@ -178,7 +178,7 @@ where
     //
     // This is shared across addr-stacks so that multiple addrs that
     // canonicalize to the same DstAddr use the same dst-stack service.
-    let dst_router = svc::stack(dst_stack)
+    let dst_router = dst_stack
         .push_buffer_pending(max_in_flight, DispatchDeadline::extract)
         .push(router::layer(
             router::Config::new("out dst", capacity, max_idle_age),
@@ -215,7 +215,7 @@ where
     //
     // 5. Finally, if the Source had an SO_ORIGINAL_DST, this TCP
     // address is used.
-    let addr_router = svc::stack(addr_stack)
+    let addr_router = addr_stack
         .push(strip_header::request::layer(super::L5D_CLIENT_ID))
         .push(strip_header::request::layer(super::DST_OVERRIDE_HEADER))
         .push(insert::target::layer())

--- a/src/proxy/accept.rs
+++ b/src/proxy/accept.rs
@@ -25,7 +25,7 @@ impl<L> Builder<L> {
     ///
     /// This layer will be applied to connections *before* the
     /// previously added layers in this builder.
-    pub fn layer<T>(self, layer: T) -> Builder<Stack<T, L>> {
+    pub fn and_then<T>(self, layer: T) -> Builder<Stack<T, L>> {
         Builder {
             accept: Stack {
                 inner: layer,

--- a/src/proxy/accept.rs
+++ b/src/proxy/accept.rs
@@ -25,11 +25,11 @@ impl<L> Builder<L> {
     ///
     /// This layer will be applied to connections *before* the
     /// previously added layers in this builder.
-    pub fn and_then<T>(self, layer: T) -> Builder<Stack<T, L>> {
+    pub fn push<O>(self, outer: O) -> Builder<Stack<L, O>> {
         Builder {
             accept: Stack {
-                inner: layer,
-                outer: self.accept,
+                inner: self.accept,
+                outer,
             },
         }
     }

--- a/src/proxy/http/profiles/router.rs
+++ b/src/proxy/http/profiles/router.rs
@@ -22,7 +22,7 @@ type RouteRouter<Target, RouteTarget, Svc, Body> =
 pub fn layer<G, Inner, RouteLayer, RouteBody, InnerBody>(
     suffixes: Vec<dns::Suffix>,
     get_routes: G,
-    route_layer: svc::Builder<RouteLayer>,
+    route_layer: RouteLayer,
 ) -> Layer<G, Inner, RouteLayer, RouteBody, InnerBody>
 where
     G: GetRoutes + Clone,
@@ -40,7 +40,7 @@ where
 #[derive(Debug)]
 pub struct Layer<G, Inner, RouteLayer, RouteBody, InnerBody> {
     get_routes: G,
-    route_layer: svc::Builder<RouteLayer>,
+    route_layer: RouteLayer,
     suffixes: Vec<dns::Suffix>,
     /// This is saved into a field so that the same `Arc`s are used and
     /// cloned, instead of calling `Route::default()` every time.
@@ -52,7 +52,7 @@ pub struct Layer<G, Inner, RouteLayer, RouteBody, InnerBody> {
 pub struct MakeSvc<G, Inner, RouteLayer, RouteBody, InnerBody> {
     inner: Inner,
     get_routes: G,
-    route_layer: svc::Builder<RouteLayer>,
+    route_layer: RouteLayer,
     suffixes: Vec<dns::Suffix>,
     default_route: Route,
     _p: ::std::marker::PhantomData<fn(RouteBody, InnerBody)>,
@@ -89,7 +89,7 @@ where
 {
     target: Target,
     inner: Inner,
-    route_layer: svc::Builder<RouteLayer>,
+    route_layer: RouteLayer,
     route_stream: Option<RouteStream>,
     concrete_router: Option<ConcreteRouter<Target, Inner::Value, InnerBody>>,
     router: RouteRouter<Target, Target::Output, RouteMake::Value, RouteBody>,
@@ -171,8 +171,7 @@ where
 
         let stack = self
             .route_layer
-            .clone()
-            .service(svc::shared(concrete_router.clone()));
+            .layer(svc::shared(concrete_router.clone()));
 
         // Initially there are no routes, so build a route router with only
         // the default route.
@@ -290,8 +289,7 @@ where
 
         let stack = self
             .route_layer
-            .clone()
-            .service(svc::shared(concrete_router));
+            .layer(svc::shared(concrete_router));
 
         let default_route = self.target.clone().with_route(self.default_route.clone());
 

--- a/src/proxy/http/profiles/router.rs
+++ b/src/proxy/http/profiles/router.rs
@@ -169,9 +169,7 @@ where
             rt::Router::new_fixed(rec, make)
         };
 
-        let stack = self
-            .route_layer
-            .layer(svc::shared(concrete_router.clone()));
+        let stack = self.route_layer.layer(svc::shared(concrete_router.clone()));
 
         // Initially there are no routes, so build a route router with only
         // the default route.
@@ -287,9 +285,7 @@ where
         // new concrete router.
         self.concrete_router = Some(concrete_router.clone());
 
-        let stack = self
-            .route_layer
-            .layer(svc::shared(concrete_router));
+        let stack = self.route_layer.layer(svc::shared(concrete_router));
 
         let default_route = self.target.clone().with_route(self.default_route.clone());
 

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -26,17 +26,17 @@ pub fn stack<S>(inner: S) -> Stack<S> {
 }
 
 impl<L> Layers<L> {
-    pub fn layer<T>(self, l: T) -> Layers<Pair<T, L>> {
+    pub fn and_then<T>(self, l: T) -> Layers<Pair<T, L>> {
         Layers(self.0.layer(l))
     }
 
     /// Buffer requests when when the next layer is out of capacity.
-    pub fn pending(self) -> Layers<Pair<pending::Layer, L>> {
-        self.layer(pending::layer())
+    pub fn and_then_pending(self) -> Layers<Pair<pending::Layer, L>> {
+        self.and_then(pending::layer())
     }
 
     /// Buffer requests when when the next layer is out of capacity.
-    pub fn buffer_pending<D, Req>(
+    pub fn and_then_buffer_pending<D, Req>(
         self,
         bound: usize,
         d: D,
@@ -45,11 +45,11 @@ impl<L> Layers<L> {
         D: buffer::Deadline<Req>,
         Req: Send + 'static,
     {
-        self.layer(buffer::layer(bound, d)).pending()
+        self.and_then(buffer::layer(bound, d)).and_then_pending()
     }
 
-    pub fn spawn_ready(self) -> Layers<Pair<SpawnReadyLayer, L>> {
-        self.layer(SpawnReadyLayer::new())
+    pub fn and_then_spawn_ready(self) -> Layers<Pair<SpawnReadyLayer, L>> {
+        self.and_then(SpawnReadyLayer::new())
     }
 
     pub fn into_inner(self) -> L {

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -24,6 +24,8 @@ pub fn stack<S>(inner: S) -> Stack<S> {
     Stack(inner)
 }
 
+// Possibly unused, but useful during development.
+#[allow(dead_code)]
 impl<L> Layers<L> {
     pub fn push<O>(self, outer: O) -> Layers<Pair<L, O>> {
         Layers(Pair::new(self.0, outer))
@@ -60,6 +62,8 @@ impl<M, L: Layer<M>> Layer<M> for Layers<L> {
     }
 }
 
+// Possibly unused, but useful during development.
+#[allow(dead_code)]
 impl<S> Stack<S> {
     pub fn push<L: Layer<S>>(self, layer: L) -> Stack<L::Service> {
         Stack(layer.layer(self.0))
@@ -83,9 +87,9 @@ impl<S> Stack<S> {
         self.push_pending().push(buffer::layer(bound, d))
     }
 
-    // pub fn push_spawn_ready(self) -> Stack<tower_spawn_ready::MakeSpawnReady<S>> {
-    //     self.push(SpawnReadyLayer::new())
-    // }
+    pub fn push_spawn_ready(self) -> Stack<tower_spawn_ready::MakeSpawnReady<S>> {
+        self.push(SpawnReadyLayer::new())
+    }
 
     pub fn push_concurrency_limit(self, max: usize) -> Stack<tower::limit::ConcurrencyLimit<S>> {
         self.push(ConcurrencyLimitLayer::new(max))

--- a/src/svc.rs
+++ b/src/svc.rs
@@ -3,7 +3,7 @@ pub use linkerd2_stack::{self as stack, layer, shared, Layer, LayerExt};
 pub use linkerd2_timeout::stack as timeout;
 use std::time::Duration;
 use tower::builder::ServiceBuilder;
-use tower::layer::util::{Identity, Stack};
+use tower::layer::util::{Identity, Stack as Pair};
 use tower::limit::concurrency::ConcurrencyLimitLayer;
 use tower::load_shed::LoadShedLayer;
 use tower::timeout::TimeoutLayer;
@@ -12,19 +12,26 @@ pub use tower::{service_fn as mk, MakeConnection, MakeService, Service, ServiceE
 use tower_spawn_ready::SpawnReadyLayer;
 
 #[derive(Clone, Debug)]
-pub struct Builder<L>(ServiceBuilder<L>);
+pub struct Layers<L>(ServiceBuilder<L>);
 
-pub fn builder() -> Builder<Identity> {
-    Builder(ServiceBuilder::new())
+#[derive(Clone, Debug)]
+pub struct Stack<S>(S);
+
+pub fn layers() -> Layers<Identity> {
+    Layers(ServiceBuilder::new())
 }
 
-impl<L> Builder<L> {
-    pub fn layer<T>(self, l: T) -> Builder<Stack<T, L>> {
-        Builder(self.0.layer(l))
+pub fn stack<S>(inner: S) -> Stack<S> {
+    Stack(inner)
+}
+
+impl<L> Layers<L> {
+    pub fn layer<T>(self, l: T) -> Layers<Pair<T, L>> {
+        Layers(self.0.layer(l))
     }
 
     /// Buffer requests when when the next layer is out of capacity.
-    pub fn pending(self) -> Builder<Stack<pending::Layer, L>> {
+    pub fn pending(self) -> Layers<Pair<pending::Layer, L>> {
         self.layer(pending::layer())
     }
 
@@ -33,7 +40,7 @@ impl<L> Builder<L> {
         self,
         bound: usize,
         d: D,
-    ) -> Builder<Stack<pending::Layer, Stack<buffer::Layer<D, Req>, L>>>
+    ) -> Layers<Pair<pending::Layer, Pair<buffer::Layer<D, Req>, L>>>
     where
         D: buffer::Deadline<Req>,
         Req: Send + 'static,
@@ -41,32 +48,80 @@ impl<L> Builder<L> {
         self.layer(buffer::layer(bound, d)).pending()
     }
 
-    /// Buffer requests when when the next layer is out of capacity.
-    pub fn spawn_ready(self) -> Builder<Stack<SpawnReadyLayer, L>> {
+    pub fn spawn_ready(self) -> Layers<Pair<SpawnReadyLayer, L>> {
         self.layer(SpawnReadyLayer::new())
-    }
-
-    pub fn concurrency_limit(self, max: usize) -> Builder<Stack<ConcurrencyLimitLayer, L>> {
-        Builder(self.0.concurrency_limit(max))
-    }
-
-    pub fn load_shed(self) -> Builder<Stack<LoadShedLayer, L>> {
-        Builder(self.0.load_shed())
-    }
-
-    pub fn timeout(self, timeout: Duration) -> Builder<Stack<TimeoutLayer, L>> {
-        Builder(self.0.timeout(timeout))
     }
 
     pub fn into_inner(self) -> L {
         self.0.into_inner()
     }
+}
 
-    /// Wrap the service `S` with the layers.
-    pub fn service<S>(self, service: S) -> L::Service
+impl<S> Stack<S> {
+    pub fn push<L: Layer<S>>(self, layer: L) -> Stack<L::Service> {
+        Stack(layer.layer(self.0))
+    }
+
+    /// Buffer requests when when the next layer is out of capacity.
+    pub fn push_pending(self) -> Stack<pending::MakePending<S>> {
+        self.push(pending::layer())
+    }
+
+    /// Buffer requests when when the next layer is out of capacity.
+    pub fn push_buffer_pending<D, Req>(
+        self,
+        bound: usize,
+        d: D,
+    ) -> Stack<buffer::Make<pending::MakePending<S>, D, Req>>
     where
-        L: Layer<S>,
+        D: buffer::Deadline<Req>,
+        Req: Send + 'static,
     {
-        self.0.service(service)
+        self.push_pending().push(buffer::layer(bound, d))
+    }
+
+    // pub fn push_spawn_ready(self) -> Stack<tower_spawn_ready::MakeSpawnReady<S>> {
+    //     self.push(SpawnReadyLayer::new())
+    // }
+
+    pub fn push_concurrency_limit(self, max: usize) -> Stack<tower::limit::ConcurrencyLimit<S>> {
+        self.push(ConcurrencyLimitLayer::new(max))
+    }
+
+    pub fn push_load_shed(self) -> Stack<tower::load_shed::LoadShed<S>> {
+        self.push(LoadShedLayer::new())
+    }
+
+    pub fn push_timeout(self, timeout: Duration) -> Stack<tower::timeout::Timeout<S>> {
+        self.push(TimeoutLayer::new(timeout))
+    }
+
+    /// Validates that this stack serves T-typed targets.
+    pub fn serves<T>(self) -> Self
+    where
+        S: Service<T>,
+    {
+        self
+    }
+
+    pub fn into_inner(self) -> S {
+        self.0
+    }
+}
+
+impl<T, S> Service<T> for Stack<S>
+where
+    S: Service<T>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self) -> futures::Poll<(), Self::Error> {
+        self.0.poll_ready()
+    }
+
+    fn call(&mut self, t: T) -> Self::Future {
+        self.0.call(t)
     }
 }


### PR DESCRIPTION
Service stacks were built from "top" to bottom, so that the concrete
service type is satisfied after all middlewares are composed together.
This leads to exceedingly complex compiler error messages.

This change adds a svc::Stack builder that aids composing layers
around a concrete inner service so that the compiler can more clearly
identity the layer that violates the type contract.

Note: this does not appear to improve compile times.

No functional changes are intended.