### PR TITLE
Use GitHub Actions for Pull Requests

### DIFF
--- a/.github/workflows/pull_request_docker.yml
+++ b/.github/workflows/pull_request_docker.yml
@@ -1,0 +1,15 @@
+name: Pull Request (Docker)
+
+on:
+  pull_request:
+    paths:
+    - '/Cargo.lock'
+    - '/Dockerfile'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: docker://rust:1.37.0-slim-buster
+    - run: make docker

--- a/.github/workflows/pull_request_rust.yml
+++ b/.github/workflows/pull_request_rust.yml
@@ -1,0 +1,29 @@
+name: Pull Request (Rust)
+
+on:
+  pull_request:
+    paths:
+    - 'Cargo.*'
+    - '*.rs'
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: docker://rust:1.37.0-slim-buster
+    - run: rustup component add rustfmt
+    - run: make check-fmt
+  lib:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: docker://rust:1.37.0-slim-buster
+    - run: make test-lib
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: docker://rust:1.37.0-slim-buster
+    - name: test-integration
+      run: make test-integration

--- a/.github/workflows/pull_request_rust.yml
+++ b/.github/workflows/pull_request_rust.yml
@@ -29,4 +29,5 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v1
     - run: make docker

--- a/.github/workflows/pull_request_rust.yml
+++ b/.github/workflows/pull_request_rust.yml
@@ -27,3 +27,7 @@ jobs:
     - uses: docker://rust:1.37.0-slim-buster
     - name: test-integration
       run: make test-integration
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: make docker

--- a/.github/workflows/pull_request_rust.yml
+++ b/.github/workflows/pull_request_rust.yml
@@ -25,9 +25,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: docker://rust:1.37.0-slim-buster
-    - name: test-integration
-      run: make test-integration
+    - run: make test-integration
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: make docker
+    - run: make docker

--- a/.github/workflows/pull_request_rust.yml
+++ b/.github/workflows/pull_request_rust.yml
@@ -7,7 +7,7 @@ on:
     - '*.rs'
 
 jobs:
-  format:
+  fmt:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -26,8 +26,3 @@ jobs:
     - uses: actions/checkout@v1
     - uses: docker://rust:1.37.0-slim-buster
     - run: make test-integration
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - run: make docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
   include:
     # Quickly run tests in dev mode.
     - rust: stable
+      if: branch = master && type != pull_request
       install:
         - rustup component add rustfmt
         - export RUSTFLAGS="-C debuginfo=0" RUST_TEST_THREADS=1 RUST_TEST_PATIENCE_MS=200

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # runtime performance.
 
 # rather than updating this manually, run update-rust-version.sh
-ARG RUST_IMAGE=rust:1.37.0-slim-buster
+ARG RUST_IMAGE=rust:1.37.0-buster
 ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-19.4.3
 
 ## Builds the proxy as incrementally as possible.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # rather than updating this manually, run update-rust-version.sh
 ARG RUST_IMAGE=rust:1.37.0-buster
-ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-19.4.3
+ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-19.8.7
 
 ## Builds the proxy as incrementally as possible.
 FROM $RUST_IMAGE as build
@@ -22,14 +22,6 @@ COPY Cargo.toml Cargo.lock ./
 COPY lib lib
 RUN cargo fetch --locked
 
-# Build libraries, leaving the proxy mocked out.
-ARG PROXY_UNOPTIMIZED
-RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
-    then cargo build --frozen ; \
-    else cargo build --frozen --release ; \
-    fi
-
-# Build the proxy binary using the already-built dependencies.
 COPY src src
 RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
     then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # runtime performance.
 
 # rather than updating this manually, run update-rust-version.sh
-ARG RUST_IMAGE=rust:1.37.0
+ARG RUST_IMAGE=rust:1.37.0-slim-buster
 ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-19.4.3
 
 ## Builds the proxy as incrementally as possible.

--- a/update-rust-version.sh
+++ b/update-rust-version.sh
@@ -10,7 +10,7 @@ fi
 VERSION=$1
 
 echo "$VERSION" > rust-toolchain
-sed -i'' -e "s/RUST_IMAGE=.*/RUST_IMAGE=rust:$VERSION-slim-buster/" Dockerfile
+sed -i'' -e "s/RUST_IMAGE=.*/RUST_IMAGE=rust:$VERSION-buster/" Dockerfile
 
 find .github -name \*.yml \
     -exec sed -i'' -e "s|docker://rust:.*|docker://rust:$VERSION-slim-buster|" '{}' \;

--- a/update-rust-version.sh
+++ b/update-rust-version.sh
@@ -10,4 +10,7 @@ fi
 VERSION=$1
 
 echo "$VERSION" > rust-toolchain
-sed -i'' -e "s/RUST_IMAGE=.*/RUST_IMAGE=rust:$VERSION/" Dockerfile
+sed -i'' -e "s/RUST_IMAGE=.*/RUST_IMAGE=rust:$VERSION-slim-buster/" Dockerfile
+
+find .github -name \*.yml \
+    -exec sed -i'' -e "s|docker://rust:.*|docker://rust:$VERSION-slim-buster|" '{}' \;


### PR DESCRIPTION
Disables Travis on Pull Requests, replacing it with GitHub Actions.
Travis remains enabled for master builds for the moment.