### PR TITLE
tap: add headers to tap events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ dependencies = [
  "linkerd2-metrics 0.1.0",
  "opencensus-proto 0.1.0",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
+ "tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -586,7 +586,7 @@ dependencies = [
  "linkerd2-identity 0.1.0",
  "linkerd2-metrics 0.1.0",
  "linkerd2-opencensus 0.1.0",
- "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=1419992e32165e1b760d657205db4573890345b2)",
+ "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=4b788dd3d82564f0600a5904367e6d37827bb930)",
  "linkerd2-proxy-api-resolve 0.1.0",
  "linkerd2-proxy-core 0.1.0",
  "linkerd2-proxy-discover 0.1.0",
@@ -619,7 +619,7 @@ dependencies = [
  "tower 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
+ "tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-load 0.1.0 (git+https://github.com/tower-rs/tower)",
  "tower-request-modifier 0.1.0 (git+https://github.com/tower-rs/tower-http)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.8"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=1419992e32165e1b760d657205db4573890345b2#1419992e32165e1b760d657205db4573890345b2"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=4b788dd3d82564f0600a5904367e6d37827bb930#4b788dd3d82564f0600a5904367e6d37827bb930"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -648,23 +648,8 @@ dependencies = [
  "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
-]
-
-[[package]]
-name = "linkerd2-proxy-api"
-version = "0.1.8"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=ddbc3a4f7f8b0058801f896d27974d19ee98094c#ddbc3a4f7f8b0058801f896d27974d19ee98094c"
-dependencies = [
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
+ "tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-grpc-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -674,12 +659,12 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-identity 0.1.0",
- "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=ddbc3a4f7f8b0058801f896d27974d19ee98094c)",
+ "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=4b788dd3d82564f0600a5904367e6d37827bb930)",
  "linkerd2-proxy-core 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
+ "tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -983,8 +968,8 @@ dependencies = [
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
- "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
+ "tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-grpc-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1716,7 +1701,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#e16ff614088624bc7fd3783ce9f055c40a7ecd50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1734,7 +1719,7 @@ dependencies = [
 [[package]]
 name = "tower-grpc-build"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc#e16ff614088624bc7fd3783ce9f055c40a7ecd50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "codegen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2251,8 +2236,7 @@ dependencies = [
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=1419992e32165e1b760d657205db4573890345b2)" = "<none>"
-"checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=ddbc3a4f7f8b0058801f896d27974d19ee98094c)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=4b788dd3d82564f0600a5904367e6d37827bb930)" = "<none>"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
@@ -2346,8 +2330,8 @@ dependencies = [
 "checksum tower-balance 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
 "checksum tower-buffer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c98a7784e6c8ba106bc98d44ed1dbb9c018a8e0322e5e894d365f9020967128"
 "checksum tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"
-"checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
-"checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
+"checksum tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "839c195fd6e4e87442e7a631ea62632799695a3f897949192325a4e509ff4328"
+"checksum tower-grpc-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8862053a26bc7b901cf52bca8ae7d4c2e041222673e38f81a475aeb6c82481df"
 "checksum tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ddf07e10c07dcc8f41da6de036dc66def1a85b70eb8a385159e3908bb258328"
 "checksum tower-limit 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09d3d0fe82c2373225025d50881794e0792e544df9752dec66288b644b40fbfe"
 "checksum tower-load 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
  "linkerd2-identity 0.1.0",
  "linkerd2-metrics 0.1.0",
  "linkerd2-opencensus 0.1.0",
- "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=kleimkuhler/tap-headers)",
+ "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=1419992e32165e1b760d657205db4573890345b2)",
  "linkerd2-proxy-api-resolve 0.1.0",
  "linkerd2-proxy-core 0.1.0",
  "linkerd2-proxy-discover 0.1.0",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.8"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=kleimkuhler/tap-headers#4b788dd3d82564f0600a5904367e6d37827bb930"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=1419992e32165e1b760d657205db4573890345b2#1419992e32165e1b760d657205db4573890345b2"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -648,8 +648,8 @@ dependencies = [
  "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
+ "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
 ]
 
 [[package]]
@@ -1732,37 +1732,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower-grpc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tower-grpc-build"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower-grpc#e16ff614088624bc7fd3783ce9f055c40a7ecd50"
-dependencies = [
- "codegen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-grpc-build"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "codegen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2279,7 +2251,7 @@ dependencies = [
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=kleimkuhler/tap-headers)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=1419992e32165e1b760d657205db4573890345b2)" = "<none>"
 "checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=ddbc3a4f7f8b0058801f896d27974d19ee98094c)" = "<none>"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
