### PR TITLE
app-core: Add `accept` context with peer addr

### DIFF
--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -98,9 +98,9 @@ impl<C: HasSpan, A: Accept<C>> tower::Service<C> for TraceAccept<A> {
     }
 
     fn call(&mut self, conn: C) -> Self::Future {
-        let _enter = self.span.enter();
         let span = conn.span();
-        self.accept.accept(conn).instrument(span)
+        let _enter = span.enter();
+        self.accept.accept(conn).in_current_span()
     }
 }
 

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -3,10 +3,15 @@ use futures::{future, try_ready, Future, Poll};
 use linkerd2_drain as drain;
 use linkerd2_error::Error;
 use linkerd2_proxy_core::listen::{Accept, Listen, Serve};
-use tracing::{debug, Span};
+use linkerd2_proxy_transport::listen::Addrs;
+use tracing::{debug, info_span, Span};
 use tracing_futures::{Instrument, Instrumented};
 
 pub type Task = Box<dyn Future<Item = (), Error = Error> + Send + 'static>;
+
+pub trait HasSpan {
+    fn span(&self) -> Span;
+}
 
 /// Spawns a task that binds an `L`-typed listener with an `A`-typed
 /// connection-accepting service.
@@ -15,6 +20,7 @@ pub type Task = Box<dyn Future<Item = (), Error = Error> + Send + 'static>;
 pub fn serve<L, A>(listen: L, accept: A, drain: drain::Watch) -> Task
 where
     L: Listen + Send + 'static,
+    L::Connection: HasSpan,
     L::Error: std::error::Error + Send + 'static,
     A: Accept<L::Connection> + Send + 'static,
     A::Error: 'static,
@@ -37,6 +43,7 @@ struct ServeAndSpawnUntilCancel<L: Listen, A: Accept<L::Connection>>(
 impl<L, A> ServeAndSpawnUntilCancel<L, A>
 where
     L: Listen,
+    L::Connection: HasSpan,
     A: Accept<L::Connection>,
     A::Error: 'static,
     A::Future: Send + 'static,
@@ -59,6 +66,7 @@ where
 impl<L, A> Future for ServeAndSpawnUntilCancel<L, A>
 where
     L: Listen,
+    L::Connection: HasSpan,
     A: Accept<L::Connection>,
     A::Future: Send + 'static,
     A::Error: 'static,
@@ -79,7 +87,7 @@ struct TraceAccept<A> {
     span: Span,
 }
 
-impl<C, A: Accept<C>> tower::Service<C> for TraceAccept<A> {
+impl<C: HasSpan, A: Accept<C>> tower::Service<C> for TraceAccept<A> {
     type Response = ();
     type Error = A::Error;
     type Future = Instrumented<A::Future>;
@@ -91,6 +99,17 @@ impl<C, A: Accept<C>> tower::Service<C> for TraceAccept<A> {
 
     fn call(&mut self, conn: C) -> Self::Future {
         let _enter = self.span.enter();
-        self.accept.accept(conn).instrument(self.span.clone())
+        let span = conn.span();
+        self.accept.accept(conn).instrument(span)
+    }
+}
+
+impl<C> HasSpan for (Addrs, C) {
+    fn span(&self) -> Span {
+        // The local addr should be instrumented from the listener's context.
+        info_span!(
+            "accept",
+            peer.addr = %self.0.peer(),
+        )
     }
 }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -258,7 +258,6 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(trace::layer(|src: &tls::accept::Meta| {
                     info_span!(
                         "source",
-                        peer.addr = %src.addrs.peer(),
                         peer.id = ?src.peer_identity,
                         target.addr = %src.addrs.target_addr(),
                     )


### PR DESCRIPTION
The proxy's server does not instrument tracing contexts with the peer's
connection metadata, causing hyper's server logs to be devoid of this
helpful context.

This change adds an _accept_ context that includes the peer's address.

Fixes #3799