### PR TITLE
fallback: Operate on Services instead of Layers

### DIFF
--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -198,9 +198,9 @@ impl<A: OrigDstAddr> Config<A> {
             // application-selected original destination.
             let distributor = balancer_stack
                 .serves::<DstAddr>()
-                .push_per_make(svc::layers().box_http_response().boxed())
+                .push_per_make(svc::layers().box_http_response())
                 .push_fallback(
-                    orig_dst_router_stack.push_per_make(svc::layers().box_http_response().boxed()),
+                    orig_dst_router_stack.push_per_make(svc::layers().box_http_response()),
                 )
                 .push(trace::layer(
                     |dst: &DstAddr| info_span!("concrete", dst.concrete = %dst.dst_concrete()),

--- a/linkerd/fallback/src/lib.rs
+++ b/linkerd/fallback/src/lib.rs
@@ -3,11 +3,10 @@ use linkerd2_error::Error;
 use tower::util::{Either, Oneshot, ServiceExt};
 use tracing::debug;
 
-/// A fallback layer composing two service builders.
+/// A fallback layer composing two services.
 ///
-/// If the future returned by the primary builder's `MakeService` fails with
-/// an error matching a given predicate, the fallback future will attempt
-/// to call the secondary `MakeService`.
+/// If the future returned by the primary service fails with an error matching a
+/// given predicate, the fallback service is called. The result is returned in an `Either`.
 #[derive(Clone, Debug)]
 pub struct FallbackLayer<F, P = fn(&Error) -> bool> {
     fallback: F,


### PR DESCRIPTION
The fallback middleware currently operates by applying a primary layer
to an underlying service and, if that primary service does not produce a
result, the fallback layer is applied to the underlying service to
produce a result.

This change modifies the middleware to no longer require that the
underlying service be shared by the primary and fallback layers.
Instead, the middleware attempts to produce a result from the underlying
service and, if that fails, the fallback service is used.

This will allow the fallback middleware to be used more flexibly in
upcoming changes.