### PR TITLE
make: Do not compile integration tests during packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ifdef CARGO_DEBUG
 endif
 
 $(TARGET_BIN): fetch
-	$(CARGO_BUILD)
+	$(CARGO_BUILD) -p linkerd2-proxy
 
 $(PKG_ROOT)/$(PKG): $(TARGET_BIN)
 	mkdir -p $(PKG_BASE)/bin


### PR DESCRIPTION
`make package` currently builds all crates, including the time-consuming
integration tests. This change ensures that only crates needed to build
the binary are compiled.