### PR TITLE
Add protocol detection timeout

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -29,6 +29,7 @@ pub struct ProxyConfig<A: OrigDstAddr = SysOrigDstAddr> {
     pub disable_protocol_detection_for_ports: Arc<IndexSet<u16>>,
     pub dispatch_timeout: Duration,
     pub max_in_flight_requests: usize,
+    pub detect_protocol_timeout: Duration,
 }
 
 #[derive(Clone, Debug)]
@@ -61,6 +62,7 @@ impl<A: OrigDstAddr> ProxyConfig<A> {
             disable_protocol_detection_for_ports: self.disable_protocol_detection_for_ports,
             max_in_flight_requests: self.max_in_flight_requests,
             dispatch_timeout: self.dispatch_timeout,
+            detect_protocol_timeout: self.detect_protocol_timeout,
         }
     }
 }

--- a/linkerd/app/core/src/proxy/server.rs
+++ b/linkerd/app/core/src/proxy/server.rs
@@ -34,6 +34,12 @@ pub struct ProtocolDetect {
     skip_ports: Arc<IndexSet<u16>>,
 }
 
+impl ProtocolDetect {
+    pub fn new(skip_ports: Arc<IndexSet<u16>>) -> Self {
+        ProtocolDetect { skip_ports }
+    }
+}
+
 impl detect::Detect<tls::accept::Meta> for ProtocolDetect {
     type Target = Protocol;
 
@@ -104,20 +110,16 @@ where
         make_http: H,
         h2_settings: H2Settings,
         drain: drain::Watch,
-        skip_ports: Arc<IndexSet<u16>>,
-    ) -> detect::Accept<ProtocolDetect, Self> {
-        detect::Accept::new(
-            ProtocolDetect { skip_ports },
-            Self {
-                http: hyper::server::conn::Http::new(),
-                h2_settings,
-                transport_labels,
-                transport_metrics,
-                forward_tcp,
-                make_http,
-                drain,
-            },
-        )
+    ) -> Self {
+        Self {
+            http: hyper::server::conn::Http::new(),
+            h2_settings,
+            transport_labels,
+            transport_metrics,
+            forward_tcp,
+            make_http,
+            drain,
+        }
     }
 }
 

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -59,6 +59,9 @@ const ENV_INBOUND_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_INBOUND_CONNECT_TIMEOU
 const ENV_OUTBOUND_CONNECT_TIMEOUT: &str = "LINKERD2_PROXY_OUTBOUND_CONNECT_TIMEOUT";
 const ENV_INBOUND_ACCEPT_KEEPALIVE: &str = "LINKERD2_PROXY_INBOUND_ACCEPT_KEEPALIVE";
 const ENV_OUTBOUND_ACCEPT_KEEPALIVE: &str = "LINKERD2_PROXY_OUTBOUND_ACCEPT_KEEPALIVE";
+const ENV_INBOUND_DETECT_PROTOCOL_TIMEOUT: &str = "LINKERD2_PROXY_INBOUND_DETECT_PROTOCOL_TIMEOUT";
+const ENV_OUTBOUND_DETECT_PROTOCOL_TIMEOUT: &str =
+    "LINKERD2_PROXY_OUTBOUND_DETECT_PROTOCOL_TIMEOUT";
 
 const ENV_INBOUND_CONNECT_KEEPALIVE: &str = "LINKERD2_PROXY_INBOUND_CONNECT_KEEPALIVE";
 const ENV_OUTBOUND_CONNECT_KEEPALIVE: &str = "LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE";
@@ -171,6 +174,7 @@ const DEFAULT_INBOUND_CONNECT_BACKOFF: ExponentialBackoff = ExponentialBackoff {
 };
 const DEFAULT_OUTBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(3);
 const DEFAULT_OUTBOUND_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+const DEFAULT_PROTOCOL_DETECT_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_OUTBOUND_CONNECT_BACKOFF: ExponentialBackoff = ExponentialBackoff {
     min: Duration::from_millis(100),
     max: Duration::from_millis(500),
@@ -232,6 +236,14 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
     let inbound_connect_keepalive = parse(strings, ENV_INBOUND_CONNECT_KEEPALIVE, parse_duration);
     let outbound_connect_keepalive = parse(strings, ENV_OUTBOUND_CONNECT_KEEPALIVE, parse_duration);
+
+    let inbound_detect_protocol_timeout =
+        parse(strings, ENV_INBOUND_DETECT_PROTOCOL_TIMEOUT, parse_duration);
+    let outbound_detect_protocol_timeout = parse(
+        strings,
+        ENV_OUTBOUND_DETECT_PROTOCOL_TIMEOUT,
+        parse_duration,
+    );
 
     let inbound_disable_ports = parse(
         strings,
@@ -354,6 +366,8 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                     .unwrap_or(DEFAULT_OUTBOUND_DISPATCH_TIMEOUT),
                 max_in_flight_requests: outbound_max_in_flight?
                     .unwrap_or(DEFAULT_OUTBOUND_MAX_IN_FLIGHT),
+                detect_protocol_timeout: outbound_detect_protocol_timeout?
+                    .unwrap_or(DEFAULT_PROTOCOL_DETECT_TIMEOUT),
             },
         }
     };
@@ -392,6 +406,8 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                     .unwrap_or(DEFAULT_INBOUND_DISPATCH_TIMEOUT),
                 max_in_flight_requests: inbound_max_in_flight?
                     .unwrap_or(DEFAULT_INBOUND_MAX_IN_FLIGHT),
+                detect_protocol_timeout: inbound_detect_protocol_timeout?
+                    .unwrap_or(DEFAULT_PROTOCOL_DETECT_TIMEOUT),
             },
         }
     };


### PR DESCRIPTION
This change changes the protocol detection functionality to be a layer. This allows us to push a timeout on it. The reason for the timeout is that in situations when we have server speaks first protocols, we can hang forever in a "peeking" state. In order to reproduce: 

1. Install Linkerd
2. Create the following config map

```yaml
apiVersion: v1
items:
- apiVersion: v1
  data:
    config-file.cnf: |
      [mysqld]
      port=15800
  kind: ConfigMap
  metadata:
    name: config
    namespace: memtest
kind: List
```
\
3. Add the following resources: https://gist.github.com/zaharidichev/fed5a5d9d7338fc960de478dd90e93ff

4. Inject the mysql and mysql-client deployments.
5. Ssh into the mysql-client container and run a script that periodically connects to the DB: 

```bash
#!/bin/bash
for value in {1..1000000}
do
   echo "Connection" $value
   mysql --port=15800 -h mysql -ppassword -e "SELECT version()" &
   sleep 1
done
```

You can see the proxy memory growing steadily. Here are the results before and after this change: 

![Screenshot 2020-03-24 at 11 43 25](https://user-images.githubusercontent.com/4391506/77412103-1a467a00-6dc6-11ea-818e-5f10a9b37f65.png)
![Screenshot 2020-03-24 at 11 31 43](https://user-images.githubusercontent.com/4391506/77412111-1e729780-6dc6-11ea-867f-5ae8775e1aeb.png)


Fixes https://github.com/linkerd/linkerd2/issues/4069

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>