### PR TITLE
CI: Run tests inside rust container

### DIFF
--- a/.github/workflows/pull_request_docker.yml
+++ b/.github/workflows/pull_request_docker.yml
@@ -1,15 +1,14 @@
-name: Pull Request (Docker)
+name: Docker PR
 
 on:
   pull_request:
     paths:
-    - '/Cargo.lock'
-    - '/Dockerfile'
+    - 'Cargo.lock'
+    - 'Dockerfile'
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: docker://rust:1.37.0-slim-buster
     - run: make docker

--- a/.github/workflows/pull_request_rust.yml
+++ b/.github/workflows/pull_request_rust.yml
@@ -1,28 +1,29 @@
-name: Pull Request (Rust)
+name: Rust PR
 
-on:
-  pull_request:
-    paths:
-    - 'Cargo.*'
-    - '*.rs'
+on: [pull_request]
 
 jobs:
   fmt:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
+    container:
+      image: docker://rust:1.37.0-buster
     steps:
     - uses: actions/checkout@v1
-    - uses: docker://rust:1.37.0-slim-buster
     - run: rustup component add rustfmt
     - run: make check-fmt
+
   lib:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
+    container:
+      image: docker://rust:1.37.0-buster
     steps:
     - uses: actions/checkout@v1
-    - uses: docker://rust:1.37.0-slim-buster
     - run: make test-lib
+
   integration:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
+    container:
+      image: docker://rust:1.37.0-buster
     steps:
     - uses: actions/checkout@v1
-    - uses: docker://rust:1.37.0-slim-buster
     - run: make test-integration

--- a/update-rust-version.sh
+++ b/update-rust-version.sh
@@ -13,4 +13,4 @@ echo "$VERSION" > rust-toolchain
 sed -i'' -e "s/RUST_IMAGE=.*/RUST_IMAGE=rust:$VERSION-buster/" Dockerfile
 
 find .github -name \*.yml \
-    -exec sed -i'' -e "s|docker://rust:.*|docker://rust:$VERSION-slim-buster|" '{}' \;
+    -exec sed -i'' -e "s|docker://rust:.*|docker://rust:$VERSION-buster|" '{}' \;


### PR DESCRIPTION
The first version of the action didn't actually use the rust containers
to drive the build. This change pins the ubuntu and rust versions.

Even though the base OS includes rust-1.37, we want to control our rust
version independently.