### PR TITLE
Time out protocol detect futures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,7 +1043,6 @@ dependencies = [
  "linkerd2-error",
  "tokio",
  "tower",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ dependencies = [
  "linkerd2-error",
  "tokio",
  "tower",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,6 +1193,7 @@ dependencies = [
  "linkerd2-io",
  "linkerd2-metrics",
  "linkerd2-proxy-core",
+ "linkerd2-stack",
  "ring",
  "rustls",
  "tokio",

--- a/linkerd/app/core/src/admin/mod.rs
+++ b/linkerd/app/core/src/admin/mod.rs
@@ -81,7 +81,7 @@ impl<M: FmtMetrics> Service for Admin<M> {
 impl<M: FmtMetrics + Clone + Send + 'static> svc::Service<Connection> for Accept<M> {
     type Response = Box<dyn Future<Item = (), Error = hyper::error::Error> + Send + 'static>;
     type Error = Error;
-    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
+    type Future = future::FutureResult<Self::Response, Self::Error>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         Ok(().into())
@@ -99,7 +99,7 @@ impl<M: FmtMetrics + Clone + Send + 'static> svc::Service<Connection> for Accept
         });
 
         let connection_future: Self::Response = Box::new(self.1.serve_connection(io, svc));
-        Box::new(future::ok(connection_future))
+        future::ok(connection_future)
     }
 }
 

--- a/linkerd/app/core/src/admin/mod.rs
+++ b/linkerd/app/core/src/admin/mod.rs
@@ -98,7 +98,7 @@ impl<M: FmtMetrics + Clone + Send + 'static> svc::Service<Connection> for Accept
             svc.call(req)
         });
 
-        let connection_future: Self::Response = Box::new(self.1.serve_connection(io, svc));
+        let connection_future = Box::new(self.1.serve_connection(io, svc));
         future::ok(connection_future)
     }
 }

--- a/linkerd/app/core/src/admin/mod.rs
+++ b/linkerd/app/core/src/admin/mod.rs
@@ -8,6 +8,7 @@ use futures::{future, Future, Poll};
 use http::StatusCode;
 use hyper::service::{service_fn, Service};
 use hyper::{Body, Request, Response};
+use linkerd2_error::Error;
 use linkerd2_metrics::{self as metrics, FmtMetrics};
 use std::io;
 
@@ -78,8 +79,8 @@ impl<M: FmtMetrics> Service for Admin<M> {
 }
 
 impl<M: FmtMetrics + Clone + Send + 'static> svc::Service<Connection> for Accept<M> {
-    type Response = ();
-    type Error = hyper::error::Error;
+    type Response = Box<dyn Future<Item = (), Error = hyper::error::Error> + Send + 'static>;
+    type Error = Error;
     type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
@@ -96,7 +97,9 @@ impl<M: FmtMetrics + Clone + Send + 'static> svc::Service<Connection> for Accept
             req.extensions_mut().insert(ClientAddr(peer));
             svc.call(req)
         });
-        Box::new(self.1.serve_connection(io, svc))
+
+        let connection_future: Self::Response = Box::new(self.1.serve_connection(io, svc));
+        Box::new(future::ok(connection_future))
     }
 }
 

--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -29,6 +29,7 @@ pub struct ProxyConfig {
     pub disable_protocol_detection_for_ports: Arc<IndexSet<u16>>,
     pub dispatch_timeout: Duration,
     pub max_in_flight_requests: usize,
+    pub detect_protocol_timeout: Duration,
 }
 
 #[derive(Clone, Debug)]

--- a/linkerd/app/core/src/proxy/server.rs
+++ b/linkerd/app/core/src/proxy/server.rs
@@ -34,6 +34,12 @@ pub struct ProtocolDetect {
     skip_ports: Arc<IndexSet<u16>>,
 }
 
+impl ProtocolDetect {
+    pub fn new(skip_ports: Arc<IndexSet<u16>>) -> Self {
+        ProtocolDetect { skip_ports }
+    }
+}
+
 impl detect::Detect<tls::accept::Meta> for ProtocolDetect {
     type Target = Protocol;
 
@@ -104,20 +110,16 @@ where
         make_http: H,
         h2_settings: H2Settings,
         drain: drain::Watch,
-        skip_ports: Arc<IndexSet<u16>>,
-    ) -> detect::Accept<ProtocolDetect, Self> {
-        detect::Accept::new(
-            ProtocolDetect { skip_ports },
-            Self {
-                http: hyper::server::conn::Http::new(),
-                h2_settings,
-                transport_labels,
-                transport_metrics,
-                forward_tcp,
-                make_http,
-                drain,
-            },
-        )
+    ) -> Self {
+        Self {
+            http: hyper::server::conn::Http::new(),
+            h2_settings,
+            transport_labels,
+            transport_metrics,
+            forward_tcp,
+            make_http,
+            drain,
+        }
     }
 }
 

