### PR TITLE
metrics: Make Counter & Gauge atomic

### DIFF
--- a/linkerd/app/core/src/handle_time.rs
+++ b/linkerd/app/core/src/handle_time.rs
@@ -259,7 +259,7 @@ impl Shared {
         if counter.clones.fetch_sub(1, Ordering::Release) == 1 {
             let elapsed = t0.elapsed();
 
-            let mut hist = match self.histogram.lock() {
+            let hist = match self.histogram.lock() {
                 Ok(lock) => lock,
                 // Avoid double panicking in drop.
                 Err(_) if panicking => return,

--- a/linkerd/app/core/src/telemetry/process.rs
+++ b/linkerd/app/core/src/telemetry/process.rs
@@ -1,6 +1,7 @@
 use self::system::System;
 use linkerd2_metrics::{metrics, FmtMetrics, Gauge};
 use std::fmt;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::debug;
 
@@ -12,7 +13,7 @@ metrics! {
 
 #[derive(Clone, Debug, Default)]
 pub struct Report {
-    start_time: Gauge,
+    start_time: Arc<Gauge>,
     system: Option<System>,
 }
 
@@ -31,7 +32,7 @@ impl Report {
             }
         };
         Self {
-            start_time: t0.into(),
+            start_time: Arc::new(t0.into()),
             system,
         }
     }
@@ -40,7 +41,7 @@ impl Report {
 impl FmtMetrics for Report {
     fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         process_start_time_seconds.fmt_help(f)?;
-        process_start_time_seconds.fmt_metric(f, self.start_time)?;
+        process_start_time_seconds.fmt_metric(f, self.start_time.as_ref())?;
 
         if let Some(ref sys) = self.system {
             sys.fmt_metrics(f)?;
@@ -129,14 +130,14 @@ mod system {
             };
 
             let clock_ticks = stat.utime as u64 + stat.stime as u64;
+            let cpu = Counter::from(clock_ticks / self.clock_ticks_per_sec);
             process_cpu_seconds_total.fmt_help(f)?;
-            process_cpu_seconds_total
-                .fmt_metric(f, Counter::from(clock_ticks / self.clock_ticks_per_sec))?;
+            process_cpu_seconds_total.fmt_metric(f, &cpu)?;
 
             match Self::open_fds(stat.pid) {
                 Ok(open_fds) => {
                     process_open_fds.fmt_help(f)?;
-                    process_open_fds.fmt_metric(f, open_fds)?;
+                    process_open_fds.fmt_metric(f, &open_fds)?;
                 }
                 Err(err) => {
                     warn!("could not determine process_open_fds: {}", err);
@@ -148,7 +149,7 @@ mod system {
                 Ok(None) => {}
                 Ok(Some(ref max_fds)) => {
                     process_max_fds.fmt_help(f)?;
-                    process_max_fds.fmt_metric(f, *max_fds)?;
+                    process_max_fds.fmt_metric(f, max_fds)?;
                 }
                 Err(err) => {
                     warn!("could not determine process_max_fds: {}", err);
@@ -157,11 +158,12 @@ mod system {
             }
 
             process_virtual_memory_bytes.fmt_help(f)?;
-            process_virtual_memory_bytes.fmt_metric(f, Gauge::from(stat.vsize as u64))?;
+            let vsz = Gauge::from(stat.vsize as u64);
+            process_virtual_memory_bytes.fmt_metric(f, &vsz)?;
 
             process_resident_memory_bytes.fmt_help(f)?;
-            process_resident_memory_bytes
-                .fmt_metric(f, Gauge::from(stat.rss as u64 * self.page_size))
+            let rss = Gauge::from(stat.rss as u64 * self.page_size);
+            process_resident_memory_bytes.fmt_metric(f, &rss)
         }
     }
 }

--- a/linkerd/metrics/src/counter.rs
+++ b/linkerd/metrics/src/counter.rs
@@ -1,6 +1,5 @@
 use super::prom::{FmtLabels, FmtMetric, MAX_PRECISE_VALUE};
 use std::fmt::{self, Display};
-use std::ops;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A Prometheus counter is represented by a `Wrapping` unsigned 52-bit integer.
@@ -49,33 +48,6 @@ impl From<u64> for Counter {
     }
 }
 
-impl ops::Add<u64> for Counter {
-    type Output = Self;
-    fn add(self, rhs: u64) -> Self::Output {
-        self.0.fetch_add(rhs, Ordering::SeqCst);
-        self
-    }
-}
-
-impl ops::Add<Self> for Counter {
-    type Output = Self;
-    fn add(self, rhs: Self) -> Self::Output {
-        self + rhs.value()
-    }
-}
-
-impl ops::AddAssign<u64> for Counter {
-    fn add_assign(&mut self, rhs: u64) {
-        self.0.fetch_add(rhs, Ordering::SeqCst);
-    }
-}
-
-impl ops::AddAssign<Self> for Counter {
-    fn add_assign(&mut self, rhs: Self) {
-        *self += rhs.value();
-    }
-}
-
 impl FmtMetric for Counter {
     const KIND: &'static str = "counter";
 
@@ -105,13 +77,13 @@ mod tests {
 
     #[test]
     fn count_simple() {
-        let mut cnt = Counter::from(0);
+        let cnt = Counter::from(0);
         assert_eq!(cnt.value(), 0);
         cnt.incr();
         assert_eq!(cnt.value(), 1);
-        cnt += 41;
+        cnt.add(41);
         assert_eq!(cnt.value(), 42);
-        cnt += 0;
+        cnt.add(0);
         assert_eq!(cnt.value(), 42);
     }
 

--- a/linkerd/metrics/src/counter.rs
+++ b/linkerd/metrics/src/counter.rs
@@ -33,7 +33,7 @@ impl Counter {
     pub fn value(&self) -> u64 {
         self.0
             .load(Ordering::Acquire)
-            .wrapping_rem(MAX_PRECISE_VALUE)
+            .wrapping_rem(MAX_PRECISE_VALUE + 1)
     }
 }
 
@@ -113,5 +113,23 @@ mod tests {
         assert_eq!(cnt.value(), 42);
         cnt += 0;
         assert_eq!(cnt.value(), 42);
+    }
+
+    #[test]
+    fn count_wrapping() {
+        let cnt = Counter::from(MAX_PRECISE_VALUE - 1);
+        assert_eq!(cnt.value(), MAX_PRECISE_VALUE - 1);
+        cnt.incr();
+        assert_eq!(cnt.value(), MAX_PRECISE_VALUE);
+        cnt.incr();
+        assert_eq!(cnt.value(), 0);
+        cnt.incr();
+        assert_eq!(cnt.value(), 1);
+
+        let max = Counter::from(MAX_PRECISE_VALUE);
+        assert_eq!(max.value(), MAX_PRECISE_VALUE);
+
+        let over = Counter::from(MAX_PRECISE_VALUE + 1);
+        assert_eq!(over.value(), 0);
     }
 }

--- a/linkerd/metrics/src/gauge.rs
+++ b/linkerd/metrics/src/gauge.rs
@@ -1,4 +1,4 @@
-use super::{FmtLabels, FmtMetric};
+use super::prom::{FmtLabels, FmtMetric, MAX_PRECISE_VALUE};
 use std::fmt::{self, Display};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -38,7 +38,7 @@ impl FmtMetric for Gauge {
     const KIND: &'static str = "gauge";
 
     fn fmt_metric<N: Display>(&self, f: &mut fmt::Formatter<'_>, name: N) -> fmt::Result {
-        writeln!(f, "{} {}", name, self.value())
+        writeln!(f, "{} {}", name, self.value().wrapping_rem(MAX_PRECISE_VALUE))
     }
 
     fn fmt_metric_labeled<N, L>(
@@ -53,6 +53,6 @@ impl FmtMetric for Gauge {
     {
         write!(f, "{}{{", name)?;
         labels.fmt_labels(f)?;
-        writeln!(f, "}} {}", self.value())
+        writeln!(f, "}} {}", self.value().wrapping_rem(MAX_PRECISE_VALUE))
     }
 }

--- a/linkerd/metrics/src/gauge.rs
+++ b/linkerd/metrics/src/gauge.rs
@@ -20,7 +20,7 @@ impl Gauge {
     pub fn value(&self) -> u64 {
         self.0
             .load(Ordering::Acquire)
-            .wrapping_rem(MAX_PRECISE_VALUE)
+            .wrapping_rem(MAX_PRECISE_VALUE + 1)
     }
 }
 

--- a/linkerd/metrics/src/histogram.rs
+++ b/linkerd/metrics/src/histogram.rs
@@ -5,7 +5,7 @@ use std::{cmp, iter, slice};
 use super::{Counter, FmtLabels, FmtMetric};
 
 /// A series of latency values and counts.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Histogram<V: Into<u64>> {
     bounds: &'static Bounds,
     buckets: Box<[Counter]>,
@@ -94,9 +94,9 @@ impl<V: Into<u64>> Histogram<V> {
 impl<V: Into<u64>> Histogram<V> {
     /// Assert the bucket containing `le` has a count of at least `at_least`.
     pub fn assert_bucket_at_least(&self, le: u64, at_least: u64) {
-        for (&bucket, &count) in self {
+        for (&bucket, ref count) in self {
             if bucket >= le {
-                let count: u64 = count.into();
+                let count = count.value();
                 assert!(count >= at_least, "le={:?}; bucket={:?};", le, bucket);
                 break;
             }
@@ -105,9 +105,9 @@ impl<V: Into<u64>> Histogram<V> {
 
     /// Assert the bucket containing `le` has a count of exactly `exactly`.
     pub fn assert_bucket_exactly(&self, le: u64, exactly: u64) -> &Self {
-        for (&bucket, &count) in self {
+        for (&bucket, ref count) in self {
             if bucket >= le {
-                let count: u64 = count.into();
+                let count = count.value();
                 assert_eq!(
                     count, exactly,
                     "le={:?}; bucket={:?}; buckets={:#?};",
@@ -137,7 +137,7 @@ impl<V: Into<u64>> Histogram<V> {
                 break;
             }
 
-            let count: u64 = self.buckets[i].into();
+            let count: u64 = self.buckets[i].value();
             assert_eq!(count, exactly, "bucket={:?}; value={:?};", bucket, value,);
         }
         self
@@ -149,7 +149,7 @@ impl<V: Into<u64>> Histogram<V> {
         // We set this to true after we've iterated past the first bucket
         // whose upper bound is >= `value`.
         let mut past_le = false;
-        for (&bucket, &count) in self {
+        for (&bucket, ref count) in self {
             if bucket < value {
                 continue;
             }
@@ -160,8 +160,13 @@ impl<V: Into<u64>> Histogram<V> {
             }
 
             if past_le {
-                let count: u64 = count.into();
-                assert_eq!(count, exactly, "bucket={:?}; value={:?};", bucket, value,);
+                assert_eq!(
+                    count.value(),
+                    exactly,
+                    "bucket={:?}; value={:?};",
+                    bucket,
+                    value,
+                );
             }
         }
         self
@@ -183,7 +188,7 @@ impl<V: Into<u64>> FmtMetric for Histogram<V> {
     fn fmt_metric<N: fmt::Display>(&self, f: &mut fmt::Formatter<'_>, name: N) -> fmt::Result {
         let mut total = Counter::default();
         for (le, count) in self {
-            total += *count;
+            total += count.value();
             total.fmt_metric_labeled(f, Key(&name, "bucket"), Label("le", le))?;
         }
         total.fmt_metric(f, Key(&name, "count"))?;
@@ -204,7 +209,7 @@ impl<V: Into<u64>> FmtMetric for Histogram<V> {
     {
         let mut total = Counter::default();
         for (le, count) in self {
-            total += *count;
+            total += count.value();
             total.fmt_metric_labeled(f, Key(&name, "bucket"), (&labels, Label("le", le)))?;
         }
         total.fmt_metric_labeled(f, Key(&name, "count"), &labels)?;
@@ -362,7 +367,7 @@ mod tests {
                 hist.add(obs);
             }
 
-            hist.sum == expected_sum
+            hist.sum.value() == expected_sum.value()
         }
 
         fn count_equals_number_of_observations(observations: Vec<u64>) -> bool {
@@ -372,11 +377,8 @@ mod tests {
                 hist.add(*obs);
             }
 
-            let count: u64 = hist.buckets.iter().map(|&c| {
-                let count: u64 = c.into();
-                count
-            }).sum();
-            count as usize == observations.len()
+            let count = hist.buckets.iter().map(|ref c| c.value()).sum::<u64>() as usize;
+            count == observations.len()
         }
 
         fn multiple_observations_increment_buckets(observations: Vec<u64>) -> bool {
@@ -398,7 +400,7 @@ mod tests {
             }
 
             for (i, count) in hist.buckets.iter().enumerate() {
-                let count: u64 = (*count).into();
+                let count = count.value();
                 assert_eq!(buckets_and_counts.get(&i).unwrap_or(&0), &count);
             }
             true

--- a/linkerd/metrics/src/prom.rs
+++ b/linkerd/metrics/src/prom.rs
@@ -1,6 +1,13 @@
 use std::fmt;
 use std::marker::{PhantomData, Sized};
 
+/// Largest `u64` that can fit without loss of precision in `f64` (2^53).
+///
+/// Wrapping is based on the fact that Prometheus models values as f64 (52-bits
+/// mantissa), thus integer values over 2^53 are not guaranteed to be correctly
+/// exposed.
+pub(crate) const MAX_PRECISE_VALUE: u64 = 0x20_0000_0000_0000;
+
 /// Writes a block of metrics in prometheus-formatted output.
 pub trait FmtMetrics {
     fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result;

--- a/linkerd/metrics/src/prom.rs
+++ b/linkerd/metrics/src/prom.rs
@@ -90,7 +90,7 @@ impl<'a, N: fmt::Display, M: FmtMetric> Metric<'a, N, M> {
     }
 
     /// Formats a single metric without labels.
-    pub fn fmt_metric(&self, f: &mut fmt::Formatter<'_>, metric: M) -> fmt::Result {
+    pub fn fmt_metric(&self, f: &mut fmt::Formatter<'_>, metric: &M) -> fmt::Result {
         metric.fmt_metric(f, &self.name)
     }
 


### PR DESCRIPTION
The `Counter` and `Gauge` metrics currently hold `u64` values. This
means that all uses need to gaurd access with a `Mutex`.

By changing both types to hold an `AtomicU64`, we can avoid using locks
in some cases.