### PR TITLE
give each test proxy its own tracing subscriber

### DIFF
--- a/linkerd/app/integration/tests/telemetry.rs
+++ b/linkerd/app/integration/tests/telemetry.rs
@@ -1,6 +1,10 @@
 #![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "128"]
 #![type_length_limit = "1110183"]
+// The compiler cannot figure out that the `use linkerd2_app_integration::*`
+// import is actually used, and putting the allow attribute on that import in
+// particular appears to do nothing... T_T
+#![allow(unused_imports)]
 
 use bytes::IntoBuf;
 use linkerd2_app_integration::*;


### PR DESCRIPTION
This branch reworks the test-support proxy so that each test gets its
own `tracing` subscriber, rather than sharing a single global
subscriber. Running a whole bunch of tests in parallel with verbose
tracing output turned on is now much snappier.

As a future extension of this, we might want to replace the test-mode
subscriber with a subscriber that, rather than printing to stdout,
writes to a buffer and dumps the whole buffer when the test completes,
along with a message identifying which test the output was collected
from, or with one that prefixes all log lines with the name of the test.
Ideally, this kind of test-specific functionality could be added 
upstream.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>