### PR TITLE
timeout: Do not synthesize HTTP response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1300,9 +1300,12 @@ name = "linkerd2-timeout"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "linkerd2-error",
+ "linkerd2-stack",
  "tokio-connect",
  "tokio-timer",
  "tower",
+ "tracing",
 ]
 
 [[package]]

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -333,7 +333,7 @@ fn timeout() {
         with_metrics: |metrics: client::Client| {
             assert_eventually_contains!(
                 metrics.get("/metrics"),
-                "route_response_total{direction=\"outbound\",dst=\"profiles.test.svc.cluster.local:80\",status_code=\"504\",classification=\"failure\",error=\"timeout\"} 1"
+                "route_response_total{direction=\"outbound\",dst=\"profiles.test.svc.cluster.local:80\",classification=\"failure\",error=\"timeout\"} 1"
             );
         }
     }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -237,7 +237,7 @@ impl<A: OrigDstAddr> Config<A> {
                     .push(http::insert::target::layer())
                     .push(metrics.http_route_actual.into_layer::<classify::Response>())
                     .push(retry::layer(metrics.http_route_retry))
-                    .push(http::timeout::layer())
+                    .push(http::MakeTimeoutLayer::default())
                     .push(metrics.http_route.into_layer::<classify::Response>())
                     .push(classify::Layer::new())
                     .push_into_new_service()

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -27,6 +27,7 @@ pub use self::{
     client::Client,
     glue::{HttpBody as Body, HyperServerSvc},
     settings::Settings,
+    timeout::MakeTimeoutLayer,
     version::Version,
 };
 pub use http::{header, uri, Request, Response};

--- a/linkerd/proxy/http/src/timeout.rs
+++ b/linkerd/proxy/http/src/timeout.rs
@@ -1,9 +1,8 @@
-use futures::{future, try_ready, Future, Poll};
-use http::{Request, Response, StatusCode};
-use linkerd2_error::Error;
-use linkerd2_timeout::{error, Timeout};
+use futures::{try_ready, Future, Poll};
+use linkerd2_stack::NewService;
+pub use linkerd2_timeout::error;
+use linkerd2_timeout::Timeout;
 use std::time::Duration;
-use tracing::{debug, error};
 
 /// Implement on targets to determine if a service has a timeout.
 pub trait HasTimeout {
@@ -17,15 +16,11 @@ pub trait HasTimeout {
 ///
 /// Timeout errors are translated into `http::Response`s with appropiate
 /// status codes.
-pub fn layer() -> Layer {
-    Layer
-}
+#[derive(Clone, Debug, Default)]
+pub struct MakeTimeoutLayer(());
 
 #[derive(Clone, Debug)]
-pub struct Layer;
-
-#[derive(Clone, Debug)]
-pub struct Stack<M> {
+pub struct MakeTimeout<M> {
     inner: M,
 }
 
@@ -34,28 +29,35 @@ pub struct MakeFuture<F> {
     timeout: Option<Duration>,
 }
 
-#[derive(Clone, Debug)]
-pub struct Service<S>(Timeout<S>);
-
-/// A marker set in `http::Response::extensions` that *this* process triggered
-/// the request timeout.
-#[derive(Debug)]
-pub struct ProxyTimedOut(());
-
-impl<M> tower::layer::Layer<M> for Layer {
-    type Service = Stack<M>;
+impl<M> tower::layer::Layer<M> for MakeTimeoutLayer {
+    type Service = MakeTimeout<M>;
 
     fn layer(&self, inner: M) -> Self::Service {
-        Stack { inner }
+        MakeTimeout { inner }
     }
 }
 
-impl<T, M> tower::Service<T> for Stack<M>
+impl<T, M> NewService<T> for MakeTimeout<M>
+where
+    M: NewService<T>,
+    T: HasTimeout,
+{
+    type Service = Timeout<M::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        match target.timeout() {
+            Some(t) => Timeout::new(self.inner.new_service(target), t),
+            None => Timeout::passthru(self.inner.new_service(target)),
+        }
+    }
+}
+
+impl<T, M> tower::Service<T> for MakeTimeout<M>
 where
     M: tower::Service<T>,
     T: HasTimeout,
 {
-    type Response = tower::util::Either<Service<M::Response>, M::Response>;
+    type Response = Timeout<M::Response>;
     type Error = M::Error;
     type Future = MakeFuture<M::Future>;
 
@@ -72,57 +74,17 @@ where
 }
 
 impl<F: Future> Future for MakeFuture<F> {
-    type Item = tower::util::Either<Service<F::Item>, F::Item>;
+    type Item = Timeout<F::Item>;
     type Error = F::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let inner = try_ready!(self.inner.poll());
 
-        let svc = if let Some(timeout) = self.timeout {
-            tower::util::Either::A(Service(Timeout::new(inner, timeout)))
-        } else {
-            tower::util::Either::B(inner)
+        let svc = match self.timeout {
+            Some(t) => Timeout::new(inner, t),
+            None => Timeout::passthru(inner),
         };
+
         Ok(svc.into())
-    }
-}
-
-impl<S, B1, B2> tower::Service<Request<B1>> for Service<S>
-where
-    S: tower::Service<Request<B1>, Response = Response<B2>>,
-    S::Error: Into<Error>,
-    B2: Default,
-{
-    type Response = S::Response;
-    type Error = Error;
-    type Future = future::OrElse<
-        <Timeout<S> as tower::Service<Request<B1>>>::Future,
-        Result<Response<B2>, Error>,
-        fn(Error) -> Result<Response<B2>, Error>,
-    >;
-
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.0.poll_ready()
-    }
-
-    fn call(&mut self, req: Request<B1>) -> Self::Future {
-        self.0.call(req).or_else(|err| {
-            if let Some(err) = err.downcast_ref::<error::Timedout>() {
-                debug!("request timed out after {:?}", err.duration());
-                let mut res = Response::default();
-                *res.status_mut() = StatusCode::GATEWAY_TIMEOUT;
-                res.extensions_mut().insert(ProxyTimedOut(()));
-                return Ok(res);
-            } else if let Some(err) = err.downcast_ref::<error::Timer>() {
-                // These are unexpected, and mean the runtime is in a bad place.
-                error!("unexpected runtime timer error: {}", err);
-                let mut res = Response::default();
-                *res.status_mut() = StatusCode::BAD_GATEWAY;
-                return Ok(res);
-            }
-
-            // else
-            Err(err)
-        })
     }
 }

--- a/linkerd/timeout/Cargo.toml
+++ b/linkerd/timeout/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 
 [dependencies]
 futures = "0.1"
+linkerd2-error = { path = "../error" }
+linkerd2-stack = { path = "../stack" }
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-timer = "0.2.4"
 tower = "0.1"
+tracing = "0.1"

--- a/linkerd/timeout/src/error.rs
+++ b/linkerd/timeout/src/error.rs
@@ -3,34 +3,32 @@
 use std::fmt;
 use std::time::Duration;
 
-pub use tokio_timer::Error as Timer;
-
-pub(crate) type Error = Box<dyn std::error::Error + Send + Sync>;
+pub use tokio_timer::Error as TimerError;
 
 /// An error representing that an operation timed out.
 #[derive(Debug)]
-pub struct Timedout(pub(crate) Duration);
+pub struct ResponseTimeout(pub(crate) Duration);
 
 /// A duration which pretty-prints as fractional seconds.
 #[derive(Copy, Clone, Debug)]
 struct HumanDuration<'a>(&'a Duration);
 
-//===== impl Timedout =====
+// === impl ResponseTimeout ===
 
-impl Timedout {
+impl ResponseTimeout {
     /// Get the amount of time waited until this error was triggered.
     pub fn duration(&self) -> Duration {
         self.0
     }
 }
 
-impl fmt::Display for Timedout {
+impl fmt::Display for ResponseTimeout {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "operation timed out after {}", HumanDuration(&self.0))
     }
 }
 
-impl std::error::Error for Timedout {}
+impl std::error::Error for ResponseTimeout {}
 
 impl<'a> fmt::Display for HumanDuration<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/linkerd/timeout/src/lib.rs
+++ b/linkerd/timeout/src/lib.rs
@@ -1,19 +1,24 @@
 #![deny(warnings, rust_2018_idioms)]
 
 use futures::{Future, Poll};
+use linkerd2_error::Error;
+use linkerd2_stack::Proxy;
 use std::time::Duration;
 use tokio_connect::Connect;
 use tokio_timer as timer;
 
 pub mod error;
 
-use self::error::{Error, Timedout};
-
 /// A timeout that wraps an underlying operation.
 #[derive(Debug, Clone)]
 pub struct Timeout<T> {
     inner: T,
-    duration: Duration,
+    duration: Option<Duration>,
+}
+
+pub enum TimeoutFuture<F> {
+    Passthru(F),
+    Timeout(timer::Timeout<F>, Duration),
 }
 
 //===== impl Timeout =====
@@ -21,45 +26,57 @@ pub struct Timeout<T> {
 impl<T> Timeout<T> {
     /// Construct a new `Timeout` wrapping `inner`.
     pub fn new(inner: T, duration: Duration) -> Self {
-        Timeout { inner, duration }
+        Timeout {
+            inner,
+            duration: Some(duration),
+        }
     }
 
-    fn timeout_error<E>(&self, error: timer::timeout::Error<E>) -> Error
-    where
-        E: Into<Error>,
-    {
-        match error {
-            _ if error.is_timer() => error
-                .into_timer()
-                .expect("error.into_timer() must succeed if error.is_timer()")
-                .into(),
-            _ if error.is_elapsed() => Timedout(self.duration).into(),
-            _ => error
-                .into_inner()
-                .expect("if error is not elapsed or timer, must be inner")
-                .into(),
+    pub fn passthru(inner: T) -> Self {
+        Timeout {
+            inner,
+            duration: None,
         }
     }
 }
 
-impl<S, T, Req> tower::Service<Req> for Timeout<S>
+impl<P, S, Req> Proxy<Req, S> for Timeout<P>
 where
-    S: tower::Service<Req, Response = T>,
+    P: Proxy<Req, S>,
+    S: tower::Service<P::Request>,
+{
+    type Request = P::Request;
+    type Response = P::Response;
+    type Error = Error;
+    type Future = TimeoutFuture<P::Future>;
+
+    fn proxy(&self, svc: &mut S, req: Req) -> Self::Future {
+        let inner = self.inner.proxy(svc, req);
+        match self.duration {
+            None => TimeoutFuture::Passthru(inner),
+            Some(t) => TimeoutFuture::Timeout(timer::Timeout::new(inner, t), t),
+        }
+    }
+}
+
+impl<S, Req> tower::Service<Req> for Timeout<S>
+where
+    S: tower::Service<Req>,
     S::Error: Into<Error>,
 {
-    type Response = T;
+    type Response = S::Response;
     type Error = Error;
-    type Future = Timeout<timer::Timeout<S::Future>>;
+    type Future = TimeoutFuture<S::Future>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         self.inner.poll_ready().map_err(Into::into)
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        let inner = timer::Timeout::new(self.inner.call(req), self.duration);
-        Timeout {
-            inner,
-            duration: self.duration,
+        let inner = self.inner.call(req);
+        match self.duration {
+            None => TimeoutFuture::Passthru(inner),
+            Some(t) => TimeoutFuture::Timeout(timer::Timeout::new(inner, t), t),
         }
     }
 }
@@ -71,25 +88,45 @@ where
 {
     type Connected = C::Connected;
     type Error = Error;
-    type Future = Timeout<timer::Timeout<C::Future>>;
+    type Future = TimeoutFuture<C::Future>;
 
     fn connect(&self) -> Self::Future {
-        let inner = timer::Timeout::new(self.inner.connect(), self.duration);
-        Timeout {
-            inner,
-            duration: self.duration,
+        let inner = self.inner.connect();
+        match self.duration {
+            None => TimeoutFuture::Passthru(inner),
+            Some(t) => TimeoutFuture::Timeout(timer::Timeout::new(inner, t), t),
         }
     }
 }
 
-impl<F> Future for Timeout<timer::Timeout<F>>
+impl<F> Future for TimeoutFuture<F>
 where
     F: Future,
     F::Error: Into<Error>,
 {
     type Item = F::Item;
     type Error = Error;
+
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        self.inner.poll().map_err(|e| self.timeout_error(e))
+        match self {
+            TimeoutFuture::Passthru(f) => f.poll().map_err(Into::into),
+            TimeoutFuture::Timeout(f, duration) => f.poll().map_err(|error| {
+                if error.is_timer() {
+                    return error
+                        .into_timer()
+                        .expect("error.into_timer() must succeed if error.is_timer()")
+                        .into();
+                }
+
+                if error.is_elapsed() {
+                    return error::ResponseTimeout(*duration).into();
+                }
+
+                error
+                    .into_inner()
+                    .expect("if error is not elapsed or timer, must be inner")
+                    .into()
+            }),
+        }
     }
 }


### PR DESCRIPTION
The `proxy::http::timeout` middleware currently creates HTTP responses
when a timeout is encountered. Instead, we should allow the error to
propagate through the stack as an error so that all synthesized
responses happen in one place.

This change means that we no longer annotate a `status_code` label in
the `route_response_total` metric, though the `classification` and
`error` labels remain unchanged.

We can also avoid using a `tower::util::Either` by encoding the optional
behavior within the implementation (cutting down on compile-time type
bloat).