### PR TITLE
Revamp transport metric labels

### DIFF
--- a/linkerd/app/core/src/metric_labels.rs
+++ b/linkerd/app/core/src/metric_labels.rs
@@ -98,8 +98,8 @@ impl FmtLabels for EndpointLabels {
         }
 
         write!(f, ",")?;
-        let tls_id = self.tls_id.clone().map(Into::<identity::Name>::into);
-        TlsStatus::from(tls_id.as_ref()).fmt_labels(f)?;
+        let tls_id = self.tls_id.as_ref().map(AsRef::<identity::Name>::as_ref);
+        TlsStatus::from(tls_id).fmt_labels(f)?;
 
         if let Conditional::Some(ref id) = self.tls_id {
             write!(f, ",")?;
@@ -119,8 +119,8 @@ impl FmtLabels for Direction {
     }
 }
 
-impl Into<identity::Name> for TlsId {
-    fn into(self) -> identity::Name {
+impl AsRef<identity::Name> for TlsId {
+    fn as_ref(&self) -> &identity::Name {
         match self {
             TlsId::ClientId(name) => name,
             TlsId::ServerId(name) => name,

--- a/linkerd/app/core/src/metric_labels.rs
+++ b/linkerd/app/core/src/metric_labels.rs
@@ -98,7 +98,8 @@ impl FmtLabels for EndpointLabels {
         }
 
         write!(f, ",")?;
-        TlsStatus::from(self.tls_id.as_ref()).fmt_labels(f)?;
+        let tls_id = self.tls_id.clone().map(Into::<identity::Name>::into);
+        TlsStatus::from(tls_id.as_ref()).fmt_labels(f)?;
 
         if let Conditional::Some(ref id) = self.tls_id {
             write!(f, ",")?;
@@ -114,6 +115,15 @@ impl FmtLabels for Direction {
         match self {
             Direction::In => write!(f, "direction=\"inbound\""),
             Direction::Out => write!(f, "direction=\"outbound\""),
+        }
+    }
+}
+
+impl Into<identity::Name> for TlsId {
+    fn into(self) -> identity::Name {
+        match self {
+            TlsId::ClientId(name) => name,
+            TlsId::ServerId(name) => name,
         }
     }
 }

--- a/linkerd/app/core/src/proxy/server.rs
+++ b/linkerd/app/core/src/proxy/server.rs
@@ -4,9 +4,7 @@ use crate::proxy::http::{
 };
 use crate::proxy::{detect, tcp};
 use crate::svc::{MakeService, Service};
-use crate::transport::{
-    io::BoxedIo, metrics::TransportLabels, tls,
-};
+use crate::transport::{io::BoxedIo, metrics::TransportLabels, tls};
 use futures::future::{self, Either};
 use futures::{Future, Poll};
 use http;

--- a/linkerd/app/core/src/tap/grpc/server.rs
+++ b/linkerd/app/core/src/tap/grpc/server.rs
@@ -557,7 +557,7 @@ fn base_event<B, I: Inspect>(req: &http::Request<B>, inspect: &I) -> api::TapEve
         source_meta: {
             let mut m = api::tap_event::EndpointMeta::default();
             let tls = inspect.src_tls(req);
-            let tls_status = TlsStatus::from(tls.as_ref());
+            let tls_status = TlsStatus::from(tls);
             m.labels.insert("tls".to_owned(), tls_status.to_string());
             if let Conditional::Some(id) = tls {
                 m.labels
@@ -571,7 +571,7 @@ fn base_event<B, I: Inspect>(req: &http::Request<B>, inspect: &I) -> api::TapEve
             m.labels
                 .extend(labels.iter().map(|(k, v)| (k.clone(), v.clone())));
             let tls = inspect.dst_tls(req);
-            let tls_status = TlsStatus::from(tls.as_ref());
+            let tls_status = TlsStatus::from(tls);
             m.labels.insert("tls".to_owned(), tls_status.to_string());
             if let Conditional::Some(id) = tls {
                 m.labels

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -72,8 +72,8 @@ impl Key {
 
     pub fn connect(
         dst_addr: SocketAddr,
-        local_identity: tls::Conditional<&identity::Name>,
         remote_identity: tls::Conditional<&identity::Name>,
+        local_identity: tls::Conditional<&identity::Name>,
         http: bool,
     ) -> Self {
         let protocol = if http { Protocol::HTTP } else { Protocol::TCP };

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -26,7 +26,7 @@ enum Direction {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 struct Addrs {
-    src_addr: IpAddr,
+    src_addr: Option<IpAddr>,
     dst_addr: SocketAddr,
 }  
 
@@ -63,7 +63,7 @@ impl Key {
         Self {
             direction: Direction::Inbound,
             addrs: Addrs {
-                src_addr: src_addr.ip(),
+                src_addr: Some(src_addr.ip()),
                 dst_addr,
             },
             identity: Identity {
@@ -75,7 +75,6 @@ impl Key {
     }
 
     pub fn connect(
-        src_addr: SocketAddr,
         dst_addr: SocketAddr,
         local_identity: tls::Conditional<&identity::Name>,
         remote_identity: tls::Conditional<&identity::Name>,
@@ -89,7 +88,7 @@ impl Key {
         Self {
             direction: Direction::Outbound,
             addrs: Addrs {
-                src_addr: src_addr.ip(),
+                src_addr: None,
                 dst_addr,
             },
             identity: Identity {
@@ -118,7 +117,9 @@ impl FmtLabels for Direction {
 
 impl FmtLabels for Addrs {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "src_addr=\"{}\",", self.src_addr)?;
+        if let Some(src) = &self.src_addr {
+            write!(f, "src_addr=\"{}\",", src)?;
+        }
         write!(f, "dst_addr=\"{}\"", self.dst_addr)
     }
 }

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -1,7 +1,7 @@
 use super::tls;
 use linkerd2_conditional::Conditional;
-use linkerd2_metrics::FmtLabels;
 use linkerd2_identity as identity;
+use linkerd2_metrics::FmtLabels;
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 
@@ -28,7 +28,7 @@ enum Direction {
 struct Addrs {
     src_addr: Option<IpAddr>,
     dst_addr: SocketAddr,
-}  
+}
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct TlsStatus(tls::Conditional<identity::Name>);
@@ -53,13 +53,9 @@ impl Key {
         dst_addr: SocketAddr,
         remote_identity: tls::Conditional<&identity::Name>,
         local_identity: tls::Conditional<&identity::Name>,
-        http: bool
+        http: bool,
     ) -> Self {
-        let protocol = if http {
-            Protocol::HTTP
-        } else {
-            Protocol::TCP
-        };
+        let protocol = if http { Protocol::HTTP } else { Protocol::TCP };
         Self {
             direction: Direction::Inbound,
             addrs: Addrs {
@@ -78,13 +74,9 @@ impl Key {
         dst_addr: SocketAddr,
         local_identity: tls::Conditional<&identity::Name>,
         remote_identity: tls::Conditional<&identity::Name>,
-        http: bool
+        http: bool,
     ) -> Self {
-        let protocol = if http {
-            Protocol::HTTP
-        } else {
-            Protocol::TCP
-        };
+        let protocol = if http { Protocol::HTTP } else { Protocol::TCP };
         Self {
             direction: Direction::Outbound,
             addrs: Addrs {
@@ -102,9 +94,15 @@ impl Key {
 
 impl FmtLabels for Key {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        (((&self.direction, &self.addrs), &self.identity), &self.protocol).fmt_labels(f)
+        (
+            ((&self.direction, &self.addrs), &self.identity),
+            &self.protocol,
+        )
+            .fmt_labels(f)
     }
 }
+
+// ===== impl Direction =====
 
 impl FmtLabels for Direction {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -115,6 +113,8 @@ impl FmtLabels for Direction {
     }
 }
 
+// ===== impl Addrs =====
+
 impl FmtLabels for Addrs {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(src) = &self.src_addr {
@@ -124,6 +124,8 @@ impl FmtLabels for Addrs {
     }
 }
 
+// ===== impl Protocol =====
+
 impl FmtLabels for Protocol {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -132,6 +134,8 @@ impl FmtLabels for Protocol {
         }
     }
 }
+
+// ===== impl TlsStatus =====
 
 impl FmtLabels for TlsStatus {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -156,6 +160,8 @@ impl From<tls::Conditional<&identity::Name>> for TlsStatus {
         TlsStatus(tls.cloned())
     }
 }
+
+// ===== impl Identity =====
 
 impl FmtLabels for Identity {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -140,6 +140,19 @@ macro_rules! assert_eventually_contains {
     };
 }
 
+#[macro_export]
+macro_rules! assert_eventually_matches {
+    ($scrape:expr, $re:expr) => {
+        let re = regex::Regex::new($re).unwrap();
+        assert_eventually!(
+            re.is_match($scrape),
+            "metrics scrape:\n{}\ndid not match:\n{}",
+            $scrape,
+            $re
+        )
+    };
+}
+
 pub mod client;
 pub mod controller;
 pub mod identity;

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -686,9 +686,9 @@ mod http2 {
         drop(srv1);
 
         // Wait until the proxy has seen the `srv1` disconnect...
-        assert_eventually_contains!(
-            metrics.get("/metrics"),
-            "tcp_close_total{direction=\"outbound\",peer=\"dst\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"} 1"
+        assert_eventually_matches!(
+            &metrics.get("/metrics"),
+            "tcp_close_total\\{direction=\"outbound\",dst_addr=\"127.0.0.1:\\d+\",tls=\"false\",no_tls_reason=\"not_provided_by_service_discovery\",protocol=\"http\",errno=\"\"\\} 1"
         );
 
         // Start a new request to the destination, now that the server is dead.

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -1083,9 +1083,9 @@ fn retry_reconnect_errors() {
 
     // wait until metrics has seen our connection, this can be flaky depending on
     // all the other threads currently running...
-    assert_eventually_contains!(
-        metrics.get("/metrics"),
-        "tcp_open_total{direction=\"inbound\",peer=\"src\",tls=\"disabled\"} 1"
+    assert_eventually_matches!(
+        &metrics.get("/metrics"),
+        "tcp_open_total\\{direction=\"inbound\",src_addr=\"127.0.0.1\",dst_addr=\"127.0.0.1:\\d+\",tls=\"false\",no_tls_reason=\"disabled\",protocol=\"http\"\\} 1"
     );
 
     drop(tx); // start `listen` now

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -305,7 +305,7 @@ pub fn spawn<A, R, P>(
     let skip_ports = std::sync::Arc::new(config.outbound_ports_disable_protocol_detection.clone());
     let proxy = Server::new(
         TransportLabels,
-        transport_metrics,
+        (),
         svc::stack(connect)
             .push(svc::map_target::layer(Endpoint::from))
             .into_inner(),
@@ -329,14 +329,18 @@ impl transport::metrics::TransportLabels<Endpoint> for TransportLabels {
     type Labels = transport::labels::Key;
 
     fn transport_labels(&self, endpoint: &Endpoint) -> Self::Labels {
-        transport::labels::Key::connect("outbound", endpoint.identity.as_ref())
+        transport::labels::Key::connect(
+            endpoint.addr,
+            &endpoint.identity,
+            endpoint.http_settings.is_http(),
+        )
     }
 }
 
 impl transport::metrics::TransportLabels<proxy::server::Protocol> for TransportLabels {
-    type Labels = transport::labels::Key;
+    type Labels = ();
 
-    fn transport_labels(&self, proto: &proxy::server::Protocol) -> Self::Labels {
-        transport::labels::Key::accept("outbound", proto.tls.peer_identity.as_ref())
+    fn transport_labels(&self, _: &proxy::server::Protocol) -> Self::Labels {
+        ()
     }
 }

--- a/linkerd/metrics/src/prom.rs
+++ b/linkerd/metrics/src/prom.rs
@@ -156,6 +156,12 @@ impl<A: FmtLabels, B: FmtLabels> FmtLabels for (Option<A>, B) {
     }
 }
 
+impl FmtLabels for () {
+    fn fmt_labels(&self, _: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Ok(())
+    }
+}
+
 // ===== impl FmtMetrics =====
 
 impl<'a, A: FmtMetrics + 'a> FmtMetrics for &'a A {

--- a/linkerd/proxy/http/src/settings.rs
+++ b/linkerd/proxy/http/src/settings.rs
@@ -72,4 +72,11 @@ impl Settings {
             Settings::Http1 { .. } | Settings::NotHttp => false,
         }
     }
+
+    pub fn is_http(&self) -> bool {
+        match self {
+            Settings::Http1 { .. } | Settings::Http2 => true,
+            Settings::NotHttp => false,
+        }
+    }
 }

--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -207,7 +207,7 @@ impl OrigDstAddr for SysOrigDstAddr {
     }
 
     #[cfg(not(target_os = "linux"))]
-    fn orig_dst_addr(&self, sock: &TcpStream) -> Option<SocketAddr> {
+    fn orig_dst_addr(&self, _sock: &TcpStream) -> Option<SocketAddr> {
         None
     }
 }

--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -28,7 +28,7 @@ pub struct Listen<O: OrigDstAddr = NoOrigDstAddr> {
 
 pub type Connection = (Addrs, TcpStream);
 
-#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug)]
 pub struct Addrs {
     local: SocketAddr,
     peer: SocketAddr,

--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -28,7 +28,7 @@ pub struct Listen<O: OrigDstAddr = NoOrigDstAddr> {
 
 pub type Connection = (Addrs, TcpStream);
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Addrs {
     local: SocketAddr,
     peer: SocketAddr,

--- a/linkerd/proxy/transport/src/metrics/mod.rs
+++ b/linkerd/proxy/transport/src/metrics/mod.rs
@@ -1,5 +1,5 @@
-use super::tls;
 use super::io::BoxedIo;
+use super::tls;
 use futures::{try_ready, Future, Poll};
 use indexmap::IndexMap;
 use linkerd2_metrics::{


### PR DESCRIPTION
This PR makes the proxy changes which are necessary for https://github.com/linkerd/linkerd2/issues/3523

We revamp the transport metrics to provide the following labels:
* direction: one of "incoming" or "outgoing"
* src_addr: the IP address of the initiator of the connection.  does not include port.  omitted when direction="outgoing" since the local address is provided by Prometheus and the ephemeral client port is not useful
* dst_addr: the IP address and port of the accepter of the connection.  always present, even when direction="incoming" since the local address provided by Prometheus does not include the relevant server port
* tls: boolean indicating if the connection has TLS
* no_tls_reason: if tls=false, this gives the reason
* remote_identity: the TLS identity of the remote peer if tls=true
* local_identity: the local TLS identity if tls=true
* protocol: the detected protocol of this connection.  one of "http" or "tcp"

Here is an example of what these metrics look like in Prometheus:

```
tcp_open_total{control_plane_ns="linkerd",deployment="authors",direction="inbound",dst_addr="10.0.0.131:4143",instance="10.0.0.131:4191",job="linkerd-proxy",local_identity="default.default.serviceaccount.identity.linkerd.cluster.local",namespace="default",pod="authors-f4b696f48-s4jzh",protocol="http",remote_identity="default.default.serviceaccount.identity.linkerd.cluster.local",src_addr="10.0.0.129",tls="true"} 1
tcp_open_total{control_plane_ns="linkerd",deployment="authors",direction="inbound",dst_addr="10.0.0.131:4143",instance="10.0.0.131:4191",job="linkerd-proxy",local_identity="default.default.serviceaccount.identity.linkerd.cluster.local",namespace="default",pod="authors-f4b696f48-s4jzh",protocol="http",remote_identity="default.default.serviceaccount.identity.linkerd.cluster.local",src_addr="10.0.0.19",tls="true"}  1
tcp_open_total{control_plane_ns="linkerd",deployment="authors",direction="inbound",dst_addr="10.0.0.131:4143",instance="10.0.0.131:4191",job="linkerd-proxy",local_identity="default.default.serviceaccount.identity.linkerd.cluster.local",namespace="default",pod="authors-f4b696f48-s4jzh",protocol="http",remote_identity="default.default.serviceaccount.identity.linkerd.cluster.local",src_addr="10.0.0.39",tls="true"}  1
tcp_open_total{control_plane_ns="linkerd",deployment="authors",direction="inbound",dst_addr="10.0.0.131:4143",instance="10.0.0.131:4191",job="linkerd-proxy",local_identity="default.default.serviceaccount.identity.linkerd.cluster.local",namespace="default",pod="authors-f4b696f48-s4jzh",protocol="http",remote_identity="default.default.serviceaccount.identity.linkerd.cluster.local",src_addr="10.0.0.71",tls="true"}  1
tcp_open_total{control_plane_ns="linkerd",deployment="authors",direction="inbound",dst_addr="10.0.0.131:4143",instance="10.0.0.131:4191",job="linkerd-proxy",namespace="default",no_tls_reason="not_provided_by_remote",pod="authors-f4b696f48-s4jzh",protocol="http",src_addr="10.0.0.128",tls="false"}  104
tcp_open_total{control_plane_ns="linkerd",deployment="authors",direction="outbound",dst_addr="10.0.0.71:7002",instance="10.0.0.131:4191",job="linkerd-proxy",local_identity="default.default.serviceaccount.identity.linkerd.cluster.local",namespace="default",pod="authors-f4b696f48-s4jzh",protocol="http",remote_identity="default.default.serviceaccount.identity.linkerd.cluster.local",tls="true"}
```