@@ -2375,9 +2347,7 @@ dependencies = [
 "checksum tower-buffer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c98a7784e6c8ba106bc98d44ed1dbb9c018a8e0322e5e894d365f9020967128"
 "checksum tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"
 "checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
-"checksum tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "839c195fd6e4e87442e7a631ea62632799695a3f897949192325a4e509ff4328"
 "checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
-"checksum tower-grpc-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8862053a26bc7b901cf52bca8ae7d4c2e041222673e38f81a475aeb6c82481df"
 "checksum tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ddf07e10c07dcc8f41da6de036dc66def1a85b70eb8a385159e3908bb258328"
 "checksum tower-limit 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09d3d0fe82c2373225025d50881794e0792e544df9752dec66288b644b40fbfe"
 "checksum tower-load 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
  "linkerd2-identity 0.1.0",
  "linkerd2-metrics 0.1.0",
  "linkerd2-opencensus 0.1.0",
- "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=4b788dd3d82564f0600a5904367e6d37827bb930)",
+ "linkerd2-proxy-api 0.1.10 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.10)",
  "linkerd2-proxy-api-resolve 0.1.0",
  "linkerd2-proxy-core 0.1.0",
  "linkerd2-proxy-discover 0.1.0",
@@ -637,8 +637,8 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.8"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=4b788dd3d82564f0600a5904367e6d37827bb930#4b788dd3d82564f0600a5904367e6d37827bb930"
+version = "0.1.10"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.10#34ab9c848f2cadb6d3e9dc47cca5b1c36adcd59f"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -659,7 +659,7 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-identity 0.1.0",
- "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=4b788dd3d82564f0600a5904367e6d37827bb930)",
+ "linkerd2-proxy-api 0.1.10 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.10)",
  "linkerd2-proxy-core 0.1.0",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2236,7 +2236,7 @@ dependencies = [
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
-"checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=4b788dd3d82564f0600a5904367e6d37827bb930)" = "<none>"
+"checksum linkerd2-proxy-api 0.1.10 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.10)" = "<none>"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
 "checksum matchers 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
  "linkerd2-identity 0.1.0",
  "linkerd2-metrics 0.1.0",
  "linkerd2-opencensus 0.1.0",
- "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=ddbc3a4f7f8b0058801f896d27974d19ee98094c)",
+ "linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=kleimkuhler/tap-headers)",
  "linkerd2-proxy-api-resolve 0.1.0",
  "linkerd2-proxy-core 0.1.0",
  "linkerd2-proxy-discover 0.1.0",
@@ -638,7 +638,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.8"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=ddbc3a4f7f8b0058801f896d27974d19ee98094c#ddbc3a4f7f8b0058801f896d27974d19ee98094c"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=kleimkuhler/tap-headers#4b788dd3d82564f0600a5904367e6d37827bb930"
 dependencies = [
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -648,6 +648,21 @@ dependencies = [
  "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-grpc-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "linkerd2-proxy-api"
+version = "0.1.8"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=ddbc3a4f7f8b0058801f896d27974d19ee98094c#ddbc3a4f7f8b0058801f896d27974d19ee98094c"
+dependencies = [
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
  "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)",
 ]
@@ -1717,9 +1732,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-grpc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tower-grpc-build"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower-grpc#e16ff614088624bc7fd3783ce9f055c40a7ecd50"
+dependencies = [
+ "codegen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tower-grpc-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "codegen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2236,6 +2279,7 @@ dependencies = [
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
+"checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=kleimkuhler/tap-headers)" = "<none>"
 "checksum linkerd2-proxy-api 0.1.8 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=ddbc3a4f7f8b0058801f896d27974d19ee98094c)" = "<none>"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum lru-cache 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d06ff7ff06f729ce5f4e227876cb88d10bc59cd4ae1e09fbb2bde15c850dc21"
@@ -2331,7 +2375,9 @@ dependencies = [
 "checksum tower-buffer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c98a7784e6c8ba106bc98d44ed1dbb9c018a8e0322e5e894d365f9020967128"
 "checksum tower-discover 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"
 "checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
+"checksum tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "839c195fd6e4e87442e7a631ea62632799695a3f897949192325a4e509ff4328"
 "checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc)" = "<none>"
+"checksum tower-grpc-build 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8862053a26bc7b901cf52bca8ae7d4c2e041222673e38f81a475aeb6c82481df"
 "checksum tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ddf07e10c07dcc8f41da6de036dc66def1a85b70eb8a385159e3908bb258328"
 "checksum tower-limit 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "09d3d0fe82c2373225025d50881794e0792e544df9752dec66288b644b40fbfe"
 "checksum tower-load 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ linkerd2-trace-context = { path = "lib/linkerd2-trace-context" }
 opencensus-proto       = { path = "lib/opencensus-proto" }
 
 # linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "ddbc3a4f7f8b0058801f896d27974d19ee98094c" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "kleimkuhler/tap-headers" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "1419992e32165e1b760d657205db4573890345b2" }
 
 bytes = "0.4"
 futures = "0.1"
@@ -129,7 +129,7 @@ quickcheck = { version = "0.8", default-features = false }
 linkerd2-metrics = { path = "./lib/linkerd2-metrics", features = ["test_util"] }
 linkerd2-task    = { path = "lib/linkerd2-task", features = ["test_util"] }
 # linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "ddbc3a4f7f8b0058801f896d27974d19ee98094c" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], branch = "kleimkuhler/tap-headers" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "1419992e32165e1b760d657205db4573890345b2" }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ linkerd2-timeout = { path = "lib/linkerd2-timeout" }
 linkerd2-trace-context = { path = "lib/linkerd2-trace-context" }
 opencensus-proto       = { path = "lib/opencensus-proto" }
 
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "1419992e32165e1b760d657205db4573890345b2" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "4b788dd3d82564f0600a5904367e6d37827bb930" }
 
 bytes = "0.4"
 futures = "0.1"
@@ -95,7 +95,7 @@ tower-balance          = { git = "https://github.com/tower-rs/tower" }
 tower-load             = { git = "https://github.com/tower-rs/tower" }
 tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 tower-spawn-ready      = { git = "https://github.com/tower-rs/tower" }
-tower-grpc             = { git = "https://github.com/tower-rs/tower-grpc", default-features = false, features = ["protobuf"] }
+tower-grpc             = { version = "0.1", default-features = false, features = ["protobuf"] }
 
 # FIXME update to a release when available (>0.11)
 trust-dns-resolver = { git = "https://github.com/bluejekyll/trust-dns", rev = "7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060", default-features = false }
@@ -127,7 +127,7 @@ net2 = "0.2"
 quickcheck = { version = "0.8", default-features = false }
 linkerd2-metrics = { path = "./lib/linkerd2-metrics", features = ["test_util"] }
 linkerd2-task    = { path = "lib/linkerd2-task", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "1419992e32165e1b760d657205db4573890345b2" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "4b788dd3d82564f0600a5904367e6d37827bb930" }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,8 @@ linkerd2-timeout = { path = "lib/linkerd2-timeout" }
 linkerd2-trace-context = { path = "lib/linkerd2-trace-context" }
 opencensus-proto       = { path = "lib/opencensus-proto" }
 
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "ddbc3a4f7f8b0058801f896d27974d19ee98094c" }
+# linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "ddbc3a4f7f8b0058801f896d27974d19ee98094c" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "kleimkuhler/tap-headers" }
 
 bytes = "0.4"
 futures = "0.1"
@@ -127,7 +128,8 @@ net2 = "0.2"
 quickcheck = { version = "0.8", default-features = false }
 linkerd2-metrics = { path = "./lib/linkerd2-metrics", features = ["test_util"] }
 linkerd2-task    = { path = "lib/linkerd2-task", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "ddbc3a4f7f8b0058801f896d27974d19ee98094c" }
+# linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "ddbc3a4f7f8b0058801f896d27974d19ee98094c" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], branch = "kleimkuhler/tap-headers" }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ linkerd2-timeout = { path = "lib/linkerd2-timeout" }
 linkerd2-trace-context = { path = "lib/linkerd2-trace-context" }
 opencensus-proto       = { path = "lib/opencensus-proto" }
 
-# linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "ddbc3a4f7f8b0058801f896d27974d19ee98094c" }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "1419992e32165e1b760d657205db4573890345b2" }
 
 bytes = "0.4"
@@ -128,7 +127,6 @@ net2 = "0.2"
 quickcheck = { version = "0.8", default-features = false }
 linkerd2-metrics = { path = "./lib/linkerd2-metrics", features = ["test_util"] }
 linkerd2-task    = { path = "lib/linkerd2-task", features = ["test_util"] }
-# linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "ddbc3a4f7f8b0058801f896d27974d19ee98094c" }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "1419992e32165e1b760d657205db4573890345b2" }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ linkerd2-timeout = { path = "lib/linkerd2-timeout" }
 linkerd2-trace-context = { path = "lib/linkerd2-trace-context" }
 opencensus-proto       = { path = "lib/opencensus-proto" }
 
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "4b788dd3d82564f0600a5904367e6d37827bb930" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.10" }
 
 bytes = "0.4"
 futures = "0.1"
@@ -127,7 +127,7 @@ net2 = "0.2"
 quickcheck = { version = "0.8", default-features = false }
 linkerd2-metrics = { path = "./lib/linkerd2-metrics", features = ["test_util"] }
 linkerd2-task    = { path = "lib/linkerd2-task", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "4b788dd3d82564f0600a5904367e6d37827bb930" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.10" }
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 # `tokio-io` is needed for TCP tests, because `tokio::io` doesn't re-export
 # the `read` function.

--- a/lib/linkerd2-opencensus/Cargo.toml
+++ b/lib/linkerd2-opencensus/Cargo.toml
@@ -11,5 +11,5 @@ linkerd2-error = { path = "../linkerd2-error" }
 linkerd2-metrics = { path = "../linkerd2-metrics" }
 opencensus-proto = { path = "../opencensus-proto" }
 tokio = "0.1"
-tower-grpc = { git = "https://github.com/tower-rs/tower-grpc", default-features = false, features = ["protobuf"] }
+tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 tracing = "0.1"

--- a/lib/linkerd2-proxy-api-resolve/Cargo.toml
+++ b/lib/linkerd2-proxy-api-resolve/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 futures = "0.1"
 linkerd2-identity = { path = "../linkerd2-identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "4b788dd3d82564f0600a5904367e6d37827bb930" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.10" }
 linkerd2-proxy-core = { path = "../linkerd2-proxy-core" }
 prost = "0.5.0"
 tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }

--- a/lib/linkerd2-proxy-api-resolve/Cargo.toml
+++ b/lib/linkerd2-proxy-api-resolve/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 [dependencies]
 futures = "0.1"
 linkerd2-identity = { path = "../linkerd2-identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "ddbc3a4f7f8b0058801f896d27974d19ee98094c" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "4b788dd3d82564f0600a5904367e6d37827bb930" }
 linkerd2-proxy-core = { path = "../linkerd2-proxy-core" }
 prost = "0.5.0"
-tower-grpc = { git = "https://github.com/tower-rs/tower-grpc", default-features = false, features = ["protobuf"] }
+tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 indexmap = "1.0"
 tokio-sync = "0.1"
 tower = "0.1"

--- a/lib/opencensus-proto/Cargo.toml
+++ b/lib/opencensus-proto/Cargo.toml
@@ -11,8 +11,8 @@ futures = "0.1"
 prost = "0.5.0"
 prost-types = "0.5.0"
 tokio = "0.1.14"
-tower-grpc = { git = "https://github.com/tower-rs/tower-grpc", default-features = false, features = ["protobuf"] }
+tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 
 [build-dependencies]
-tower-grpc-build = { git = "https://github.com/tower-rs/tower-grpc", default-features = false }
+tower-grpc-build = { version = "0.1", default-features = false }
 

--- a/src/tap/grpc/server.rs
+++ b/src/tap/grpc/server.rs
@@ -288,7 +288,6 @@ impl iface::Tap for Tap {
                     Extract::Http { headers } => {
                         return Some((id, shared.events_tx.clone(), headers))
                     }
-                    // _ => {}
                 }
             }
             None

--- a/src/tap/grpc/server.rs
+++ b/src/tap/grpc/server.rs
@@ -278,7 +278,11 @@ impl iface::Tap for Tap {
                 },
                 http_types::headers::Header {
                     name: ":scheme".to_owned(),
-                    value: req.uri().scheme_part().map(|scheme| scheme.as_str().as_bytes().into()).unwrap_or_default(),
+                    value: req
+                        .uri()
+                        .scheme_part()
+                        .map(|scheme| scheme.as_str().as_bytes().into())
+                        .unwrap_or_default(),
                 },
                 http_types::headers::Header {
                     name: ":authority".to_owned(),
@@ -503,16 +507,21 @@ fn base_event<B, I: Inspect>(req: &http::Request<B>, inspect: &I) -> api::TapEve
     }
 }
 
-fn headers_to_pb(pseudos: impl IntoIterator<Item = http_types::headers::Header>, headers: &http::HeaderMap) -> http_types::Headers {
+fn headers_to_pb(
+    pseudos: impl IntoIterator<Item = http_types::headers::Header>,
+    headers: &http::HeaderMap,
+) -> http_types::Headers {
     http_types::Headers {
-        headers: pseudos.into_iter().chain(
-                headers.iter()
-                .map(|(name, value)| {
-                    http_types::headers::Header {
+        headers: pseudos
+            .into_iter()
+            .chain(
+                headers
+                    .iter()
+                    .map(|(name, value)| http_types::headers::Header {
                         name: name.as_str().to_owned(),
                         value: value.as_bytes().into(),
-                    }
-                }))
-            .collect()
+                    }),
+            )
+            .collect(),
     }
 }

--- a/src/tap/grpc/server.rs
+++ b/src/tap/grpc/server.rs
@@ -271,6 +271,16 @@ impl iface::Tap for Tap {
             scheme: req.uri().scheme_part().map(http_types::Scheme::from),
             authority: inspect.authority(req).unwrap_or_default(),
             path: req.uri().path().into(),
+            headers: req
+                .headers()
+                .iter()
+                .filter_map(|(name, value)| {
+                    value
+                        .to_str()
+                        .and_then(|v| Ok((name.as_str().to_owned(), v.to_owned())))
+                        .ok()
+                })
+                .collect(),
         };
 ;
         let event = api::TapEvent {

--- a/src/tap/grpc/server.rs
+++ b/src/tap/grpc/server.rs
@@ -280,8 +280,8 @@ impl iface::Tap for Tap {
                     name: ":scheme".to_owned(),
                     value: req
                         .uri()
-                        .scheme_part()
-                        .map(|scheme| scheme.as_str().as_bytes().into())
+                        .scheme_str()
+                        .map(|s| s.as_bytes().into())
                         .unwrap_or_default(),
                 },
                 http_types::headers::Header {
@@ -290,7 +290,11 @@ impl iface::Tap for Tap {
                 },
                 http_types::headers::Header {
                     name: ":path".to_owned(),
-                    value: req.uri().path().as_bytes().into(),
+                    value: req
+                        .uri()
+                        .path_and_query()
+                        .map(|p| p.as_str().as_bytes().into())
+                        .unwrap_or_default(),
                 },
             ];
             headers_to_pb(pseudos, req.headers())

--- a/src/tap/grpc/server.rs
+++ b/src/tap/grpc/server.rs
@@ -8,11 +8,11 @@ use bytes::Buf;
 use futures::sync::mpsc;
 use futures::{future, Async, Future, Poll, Stream};
 use hyper::body::Payload;
+use std::convert::TryFrom;
 use std::iter;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::Instant;
-use std::convert::TryFrom;
 use tokio_timer::clock;
 use tower_grpc::{self as grpc, Response};
 use tracing::{debug, trace, warn};
@@ -85,12 +85,10 @@ pub struct TapResponsePayload {
     grpc_status: Option<u32>,
 }
 
-
 #[derive(Debug)]
 enum Extract {
     Http { headers: bool },
 }
-
 
 // === impl Server ===
 
@@ -150,7 +148,7 @@ where
                 let default = Extract::Http { headers: false };
                 warn!(?default, "tap request with no extract field; using default");
                 default
-            },
+            }
         };
 
         // Wrapping is okay. This is realy just to disambiguate events within a
@@ -287,7 +285,9 @@ impl iface::Tap for Tap {
                 // Is HTTP data being extracted from the request, and should
                 // headers be included?
                 match shared.extract {
-                    Extract::Http { headers } => return Some((id, shared.events_tx.clone(), headers)),
+                    Extract::Http { headers } => {
+                        return Some((id, shared.events_tx.clone(), headers))
+                    }
                     // _ => {}
                 }
             }
@@ -525,8 +525,8 @@ impl TryFrom<api::observe_request::Extract> for Extract {
                     _ => false,
                 };
                 Ok(Extract::Http { headers })
-            },
-            _ => Err(())
+            }
+            _ => Err(()),
         }
     }
 }

