### PR TITLE
Add liveness endpoint to admin server

### DIFF
--- a/linkerd/app/core/src/admin/mod.rs
+++ b/linkerd/app/core/src/admin/mod.rs
@@ -59,6 +59,13 @@ impl<M: FmtMetrics> Admin<M> {
                 .expect("builder with known status code must not fail")
         }
     }
+
+    fn live_rsp(&self) -> Response<Body> {
+        Response::builder()
+            .status(StatusCode::OK)
+            .body("live\n".into())
+            .expect("builder with known status code must not fail")
+    }
 }
 
 impl<M: FmtMetrics> Service for Admin<M> {
@@ -72,6 +79,7 @@ impl<M: FmtMetrics> Service for Admin<M> {
             "/metrics" => Box::new(self.metrics.call(req)),
             "/proxy-log-level" => self.trace_level.call(req),
             "/ready" => Box::new(future::ok(self.ready_rsp())),
+            "/live" => Box::new(future::ok(self.live_rsp())),
             _ => Box::new(future::ok(rsp(StatusCode::NOT_FOUND, Body::empty()))),
         }
     }


### PR DESCRIPTION
Relates to https://github.com/linkerd/linkerd2/issues/3984

Add a `/live` endpoint to the admin server which always returns a 200 success.  This can be used for liveness checking.

Signed-off-by: Alex Leong <alex@buoyant.io>