### PR TITLE
Handle 8 byte trace ids

### DIFF
--- a/lib/linkerd2-trace-context/src/layer.rs
+++ b/lib/linkerd2-trace-context/src/layer.rs
@@ -178,8 +178,9 @@ where
             span.end = SystemTime::now();
             response_labels(&mut span.labels, &inner);
             trace!(message = "emitting span", ?span);
-            if sink.try_send(span).is_err() {
-                warn!("span dropped due to backpressure");
+            match sink.try_send(span) {
+                Ok(()) => {}
+                Err(e) => warn!(message = "span dropped", %e),
             }
         }
         Ok(Async::Ready(inner))

--- a/lib/linkerd2-trace-context/src/layer.rs
+++ b/lib/linkerd2-trace-context/src/layer.rs
@@ -180,7 +180,7 @@ where
             trace!(message = "emitting span", ?span);
             match sink.try_send(span) {
                 Ok(()) => {}
-                Err(e) => warn!(message = "span dropped", %e),
+                Err(e) => warn!(message = "span dropped", error = %e),
             }
         }
         Ok(Async::Ready(inner))

--- a/lib/linkerd2-trace-context/src/layer.rs
+++ b/lib/linkerd2-trace-context/src/layer.rs
@@ -178,9 +178,8 @@ where
             span.end = SystemTime::now();
             response_labels(&mut span.labels, &inner);
             trace!(message = "emitting span", ?span);
-            match sink.try_send(span) {
-                Ok(()) => {}
-                Err(e) => warn!(message = "span dropped", error = %e),
+            if let Err(error) = sink.try_send(span) {
+                warn!(message = "span dropped", %error);
             }
         }
         Ok(Async::Ready(inner))

--- a/src/app/spans.rs
+++ b/src/app/spans.rs
@@ -2,7 +2,6 @@ use crate::trace_context;
 use linkerd2_error::Error;
 use opencensus_proto::trace::v1 as oc;
 use std::collections::HashMap;
-use std::{error, fmt};
 use tokio::sync::mpsc;
 
 const SPAN_KIND_SERVER: i32 = 1;
@@ -18,25 +17,6 @@ pub struct SpanConverter {
     kind: i32,
     sink: mpsc::Sender<oc::Span>,
     labels: HashMap<String, String>,
-}
-
-#[derive(Debug)]
-pub struct IdLengthError {
-    id: Vec<u8>,
-    expected_size: usize,
-    actual_size: usize,
-}
-
-impl error::Error for IdLengthError {}
-
-impl fmt::Display for IdLengthError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Id '{:?}' should have {} bytes but it has {}",
-            self.id, self.expected_size, self.actual_size
-        )
-    }
 }
 
 impl SpanConverter {
@@ -56,7 +36,7 @@ impl SpanConverter {
         }
     }
 
-    fn mk_span(&self, mut span: trace_context::Span) -> Result<oc::Span, IdLengthError> {
+    fn mk_span(&self, mut span: trace_context::Span) -> oc::Span {
         let mut attributes = HashMap::<String, oc::AttributeValue>::new();
         for (k, v) in self.labels.iter() {
             attributes.insert(
@@ -76,11 +56,11 @@ impl SpanConverter {
                 },
             );
         }
-        Ok(oc::Span {
-            trace_id: into_bytes(span.trace_id, 16)?,
-            span_id: into_bytes(span.span_id, 8)?,
+        oc::Span {
+            trace_id: span.trace_id.into(),
+            span_id: span.span_id.into(),
             tracestate: None,
-            parent_span_id: into_bytes(span.parent_id, 8)?,
+            parent_span_id: span.parent_id.into(),
             name: Some(truncatable(span.span_name)),
             kind: self.kind,
             start_time: Some(span.start.into()),
@@ -96,28 +76,14 @@ impl SpanConverter {
             resource: None,
             same_process_as_parent_span: Some(self.kind == SPAN_KIND_CLIENT),
             child_span_count: None,
-        })
+        }
     }
 }
 
 impl trace_context::SpanSink for SpanConverter {
     fn try_send(&mut self, span: trace_context::Span) -> Result<(), Error> {
-        let span = self.mk_span(span)?;
+        let span = self.mk_span(span);
         self.sink.try_send(span).map_err(Into::into)
-    }
-}
-
-fn into_bytes(id: trace_context::Id, size: usize) -> Result<Vec<u8>, IdLengthError> {
-    let bytes: Vec<u8> = id.into();
-    if bytes.len() == size {
-        Ok(bytes)
-    } else {
-        let actual_size = bytes.len();
-        Err(IdLengthError {
-            id: bytes,
-            expected_size: size,
-            actual_size,
-        })
     }
 }
 


### PR DESCRIPTION
Nginx uses 8 byte trace ids whereas OpenCensus expects trace ids which are 16 bytes.  When we encounter an 8 byte trace id, we discard it, breaking the trace tree.

When reading trace id headers, we now left-pad trace ids with 0s to 16 bytes.  This is consistent with the way that OpenCensus handles trace ids less than 16 bytes: https://github.com/census-instrumentation/opencensus-go/blob/master/plugin/ochttp/propagation/b3/b3.go#L66

We also now log the appropriate error when we fail to emit a span.  This will allow us to distinguish between the scenario when the span receiver has been dropped vs when span conversion fails.