### PR TITLE
Record a metric of proxy errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,10 +138,11 @@ checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 
 [[package]]
 name = "chrono"
-version = "0.4.10"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+checksum = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 dependencies = [
+ "libc",
  "num-integer",
  "num-traits 0.2.6",
  "time",
@@ -628,6 +629,7 @@ dependencies = [
  "linkerd2-drain",
  "linkerd2-duplex",
  "linkerd2-error",
+ "linkerd2-error-metrics",
  "linkerd2-error-respond",
  "linkerd2-exp-backoff",
  "linkerd2-fallback",
@@ -784,6 +786,17 @@ name = "linkerd2-error"
 version = "0.1.0"
 dependencies = [
  "futures",
+]
+
+[[package]]
+name = "linkerd2-error-metrics"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "indexmap",
+ "linkerd2-error",
+ "linkerd2-metrics",
+ "tower",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,11 +138,10 @@ checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 
 [[package]]
 name = "chrono"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
+checksum = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
 dependencies = [
- "libc",
  "num-integer",
  "num-traits 0.2.6",
  "time",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -23,6 +23,7 @@ linkerd2-dns = { path = "../../dns" }
 linkerd2-drain = { path = "../../drain" }
 linkerd2-duplex = { path = "../../duplex" }
 linkerd2-error = { path = "../../error" }
+linkerd2-error-metrics = { path = "../../error-metrics" }
 linkerd2-error-respond = { path = "../../error-respond" }
 linkerd2-exp-backoff = { path = "../../exp-backoff" }
 linkerd2-fallback = { path = "../../fallback" }

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -111,5 +111,6 @@ pub struct ProxyMetrics {
     pub http_route_actual: HttpRouteMetrics,
     pub http_route_retry: HttpRouteRetry,
     pub http_endpoint: HttpEndpointMetrics,
+    pub http_errors: errors::MetricsLayer,
     pub transport: transport::Metrics,
 }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -247,6 +247,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(insert::layer(move || {
                     DispatchDeadline::after(buffer.dispatch_timeout)
                 }))
+                .push_per_make(metrics.http_errors)
                 .push_per_make(errors::layer())
                 .push(trace::layer(|src: &tls::accept::Meta| {
                     info_span!(

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -318,6 +318,7 @@ impl<A: OrigDstAddr> Config<A> {
                     DispatchDeadline::after(buffer.dispatch_timeout)
                 }))
                 .push(http::insert::target::layer())
+                .push_per_make(metrics.http_errors)
                 .push_per_make(errors::layer())
                 .push(trace::layer(
                     |src: &tls::accept::Meta| info_span!("source", target.addr = %src.addrs.target_addr()),

--- a/linkerd/error-metrics/Cargo.toml
+++ b/linkerd/error-metrics/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "linkerd2-error-metrics"
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+edition = "2018"
+publish = false
+
+
+[dependencies]
+futures = "0.1"
+indexmap = "1.0"
+linkerd2-error = { path = "../error" }
+linkerd2-metrics = { path = "../metrics" }
+tower = "0.1"

--- a/linkerd/error-metrics/src/layer.rs
+++ b/linkerd/error-metrics/src/layer.rs
@@ -1,0 +1,33 @@
+use crate::RecordError;
+use indexmap::IndexMap;
+use linkerd2_metrics::Counter;
+use std::hash::Hash;
+use std::sync::{Arc, Mutex};
+
+pub struct RecordErrorLayer<L, K: Hash + Eq> {
+    label: L,
+    errors: Arc<Mutex<IndexMap<K, Counter>>>,
+}
+
+impl<L, K: Hash + Eq> RecordErrorLayer<L, K> {
+    pub(crate) fn new(label: L, errors: Arc<Mutex<IndexMap<K, Counter>>>) -> Self {
+        Self { label, errors }
+    }
+}
+
+impl<L: Clone, K: Hash + Eq, S> tower::layer::Layer<S> for RecordErrorLayer<L, K> {
+    type Service = RecordError<L, K, S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RecordError::new(self.label.clone(), self.errors.clone(), inner)
+    }
+}
+
+impl<L: Clone, K: Hash + Eq> Clone for RecordErrorLayer<L, K> {
+    fn clone(&self) -> Self {
+        Self {
+            errors: self.errors.clone(),
+            label: self.label.clone(),
+        }
+    }
+}

--- a/linkerd/error-metrics/src/lib.rs
+++ b/linkerd/error-metrics/src/lib.rs
@@ -1,6 +1,10 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use futures::{Future, Poll};
+mod layer;
+mod service;
+
+pub use self::layer::RecordErrorLayer;
+pub use self::service::RecordError;
 use indexmap::IndexMap;
 pub use linkerd2_metrics::FmtLabels;
 use linkerd2_metrics::{metrics, Counter, FmtMetrics};
@@ -20,28 +24,15 @@ pub trait LabelError<E> {
     fn label_error(&self, error: &E) -> Self::Labels;
 }
 
+/// Produces layers and reports results.
 #[derive(Debug)]
 pub struct Registry<K: Hash + Eq> {
     errors: Arc<Mutex<IndexMap<K, Counter>>>,
 }
 
-pub struct RecordErrorLayer<L, K: Hash + Eq> {
-    label: L,
-    errors: Arc<Mutex<IndexMap<K, Counter>>>,
-}
-
-pub struct RecordError<L, K: Hash + Eq, S> {
-    label: L,
-    errors: Arc<Mutex<IndexMap<K, Counter>>>,
-    inner: S,
-}
-
 impl<K: Hash + Eq> Registry<K> {
     pub fn layer<L>(&self, label: L) -> RecordErrorLayer<L, K> {
-        RecordErrorLayer {
-            label,
-            errors: self.errors.clone(),
-        }
+        RecordErrorLayer::new(label, self.errors.clone())
     }
 }
 
@@ -57,99 +48,6 @@ impl<K: Hash + Eq> Clone for Registry<K> {
     fn clone(&self) -> Self {
         Self {
             errors: self.errors.clone(),
-        }
-    }
-}
-
-impl<L: Clone, K: Hash + Eq, S> tower::layer::Layer<S> for RecordErrorLayer<L, K> {
-    type Service = RecordError<L, K, S>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        Self::Service {
-            inner,
-            label: self.label.clone(),
-            errors: self.errors.clone(),
-        }
-    }
-}
-
-impl<L: Clone, K: Hash + Eq> Clone for RecordErrorLayer<L, K> {
-    fn clone(&self) -> Self {
-        Self {
-            errors: self.errors.clone(),
-            label: self.label.clone(),
-        }
-    }
-}
-
-impl<L: Clone, K: Hash + Eq, S: Clone> Clone for RecordError<L, K, S> {
-    fn clone(&self) -> Self {
-        Self {
-            errors: self.errors.clone(),
-            label: self.label.clone(),
-            inner: self.inner.clone(),
-        }
-    }
-}
-
-impl<L, K: FmtLabels + Hash + Eq, S> RecordError<L, K, S> {
-    fn record<E>(&self, err: &E)
-    where
-        L: LabelError<E, Labels = K> + Clone,
-    {
-        let labels = self.label.label_error(&err);
-        if let Ok(mut errors) = self.errors.lock() {
-            errors
-                .entry(labels)
-                .or_insert_with(|| Default::default())
-                .incr();
-        }
-    }
-}
-
-impl<Req, L, S> tower::Service<Req> for RecordError<L, L::Labels, S>
-where
-    S: tower::Service<Req>,
-    L: LabelError<S::Error> + Clone,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = RecordError<L, L::Labels, S::Future>;
-
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        match self.inner.poll_ready() {
-            Ok(ready) => Ok(ready),
-            Err(err) => {
-                self.record(&err);
-                return Err(err);
-            }
-        }
-    }
-
-    fn call(&mut self, req: Req) -> Self::Future {
-        RecordError {
-            inner: self.inner.call(req),
-            errors: self.errors.clone(),
-            label: self.label.clone(),
-        }
-    }
-}
-
-impl<L, F> Future for RecordError<L, L::Labels, F>
-where
-    F: Future,
-    L: LabelError<F::Error> + Clone,
-{
-    type Item = F::Item;
-    type Error = F::Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.inner.poll() {
-            Ok(ready) => Ok(ready),
-            Err(err) => {
-                self.record(&err);
-                return Err(err);
-            }
         }
     }
 }

--- a/linkerd/error-metrics/src/lib.rs
+++ b/linkerd/error-metrics/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings, rust_2018_idioms)]
+
 use futures::{Future, Poll};
 use indexmap::IndexMap;
 pub use linkerd2_metrics::FmtLabels;

