### PR TITLE
Wire authority override coming from discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.11"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.11#ddf72e619e654b4139f14801b517ba6ed98b5fe3"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/auth_override#75a7b3b2059704ba81917bd1ccb0719d39ec5558"
 dependencies = [
  "bytes",
  "futures",
@@ -1023,6 +1023,7 @@ name = "linkerd2-proxy-api-resolve"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "http",
  "indexmap",
  "linkerd2-identity",
  "linkerd2-proxy-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,8 +1003,8 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.11"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/auth_override#75a7b3b2059704ba81917bd1ccb0719d39ec5558"
+version = "0.1.12"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12#85f24e80f695378928da985bf9d52af747047e10"
 dependencies = [
  "bytes",
  "futures",

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -31,7 +31,7 @@ http = "0.1"
 http-body = "0.1"
 hyper = "0.12"
 linkerd2-metrics = { path = "../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], branch = "zd/auth_override" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.12" }
 net2 = "0.2"
 quickcheck = { version = "0.9", default-features = false }
 ring = "0.16"

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -31,7 +31,7 @@ http = "0.1"
 http-body = "0.1"
 hyper = "0.12"
 linkerd2-metrics = { path = "../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.11" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], branch = "zd/auth_override" }
 net2 = "0.2"
 quickcheck = { version = "0.9", default-features = false }
 ring = "0.16"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -36,7 +36,7 @@ linkerd2-lock = { path = "../../lock" }
 linkerd2-metrics = { path = "../../metrics" }
 linkerd2-opencensus = { path = "../../opencensus" }
 linkerd2-proxy-core = { path = "../../proxy/core" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.11" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
 linkerd2-proxy-api-resolve = { path = "../../proxy/api-resolve" }
 linkerd2-proxy-detect = { path = "../../proxy/detect" }
 linkerd2-proxy-discover = { path = "../../proxy/discover" }
@@ -82,6 +82,6 @@ procinfo = "0.4.2"
 
 [dev-dependencies]
 linkerd2-test-util = { path = "../../test-util" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.11" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
 prost-types = "0.5.0"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -36,7 +36,7 @@ linkerd2-lock = { path = "../../lock" }
 linkerd2-metrics = { path = "../../metrics" }
 linkerd2-opencensus = { path = "../../opencensus" }
 linkerd2-proxy-core = { path = "../../proxy/core" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.12" }
 linkerd2-proxy-api-resolve = { path = "../../proxy/api-resolve" }
 linkerd2-proxy-detect = { path = "../../proxy/detect" }
 linkerd2-proxy-discover = { path = "../../proxy/discover" }
@@ -82,6 +82,6 @@ procinfo = "0.4.2"
 
 [dev-dependencies]
 linkerd2-test-util = { path = "../../test-util" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.12" }
 prost-types = "0.5.0"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -26,7 +26,7 @@ linkerd2-app = { path = ".." }
 linkerd2-app-core = { path = "../core" }
 linkerd2-metrics = { path = "../../metrics", features = ["test_util"] }
 linkerd2-test-util = { path = "../../test-util" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.11" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], branch = "zd/auth_override" }
 regex = "0.1"
 net2 = "0.2"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -26,7 +26,7 @@ linkerd2-app = { path = ".." }
 linkerd2-app-core = { path = "../core" }
 linkerd2-metrics = { path = "../../metrics", features = ["test_util"] }
 linkerd2-test-util = { path = "../../test-util" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], branch = "zd/auth_override" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.12" }
 regex = "0.1"
 net2 = "0.2"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -11,9 +11,10 @@ Implements the Resolve trait using the proxy's gRPC API
 [dependencies]
 futures = "0.1"
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.11" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
 linkerd2-proxy-core = { path = "../core" }
 prost = "0.5.0"
+http = "0.1"
 tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 indexmap = "1.0"
 tokio-sync = "0.1"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -11,7 +11,7 @@ Implements the Resolve trait using the proxy's gRPC API
 [dependencies]
 futures = "0.1"
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.12" }
 linkerd2-proxy-core = { path = "../core" }
 prost = "0.5.0"
 http = "0.1"

--- a/linkerd/proxy/api-resolve/src/metadata.rs
+++ b/linkerd/proxy/api-resolve/src/metadata.rs
@@ -1,4 +1,5 @@
 use crate::identity;
+use http::uri::Authority;
 use indexmap::IndexMap;
 
 /// Metadata describing an endpoint.
@@ -24,6 +25,9 @@ pub struct Metadata {
 
     /// How to verify TLS for the endpoint.
     identity: Option<identity::Name>,
+
+    /// Used to override the the authority if needed
+    authority_override: Option<Authority>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -44,6 +48,7 @@ impl Metadata {
             protocol_hint: ProtocolHint::Unknown,
             identity: None,
             weight: 10_000,
+            authority_override: None,
         }
     }
 
@@ -52,12 +57,14 @@ impl Metadata {
         protocol_hint: ProtocolHint,
         identity: Option<identity::Name>,
         weight: u32,
+        authority_override: Option<Authority>,
     ) -> Self {
         Self {
             labels,
             protocol_hint,
             identity,
             weight,
+            authority_override,
         }
     }
 
@@ -72,5 +79,9 @@ impl Metadata {
 
     pub fn identity(&self) -> Option<&identity::Name> {
         self.identity.as_ref()
+    }
+
+    pub fn authority_override(&self) -> Option<&Authority> {
+        self.authority_override.as_ref()
     }
 }

--- a/linkerd/proxy/api-resolve/src/pb.rs
+++ b/linkerd/proxy/api-resolve/src/pb.rs
@@ -64,7 +64,7 @@ pub(in crate) fn to_authority(o: AuthorityOverride) -> Option<Authority> {
     match o.authority_override.parse() {
         Ok(name) => Some(name),
         Err(_) => {
-            tracing::warn!(
+            tracing::debug!(
                 "Ignoring invalid authority override: {}",
                 o.authority_override
             );

--- a/linkerd/proxy/api-resolve/src/pb.rs
+++ b/linkerd/proxy/api-resolve/src/pb.rs
@@ -1,7 +1,10 @@
-use crate::api::destination::{protocol_hint::Protocol, TlsIdentity, WeightedAddr};
+use crate::api::destination::{
+    protocol_hint::Protocol, AuthorityOverride, TlsIdentity, WeightedAddr,
+};
 use crate::api::net::TcpAddress;
 use crate::identity;
 use crate::metadata::{Metadata, ProtocolHint};
+use http::uri::Authority;
 use indexmap::IndexMap;
 use std::{collections::HashMap, net::SocketAddr};
 
@@ -10,6 +13,7 @@ pub(in crate) fn to_addr_meta(
     pb: WeightedAddr,
     set_labels: &HashMap<String, String>,
 ) -> Option<(SocketAddr, Metadata)> {
+    let authority_override = pb.authority_override.and_then(to_authority);
     let addr = pb.addr.and_then(to_sock_addr)?;
 
     let meta = {
@@ -39,7 +43,7 @@ pub(in crate) fn to_addr_meta(
     }
 
     let tls_id = pb.tls_identity.and_then(to_id);
-    let meta = Metadata::new(meta, proto_hint, tls_id, pb.weight);
+    let meta = Metadata::new(meta, proto_hint, tls_id, pb.weight, authority_override);
     Some((addr, meta))
 }
 
@@ -51,6 +55,19 @@ fn to_id(pb: TlsIdentity) -> Option<identity::Name> {
         Ok(i) => Some(i),
         Err(_) => {
             tracing::warn!("Ignoring invalid identity: {}", i.name);
+            None
+        }
+    }
+}
+
+pub(in crate) fn to_authority(o: AuthorityOverride) -> Option<Authority> {
+    match o.authority_override.parse() {
+        Ok(name) => Some(name),
+        Err(_) => {
+            tracing::warn!(
+                "Ignoring invalid authority override: {}",
+                o.authority_override
+            );
             None
         }
     }

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 futures = "0.1"
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.11" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
 linkerd2-proxy-transport = { path = "../transport" }
 tokio = "0.1.14"
 tokio-timer = "0.2"

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 futures = "0.1"
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.12" }
 linkerd2-proxy-transport = { path = "../transport" }
 tokio = "0.1.14"
 tokio-timer = "0.2"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -16,7 +16,7 @@ linkerd2-conditional = { path = "../../conditional" }
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
 linkerd2-proxy-core = { path = "../core" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.11" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
 linkerd2-proxy-http = { path = "../http" }
 linkerd2-proxy-transport = { path = "../transport" }
 linkerd2-stack = { path = "../../stack" }
@@ -29,6 +29,6 @@ tracing = "0.1.9"
 tracing-futures = "0.1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.11" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], branch = "zd/auth_override" }
 prost-types = "0.5.0"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -16,7 +16,7 @@ linkerd2-conditional = { path = "../../conditional" }
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
 linkerd2-proxy-core = { path = "../core" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.12" }
 linkerd2-proxy-http = { path = "../http" }
 linkerd2-proxy-transport = { path = "../transport" }
 linkerd2-stack = { path = "../../stack" }
@@ -29,6 +29,6 @@ tracing = "0.1.9"
 tracing-futures = "0.1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], branch = "zd/auth_override" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.12" }
 prost-types = "0.5.0"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -16,7 +16,7 @@ indexmap = "1.0"
 linkerd2-addr = { path  = "../addr" }
 linkerd2-dns = { path  = "../dns" }
 linkerd2-error = { path  = "../error" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.12" }
 linkerd2-stack = { path  = "../stack" }
 rand = { version = "0.7", features = ["small_rng"] }
 regex = "1.0.0"
@@ -29,6 +29,6 @@ tracing-futures = "0.1"
 
 [dev-dependencies]
 linkerd2-test-util = { path = "../test-util" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], branch = "zd/auth_override" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.12" }
 prost-types = "0.5.0"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -16,7 +16,7 @@ indexmap = "1.0"
 linkerd2-addr = { path  = "../addr" }
 linkerd2-dns = { path  = "../dns" }
 linkerd2-error = { path  = "../error" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.11" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "zd/auth_override" }
 linkerd2-stack = { path  = "../stack" }
 rand = { version = "0.7", features = ["small_rng"] }
 regex = "1.0.0"
@@ -29,6 +29,6 @@ tracing-futures = "0.1"
 
 [dev-dependencies]
 linkerd2-test-util = { path = "../test-util" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.11" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], branch = "zd/auth_override" }
 prost-types = "0.5.0"
 quickcheck = { version = "0.9", default-features = false }


### PR DESCRIPTION
This PR uses the latest changes to the proxy-api and consumes the authority override data, adding to the `Metadata` struct

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>