### PR TITLE
Make the router HTTP-agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,13 +1035,14 @@ version = "0.1.0"
 dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linkerd2-error 0.1.0",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-load-shed 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing-futures 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/linkerd/app/core/src/errors.rs
+++ b/linkerd/app/core/src/errors.rs
@@ -116,7 +116,7 @@ where
 
 fn map_err_to_5xx(e: Error) -> StatusCode {
     use crate::proxy::buffer;
-    use crate::proxy::http::router::error as router;
+    use linkerd2_router::error as router;
     use tower::load_shed::error as shed;
 
     if let Some(ref c) = e.downcast_ref::<router::NoCapacity>() {

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -18,6 +18,7 @@ pub use linkerd2_metrics as metrics;
 pub use linkerd2_opencensus as opencensus;
 pub use linkerd2_reconnect as reconnect;
 pub use linkerd2_request_filter as request_filter;
+pub use linkerd2_router as router;
 pub use linkerd2_trace_context as trace_context;
 
 pub mod accept_error;

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -154,7 +154,8 @@ mod tests {
     use super::{Endpoint, RecognizeEndpoint};
     use http;
     use linkerd2_app_core::{
-        proxy::http::{router::Recognize, Settings},
+        proxy::http::Settings,
+        router::Recognize,
         transport::{listen, tls},
         Conditional,
     };

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -4,10 +4,8 @@ use linkerd2_app_core::{
     classify,
     dst::{DstAddr, Route},
     metric_labels::EndpointLabels,
-    proxy::{
-        http::{router, settings},
-        identity, tap,
-    },
+    proxy::{http::settings, identity, tap},
+    router,
     transport::{connect, tls},
     Conditional, NameAddr,
 };

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -20,7 +20,6 @@ pub mod normalize_uri;
 pub mod orig_proto;
 pub mod profiles;
 pub mod retry;
-pub mod router;
 pub mod settings;
 pub mod strip_header;
 pub mod timeout;

--- a/linkerd/router/Cargo.toml
+++ b/linkerd/router/Cargo.toml
@@ -8,10 +8,11 @@ publish = false
 [dependencies]
 futures = "0.1"
 indexmap = "1.0.0"
-log = "0.4"
+linkerd2-error = { path = "../error" }
 tower-load-shed = "0.1"
 tokio = "0.1.20"
 tokio-sync = "0.1.6"
 tokio-timer = "0.2.4"
-tower-service = "0.2"
+tower = "0.1"
 tracing = "0.1.2"
+tracing-futures = "0.1"

--- a/linkerd/router/src/lib.rs
+++ b/linkerd/router/src/lib.rs
@@ -370,7 +370,7 @@ mod test_util {
     use std::cell::Cell;
     use std::fmt;
     use std::rc::Rc;
-    use tower_service::Service;
+    use tower::Service;
 
     #[derive(Clone)]
     pub struct Recognize;
@@ -494,7 +494,7 @@ mod tests {
     use futures::Future;
     use std::time::Duration;
     use std::usize;
-    use tower_service::{self as svc, Service};
+    use tower::Service;
 
     impl<Mk> Router<Request, Recognize, Mk>
     where


### PR DESCRIPTION
There's nothing HTTP-specific about the router.

This change moves the layer implementations--which unnecessarily enforce
HTTP-specific type requirements--into the generic router crate, relaxing
its type constraints.