### PR TITLE
ci: Run integration tests on dedicated host

### DIFF
--- a/.github/actions/remote/Dockerfile
+++ b/.github/actions/remote/Dockerfile
@@ -1,0 +1,7 @@
+# Intended to be run on a remote DOCKER_HOST
+ARG RUST_IMAGE=rust:1.37.0-buster
+FROM $RUST_IMAGE as build
+WORKDIR /usr/src/linkerd2-proxy
+COPY . ./
+RUN ["make", "fetch"]
+ENTRYPOINT ["make"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,10 @@ jobs:
         echo "${{ secrets.DOCKER_PRIVATE_KEY }}" >~/.ssh/id
         # Use well-known public keys for the host to prevent middlemen.
         echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" >~/.ssh/known_hosts
-        # Configure host with BatchMode to prevent idlelocking.
+        # Configure host with ServerAliveInterval to ensure that the client
+        # stays alive even when the server is busy emitting nothing.
+        # ServerAliveMaxCount ensures that server responds to these pings
+        # within ~5 minutes.
         (
           echo "Host linkerd-docker"
           echo "    User github"
@@ -54,6 +57,7 @@ jobs:
           echo "    IdentityFile ~/.ssh/id"
           echo "    BatchMode yes"
           echo "    ServerAliveInterval 60"
+          echo "    ServerAliveMaxCount 5"
         ) >~/.ssh/config
         # Build once with output, then build again to get the img ref (should
         # be a noop).
@@ -66,7 +70,6 @@ jobs:
       env:
         DOCKER_HOST: "ssh://linkerd-docker"
       run: docker run --rm $(cat image.ref) test-integration
-
 
     # Try to delete the build image.
     - name: Cleanup (Origin)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,8 @@ jobs:
           echo "    ServerAliveInterval 60"
           echo "    ServerAliveMaxCount 5"
         ) >~/.ssh/config
+        # Confirm that the SSH configuration works.
+        ssh linkerd-docker docker version
         # Build once with output, then build again to get the img ref (should
         # be a noop).
         docker build -f .github/actions/remote/Dockerfile .

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,7 @@ jobs:
         echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" >~/.ssh/known_hosts
         # Configure host with ServerAliveInterval to ensure that the client
         # stays alive even when the server is busy emitting nothing.
-        # ServerAliveMaxCount ensures that server responds to these pings
+        # ServerAliveCountMax ensures that server responds to these pings
         # within ~5 minutes.
         (
           echo "Host linkerd-docker"
@@ -57,7 +57,7 @@ jobs:
           echo "    IdentityFile ~/.ssh/id"
           echo "    BatchMode yes"
           echo "    ServerAliveInterval 60"
-          echo "    ServerAliveMaxCount 5"
+          echo "    ServerAliveCountMax 5"
         ) >~/.ssh/config
         # Confirm that the SSH configuration works.
         ssh linkerd-docker docker version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,8 +26,50 @@ jobs:
 
   integration:
     runs-on: ubuntu-18.04
-    container:
-      image: docker://rust:1.37.0-buster
     steps:
     - uses: actions/checkout@v1
-    - run: make test-integration
+
+    # Forks run in GitHub actions, as they don't have access to secrets.
+    - name: Test (Fork)
+      if: github.event.pull_request.head.repo.fork
+      run: make test-integration
+
+    # Create a build image on a Linkerd build host.
+    - name: Setup (Origin)
+      if: '!github.event.pull_request.head.repo.fork'
+      run: |
+        mkdir -p ~/.ssh
+        # Create an identity file and protect before writing contents to it.
+        touch ~/.ssh/id && chmod 600 ~/.ssh/id
+        echo "${{ secrets.DOCKER_PRIVATE_KEY }}" >~/.ssh/id
+        # Use well-known public keys for the host to prevent middlemen.
+        echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" >~/.ssh/known_hosts
+        # Configure host with BatchMode to prevent idlelocking.
+        (
+          echo "Host ${{ secrets.DOCKER_ADDRESS }}"
+          echo "    User github"
+          echo "    IdentityFile ~/.ssh/id"
+          echo "    BatchMode yes"
+          echo "    ServerAliveInterval 60"
+        ) >~/.ssh/config
+        # Build once with output, then build again to get the img ref (should
+        # be a noop).
+        export DOCKER_HOST="ssh://${{ secrets.DOCKER_ADDRESS }}"
+        docker build -f .github/actions/remote/Dockerfile .
+        docker build -qf .github/actions/remote/Dockerfile . >image.ref
+
+    # Use the previously built image to run tests.
+    - name: Test (Origin)
+      if: '!github.event.pull_request.head.repo.fork'
+      run: |
+        export DOCKER_HOST="ssh://${{ secrets.DOCKER_ADDRESS }}"
+        docker run --rm $(cat image.ref) test-integration
+
+    # Try to delete the build image.
+    - name: Cleanup (Origin)
+      if: always() && !github.event.pull_request.head.repo.fork
+      run: |
+        export DOCKER_HOST="ssh://${{ secrets.DOCKER_ADDRESS }}"
+        if [ -f image.ref ]; then docker rmi -f $(cat image.ref)
+        else echo "skipped" >&2
+        fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,8 @@ jobs:
     # Create a build image on a Linkerd build host.
     - name: Setup (Origin)
       if: '!github.event.pull_request.head.repo.fork'
+      env:
+        DOCKER_HOST: "ssh://linkerd-docker"
       run: |
         mkdir -p ~/.ssh
         # Create an identity file and protect before writing contents to it.
@@ -46,30 +48,32 @@ jobs:
         echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" >~/.ssh/known_hosts
         # Configure host with BatchMode to prevent idlelocking.
         (
-          echo "Host ${{ secrets.DOCKER_ADDRESS }}"
+          echo "Host linkerd-docker"
           echo "    User github"
+          echo "    Hostname ${{ secrets.DOCKER_ADDRESS }}"
           echo "    IdentityFile ~/.ssh/id"
           echo "    BatchMode yes"
           echo "    ServerAliveInterval 60"
         ) >~/.ssh/config
         # Build once with output, then build again to get the img ref (should
         # be a noop).
-        export DOCKER_HOST="ssh://${{ secrets.DOCKER_ADDRESS }}"
         docker build -f .github/actions/remote/Dockerfile .
         docker build -qf .github/actions/remote/Dockerfile . >image.ref
 
     # Use the previously built image to run tests.
     - name: Test (Origin)
       if: '!github.event.pull_request.head.repo.fork'
-      run: |
-        export DOCKER_HOST="ssh://${{ secrets.DOCKER_ADDRESS }}"
-        docker run --rm $(cat image.ref) test-integration
+      env:
+        DOCKER_HOST: "ssh://linkerd-docker"
+      run: docker run --rm $(cat image.ref) test-integration
+
 
     # Try to delete the build image.
     - name: Cleanup (Origin)
       if: always() && !github.event.pull_request.head.repo.fork
+      env:
+        DOCKER_HOST: "ssh://linkerd-docker"
       run: |
-        export DOCKER_HOST="ssh://${{ secrets.DOCKER_ADDRESS }}"
         if [ -f image.ref ]; then docker rmi -f $(cat image.ref)
         else echo "skipped" >&2
         fi


### PR DESCRIPTION
The linkerd org has dedicated hardware on which our integration tests
can be run.

This change reduces test time from ~80 minutes to...[pending]