### PR TITLE
ci: Use a readymade release action

### DIFF
--- a/.github/actions/release-tag-meta/Dockerfile
+++ b/.github/actions/release-tag-meta/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox:1.31
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/release-tag-meta/action.yml
+++ b/.github/actions/release-tag-meta/action.yml
@@ -1,0 +1,16 @@
+name: release-tag-meta
+description: Extract release metadata from the tag
+inputs:
+  git-ref:
+    required: true
+    description: "The git ref (i.e. starting with refs/tags)"
+outputs:
+  tag:
+    description: "The git tag (without the refs prefix)"
+  name:
+    description: "The release name"
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - ${{ inputs.git-ref }}

--- a/.github/actions/release-tag-meta/entrypoint.sh
+++ b/.github/actions/release-tag-meta/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eu
+
+ref="$1"
+tag=$(echo "$ref" | sed s,^refs/tags/,,)
+name=$(echo "$tag" | sed s,^release/,,)
+
+echo ::set-output "name=tag::$tag"
+echo ::set-output "name=name::$name"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - name: git co
       uses: actions/checkout@v1
-    - name: Get Tag Info
+    - name: meta
       id: release-tag-meta
       uses: ./.github/actions/release-tag-meta
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,41 +18,12 @@ jobs:
       uses: ./.github/actions/release-tag-meta
       with:
         git-ref: ${{ github.ref }}
+    - runs: echo ${{ toJSON(steps) }}
     - name: make package
       env:
-        CARGO_RELEASE: 1
-      run: PACKAGE_VERSION=${{steps.release-tag-meta.name}} make package
-    - uses: actions/upload-artifact@v1
-      with:
-        name: package
-        path: target/release/package
-
-  test:
-    runs-on: ubuntu-latest
-    container:
-      image: docker://rust:1.37-buster
-    steps:
-    - name: git co
-      uses: actions/checkout@v1
-    - run: make test-integration
-
-  publish:
-    needs: [package, test]
-    runs-on: ubuntu-latest
-    steps:
-    - name: git co
-      uses: actions/checkout@v1
-    - name: Get Tag Info
-      id: release-tag-meta
-      uses: ./.github/actions/release-tag-meta
-      with:
-        git-ref: ${{ github.ref }}
-    - name: fetch
-      uses: actions/download-artifact@v1
-      with:
-        name: package
-        path: package
-    - runs: echo ${{ toJSON(steps) }}
+        CARGO_RELEASE: "1"
+        PACKAGE_VERSION: ${{ steps.release-tag-meta.name }}
+      run: make package
     - name: release
       uses: softprops/action-gh-release@b21b43d
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       uses: ./.github/actions/release-tag-meta
       with:
         git-ref: ${{ github.ref }}
-    - runs: echo ${{ toJSON(steps) }}
+    - run: echo ${{ toJSON(steps) }}
     - name: make package
       env:
         CARGO_RELEASE: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,16 +18,16 @@ jobs:
       uses: ./.github/actions/release-tag-meta
       with:
         git-ref: ${{ github.ref }}
-    - run: echo "${{ toJSON(steps) }}"
+    #- run: echo "${{ toJSON(steps.release-tag-meta) }}"
     - name: make package
       env:
         CARGO_RELEASE: "1"
-        PACKAGE_VERSION: ${{ steps.release-tag-meta.name }}
+        PACKAGE_VERSION: ${{ steps.release-tag-meta.outputs.name }}
       run: make package
     - name: release
       uses: softprops/action-gh-release@b21b43d
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: ${{ steps.release-tag-meta.name }}
+        name: ${{ steps.release-tag-meta.outputs.name }}
         files: package/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,8 @@ jobs:
       with:
         name: package
         path: package
+    - name: git co
+      uses: actions/checkout@v1
     - name: Get Tag Info
       id: release-tag-meta
       uses: ./.github/actions/release-tag-meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         name: ${{ steps.release-tag-meta.outputs.name }}
-        files: package/*
+        files: target/release/package/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,15 @@ jobs:
     steps:
     - name: git co
       uses: actions/checkout@v1
-
+    - name: Get Tag Info
+      id: release-tag-meta
+      uses: ./.github/actions/release-tag-meta
+      with:
+        git-ref: ${{ github.ref }}
     - name: make package
       env:
         CARGO_RELEASE: 1
-      run: PACKAGE_VERSION=$(echo $GITHUB_REF | sed -E 's,^refs/tags/release/,,') make package
-
+      run: PACKAGE_VERSION=${{steps.release-tag-meta.name}} make package
     - uses: actions/upload-artifact@v1
       with:
         name: package
@@ -42,14 +45,15 @@ jobs:
       with:
         name: package
         path: package
+    - name: Get Tag Info
+      id: release-tag-meta
+      uses: ./.github/actions/release-tag-meta
+      with:
+        git-ref: ${{ github.ref }}
     - name: release
-      uses: docker://github/ghx:master
+      uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # ghx reads GITHUB_REF and then barfs on it, no matter its command-line
-      # args. so, we override it to the SHA so it all works out.
       with:
-        entrypoint: sh
-        args: -c "export TAG=$(echo $GITHUB_REF | sed -E 's,^refs/tags/,,') NAME=$(echo $GITHUB_REF | sed -E 's,^refs/tags/release/,,') ; export GITHUB_REF=$GITHUB_SHA ; cd package && ghx release create --verbose --tag=$TAG --name=$NAME *.tar.gz"
-
-
+        files: package/*.tar.gz
+        name: ${{steps.release-tag-meta.name}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         git-ref: ${{ github.ref }}
     - name: release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@b21b43d
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       uses: ./.github/actions/release-tag-meta
       with:
         git-ref: ${{ github.ref }}
-    - run: echo ${{ toJSON(steps) }}
+    - run: echo "${{ toJSON(steps) }}"
     - name: make package
       env:
         CARGO_RELEASE: "1"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,11 +40,6 @@ jobs:
     needs: [package, test]
     runs-on: ubuntu-latest
     steps:
-    - name: fetch
-      uses: actions/download-artifact@v1
-      with:
-        name: package
-        path: package
     - name: git co
       uses: actions/checkout@v1
     - name: Get Tag Info
@@ -52,10 +47,16 @@ jobs:
       uses: ./.github/actions/release-tag-meta
       with:
         git-ref: ${{ github.ref }}
+    - name: fetch
+      uses: actions/download-artifact@v1
+      with:
+        name: package
+        path: package
+    - runs: echo ${{ toJSON(steps) }}
     - name: release
       uses: softprops/action-gh-release@b21b43d
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        files: package/*.tar.gz
-        name: ${{steps.release-tag-meta.name}}
+        name: ${{ steps.release-tag-meta.name }}
+        files: package/*


### PR DESCRIPTION
The first pass at releases used a container I found on the internet
called `github/ghx`, which provides a CLI interface to github that was
usable within actions. I've contacted the author, who says it is
unmaintained (and the sources for it are not public); so I've elected to
use softprops' release action.

In order to do this, I added a local action that handles the parsing of
the git `refs/*` syntax into the proper release metadata.