### PR TITLE
trace: update tracing-subscriber to 0.2.0-alpha.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4055f329d81a5948a02fb203bc51ab3579541cdca746631b0a3a8a7204d9ec96"
+checksum = "8178ab65c2ae72cd431fcdb51e7317fb0b48d64599e66d52c7b64cd86ee5b482"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,15 +25,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.7",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,18 +126,6 @@ name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
-
-[[package]]
-name = "chrono"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits 0.2.6",
- "time",
-]
 
 [[package]]
 name = "cloudabi"
@@ -1383,15 +1362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
-dependencies = [
- "num-traits 0.2.6",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,12 +1815,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
-
-[[package]]
 name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,27 +1846,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
-name = "serde"
-version = "1.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
-
-[[package]]
-name = "serde_json"
-version = "1.0.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59790990c5115d16027f00913e2e66de23a51f70422e549d2ad68c8c5f268f1c"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "sharded-slab"
-version = "0.0.7"
+version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ee8b66dea1777ef2c5f33ffeb90fd54afe43bb5c97bdaf82b521ad7c90a395"
+checksum = "ae75d0445b5d3778c9da3d1f840faa16d0627c8607f78a74daf69e5b988c39a1"
 dependencies = [
  "lazy_static",
 ]
@@ -1918,6 +1865,12 @@ name = "smallvec"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+
+[[package]]
+name = "smallvec"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
 name = "socket2"
@@ -2549,33 +2502,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65dea8255e378ab7db9db2077a90cb3e051515e18eaa819a405c4eb129b9beb"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ec8cdf2ebadeefbb5a0fac5f3d54757415cdcc46f40542eaa0be56cd6d6361"
+checksum = "4055f329d81a5948a02fb203bc51ab3579541cdca746631b0a3a8a7204d9ec96"
 dependencies = [
- "ansi_term",
- "chrono",
  "lazy_static",
  "matchers",
  "regex 1.0.0",
- "serde",
- "serde_json",
  "sharded-slab",
- "smallvec",
+ "smallvec 1.2.0",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -2590,7 +2528,7 @@ dependencies = [
  "lazy_static",
  "log",
  "rand 0.6.5",
- "smallvec",
+ "smallvec 0.6.10",
  "socket2",
  "tokio-executor",
  "tokio-io",
@@ -2614,7 +2552,7 @@ dependencies = [
  "log",
  "lru-cache",
  "resolv-conf",
- "smallvec",
+ "smallvec 0.6.10",
  "tokio",
  "trust-dns-proto",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi 0.3.7",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +135,17 @@ name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+
+[[package]]
+name = "chrono"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31850b4a4d6bae316f7a09e691c944c28299298837edc0a03f755618c23cbc01"
+dependencies = [
+ "num-integer",
+ "num-traits 0.2.6",
+ "time",
+]
 
 [[package]]
 name = "cloudabi"
@@ -1362,6 +1382,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+dependencies = [
+ "num-traits 0.2.6",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1844,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
+
+[[package]]
 name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,6 +1879,23 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+
+[[package]]
+name = "serde_json"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59790990c5115d16027f00913e2e66de23a51f70422e549d2ad68c8c5f268f1c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -2502,18 +2554,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65dea8255e378ab7db9db2077a90cb3e051515e18eaa819a405c4eb129b9beb"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.2.0-alpha.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4055f329d81a5948a02fb203bc51ab3579541cdca746631b0a3a8a7204d9ec96"
 dependencies = [
+ "ansi_term",
+ "chrono",
  "lazy_static",
  "matchers",
  "regex 1.0.0",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec 1.2.0",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -63,7 +63,7 @@ tracing-futures = "0.1"
 tracing-log = "0.1"
 
 [dependencies.tracing-subscriber]
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 # we don't need `chrono` time formatting
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "ansi"]

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -63,7 +63,7 @@ tracing-futures = "0.1"
 tracing-log = "0.1"
 
 [dependencies.tracing-subscriber]
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 # we don't need ANSI colors or `chrono` time formatting
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log"]

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -64,9 +64,9 @@ tracing-log = "0.1"
 
 [dependencies.tracing-subscriber]
 version = "0.2.0-alpha.5"
-# we don't need ANSI colors or `chrono` time formatting
+# we don't need `chrono` time formatting
 default-features = false
-features = ["env-filter", "fmt", "smallvec", "tracing-log"]
+features = ["env-filter", "fmt", "smallvec", "tracing-log", "ansi"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -41,7 +41,8 @@ pub fn with_filter(filter: impl AsRef<str>) -> (Dispatch, LevelHandle) {
     let builder = FmtSubscriber::builder()
         .with_timer(Uptime { start_time })
         .with_env_filter(filter)
-        .with_filter_reloading();
+        .with_filter_reloading()
+        .with_ansi(cfg!(test));
     let handle = LevelHandle {
         inner: builder.reload_handle(),
     };

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -36,4 +36,4 @@ libc = "0.2"
 [dev-dependencies]
 linkerd2-identity = { path = "../../identity", features = ["test-util"] }
 tower-util = "0.1"
-tracing-subscriber = "0.2.0-alpha.5"
+tracing-subscriber = "0.2.0-alpha.6"

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -36,4 +36,4 @@ libc = "0.2"
 [dev-dependencies]
 linkerd2-identity = { path = "../../identity", features = ["test-util"] }
 tower-util = "0.1"
-tracing-subscriber = "0.2.0-alpha.4"
+tracing-subscriber = "0.2.0-alpha.5"


### PR DESCRIPTION
Version 0.0.7 of `sharded-slab` contains a bug where, when the `remove`
method is called with the index of a slot that is not being accessed
concurrently, the slot is emptied but **not** placed on the free list.
This issue meant that, under `tracing-subscriber`'s usage pattern, where
slab entries are almost always uncontended when reused, allocated slab
pages are almost never reused, resulting in unbounded slab growth over
time (i.e. a memory leak).

This commit updates `tracing-subscriber`' to version 0.2.0-alpha.6,
which in turn bumps the `sharded-slab` dependency to v0.0.8, which
includes commit hawkw/sharded-slab@dfdd7ae. That commit fixes this bug.

I've empirically verified that, after running `linkerd2-proxy` under
load with a global `trace` filter that enables a *lot* of spans, heap
usage remains stable, and the characteristic stair-step heap growth
pattern of doubling slab allocations doesn't occur. This indicates that
freed slots are actually being reused, and (once fully warmed up), the
slab will only grow when the number of active spans in the system
increases.

![mem_plot](https://user-images.githubusercontent.com/2796466/73581369-cd859900-443d-11ea-8522-abeace03d745.png)

Closes linkerd/linkerd2#3998 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>