### PR TITLE
router: Avoid large up-front allocations

### DIFF
--- a/linkerd/router/src/cache.rs
+++ b/linkerd/router/src/cache.rs
@@ -58,7 +58,7 @@ where
         Self {
             capacity,
             expires,
-            expirations: DelayQueue::with_capacity(1),
+            expirations: DelayQueue::new(),
             values: IndexMap::default(),
             purge_task: None,
         }

--- a/linkerd/router/src/cache.rs
+++ b/linkerd/router/src/cache.rs
@@ -58,7 +58,7 @@ where
         Self {
             capacity,
             expires,
-            expirations: DelayQueue::with_capacity(capacity),
+            expirations: DelayQueue::with_capacity(1),
             values: IndexMap::default(),
             purge_task: None,
         }


### PR DESCRIPTION
We initially opted to pre-allocate the delay queue to avoid allocation
at runtime. However, practically, router capacities are _much_ higher
than their typical usage; so we incur an extra ~1MB+ of allocation that
will never really be used (for outbound routers).

This change initializes the router's DelayQueue with only a single slot
by default. The capacity will be increased at runtime as needed.