### PR TITLE
Remove Clone requirement from controller clients

### DIFF
--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -57,7 +57,6 @@ impl Config {
                     .push_on_response(proxy::grpc::req_body_as_payload::layer())
                     .push(control::add_origin::layer())
                     .into_new_service()
-                    .push_on_response(svc::layers().push_lock())
                     .new_service(addr.clone());
 
                 // Save to be spawned on an auxiliary runtime.

--- a/linkerd/app/src/oc_collector.rs
+++ b/linkerd/app/src/oc_collector.rs
@@ -64,7 +64,6 @@ impl Config {
                     .push_on_response(proxy::grpc::req_body_as_payload::layer())
                     .push(control::add_origin::layer())
                     .into_new_service()
-                    .push_on_response(svc::layers().push_lock())
                     .new_service(addr.clone());
 
                 let (span_sink, spans_rx) = mpsc::channel(Self::SPAN_BUFFER_CAPACITY);

--- a/linkerd/proxy/identity/src/certify.rs
+++ b/linkerd/proxy/identity/src/certify.rs
@@ -139,7 +139,7 @@ impl tls::accept::HasConfig for Local {
 
 impl<T> Daemon<T>
 where
-    T: GrpcService<BoxBody> + Clone,
+    T: GrpcService<BoxBody>,
 {
     pub fn new(config: Config, crt_key: CrtKeySender, client: T) -> Self {
         Self {
@@ -154,7 +154,7 @@ where
 
 impl<T> Future for Daemon<T>
 where
-    T: GrpcService<BoxBody> + Clone,
+    T: GrpcService<BoxBody>,
 {
     type Item = ();
     type Error = Never;


### PR DESCRIPTION
`proxy::identity::certify::Daemon` unnecessarily requires that the gRPC
client implements `Clone`, despite there being no such logical
requirement in the implementation.

This change removes the `Clone` requirement and the `Lock` from the
identity client's stack. This change also removes the `Lock` from the
`oc_collector`, as it has no `Clone` requirement.