### PR TITLE
router: Move the `Make` trait to `stack` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "linkerd2-error 0.1.0",
+ "linkerd2-stack 0.1.0",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/linkerd/app/core/src/proxy/pending.rs
+++ b/linkerd/app/core/src/proxy/pending.rs
@@ -1,7 +1,7 @@
 use crate::svc::{self, ServiceExt};
 use futures::{try_ready, Future, Poll};
 use linkerd2_error::Error;
-use linkerd2_router as rt;
+use linkerd2_stack::Make;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Layer(());
@@ -36,16 +36,15 @@ impl<M> svc::Layer<M> for Layer {
 
 // === impl MakePending ===
 
-impl<T, M> rt::Make<T> for MakePending<M>
+impl<T, M> Make<T> for MakePending<M>
 where
     M: svc::Service<T> + Clone,
     M::Error: Into<Error>,
-    T: Clone,
 {
-    type Value = Svc<M, T>;
+    type Service = Svc<M, T>;
 
-    fn make(&self, target: &T) -> Self::Value {
-        let fut = self.inner.clone().oneshot(target.clone());
+    fn make(&self, target: T) -> Self::Service {
+        let fut = self.inner.clone().oneshot(target);
         Pending::Making(fut)
     }
 }

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -1,7 +1,6 @@
 use crate::proxy::{buffer, http, pending};
 use crate::Error;
-pub use linkerd2_router::Make;
-pub use linkerd2_stack::{self as stack, layer, map_target, Layer, LayerExt, Shared};
+pub use linkerd2_stack::{self as stack, layer, map_target, Layer, LayerExt, Shared, Make};
 pub use linkerd2_timeout::stack as timeout;
 use std::time::Duration;
 use tower::layer::util::{Identity, Stack as Pair};
@@ -89,7 +88,7 @@ impl<S> Stack<S> {
         self,
         bound: usize,
         d: D,
-    ) -> Stack<buffer::Make<pending::MakePending<S>, D, Req>>
+    ) -> Stack<buffer::MakeBuffer<pending::MakePending<S>, D, Req>>
     where
         D: buffer::Deadline<Req>,
         Req: Send + 'static,

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -1,6 +1,6 @@
 use crate::proxy::{buffer, http, pending};
 use crate::Error;
-pub use linkerd2_stack::{self as stack, layer, map_target, Layer, LayerExt, Shared, Make};
+pub use linkerd2_stack::{self as stack, layer, map_target, Layer, LayerExt, Make, Shared};
 pub use linkerd2_timeout::stack as timeout;
 use std::time::Duration;
 use tower::layer::util::{Identity, Stack as Pair};

--- a/linkerd/proxy/http/src/profiles/router.rs
+++ b/linkerd/proxy/http/src/profiles/router.rs
@@ -5,7 +5,7 @@ use http;
 use indexmap::IndexMap;
 use linkerd2_error::{Error, Never};
 use linkerd2_router as rt;
-use linkerd2_stack::{Shared, Make};
+use linkerd2_stack::{Make, Shared};
 use std::hash::Hash;
 use tracing::{debug, error};
 

--- a/linkerd/router/Cargo.toml
+++ b/linkerd/router/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 futures = "0.1"
 indexmap = "1.0.0"
 linkerd2-error = { path = "../error" }
+linkerd2-stack = { path = "../stack" }
 tower-load-shed = "0.1"
 tokio = "0.1.20"
 tokio-sync = "0.1.6"

--- a/linkerd/router/src/cache.rs
+++ b/linkerd/router/src/cache.rs
@@ -51,7 +51,6 @@ struct Node<T> {
 impl<K, V> Cache<K, V>
 where
     K: Clone + Eq + Hash,
-    V: Clone,
 {
     pub fn new(capacity: usize, expires: Duration) -> Self {
         assert!(capacity != 0);
@@ -76,12 +75,12 @@ where
     ///
     /// If a value is returned, this key will not be considered for eviction
     /// for another `expires` span of time.
-    pub fn access(&mut self, key: &K) -> Option<V> {
+    pub fn access(&mut self, key: &K) -> Option<&mut V> {
         if let Some(node) = self.values.get_mut(key) {
             self.expirations.reset(&node.dq_key, self.expires);
             trace!("reset expiration for cache value associated with key");
 
-            return Some(node.value.clone());
+            return Some(&mut node.value);
         }
 
         None
@@ -167,8 +166,8 @@ mod tests {
             assert!(cache.access(&1).is_some());
             assert!(cache.access(&2).is_some());
 
-            assert_eq!(cache.access(&1).take().unwrap(), 2);
-            assert_eq!(cache.access(&2).take().unwrap(), 3);
+            assert_eq!(cache.access(&1).take().unwrap(), &2);
+            assert_eq!(cache.access(&2).take().unwrap(), &3);
 
             Ok::<_, ()>(())
         }))

--- a/linkerd/router/src/lib.rs
+++ b/linkerd/router/src/lib.rs
@@ -5,11 +5,11 @@ pub mod error;
 pub mod layer;
 mod purge;
 
-use indexmap::IndexMap;
 use self::cache::Cache;
 pub use self::layer::{Config, Layer};
 pub use self::purge::Purge;
 use futures::{Async, Future, Poll};
+use indexmap::IndexMap;
 use linkerd2_stack::Make;
 use std::hash::Hash;
 use std::time::Duration;

--- a/linkerd/router/src/purge.rs
+++ b/linkerd/router/src/purge.rs
@@ -33,7 +33,6 @@ where
 impl<K, V> Future for Purge<K, V>
 where
     K: Clone + Eq + Hash,
-    V: Clone,
 {
     type Item = ();
     type Error = Never;

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -1,9 +1,13 @@
 #![deny(warnings, rust_2018_idioms)]
 
 pub mod layer;
+pub mod make;
 pub mod map_target;
 pub mod per_make;
 mod shared;
 
-pub use self::layer::{Layer, LayerExt};
-pub use self::shared::Shared;
+pub use self::{
+    layer::{Layer, LayerExt},
+    make::Make,
+    shared::Shared,
+};

--- a/linkerd/stack/src/make.rs
+++ b/linkerd/stack/src/make.rs
@@ -1,0 +1,52 @@
+use futures::{future, Poll};
+use linkerd2_error::Never;
+use tower_service::Service;
+
+pub trait Make<T> {
+    type Service;
+
+    fn make(&self, target: T) -> Self::Service;
+
+    fn into_service(self) -> MakeService<Self>
+    where
+        Self: Sized,
+    {
+        MakeService(self)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MakeService<M>(M);
+
+impl<F, T, S> Make<T> for F
+where
+    F: Fn(T) -> S,
+{
+    type Service = S;
+
+    fn make(&self, target: T) -> Self::Service {
+        (*self)(target)
+    }
+}
+
+impl<T> Make<T> for () {
+    type Service = ();
+
+    fn make(&self, _: T) -> Self::Service {
+        ()
+    }
+}
+
+impl<M: Make<T>, T> Service<T> for MakeService<M> {
+    type Response = M::Service;
+    type Error = Never;
+    type Future = future::FutureResult<M::Service, Never>;
+
+    fn poll_ready(&mut self) -> Poll<(), Never> {
+        Ok(().into())
+    }
+
+    fn call(&mut self, target: T) -> Self::Future {
+        future::ok(self.0.make(target))
+    }
+}

--- a/linkerd/stack/src/shared.rs
+++ b/linkerd/stack/src/shared.rs
@@ -12,6 +12,14 @@ impl<V: Clone> Shared<V> {
     }
 }
 
+impl<T, V: Clone> super::Make<T> for Shared<V> {
+    type Service = V;
+
+    fn make(&self, _: T) -> Self::Service {
+        self.0.clone()
+    }
+}
+
 impl<T, V: Clone> svc::Service<T> for Shared<V> {
     type Response = V;
     type Error = Never;


### PR DESCRIPTION
The router's `Make` trait is generally useful when we have to build
middlewares. In preparation for improvements to the profile router, this
change moves the `Make` trait into the `linkerd2-stack` crate, with some
API improvements.

Furthermore, the Router is changed to avoid requiring that its services
implement `Clone`.

In general, we expect targets to be cheaply cloneable, but we should
only require that services are cloneable when absolutely necessary.