### PR TITLE
Restore the route_actual_response_total metric

### DIFF
--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -263,6 +263,7 @@ impl Config {
 
             let http_profile_route_proxy = svc::proxies()
                 .check_new_clone_service::<dst::Route>()
+                .push(metrics.http_route_actual.into_layer::<classify::Response>())
                 // Sets an optional retry policy.
                 .push(retry::layer(metrics.http_route_retry))
                 .check_new_clone_service::<dst::Route>()

--- a/linkerd/app/src/metrics.rs
+++ b/linkerd/app/src/metrics.rs
@@ -48,7 +48,7 @@ impl Metrics {
                 .clone()
                 .into_report(retain_idle)
                 .with_prefix("route_actual");
-            (m, r)
+            (m, r.without_latencies())
         };
 
         let http_errors = errors::Metrics::default();

--- a/linkerd/http-metrics/src/lib.rs
+++ b/linkerd/http-metrics/src/lib.rs
@@ -26,12 +26,16 @@ where
 {
     prefix: &'static str,
     registry: Arc<Mutex<Registry<T, M>>>,
+    /// The amount time metrics with no updates should be retained for reports
     retain_idle: Duration,
+    /// Whether latencies should be reported.
+    include_latencies: bool,
 }
 
 impl<T: Hash + Eq, M> Clone for Report<T, M> {
     fn clone(&self) -> Self {
         Self {
+            include_latencies: self.include_latencies,
             prefix: self.prefix.clone(),
             registry: self.registry.clone(),
             retain_idle: self.retain_idle,
@@ -82,6 +86,7 @@ where
             prefix: "",
             registry,
             retain_idle,
+            include_latencies: true,
         }
     }
 
@@ -91,6 +96,13 @@ where
         }
 
         Self { prefix, ..self }
+    }
+
+    pub fn without_latencies(self) -> Self {
+        Self {
+            include_latencies: false,
+            ..self
+        }
     }
 
     fn prefix_key<N: fmt::Display>(&self, name: N) -> Prefixed<'_, N> {

--- a/linkerd/http-metrics/src/requests/report.rs
+++ b/linkerd/http-metrics/src/requests/report.rs
@@ -49,8 +49,9 @@ where
             Ok(r) => r,
         };
         trace!(
-            prfefix = %self.prefix,
-            targets = %registry.by_target.len(),
+            prefix = self.prefix,
+            targets = registry.by_target.len(),
+            include_latencies = self.include_latencies,
             "Formatting HTTP request metrics",
         );
 
@@ -62,9 +63,11 @@ where
         metric.fmt_help(f)?;
         registry.fmt_by_target(f, metric, |s| &s.total)?;
 
-        let metric = self.response_latency_ms();
-        metric.fmt_help(f)?;
-        registry.fmt_by_status(f, metric, |s| &s.latency)?;
+        if self.include_latencies {
+            let metric = self.response_latency_ms();
+            metric.fmt_help(f)?;
+            registry.fmt_by_status(f, metric, |s| &s.latency)?;
+        }
 
         let metric = self.response_total();
         metric.fmt_help(f)?;


### PR DESCRIPTION
339efa8 incorrectly removed the route_actual metrics scope from the
outbound stack. This change restores these metrics but omits latency
buckets from export.

Fixes linkerd/linkerd2#4215