### PR TITLE
outbound: Relax type constraints in require_identity_on_endpoint

### DIFF
--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -43,6 +43,7 @@ mod orig_proto_upgrade;
 mod require_identity_on_endpoint;
 
 pub use self::endpoint::Endpoint;
+use self::require_identity_on_endpoint::MakeRequireIdentityLayer;
 
 const EWMA_DEFAULT_RTT: Duration = Duration::from_millis(30);
 const EWMA_DECAY: Duration = Duration::from_secs(10);
@@ -163,7 +164,7 @@ impl<A: OrigDstAddr> Config<A> {
                 .push(
                     metrics.http_endpoint.into_layer::<classify::Response>()
                 )
-                .push(require_identity_on_endpoint::layer())
+                .push(MakeRequireIdentityLayer::new())
                 .instrument(|endpoint: &Endpoint| {
                     info_span!("endpoint", peer.addr = %endpoint.addr, peer.id = ?endpoint.identity)
                 })

--- a/linkerd/app/outbound/src/require_identity_on_endpoint.rs
+++ b/linkerd/app/outbound/src/require_identity_on_endpoint.rs
@@ -80,10 +80,6 @@ where
 
     fn call(&mut self, target: T) -> Self::Future {
         // After the inner service is made, we want to wrap that service
-        // with a filter that compares the target's `peer_identity` and
-        // `l5d_require_id` header if present
-
-        // After the inner service is made, we want to wrap that service
         // with a service that checks for the presence of the
         // `l5d-require-id` header. If is present then assert it is the
         // endpoint identity; otherwise fail the request.


### PR DESCRIPTION
Makes the naming uniform with newer stack modules and relaxes type
constraints to avoid capturing body types in the Layer (i.e. so the
layer can be used across stacks of varying body types).