### PR TITLE
http: Use the endpoint type to inform URI normalization

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -88,7 +88,7 @@ pub mod add_origin {
         }
 
         fn call(&mut self, target: ControlAddr) -> Self::Future {
-            let authority = target.addr.as_authority();
+            let authority = target.addr.to_http_authority();
             let inner = self.inner.call(target);
             MakeFuture {
                 inner,

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -33,7 +33,7 @@ pub use self::{
     settings::Settings,
     version::Version,
 };
-pub use http::{Request, Response};
+pub use http::{header, uri, Request, Response};
 
 pub trait HasH2Reason {
     fn h2_reason(&self) -> Option<::h2::Reason>;

--- a/linkerd/proxy/http/src/normalize_uri.rs
+++ b/linkerd/proxy/http/src/normalize_uri.rs
@@ -1,44 +1,43 @@
-use super::{
-    h1,
-    settings::{HasSettings, Settings},
-};
+use super::h1;
 use futures::{try_ready, Future, Poll};
-use http;
+use http::uri::Authority;
 use linkerd2_stack::layer;
+use tracing::trace;
+
+pub trait ShouldNormalizeUri {
+    fn should_normalize_uri(&self) -> Option<Authority>;
+}
 
 #[derive(Clone, Debug)]
-pub struct Stack<N> {
+pub struct MakeNormalizeUri<N> {
     inner: N,
 }
 
 pub struct MakeFuture<F> {
     inner: F,
-    should_normalize_uri: bool,
+    authority: Option<Authority>,
 }
 
 #[derive(Clone, Debug)]
-pub struct Service<S> {
+pub struct NormalizeUri<S> {
     inner: S,
-}
-
-fn should_normalize_uri(settings: &Settings) -> bool {
-    !settings.is_http2() && !settings.was_absolute_form()
+    authority: Option<Authority>,
 }
 
 // === impl Layer ===
 
-pub fn layer<M>() -> impl layer::Layer<M, Service = Stack<M>> + Copy {
-    layer::mk(|inner| Stack { inner })
+pub fn layer<M>() -> impl tower::layer::Layer<M, Service = MakeNormalizeUri<M>> + Copy {
+    layer::mk(|inner| MakeNormalizeUri { inner })
 }
 
-// === impl Stack ===
+// === impl MakeNormalizeUri ===
 
-impl<T, M> tower::Service<T> for Stack<M>
+impl<T, M> tower::Service<T> for MakeNormalizeUri<M>
 where
-    T: HasSettings,
+    T: ShouldNormalizeUri,
     M: tower::Service<T>,
 {
-    type Response = tower::util::Either<Service<M::Response>, M::Response>;
+    type Response = NormalizeUri<M::Response>;
     type Error = M::Error;
     type Future = MakeFuture<M::Future>;
 
@@ -47,12 +46,12 @@ where
     }
 
     fn call(&mut self, target: T) -> Self::Future {
-        let should_normalize_uri = should_normalize_uri(target.http_settings());
-        let inner = self.inner.call(target);
+        let authority = target.should_normalize_uri();
+        tracing::trace!(?authority, "make");
 
         MakeFuture {
-            inner,
-            should_normalize_uri,
+            authority,
+            inner: self.inner.call(target),
         }
     }
 }
@@ -60,23 +59,22 @@ where
 // === impl MakeFuture ===
 
 impl<F: Future> Future for MakeFuture<F> {
-    type Item = tower::util::Either<Service<F::Item>, F::Item>;
+    type Item = NormalizeUri<F::Item>;
     type Error = F::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let inner = try_ready!(self.inner.poll());
-
-        if self.should_normalize_uri {
-            Ok(tower::util::Either::A(Service { inner }).into())
-        } else {
-            Ok(tower::util::Either::B(inner).into())
-        }
+        let svc = NormalizeUri {
+            inner,
+            authority: self.authority.take(),
+        };
+        Ok(svc.into())
     }
 }
 
-// === impl Service ===
+// === impl NormalizeUri ===
 
-impl<S, B> tower::Service<http::Request<B>> for Service<S>
+impl<S, B> tower::Service<http::Request<B>> for NormalizeUri<S>
 where
     S: tower::Service<http::Request<B>>,
 {
@@ -89,11 +87,17 @@ where
     }
 
     fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
-        debug_assert!(
-            request.version() != http::Version::HTTP_2,
-            "normalize_uri must only be applied to HTTP/1"
-        );
-        h1::normalize_our_view_of_uri(&mut request);
+        if let Some(ref authority) = self.authority {
+            trace!(%authority, "Normalizing URI");
+            debug_assert!(
+                request.version() != http::Version::HTTP_2,
+                "normalize_uri must only be applied to HTTP/1"
+            );
+            h1::set_authority(request.uri_mut(), authority.clone());
+        } else {
+            trace!("Not normalizing URI");
+        }
+
         self.inner.call(request)
     }
 }


### PR DESCRIPTION
Currently, the `http::normalize_uri` middleware determines absolute-form
authorities by reading request extensions. This hidden coupling makes
changing things fairly difficult. Instead, we can use the target types,
which already hold the relevant info, to determine the absolute-form
authority if needed.