### PR TITLE
app: Use locks with controller clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ dependencies = [
  "linkerd2-exp-backoff",
  "linkerd2-http-classify",
  "linkerd2-http-metrics",
+ "linkerd2-lock",
  "linkerd2-metrics",
  "linkerd2-opencensus",
  "linkerd2-proxy-api",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -30,6 +30,7 @@ linkerd2-error-respond = { path = "../../error-respond" }
 linkerd2-exp-backoff = { path = "../../exp-backoff" }
 linkerd2-http-classify = { path = "../../http-classify" }
 linkerd2-http-metrics = { path = "../../http-metrics" }
+linkerd2-lock = { path = "../../lock" }
 linkerd2-metrics = { path = "../../metrics" }
 linkerd2-opencensus = { path = "../../opencensus" }
 linkerd2-proxy-core = { path = "../../proxy/core" }

--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -57,11 +57,7 @@ impl Config {
                     .push_on_response(proxy::grpc::req_body_as_payload::layer())
                     .push(control::add_origin::layer())
                     .into_new_service()
-                    .push_on_response(svc::layers().push_buffer(
-                        control.buffer.max_in_flight,
-                        control.buffer.dispatch_timeout,
-                    ))
-                    .into_inner()
+                    .push_on_response(svc::layers().push_lock())
                     .new_service(addr.clone());
 
                 // Save to be spawned on an auxiliary runtime.

--- a/linkerd/app/src/oc_collector.rs
+++ b/linkerd/app/src/oc_collector.rs
@@ -64,11 +64,7 @@ impl Config {
                     .push_on_response(proxy::grpc::req_body_as_payload::layer())
                     .push(control::add_origin::layer())
                     .into_new_service()
-                    .push_on_response(svc::layers().push_buffer(
-                        control.buffer.max_in_flight,
-                        control.buffer.dispatch_timeout,
-                    ))
-                    .into_inner()
+                    .push_on_response(svc::layers().push_lock())
                     .new_service(addr.clone());
 
                 let (span_sink, spans_rx) = mpsc::channel(Self::SPAN_BUFFER_CAPACITY);


### PR DESCRIPTION
In preparation of using the Lock service-sharing strategy more broadly,
this change modifies the identity and tracing collector to use `lock`
for cloneability.

Note that the lock may not yet be used with the destination client, due
to Send/Sync issues.