### PR TITLE
concurrency-limit: Share a limit across Services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,7 @@ dependencies = [
  "indexmap",
  "libc",
  "linkerd2-addr",
+ "linkerd2-concurrency-limit",
  "linkerd2-conditional",
  "linkerd2-dns",
  "linkerd2-drain",
@@ -735,6 +736,17 @@ dependencies = [
  "tokio",
  "tower",
  "tower-grpc",
+ "tracing",
+]
+
+[[package]]
+name = "linkerd2-concurrency-limit"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "linkerd2-error",
+ "tokio-sync",
+ "tower",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "linkerd/app/integration",
     "linkerd/app/outbound",
     "linkerd/app",
+    "linkerd/concurrency-limit",
     "linkerd/conditional",
     "linkerd/dns/name",
     "linkerd/dns",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -18,6 +18,7 @@ hyper = "0.12"
 futures = "0.1"
 indexmap = "1.0"
 linkerd2-addr = { path = "../../addr" }
+linkerd2-concurrency-limit = { path = "../../concurrency-limit" }
 linkerd2-conditional = { path = "../../conditional" }
 linkerd2-dns = { path = "../../dns" }
 linkerd2-drain = { path = "../../drain" }

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -1,11 +1,11 @@
 use crate::proxy::{buffer, http, pending};
 use crate::Error;
+use linkerd2_concurrency_limit as concurrency_limit;
 pub use linkerd2_router::Make;
 pub use linkerd2_stack::{self as stack, layer, map_target, Layer, LayerExt, Shared};
 pub use linkerd2_timeout::stack as timeout;
 use std::time::Duration;
 use tower::layer::util::{Identity, Stack as Pair};
-use tower::limit::concurrency::ConcurrencyLimitLayer;
 use tower::load_shed::LoadShedLayer;
 use tower::timeout::TimeoutLayer;
 pub use tower::util::{Either, Oneshot};
@@ -105,8 +105,11 @@ impl<S> Stack<S> {
         self.push(SpawnReadyLayer::new())
     }
 
-    pub fn push_concurrency_limit(self, max: usize) -> Stack<tower::limit::ConcurrencyLimit<S>> {
-        self.push(ConcurrencyLimitLayer::new(max))
+    pub fn push_concurrency_limit(
+        self,
+        max: usize,
+    ) -> Stack<concurrency_limit::ConcurrencyLimit<S>> {
+        self.push(concurrency_limit::Layer::new(max))
     }
 
     pub fn push_load_shed(self) -> Stack<tower::load_shed::LoadShed<S>> {

--- a/linkerd/concurrency-limit/Cargo.toml
+++ b/linkerd/concurrency-limit/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "linkerd2-concurrency-limit"
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+edition = "2018"
+publish = false
+
+
+[dependencies]
+futures = "0.1"
+linkerd2-error = { path = "../error" }
+tokio-sync = "0.1"
+tower = "0.1"
+tracing = "0.1"

--- a/linkerd/concurrency-limit/src/lib.rs
+++ b/linkerd/concurrency-limit/src/lib.rs
@@ -1,0 +1,172 @@
+//! A layer that limits the number of in-flight requests to inner service.
+//!
+//! Modified from tower-concurrency-limit so that the Layer holds a semaphore
+//! and, therefore, so that the limit applies across all services created by this layer..
+
+#![deny(warnings, rust_2018_idioms)]
+
+use futures::{try_ready, Future, Poll};
+use linkerd2_error::Error;
+use std::sync::Arc;
+use tokio_sync::semaphore::{Permit, Semaphore};
+use tower::Service;
+use tracing::trace;
+
+#[derive(Clone, Debug)]
+pub struct Layer {
+    semaphore: Arc<Semaphore>,
+}
+
+/// Enforces a limit on the number of concurrent requests to the inner service.
+#[derive(Debug)]
+pub struct ConcurrencyLimit<T> {
+    inner: T,
+    limit: Limit,
+}
+
+#[derive(Debug)]
+struct Limit {
+    semaphore: Arc<Semaphore>,
+    permit: Permit,
+}
+
+/// Future for the `ConcurrencyLimit` service.
+#[derive(Debug)]
+pub struct ResponseFuture<T> {
+    inner: T,
+    semaphore: Arc<Semaphore>,
+}
+
+impl From<Arc<Semaphore>> for Layer {
+    fn from(semaphore: Arc<Semaphore>) -> Self {
+        Self { semaphore }
+    }
+}
+
+impl Layer {
+    pub fn new(max: usize) -> Self {
+        Arc::new(Semaphore::new(max)).into()
+    }
+}
+
+impl<S> tower::layer::Layer<S> for Layer {
+    type Service = ConcurrencyLimit<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        ConcurrencyLimit::new(inner, self.semaphore.clone())
+    }
+}
+
+impl<T> ConcurrencyLimit<T> {
+    /// Create a new concurrency limiter.
+    pub fn new(inner: T, semaphore: Arc<Semaphore>) -> Self {
+        ConcurrencyLimit {
+            inner,
+            limit: Limit {
+                semaphore,
+                permit: Permit::new(),
+            },
+        }
+    }
+
+    /// Get a reference to the inner service
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the inner service
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Consume `self`, returning the inner service
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+}
+
+impl<S, Request> Service<Request> for ConcurrencyLimit<S>
+where
+    S: Service<Request>,
+    S::Error: Into<Error>,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        trace!(available = %self.limit.semaphore.available_permits(), "acquiring permit");
+        try_ready!(self
+            .limit
+            .permit
+            .poll_acquire(&self.limit.semaphore)
+            .map_err(Error::from));
+
+        self.inner.poll_ready().map_err(Into::into)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        // Make sure a permit has been acquired
+        if self
+            .limit
+            .permit
+            .try_acquire(&self.limit.semaphore)
+            .is_err()
+        {
+            panic!("max requests in-flight; poll_ready must be called first");
+        }
+
+        // Call the inner service
+        let inner = self.inner.call(request);
+
+        // Forget the permit, the permit will be returned when
+        // `future::ResponseFuture` is dropped.
+        self.limit.permit.forget();
+
+        ResponseFuture {
+            inner,
+            semaphore: self.limit.semaphore.clone(),
+        }
+    }
+}
+
+impl<S> Clone for ConcurrencyLimit<S>
+where
+    S: Clone,
+{
+    fn clone(&self) -> ConcurrencyLimit<S> {
+        ConcurrencyLimit {
+            inner: self.inner.clone(),
+            limit: Limit {
+                semaphore: self.limit.semaphore.clone(),
+                permit: Permit::new(),
+            },
+        }
+    }
+}
+
+impl Drop for Limit {
+    fn drop(&mut self) {
+        self.permit.release(&self.semaphore);
+    }
+}
+
+impl<T> Future for ResponseFuture<T>
+where
+    T: Future,
+    T::Error: Into<Error>,
+{
+    type Item = T::Item;
+    type Error = Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.inner.poll().map_err(Into::into)
+    }
+}
+
+impl<T> Drop for ResponseFuture<T> {
+    fn drop(&mut self) {
+        trace!(available = %self.semaphore.available_permits() + 1, "releasing permit");
+        self.semaphore.add_permits(1);
+    }
+}

--- a/linkerd/concurrency-limit/src/lib.rs
+++ b/linkerd/concurrency-limit/src/lib.rs
@@ -1,7 +1,8 @@
 //! A layer that limits the number of in-flight requests to inner service.
 //!
 //! Modified from tower-concurrency-limit so that the Layer holds a semaphore
-//! and, therefore, so that the limit applies across all services created by this layer..
+//! and, therefore, so that the limit applies across all services created by
+//! this layer.
 
 #![deny(warnings, rust_2018_idioms)]
 


### PR DESCRIPTION
Tower's `ConcurrencyLimit` middleware instantiates a new semaphore for
each service created by the layer. However, in an upcoming proxy change,
I'd like to avoid having a single `Service` instance that all requests
must flow through and, instead, wrap a service created for each
connection. In order to enforce a global concurrency limit, the
middleware needs to be changed to share a semaphore across all services
created by the layer.

This presents no functional change to how the concurrency limit is
applied today.

This is basically copy/pasted from https://github.com/tower-rs/tower/blob/v0.1.x/tower-limit/src/concurrency/service.rs