### PR TITLE
trace: update `tracing-subscriber` dependency to 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.0-alpha.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8178ab65c2ae72cd431fcdb51e7317fb0b48d64599e66d52c7b64cd86ee5b482"
+checksum = "c6bbfcf5ab0799649189b0df4bd7f730f1929a3846d33ae56cb0ad6e0bbdad09"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -63,7 +63,7 @@ tracing-futures = "0.1"
 tracing-log = "0.1"
 
 [dependencies.tracing-subscriber]
-version = "0.2.0-alpha.6"
+version = "0.2.1"
 # we don't need `chrono` time formatting
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "ansi"]

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -36,4 +36,4 @@ libc = "0.2"
 [dev-dependencies]
 linkerd2-identity = { path = "../../identity", features = ["test-util"] }
 tower-util = "0.1"
-tracing-subscriber = "0.2.0-alpha.6"
+tracing-subscriber = "0.2.1"


### PR DESCRIPTION
This release makes a number of significant performance improvements when
filtering events emitted through the `log` compatibility layer (such as
from `hyper` and `h2`). See tokio-rs/tracing#586 for details.

Since these performance improvements apply to cases where a filter
_disables_ an event, as well as to enabling events, this should improve
the proxy's performance with the default log configuration, especially
given that `h2` and `hyper` emit a _lot_ of `trace`-level logs in hot
paths. Ignoring those logs should now have a much lower overhead.

In addition, 0.2.1 fixes a bug where `EnvFilter`'s filter selection
differed from the `env_logger` behavior it was intended to emulate. If
the most specific filter directive that applies to a given event did not
enable that  event's level, filter selection would continue to try
decreasingly-specific filters, and would only disable the event if
**no** filters enabled it (see tokio-rs/tracing#512).

In practice, this means that if you set a filter like

```
LINKERD2_PROXY_LOG=warn,linkerd=debug,linkerd2_metrics=info
```

in an attempt to disable the `debug`-level events in the
`linkerd2_metrics` crate, they would still be enabled by the
`linkerd=debug` directive.

This is now fixed.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>