--- a/tests/support/tap.rs
+++ b/tests/support/tap.rs
@@ -69,9 +69,9 @@ pub fn observe_request() -> ObserveBuilder {
         extract: Some(pb::observe_request::Extract {
             extract: Some(pb::observe_request::extract::Extract::Http(
                 pb::observe_request::extract::Http {
-                    extract: None // no headers
-                }
-            ))
+                    extract: None, // no headers
+                },
+            )),
         }),
     })
 }

--- a/tests/support/tap.rs
+++ b/tests/support/tap.rs
@@ -66,6 +66,13 @@ pub fn observe_request() -> ObserveBuilder {
                 },
             )),
         }),
+        extract: Some(pb::observe_request::Extract {
+            extract: Some(pb::observe_request::extract::Extract::Http(
+                pb::observe_request::extract::Http {
+                    extract: None // no headers
+                }
+            ))
+        }),
     })
 }
 


### PR DESCRIPTION
PR linkerd/linkerd2-proxy-api#33 adds headers to the `RequestInit`,
`ResponseInit`, and `ResponseEnd` tap events. This branch updates the
proxy to populate these fields.

This updates the proxy-api dependency to the tag  `v0.1.10`, or
linkerd/linkerd2-proxy-api@34ab9c848f2cadb6d3e9dc47cca5b1c36adcd59f