### PR TITLE
trace: Use debug_span! instead of info_span!

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -152,7 +152,7 @@ pub mod resolve {
     use linkerd2_dns as dns;
     use std::net::SocketAddr;
     use std::{error, fmt};
-    use tracing::info_span;
+    use tracing::debug_span;
     use tracing_futures::{Instrument, Instrumented};
 
     #[derive(Clone, Debug)]
@@ -270,7 +270,7 @@ pub mod resolve {
                 server_name: dst.identity.clone(),
             };
 
-            info_span!("control", peer.addr = %addr, peer.identity = ?dst.identity)
+            debug_span!("control", peer.addr = %addr, peer.identity = ?dst.identity)
                 .in_scope(move || State::Inner(mk_svc.call(target).in_current_span()))
         }
     }

--- a/linkerd/app/core/src/proxy/server.rs
+++ b/linkerd/app/core/src/proxy/server.rs
@@ -18,7 +18,7 @@ use http;
 use hyper;
 use indexmap::IndexSet;
 use std::sync::Arc;
-use tracing::{info_span, trace};
+use tracing::{debug_span, trace};
 use tracing_futures::Instrument;
 
 #[derive(Clone, Debug)]
@@ -201,7 +201,7 @@ where
                 // Enable support for HTTP upgrades (CONNECT and websockets).
                 let svc = upgrade::Service::new(http_svc, drain.clone());
                 let exec =
-                    tokio::executor::DefaultExecutor::current().instrument(info_span!("http1"));
+                    tokio::executor::DefaultExecutor::current().instrument(debug_span!("http1"));
                 let conn = http
                     .with_executor(exec)
                     .http1_only(true)
