### PR TITLE
outbound: Set logical address on endpoints

### DIFF
--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -271,7 +271,8 @@ impl MapEndpoint<Concrete<http::Settings>, Metadata> for FromMetadata {
             });
 
         Target {
-            addr: concrete.addr.clone(),
+            // Use the logical addr for the target.
+            addr: concrete.inner.addr.clone(),
             inner: HttpEndpoint {
                 addr,
                 identity,


### PR DESCRIPTION
Our metrics expect the `authority` to be set to the logical address, not
the concrete address (i.e. when TrafficSplit may override the concrete
destination). The concrete service is annotated via endpoint labels.