### PR TITLE
app: initialize tracing prior to parsing env vars

### DIFF
--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -10,6 +10,7 @@ use linkerd2_signal as signal;
 pub use tracing::{debug, error, info, warn};
 
 fn main() {
+    let trace = trace::init();
     // Load configuration from the environment without binding ports.
     let config = match Config::try_from_env() {
         Ok(config) => config,
@@ -23,7 +24,7 @@ fn main() {
     tokio::runtime::current_thread::Runtime::new()
         .expect("main runtime")
         .block_on(future::lazy(move || {
-            let app = match trace::init().and_then(move |t| config.build(t)) {
+            let app = match trace.and_then(move |t| config.build(t)) {
                 Ok(app) => app,
                 Err(e) => {
                     eprintln!("Initialization failure: {}", e);


### PR DESCRIPTION
Before migrating from `env_logger` to `tracing`, the proxy set up
logging before trying to read a configuration from the environment. This
meant that any errors that occurred while parsing env vars could be
logged at the error level and would be displayed to the user. Since we
log these errors when they occur, the formatted output from the error
types the parsing methods return is pretty minimal.

When we switched to `tracing`, we moved the tracing initialization so
that it occurs _after_ parsing the config from the env. This means that
the event macros for config errors now occur when there is no `tracing`
subscriber to collect and format them. Currently, if an env var is
malformed, we see something like this:

```console
$ LINKERD2_PROXY_DESTINATION_SVC_ADDR="bad" cargo run
    Finished dev [unoptimized] target(s) in 0.20s
     Running `target/debug/linkerd2-proxy`
Invalid configuration: invalid environment variable
```

This is not terribly helpful. More complex misconfigurations, like the
requirement that if `LINKERD2_PROXY_IDENTITY_DISABLED` is set,
`LINEKRD2_PROXY_TAP_DISABLED` must also be set, are very difficult to
diagnose: For example:

```console
$ LINKERD2_PROXY_DESTINATION_SVC_ADDR=127.0.0.1:42069 \
  LINKERD2_PROXY_IDENTITY_DISABLED=yes \
  cargo run
    Finished dev [unoptimized] target(s) in 0.41s
     Running `target/debug/linkerd2-proxy`
Invalid configuration: invalid environment variable
```

This commit moves the tracing initialization to occur *before* parsing
the config. Now, any errors parsing the configuration from the
environment are once again logged, and all is right in the world:

```console
$ LINKERD2_PROXY_DESTINATION_SVC_ADDR="bad" cargo run
    Finished dev [unoptimized] target(s) in 0.55s
     Running `target/debug/linkerd2-proxy`
ignoring ``: invalid filter directive
[     0.47490772s] ERROR linkerd2_app::env: LINKERD2_PROXY_IDENTITY_DISABLED must be set or identity configuration must be specified.
[     0.47704003s] ERROR linkerd2_app::env: Not a valid address: bad
[     0.47743234s] ERROR linkerd2_app::env: LINKERD2_PROXY_DESTINATION_SVC_ADDR="bad" is not valid: AddrError(MissingPort)
[     0.47803128s] ERROR linkerd2_app::env: LINKERD2_PROXY_TAP_SVC_NAME must be set or tap must be disabled
Invalid configuration: invalid environment variable
```

```console
$ LINKERD2_PROXY_DESTINATION_SVC_ADDR=127.0.0.1:42069 \
  LINKERD2_PROXY_IDENTITY_DISABLED=yes \
  cargo run
    Finished dev [unoptimized] target(s) in 0.24s
     Running `target/debug/linkerd2-proxy`
ignoring ``: invalid filter directive
[     0.48071794s] ERROR linkerd2_app::env: LINKERD2_PROXY_TAP_DISABLED must be set if identity is disabled
Invalid configuration: invalid environment variable
```

Signed-off-by: Eliza Weisman <eliza@buoyant.io>