### PR TITLE
ci: Run docker builds on linkerd-docker host

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
       env:
         DOCKER_HOST: "ssh://linkerd-docker"
       run: |
-        export DOCKER_TAG="proxy-ci:$(dd bs=64 count=1 if=/dev/urandom status=none | tr -dc 'a-zA-Z0-9')""
+        export DOCKER_TAG="proxy-ci:$(dd bs=64 count=1 if=/dev/urandom status=none | tr -dc 'a-zA-Z0-9')"
         make docker
         docker image rm -f "$DOCKER_TAG"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,12 +51,11 @@ jobs:
         # Confirm that the SSH configuration works.
         ssh linkerd-docker docker version
 
-    # Use the previously built image to run tests.
+    # Use the previously built image to run tests. The image will be left on
+    # the build host; but orphaned image layers are pruned regularly.
     - name: Docker (Origin)
       if: '!github.event.pull_request.head.repo.fork'
       env:
         DOCKER_HOST: "ssh://linkerd-docker"
-      run:
-        export DOCKER_TAG="ci-proxy:$(tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w 8 | head -n 1)"
-        make docker
-        docker rmi -f "$DOCKER_TAG"
+      run: make docker
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,3 +1,6 @@
+# Ensures that the local development dockerfile builds properly.
+#
+# The resulting Docker image is discarded.
 name: Docker
 
 on:
@@ -20,10 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-
-    - name: Docker (Fork)
-      if: github.event.pull_request.head.repo.fork
-      run: make docker
 
     # Create a build image on a Linkerd build host.
     - name: Setup (Origin)
@@ -59,3 +58,6 @@ jobs:
         DOCKER_HOST: "ssh://linkerd-docker"
       run: make docker
 
+    - name: Docker (Fork)
+      if: github.event.pull_request.head.repo.fork
+      run: make docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,7 +50,7 @@ jobs:
         ) >~/.ssh/config
         # Confirm that the SSH configuration works.
         ssh linkerd-docker docker version
-        cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1 >image.tag
+        (tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w 8 | head -n 1) >image.tag
 
     # Use the previously built image to run tests.
     - name: Docker (Origin)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,6 +57,6 @@ jobs:
       env:
         DOCKER_HOST: "ssh://linkerd-docker"
       run:
-        #DOCKER_TAG="ci-proxy:$(tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w 8 | head -n 1)"
+        export DOCKER_TAG="ci-proxy:$(tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w 8 | head -n 1)"
         make docker
-        #docker rmi -f "$DOCKER_TAG"
+        docker rmi -f "$DOCKER_TAG"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,10 @@ jobs:
       if: '!github.event.pull_request.head.repo.fork'
       env:
         DOCKER_HOST: "ssh://linkerd-docker"
-      run: make docker
+      run: |
+        export DOCKER_TAG="proxy-ci:$(dd bs=64 count=1 if=/dev/urandom status=none | tr -dc 'a-zA-Z0-9')""
+        make docker
+        docker image rm -f "$DOCKER_TAG"
 
     - name: Docker (Fork)
       if: github.event.pull_request.head.repo.fork

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,9 +12,58 @@ on:
     - 'Cargo.lock'
     - 'Dockerfile'
 
+env:
+  DOCKER_UNOPTIMIZED: "1"
+
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: make docker
+
+    - name: Docker (Fork)
+      if: github.event.pull_request.head.repo.fork
+      run: make docker
+
+    # Create a build image on a Linkerd build host.
+    - name: Setup (Origin)
+      if: '!github.event.pull_request.head.repo.fork'
+      run: |
+        mkdir -p ~/.ssh
+        # Create an identity file and protect before writing contents to it.
+        touch ~/.ssh/id && chmod 600 ~/.ssh/id
+        echo "${{ secrets.DOCKER_PRIVATE_KEY }}" >~/.ssh/id
+        # Use well-known public keys for the host to prevent middlemen.
+        echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" >~/.ssh/known_hosts
+        # Configure host with ServerAliveInterval to ensure that the client
+        # stays alive even when the server is busy emitting nothing.
+        # ServerAliveCountMax ensures that server responds to these pings
+        # within ~5 minutes.
+        (
+          echo "Host linkerd-docker"
+          echo "    User github"
+          echo "    Hostname ${{ secrets.DOCKER_ADDRESS }}"
+          echo "    IdentityFile ~/.ssh/id"
+          echo "    BatchMode yes"
+          echo "    ServerAliveInterval 60"
+          echo "    ServerAliveCountMax 5"
+        ) >~/.ssh/config
+        # Confirm that the SSH configuration works.
+        ssh linkerd-docker docker version
+
+    # Use the previously built image to run tests.
+    - name: Docker (Origin)
+      if: '!github.event.pull_request.head.repo.fork'
+      env:
+        DOCKER_HOST: "ssh://linkerd-docker"
+      run: DOCKER_TAG=ci-proxy:${{ job.container.id }} make docker
+
+    # Try to delete the build image.
+    - name: Cleanup (Origin)
+      if: always() && !github.event.pull_request.head.repo.fork
+      env:
+        DOCKER_HOST: "ssh://linkerd-docker"
+      run: |
+        if [ -f image.ref ]; then docker rmi -f ci-proxy:${{ job.container.id }}
+        else echo "skipped" >&2
+        fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,20 +50,21 @@ jobs:
         ) >~/.ssh/config
         # Confirm that the SSH configuration works.
         ssh linkerd-docker docker version