--- a/linkerd/app/core/src/proxy/server.rs
+++ b/linkerd/app/core/src/proxy/server.rs
@@ -168,7 +168,9 @@ where
                     .clone()
                     .into_service()
                     .oneshot((proto.tls, io))
-                    .map(|conn| Box::new(drain.watch(conn, |_| {}).map_err(Into::into)) as Self::Response);
+                    .map(|conn| {
+                        Box::new(drain.watch(conn, |_| {}).map_err(Into::into)) as Self::Response
+                    });
 
                 return Box::new(fwd.map_err(Into::into));
             }

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -49,6 +49,7 @@ where
     A: Accept<L::Connection>,
     A::Error: 'static,
     A::Future: Send + 'static,
+    A::ConnectionError: 'static,
     A::ConnectionFuture: Send + 'static,
 {
     fn new(listen: L, accept: A) -> Self {
@@ -72,7 +73,8 @@ where
     L::Connection: HasSpan,
     A: Accept<L::Connection>,
     A::Future: Send + 'static,
-    A::Error: Into<Error> + Send + 'static,
+    A::Error: Send + 'static,
+    A::ConnectionError: 'static,
     A::ConnectionFuture: Send + 'static,
 {
     type Item = ();

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -23,8 +23,10 @@ where
     L::Connection: HasSpan,
     L::Error: std::error::Error + Send + 'static,
     A: Accept<L::Connection> + Send + 'static,
-    A::Error: 'static,
+    A::Error: Send + 'static,
     A::Future: Send + 'static,
+    A::Error: Into<Error>,
+    A::ConnectionFuture: Send + 'static,
 {
     // As soon as we get a shutdown signal, the listener task completes and
     // stops accepting new connections.
@@ -47,6 +49,7 @@ where
     A: Accept<L::Connection>,
     A::Error: 'static,
     A::Future: Send + 'static,
+    A::ConnectionFuture: Send + 'static,
 {
     fn new(listen: L, accept: A) -> Self {
         let exec = tokio::executor::DefaultExecutor::current().in_current_span();
@@ -69,7 +72,8 @@ where
     L::Connection: HasSpan,
     A: Accept<L::Connection>,
     A::Future: Send + 'static,
-    A::Error: 'static,
+    A::Error: Into<Error> + Send + 'static,
+    A::ConnectionFuture: Send + 'static,
 {
     type Item = ();
     type Error = Error;
@@ -88,7 +92,7 @@ struct TraceAccept<A> {
 }
 
 impl<C: HasSpan, A: Accept<C>> tower::Service<C> for TraceAccept<A> {
-    type Response = ();
+    type Response = A::ConnectionFuture;
     type Error = A::Error;
     type Future = Instrumented<A::Future>;
 

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -281,11 +281,14 @@ impl Config {
                 .push(DetectProtocolLayer::new(ProtocolDetect::new(
                     disable_protocol_detection_for_ports.clone(),
                 )))
-                // Terminate inbound mTLS from other outbound proxies.
+                // Terminates inbound mTLS from other outbound proxies.
                 .push(tls::AcceptTls::layer(
                     local_identity,
                     disable_protocol_detection_for_ports,
                 ))
+                // Limits the amount of time that the TCP server spends waiting for TLS handshake &
+                // protocol detection. Ensures that connections that never emit data are dropped
+                // eventually.
                 .push_timeout(detect_protocol_timeout);
 
             info!(listen.addr = %listen.listen_addr(), "Serving");

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -430,13 +430,16 @@ impl Config {
                 .push(DetectProtocolLayer::new(ProtocolDetect::new(
                     disable_protocol_detection_for_ports.clone(),
                 )))
+                // The local application never establishes mTLS with the proxy, so don't try to
+                // terminate TLS, just annotate with the connection with the reason.
                 .push(tls::AcceptTls::layer(
                     no_tls,
                     disable_protocol_detection_for_ports,
                 ))
+                // Limits the amount of time that the TCP server spends waiting for protocol
+                // detection. Ensures that connections that never emit data are dropped eventually.
                 .push_timeout(detect_protocol_timeout);
 
-            // The local application does not establish mTLS with the proxy.
             serve::serve(listen, tcp_detect.into_inner(), drain)
         }));
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -17,8 +17,8 @@ use linkerd2_app_core::{
     opencensus::proto::trace::v1 as oc,
     profiles,
     proxy::{
-        self, core::resolve::Resolve, discover, http, identity, resolve::map_endpoint, tap, tcp,
-        Server,
+        self, core::resolve::Resolve, detect::DetectProtocolLayer, discover, http, identity,
+        resolve::map_endpoint, server::ProtocolDetect, tap, tcp, Server,
     },
     reconnect, retry, router, serve,
     spans::SpanConverter,
@@ -93,6 +93,7 @@ impl Config {
                     disable_protocol_detection_for_ports,
                     dispatch_timeout,
                     max_in_flight_requests,
+                    detect_protocol_timeout,
                 },
         } = self;
 
@@ -420,16 +421,23 @@ impl Config {
                 http_server.into_inner(),
                 h2_settings,
                 drain.clone(),
-                disable_protocol_detection_for_ports.clone(),
             );
 
-            // The local application does not establish mTLS with the proxy.
             let no_tls: tls::Conditional<identity::Local> =
                 Conditional::None(tls::ReasonForNoPeerName::Loopback.into());
-            let accept = tls::AcceptTls::new(no_tls, tcp_server)
-                .with_skip_ports(disable_protocol_detection_for_ports);
 
-            serve::serve(listen, accept, drain)
+            let tcp_detect = svc::stack(tcp_server)
+                .push(DetectProtocolLayer::new(ProtocolDetect::new(
+                    disable_protocol_detection_for_ports.clone(),
+                )))
+                .push(tls::AcceptTls::layer(
+                    no_tls,
+                    disable_protocol_detection_for_ports,
+                ))
+                .push_timeout(detect_protocol_timeout);
+
+            // The local application does not establish mTLS with the proxy.
+            serve::serve(listen, tcp_detect.into_inner(), drain)
         }));
 
         Ok(Outbound { listen_addr, serve })

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -377,6 +377,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             )?,
             h2_settings,
         };
+
+        let dispatch_timeout =
+            outbound_dispatch_timeout?.unwrap_or(DEFAULT_OUTBOUND_DISPATCH_TIMEOUT);
+
         outbound::Config {
             canonicalize_timeout: dns_canonicalize_timeout?
                 .unwrap_or(DEFAULT_DNS_CANONICALIZE_TIMEOUT),
@@ -389,10 +393,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 cache_max_idle_age: outbound_cache_max_idle_age?
                     .unwrap_or(DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE),
                 buffer_capacity,
-                dispatch_timeout: outbound_dispatch_timeout?
-                    .unwrap_or(DEFAULT_OUTBOUND_DISPATCH_TIMEOUT),
+                dispatch_timeout,
                 max_in_flight_requests: outbound_max_in_flight?
                     .unwrap_or(DEFAULT_OUTBOUND_MAX_IN_FLIGHT),
+                detect_protocol_timeout: dispatch_timeout,
             },
         }
     };
