### PR TITLE
lock: Generalize to protect a guarded value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,6 +1186,7 @@ dependencies = [
  "futures",
  "indexmap",
  "linkerd2-error",
+ "linkerd2-lock",
  "tokio",
  "tokio-sync",
  "tokio-timer",

--- a/linkerd/lock/src/error.rs
+++ b/linkerd/lock/src/error.rs
@@ -1,27 +1,8 @@
 pub use linkerd2_error::Error;
 use std::sync::Arc;
 
-#[derive(Debug)]
-pub struct Poisoned(());
-
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ServiceError(Arc<Error>);
-
-// === impl Poisoned ===
-
-impl Poisoned {
-    pub fn new() -> Self {
-        Poisoned(())
-    }
-}
-
-impl std::fmt::Display for Poisoned {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "poisoned")
-    }
-}
-
-impl std::error::Error for Poisoned {}
 
 // === impl ServiceError ===
 

--- a/linkerd/lock/src/layer.rs
+++ b/linkerd/lock/src/layer.rs
@@ -1,4 +1,4 @@
-use super::Lock;
+use super::LockService;
 
 #[derive(Clone, Debug, Default)]
 pub struct LockLayer(());
@@ -12,7 +12,7 @@ impl LockLayer {
 }
 
 impl<S> tower::layer::Layer<S> for LockLayer {
-    type Service = Lock<S>;
+    type Service = LockService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
         Self::Service::new(inner)

--- a/linkerd/lock/src/lib.rs
+++ b/linkerd/lock/src/lib.rs
@@ -4,9 +4,14 @@
 
 pub mod error;
 mod layer;
+mod lock;
 mod service;
 mod shared;
 #[cfg(test)]
 mod test;
 
-pub use self::{layer::LockLayer, service::Lock};
+pub use self::{
+    layer::LockLayer,
+    lock::{Guard, Lock},
+    service::LockService,
+};

--- a/linkerd/lock/src/lock.rs
+++ b/linkerd/lock/src/lock.rs
@@ -1,0 +1,122 @@
+use crate::shared::{Shared, Wait};
+use futures::Async;
+use std::sync::{Arc, Mutex};
+
+/// A middleware that safely shares an inner service among clones.
+///
+/// As the service is polled to readiness, the lock is acquired and the inner service is polled. If
+/// the service is cloned, the service's lock state isnot retained by the clone.
+pub struct Lock<T> {
+    /// Set when this Lock is interested in acquiring the value.
+    waiting: Option<Wait>,
+    shared: Arc<Mutex<Shared<T>>>,
+}
+
+/// Guards access to a `T`-typed value, ensuring the value is released on Drop.
+pub struct Guard<T> {
+    /// Must always be Some; Used to reclaim the value in Drop.
+    value: Option<T>,
+
+    shared: Arc<Mutex<Shared<T>>>,
+}
+
+// === impl Lock ===
+
+impl<S> Lock<S> {
+    pub fn new(service: S) -> Self {
+        Self {
+            waiting: None,
+            shared: Arc::new(Mutex::new(Shared::new(service))),
+        }
+    }
+}
+
+impl<S> Clone for Lock<S> {
+    fn clone(&self) -> Self {
+        Self {
+            // Clones have an independent local lock state.
+            waiting: None,
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl<T> Lock<T> {
+    fn guard(&self, value: T) -> Guard<T> {
+        Guard {
+            value: Some(value),
+            shared: self.shared.clone(),
+        }
+    }
+
+    pub fn poll_acquire(&mut self) -> Async<Guard<T>> {
+        let mut shared = self.shared.lock().expect("Lock poisoned");
+
+        loop {
+            self.waiting = match self.waiting {
+                // This instance has not registered interest in the lock.
+                None => match shared.acquire() {
+                    // This instance has exclusive access to the inner service.
+                    Some(value) => {
+                        // The state remains Released.
+                        return Async::Ready(self.guard(value));
+                    }
+                    None => Some(Wait::default()),
+                },
+
+                // This instance is interested in the lock.
+                Some(ref waiter) => match shared.poll_acquire(waiter) {
+                    Async::NotReady => return Async::NotReady,
+                    Async::Ready(value) => {
+                        self.waiting = None;
+                        return Async::Ready(self.guard(value));
+                    }
+                },
+            };
+        }
+    }
+}
+
+impl<T> Drop for Lock<T> {
+    fn drop(&mut self) {
+        if let Some(wait) = self.waiting.take() {
+            if let Ok(mut shared) = self.shared.lock() {
+                shared.release_waiter(wait);
+            }
+        }
+    }
+}
+
+impl<T> std::ops::Deref for Guard<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        self.value.as_ref().expect("Value dropped from guard")
+    }
+}
+
+impl<T> std::ops::DerefMut for Guard<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.value.as_mut().expect("Value dropped from guard")
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for Guard<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Guard({:?}(", &**self)
+    }
+}
+
+impl<T: std::fmt::Display> std::fmt::Display for Guard<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<T> Drop for Guard<T> {
+    fn drop(&mut self) {
+        let value = self.value.take().expect("Guard may not be dropped twice");
+        if let Ok(mut shared) = self.shared.lock() {
+            shared.release_and_notify(value);
+        }
+    }
+}

--- a/linkerd/lock/src/lock.rs
+++ b/linkerd/lock/src/lock.rs
@@ -2,10 +2,10 @@ use crate::shared::{Shared, Wait};
 use futures::Async;
 use std::sync::{Arc, Mutex};
 
-/// A middleware that safely shares an inner service among clones.
+/// Provides mutually exclusive to a `T`-typed value, asynchronously.
 ///
-/// As the service is polled to readiness, the lock is acquired and the inner service is polled. If
-/// the service is cloned, the service's lock state isnot retained by the clone.
+/// Note that, when the lock is contested, waiters are notified in a LIFO
+/// fashion. This is done to minimize latency at the expense of unfairness.
 pub struct Lock<T> {
     /// Set when this Lock is interested in acquiring the value.
     waiting: Option<Wait>,

--- a/linkerd/lock/src/lock.rs
+++ b/linkerd/lock/src/lock.rs
@@ -102,7 +102,7 @@ impl<T> std::ops::DerefMut for Guard<T> {
 
 impl<T: std::fmt::Debug> std::fmt::Debug for Guard<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Guard({:?}(", &**self)
+        write!(f, "Guard({:?})", &**self)
     }
 }
 

--- a/linkerd/lock/src/service.rs
+++ b/linkerd/lock/src/service.rs
@@ -1,55 +1,33 @@
-use crate::error::{Error, Poisoned, ServiceError};
-use crate::shared::{Shared, Wait};
+use crate::error::{Error, ServiceError};
+use crate::{Guard, Lock};
 use futures::{future, Async, Future, Poll};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tracing::trace;
 
-/// A middleware that safely shares an inner service among clones.
-///
-/// As the service is polled to readiness, the lock is acquired and the inner service is polled. If
-/// the service is cloned, the service's lock state isnot retained by the clone.
-pub struct Lock<S> {
-    state: State<S>,
-    shared: Arc<Mutex<Shared<S>>>,
+pub struct LockService<S> {
+    lock: Lock<Result<S, ServiceError>>,
+    guard: Option<Guard<Result<S, ServiceError>>>,
 }
 
-/// The state of a single `Lock` consumer.
-enum State<S> {
-    /// This lock has not registered interest in the inner service.
-    Released,
-
-    /// This lock is interested in the inner service.
-    Waiting(Wait),
-
-    /// This lock instance has exclusive ownership of the inner service.
-    Acquired(S),
-
-    /// The inner service has failed.
-    Failed(Arc<Error>),
-}
-
-// === impl Lock ===
-
-impl<S> Lock<S> {
-    pub fn new(service: S) -> Self {
+impl<S> LockService<S> {
+    pub fn new(inner: S) -> Self {
         Self {
-            state: State::Released,
-            shared: Arc::new(Mutex::new(Shared::new(service))),
+            lock: Lock::new(Ok(inner)),
+            guard: None,
         }
     }
 }
 
-impl<S> Clone for Lock<S> {
+impl<S> Clone for LockService<S> {
     fn clone(&self) -> Self {
         Self {
-            // Clones have an independent local lock state.
-            state: State::Released,
-            shared: self.shared.clone(),
+            lock: self.lock.clone(),
+            guard: None,
         }
     }
 }
 
-impl<T, S> tower::Service<T> for Lock<S>
+impl<T, S> tower::Service<T> for LockService<S>
 where
     S: tower::Service<T>,
     S::Error: Into<Error>,
@@ -60,111 +38,47 @@ where
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         loop {
-            trace!(state = ?self.state, "Polling");
-            self.state = match self.state {
-                // This instance has exclusive access to the inner service.
-                State::Acquired(ref mut svc) => match svc.poll_ready() {
-                    Ok(ok) => {
-                        trace!(ready = ok.is_ready());
-                        return Ok(ok);
-                    }
-                    Err(inner) => {
-                        // If the inner service fails to become ready, share that error with all
-                        // other consumers and update this lock's state to prevent tryingto acquire
-                        // the shared state again.
-                        let error = Arc::new(inner.into());
-                        trace!(%error);
-                        if let Ok(mut shared) = self.shared.lock() {
-                            shared.fail(error.clone());
+            trace!(acquired = self.guard.is_some());
+            if let Some(guard) = self.guard.as_mut() {
+                return match guard.as_mut() {
+                    Err(err) => Err(err.clone().into()),
+                    Ok(ref mut svc) => match svc.poll_ready() {
+                        Ok(ok) => {
+                            trace!(ready = ok.is_ready());
+                            Ok(ok)
                         }
-                        State::Failed(error)
-                    }
-                },
+                        Err(inner) => {
+                            let error = ServiceError::new(Arc::new(inner.into()));
+                            **guard = Err(error.clone());
 
-                // This instance has not registered interest in the lock.
-                State::Released => match self.shared.lock() {
-                    Err(_) => return Err(Poisoned::new().into()),
-                    // First, try to acquire the lock without creating a waiter. If the lock isn't
-                    // available, create a waiter and try again, registering interest.
-                    Ok(mut shared) => match shared.try_acquire() {
-                        Ok(None) => State::Waiting(Wait::default()),
-                        Ok(Some(svc)) => State::Acquired(svc),
-                        Err(error) => State::Failed(error),
+                            // Drop the guard.
+                            self.guard = None;
+                            Err(error.into())
+                        }
                     },
-                },
+                };
+            }
+            debug_assert!(self.guard.is_none());
 
-                // This instance is interested in the lock.
-                State::Waiting(ref waiter) => match self.shared.lock() {
-                    Err(_) => return Err(Poisoned::new().into()),
-                    Ok(mut shared) => match shared.poll_acquire(waiter) {
-                        Ok(Async::NotReady) => return Ok(Async::NotReady),
-                        Ok(Async::Ready(svc)) => State::Acquired(svc),
-                        Err(error) => State::Failed(error),
-                    },
-                },
-
-                // The inner service failed, so share that failure with all consumers.
-                State::Failed(ref error) => return Err(ServiceError::new(error.clone()).into()),
-            };
+            match self.lock.poll_acquire() {
+                Async::NotReady => return Ok(Async::NotReady),
+                Async::Ready(guard) => {
+                    self.guard = Some(guard);
+                }
+            }
         }
     }
 
     fn call(&mut self, req: T) -> Self::Future {
+        trace!("Calling");
         // The service must have been acquired by poll_ready. Reset this lock's
         // state so that it must reacquire the service via poll_ready.
-        let mut svc = match std::mem::replace(&mut self.state, State::Released) {
-            State::Acquired(svc) => svc,
-            _ => panic!("Called before ready"),
-        };
-
-        let fut = svc.call(req);
-
-        // Return the service to the shared state, notifying waiters as needed.
-        //
-        // The service is dropped if the inner mutex has been poisoned, and subsequent calls to
-        // poll_ready will return a Poisoned error.
-        if let Ok(mut shared) = self.shared.lock() {
-            trace!("Releasing acquired lock after use");
-            shared.release_and_notify(svc);
-        }
-
-        // The inner service's error type is *not* wrapped with a ServiceError.
-        fut.map_err(Into::into)
-    }
-}
-
-impl<S> Drop for Lock<S> {
-    fn drop(&mut self) {
-        let state = std::mem::replace(&mut self.state, State::Released);
-        trace!(?state, "Dropping");
-        match state {
-            // If this lock was holding the service, return it back to the shared state so another
-            // lock may acquire it. Waiters are notified.
-            State::Acquired(service) => {
-                if let Ok(mut shared) = self.shared.lock() {
-                    shared.release_and_notify(service);
-                }
-            }
-
-            State::Waiting(wait) => {
-                if let Ok(mut shared) = self.shared.lock() {
-                    shared.release_waiter(wait);
-                }
-            }
-
-            // No state to cleanup.
-            State::Released | State::Failed(_) => {}
-        }
-    }
-}
-
-impl<S> std::fmt::Debug for State<S> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            State::Released => write!(f, "Released"),
-            State::Acquired(_) => write!(f, "Acquired(..)"),
-            State::Waiting(ref w) => write!(f, "Waiting({:?})", w),
-            State::Failed(ref e) => write!(f, "Failed({:?})", e),
-        }
+        self.guard
+            .take()
+            .expect("Called before ready")
+            .as_mut()
+            .expect("Called before ready")
+            .call(req)
+            .map_err(Into::into)
     }
 }

--- a/linkerd/lock/src/service.rs
+++ b/linkerd/lock/src/service.rs
@@ -4,6 +4,10 @@ use futures::{future, Async, Future, Poll};
 use std::sync::Arc;
 use tracing::trace;
 
+/// A middleware that safely shares an inner service among clones.
+///
+/// As the service is polled to readiness, the lock is acquired and the inner service is polled. If
+/// the service is cloned, the service's lock state isnot retained by the clone.
 pub struct LockService<S> {
     lock: Lock<Result<S, ServiceError>>,
     guard: Option<Guard<Result<S, ServiceError>>>,

--- a/linkerd/router/Cargo.toml
+++ b/linkerd/router/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 futures = "0.1"
 indexmap = "1.0.0"
 linkerd2-error = { path = "../error" }
+linkerd2-lock = { path = "../lock" }
 tower-load-shed = "0.1"
 tokio = "0.1.20"
 tokio-sync = "0.1.6"

--- a/linkerd/router/src/cache.rs
+++ b/linkerd/router/src/cache.rs
@@ -132,8 +132,8 @@ mod tests {
     use super::*;
     use crate::Purge;
     use futures::{future, Async, Future};
+    use linkerd2_lock::Lock;
     use tokio::runtime::current_thread::{self, Runtime};
-    use tokio::sync::lock::Lock;
 
     #[test]
     fn check_capacity_and_insert() {
@@ -186,7 +186,7 @@ mod tests {
 
         // Fill the cache
         rt.block_on(future::lazy(|| {
-            let mut cache = match lock.poll_lock() {
+            let mut cache = match lock.poll_acquire() {
                 Async::Ready(cache) => cache,
                 _ => panic!("cache lock should be Ready"),
             };
@@ -203,7 +203,7 @@ mod tests {
         rt.block_on(tokio_timer::sleep(Duration::from_millis(100)))
             .unwrap();
 
-        let cache = match lock.poll_lock() {
+        let cache = match lock.poll_acquire() {
             Async::Ready(acquired) => acquired,
             _ => panic!("cache lock should be Ready"),
         };
@@ -222,7 +222,7 @@ mod tests {
 
         // Insert into the cache
         rt.block_on(future::lazy(|| {
-            let mut cache = match lock.poll_lock() {
+            let mut cache = match lock.poll_acquire() {
                 Async::Ready(cache) => cache,
                 _ => panic!("cache lock should be Ready"),
             };
@@ -240,7 +240,7 @@ mod tests {
 
         // Access the value that was inserted
         rt.block_on(future::lazy(|| {
-            let mut cache = match lock.poll_lock() {
+            let mut cache = match lock.poll_acquire() {
                 Async::Ready(cache) => cache,
                 _ => panic!("cache lock should be Ready"),
             };
@@ -257,7 +257,7 @@ mod tests {
         // If the access reset the value's expiration, it should still be
         // retrievable
         rt.block_on(future::lazy(|| {
-            let mut cache = match lock.poll_lock() {
+            let mut cache = match lock.poll_acquire() {
                 Async::Ready(acquired) => acquired,
                 _ => panic!("cache lock should be Ready"),
             };

--- a/linkerd/router/src/lib.rs
+++ b/linkerd/router/src/lib.rs
@@ -10,9 +10,9 @@ pub use self::layer::{Config, Layer};
 pub use self::purge::Purge;
 use futures::{Async, Future, Poll};
 use indexmap::IndexMap;
+use linkerd2_lock::Lock;
 use std::hash::Hash;
 use std::time::Duration;
-use tokio::sync::lock::Lock;
 pub use tower_load_shed::LoadShed;
 use tracing::{debug, trace};
 
@@ -300,7 +300,7 @@ where
                     ref mut cache,
                 } => {
                     // Aquire the lock for the router cache
-                    let mut cache = match cache.poll_lock() {
+                    let mut cache = match cache.poll_acquire() {
                         Async::Ready(aquired) => aquired,
                         Async::NotReady => return Ok(Async::NotReady),
                     };

--- a/linkerd/router/src/purge.rs
+++ b/linkerd/router/src/purge.rs
@@ -1,8 +1,8 @@
 use super::Cache;
 use futures::{Async, Future, Poll, Stream};
 use linkerd2_error::Never;
+use linkerd2_lock::Lock;
 use std::hash::Hash;
-use tokio::sync::lock::Lock;
 use tokio::sync::mpsc;
 
 /// A background future that eagerly removes expired cache values.
@@ -46,7 +46,7 @@ where
             Err(_) => unreachable!("purge hangup handle must not error"),
         };
 
-        if let Async::Ready(mut cache) = self.cache.poll_lock() {
+        if let Async::Ready(mut cache) = self.cache.poll_acquire() {
             cache.purge();
         }
 


### PR DESCRIPTION
We used Tokio's Lock implementation in the router's cache
implementation, though we know it can leak under contention.

This change generalizes the Lock to return a guarded value (like Tokio's
lock). This change simplifies the Lock's state management: the Lock may
no longer hold a value, nor can it fail.

The `lock::Service` implementation now holds a `Result<Service,
ServiceError>` so that lock services may still broadcast the inner
service's failure.