### PR TITLE
Actually update http to v0.1.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.1.16"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe67e3678f2827030e89cc4b9e7ecd16d52f132c0b940ab5005f88e821500f6a"
+checksum = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
Should have been in https://github.com/linkerd/linkerd2-proxy/commit/eb49e697b907f5be4da1376ea69ae9e198092d87