### PR TITLE
Remove clone in opencensus exporter to ensure task is notified

### DIFF
--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -180,10 +180,9 @@ where
                     ref mut metrics,
                     ..
                 } => {
-                    let mut sender = sender.clone();
                     match Self::poll_send_spans(
                         &mut self.spans,
-                        &mut sender,
+                        sender,
                         node,
                         self.max_batch_size,
                         metrics,


### PR DESCRIPTION
In the opencensus span exporter, we call `poll_ready` on the span send channel sender to determine if there is capacity in this channel to send spans.  However, the channel sender that we `poll_ready` on is a clone of the original and the clone is dropped shortly after the call to `poll_ready`.  This can cause our interest registration to be dropped and the task may not be notified when capacity becomes available.

The clone is unnecessarily and we can remove it.

Signed-off-by: Alex Leong <alex@buoyant.io>