### PR TITLE
http-metrics: Make latency export optional

### DIFF
--- a/linkerd/http-metrics/src/lib.rs
+++ b/linkerd/http-metrics/src/lib.rs
@@ -26,12 +26,16 @@ where
 {
     prefix: &'static str,
     registry: Arc<Mutex<Registry<T, M>>>,
+    /// The amount time metrics with no updates should be retained for reports
     retain_idle: Duration,
+    /// Whether latencies should be reported.
+    include_latencies: bool,
 }
 
 impl<T: Hash + Eq, M> Clone for Report<T, M> {
     fn clone(&self) -> Self {
         Self {
+            include_latencies: self.include_latencies,
             prefix: self.prefix.clone(),
             registry: self.registry.clone(),
             retain_idle: self.retain_idle,
@@ -82,6 +86,7 @@ where
             prefix: "",
             registry,
             retain_idle,
+            include_latencies: true,
         }
     }
 
@@ -91,6 +96,13 @@ where
         }
 
         Self { prefix, ..self }
+    }
+
+    pub fn without_latencies(self) -> Self {
+        Self {
+            include_latencies: false,
+            ..self
+        }
     }
 
     fn prefix_key<N: fmt::Display>(&self, name: N) -> Prefixed<'_, N> {

--- a/linkerd/http-metrics/src/requests/report.rs
+++ b/linkerd/http-metrics/src/requests/report.rs
@@ -49,8 +49,9 @@ where
             Ok(r) => r,
         };
         trace!(
-            prfefix = %self.prefix,
-            targets = %registry.by_target.len(),
+            prefix = self.prefix,
+            targets = registry.by_target.len(),
+            include_latencies = self.include_latencies,
             "Formatting HTTP request metrics",
         );
 
@@ -62,9 +63,11 @@ where
         metric.fmt_help(f)?;
         registry.fmt_by_target(f, metric, |s| &s.total)?;
 
-        let metric = self.response_latency_ms();
-        metric.fmt_help(f)?;
-        registry.fmt_by_status(f, metric, |s| &s.latency)?;
+        if self.include_latencies {
+            let metric = self.response_latency_ms();
+            metric.fmt_help(f)?;
+            registry.fmt_by_status(f, metric, |s| &s.latency)?;
+        }
 
         let metric = self.response_total();
         metric.fmt_help(f)?;


### PR DESCRIPTION
We export raw histograms for all HTTP metrics layers; but in some cases
these values are never consumed. This change modifies the http metrics
`Report` type to support disabling export of latencies.

This feature is not used yet but will be used in a follow-up.

---

We can revisit how to skip recording as well, but in order to address https://github.com/linkerd/linkerd2/issues/4215 expediently, I think addressing this only on the report-side is a good stopgap.