### PR TITLE
Remove the LINKERD2_PROXY_INBOUND_FORWARD config

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -36,9 +36,6 @@ pub struct Config {
     /// Where to serve admin HTTP.
     pub admin_listener: Listener,
 
-    /// Where to forward externally received connections.
-    pub inbound_forward: Option<SocketAddr>,
-
     /// The maximum amount of time that an inbound request can spend buffered in the inbound proxy.
     pub inbound_dispatch_timeout: Duration,
 
@@ -200,7 +197,6 @@ pub struct TestEnv {
 
 // Environment variables to look at when loading the configuration
 pub const ENV_OUTBOUND_LISTEN_ADDR: &str = "LINKERD2_PROXY_OUTBOUND_LISTEN_ADDR";
-pub const ENV_INBOUND_FORWARD: &str = "LINKERD2_PROXY_INBOUND_FORWARD";
 pub const ENV_INBOUND_LISTEN_ADDR: &str = "LINKERD2_PROXY_INBOUND_LISTEN_ADDR";
 pub const ENV_CONTROL_LISTEN_ADDR: &str = "LINKERD2_PROXY_CONTROL_LISTEN_ADDR";
 pub const ENV_ADMIN_LISTEN_ADDR: &str = "LINKERD2_PROXY_ADMIN_LISTEN_ADDR";
@@ -216,7 +212,6 @@ const ENV_INBOUND_CONNECT_KEEPALIVE: &str = "LINKERD2_PROXY_INBOUND_CONNECT_KEEP
 const ENV_OUTBOUND_CONNECT_KEEPALIVE: &str = "LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE";
 
 pub const DEPRECATED_ENV_PRIVATE_LISTEN_ADDR: &str = "LINKERD2_PROXY_PRIVATE_LISTEN_ADDR";
-pub const DEPRECATED_ENV_PRIVATE_FORWARD: &str = "LINKERD2_PROXY_PRIVATE_FORWARD";
 
 // Limits the number of HTTP routes that may be active in the proxy at any time. There is
 // an inbound route for each local port that receives connections. There is an outbound
@@ -391,7 +386,6 @@ impl Config {
         let outbound_listener_addr = parse(strings, ENV_OUTBOUND_LISTEN_ADDR, parse_socket_addr);
         let inbound_listener_addr = parse(strings, ENV_INBOUND_LISTEN_ADDR, parse_socket_addr);
         let admin_listener_addr = parse(strings, ENV_ADMIN_LISTEN_ADDR, parse_socket_addr);
-        let inbound_forward = parse(strings, ENV_INBOUND_FORWARD, parse_socket_addr);
 
         let inbound_dispatch_timeout = parse(strings, ENV_INBOUND_DISPATCH_TIMEOUT, parse_duration);
         let inbound_connect_timeout = parse(strings, ENV_INBOUND_CONNECT_TIMEOUT, parse_duration);
@@ -500,7 +494,6 @@ impl Config {
                 addr: admin_listener_addr?
                     .unwrap_or_else(|| parse_socket_addr(DEFAULT_ADMIN_LISTEN_ADDR).unwrap()),
             },
-            inbound_forward: inbound_forward?,
 
             inbound_connect_timeout: inbound_connect_timeout?
                 .unwrap_or(DEFAULT_INBOUND_CONNECT_TIMEOUT),

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -179,7 +179,6 @@ fn run(proxy: Proxy, mut env: app::config::TestEnv) -> Listening {
     );
 
     if let Some(inbound) = inbound {
-        env.put(app::config::ENV_INBOUND_FORWARD, format!("{}", inbound));
         mock_orig_dst.inbound_orig_addr = Some(inbound);
     }
 

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -203,13 +203,13 @@ where
             Conditional::Some(config) => info!("using identity service at {:?}", config.svc.addr),
             Conditional::None(reason) => info!("identity is DISABLED: {}", reason),
         }
-        info!("admin on {}", admin_listener.local_addr(),);
+        info!("admin on {}", admin_listener.local_addr());
         info!(
             "tap on {:?}",
             control_listener.as_ref().map(|l| l.0.local_addr())
         );
         info!("outbound on {:?}", outbound_listener.local_addr());
-        info!("inbound on {}", inbound_listener.local_addr(),);
+        info!("inbound on {}", inbound_listener.local_addr());
         info!(
             "protocol detection disabled for inbound ports {:?}",
             config.inbound_ports_disable_protocol_detection,

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -203,16 +203,13 @@ where
             Conditional::Some(config) => info!("using identity service at {:?}", config.svc.addr),
             Conditional::None(reason) => info!("identity is DISABLED: {}", reason),
         }
-        info!("routing on {:?}", outbound_listener.local_addr());
+        info!("admin on {}", admin_listener.local_addr(),);
         info!(
-            "proxying on {:?} to {:?}",
-            inbound_listener.local_addr(),
-            config.inbound_forward
+            "tap on {:?}",
+            control_listener.as_ref().map(|l| l.0.local_addr())
         );
-        info!(
-            "serving admin endpoint metrics on {:?}",
-            admin_listener.local_addr(),
-        );
+        info!("outbound on {:?}", outbound_listener.local_addr());
+        info!("inbound on {}", inbound_listener.local_addr(),);
         info!(
             "protocol detection disabled for inbound ports {:?}",
             config.inbound_ports_disable_protocol_detection,

--- a/opencensus-proto/Cargo.toml
+++ b/opencensus-proto/Cargo.toml
@@ -20,3 +20,5 @@ tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"
 [build-dependencies]
 tower-grpc-build = { version = "0.1", default-features = false }
 
+[lib]
+doctest = false


### PR DESCRIPTION
The `LINKERD2_PROXY_INBOUND_FORWARD` configuration was implemented to support local testing; but the proxy has evolved to the point where it
needs a proper runtime harness (as in docker or the integration test
infrastructure) to run.

This option is just a bit of debt that should be removed to simplify 
code/diagnostics.

This also disables doctests in the opencensus crate to prevent spurious failures.

Furthermore, the proxy's initial logging has been clarified somewhat.

Closes linkerd/linkerd2#3609