### PR TITLE
server: Simplify HTTP server type constraints

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -283,7 +283,8 @@ impl<A: OrigDstAddr> Config<A> {
                     span_sink.map(|span_sink| SpanConverter::server(span_sink, trace_labels())),
                 ))
                 .push(metrics.http_handle_time.layer())
-                .check_service::<tls::accept::Meta>();
+                .check_service::<tls::accept::Meta>()
+                .into_new_service();
 
             let forward_tcp = tcp::Forward::new(
                 svc::stack(connect_stack)

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -356,7 +356,8 @@ impl<A: OrigDstAddr> Config<A> {
                 .push_on_response(TraceContextLayer::new(span_sink.map(|span_sink| {
                     SpanConverter::server(span_sink, trace_labels())
                 })))
-                .push(metrics.http_handle_time.layer());
+                .push(metrics.http_handle_time.layer())
+                .into_new_service();
 
             let forward_tcp = tcp::Forward::new(
                 svc::stack(connect_stack)


### PR DESCRIPTION
`proxy::server` accepts a `MakeService` to build an HTTP service for
each connection; but it doesn't properly drive the service before
invoking it (which is a violation of the Service contract, though a
benign one in this instance).

This change uses `stack::NewService` to avoid these readiness concerns.
We also relax unnecessary type constraints.