### PR TITLE
Cleanup transport::Connect & http::Client types

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -311,8 +311,8 @@ pub mod client {
 
     // === impl Target ===
 
-    impl connect::HasPeerAddr for Target {
-        fn peer_addr(&self) -> SocketAddr {
+    impl connect::ConnectAddr for Target {
+        fn connect_addr(&self) -> SocketAddr {
             self.addr
         }
     }

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -1,4 +1,5 @@
 use crate::proxy::{buffer, http};
+use crate::transport::Connect;
 use crate::Error;
 pub use linkerd2_box as boxed;
 use linkerd2_concurrency_limit as concurrency_limit;
@@ -25,6 +26,10 @@ pub fn layers() -> Layers<Identity> {
 
 pub fn stack<S>(inner: S) -> Stack<S> {
     Stack(inner)
+}
+
+pub fn connect(keepalive: Option<Duration>) -> Stack<Connect> {
+    Stack(Connect::new(keepalive))
 }
 
 // Possibly unused, but useful during development.

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -185,6 +185,10 @@ impl<S> Stack<S> {
         self.push(stack::MapTargetLayer::new(map))
     }
 
+    pub fn push_map_response<M: Clone>(self, map: M) -> Stack<stack::MapResponse<S, M>> {
+        self.push(stack::MapResponseLayer::new(map))
+    }
+
     pub fn instrument<G: Clone>(self, get_span: G) -> Stack<InstrumentMake<G, S>> {
         self.push(InstrumentMakeLayer::new(get_span))
     }

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -39,8 +39,8 @@ impl From<SocketAddr> for Endpoint {
     }
 }
 
-impl connect::HasPeerAddr for Endpoint {
-    fn peer_addr(&self) -> SocketAddr {
+impl connect::ConnectAddr for Endpoint {
+    fn connect_addr(&self) -> SocketAddr {
         self.addr
     }
 }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -17,7 +17,7 @@ use linkerd2_app_core::{
     profiles,
     proxy::{
         self,
-        http::{client, insert, normalize_uri, settings, strip_header},
+        http::{self, insert, normalize_uri, settings, strip_header},
         identity,
         server::{Protocol as ServerProtocol, Server},
         tap, tcp,
@@ -116,7 +116,7 @@ impl<A: OrigDstAddr> Config<A> {
             // Instantiates an HTTP client for a `client::Config`
             let client_stack = connect_stack
                 .clone()
-                .push(client::layer(connect.h2_settings))
+                .push(http::MakeClientLayer::new(connect.h2_settings))
                 .push(reconnect::layer({
                     let backoff = connect.backoff.clone();
                     move |_| Ok(backoff.stream())

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -25,7 +25,7 @@ use linkerd2_app_core::{
     reconnect, router, serve,
     spans::SpanConverter,
     svc,
-    transport::{self, tls, OrigDstAddr, SysOrigDstAddr},
+    transport::{self, io::BoxedIo, tls, OrigDstAddr, SysOrigDstAddr},
     Addr, DispatchDeadline, Error, ProxyMetrics, TraceContextLayer, CANONICAL_DST_HEADER,
     DST_OVERRIDE_HEADER, L5D_CLIENT_ID, L5D_REMOTE_IP, L5D_SERVER_ID,
 };
@@ -105,10 +105,8 @@ impl<A: OrigDstAddr> Config<A> {
             // Establishes connections to the local application (for both
             // TCP forwarding and HTTP proxying).
             let connect_stack = svc::connect(connect.keepalive)
-                // XXX We shouldn't ever to attempt to actually establish TLS
-                // here, but we rely on the IO-boxing behavior to ensure that
-                // shutdown is propagated properly.
-                .push(tls::ConnectLayer::new(local_identity.clone()))
+                // Ensures that shutdown is propagated properly.
+                .push_map_response(BoxedIo::new)
                 .push_timeout(connect.timeout)
                 .push(metrics.transport.layer_connect(TransportLabels))
                 .push(rewrite_loopback_addr::layer());

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -113,8 +113,8 @@ impl tls::HasPeerIdentity for Endpoint {
     }
 }
 
-impl connect::HasPeerAddr for Endpoint {
-    fn peer_addr(&self) -> SocketAddr {
+impl connect::ConnectAddr for Endpoint {
+    fn connect_addr(&self) -> SocketAddr {
         self.addr
     }
 }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -22,7 +22,7 @@ use linkerd2_app_core::{
     reconnect, retry, router, serve,
     spans::SpanConverter,
     svc,
-    transport::{self, connect, tls, OrigDstAddr, SysOrigDstAddr},
+    transport::{self, tls, OrigDstAddr, SysOrigDstAddr},
     Addr, Conditional, DispatchDeadline, Error, ProxyMetrics, TraceContextLayer,
     CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER, L5D_CLIENT_ID, L5D_REMOTE_IP, L5D_REQUIRE_ID,
     L5D_SERVER_ID,
@@ -118,8 +118,8 @@ impl<A: OrigDstAddr> Config<A> {
         let serve = Box::new(future::lazy(move || {
             // Establishes connections to remote peers (for both TCP
             // forwarding and HTTP proxying).
-            let connect_stack = svc::stack(connect::svc(connect.keepalive))
-                .push(tls::client::layer(local_identity))
+            let connect_stack = svc::connect(connect.keepalive)
+                .push(tls::ConnectLayer::new(local_identity))
                 .push_timeout(connect.timeout)
                 .push(metrics.transport.layer_connect(TransportLabels));
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -127,7 +127,7 @@ impl<A: OrigDstAddr> Config<A> {
             // Instantiates an HTTP client for for a `client::Config`
             let client_stack = connect_stack
                 .clone()
-                .push(http::client::layer(connect.h2_settings))
+                .push(http::MakeClientLayer::new(connect.h2_settings))
                 .push(reconnect::layer({
                     let backoff = connect.backoff.clone();
                     move |_| Ok(backoff.stream())

--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -7,7 +7,7 @@ use linkerd2_app_core::{
     config::{ControlAddr, ControlConfig},
     control, dns, proxy, reconnect,
     svc::{self, NewService},
-    transport::{connect, tls},
+    transport::tls,
     ControlHttpMetrics as Metrics, Error, Never,
 };
 use tracing::debug;
@@ -42,8 +42,8 @@ impl Config {
                 let (local, crt_store) = Local::new(&certify);
 
                 let addr = control.addr;
-                let svc = svc::stack(connect::svc(control.connect.keepalive))
-                    .push(tls::client::layer(tls::Conditional::Some(
+                let svc = svc::connect(control.connect.keepalive)
+                    .push(tls::ConnectLayer::new(tls::Conditional::Some(
                         certify.trust_anchors.clone(),
                     )))
                     .push_timeout(control.connect.timeout)

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -115,7 +115,7 @@ impl<A: OrigDstAddr + Send + 'static> Config<A> {
                 proxy::grpc,
                 reconnect,
                 svc::{self, NewService},
-                transport::{connect, tls},
+                transport::tls,
             };
 
             let metrics = metrics.control.clone();
@@ -125,8 +125,8 @@ impl<A: OrigDstAddr + Send + 'static> Config<A> {
                 // task in the build, so we'd have to name the motherfucker. And that's
                 // not happening today. Really, we should daemonize the whole client
                 // into a task so consumers can be ignorant.
-                let svc = svc::stack(connect::svc(dst.control.connect.keepalive))
-                    .push(tls::client::layer(identity.local()))
+                let svc = svc::connect(dst.control.connect.keepalive)
+                    .push(tls::ConnectLayer::new(identity.local()))
                     .push_timeout(dst.control.connect.timeout)
                     .push(control::client::layer())
                     .push(control::resolve::layer(dns))

--- a/linkerd/app/src/oc_collector.rs
+++ b/linkerd/app/src/oc_collector.rs
@@ -4,7 +4,7 @@ use linkerd2_app_core::{
     config::{ControlAddr, ControlConfig},
     control, proxy, reconnect,
     svc::{self, NewService},
-    transport::{connect, tls},
+    transport::tls,
     Error,
 };
 use linkerd2_opencensus::{metrics, proto, SpanExporter};
@@ -48,8 +48,8 @@ impl Config {
             Config::Disabled => Ok(OcCollector::Disabled),
             Config::Enabled { control, hostname } => {
                 let addr = control.addr;
-                let svc = svc::stack(connect::svc(control.connect.keepalive))
-                    .push(tls::client::layer(identity))
+                let svc = svc::connect(control.connect.keepalive)
+                    .push(tls::ConnectLayer::new(identity))
                     .push_timeout(control.connect.timeout)
                     // TODO: perhaps rename from "control" to "grpc"
                     .push(control::client::layer())

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -8,55 +8,53 @@ use futures::{try_ready, Async, Future, Poll};
 use http;
 use hyper;
 use linkerd2_error::Error;
-use linkerd2_proxy_transport::connect;
 use std::fmt;
 use std::marker::PhantomData;
 use tower::ServiceExt;
 use tracing::{debug, info_span, trace};
 use tracing_futures::Instrument;
 
-/// Configurs an HTTP client that uses a `C`-typed connector
+/// Configures an HTTP client that uses a `C`-typed connector
 ///
 /// The `span` is used for diagnostics (logging, mostly).
 #[derive(Debug)]
-pub struct Layer<T, B> {
+pub struct Layer<B> {
     h2_settings: crate::h2::Settings,
-    _p: PhantomData<fn(T) -> B>,
+    _marker: PhantomData<fn() -> B>,
 }
 
-type HyperClient<C, T, B> = hyper::Client<HyperConnect<C, T>, B>;
+type HyperMakeClient<C, T, B> = hyper::Client<HyperConnect<C, T>, B>;
 
 /// A `MakeService` that can speak either HTTP/1 or HTTP/2.
-pub struct Client<C, T, B> {
+pub struct MakeClient<C, B> {
     connect: C,
     h2_settings: crate::h2::Settings,
-    _p: PhantomData<fn(T) -> B>,
+    _marker: PhantomData<fn() -> B>,
 }
 
 /// A `Future` returned from `Client::new_service()`.
-pub enum ClientNewServiceFuture<C, T, B>
+pub enum MakeFuture<C, T, B>
 where
-    T: connect::HasPeerAddr,
     B: hyper::body::Payload + 'static,
     C: tower::MakeConnection<T> + 'static,
     C::Connection: Send + 'static,
     C::Error: Into<Error>,
 {
-    Http1(Option<HyperClient<C, T, B>>),
+    Http1(Option<HyperMakeClient<C, T, B>>),
     Http2(::tower_util::Oneshot<h2::Connect<C, B>, T>),
 }
 
 /// The `Service` yielded by `Client::new_service()`.
-pub enum ClientService<C, T, B>
+pub enum Client<C, T, B>
 where
     B: hyper::body::Payload + 'static,
     C: tower::MakeConnection<T> + 'static,
 {
-    Http1(HyperClient<C, T, B>),
+    Http1(HyperMakeClient<C, T, B>),
     Http2(h2::Connection<B>),
 }
 
-pub enum ClientServiceFuture {
+pub enum ClientFuture {
     Http1 {
         future: hyper::client::ResponseFuture,
         upgrade: Option<Http11Upgrade>,
@@ -67,141 +65,129 @@ pub enum ClientServiceFuture {
 
 // === impl Layer ===
 
-pub fn layer<T, B>(h2_settings: crate::h2::Settings) -> Layer<T, B>
+pub fn layer<B>(h2_settings: crate::h2::Settings) -> Layer<B>
 where
     B: hyper::body::Payload + Send + 'static,
 {
     Layer {
         h2_settings,
-        _p: PhantomData,
+        _marker: PhantomData,
     }
 }
 
-impl<T, B> Clone for Layer<T, B>
+impl<B> Clone for Layer<B>
 where
     B: hyper::body::Payload + Send + 'static,
 {
     fn clone(&self) -> Self {
         Self {
             h2_settings: self.h2_settings,
-            _p: PhantomData,
+            _marker: self._marker,
         }
     }
 }
 
-impl<T, C, B> tower::layer::Layer<C> for Layer<T, B>
+impl<C, B> tower::layer::Layer<C> for Layer<B>
 where
-    Client<C, T, B>: tower::Service<T>,
     B: hyper::body::Payload + Send + 'static,
 {
-    type Service = Client<C, T, B>;
+    type Service = MakeClient<C, B>;
 
     fn layer(&self, connect: C) -> Self::Service {
-        Client {
+        MakeClient {
             connect,
             h2_settings: self.h2_settings,
-            _p: PhantomData,
+            _marker: PhantomData,
         }
     }
 }
 
 // === impl Client ===
 
-/// MakeService
-impl<C, T, B> tower::Service<T> for Client<C, T, B>
+impl<C, T, B> tower::Service<T> for MakeClient<C, B>
 where
     C: tower::MakeConnection<T> + Clone + Send + Sync + 'static,
     C::Future: Send + 'static,
     <C::Future as Future>::Error: Into<Error>,
     C::Connection: Send + 'static,
-    T: connect::HasPeerAddr + HasSettings + fmt::Debug + Clone + Send + Sync,
+    T: HasSettings + fmt::Debug + Clone + Send + Sync,
     B: hyper::body::Payload + 'static,
 {
-    type Response = ClientService<C, T, B>;
+    type Response = Client<C, T, B>;
     type Error = Error;
-    type Future = ClientNewServiceFuture<C, T, B>;
+    type Future = MakeFuture<C, T, B>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         Ok(().into())
     }
 
-    fn call(&mut self, config: T) -> Self::Future {
-        debug!("building client={:?}", config);
-        let peer_addr = config.peer_addr();
-
+    fn call(&mut self, target: T) -> Self::Future {
+        trace!("Building HTTP client");
         let connect = self.connect.clone();
-        match *config.http_settings() {
+        match *target.http_settings() {
             Settings::Http1 {
                 keep_alive,
                 wants_h1_upgrade: _,
                 was_absolute_form,
             } => {
-                let exec = tokio::executor::DefaultExecutor::current()
-                    .instrument(info_span!("http1", %peer_addr));
+                let exec =
+                    tokio::executor::DefaultExecutor::current().instrument(info_span!("http1"));
                 let h1 = hyper::Client::builder()
                     .executor(exec)
                     .keep_alive(keep_alive)
                     // hyper should never try to automatically set the Host
                     // header, instead always just passing whatever we received.
                     .set_host(false)
-                    .build(HyperConnect::new(connect, config, was_absolute_form));
-                ClientNewServiceFuture::Http1(Some(h1))
+                    .build(HyperConnect::new(connect, target, was_absolute_form));
+                MakeFuture::Http1(Some(h1))
             }
             Settings::Http2 => {
-                let h2 = h2::Connect::new(connect, self.h2_settings.clone()).oneshot(config);
-                ClientNewServiceFuture::Http2(h2)
+                let h2 = h2::Connect::new(connect, self.h2_settings.clone()).oneshot(target);
+                MakeFuture::Http2(h2)
             }
-            Settings::NotHttp => {
-                unreachable!("client config has invalid HTTP settings: {:?}", config);
-            }
+            Settings::NotHttp => unreachable!("Client may only be used for HTTP endpoints"),
         }
     }
 }
 
-impl<C, T, B> Clone for Client<C, T, B>
-where
-    C: Clone,
-{
+impl<C: Clone, B> Clone for MakeClient<C, B> {
     fn clone(&self) -> Self {
-        Client {
+        Self {
             connect: self.connect.clone(),
             h2_settings: self.h2_settings,
-            _p: PhantomData,
+            _marker: self._marker,
         }
     }
 }
 
-// === impl ClientNewServiceFuture ===
+// === impl MakeFuture ===
 
-impl<C, T, B> Future for ClientNewServiceFuture<C, T, B>
+impl<C, T, B> Future for MakeFuture<C, T, B>
 where
-    T: connect::HasPeerAddr,
     C: tower::MakeConnection<T> + Send + Sync + 'static,
     C::Connection: Send + 'static,
     C::Future: Send + 'static,
     C::Error: Into<Error>,
     B: hyper::body::Payload + 'static,
 {
-    type Item = ClientService<C, T, B>;
+    type Item = Client<C, T, B>;
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let svc = match *self {
-            ClientNewServiceFuture::Http1(ref mut h1) => {
-                ClientService::Http1(h1.take().expect("poll more than once"))
-            }
-            ClientNewServiceFuture::Http2(ref mut h2) => {
+            MakeFuture::Http1(ref mut h1) => Client::Http1(h1.take().expect("poll more than once")),
+            MakeFuture::Http2(ref mut h2) => {
                 let svc = try_ready!(h2.poll());
-                ClientService::Http2(svc)
+                Client::Http2(svc)
             }
         };
         Ok(Async::Ready(svc))
     }
 }
 
-// === impl ClientService ===
+// === impl Client ===
 
-impl<C, T, B> tower::Service<http::Request<B>> for ClientService<C, T, B>
+impl<C, T, B> tower::Service<http::Request<B>> for Client<C, T, B>
 where
     C: tower::MakeConnection<T> + Clone + Send + Sync + 'static,
     C::Connection: Send,
@@ -212,51 +198,51 @@ where
 {
     type Response = http::Response<HttpBody>;
     type Error = Error;
-    type Future = ClientServiceFuture;
+    type Future = ClientFuture;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         match *self {
-            ClientService::Http1(_) => Ok(Async::Ready(())),
-            ClientService::Http2(ref mut h2) => h2.poll_ready().map_err(Into::into),
+            Client::Http1(_) => Ok(Async::Ready(())),
+            Client::Http2(ref mut h2) => h2.poll_ready().map_err(Into::into),
         }
     }
 
     fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
         debug!(
-            "client request: method={} uri={} version={:?} headers={:?}",
-            req.method(),
-            req.uri(),
-            req.version(),
-            req.headers()
+            method = %req.method(),
+            uri = %req.uri(),
+            version = ?req.version(),
+            headers = ?req.headers(),
         );
+
         match *self {
-            ClientService::Http1(ref h1) => {
+            Client::Http1(ref h1) => {
                 let upgrade = req.extensions_mut().remove::<Http11Upgrade>();
                 let is_http_connect = if upgrade.is_some() {
                     req.method() == &http::Method::CONNECT
                 } else {
                     false
                 };
-                ClientServiceFuture::Http1 {
+                ClientFuture::Http1 {
                     future: h1.request(req),
                     upgrade,
                     is_http_connect,
                 }
             }
-            ClientService::Http2(ref mut h2) => ClientServiceFuture::Http2(h2.call(req)),
+            Client::Http2(ref mut h2) => ClientFuture::Http2(h2.call(req)),
         }
     }
 }
 
-// === impl ClientServiceFuture ===
+// === impl ClientFuture ===
 
-impl Future for ClientServiceFuture {
+impl Future for ClientFuture {
     type Item = http::Response<HttpBody>;
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         match self {
-            ClientServiceFuture::Http1 {
+            ClientFuture::Http1 {
                 future,
                 upgrade,
                 is_http_connect,
@@ -276,7 +262,7 @@ impl Future for ClientServiceFuture {
                 }
                 Ok(Async::Ready(res))
             }
-            ClientServiceFuture::Http2(f) => f.poll().map_err(Into::into),
+            ClientFuture::Http2(f) => f.poll().map_err(Into::into),
         }
     }
 }

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -32,7 +32,7 @@ pub struct MakeClient<C, B> {
     _marker: PhantomData<fn() -> B>,
 }
 
-/// A `Future` returned from `Client::new_service()`.
+/// A `Future` returned from `MakeClient::new_service()`.
 pub enum MakeFuture<C, T, B>
 where
     B: hyper::body::Payload + 'static,
@@ -44,7 +44,7 @@ where
     Http2(::tower_util::Oneshot<h2::Connect<C, B>, T>),
 }
 
-/// The `Service` yielded by `Client::new_service()`.
+/// The `Service` yielded by `MakeClient::new_service()`.
 pub enum Client<C, T, B>
 where
     B: hyper::body::Payload + 'static,

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -24,7 +24,7 @@ pub mod upgrade;
 mod version;
 
 pub use self::{
-    client::Client,
+    client::MakeClientLayer,
     glue::{HttpBody as Body, HyperServerSvc},
     settings::Settings,
     timeout::MakeTimeoutLayer,

--- a/linkerd/proxy/transport/src/connect.rs
+++ b/linkerd/proxy/transport/src/connect.rs
@@ -52,7 +52,7 @@ impl Future for ConnectFuture {
         super::set_keepalive_or_warn(&io, self.keepalive);
         debug!(
             local.addr = %io.local_addr().expect("cannot load local addr"),
-            keepalve = ?self.keepalive,
+            keepalive = ?self.keepalive,
             "Connected",
         );
         Ok(io.into())

--- a/linkerd/proxy/transport/src/connect.rs
+++ b/linkerd/proxy/transport/src/connect.rs
@@ -1,54 +1,60 @@
 use futures::{try_ready, Future, Poll};
 use std::{io, net::SocketAddr, time::Duration};
 use tokio::net::{tcp, TcpStream};
-use tower::{service_fn, Service};
 use tracing::debug;
 
-pub trait HasPeerAddr {
-    fn peer_addr(&self) -> SocketAddr;
+pub trait ConnectAddr {
+    fn connect_addr(&self) -> SocketAddr;
 }
 
-pub fn svc<T: HasPeerAddr>(
+#[derive(Copy, Clone, Debug)]
+pub struct Connect {
     keepalive: Option<Duration>,
-) -> impl Service<T, Response = TcpStream, Error = io::Error, Future = ConnectFuture> + Clone {
-    service_fn(move |target: T| {
-        let addr = target.peer_addr();
-        debug!("connecting to {}", addr);
-        ConnectFuture {
-            addr,
-            keepalive,
-            future: TcpStream::connect(&addr),
-        }
-    })
 }
 
 #[derive(Debug)]
 pub struct ConnectFuture {
-    addr: SocketAddr,
     keepalive: Option<Duration>,
     future: tcp::ConnectFuture,
 }
 
-impl HasPeerAddr for SocketAddr {
-    fn peer_addr(&self) -> SocketAddr {
-        *self
+impl Connect {
+    pub fn new(keepalive: Option<Duration>) -> Self {
+        Connect { keepalive }
     }
 }
 
-// === impl ConnectFuture ===
+impl<C: ConnectAddr> tower::Service<C> for Connect {
+    type Response = TcpStream;
+    type Error = io::Error;
+    type Future = ConnectFuture;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        Ok(().into())
+    }
+
+    fn call(&mut self, c: C) -> Self::Future {
+        let keepalive = self.keepalive;
+        let addr = c.connect_addr();
+        debug!(peer.addr = %addr, "Connecting");
+        let future = TcpStream::connect(&addr);
+        ConnectFuture { future, keepalive }
+    }
+}
 
 impl Future for ConnectFuture {
     type Item = TcpStream;
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let io = try_ready!(self.future.poll().map_err(|e| {
-            let details = format!("{} (address: {})", e, self.addr);
-            io::Error::new(e.kind(), details)
-        }));
-        debug!("connection established to {}", self.addr);
+        let io = try_ready!(self.future.poll());
         super::set_nodelay_or_warn(&io);
         super::set_keepalive_or_warn(&io, self.keepalive);
+        debug!(
+            local.addr = %io.local_addr().expect("cannot load local addr"),
+            keepalve = ?self.keepalive,
+            "Connected",
+        );
         Ok(io.into())
     }
 }

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -10,6 +10,7 @@ pub mod metrics;
 pub mod tls;
 
 pub use self::{
+    connect::Connect,
     io::BoxedIo,
     listen::{Bind, Listen, NoOrigDstAddr, OrigDstAddr, SysOrigDstAddr},
 };

--- a/linkerd/proxy/transport/src/metrics/mod.rs
+++ b/linkerd/proxy/transport/src/metrics/mod.rs
@@ -44,7 +44,7 @@ pub struct Report<K: Eq + Hash + FmtLabels>(Arc<Mutex<Inner<K>>>);
 pub struct Registry<K: Eq + Hash + FmtLabels>(Arc<Mutex<Inner<K>>>);
 
 #[derive(Debug)]
-pub struct LayerConnect<L, K: Eq + Hash + FmtLabels> {
+pub struct ConnectLayer<L, K: Eq + Hash + FmtLabels> {
     label: L,
     registry: Arc<Mutex<Inner<K>>>,
 }
@@ -172,8 +172,8 @@ impl<K: Eq + Hash + FmtLabels> Inner<K> {
 // ===== impl Registry =====
 
 impl<K: Eq + Hash + FmtLabels> Registry<K> {
-    pub fn layer_connect<L>(&self, label: L) -> LayerConnect<L, K> {
-        LayerConnect::new(label, self.0.clone())
+    pub fn layer_connect<L>(&self, label: L) -> ConnectLayer<L, K> {
+        ConnectLayer::new(label, self.0.clone())
     }
 
     pub fn wrap_server_transport<T: AsyncRead + AsyncWrite>(&self, labels: K, io: T) -> Io<T> {
@@ -187,19 +187,19 @@ impl<K: Eq + Hash + FmtLabels> Registry<K> {
     }
 }
 
-impl<L, K: Eq + Hash + FmtLabels> LayerConnect<L, K> {
+impl<L, K: Eq + Hash + FmtLabels> ConnectLayer<L, K> {
     fn new(label: L, registry: Arc<Mutex<Inner<K>>>) -> Self {
         Self { label, registry }
     }
 }
 
-impl<L: Clone, K: Eq + Hash + FmtLabels> Clone for LayerConnect<L, K> {
+impl<L: Clone, K: Eq + Hash + FmtLabels> Clone for ConnectLayer<L, K> {
     fn clone(&self) -> Self {
         Self::new(self.label.clone(), self.registry.clone())
     }
 }
 
-impl<L: Clone, K: Eq + Hash + FmtLabels, M> tower::layer::Layer<M> for LayerConnect<L, K> {
+impl<L: Clone, K: Eq + Hash + FmtLabels, M> tower::layer::Layer<M> for ConnectLayer<L, K> {
     type Service = Connect<L, K, M>;
 
     fn layer(&self, inner: M) -> Self::Service {

--- a/linkerd/proxy/transport/src/metrics/mod.rs
+++ b/linkerd/proxy/transport/src/metrics/mod.rs
@@ -1,4 +1,3 @@
-use super::tls;
 use futures::{try_ready, Future, Poll};
 use indexmap::IndexMap;
 use linkerd2_metrics::{
@@ -6,7 +5,6 @@ use linkerd2_metrics::{
 };
 use std::fmt;
 use std::hash::Hash;
-use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -46,18 +44,16 @@ pub struct Report<K: Eq + Hash + FmtLabels>(Arc<Mutex<Inner<K>>>);
 pub struct Registry<K: Eq + Hash + FmtLabels>(Arc<Mutex<Inner<K>>>);
 
 #[derive(Debug)]
-pub struct LayerConnect<L: TransportLabels<T>, T, M> {
+pub struct LayerConnect<L, K: Eq + Hash + FmtLabels> {
     label: L,
-    registry: Arc<Mutex<Inner<L::Labels>>>,
-    _p: PhantomData<fn() -> (T, M)>,
+    registry: Arc<Mutex<Inner<K>>>,
 }
 
 #[derive(Debug)]
-pub struct Connect<L: TransportLabels<T>, T, M> {
+pub struct Connect<L, K: Eq + Hash + FmtLabels, M> {
     label: L,
     inner: M,
-    registry: Arc<Mutex<Inner<L::Labels>>>,
-    _p: PhantomData<fn(T) -> ()>,
+    registry: Arc<Mutex<Inner<K>>>,
 }
 
 pub struct Connecting<F> {
@@ -176,11 +172,7 @@ impl<K: Eq + Hash + FmtLabels> Inner<K> {
 // ===== impl Registry =====
 
 impl<K: Eq + Hash + FmtLabels> Registry<K> {
-    pub fn layer_connect<T, L, M>(&self, label: L) -> LayerConnect<L, T, M>
-    where
-        L: TransportLabels<T, Labels = K>,
-        M: tower::MakeConnection<T>,
-    {
+    pub fn layer_connect<L>(&self, label: L) -> LayerConnect<L, K> {
         LayerConnect::new(label, self.0.clone())
     }
 
@@ -195,47 +187,34 @@ impl<K: Eq + Hash + FmtLabels> Registry<K> {
     }
 }
 
-impl<L: TransportLabels<T>, T, M> LayerConnect<L, T, M> {
-    fn new(label: L, registry: Arc<Mutex<Inner<L::Labels>>>) -> Self {
-        Self {
-            label,
-            registry,
-            _p: PhantomData,
-        }
+impl<L, K: Eq + Hash + FmtLabels> LayerConnect<L, K> {
+    fn new(label: L, registry: Arc<Mutex<Inner<K>>>) -> Self {
+        Self { label, registry }
     }
 }
 
-impl<L, T, M> Clone for LayerConnect<L, T, M>
-where
-    L: TransportLabels<T> + Clone,
-    T: Clone,
-{
+impl<L: Clone, K: Eq + Hash + FmtLabels> Clone for LayerConnect<L, K> {
     fn clone(&self) -> Self {
         Self::new(self.label.clone(), self.registry.clone())
     }
 }
 
-impl<L, T, M> tower::layer::Layer<M> for LayerConnect<L, T, M>
-where
-    L: TransportLabels<T> + Clone,
-    T: tls::HasPeerIdentity,
-    M: tower::MakeConnection<T>,
-{
-    type Service = Connect<L, T, M>;
+impl<L: Clone, K: Eq + Hash + FmtLabels, M> tower::layer::Layer<M> for LayerConnect<L, K> {
+    type Service = Connect<L, K, M>;
 
     fn layer(&self, inner: M) -> Self::Service {
         Connect {
             inner,
             label: self.label.clone(),
             registry: self.registry.clone(),
-            _p: PhantomData,
         }
     }
 }
 
-impl<L, T, M> Clone for Connect<L, T, M>
+impl<L, K, M> Clone for Connect<L, K, M>
 where
-    L: TransportLabels<T> + Clone,
+    L: Clone,
+    K: Eq + Hash + FmtLabels,
     M: Clone,
 {
     fn clone(&self) -> Self {
@@ -243,14 +222,13 @@ where
             inner: self.inner.clone(),
             label: self.label.clone(),
             registry: self.registry.clone(),
-            _p: PhantomData,
         }
     }
 }
 
-// === impl MakeConnection ===
+// === impl Connect ===
 
-impl<L, T, M> tower::Service<T> for Connect<L, T, M>
+impl<L, T, M> tower::Service<T> for Connect<L, L::Labels, M>
 where
     L: TransportLabels<T>,
     M: tower::MakeConnection<T>,

--- a/linkerd/proxy/transport/src/tls/mod.rs
+++ b/linkerd/proxy/transport/src/tls/mod.rs
@@ -7,6 +7,7 @@ pub mod client;
 mod conditional_accept;
 
 pub use self::accept::AcceptTls;
+pub use self::client::ConnectLayer;
 
 /// Describes whether or not a connection was secured with TLS and, if it was
 /// not, the reason why.

--- a/linkerd/proxy/transport/tests/tls_accept.rs
+++ b/linkerd/proxy/transport/tests/tls_accept.rs
@@ -17,7 +17,7 @@ use linkerd2_proxy_transport::tls::{
 use linkerd2_proxy_transport::{connect, Bind, Listen};
 use std::{net::SocketAddr, sync::mpsc};
 use tokio::{self, io, prelude::*};
-use tower::{layer::Layer, Service, ServiceExt};
+use tower::{layer::Layer, ServiceExt};
 use tower_util::service_fn;
 
 #[test]
@@ -172,10 +172,9 @@ where
         let sender_clone = sender.clone();
 
         let peer_identity = Some(client_target_name.clone());
-        let client = tls::client::layer(client_tls)
-            .layer(connect::svc(None))
-            .ready()
-            .and_then(move |mut svc| svc.call(Target(server_addr, client_target_name)))
+        let client = tls::ConnectLayer::new(client_tls)
+            .layer(connect::Connect::new(None))
+            .oneshot(Target(server_addr, client_target_name))
             .map_err(move |e| {
                 sender_clone
                     .send(Transported {
@@ -298,8 +297,8 @@ impl<A: Accept<ServerConnection> + Clone> Future for Server<A> {
     }
 }
 
-impl connect::HasPeerAddr for Target {
-    fn peer_addr(&self) -> SocketAddr {
+impl connect::ConnectAddr for Target {
+    fn connect_addr(&self) -> SocketAddr {
         self.0
     }
 }

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod fallback;
 mod future_service;
 pub mod layer;
+pub mod map_response;
 pub mod map_target;
 pub mod new_service;
 pub mod on_response;
@@ -13,6 +14,7 @@ pub mod shared;
 
 pub use self::fallback::{Fallback, FallbackLayer};
 pub use self::future_service::FutureService;
+pub use self::map_response::{MapResponse, MapResponseLayer};
 pub use self::map_target::{MapTarget, MapTargetLayer, MapTargetService};
 pub use self::new_service::NewService;
 pub use self::on_response::{OnResponse, OnResponseLayer};

--- a/linkerd/stack/src/map_response.rs
+++ b/linkerd/stack/src/map_response.rs
@@ -1,0 +1,79 @@
+use futures::{try_ready, Future, Poll};
+
+pub trait ResponseMap<Rsp> {
+    type Response;
+
+    fn map_response(&self, rsp: Rsp) -> Self::Response;
+}
+
+#[derive(Clone, Debug)]
+pub struct MapResponseLayer<R>(R);
+
+#[derive(Clone, Debug)]
+pub struct MapResponse<S, R> {
+    inner: S,
+    response_map: R,
+}
+
+impl<R> MapResponseLayer<R> {
+    pub fn new(response_map: R) -> Self {
+        MapResponseLayer(response_map)
+    }
+}
+
+impl<S, R: Clone> tower::layer::Layer<S> for MapResponseLayer<R> {
+    type Service = MapResponse<S, R>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Self::Service {
+            inner,
+            response_map: self.0.clone(),
+        }
+    }
+}
+
+impl<T, S, R> tower::Service<T> for MapResponse<S, R>
+where
+    S: tower::Service<T>,
+    R: ResponseMap<S::Response> + Clone,
+{
+    type Response = R::Response;
+    type Error = S::Error;
+    type Future = MapResponse<S::Future, R>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, req: T) -> Self::Future {
+        MapResponse {
+            inner: self.inner.call(req),
+            response_map: self.response_map.clone(),
+        }
+    }
+}
+
+impl<F, R> Future for MapResponse<F, R>
+where
+    F: Future,
+    R: ResponseMap<F::Item>,
+{
+    type Item = R::Response;
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let rsp = try_ready!(self.inner.poll());
+        Ok(self.response_map.map_response(rsp).into())
+    }
+}
+
+impl<T, U, F> ResponseMap<T> for F
+where
+    F: Fn(T) -> U,
+{
+    type Response = U;
+
+    fn map_response(&self, rsp: T) -> Self::Response {
+        (self)(rsp)
+    }
+}


### PR DESCRIPTION
This change:

* Renames `HasPeerAddr` to be `ConnectAddr`. "Peer" is ambiguous, and
  not clear about the intended use;
* Creates a named `transport::Connect` service type. This supports the
  `svc::connect` stack helper;
* Removes unnecessary type constraints from various modules;
* Simplifies naming & logic in `http::client`;
* Removes redundant trace context information from `http::h2`;