### PR TITLE
Configure the HTTP/2 connection window to 1MB

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -310,10 +310,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
     let h2_settings = h2::Settings {
         initial_stream_window_size: Some(
-            initial_stream_window_size?.unwrap_or(DEFAULT_STREAM_WINDOW_SIZE),
+            initial_stream_window_size?.unwrap_or(DEFAULT_INITIAL_STREAM_WINDOW_SIZE),
         ),
         initial_connection_window_size: Some(
-            initial_connection_window_size?.unwrap_or(DEFAULT_CONNECTION_WINDOW_SIZE),
+            initial_connection_window_size?.unwrap_or(DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE),
         ),
     };
 

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -181,6 +181,9 @@ const DEFAULT_OUTBOUND_CONNECT_BACKOFF: ExponentialBackoff = ExponentialBackoff 
 const DEFAULT_DNS_CANONICALIZE_TIMEOUT: Duration = Duration::from_millis(100);
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 
+const DEFAULT_INITIAL_STREAM_WINDOW_SIZE: usize = 65_535; // Protocol default
+const DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE: usize = 1048576; // 1MB ~ 16 streams at capacity
+
 /// It's assumed that a typical proxy can serve inbound traffic for up to 100 pod-local
 /// HTTP services and may communicate with up to 10K external HTTP domains.
 const DEFAULT_INBOUND_ROUTER_CAPACITY: usize = 100;
@@ -306,8 +309,12 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let tap = parse_tap_config(strings, id_disabled);
 
     let h2_settings = h2::Settings {
-        initial_stream_window_size: initial_stream_window_size?,
-        initial_connection_window_size: initial_connection_window_size?,
+        initial_stream_window_size: Some(
+            initial_stream_window_size?.unwrap_or(DEFAULT_STREAM_WINDOW_SIZE),
+        ),
+        initial_connection_window_size: Some(
+            initial_connection_window_size?.unwrap_or(DEFAULT_CONNECTION_WINDOW_SIZE),
+        ),
     };
 
     let outbound = {

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -181,8 +181,8 @@ const DEFAULT_OUTBOUND_CONNECT_BACKOFF: ExponentialBackoff = ExponentialBackoff 
 const DEFAULT_DNS_CANONICALIZE_TIMEOUT: Duration = Duration::from_millis(100);
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 
-const DEFAULT_INITIAL_STREAM_WINDOW_SIZE: usize = 65_535; // Protocol default
-const DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE: usize = 1048576; // 1MB ~ 16 streams at capacity
+const DEFAULT_INITIAL_STREAM_WINDOW_SIZE: u32 = 65_535; // Protocol default
+const DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE: u32 = 1048576; // 1MB ~ 16 streams at capacity
 
 /// It's assumed that a typical proxy can serve inbound traffic for up to 100 pod-local
 /// HTTP services and may communicate with up to 10K external HTTP domains.


### PR DESCRIPTION
Currently, the proxy uses the protocol defaults for HTTP/2 connection
window size (64K). Because this is the same as the stream window size, a
single stream can consume the entire connection window, stalling other
streams.

This change alters the default connection window to be 1MB, supporting
up to 16 stalled streams.

While we primarily care about this setting for client (response)
receiver windows, it seems like a good thing to open the server
(request) receiver window as well (and the configuration is not
currently distinguishable).