--- a/linkerd/error-metrics/src/lib.rs
+++ b/linkerd/error-metrics/src/lib.rs
@@ -1,0 +1,170 @@
+use futures::{Future, Poll};
+use indexmap::IndexMap;
+pub use linkerd2_metrics::FmtLabels;
+use linkerd2_metrics::{metrics, Counter, FmtMetrics};
+use std::fmt;
+use std::hash::Hash;
+use std::sync::{Arc, Mutex};
+
+metrics! {
+    request_errors_total: Counter {
+        "The total number of HTTP requests that could not be processed due to a proxy error."
+    }
+}
+
+pub trait LabelError<E> {
+    type Labels: FmtLabels + Hash + Eq;
+
+    fn label_error(&self, error: &E) -> Self::Labels;
+}
+
+#[derive(Debug)]
+pub struct Registry<K: Hash + Eq> {
+    errors: Arc<Mutex<IndexMap<K, Counter>>>,
+}
+
+pub struct RecordErrorLayer<L, K: Hash + Eq> {
+    label: L,
+    errors: Arc<Mutex<IndexMap<K, Counter>>>,
+}
+
+pub struct RecordError<L, K: Hash + Eq, S> {
+    label: L,
+    errors: Arc<Mutex<IndexMap<K, Counter>>>,
+    inner: S,
+}
+
+impl<K: Hash + Eq> Registry<K> {
+    pub fn layer<L>(&self, label: L) -> RecordErrorLayer<L, K> {
+        RecordErrorLayer {
+            label,
+            errors: self.errors.clone(),
+        }
+    }
+}
+
+impl<K: Hash + Eq> Default for Registry<K> {
+    fn default() -> Self {
+        Self {
+            errors: Default::default(),
+        }
+    }
+}
+
+impl<K: Hash + Eq> Clone for Registry<K> {
+    fn clone(&self) -> Self {
+        Self {
+            errors: self.errors.clone(),
+        }
+    }
+}
+
+impl<L: Clone, K: Hash + Eq, S> tower::layer::Layer<S> for RecordErrorLayer<L, K> {
+    type Service = RecordError<L, K, S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Self::Service {
+            inner,
+            label: self.label.clone(),
+            errors: self.errors.clone(),
+        }
+    }
+}
+
+impl<L: Clone, K: Hash + Eq> Clone for RecordErrorLayer<L, K> {
+    fn clone(&self) -> Self {
+        Self {
+            errors: self.errors.clone(),
+            label: self.label.clone(),
+        }
+    }
+}
+
+impl<L: Clone, K: Hash + Eq, S: Clone> Clone for RecordError<L, K, S> {
+    fn clone(&self) -> Self {
+        Self {
+            errors: self.errors.clone(),
+            label: self.label.clone(),
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<L, K: FmtLabels + Hash + Eq, S> RecordError<L, K, S> {
+    fn record<E>(&self, err: &E)
+    where
+        L: LabelError<E, Labels = K> + Clone,
+    {
+        let labels = self.label.label_error(&err);
+        if let Ok(mut errors) = self.errors.lock() {
+            errors
+                .entry(labels)
+                .or_insert_with(|| Default::default())
+                .incr();
+        }
+    }
+}
+
+impl<Req, L, S> tower::Service<Req> for RecordError<L, L::Labels, S>
+where
+    S: tower::Service<Req>,
+    L: LabelError<S::Error> + Clone,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = RecordError<L, L::Labels, S::Future>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        match self.inner.poll_ready() {
+            Ok(ready) => Ok(ready),
+            Err(err) => {
+                self.record(&err);
+                return Err(err);
+            }
+        }
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        RecordError {
+            inner: self.inner.call(req),
+            errors: self.errors.clone(),
+            label: self.label.clone(),
+        }
+    }
+}
+
+impl<L, F> Future for RecordError<L, L::Labels, F>
+where
+    F: Future,
+    L: LabelError<F::Error> + Clone,
+{
+    type Item = F::Item;
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.inner.poll() {
+            Ok(ready) => Ok(ready),
+            Err(err) => {
+                self.record(&err);
+                return Err(err);
+            }
+        }
+    }
+}
+
+impl<K: FmtLabels + Hash + Eq> FmtMetrics for Registry<K> {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let errors = match self.errors.lock() {
+            Ok(errors) => errors,
+            Err(_) => return Ok(()),
+        };
+        if errors.is_empty() {
+            return Ok(());
+        }
+
+        request_errors_total.fmt_help(f)?;
+        request_errors_total.fmt_scopes(f, errors.iter(), |c| &c)?;
+
+        Ok(())
+    }
+}