@@ -417,6 +421,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             )?,
             h2_settings,
         };
+
+        let dispatch_timeout =
+            inbound_dispatch_timeout?.unwrap_or(DEFAULT_INBOUND_DISPATCH_TIMEOUT);
+
         inbound::Config {
             proxy: ProxyConfig {
                 server,
@@ -427,10 +435,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 cache_max_idle_age: inbound_cache_max_idle_age?
                     .unwrap_or(DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE),
                 buffer_capacity,
-                dispatch_timeout: inbound_dispatch_timeout?
-                    .unwrap_or(DEFAULT_INBOUND_DISPATCH_TIMEOUT),
+                dispatch_timeout,
                 max_in_flight_requests: inbound_max_in_flight?
                     .unwrap_or(DEFAULT_INBOUND_MAX_IN_FLIGHT),
+                detect_protocol_timeout: dispatch_timeout,
             },
         }
     };

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -13,4 +13,3 @@ futures = "0.1"
 linkerd2-error = { path = "../../error" }
 tokio = "0.1"
 tower = "0.1"
-tracing = "0.1"

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -13,3 +13,4 @@ futures = "0.1"
 linkerd2-error = { path = "../../error" }
 tokio = "0.1"
 tower = "0.1"
+tracing = "0.1"

--- a/linkerd/proxy/core/src/listen.rs
+++ b/linkerd/proxy/core/src/listen.rs
@@ -36,8 +36,10 @@ pub trait Listen {
 
 /// Handles an accepted connection.
 pub trait Accept<C> {
+    type ConnectionError: Into<Error>;
+    type ConnectionFuture: Future<Item = (), Error = Self::ConnectionError>;
     type Error: Into<Error>;
-    type Future: Future<Item = (), Error = Self::Error>;
+    type Future: Future<Item = Self::ConnectionFuture, Error = Self::Error>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error>;
 
@@ -54,11 +56,15 @@ pub trait Accept<C> {
 #[derive(Clone, Debug)]
 pub struct AcceptService<S>(S);
 
-impl<C, S> Accept<C> for S
+impl<C, S, E> Accept<C> for S
 where
-    S: Service<C, Response = ()>,
+    E: Into<Error>,
+    S: Service<C>,
+    S::Response: Future<Item = (), Error = E>,
     S::Error: Into<Error>,
 {
+    type ConnectionError = E;
+    type ConnectionFuture = S::Response;
     type Error = S::Error;
     type Future = S::Future;
 
@@ -72,7 +78,7 @@ where
 }
 
 impl<C, S: Accept<C>> Service<C> for AcceptService<S> {
-    type Response = ();
+    type Response = S::ConnectionFuture;
     type Error = S::Error;
     type Future = S::Future;
 
@@ -94,7 +100,7 @@ pub struct Serve<L, A, E> {
 impl<L, A> Serve<L, A, tokio::executor::DefaultExecutor>
 where
     L: Listen,
-    A: Accept<L::Connection, Error = Never>,
+    A: Accept<L::Connection>,
     A::Future: Send + 'static,
 {
     pub fn with_executor<E: tokio::executor::Executor>(self, executor: E) -> Serve<L, A, E> {
@@ -109,7 +115,10 @@ where
 impl<L, A, E> Future for Serve<L, A, E>
 where
     L: Listen,
-    A: Accept<L::Connection, Error = Never>,
+    A: Accept<L::Connection>,
+    A::Error: Into<Error>,
+    A::ConnectionFuture: Send + 'static,
+    A::ConnectionError: Into<Error>,
     A::Future: Send + 'static,
     E: tokio::executor::Executor,
 {
@@ -118,10 +127,14 @@ where
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         loop {
-            try_ready!(self.accept.poll_ready());
+            try_ready!(self.accept.poll_ready().map_err(Into::into));
             let conn = try_ready!(self.listen.poll_accept().map_err(Into::into));
-            let accept = self.accept.accept(conn).map_err(|e| match e {});
-            self.executor.spawn(Box::new(accept)).map_err(Error::from)?;
+            let accept = self.accept.accept(conn).map_err(|_| {});
+            self.executor
+                .spawn(Box::new(
+                    accept.and_then(|conn_future| conn_future.map_err(|_| {})),
+                ))
+                .map_err(Error::from)?;
         }
     }
 }

--- a/linkerd/proxy/detect/src/lib.rs
+++ b/linkerd/proxy/detect/src/lib.rs
@@ -66,8 +66,9 @@ impl<T, D, A> tower::Service<(T, BoxedIo)> for Accept<D, A>
 where
     D: Detect<T>,
     A: core::listen::Accept<(D::Target, BoxedIo)> + Clone,
+    D::Target: std::fmt::Debug,
 {
-    type Response = ();
+    type Response = A::ConnectionFuture;
     type Error = Error;
     type Future = AcceptFuture<T, D, A>;
 
@@ -93,9 +94,10 @@ where
 impl<T, D, A> Future for AcceptFuture<T, D, A>
 where
     D: Detect<T>,
+    D::Target: std::fmt::Debug,
     A: core::listen::Accept<(D::Target, BoxedIo)>,
 {
-    type Item = ();
+    type Item = A::ConnectionFuture;
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {

--- a/linkerd/proxy/tap/src/accept.rs
+++ b/linkerd/proxy/tap/src/accept.rs
@@ -70,19 +70,19 @@ impl Service<Connection> for AcceptPermittedClients {
         match meta.peer_identity {
             Conditional::Some(ref peer) => {
                 if self.permitted_client_ids.contains(peer) {
-                    future::ok::<Self::Response, Self::Error>(self.serve_authenticated(io))
+                    future::ok(self.serve_authenticated(io))
                 } else {
-                    future::ok::<Self::Response, Self::Error>(
+                    future::ok(
                         self.serve_unauthenticated(io, format!("Unauthorized peer: {}", peer)),
                     )
                 }
             }
             Conditional::None(ReasonForNoIdentity::NoPeerName(ReasonForNoPeerName::Loopback)) => {
-                future::ok::<Self::Response, Self::Error>(self.serve_authenticated(io))
+                future::ok(self.serve_authenticated(io))
             }
-            Conditional::None(reason) => future::ok::<Self::Response, Self::Error>(
-                self.serve_unauthenticated(io, reason.to_string()),
-            ),
+            Conditional::None(reason) => {
+                future::ok(self.serve_unauthenticated(io, reason.to_string()))
+            }
         }
     }
 }

--- a/linkerd/proxy/tap/src/accept.rs
+++ b/linkerd/proxy/tap/src/accept.rs
@@ -67,23 +67,19 @@ impl Service<Connection> for AcceptPermittedClients {
     }
 
     fn call(&mut self, (meta, io): Connection) -> Self::Future {
-        match meta.peer_identity {
+        future::ok(match meta.peer_identity {
             Conditional::Some(ref peer) => {
                 if self.permitted_client_ids.contains(peer) {
-                    future::ok(self.serve_authenticated(io))
+                    self.serve_authenticated(io)
                 } else {
-                    future::ok(
-                        self.serve_unauthenticated(io, format!("Unauthorized peer: {}", peer)),
-                    )
+                    self.serve_unauthenticated(io, format!("Unauthorized peer: {}", peer))
                 }
             }
             Conditional::None(ReasonForNoIdentity::NoPeerName(ReasonForNoPeerName::Loopback)) => {
-                future::ok(self.serve_authenticated(io))
+                self.serve_authenticated(io)
             }
-            Conditional::None(reason) => {
-                future::ok(self.serve_unauthenticated(io, reason.to_string()))
-            }
-        }
+            Conditional::None(reason) => self.serve_unauthenticated(io, reason.to_string()),
+        })
     }
 }
 

--- a/linkerd/proxy/tcp/src/forward.rs
+++ b/linkerd/proxy/tcp/src/forward.rs
@@ -42,7 +42,7 @@ where
     }
 
     fn call(&mut self, (meta, io): (T, I)) -> Self::Future {
-        futures::future::ok::<Self::Response, Error>(ForwardFuture::Connect {
+        futures::future::ok(ForwardFuture::Connect {
             io: Some(io),
             connect: self.connect.call(meta),
         })

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -24,6 +24,7 @@ linkerd2-identity = { path = "../../identity" }
 linkerd2-io = { path = "../../io" }
 linkerd2-metrics = { path = "../../metrics" }
 linkerd2-proxy-core = { path = "../core" }
+linkerd2-stack = { path = "../../stack" }
 ring = "0.16"
 rustls = "0.16"
 tokio = "0.1.14"

--- a/linkerd/proxy/transport/src/tls/accept.rs
+++ b/linkerd/proxy/transport/src/tls/accept.rs
@@ -87,7 +87,7 @@ where
     A: Accept<Connection> + Clone,
     T: HasConfig + Send + 'static,
 {
-    type Response = ();
+    type Response = A::ConnectionFuture;
     type Error = Error;
     type Future = AcceptFuture<A>;
 
@@ -144,7 +144,7 @@ where
 }
 
 impl<A: Accept<Connection>> Future for AcceptFuture<A> {
-    type Item = ();
+    type Item = A::ConnectionFuture;
     type Error = Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {


### PR DESCRIPTION
This PR changes the Accept trait to return a Future<Item = Future<()>>. The inner future is the one driving the connection while the outer future represents work such as protocol detect. This allows us to time out the outer future independently of the inner one. Additionally a timeout has been introduced to guard against serve first connections that do not run on a standard for the protocol port hanging and causing memory issues.

Fixes linkerd/linkerd2#4069

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>