### PR TITLE
resolve: Do not send the 'k8s' scheme

### DIFF
--- a/src/app/main.rs
+++ b/src/app/main.rs
@@ -339,7 +339,6 @@ where
         };
 
         let resolver = crate::api_resolve::Resolve::new(dst_svc.clone())
-            .with_scheme("k8s")
             .with_context_token(&config.destination_context);
 
         let (tap_layer, tap_grpc, tap_daemon) = tap::new();

--- a/src/app/profiles.rs
+++ b/src/app/profiles.rs
@@ -213,9 +213,9 @@ where
                     };
 
                     let req = api::GetDestination {
-                        scheme: "k8s".to_owned(),
                         path: self.dst.clone(),
                         context_token: self.context_token.clone(),
+                        ..Default::default()
                     };
                     debug!("getting profile: {:?}", req);
                     let rspf = self.service.get_profile(grpc::Request::new(req));

--- a/tests/support/controller.rs
+++ b/tests/support/controller.rs
@@ -76,7 +76,6 @@ impl Controller {
             format!("{}:80", dest)
         };
         let dst = pb::GetDestination {
-            scheme: "k8s".into(),
             path,
             ..Default::default()
         };
@@ -94,7 +93,6 @@ impl Controller {
             format!("{}:80", dest)
         };
         let dst = pb::GetDestination {
-            scheme: "k8s".into(),
             path,
             ..Default::default()
         };
@@ -145,7 +143,6 @@ impl Controller {
             format!("{}:80", dest)
         };
         let dst = pb::GetDestination {
-            scheme: "k8s".into(),
             path,
             ..Default::default()
         };


### PR DESCRIPTION
The fact that the proxy sends resolve requests with a scheme value of
`k8s` is an accident of history. Given that this value is currently
unused by the controller, stop setting a scheme value entirely.