+        cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1 >image.tag
 
     # Use the previously built image to run tests.
     - name: Docker (Origin)
       if: '!github.event.pull_request.head.repo.fork'
       env:
         DOCKER_HOST: "ssh://linkerd-docker"
-      run: DOCKER_TAG=ci-proxy:${{ job.container.id }} make docker
+      run: DOCKER_TAG=ci-proxy:$(cat image.tag) make docker
 
     # Try to delete the build image.
     - name: Cleanup (Origin)
-      if: always() && !github.event.pull_request.head.repo.fork
+      if: '!github.event.pull_request.head.repo.fork'
       env:
         DOCKER_HOST: "ssh://linkerd-docker"
       run: |
-        if [ -f image.ref ]; then docker rmi -f ci-proxy:${{ job.container.id }}
+        if [ -f image.ref ]; then docker rmi -f ci-proxy:$(cat image.tag)
         else echo "skipped" >&2
         fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,6 +57,6 @@ jobs:
       env:
         DOCKER_HOST: "ssh://linkerd-docker"
       run:
-        DOCKER_TAG="ci-proxy:$(tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w 8 | head -n 1)"
+        #DOCKER_TAG="ci-proxy:$(tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w 8 | head -n 1)"
         make docker
-        docker rmi -f "$DOCKER_TAG"
+        #docker rmi -f "$DOCKER_TAG"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,8 +50,6 @@ jobs:
         # Confirm that the SSH configuration works.
         ssh linkerd-docker docker version
 
-    # Use the previously built image to run tests. The image will be left on
-    # the build host; but orphaned image layers are pruned regularly.
     - name: Docker (Origin)
       if: '!github.event.pull_request.head.repo.fork'
       env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,21 +50,13 @@ jobs:
         ) >~/.ssh/config
         # Confirm that the SSH configuration works.
         ssh linkerd-docker docker version
-        (tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w 8 | head -n 1) >image.tag
 
     # Use the previously built image to run tests.
     - name: Docker (Origin)
       if: '!github.event.pull_request.head.repo.fork'
       env:
         DOCKER_HOST: "ssh://linkerd-docker"
-      run: DOCKER_TAG=ci-proxy:$(cat image.tag) make docker
-
-    # Try to delete the build image.
-    - name: Cleanup (Origin)
-      if: '!github.event.pull_request.head.repo.fork'
-      env:
-        DOCKER_HOST: "ssh://linkerd-docker"
-      run: |
-        if [ -f image.ref ]; then docker rmi -f ci-proxy:$(cat image.tag)
-        else echo "skipped" >&2
-        fi
+      run:
+        DOCKER_TAG="ci-proxy:$(tr -dc 'a-zA-Z0-9' </dev/urandom | fold -w 8 | head -n 1)"
+        make docker
+        docker rmi -f "$DOCKER_TAG"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@
 # rather than updating this manually, run update-rust-version.sh
 ARG RUST_IMAGE=rust:1.37.0-buster
 ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-19.10.2
+ARG PROXY_UNOPTIMIZED
 
 ## Builds the proxy as incrementally as possible.
 FROM $RUST_IMAGE as build

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 
 # rather than updating this manually, run update-rust-version.sh
 ARG RUST_IMAGE=rust:1.37.0-buster
-ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-19.8.7
+ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-19.10.2
 
 ## Builds the proxy as incrementally as possible.
 FROM $RUST_IMAGE as build

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ DOCKER_BUILD = docker build
 ifdef DOCKER_TAG
 	DOCKER_BUILD = docker build -t $(DOCKER_TAG)
 endif
+ifdef DOCKER_UNOPTIMIZED
+	DOCKER_BUILD += --build-arg="PROXY_UNOPTIMIZED=$(DOCKER_UNOPTIMIZED)"
+endif
 
 RUSTCFLAGS ?=
 ifdef CARGO_DEBUG


### PR DESCRIPTION
Replicate our integration test configuration to also run docker builds
on our remote host.

Furthermore, run these builds in unoptimized mode (since we don't
consume the results).