### PR TITLE
internal: Move suffix-filtering into profiles API

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -64,7 +64,6 @@ pub fn spawn<A, P>(
     let capacity = config.inbound_router_capacity;
     let max_idle_age = config.inbound_router_max_idle_age;
     let max_in_flight = config.inbound_max_requests_in_flight;
-    let profile_suffixes = config.destination_profile_suffixes.clone();
     let dispatch_timeout = config.inbound_dispatch_timeout;
 
     let mut trace_labels = HashMap::new();
@@ -137,11 +136,7 @@ pub fn spawn<A, P>(
     let dst_stack = svc::stack(svc::Shared::new(endpoint_router))
         .push(insert::target::layer())
         .push_buffer_pending(max_in_flight, DispatchDeadline::extract)
-        .push(profiles::router::layer(
-            profile_suffixes,
-            profiles_client,
-            dst_route_layer,
-        ))
+        .push(profiles::router::layer(profiles_client, dst_route_layer))
         .push(strip_header::request::layer(DST_OVERRIDE_HEADER))
         .push(trace::layer(
             |dst: &DstAddr| info_span!("logical", dst = %dst.dst_logical()),

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -80,7 +80,6 @@ pub fn spawn<A, R, P>(
     let capacity = config.outbound_router_capacity;
     let max_idle_age = config.outbound_router_max_idle_age;
     let max_in_flight = config.outbound_max_requests_in_flight;
-    let profile_suffixes = config.destination_profile_suffixes.clone();
     let canonicalize_timeout = config.dns_canonicalize_timeout;
     let dispatch_timeout = config.outbound_dispatch_timeout;
 
@@ -206,11 +205,7 @@ pub fn spawn<A, R, P>(
     //   `DstAddr` with a resolver.
     let dst_stack = distributor
         .push_buffer_pending(max_in_flight, DispatchDeadline::extract)
-        .push(profiles::router::layer(
-            profile_suffixes,
-            profiles_client,
-            dst_route_layer,
-        ))
+        .push(profiles::router::layer(profiles_client, dst_route_layer))
         .push(header_from_target::layer(CANONICAL_DST_HEADER));
 
     // Routes request using the `DstAddr` extension.

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -427,6 +427,7 @@ where
             dst_svc,
             Duration::from_secs(3),
             config.destination_context.clone(),
+            config.destination_profile_suffixes.clone(),
         );
 
         let trace_collector_svc = config.trace_collector_addr.as_ref().map(|addr| {

--- a/linkerd/proxy/http/src/profiles/router.rs
+++ b/linkerd/proxy/http/src/profiles/router.rs
@@ -3,12 +3,11 @@ use super::{CanGetDestination, GetRoutes, Route, Routes, WeightedAddr, WithAddr,
 use futures::{Async, Poll, Stream};
 use http;
 use indexmap::IndexMap;
-use linkerd2_dns as dns;
 use linkerd2_error::{Error, Never};
 use linkerd2_router as rt;
 use linkerd2_stack::Shared;
 use std::hash::Hash;
-use tracing::{debug, error};
+use tracing::{debug, error, trace};
 
 // A router which routes based on the `dst_overrides` of the profile or, if
 // no `dst_overrdies` exist, on the router's target.
@@ -20,7 +19,6 @@ type RouteRouter<Target, RouteTarget, Svc, Body> =
     rt::Router<http::Request<Body>, RouteRecognize<Target>, rt::FixedMake<RouteTarget, Svc>>;
 
 pub fn layer<G, Inner, RouteLayer, RouteBody, InnerBody>(
-    suffixes: Vec<dns::Suffix>,
     get_routes: G,
     route_layer: RouteLayer,
 ) -> Layer<G, Inner, RouteLayer, RouteBody, InnerBody>
@@ -29,7 +27,6 @@ where
     RouteLayer: Clone,
 {
     Layer {
-        suffixes,
         get_routes,
         route_layer,
         default_route: Route::default(),
@@ -41,7 +38,6 @@ where
 pub struct Layer<G, Inner, RouteLayer, RouteBody, InnerBody> {
     get_routes: G,
     route_layer: RouteLayer,
-    suffixes: Vec<dns::Suffix>,
     /// This is saved into a field so that the same `Arc`s are used and
     /// cloned, instead of calling `Route::default()` every time.
     default_route: Route,
@@ -53,7 +49,6 @@ pub struct MakeSvc<G, Inner, RouteLayer, RouteBody, InnerBody> {
     inner: Inner,
     get_routes: G,
     route_layer: RouteLayer,
-    suffixes: Vec<dns::Suffix>,
     default_route: Route,
     _p: ::std::marker::PhantomData<fn(RouteBody, InnerBody)>,
 }
@@ -109,7 +104,6 @@ where
             inner,
             get_routes: self.get_routes.clone(),
             route_layer: self.route_layer.clone(),
-            suffixes: self.suffixes.clone(),
             default_route: self.default_route.clone(),
             _p: ::std::marker::PhantomData,
         }
@@ -124,7 +118,6 @@ where
 {
     fn clone(&self) -> Self {
         Layer {
-            suffixes: self.suffixes.clone(),
             get_routes: self.get_routes.clone(),
             route_layer: self.route_layer.clone(),
             default_route: self.default_route.clone(),
@@ -187,16 +180,11 @@ where
         // destination.
         let route_stream = match target.get_destination() {
             Some(ref dst) => {
-                if self.suffixes.iter().any(|s| s.contains(dst.name())) {
-                    debug!("fetching routes for {:?}", dst);
-                    self.get_routes.get_routes(&dst)
-                } else {
-                    debug!("skipping route discovery for dst={:?}", dst);
-                    None
-                }
+                debug!("fetching routes");
+                self.get_routes.get_routes(&dst)
             }
             None => {
-                debug!("no destination for routes");
+                trace!("no destination for routes");
                 None
             }
         };
@@ -225,7 +213,6 @@ where
             inner: self.inner.clone(),
             get_routes: self.get_routes.clone(),
             route_layer: self.route_layer.clone(),
-            suffixes: self.suffixes.clone(),
             default_route: self.default_route.clone(),
             _p: ::std::marker::PhantomData,
         }


### PR DESCRIPTION
Currently, the profile_suffixes are wired through into the inbound and
outbound proxies to configure the profile layer.

This change decouples inbound/outbound proxy initialization from this
detail of the profile client.