### PR TITLE
router: Ensure that the purge task completes

### DIFF
--- a/linkerd/app/core/src/profiles.rs
+++ b/linkerd/app/core/src/profiles.rs
@@ -109,7 +109,7 @@ where
             },
         };
 
-        tokio::spawn(daemon.in_current_span().map_err(|e| match e {}));
+        tokio::spawn(daemon.in_current_span().map_err(|never| match never {}));
         Some(Rx {
             rx,
             _hangup: hangup_tx,

--- a/linkerd/app/core/src/profiles.rs
+++ b/linkerd/app/core/src/profiles.rs
@@ -106,7 +106,7 @@ where
             context_token: self.context_token.clone(),
         };
 
-        tokio::spawn(daemon.map_err(|_| ()));
+        tokio::spawn(daemon.map_err(|never| match never {}));
         Some(Rx {
             rx,
             _hangup: hangup_tx,

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -260,7 +260,7 @@ impl<A: OrigDstAddr> Config<A> {
                     },
                 ))
                 .into_inner()
-                .make();
+                .spawn();
 
             // Canonicalizes the request-specified `Addr` via DNS, and
             // annotates each request with a refined `Addr` so that it may be
@@ -305,7 +305,7 @@ impl<A: OrigDstAddr> Config<A> {
                     },
                 ))
                 .into_inner()
-                .make();
+                .spawn();
 
             // Share a single semaphore across all requests to signal when
             // the proxy is overloaded.

--- a/linkerd/router/src/layer.rs
+++ b/linkerd/router/src/layer.rs
@@ -1,5 +1,5 @@
 use crate::{Recognize, Router};
-use futures::Poll;
+use futures::{Future, Poll};
 use linkerd2_error::{Error, Never};
 use std::marker::PhantomData;
 use std::time::Duration;
@@ -111,7 +111,11 @@ where
             self.config.capacity,
             self.config.max_idle_age,
         );
-        tokio::spawn(cache_bg.instrument(info_span!("router.purge")));
+        tokio::spawn(
+            cache_bg
+                .map_err(|never| match never {})
+                .instrument(info_span!("router.purge")),
+        );
         Service { inner }
     }
 }

--- a/linkerd/router/src/layer.rs
+++ b/linkerd/router/src/layer.rs
@@ -104,7 +104,7 @@ where
     Mk::Value: tower::Service<Req> + Clone + Send + 'static,
     <Mk::Value as tower::Service<Req>>::Error: Into<Error>,
 {
-    pub fn make(&self) -> Service<Req, Rec, Mk> {
+    pub fn spawn(&self) -> Service<Req, Rec, Mk> {
         let (inner, purge) = Router::new(
             self.recognize.clone(),
             self.inner.clone(),
@@ -113,7 +113,7 @@ where
         );
         tokio::spawn(
             purge
-                .map_err(|never| match never {})
+                .map_err(|e| match e {})
                 .instrument(info_span!("router.purge")),
         );
         Service { inner }
@@ -137,7 +137,7 @@ where
     }
 
     fn call(&mut self, _: T) -> Self::Future {
-        futures::future::ok(self.make())
+        futures::future::ok(self.spawn())
     }
 }
 

--- a/linkerd/router/src/layer.rs
+++ b/linkerd/router/src/layer.rs
@@ -105,14 +105,14 @@ where
     <Mk::Value as tower::Service<Req>>::Error: Into<Error>,
 {
     pub fn make(&self) -> Service<Req, Rec, Mk> {
-        let (inner, cache_bg) = Router::new(
+        let (inner, purge) = Router::new(
             self.recognize.clone(),
             self.inner.clone(),
             self.config.capacity,
             self.config.max_idle_age,
         );
         tokio::spawn(
-            cache_bg
+            purge
                 .map_err(|never| match never {})
                 .instrument(info_span!("router.purge")),
         );

--- a/linkerd/router/src/purge.rs
+++ b/linkerd/router/src/purge.rs
@@ -58,9 +58,7 @@ where
 pub mod tests {
     use super::*;
     use futures::future;
-    use std::sync::{
-        Arc,
-    };
+    use std::sync::Arc;
     use std::time::{Duration, Instant};
 
     const UNUSED: Duration = Duration::from_secs(12345);

--- a/linkerd/router/src/purge.rs
+++ b/linkerd/router/src/purge.rs
@@ -1,0 +1,54 @@
+use super::Cache;
+use futures::{Async, Future, Poll, Stream};
+use linkerd2_error::Never;
+use std::hash::Hash;
+use tokio::sync::lock::Lock;
+use tokio::sync::mpsc;
+
+/// A background future that eagerly removes expired cache values.
+///
+/// If the cache is dropped, this future will complete.
+pub struct Purge<K: Clone + Eq + Hash, V> {
+    cache: Lock<Cache<K, V>>,
+    hangup: mpsc::Receiver<Never>,
+}
+
+/// Ensures that `Purge` runs until all handles are dropped.
+#[derive(Clone)]
+pub struct Handle(mpsc::Sender<Never>);
+
+// ===== impl PurgeCache =====
+
+impl<K, V> Purge<K, V>
+where
+    K: Clone + Eq + Hash,
+{
+    pub(crate) fn new(cache: Lock<Cache<K, V>>) -> (Self, Handle) {
+        let (tx, hangup) = mpsc::channel(1);
+        (Purge { cache, hangup }, Handle(tx))
+    }
+}
+
+impl<K, V> Future for Purge<K, V>
+where
+    K: Clone + Eq + Hash,
+    V: Clone,
+{
+    type Item = ();
+    type Error = Never;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.hangup.poll() {
+            Ok(Async::NotReady) => {}
+            Ok(Async::Ready(None)) => return Ok(Async::Ready(())),
+            Ok(Async::Ready(Some(never))) => match never {},
+            Err(_) => unreachable!("purge hangup handle must not error"),
+        };
+
+        if let Async::Ready(mut cache) = self.cache.poll_lock() {
+            cache.purge();
+        }
+
+        Ok(Async::NotReady)
+    }
+}


### PR DESCRIPTION
The router's cache purging tasks never complete. This means that
when a router is dropped, it's purge task is leaked into the executor,
possibly holding services.

This change uses an mpsc to ensure that the purge task is notified when
all of the routers using this cache have been dropped.