### PR TITLE
update tracing crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -514,7 +514,7 @@ dependencies = [
  "linkerd2-dns-name 0.1.0",
  "ring 0.16.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki 0.21.0 (git+https://github.com/seanmonstar/webpki?branch=cert-dns-names-0.21)",
 ]
@@ -529,7 +529,7 @@ dependencies = [
  "hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -593,10 +593,10 @@ dependencies = [
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-spawn-ready 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-fmt 0.0.1-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-futures 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-log 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.1.1 (git+https://github.com/tokio-rs/tracing)",
  "trust-dns-resolver 0.10.2 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)",
  "try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -638,7 +638,7 @@ dependencies = [
  "hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-proxy-core 0.1.0",
  "tower 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -656,7 +656,7 @@ dependencies = [
  "linkerd2-task 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-futures 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -673,7 +673,7 @@ dependencies = [
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -682,7 +682,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -706,7 +706,7 @@ dependencies = [
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1787,48 +1787,31 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-attributes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-attributes 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tracing-fmt"
-version = "0.0.1-alpha.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-log 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1838,31 +1821,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-log"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-subscriber 0.0.1-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.0.1-alpha.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.1"
+source = "git+https://github.com/tokio-rs/tracing#49dab30847823a10f4398595616c19c0ee96d737"
 dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2317,13 +2304,12 @@ dependencies = [
 "checksum tower-spawn-ready 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-timeout 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "daa179ec4087589dc67148dc661abce5badc2c3ed4197adc7bd64b39f1f33c31"
 "checksum tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4792342fac093db5d2558655055a89a04ca909663467a4310c7739d9f8b64698"
-"checksum tracing 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b3dd549612b88fd19635628c1e6773f557ac419eece8deaefab1295928324d"
-"checksum tracing-attributes 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "af9da7f5256f2d11e322c9f10ba848a3eefae64f0272df5e7100dcda53892801"
-"checksum tracing-core 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a092e91612f25f6571c7bff934e1157b708f2b09e229fdc7760e791e1d2fd74f"
-"checksum tracing-fmt 0.0.1-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5b7dced65cefbb0445d76d28d023be32527d6b96ef02b2db9b65d1632d293cc7"
+"checksum tracing 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "701f355a504d1b7ae24eed42a19346701a8a3ac139058967895b6b1b56b13e64"
+"checksum tracing-attributes 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5b43a1835d0cb99f4a36fcdd0f777f72e4d4ff2eb6e78a0e105ac25e41309efa"
+"checksum tracing-core 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e94af5e2a5f1700cc58127f93d4b7e46c2b925856592066b9880aabce633b6d8"
 "checksum tracing-futures 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08c7446f4fb35df7ba2c537b7e2f812f91b20a58aa2b846f028342c4d2429be0"
-"checksum tracing-log 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5e73cad5d3da047803f3714aa0a34b47aee03e1e321e22968783dfc0208b97"
-"checksum tracing-subscriber 0.0.1-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d00a4e1771dca8725b0e1630397d85eff67ac7632c999877562b65304dea04c6"
+"checksum tracing-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "652bc99e1286541d6ccc42d5fb37213d1cdde544f88b19fac3d94e3117b55163"
+"checksum tracing-subscriber 0.1.1 (git+https://github.com/tokio-rs/tracing)" = "<none>"
 "checksum trust-dns-proto 0.6.0 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)" = "<none>"
 "checksum trust-dns-resolver 0.10.2 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)" = "<none>"
 "checksum try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "119b532a17fbe772d360be65617310164549a07c25a1deab04c84168ce0d4545"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,10 +86,10 @@ tower-grpc             = { git = "https://github.com/tower-rs/tower-grpc", defau
 trust-dns-resolver = { git = "https://github.com/bluejekyll/trust-dns", rev = "7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060", default-features = false }
 
 # tracing
-tracing         = "0.1.3"
-tracing-fmt     = "0.0.1-alpha.3"
-tracing-futures = "0.0.1-alpha.1"
-tracing-log     = "0.0.1-alpha.1"
+tracing            = "0.1.8"
+tracing-futures    = "0.0.1-alpha.1"
+tracing-log        = "0.1"
+tracing-subscriber = "0.1.1"
 
 # tls
 ring = "0.16"
@@ -123,4 +123,6 @@ debug = false
 
 [patch.crates-io]
 webpki = { git = "https://github.com/seanmonstar/webpki", branch = "cert-dns-names-0.21" }
+# this can be un-patched when `tracing-subscriber` 0.1.2 is released.
+tracing-subscriber = { git = "https://github.com/tokio-rs/tracing" }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -17,14 +17,16 @@ pub mod trace {
     use super::{clock, Context as LegacyContext, CONTEXT as LEGACY_CONTEXT};
     use crate::Error;
     use std::{env, fmt, str, time::Instant};
+    use tracing_subscriber::{layer, fmt::{format, Builder, Context}};
     pub use tracing::*;
-    pub use tracing_fmt::*;
+    pub use tracing_subscriber::{Filter, reload, FmtSubscriber};
 
-    type SubscriberBuilder = Builder<format::NewRecorder, Format, filter::EnvFilter>;
+    type SubscriberBuilder = Builder<format::NewRecorder, Format, layer::Identity>;
+    type Subscriber = FmtSubscriber<format::NewRecorder, Format>;
 
     #[derive(Clone)]
     pub struct LevelHandle {
-        inner: filter::reload::Handle<filter::EnvFilter, format::NewRecorder>,
+        inner: reload::Handle<Filter, Subscriber>,
     }
 
     /// Initialize tracing and logging with the value of the `ENV_LOG`
@@ -36,13 +38,17 @@ pub mod trace {
 
     /// Initialize tracing and logging with the provided verbosity-level filter.
     pub fn init_with_filter<F: AsRef<str>>(filter: F) -> Result<LevelHandle, Error> {
+        let filter = filter.as_ref();
+
         // Set up the subscriber
         let builder = subscriber_builder()
-            .with_filter(filter::EnvFilter::from(filter))
+            .with_filter(filter)
             .with_filter_reloading();
         let handle = builder.reload_handle();
         let dispatch = Dispatch::new(builder.finish());
         dispatcher::set_global_default(dispatch)?;
+
+        // Set up log compatibility.
         tracing_log::LogTracer::init()?;
 
         Ok(LevelHandle { inner: handle })
@@ -58,9 +64,9 @@ pub mod trace {
         start_time: Instant,
     }
 
-    impl<N> tracing_fmt::FormatEvent<N> for Format
+    impl<N> tracing_subscriber::fmt::FormatEvent<N> for Format
     where
-        N: for<'a> tracing_fmt::NewVisitor<'a>,
+        N: for<'a> tracing_subscriber::fmt::NewVisitor<'a>,
     {
         fn format_event(
             &self,
@@ -112,7 +118,7 @@ pub mod trace {
         /// do not exercise the `proxy-log-level` endpoint.
         pub fn dangling() -> Self {
             let builder = subscriber_builder()
-                .with_filter(filter::EnvFilter::default())
+                .with_filter(Filter::default())
                 .with_filter_reloading();
             let inner = builder.reload_handle();
             LevelHandle { inner }
@@ -120,7 +126,7 @@ pub mod trace {
 
         pub fn set_level(&self, level: impl AsRef<str>) -> Result<(), Error> {
             let level = level.as_ref();
-            let filter = level.parse::<filter::EnvFilter>()?;
+            let filter = level.parse::<Filter>()?;
             self.inner.reload(filter)?;
             info!(message = "set new log level", %level);
             Ok(())

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -17,9 +17,12 @@ pub mod trace {
     use super::{clock, Context as LegacyContext, CONTEXT as LEGACY_CONTEXT};
     use crate::Error;
     use std::{env, fmt, str, time::Instant};
-    use tracing_subscriber::{layer, fmt::{format, Builder, Context}};
     pub use tracing::*;
-    pub use tracing_subscriber::{Filter, reload, FmtSubscriber};
+    use tracing_subscriber::{
+        fmt::{format, Builder, Context},
+        layer,
+    };
+    pub use tracing_subscriber::{reload, Filter, FmtSubscriber};
 
     type SubscriberBuilder = Builder<format::NewRecorder, Format, layer::Identity>;
     type Subscriber = FmtSubscriber<format::NewRecorder, Format>;


### PR DESCRIPTION
This branch updates the proxy to depend on 0.1 versions of `tracing-log`
and `tracing-subscriber`, rather than alpha versions. The dependency on
`tracing-fmt` was removed, as that code was moved into
`tracing-subscriber` in tokio-rs/tracing#311.

Additionally, this should now allow us to use filter configuration that
involve dynamic filters on span fields, as well as on static targets.
Note that this may be of limited value *currently*, since the proxy
still uses our sui generis logging contexts rather than `tracing` spans,
but could be useful in the future.

Note that this is a duplicate of #342. I've submitted a new PR since CI
seems to be stuck refusing to build that branch. Therefore, this
closes #342.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>