### PR TITLE
Add 587 to the list of ports to disable protocol detection

### DIFF
--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -359,6 +359,7 @@ const DEFAULT_IDENTITY_MAX_REFRESH: Duration = Duration::from_secs(60 * 60 * 24)
 // https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt
 const DEFAULT_PORTS_DISABLE_PROTOCOL_DETECTION: &[u16] = &[
     25,   // SMTP
+    587,  // SMTP
     3306, // MySQL
 ];
 


### PR DESCRIPTION
Port `587` is very commonly used for SMTP, and I think it would be useful to have it included in the default list of ports to skip protocol detection.

For example, the docs for [`sendgrid`](https://sendgrid.com/docs/for-developers/sending-email/rubyonrails/#configure-actionmailer-to-use-sendgrid), [`mailgun`](https://www.mailgun.com/blog/which-smtp-port-understanding-ports-25-465-587) and [`ses`](https://aws.amazon.com/blogs/messaging-and-targeting/debugging-smtp-conversations-part-1-how-to-speak-smtp/) will all mention port `587`, and usually use that in their examples as well, instead of `25`.