### PR TITLE
logging: update tracing-subscriber to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,7 @@ dependencies = [
  "tracing 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-futures 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tracing-subscriber 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-subscriber 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "trust-dns-resolver 0.10.2 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)",
  "try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2347,7 +2347,7 @@ dependencies = [
 "checksum tracing-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "528c8ebaaa16cdac34795180b046c031775b0d56402704d98c096788f33d646a"
 "checksum tracing-futures 0.0.1-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08c7446f4fb35df7ba2c537b7e2f812f91b20a58aa2b846f028342c4d2429be0"
 "checksum tracing-log 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "652bc99e1286541d6ccc42d5fb37213d1cdde544f88b19fac3d94e3117b55163"
-"checksum tracing-subscriber 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "90f01ec88a73a6da1127f03dc93e9745aacbeba16e5f33cfb91c7639f75932df"
+"checksum tracing-subscriber 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c63b1771a75314374703309107e685805628c04643e6dd2c7a5cf8f94348c62e"
 "checksum trust-dns-proto 0.6.0 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)" = "<none>"
 "checksum trust-dns-resolver 0.10.2 (git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fddfe86b8bbe2aa52d060)" = "<none>"
 "checksum try-lock 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "119b532a17fbe772d360be65617310164549a07c25a1deab04c84168ce0d4545"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ tokio-rustls = "0.10"
 untrusted = "0.7"
 
 [dependencies.tracing-subscriber]
-version = "0.1.2"
+version = "0.1.4"
 # we don't need ANSI colors or `chrono` time formatting
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log"]


### PR DESCRIPTION
This picks up several bugfixes, including one for a potential memory
leak (tokio-rs/tracing#366), which probably doesn't occur in the proxy
currently but could be triggered in the future.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>