### PR TITLE
Add Labels from a path as oc-collector attributes

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -457,10 +457,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             let labels = oc_labels_file_path
                 .map(|path| match path {
                     Some(path) => oc_trace_labels(path),
-                    None => {
-                        warn!("env variable {} not present", ENV_LABELS_FILE_PATH);
-                        HashMap::new()
-                    }
+                    None => HashMap::new(),
                 })
                 .unwrap_or_default();
 

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -462,13 +462,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                         HashMap::new()
                     }
                 })
-                .unwrap_or_else(|err| {
-                    warn!(
-                        "could not read env variable {}: {}",
-                        ENV_LABELS_FILE_PATH, err
-                    );
-                    HashMap::new()
-                });
+                .unwrap_or_default();
 
             oc_collector::Config::Enabled {
                 labels,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -284,7 +284,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let hostname = strings.get(ENV_HOSTNAME);
 
     let f = fs::read_to_string(LABELS_FILE_PATH);
-    let labels = convert_labels_to_map(f.unwrap_or_default());
+    let labels = f.ok().map(convert_labels_to_map);
 
     let trace_collector_addr = if id_disabled {
         parse_control_addr_disable_identity(strings, ENV_TRACE_COLLECTOR_SVC_BASE)
@@ -455,7 +455,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 outbound.proxy.connect.clone()
             };
             oc_collector::Config::Enabled {
-                labels: Some(labels),
+                labels: labels.unwrap_or_default(),
                 hostname: hostname?,
                 control: ControlConfig {
                     addr,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -459,7 +459,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 outbound.proxy.connect.clone()
             };
             oc_collector::Config::Enabled {
-                labels: labels?,
+                labels: labels.unwrap_or_default(),
                 hostname: hostname?,
                 control: ControlConfig {
                     addr,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -1022,7 +1022,7 @@ mod tests {
 
     #[test]
     fn convert_labels_to_map_different_values() {
-        let labels_string = "cluster=\"test-cluster1\"\nrack=\"rack-22\nzone=us-est-coast\n
+        let labels_string = "cluster=\"test-cluster1\"\nrack=\"rack-22\nzone=us-est-coast\nlinkerd.io/control-plane-component=\"controller\"\nlinkerd.io/proxy-deployment=\"linkerd-controller\"\nworkload=\nkind=\"\"\n
         "
         .to_string();
 
@@ -1030,6 +1030,16 @@ mod tests {
             ("cluster".to_string(), "test-cluster1".to_string()),
             ("rack".to_string(), "rack-22".to_string()),
             ("zone".to_string(), "us-est-coast".to_string()),
+            (
+                "linkerd.io/control-plane-component".to_string(),
+                "controller".to_string(),
+            ),
+            (
+                "linkerd.io/proxy-deployment".to_string(),
+                "linkerd-controller".to_string(),
+            ),
+            ("workload".to_string(), "".to_string()),
+            ("kind".to_string(), "".to_string()),
         ]
         .iter()
         .cloned()

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -128,7 +128,6 @@ pub const ENV_IDENTITY_SVC_BASE: &str = "LINKERD2_PROXY_IDENTITY_SVC";
 pub const ENV_DESTINATION_SVC_BASE: &str = "LINKERD2_PROXY_DESTINATION_SVC";
 
 pub const ENV_HOSTNAME: &str = "HOSTNAME";
-pub const ENV_NAMESPACE: &str = "_pod_ns";
 
 pub const ENV_TRACE_COLLECTOR_SVC_BASE: &str = "LINKERD2_PROXY_TRACE_COLLECTOR_SVC";
 
@@ -283,7 +282,6 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     };
 
     let hostname = strings.get(ENV_HOSTNAME);
-    let namespace = strings.get(ENV_NAMESPACE);
 
     let oc_labels_file_path = strings.get(ENV_LABELS_FILE_PATH);
 
@@ -455,20 +453,8 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             } else {
                 outbound.proxy.connect.clone()
             };
-
-            // Add any extra Labels, that are not present in the labels file
-            let mut labels: HashMap<String, String> = [(
-                "namespace".to_string(),
-                namespace.unwrap_or_default().unwrap_or_default(),
-            )]
-            .iter()
-            .cloned()
-            .collect();
-
-            labels.extend(oc_trace_labels(oc_labels_file_path));
-
             oc_collector::Config::Enabled {
-                labels: labels,
+                labels: oc_trace_labels(oc_labels_file_path),
                 hostname: hostname?,
                 control: ControlConfig {
                     addr,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -7,6 +7,7 @@ use crate::core::{
 };
 use crate::{dns, identity, inbound, oc_collector, outbound};
 use indexmap::IndexSet;
+use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::iter::FromIterator;
 use std::net::SocketAddr;
@@ -14,7 +15,6 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Duration;
 use std::{fmt, fs};
-use std::collections::HashMap;
 use tracing::{error, warn};
 
 /// The strings used to build a configuration.
@@ -507,11 +507,14 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     })
 }
 
-fn convert_string_to_map(labels :String) -> HashMap<String, String> {
-    let mut labels_map: HashMap<String,String> = HashMap::new();
+fn convert_string_to_map(labels: String) -> HashMap<String, String> {
+    let mut labels_map: HashMap<String, String> = HashMap::new();
     for line in labels.lines() {
         let label = line.split("=").collect::<Vec<&str>>();
-        labels_map.insert(label[0].to_string(), label[1][1..label[1].len()-1].to_string());
+        labels_map.insert(
+            label[0].to_string(),
+            label[1][1..label[1].len() - 1].to_string(),
+        );
     }
     labels_map
 }

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -128,6 +128,7 @@ pub const ENV_IDENTITY_SVC_BASE: &str = "LINKERD2_PROXY_IDENTITY_SVC";
 pub const ENV_DESTINATION_SVC_BASE: &str = "LINKERD2_PROXY_DESTINATION_SVC";
 
 pub const ENV_HOSTNAME: &str = "HOSTNAME";
+pub const ENV_NAMESPACE: &str = "_pod_ns";
 
 pub const ENV_TRACE_COLLECTOR_SVC_BASE: &str = "LINKERD2_PROXY_TRACE_COLLECTOR_SVC";
 
@@ -282,6 +283,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     };
 
     let hostname = strings.get(ENV_HOSTNAME);
+    let namespace = strings.get(ENV_NAMESPACE);
 
     let oc_labels_file_path = strings.get(ENV_LABELS_FILE_PATH);
 
@@ -453,8 +455,20 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             } else {
                 outbound.proxy.connect.clone()
             };
+
+            // Add any extra Labels, that are not present in the labels file
+            let mut labels: HashMap<String, String> = [(
+                "namespace".to_string(),
+                namespace.unwrap_or_default().unwrap_or_default(),
+            )]
+            .iter()
+            .cloned()
+            .collect();
+
+            labels.extend(oc_trace_labels(oc_labels_file_path));
+
             oc_collector::Config::Enabled {
-                labels: oc_trace_labels(oc_labels_file_path),
+                labels: labels,
                 hostname: hostname?,
                 control: ControlConfig {
                     addr,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -1026,7 +1026,7 @@ mod tests {
 
     #[test]
     fn convert_labels_to_map_different_values() {
-        let labels_string = "cluster=\"test-cluster1\"\nrack=\"rack-22\nzone=us-est-coast\nlinkerd.io/control-plane-component=\"controller\"\nlinkerd.io/proxy-deployment=\"linkerd-controller\"\nworkload=\nkind=\"\"\n
+        let labels_string = "cluster=\"test-cluster1\"\nrack=\"rack-22\nzone=us-est-coast\nlinkerd.io/control-plane-component=\"controller\"\nlinkerd.io/proxy-deployment=\"linkerd-controller\"\nworkload=\nkind=\"\"\nkey1=\"=\"\nkey2==value2\nkey3\n=key4\n
         "
         .to_string();
 
@@ -1044,6 +1044,9 @@ mod tests {
             ),
             ("workload".to_string(), "".to_string()),
             ("kind".to_string(), "".to_string()),
+            ("key1".to_string(), "=".to_string()),
+            ("key2".to_string(), "=value2".to_string()),
+            ("".to_string(), "key4".to_string()),
         ]
         .iter()
         .cloned()

--- a/linkerd/app/src/oc_collector.rs
+++ b/linkerd/app/src/oc_collector.rs
@@ -17,7 +17,7 @@ pub enum Config {
     Disabled,
     Enabled {
         control: ControlConfig,
-        labels: HashMap<String, String>,
+        attributes: HashMap<String, String>,
         hostname: Option<String>,
     },
 }
@@ -50,7 +50,7 @@ impl Config {
             Config::Enabled {
                 control,
                 hostname,
-                labels,
+                attributes,
             } => {
                 let addr = control.addr;
                 let svc = svc::connect(control.connect.keepalive)
@@ -85,7 +85,7 @@ impl Config {
                         service_info: Some(oc::ServiceInfo {
                             name: Self::SERVICE_NAME.to_string(),
                         }),
-                        attributes: labels,
+                        attributes,
                         ..oc::Node::default()
                     };
 

--- a/linkerd/app/src/oc_collector.rs
+++ b/linkerd/app/src/oc_collector.rs
@@ -17,7 +17,7 @@ pub enum Config {
     Disabled,
     Enabled {
         control: ControlConfig,
-        labels: Option<HashMap<String, String>>,
+        labels: HashMap<String, String>,
         hostname: Option<String>,
     },
 }
@@ -85,7 +85,7 @@ impl Config {
                         service_info: Some(oc::ServiceInfo {
                             name: Self::SERVICE_NAME.to_string(),
                         }),
-                        attributes: labels.unwrap_or_default(),
+                        attributes: labels,
                         ..oc::Node::default()
                     };
 

--- a/linkerd/app/src/oc_collector.rs
+++ b/linkerd/app/src/oc_collector.rs
@@ -8,10 +8,7 @@ use linkerd2_app_core::{
     Error,
 };
 use linkerd2_opencensus::{metrics, proto, SpanExporter};
-use std::{
-    time::SystemTime,
-    collections::HashMap
-};
+use std::{collections::HashMap, time::SystemTime};
 use tokio::sync::mpsc;
 use tracing::debug;
 
@@ -20,7 +17,7 @@ pub enum Config {
     Disabled,
     Enabled {
         control: ControlConfig,
-        labels: Option<HashMap<String,String>>,
+        labels: Option<HashMap<String, String>>,
         hostname: Option<String>,
     },
 }
@@ -50,7 +47,11 @@ impl Config {
     ) -> Result<OcCollector, Error> {
         match self {
             Config::Disabled => Ok(OcCollector::Disabled),
-            Config::Enabled { control, hostname, labels } => {
+            Config::Enabled {
+                control,
+                hostname,
+                labels,
+            } => {
                 let addr = control.addr;
                 let svc = svc::connect(control.connect.keepalive)
                     .push(tls::ConnectLayer::new(identity))


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/4008

This PR makes the proxy read file present at `/var/run/linkerd/podinfo/labels` and convert it into a `HashMap` and use those labels as attributes for spans/traces. 

https://github.com/linkerd/linkerd2/pull/4199 updates the control-plane helm charts to mount pod labels as file to the proxy coontainer [using downwardAPI](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/)

With these changes, Traces would have pod labels as attributes, Allowing us to directly link jager dashboard links from the Linkerd dashboard (like we do with Grafana), part of https://github.com/linkerd/linkerd2/pull/4177 . This was not possible previously because we didn't have a way to know the distinguish traces based on `workloadKind` and `workloadName`

![Screenshot_2020-03-25 Jaeger UI](https://user-images.githubusercontent.com/7892868/77521340-89949a80-6ea8-11ea-9a94-0ceb5ec6c8c4.png)
![image](https://user-images.githubusercontent.com/7892868/77521373-974a2000-6ea8-11ea-947e-0d54e215688d.png)



P.S: This is my first take in Rust and the proxy, Sorry if there are any mistakes :) 
Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>