### PR TITLE
Expose the number of service instances in the proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,7 @@ dependencies = [
  "linkerd2-retry",
  "linkerd2-router",
  "linkerd2-stack",
+ "linkerd2-stack-metrics",
  "linkerd2-test-util",
  "linkerd2-timeout",
  "linkerd2-trace-context",
@@ -1187,6 +1188,22 @@ dependencies = [
  "linkerd2-error",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "linkerd2-stack-metrics"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "indexmap",
+ "linkerd2-error",
+ "linkerd2-metrics",
+ "linkerd2-stack",
+ "tokio",
+ "tokio-timer",
+ "tower",
+ "tower-util",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "linkerd/router",
     "linkerd/signal",
     "linkerd/stack",
+    "linkerd/stack-metrics",
     "linkerd/test-util",
     "linkerd/timeout",
     "linkerd2-proxy",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -46,6 +46,7 @@ linkerd2-request-filter = { path = "../../request-filter" }
 linkerd2-retry = { path = "../../retry" }
 linkerd2-router = { path = "../../router" }
 linkerd2-stack = { path = "../../stack" }
+linkerd2-stack-metrics = { path = "../../stack-metrics" }
 linkerd2-timeout = { path = "../../timeout" }
 linkerd2-trace-context = { path = "../../trace-context" }
 rand = { version = "0.7", features = ["small_rng"] }

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -20,6 +20,7 @@ pub use linkerd2_opencensus as opencensus;
 pub use linkerd2_reconnect as reconnect;
 pub use linkerd2_request_filter as request_filter;
 pub use linkerd2_router as router;
+pub use linkerd2_stack_metrics as stack_metrics;
 pub use linkerd2_trace_context as trace_context;
 
 pub mod accept_error;
@@ -104,6 +105,8 @@ pub type HttpRouteMetrics = http_metrics::Requests<metric_labels::RouteLabels, c
 
 pub type HttpRouteRetry = http_metrics::Retries<metric_labels::RouteLabels>;
 
+pub type StackMetrics = stack_metrics::NewLayer<metric_labels::StackLabels>;
+
 #[derive(Clone)]
 pub struct ProxyMetrics {
     pub http_handle_time: handle_time::Scope,
@@ -111,5 +114,6 @@ pub struct ProxyMetrics {
     pub http_route_actual: HttpRouteMetrics,
     pub http_route_retry: HttpRouteRetry,
     pub http_endpoint: HttpEndpointMetrics,
+    pub stack: StackMetrics,
     pub transport: transport::Metrics,
 }

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -105,7 +105,7 @@ pub type HttpRouteMetrics = http_metrics::Requests<metric_labels::RouteLabels, c
 
 pub type HttpRouteRetry = http_metrics::Retries<metric_labels::RouteLabels>;
 
-pub type StackMetrics = stack_metrics::NewLayer<metric_labels::StackLabels>;
+pub type StackMetrics = stack_metrics::Registry<metric_labels::StackLabels>;
 
 #[derive(Clone)]
 pub struct ProxyMetrics {

--- a/linkerd/app/core/src/metric_labels.rs
+++ b/linkerd/app/core/src/metric_labels.rs
@@ -23,6 +23,12 @@ pub struct EndpointLabels {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct StackLabels {
+    pub direction: Direction,
+    pub name: &'static str,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct RouteLabels {
     dst: dst::DstAddr,
     labels: Option<String>,
@@ -185,4 +191,29 @@ where
         write!(out, ",{}_{}=\"{}\"", prefix, k, v).expect("label concat must succeed");
     }
     Some(out)
+}
+
+// === impl StackLabels ===
+
+impl StackLabels {
+    pub fn inbound(name: &'static str) -> Self {
+        Self {
+            direction: Direction::In,
+            name,
+        }
+    }
+
+    pub fn outbound(name: &'static str) -> Self {
+        Self {
+            direction: Direction::Out,
+            name,
+        }
+    }
+}
+
+impl FmtLabels for StackLabels {
+    fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.direction.fmt_labels(f)?;
+        write!(f, ",name=\"{}\"", self.name)
+    }
 }

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -51,6 +51,10 @@ impl<L> Layers<L> {
         self.push_pending().push(buffer::layer(bound, d))
     }
 
+    pub fn push_per_make<T: Clone>(self, layer: T) -> Layers<Pair<L, stack::per_make::Layer<T>>> {
+        self.push(stack::per_make::layer(layer))
+    }
+
     pub fn push_spawn_ready(self) -> Layers<Pair<L, SpawnReadyLayer>> {
         self.push(SpawnReadyLayer::new())
     }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -131,7 +131,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(trace::layer(
                     |endpoint: &Endpoint| info_span!("endpoint", peer.addr = %endpoint.addr),
                 ))
-                .push_per_make(metrics.stack.new_layer(stack_labels("endpoint")))
+                .push_per_make(metrics.stack.layer(stack_labels("endpoint")))
                 .push_buffer_pending(buffer.max_in_flight, DispatchDeadline::extract)
                 .makes::<Endpoint>()
                 .push(router::Layer::new(
@@ -151,7 +151,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(insert::target::layer())
                 .push(metrics.http_route.into_layer::<classify::Response>())
                 .push(classify::Layer::new())
-                .push_per_make(metrics.stack.new_layer(stack_labels("route")))
+                .push_per_make(metrics.stack.layer(stack_labels("route")))
                 .push_buffer_pending(buffer.max_in_flight, DispatchDeadline::extract);
 
             // A per-`DstAddr` stack that does the following:
@@ -165,7 +165,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push_buffer_pending(buffer.max_in_flight, DispatchDeadline::extract)
                 .push(profiles::router::layer(profiles_client, dst_route_layer))
                 .push(strip_header::request::layer(DST_OVERRIDE_HEADER))
-                .push_per_make(metrics.stack.new_layer(stack_labels("logical")))
+                .push_per_make(metrics.stack.layer(stack_labels("logical")))
                 .push(trace::layer(
                     |dst: &DstAddr| info_span!("logical", dst = %dst.dst_logical()),
                 ));
@@ -251,7 +251,7 @@ impl<A: OrigDstAddr> Config<A> {
                     DispatchDeadline::after(buffer.dispatch_timeout)
                 }))
                 .push_per_make(errors::layer())
-                .push_per_make(metrics.stack.new_layer(stack_labels("source")))
+                .push_per_make(metrics.stack.layer(stack_labels("source")))
                 .push(trace::layer(|src: &tls::accept::Meta| {
                     info_span!(
                         "source",

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -12,7 +12,7 @@ use linkerd2_app_core::{
     drain,
     dst::DstAddr,
     errors, http_request_authority_addr, http_request_host_addr,
-    http_request_l5d_override_dst_addr, http_request_orig_dst_addr,
+    http_request_l5d_override_dst_addr, http_request_orig_dst_addr, metric_labels,
     opencensus::proto::trace::v1 as oc,
     proxy::{
         self,
@@ -131,6 +131,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(trace::layer(
                     |endpoint: &Endpoint| info_span!("endpoint", peer.addr = %endpoint.addr),
                 ))
+                .push_per_make(metrics.stack.new_layer(stack_labels("endpoint")))
                 .push_buffer_pending(buffer.max_in_flight, DispatchDeadline::extract)
                 .makes::<Endpoint>()
                 .push(router::Layer::new(
@@ -150,6 +151,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(insert::target::layer())
                 .push(metrics.http_route.into_layer::<classify::Response>())
                 .push(classify::Layer::new())
+                .push_per_make(metrics.stack.new_layer(stack_labels("route")))
                 .push_buffer_pending(buffer.max_in_flight, DispatchDeadline::extract);
 
             // A per-`DstAddr` stack that does the following:
@@ -163,6 +165,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push_buffer_pending(buffer.max_in_flight, DispatchDeadline::extract)
                 .push(profiles::router::layer(profiles_client, dst_route_layer))
                 .push(strip_header::request::layer(DST_OVERRIDE_HEADER))
+                .push_per_make(metrics.stack.new_layer(stack_labels("logical")))
                 .push(trace::layer(
                     |dst: &DstAddr| info_span!("logical", dst = %dst.dst_logical()),
                 ));
@@ -248,6 +251,7 @@ impl<A: OrigDstAddr> Config<A> {
                     DispatchDeadline::after(buffer.dispatch_timeout)
                 }))
                 .push_per_make(errors::layer())
+                .push_per_make(metrics.stack.new_layer(stack_labels("source")))
                 .push(trace::layer(|src: &tls::accept::Meta| {
                     info_span!(
                         "source",
@@ -316,4 +320,8 @@ pub fn trace_labels() -> HashMap<String, String> {
     let mut l = HashMap::new();
     l.insert("direction".to_string(), "inbound".to_string());
     l
+}
+
+fn stack_labels(name: &'static str) -> metric_labels::StackLabels {
+    metric_labels::StackLabels::inbound(name)
 }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -191,7 +191,7 @@ impl<A: OrigDstAddr> Config<A> {
             // If the `l5d-require-id` header is present, then that identity is
             // used as the server name when connecting to the endpoint.
             let orig_dst_router_layer = svc::layers()
-                .push_per_make(metrics.stack.new_layer(stack_labels("fallback.endpoint")))
+                .push_per_make(metrics.stack.layer(stack_labels("fallback.endpoint")))
                 .push_buffer_pending(buffer.max_in_flight, DispatchDeadline::extract)
                 .push(router::Layer::new(
                     router::Config::new(router_capacity, router_max_idle_age),
@@ -202,7 +202,7 @@ impl<A: OrigDstAddr> Config<A> {
             // over all endpoints returned from the destination service.
             const DISCOVER_UPDATE_BUFFER_CAPACITY: usize = 10;
             let balancer_layer = svc::layers()
-                .push_per_make(metrics.stack.new_layer(stack_labels("balance.endpoint")))
+                .push_per_make(metrics.stack.layer(stack_labels("balance.endpoint")))
                 .push_spawn_ready()
                 .push(discover::Layer::new(
                     DISCOVER_UPDATE_BUFFER_CAPACITY,
@@ -249,7 +249,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(trace::layer(
                     |dst: &DstAddr| info_span!("logical", dst.logical = %dst.dst_logical()),
                 ))
-                .push_per_make(metrics.stack.new_layer(stack_labels("logical.dst")))
+                .push_per_make(metrics.stack.layer(stack_labels("logical.dst")))
                 .push_buffer_pending(buffer.max_in_flight, DispatchDeadline::extract)
                 .push(router::Layer::new(
                     router::Config::new(router_capacity, router_max_idle_age),
@@ -289,7 +289,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER))
                 .push(http::insert::target::layer())
                 .push(trace::layer(|addr: &Addr| info_span!("addr", %addr)))
-                .push_per_make(metrics.stack.new_layer(stack_labels("addr")))
+                .push_per_make(metrics.stack.layer(stack_labels("addr")))
                 .push_buffer_pending(buffer.max_in_flight, DispatchDeadline::extract)
                 .push(router::Layer::new(
                     router::Config::new(router_capacity, router_max_idle_age),
@@ -326,7 +326,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(trace::layer(
                     |src: &tls::accept::Meta| info_span!("source", target.addr = %src.addrs.target_addr()),
                 ))
-                .push_per_make(metrics.stack.new_layer(stack_labels("source")))
+                .push_per_make(metrics.stack.layer(stack_labels("source")))
                 .push(trace_context::layer(span_sink.map(|span_sink| {
                     SpanConverter::server(span_sink, trace_labels())
                 })))

--- a/linkerd/app/src/metrics.rs
+++ b/linkerd/app/src/metrics.rs
@@ -3,7 +3,7 @@ pub use linkerd2_app_core::{
     handle_time, http_metrics as metrics,
     metric_labels::{ControlLabels, EndpointLabels, RouteLabels},
     metrics::FmtMetrics,
-    opencensus, proxy, telemetry, transport, ControlHttpMetrics, ProxyMetrics,
+    opencensus, proxy, stack_metrics, telemetry, transport, ControlHttpMetrics, ProxyMetrics,
 };
 use std::time::{Duration, SystemTime};
 
@@ -55,6 +55,8 @@ impl Metrics {
         let inbound_handle_time = handle_time_report.inbound();
         let outbound_handle_time = handle_time_report.outbound();
 
+        let stack = stack_metrics::NewLayer::default();
+
         let (transport, transport_report) = transport::metrics::new();
 
         let (opencensus, opencensus_report) = opencensus::metrics::new();
@@ -66,6 +68,7 @@ impl Metrics {
                 http_route: http_route.clone(),
                 http_route_actual: http_route_actual.clone(),
                 http_route_retry: http_route_retry.clone(),
+                stack: stack.clone(),
                 transport: transport.clone(),
             },
             outbound: ProxyMetrics {
@@ -74,6 +77,7 @@ impl Metrics {
                 http_route,
                 http_route_retry,
                 http_route_actual,
+                stack: stack.clone(),
                 transport,
             },
             control,
@@ -88,6 +92,7 @@ impl Metrics {
             .and_then(handle_time_report)
             .and_then(transport_report)
             .and_then(opencensus_report)
+            .and_then(stack.report())
             .and_then(process);
 
         (metrics, report)

--- a/linkerd/app/src/metrics.rs
+++ b/linkerd/app/src/metrics.rs
@@ -55,7 +55,7 @@ impl Metrics {
         let inbound_handle_time = handle_time_report.inbound();
         let outbound_handle_time = handle_time_report.outbound();
 
-        let stack = stack_metrics::NewLayer::default();
+        let stack = stack_metrics::Registry::default();
 
         let (transport, transport_report) = transport::metrics::new();
 
@@ -92,7 +92,7 @@ impl Metrics {
             .and_then(handle_time_report)
             .and_then(transport_report)
             .and_then(opencensus_report)
-            .and_then(stack.report())
+            .and_then(stack)
             .and_then(process);
 
         (metrics, report)

--- a/linkerd/stack-metrics/Cargo.toml
+++ b/linkerd/stack-metrics/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "linkerd2-stack-metrics"
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+futures = "0.1"
+indexmap = "1.0"
+linkerd2-error = { path  = "../error" }
+linkerd2-metrics = { path  = "../metrics" }
+linkerd2-stack = { path  = "../stack" }
+tokio = "0.1"
+tokio-timer = "0.2"   # for tokio_timer::clock
+tower = "0.1"
+tower-util = "0.1"
+tracing = "0.1.9"

--- a/linkerd/stack-metrics/src/layer.rs
+++ b/linkerd/stack-metrics/src/layer.rs
@@ -1,0 +1,20 @@
+use crate::{Metrics, TrackService};
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct TrackServiceLayer(Arc<Metrics>);
+
+impl TrackServiceLayer {
+    pub(crate) fn new(metrics: Arc<Metrics>) -> Self {
+        TrackServiceLayer(metrics)
+    }
+}
+
+impl<S> tower::layer::Layer<S> for TrackServiceLayer {
+    type Service = TrackService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        self.0.create_total.incr();
+        TrackService::new(inner, self.0.clone())
+    }
+}

--- a/linkerd/stack-metrics/src/lib.rs
+++ b/linkerd/stack-metrics/src/lib.rs
@@ -1,12 +1,15 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use futures::{Async, Poll};
+mod layer;
+mod service;
+
+pub use self::layer::TrackServiceLayer;
+pub use self::service::TrackService;
 use indexmap::IndexMap;
 use linkerd2_metrics::{metrics, Counter, FmtLabels, FmtMetrics};
 use std::fmt;
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
 
 metrics! {
     stack_create_total: Counter { "Total number of services created" },
@@ -15,23 +18,10 @@ metrics! {
     stack_poll_total_ms: Counter { "Total number of milliseconds this service has spent awaiting readiness" }
 }
 
-type Registry<L> = Arc<Mutex<IndexMap<L, Arc<Metrics>>>>;
+type Shared<L> = Arc<Mutex<IndexMap<L, Arc<Metrics>>>>;
 
 #[derive(Debug)]
-pub struct NewLayer<L: Hash + Eq> {
-    registry: Registry<L>,
-}
-
-/// Reports metrics for prometheus.
-#[derive(Debug)]
-pub struct Report<L: Hash + Eq> {
-    registry: Registry<L>,
-}
-
-#[derive(Clone, Debug)]
-pub struct Layer {
-    metrics: Arc<Metrics>,
-}
+pub struct Registry<L: Hash + Eq>(Shared<L>);
 
 #[derive(Debug, Default)]
 struct Metrics {
@@ -43,156 +33,66 @@ struct Metrics {
     error_total: Counter,
 }
 
-#[derive(Debug)]
-pub struct Service<S> {
-    inner: S,
-    metrics: Arc<Metrics>,
-    blocked_since: Option<Instant>,
-    // Helps determine when all instances are dropped.
-    _tracker: Arc<()>,
-}
-
-impl<L> NewLayer<L>
+impl<L> Registry<L>
 where
     L: Hash + Eq,
 {
-    pub fn new_layer(&self, labels: L) -> Layer {
-        let metrics = {
-            let mut registry = self.registry.lock().expect("stack metrics lock poisoned");
-            registry
-                .entry(labels.into())
-                .or_insert_with(|| Default::default())
-                .clone()
-        };
-        Layer { metrics }
-    }
-
-    pub fn report(&self) -> Report<L> {
-        Report {
-            registry: self.registry.clone(),
-        }
+    pub fn layer(&self, labels: L) -> TrackServiceLayer {
+        let metrics = self
+            .0
+            .lock()
+            .expect("stack metrics lock poisoned")
+            .entry(labels.into())
+            .or_insert_with(Default::default)
+            .clone();
+        TrackServiceLayer::new(metrics)
     }
 }
 
-impl<L: Hash + Eq> Default for NewLayer<L> {
+impl<L: Hash + Eq> Default for Registry<L> {
     fn default() -> Self {
-        Self {
-            registry: Registry::default(),
-        }
+        Registry(Shared::default())
     }
 }
 
-impl<L: Hash + Eq> Clone for NewLayer<L> {
+impl<L: Hash + Eq> Clone for Registry<L> {
     fn clone(&self) -> Self {
-        Self {
-            registry: self.registry.clone(),
-        }
+        Registry(self.0.clone())
     }
 }
 
-impl<S> tower::layer::Layer<S> for Layer {
-    type Service = Service<S>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        self.metrics.create_total.incr();
-        Self::Service {
-            inner,
-            metrics: self.metrics.clone(),
-            blocked_since: None,
-            _tracker: Arc::new(()),
-        }
-    }
-}
-
-impl<T, S> tower::Service<T> for Service<S>
-where
-    S: tower::Service<T>,
-{
-    type Response = S::Response;
-    type Error = S::Error;
-    type Future = S::Future;
-
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        match self.inner.poll_ready() {
-            Ok(Async::NotReady) => {
-                self.metrics.not_ready_total.incr();
-                if self.blocked_since.is_none() {
-                    self.blocked_since = Some(Instant::now());
-                }
-                Ok(Async::NotReady)
-            }
-            Ok(Async::Ready(())) => {
-                self.metrics.ready_total.incr();
-                if let Some(t0) = self.blocked_since.take() {
-                    let not_ready = Instant::now() - t0;
-                    self.metrics.poll_millis.add(not_ready.as_millis() as u64);
-                }
-                Ok(Async::Ready(()))
-            }
-            Err(e) => {
-                self.metrics.error_total.incr();
-                if let Some(t0) = self.blocked_since.take() {
-                    let not_ready = Instant::now() - t0;
-                    self.metrics.poll_millis.add(not_ready.as_millis() as u64);
-                }
-                Err(e)
-            }
-        }
-    }
-
-    fn call(&mut self, target: T) -> Self::Future {
-        self.inner.call(target)
-    }
-}
-
-impl<S> Drop for Service<S> {
-    fn drop(&mut self) {
-        if Arc::strong_count(&self._tracker) == 1 {
-            self.metrics.drop_total.incr();
-        }
-    }
-}
-
-impl<L: Hash + Eq> Clone for Report<L> {
-    fn clone(&self) -> Self {
-        Self {
-            registry: self.registry.clone(),
-        }
-    }
-}
-
-impl<L: FmtLabels + Hash + Eq> FmtMetrics for Report<L> {
+impl<L: FmtLabels + Hash + Eq> FmtMetrics for Registry<L> {
     fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let registry = self.registry.lock().expect("metrics registry poisoned");
-        if registry.is_empty() {
+        let metrics = self.0.lock().expect("metrics registry poisoned");
+        if metrics.is_empty() {
             return Ok(());
         }
 
         stack_create_total.fmt_help(f)?;
-        stack_create_total.fmt_scopes(f, registry.iter(), |m| &m.create_total)?;
+        stack_create_total.fmt_scopes(f, metrics.iter(), |m| &m.create_total)?;
 
         stack_drop_total.fmt_help(f)?;
-        stack_drop_total.fmt_scopes(f, registry.iter(), |m| &m.drop_total)?;
+        stack_drop_total.fmt_scopes(f, metrics.iter(), |m| &m.drop_total)?;
 
         stack_poll_total.fmt_help(f)?;
         stack_poll_total.fmt_scopes(
             f,
-            registry.iter().map(|(s, m)| ((s, Ready::Ready), m)),
+            metrics.iter().map(|(s, m)| ((s, Ready::Ready), m)),
             |m| &m.ready_total,
         )?;
         stack_poll_total.fmt_scopes(
             f,
-            registry.iter().map(|(s, m)| ((s, Ready::NotReady), m)),
+            metrics.iter().map(|(s, m)| ((s, Ready::NotReady), m)),
             |m| &m.not_ready_total,
         )?;
         stack_poll_total.fmt_scopes(
             f,
-            registry.iter().map(|(s, m)| ((s, Ready::Error), m)),
+            metrics.iter().map(|(s, m)| ((s, Ready::Error), m)),
             |m| &m.error_total,
         )?;
 
         stack_poll_total_ms.fmt_help(f)?;
-        stack_poll_total_ms.fmt_scopes(f, registry.iter(), |m| &m.poll_millis)?;
+        stack_poll_total_ms.fmt_scopes(f, metrics.iter(), |m| &m.poll_millis)?;
 
         Ok(())
     }

--- a/linkerd/stack-metrics/src/lib.rs
+++ b/linkerd/stack-metrics/src/lib.rs
@@ -1,0 +1,215 @@
+#![deny(warnings, rust_2018_idioms)]
+
+use futures::{Async, Poll};
+use indexmap::IndexMap;
+use linkerd2_metrics::{metrics, Counter, FmtLabels, FmtMetrics};
+use std::fmt;
+use std::hash::Hash;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+metrics! {
+    stack_create_total: Counter { "Total number of services created" },
+    stack_drop_total: Counter { "Total number of services dropped" },
+    stack_poll_total: Counter { "Total number of stack polls" },
+    stack_poll_total_ms: Counter { "Total number of milliseconds this service has spent awaiting readiness" }
+}
+
+type Registry<L> = Arc<Mutex<IndexMap<L, Arc<Metrics>>>>;
+
+#[derive(Debug)]
+pub struct NewLayer<L: Hash + Eq> {
+    registry: Registry<L>,
+}
+
+/// Reports metrics for prometheus.
+#[derive(Debug)]
+pub struct Report<L: Hash + Eq> {
+    registry: Registry<L>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Layer {
+    metrics: Arc<Metrics>,
+}
+
+#[derive(Debug, Default)]
+struct Metrics {
+    create_total: Counter,
+    drop_total: Counter,
+    ready_total: Counter,
+    not_ready_total: Counter,
+    poll_millis: Counter,
+    error_total: Counter,
+}
+
+#[derive(Debug)]
+pub struct Service<S> {
+    inner: S,
+    metrics: Arc<Metrics>,
+    blocked_since: Option<Instant>,
+    // Helps determine when all instances are dropped.
+    _tracker: Arc<()>,
+}
+
+impl<L> NewLayer<L>
+where
+    L: Hash + Eq,
+{
+    pub fn new_layer(&self, labels: L) -> Layer {
+        let metrics = {
+            let mut registry = self.registry.lock().expect("stack metrics lock poisoned");
+            registry
+                .entry(labels.into())
+                .or_insert_with(|| Default::default())
+                .clone()
+        };
+        Layer { metrics }
+    }
+
+    pub fn report(&self) -> Report<L> {
+        Report {
+            registry: self.registry.clone(),
+        }
+    }
+}
+
+impl<L: Hash + Eq> Default for NewLayer<L> {
+    fn default() -> Self {
+        Self {
+            registry: Registry::default(),
+        }
+    }
+}
+
+impl<L: Hash + Eq> Clone for NewLayer<L> {
+    fn clone(&self) -> Self {
+        Self {
+            registry: self.registry.clone(),
+        }
+    }
+}
+
+impl<S> tower::layer::Layer<S> for Layer {
+    type Service = Service<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        self.metrics.create_total.incr();
+        Self::Service {
+            inner,
+            metrics: self.metrics.clone(),
+            blocked_since: None,
+            _tracker: Arc::new(()),
+        }
+    }
+}
+
+impl<T, S> tower::Service<T> for Service<S>
+where
+    S: tower::Service<T>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        match self.inner.poll_ready() {
+            Ok(Async::NotReady) => {
+                self.metrics.not_ready_total.incr();
+                if self.blocked_since.is_none() {
+                    self.blocked_since = Some(Instant::now());
+                }
+                Ok(Async::NotReady)
+            }
+            Ok(Async::Ready(())) => {
+                self.metrics.ready_total.incr();
+                if let Some(t0) = self.blocked_since.take() {
+                    let not_ready = Instant::now() - t0;
+                    self.metrics.poll_millis.add(not_ready.as_millis() as u64);
+                }
+                Ok(Async::Ready(()))
+            }
+            Err(e) => {
+                self.metrics.error_total.incr();
+                if let Some(t0) = self.blocked_since.take() {
+                    let not_ready = Instant::now() - t0;
+                    self.metrics.poll_millis.add(not_ready.as_millis() as u64);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    fn call(&mut self, target: T) -> Self::Future {
+        self.inner.call(target)
+    }
+}
+
+impl<S> Drop for Service<S> {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self._tracker) == 1 {
+            self.metrics.drop_total.incr();
+        }
+    }
+}
+
+impl<L: Hash + Eq> Clone for Report<L> {
+    fn clone(&self) -> Self {
+        Self {
+            registry: self.registry.clone(),
+        }
+    }
+}
+
+impl<L: FmtLabels + Hash + Eq> FmtMetrics for Report<L> {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let registry = self.registry.lock().expect("metrics registry poisoned");
+        if registry.is_empty() {
+            return Ok(());
+        }
+
+        stack_create_total.fmt_help(f)?;
+        stack_create_total.fmt_scopes(f, registry.iter(), |m| &m.create_total)?;
+
+        stack_drop_total.fmt_help(f)?;
+        stack_drop_total.fmt_scopes(f, registry.iter(), |m| &m.drop_total)?;
+
+        stack_poll_total.fmt_help(f)?;
+        stack_poll_total.fmt_scopes(
+            f,
+            registry.iter().map(|(s, m)| ((s, Ready::Ready), m)),
+            |m| &m.ready_total,
+        )?;
+        stack_poll_total.fmt_scopes(
+            f,
+            registry.iter().map(|(s, m)| ((s, Ready::NotReady), m)),
+            |m| &m.not_ready_total,
+        )?;
+        stack_poll_total.fmt_scopes(
+            f,
+            registry.iter().map(|(s, m)| ((s, Ready::Error), m)),
+            |m| &m.error_total,
+        )?;
+
+        stack_poll_total_ms.fmt_help(f)?;
+        stack_poll_total_ms.fmt_scopes(f, registry.iter(), |m| &m.poll_millis)?;
+
+        Ok(())
+    }
+}
+
+enum Ready {
+    Ready,
+    NotReady,
+    Error,
+}
+
+impl FmtLabels for Ready {
+    fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Ready::Ready => write!(f, "ready=\"true\""),
+            Ready::NotReady => write!(f, "ready=\"false\""),
+            Ready::Error => write!(f, "ready=\"error\""),
+        }
+    }
+}

--- a/linkerd/stack-metrics/src/service.rs
+++ b/linkerd/stack-metrics/src/service.rs
@@ -1,0 +1,73 @@
+use crate::Metrics;
+use futures::{Async, Poll};
+use std::sync::Arc;
+use std::time::Instant;
+
+#[derive(Debug)]
+pub struct TrackService<S> {
+    inner: S,
+    metrics: Arc<Metrics>,
+    blocked_since: Option<Instant>,
+    // Helps determine when all instances are dropped.
+    _tracker: Arc<()>,
+}
+
+impl<S> TrackService<S> {
+    pub(crate) fn new(inner: S, metrics: Arc<Metrics>) -> Self {
+        Self {
+            inner,
+            metrics,
+            blocked_since: None,
+            _tracker: Arc::new(()),
+        }
+    }
+}
+
+impl<T, S> tower::Service<T> for TrackService<S>
+where
+    S: tower::Service<T>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        match self.inner.poll_ready() {
+            Ok(Async::NotReady) => {
+                self.metrics.not_ready_total.incr();
+                if self.blocked_since.is_none() {
+                    self.blocked_since = Some(Instant::now());
+                }
+                Ok(Async::NotReady)
+            }
+            Ok(Async::Ready(())) => {
+                self.metrics.ready_total.incr();
+                if let Some(t0) = self.blocked_since.take() {
+                    let not_ready = Instant::now() - t0;
+                    self.metrics.poll_millis.add(not_ready.as_millis() as u64);
+                }
+                Ok(Async::Ready(()))
+            }
+            Err(e) => {
+                self.metrics.error_total.incr();
+                if let Some(t0) = self.blocked_since.take() {
+                    let not_ready = Instant::now() - t0;
+                    self.metrics.poll_millis.add(not_ready.as_millis() as u64);
+                }
+                Err(e)
+            }
+        }
+    }
+
+    fn call(&mut self, target: T) -> Self::Future {
+        self.inner.call(target)
+    }
+}
+
+impl<S> Drop for TrackService<S> {
+    fn drop(&mut self) {
+        if Arc::strong_count(&self._tracker) == 1 {
+            self.metrics.drop_total.incr();
+        }
+    }
+}


### PR DESCRIPTION
When diagnosing issues, it can be difficult to reason about the states
of the various caches in the proxy.

This change introduces a set of `stack` metrics to help proxy developers
diagnose issues. The metrics track stack creations, stack deletions, and
the amount of time a given service is not available (via
`stack_poll_total_ms`)

```
:; kubectl exec  -n burn-http deploy/client-burst -c client -- curl -s localhost:4191/metrics |grep -e ^stack
stack_create_total{direction="outbound",name="fallback.endpoint"} 0
stack_create_total{direction="outbound",name="balance.endpoint"} 1
stack_create_total{direction="outbound",name="logical.dst"} 1
stack_create_total{direction="outbound",name="addr"} 1
stack_create_total{direction="outbound",name="source"} 100
stack_create_total{direction="inbound",name="endpoint"} 0
stack_create_total{direction="inbound",name="route"} 0
stack_create_total{direction="inbound",name="logical"} 0
stack_create_total{direction="inbound",name="source"} 0
stack_drop_total{direction="outbound",name="fallback.endpoint"} 0
stack_drop_total{direction="outbound",name="balance.endpoint"} 0
stack_drop_total{direction="outbound",name="logical.dst"} 0
stack_drop_total{direction="outbound",name="addr"} 0
stack_drop_total{direction="outbound",name="source"} 0
stack_drop_total{direction="inbound",name="endpoint"} 0
stack_drop_total{direction="inbound",name="route"} 0
stack_drop_total{direction="inbound",name="logical"} 0
stack_drop_total{direction="inbound",name="source"} 0
stack_poll_total{direction="outbound",name="fallback.endpoint",ready="true"} 0
stack_poll_total{direction="outbound",name="balance.endpoint",ready="true"} 70371
stack_poll_total{direction="outbound",name="logical.dst",ready="true"} 23600
stack_poll_total{direction="outbound",name="addr",ready="true"} 23600
stack_poll_total{direction="outbound",name="source",ready="true"} 23600
stack_poll_total{direction="inbound",name="endpoint",ready="true"} 0
stack_poll_total{direction="inbound",name="route",ready="true"} 0
stack_poll_total{direction="inbound",name="logical",ready="true"} 0
stack_poll_total{direction="inbound",name="source",ready="true"} 0
stack_poll_total{direction="outbound",name="fallback.endpoint",ready="false"} 0
stack_poll_total{direction="outbound",name="balance.endpoint",ready="false"} 23175
stack_poll_total{direction="outbound",name="logical.dst",ready="false"} 0
stack_poll_total{direction="outbound",name="addr",ready="false"} 1
stack_poll_total{direction="outbound",name="source",ready="false"} 0
stack_poll_total{direction="inbound",name="endpoint",ready="false"} 0
stack_poll_total{direction="inbound",name="route",ready="false"} 0
stack_poll_total{direction="inbound",name="logical",ready="false"} 0
stack_poll_total{direction="inbound",name="source",ready="false"} 0
stack_poll_total{direction="outbound",name="fallback.endpoint",ready="error"} 0
stack_poll_total{direction="outbound",name="balance.endpoint",ready="error"} 0
stack_poll_total{direction="outbound",name="logical.dst",ready="error"} 0
stack_poll_total{direction="outbound",name="addr",ready="error"} 0
stack_poll_total{direction="outbound",name="source",ready="error"} 0
stack_poll_total{direction="inbound",name="endpoint",ready="error"} 0
stack_poll_total{direction="inbound",name="route",ready="error"} 0
stack_poll_total{direction="inbound",name="logical",ready="error"} 0
stack_poll_total{direction="inbound",name="source",ready="error"} 0
stack_poll_total_ms{direction="outbound",name="fallback.endpoint"} 0
stack_poll_total_ms{direction="outbound",name="balance.endpoint"} 40
stack_poll_total_ms{direction="outbound",name="logical.dst"} 0
stack_poll_total_ms{direction="outbound",name="addr"} 2
stack_poll_total_ms{direction="outbound",name="source"} 0
stack_poll_total_ms{direction="inbound",name="endpoint"} 0
stack_poll_total_ms{direction="inbound",name="route"} 0
stack_poll_total_ms{direction="inbound",name="logical"} 0
stack_poll_total_ms{direction="inbound",name="source"} 0
```