--- a/linkerd/error-metrics/src/service.rs
+++ b/linkerd/error-metrics/src/service.rs
@@ -5,7 +5,7 @@ use linkerd2_metrics::{Counter, FmtLabels};
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
-/// A middlware taht records errors.
+/// A middlware that records errors.
 pub struct RecordError<L, K: Hash + Eq, S> {
     label: L,
     errors: Arc<Mutex<IndexMap<K, Counter>>>,

--- a/linkerd/error-metrics/src/service.rs
+++ b/linkerd/error-metrics/src/service.rs
@@ -1,0 +1,95 @@
+use crate::LabelError;
+use futures::{Future, Poll};
+use indexmap::IndexMap;
+use linkerd2_metrics::{Counter, FmtLabels};
+use std::hash::Hash;
+use std::sync::{Arc, Mutex};
+
+/// A middlware taht records errors.
+pub struct RecordError<L, K: Hash + Eq, S> {
+    label: L,
+    errors: Arc<Mutex<IndexMap<K, Counter>>>,
+    inner: S,
+}
+
+impl<L, K: Hash + Eq, S> RecordError<L, K, S> {
+    pub(crate) fn new(label: L, errors: Arc<Mutex<IndexMap<K, Counter>>>, inner: S) -> Self {
+        RecordError {
+            label,
+            errors,
+            inner,
+        }
+    }
+}
+
+impl<L, K: FmtLabels + Hash + Eq, S> RecordError<L, K, S> {
+    fn record<E>(&self, err: &E)
+    where
+        L: LabelError<E, Labels = K> + Clone,
+    {
+        let labels = self.label.label_error(&err);
+        if let Ok(mut errors) = self.errors.lock() {
+            errors
+                .entry(labels)
+                .or_insert_with(|| Default::default())
+                .incr();
+        }
+    }
+}
+
+impl<Req, L, S> tower::Service<Req> for RecordError<L, L::Labels, S>
+where
+    S: tower::Service<Req>,
+    L: LabelError<S::Error> + Clone,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = RecordError<L, L::Labels, S::Future>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        match self.inner.poll_ready() {
+            Ok(ready) => Ok(ready),
+            Err(err) => {
+                self.record(&err);
+                return Err(err);
+            }
+        }
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        RecordError {
+            inner: self.inner.call(req),
+            errors: self.errors.clone(),
+            label: self.label.clone(),
+        }
+    }
+}
+
+impl<L, F> Future for RecordError<L, L::Labels, F>
+where
+    F: Future,
+    L: LabelError<F::Error> + Clone,
+{
+    type Item = F::Item;
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.inner.poll() {
+            Ok(ready) => Ok(ready),
+            Err(err) => {
+                self.record(&err);
+                return Err(err);
+            }
+        }
+    }
+}
+
+impl<L: Clone, K: Hash + Eq, S: Clone> Clone for RecordError<L, K, S> {
+    fn clone(&self) -> Self {
+        Self {
+            errors: self.errors.clone(),
+            label: self.label.clone(),
+            inner: self.inner.clone(),
+        }
+    }
+}


### PR DESCRIPTION
The proxy handles errors by synthesizing responses; however, depending
on where such an error occurs, it may not be recorded by a metrics
layer.

This change introduces a `request_errors_total` counter that records
the number/kind of errors encountered. This is immediately helpful for
debugging and diagnostics, but could also be helpful to view in the UI.
We may want to revisit this metric, especialy its labels, before relying
on it more prominently. But in the meantime it's extraordinarily useful
as it is.