### PR TITLE
build: only deny warnings on CI, not locally

### DIFF
--- a/.github/actions/remote/Dockerfile
+++ b/.github/actions/remote/Dockerfile
@@ -4,4 +4,5 @@ FROM $RUST_IMAGE as build
 WORKDIR /usr/src/linkerd2-proxy
 COPY . ./
 RUN ["make", "fetch"]
+ENV RUSTFLAGS="-D warnings"
 ENTRYPOINT ["make"]

--- a/.github/actions/remote/Dockerfile
+++ b/.github/actions/remote/Dockerfile
@@ -4,5 +4,4 @@ FROM $RUST_IMAGE as build
 WORKDIR /usr/src/linkerd2-proxy
 COPY . ./
 RUN ["make", "fetch"]
-ENV RUSTFLAGS="-D warnings"
 ENTRYPOINT ["make"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: make test-lib
-      env:
-        RUSTFLAGS: "-D warnings"
 
   integration:
     runs-on: ubuntu-18.04
@@ -35,8 +33,6 @@ jobs:
     - name: Test (Fork)
       if: github.event.pull_request.head.repo.fork
       run: make test-integration
-      env:
-        RUSTFLAGS: "-D warnings"
 
     # Create a build image on a Linkerd build host.
     - name: Setup (Origin)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: make test-lib
+      env:
+        RUSTFLAGS: "-D warnings"
 
   integration:
     runs-on: ubuntu-18.04
@@ -33,6 +35,8 @@ jobs:
     - name: Test (Fork)
       if: github.event.pull_request.head.repo.fork
       run: make test-integration
+      env:
+        RUSTFLAGS: "-D warnings"
 
     # Create a build image on a Linkerd build host.
     - name: Setup (Origin)

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,12 @@ PKG = $(PKG_NAME).tar.gz
 
 SHASUM = shasum -a 256
 
+RUSTFLAGS = "-D warnings"
+
 CARGO ?= cargo
 CARGO_BUILD = $(CARGO) build --frozen $(RELEASE)
-CARGO_TEST = $(CARGO) test --frozen $(RELEASE)
+CARGO_TEST = env RUSTFLAGS=$(RUSTFLAGS) \
+	$(CARGO) test --frozen $(RELEASE)
 CARGO_FMT = $(CARGO) fmt --all
 
 DOCKER = docker

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ following targets:
    If the `DOCKER_TAG` environment variable is set, the image is given this
    name. Otherwise, the image is not named.
 
+The `Makefile` test targets are intended to replicate the tests run on CI.
+Therefore, the Rust compiler is configured to deny all warnings. For testing a
+local in-development branch, the `cargo test` command can be used directly,
+which will emit warnings but not fail the build if they are present. The
+`Makefile` test targets may then be used to ensure the branch is ready to merge.
+
 ### Cargo
 
 Usually, [Cargo][cargo], Rust's package manager, is used to build and test this

--- a/hyper-balance/src/lib.rs
+++ b/hyper-balance/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use futures::{Async, Poll};
 use http;

--- a/linkerd/addr/src/lib.rs
+++ b/linkerd/addr/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use http;
 use linkerd2_dns_name::Name;

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -7,7 +7,7 @@
 //! - Tap
 //! - Metric labeling
 
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 pub use linkerd2_addr::{self as addr, Addr, NameAddr};
 pub use linkerd2_conditional::Conditional;

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -3,7 +3,7 @@
 //! The inbound proxy is responsible for terminating traffic from other network
 //! endpoints inbound to the local application.
 
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use linkerd2_app_core::{
     classify,

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![recursion_limit = "128"]
 #![type_length_limit = "1110183"]
 

--- a/linkerd/app/integration/tests/identity.rs
+++ b/linkerd/app/integration/tests/identity.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![recursion_limit = "128"]
 #![type_length_limit = "1110183"]
 

--- a/linkerd/app/integration/tests/profile_dst_overrides.rs
+++ b/linkerd/app/integration/tests/profile_dst_overrides.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![recursion_limit = "128"]
 #![type_length_limit = "1110183"]
 

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![recursion_limit = "128"]
 #![type_length_limit = "1110183"]
 

--- a/linkerd/app/integration/tests/shutdown.rs
+++ b/linkerd/app/integration/tests/shutdown.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![recursion_limit = "128"]
 #![type_length_limit = "1110183"]
 

--- a/linkerd/app/integration/tests/tap.rs
+++ b/linkerd/app/integration/tests/tap.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![recursion_limit = "128"]
 #![type_length_limit = "1110183"]
 

--- a/linkerd/app/integration/tests/telemetry.rs
+++ b/linkerd/app/integration/tests/telemetry.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![recursion_limit = "128"]
 #![type_length_limit = "1110183"]
 // The compiler cannot figure out that the `use linkerd2_app_integration::*`

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![recursion_limit = "128"]
 #![type_length_limit = "1110183"]
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -3,7 +3,7 @@
 //! The outound proxy is responsible for routing traffic from the local
 //! application to external network endpoints.
 
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use linkerd2_app_core::{
     classify,

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -1,6 +1,6 @@
 //! Configures and executes the proxy
 
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use futures::{self, future, Future};
 pub use linkerd2_app_core::init;

--- a/linkerd/conditional/src/lib.rs
+++ b/linkerd/conditional/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 /// Like `std::option::Option<C>` but `None` carries a reason why the value
 /// isn't available.

--- a/linkerd/dns/name/src/lib.rs
+++ b/linkerd/dns/name/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 mod name;
 mod suffix;

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use futures::{prelude::*, try_ready};
 pub use linkerd2_dns_name::{InvalidName, Name, Suffix};

--- a/linkerd/drain/src/lib.rs
+++ b/linkerd/drain/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use futures::future::Shared;
 use futures::sync::{mpsc, oneshot};

--- a/linkerd/duplex/src/lib.rs
+++ b/linkerd/duplex/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use bytes::{Buf, BufMut};
 use futures::{try_ready, Async, Future, Poll};

--- a/linkerd/error/src/lib.rs
+++ b/linkerd/error/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 mod never;
 pub mod recover;

--- a/linkerd/exp-backoff/src/lib.rs
+++ b/linkerd/exp-backoff/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use futures::{try_ready, Future, Poll, Stream};
 use rand::{rngs::SmallRng, FromEntropy};

--- a/linkerd/fallback/src/lib.rs
+++ b/linkerd/fallback/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use bytes::Buf;
 use futures::{try_ready, Future, Poll};

--- a/linkerd/identity/src/lib.rs
+++ b/linkerd/identity/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use linkerd2_dns_name;
 pub use ring::error::KeyRejected;

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 //! Utilties for exposing metrics to Prometheus.
 

--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use futures::{task, try_ready, Async, Future, Poll, Stream};
 use linkerd2_error::Error;

--- a/linkerd/proxy/api-resolve/src/lib.rs
+++ b/linkerd/proxy/api-resolve/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use linkerd2_identity as identity;
 use linkerd2_proxy_api as api;

--- a/linkerd/proxy/core/src/lib.rs
+++ b/linkerd/proxy/core/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 pub mod listen;
 pub mod resolve;

--- a/linkerd/proxy/discover/src/lib.rs
+++ b/linkerd/proxy/discover/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use linkerd2_error::Error;
 use linkerd2_proxy_core::Resolve;

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use http::header::AsHeaderName;
 use http::uri::Authority;

--- a/linkerd/proxy/resolve/src/lib.rs
+++ b/linkerd/proxy/resolve/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 pub mod map_endpoint;
 pub mod recover;

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use std::net::SocketAddr;
 use std::time::Duration;

--- a/linkerd/reconnect/src/lib.rs
+++ b/linkerd/reconnect/src/lib.rs
@@ -1,5 +1,5 @@
 //! Conditionally reconnects with a pluggable recovery/backoff strategy.
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use linkerd2_error::Recover;
 

--- a/linkerd/request-filter/src/lib.rs
+++ b/linkerd/request-filter/src/lib.rs
@@ -1,7 +1,7 @@
 //! A `Service` middleware that applies arbitrary-user provided logic to each
 //! target before it is issued to an inner service.
 
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use futures::{Future, Poll};
 

--- a/linkerd/router/src/lib.rs
+++ b/linkerd/router/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use std::hash::Hash;
 use std::time::Duration;

--- a/linkerd/signal/src/lib.rs
+++ b/linkerd/signal/src/lib.rs
@@ -1,6 +1,6 @@
 //! Unix signal handling for the proxy binary.
 
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use futures::Future;
 

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 pub mod layer;
 pub mod map_target;

--- a/linkerd/task/src/lib.rs
+++ b/linkerd/task/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 //! Task execution utilities.
 

--- a/linkerd/timeout/src/lib.rs
+++ b/linkerd/timeout/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use futures::{Future, Poll};
 use std::time::Duration;

--- a/linkerd/trace-context/src/lib.rs
+++ b/linkerd/trace-context/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 use bytes::Bytes;
 use futures::Sink;

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -1,6 +1,6 @@
 //! The main entrypoint for the proxy.
 
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 #![recursion_limit = "128"]
 #![type_length_limit = "1110183"]
 

--- a/opencensus-proto/src/lib.rs
+++ b/opencensus-proto/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Vendored from https://github.com/census-instrumentation/opencensus-proto/.
 
-#![deny(warnings, rust_2018_idioms)]
+#![warn(rust_2018_idioms)]
 
 pub mod agent {
     pub mod trace {


### PR DESCRIPTION
Currently, all crates in the proxy repo are configured to always deny
all Rust compiler warnings. This means that if the compiler reports any
warnings, the build will fail. This can be an issue when changes are
made locally that introduce warnings (i.e. unused code is added, imports
are no longer needed, etc) and the developer wishes to test an
incomplete state to ensure their changes are on the right path. With
warnings denied, tests will not run if the project contains any
warnings, so developers must either fix all warnings or disable the deny
attribute. Disabling the deny attribute when making changes locally has
become a fairly common practice, but it's error-prone: sometimes, the
deny attribute is commented out and then accidentally committed.

This branch is a proposal for a new way to handle Rust warnings. Rather
than always failing the build if any warnings are reported, we now
export an env var on CI that configures the compiler to deny warnings.
Local in-development builds will report warnings, but not *fail* the
build, making it easier to run tests for incomplete changes, but code
with warnings won't be allowed to merge to master. Hopefully, this
obsoletes the practice of commenting out `#![deny(warnings)]` when
making changes.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>