### PR TITLE
inbound: Box client transports to ensure shutdown

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -185,6 +185,10 @@ impl<S> Stack<S> {
         self.push(stack::MapTargetLayer::new(map))
     }
 
+    pub fn push_map_response<M: Clone>(self, map: M) -> Stack<stack::MapResponse<S, M>> {
+        self.push(stack::MapResponseLayer::new(map))
+    }
+
     pub fn instrument<G: Clone>(self, get_span: G) -> Stack<InstrumentMake<G, S>> {
         self.push(InstrumentMakeLayer::new(get_span))
     }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -25,7 +25,7 @@ use linkerd2_app_core::{
     reconnect, router, serve,
     spans::SpanConverter,
     svc,
-    transport::{self, tls, OrigDstAddr, SysOrigDstAddr},
+    transport::{self, io::BoxedIo, tls, OrigDstAddr, SysOrigDstAddr},
     Addr, DispatchDeadline, Error, ProxyMetrics, TraceContextLayer, CANONICAL_DST_HEADER,
     DST_OVERRIDE_HEADER, L5D_CLIENT_ID, L5D_REMOTE_IP, L5D_SERVER_ID,
 };
@@ -105,10 +105,8 @@ impl<A: OrigDstAddr> Config<A> {
             // Establishes connections to the local application (for both
             // TCP forwarding and HTTP proxying).
             let connect_stack = svc::connect(connect.keepalive)
-                // XXX We shouldn't ever to attempt to actually establish TLS
-                // here, but we rely on the IO-boxing behavior to ensure that
-                // shutdown is propagated properly.
-                .push(tls::ConnectLayer::new(local_identity.clone()))
+                // Ensures that shutdown is propagated properly.
+                .push_map_response(BoxedIo::new)
                 .push_timeout(connect.timeout)
                 .push(metrics.transport.layer_connect(TransportLabels))
                 .push(rewrite_loopback_addr::layer());

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod fallback;
 mod future_service;
 pub mod layer;
+pub mod map_response;
 pub mod map_target;
 pub mod new_service;
 pub mod on_response;
@@ -13,6 +14,7 @@ pub mod shared;
 
 pub use self::fallback::{Fallback, FallbackLayer};
 pub use self::future_service::FutureService;
+pub use self::map_response::{MapResponse, MapResponseLayer};
 pub use self::map_target::{MapTarget, MapTargetLayer, MapTargetService};
 pub use self::new_service::NewService;
 pub use self::on_response::{OnResponse, OnResponseLayer};

--- a/linkerd/stack/src/map_response.rs
+++ b/linkerd/stack/src/map_response.rs
@@ -1,0 +1,79 @@
+use futures::{try_ready, Future, Poll};
+
+pub trait ResponseMap<Rsp> {
+    type Response;
+
+    fn map_response(&self, rsp: Rsp) -> Self::Response;
+}
+
+#[derive(Clone, Debug)]
+pub struct MapResponseLayer<R>(R);
+
+#[derive(Clone, Debug)]
+pub struct MapResponse<S, R> {
+    inner: S,
+    response_map: R,
+}
+
+impl<R> MapResponseLayer<R> {
+    pub fn new(response_map: R) -> Self {
+        MapResponseLayer(response_map)
+    }
+}
+
+impl<S, R: Clone> tower::layer::Layer<S> for MapResponseLayer<R> {
+    type Service = MapResponse<S, R>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Self::Service {
+            inner,
+            response_map: self.0.clone(),
+        }
+    }
+}
+
+impl<T, S, R> tower::Service<T> for MapResponse<S, R>
+where
+    S: tower::Service<T>,
+    R: ResponseMap<S::Response> + Clone,
+{
+    type Response = R::Response;
+    type Error = S::Error;
+    type Future = MapResponse<S::Future, R>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.inner.poll_ready()
+    }
+
+    fn call(&mut self, req: T) -> Self::Future {
+        MapResponse {
+            inner: self.inner.call(req),
+            response_map: self.response_map.clone(),
+        }
+    }
+}
+
+impl<F, R> Future for MapResponse<F, R>
+where
+    F: Future,
+    R: ResponseMap<F::Item>,
+{
+    type Item = R::Response;
+    type Error = F::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let rsp = try_ready!(self.inner.poll());
+        Ok(self.response_map.map_response(rsp).into())
+    }
+}
+
+impl<T, U, F> ResponseMap<T> for F
+where
+    F: Fn(T) -> U,
+{
+    type Response = U;
+
+    fn map_response(&self, rsp: T) -> Self::Response {
+        (self)(rsp)
+    }
+}


### PR DESCRIPTION
The inbound client may never initiate a TLS connection, but we use a TLS
middleware to ensure the underlying transport is boxed. The BoxedIo type
enforces shutdown semantics differently than the raw TcpStream, and we
rely on this behavior in TCP forwarding.

This change introduces a stack::map_response middleware; and replaces
use of the inbound TLS client with a layer that boxes transports.