@@ -216,7 +216,7 @@ where
             }
 
             HttpVersion::H2 => {
-                let exec = tokio::executor::DefaultExecutor::current().instrument(info_span!("h2"));
+                let exec = tokio::executor::DefaultExecutor::current().instrument(debug_span!("h2"));
                 let conn = http
                     .with_executor(exec)
                     .http2_only(true)

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -4,7 +4,7 @@ use linkerd2_drain as drain;
 use linkerd2_error::Error;
 use linkerd2_proxy_core::listen::{Accept, Listen, Serve};
 use linkerd2_proxy_transport::listen::Addrs;
-use tracing::{debug, info_span, Span};
+use tracing::{debug, debug_span, Span};
 use tracing_futures::{Instrument, Instrumented};
 
 pub type Task = Box<dyn Future<Item = (), Error = Error> + Send + 'static>;
@@ -107,7 +107,7 @@ impl<C: HasSpan, A: Accept<C>> tower::Service<C> for TraceAccept<A> {
 impl<C> HasSpan for (Addrs, C) {
     fn span(&self) -> Span {
         // The local addr should be instrumented from the listener's context.
-        info_span!(
+        debug_span!(
             "accept",
             peer.addr = %self.0.peer(),
         )

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -32,7 +32,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use tokio::sync::mpsc;
 use tower_grpc::{self as grpc, generic::client::GrpcService};
-use tracing::{debug, info, info_span};
+use tracing::{debug, info, debug_span};
 
 mod endpoint;
 mod orig_proto_downgrade;
@@ -129,7 +129,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(metrics.http_endpoint.into_layer::<classify::Response>())
                 .serves::<Endpoint>()
                 .push(trace::layer(
-                    |endpoint: &Endpoint| info_span!("endpoint", peer.addr = %endpoint.addr),
+                    |endpoint: &Endpoint| debug_span!("endpoint", peer.addr = %endpoint.addr),
                 ))
                 .push_buffer_pending(buffer.max_in_flight, DispatchDeadline::extract)
                 .makes::<Endpoint>()
@@ -164,7 +164,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(profiles::router::layer(profiles_client, dst_route_layer))
                 .push(strip_header::request::layer(DST_OVERRIDE_HEADER))
                 .push(trace::layer(
-                    |dst: &DstAddr| info_span!("logical", dst = %dst.dst_logical()),
+                    |dst: &DstAddr| debug_span!("logical", dst = %dst.dst_logical()),
                 ));
 
             // Routes requests to a `DstAddr`.
@@ -249,7 +249,7 @@ impl<A: OrigDstAddr> Config<A> {
                 }))
                 .push_per_make(errors::layer())
                 .push(trace::layer(|src: &tls::accept::Meta| {
-                    info_span!(
+                    debug_span!(
                         "source",
                         peer.id = ?src.peer_identity,
                         target.addr = %src.addrs.target_addr(),

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -5,7 +5,7 @@ pub use linkerd2_dns_name::{InvalidName, Name, Suffix};
 use std::convert::TryFrom;
 use std::time::Instant;
 use std::{fmt, net};
-use tracing::{info_span, trace};
+use tracing::{debug_span, trace};
 use tracing_futures::Instrument;
 pub use trust_dns_resolver::config::ResolverOpts;
 pub use trust_dns_resolver::error::{ResolveError, ResolveErrorKind};
@@ -75,7 +75,7 @@ impl Resolver {
         let f = self
             .resolver
             .lookup_ip(name.as_ref())
-            .instrument(info_span!("resolve_one_ip", %name));
+            .instrument(debug_span!("resolve_one_ip", %name));
         IpAddrFuture(Box::new(f))
     }
 
@@ -91,7 +91,7 @@ impl Resolver {
         let f = self
             .resolver
             .lookup_ip(name.as_ref())
-            .instrument(info_span!("refine", %name));
+            .instrument(debug_span!("refine", %name));
         RefineFuture(Box::new(f))
     }
 }

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -12,7 +12,7 @@ use linkerd2_proxy_transport::connect;
 use std::fmt;
 use std::marker::PhantomData;
 use tower::ServiceExt;
-use tracing::{debug, info_span, trace};
+use tracing::{debug, debug_span, trace};
 use tracing_futures::Instrument;
 
 /// Configurs an HTTP client that uses a `C`-typed connector
@@ -137,7 +137,7 @@ where
                 was_absolute_form,
             } => {
                 let exec = tokio::executor::DefaultExecutor::current()
-                    .instrument(info_span!("http1", %peer_addr));
+                    .instrument(debug_span!("http1", %peer_addr));
                 let h1 = hyper::Client::builder()
                     .executor(exec)
                     .keep_alive(keep_alive)

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 use std::net::SocketAddr;
 use tokio::executor::{DefaultExecutor, Executor};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tracing::{debug, info_span};
+use tracing::{debug, debug_span};
 use tracing_futures::Instrument;
 
 #[derive(Copy, Clone, Debug, Default)]
@@ -114,7 +114,7 @@ where
                     let (tx, conn) = try_ready!(hs.poll());
 
                     DefaultExecutor::current()
-                        .instrument(info_span!("h2", peer_addr=%self.peer_addr))
+                        .instrument(debug_span!("h2", peer_addr=%self.peer_addr))
                         .spawn(Box::new(conn.map_err(|error| debug!(%error, "failed"))))
                         .map_err(Error::from)?;
 
@@ -123,7 +123,7 @@ where
             };
 
             let exec =
-                DefaultExecutor::current().instrument(info_span!("h2", peer_addr=%self.peer_addr));
+                DefaultExecutor::current().instrument(debug_span!("h2", peer_addr=%self.peer_addr));
             let hs = conn::Builder::new()
                 .executor(exec)
                 .http2_only(true)

--- a/linkerd/router/src/layer.rs
+++ b/linkerd/router/src/layer.rs
@@ -3,7 +3,7 @@ use futures::{Future, Poll};
 use linkerd2_error::{Error, Never};
 use std::marker::PhantomData;
 use std::time::Duration;
-use tracing::{info_span, trace};
+use tracing::{debug_span, trace};
 use tracing_futures::Instrument;
 
 #[derive(Clone, Debug)]
@@ -114,7 +114,7 @@ where
         tokio::spawn(
             purge
                 .map_err(|e| match e {})
-                .instrument(info_span!("router.purge")),
+                .instrument(debug_span!("router.purge")),
         );
         Service { inner }
     }


### PR DESCRIPTION
linkerd/linkerd2#3998 describes an issue where the proxy's memory grows
with traffic. After testing, we've identified that this is caused by
logging emitted by `tracing`. 07667b8b upgraded the `tracing-subscriber`
trait, which reduced memory pressure; however, we continue to observe
heap usage grow in large leaps when running with the default log level
`linkerd=info,warn`. This appears to be due to span creation, which
occurs on every new connection.

By changing uses of `info_span!` to `debug_span!`, we can avoid this
allocation path at the expense of losing contextual logging. This seems
like a suitable tradeoff until we can address the underling issues in
`tracing`.

I've tested this overnight and memory usage remains effectively flat.