### PR TITLE
fmt_metric should only borrow metric

### DIFF
--- a/lib/linkerd2-metrics/src/prom.rs
+++ b/lib/linkerd2-metrics/src/prom.rs
@@ -90,7 +90,7 @@ impl<'a, M: FmtMetric> Metric<'a, M> {
     }
 
     /// Formats a single metric without labels.
-    pub fn fmt_metric(&self, f: &mut fmt::Formatter<'_>, metric: M) -> fmt::Result {
+    pub fn fmt_metric(&self, f: &mut fmt::Formatter<'_>, metric: &M) -> fmt::Result {
         metric.fmt_metric(f, self.name)
     }
 

--- a/src/telemetry/process.rs
+++ b/src/telemetry/process.rs
@@ -40,7 +40,7 @@ impl Report {
 impl FmtMetrics for Report {
     fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         process_start_time_seconds.fmt_help(f)?;
-        process_start_time_seconds.fmt_metric(f, self.start_time)?;
+        process_start_time_seconds.fmt_metric(f, &self.start_time)?;
 
         if let Some(ref sys) = self.system {
             sys.fmt_metrics(f)?;
@@ -131,12 +131,12 @@ mod system {
             let clock_ticks = stat.utime as u64 + stat.stime as u64;
             process_cpu_seconds_total.fmt_help(f)?;
             process_cpu_seconds_total
-                .fmt_metric(f, Counter::from(clock_ticks / self.clock_ticks_per_sec))?;
+                .fmt_metric(f, &Counter::from(clock_ticks / self.clock_ticks_per_sec))?;
 
             match Self::open_fds(stat.pid) {
                 Ok(open_fds) => {
                     process_open_fds.fmt_help(f)?;
-                    process_open_fds.fmt_metric(f, open_fds)?;
+                    process_open_fds.fmt_metric(f, &open_fds)?;
                 }
                 Err(err) => {
                     warn!("could not determine process_open_fds: {}", err);
@@ -148,7 +148,7 @@ mod system {
                 Ok(None) => {}
                 Ok(Some(ref max_fds)) => {
                     process_max_fds.fmt_help(f)?;
-                    process_max_fds.fmt_metric(f, *max_fds)?;
+                    process_max_fds.fmt_metric(f, max_fds)?;
                 }
                 Err(err) => {
                     warn!("could not determine process_max_fds: {}", err);
@@ -157,11 +157,11 @@ mod system {
             }
 
             process_virtual_memory_bytes.fmt_help(f)?;
-            process_virtual_memory_bytes.fmt_metric(f, Gauge::from(stat.vsize as u64))?;
+            process_virtual_memory_bytes.fmt_metric(f, &Gauge::from(stat.vsize as u64))?;
 
             process_resident_memory_bytes.fmt_help(f)?;
             process_resident_memory_bytes
-                .fmt_metric(f, Gauge::from(stat.rss as u64 * self.page_size))
+                .fmt_metric(f, &Gauge::from(stat.rss as u64 * self.page_size))
         }
     }
 }


### PR DESCRIPTION
`Metric::fmt_metric` takes ownership of a metric parameter `M` even though it only needs to borrow this value to format it.  We change the trait definition to only borrow this parameter to allow it to be used in situations where you don't want `M` to be consumed.

Signed-off-by: Alex Leong <alex@buoyant.io>