### PR TITLE
trace: update `tracing-subscriber` to 0.2.0-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,15 +1428,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owning_ref"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +1845,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
+
+[[package]]
 name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +1880,32 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+
+[[package]]
+name = "serde_json"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59790990c5115d16027f00913e2e66de23a51f70422e549d2ad68c8c5f268f1c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ee8b66dea1777ef2c5f33ffeb90fd54afe43bb5c97bdaf82b521ad7c90a395"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "slab"
@@ -1918,12 +1941,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 
 [[package]]
 name = "string"
@@ -2522,9 +2539,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652bc99e1286541d6ccc42d5fb37213d1cdde544f88b19fac3d94e3117b55163"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
 dependencies = [
  "lazy_static",
  "log",
@@ -2532,20 +2549,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.1.4"
+name = "tracing-serde"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c63b1771a75314374703309107e685805628c04643e6dd2c7a5cf8f94348c62e"
+checksum = "d65dea8255e378ab7db9db2077a90cb3e051515e18eaa819a405c4eb129b9beb"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ec8cdf2ebadeefbb5a0fac5f3d54757415cdcc46f40542eaa0be56cd6d6361"
 dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",
- "owning_ref",
  "regex 1.0.0",
+ "serde",
+ "serde_json",
+ "sharded-slab",
  "smallvec",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -63,7 +63,7 @@ tracing-futures = "0.1"
 tracing-log = "0.1"
 
 [dependencies.tracing-subscriber]
-version = "0.1.4"
+version = "0.2.0-alpha.4"
 # we don't need ANSI colors or `chrono` time formatting
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log"]

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -36,4 +36,4 @@ libc = "0.2"
 [dev-dependencies]
 linkerd2-identity = { path = "../../identity", features = ["test-util"] }
 tower-util = "0.1"
-tracing-subscriber = "0.1"
+tracing-subscriber = "0.2.0-alpha.4"


### PR DESCRIPTION
This commit updates the proxy's `tracing-subscriber` dependency from
0.1.4 to 0.2.0-alpha.4. This alpha includes tokio-rs/tracing#514, which
fixes a pair of issues which prevent spans from being considered closed.
One of these issues exists in 0.1.x as well.

When spans are not considered closed, storage allocated for those spans'
per-span data is not reused. Therefore, this issue results in a memory
leak.

Note that some span storage will still not appear to be
_deallocated_ after this change, but that storage will be reused when
spans are allowed to close correctly.

In addition, I've updated the proxy's `trace` module to remove the
custom formatter. This was used only to add Linkerd's custom logging
contexts to `tracing-subscriber` logs, and as we no longer use the
logging contexts, we can use `tracing-subscriber`'s default formatter.
Now, we only override the timestamp format.

This may fix linkerd/linkerd2#3998 (pending verification).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>