### PR TITLE
patch `prost` 0.5 to pick up security fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,10 +1480,8 @@ dependencies = [
 [[package]]
 name = "prost"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
+source = "git+https://github.com/linkerd/prost?branch=v0.5.x#8875bb9404ed50de20ef51c61bd2eaff5812fb1e"
 dependencies = [
- "byteorder",
  "bytes",
  "prost-derive",
 ]
@@ -1509,8 +1507,7 @@ dependencies = [
 [[package]]
 name = "prost-derive"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
+source = "git+https://github.com/linkerd/prost?branch=v0.5.x#8875bb9404ed50de20ef51c61bd2eaff5812fb1e"
 dependencies = [
  "failure",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,5 @@ debug = false
 
 [patch.crates-io]
 webpki = { git = "https://github.com/seanmonstar/webpki", branch = "cert-dns-names-0.21" }
+# backport danburkert/prost#268 to `prost` 0.5 temporarily.
+prost = { git = "https://github.com/linkerd/prost", branch = "v0.5.x" }


### PR DESCRIPTION
This branch updates the proxy's `prost` dependency to a patched version
of `prost` 0.5 that incorporates the cahnges in danburkert/prost#268.
This patch fixes a security issue where a malicious protobuf message
could be used to trigger a stack overflow.

We are unfortunately unable to easily update to `prost` 0.6.1, which
includes this fix, as 0.6 updates the `bytes` dependency to 0.5. The
`tokio` 0.1 ecosystem that the proxy currently uses still depends on
0.4, and the breaking changes in 0.5 are quite significant. Therefore,
updating to `bytes` 0.5 would require a lot of fairly large changes to
legacy versions of...pretty much everything (`tokio-io`, `tokio-buf`,
`hyper`, `http-body`...). As we intend to update to `tokio` 0.2 in the
near future, patching all these legacy dependencies is a bit of a waste
of time. Therefore, I opted to backport the security fix to a compatible
`prost` version instead.

Closes linkerd/linkerd2#3963

Signed-off-by: Eliza Weisman <eliza@buoyant.io>