### PR TITLE
Eliminate tower::util::Either from add_header

### DIFF
--- a/linkerd/app/core/src/proxy/pending.rs
+++ b/linkerd/app/core/src/proxy/pending.rs
@@ -18,7 +18,7 @@ pub enum Pending<F, S> {
     Made(S),
 }
 
-pub type Svc<M, T> = Pending<svc::Oneshot<M, T>, <M as svc::Service<T>>::Response>;
+pub type Svc<M, T> = Pending<tower::util::Oneshot<M, T>, <M as svc::Service<T>>::Response>;
 
 pub fn layer() -> Layer {
     Layer(())


### PR DESCRIPTION
I have a hypothesis that layers with `Either` services are especially costly for our compile-times.

This change removes one such usage in the `add_header` module, which is used several times in each stack.