### PR TITLE
docker: Use buildkit for caching

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,5 +21,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Docker
-        if: github.event.pull_request.head.repo.fork
         run: DOCKER_UNOPTIMIZED=1 make docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,10 +15,50 @@ on:
       - "Cargo.lock"
       - "Dockerfile"
 
+env:
+  DOCKER_UNOPTIMIZED: "1"
+
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Docker
-        run: DOCKER_UNOPTIMIZED=1 make docker
+
+      # Create a build image on a Linkerd build host.
+      - name: Setup (Origin)
+        if: "!github.event.pull_request.head.repo.fork"
+        run: |
+          mkdir -p ~/.ssh
+          # Create an identity file and protect before writing contents to it.
+          touch ~/.ssh/id && chmod 600 ~/.ssh/id
+          echo "${{ secrets.DOCKER_PRIVATE_KEY }}" >~/.ssh/id
+          # Use well-known public keys for the host to prevent middlemen.
+          echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" >~/.ssh/known_hosts
+          # Configure host with ServerAliveInterval to ensure that the client
+          # stays alive even when the server is busy emitting nothing.
+          # ServerAliveCountMax ensures that server responds to these pings
+          # within ~5 minutes.
+          (
+            echo "Host linkerd-docker"
+            echo "    User github"
+            echo "    Hostname ${{ secrets.DOCKER_ADDRESS }}"
+            echo "    IdentityFile ~/.ssh/id"
+            echo "    BatchMode yes"
+            echo "    ServerAliveInterval 60"
+            echo "    ServerAliveCountMax 5"
+          ) >~/.ssh/config
+          # Confirm that the SSH configuration works.
+          ssh linkerd-docker docker version
+
+      - name: Docker (Origin)
+        if: "!github.event.pull_request.head.repo.fork"
+        env:
+          DOCKER_HOST: "ssh://linkerd-docker"
+        run: |
+          export DOCKER_TAG="proxy-ci:$(dd bs=64 count=1 if=/dev/urandom status=none | tr -dc 'a-zA-Z0-9')"
+          make docker
+          docker image rm -f "$DOCKER_TAG"
+
+      - name: Docker (Fork)
+        if: github.event.pull_request.head.repo.fork
+        run: make docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ name: Docker
 
 # This workflow is temporarily disabled, as the current Dockerfile requires
 # experimental features.
-on: {}
+on: { push: [] }
 #   push:
 #     branches:
 #     - master
@@ -24,43 +24,43 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    # Create a build image on a Linkerd build host.
-    - name: Setup (Origin)
-      if: '!github.event.pull_request.head.repo.fork'
-      run: |
-        mkdir -p ~/.ssh
-        # Create an identity file and protect before writing contents to it.
-        touch ~/.ssh/id && chmod 600 ~/.ssh/id
-        echo "${{ secrets.DOCKER_PRIVATE_KEY }}" >~/.ssh/id
-        # Use well-known public keys for the host to prevent middlemen.
-        echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" >~/.ssh/known_hosts
-        # Configure host with ServerAliveInterval to ensure that the client
-        # stays alive even when the server is busy emitting nothing.
-        # ServerAliveCountMax ensures that server responds to these pings
-        # within ~5 minutes.
-        (
-          echo "Host linkerd-docker"
-          echo "    User github"
-          echo "    Hostname ${{ secrets.DOCKER_ADDRESS }}"
-          echo "    IdentityFile ~/.ssh/id"
-          echo "    BatchMode yes"
-          echo "    ServerAliveInterval 60"
-          echo "    ServerAliveCountMax 5"
-        ) >~/.ssh/config
-        # Confirm that the SSH configuration works.
-        ssh linkerd-docker docker version
+      # Create a build image on a Linkerd build host.
+      - name: Setup (Origin)
+        if: "!github.event.pull_request.head.repo.fork"
+        run: |
+          mkdir -p ~/.ssh
+          # Create an identity file and protect before writing contents to it.
+          touch ~/.ssh/id && chmod 600 ~/.ssh/id
+          echo "${{ secrets.DOCKER_PRIVATE_KEY }}" >~/.ssh/id
+          # Use well-known public keys for the host to prevent middlemen.
+          echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" >~/.ssh/known_hosts
+          # Configure host with ServerAliveInterval to ensure that the client
+          # stays alive even when the server is busy emitting nothing.
+          # ServerAliveCountMax ensures that server responds to these pings
+          # within ~5 minutes.
+          (
+            echo "Host linkerd-docker"
+            echo "    User github"
+            echo "    Hostname ${{ secrets.DOCKER_ADDRESS }}"
+            echo "    IdentityFile ~/.ssh/id"
+            echo "    BatchMode yes"
+            echo "    ServerAliveInterval 60"
+            echo "    ServerAliveCountMax 5"
+          ) >~/.ssh/config
+          # Confirm that the SSH configuration works.
+          ssh linkerd-docker docker version
 
-    - name: Docker (Origin)
-      if: '!github.event.pull_request.head.repo.fork'
-      env:
-        DOCKER_HOST: "ssh://linkerd-docker"
-      run: |
-        export DOCKER_TAG="proxy-ci:$(dd bs=64 count=1 if=/dev/urandom status=none | tr -dc 'a-zA-Z0-9')"
-        make docker
-        docker image rm -f "$DOCKER_TAG"
+      - name: Docker (Origin)
+        if: "!github.event.pull_request.head.repo.fork"
+        env:
+          DOCKER_HOST: "ssh://linkerd-docker"
+        run: |
+          export DOCKER_TAG="proxy-ci:$(dd bs=64 count=1 if=/dev/urandom status=none | tr -dc 'a-zA-Z0-9')"
+          make docker
+          docker image rm -f "$DOCKER_TAG"
 
-    - name: Docker (Fork)
-      if: github.event.pull_request.head.repo.fork
-      run: make docker
+      - name: Docker (Fork)
+        if: github.event.pull_request.head.repo.fork
+        run: make docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,17 +3,19 @@
 # The resulting Docker image is discarded.
 name: Docker
 
-on:
-  push:
-    branches:
-    - master
-    paths:
-    - 'Cargo.lock'
-    - 'Dockerfile'
-  pull_request:
-    paths:
-    - 'Cargo.lock'
-    - 'Dockerfile'
+# This workflow is temporarily disabled, as the current Dockerfile requires
+# experimental features.
+on: {}
+#   push:
+#     branches:
+#     - master
+#     paths:
+#     - 'Cargo.lock'
+#     - 'Dockerfile'
+#   pull_request:
+#     paths:
+#     - 'Cargo.lock'
+#     - 'Dockerfile'
 
 env:
   DOCKER_UNOPTIMIZED: "1"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,64 +3,23 @@
 # The resulting Docker image is discarded.
 name: Docker
 
-# This workflow is temporarily disabled, as the current Dockerfile requires
-# experimental features.
-on: { push: [] }
-#   push:
-#     branches:
-#     - master
-#     paths:
-#     - 'Cargo.lock'
-#     - 'Dockerfile'
-#   pull_request:
-#     paths:
-#     - 'Cargo.lock'
-#     - 'Dockerfile'
-
-env:
-  DOCKER_UNOPTIMIZED: "1"
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Cargo.lock"
+      - "Dockerfile"
+  pull_request:
+    paths:
+      - "Cargo.lock"
+      - "Dockerfile"
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-
-      # Create a build image on a Linkerd build host.
-      - name: Setup (Origin)
-        if: "!github.event.pull_request.head.repo.fork"
-        run: |
-          mkdir -p ~/.ssh
-          # Create an identity file and protect before writing contents to it.
-          touch ~/.ssh/id && chmod 600 ~/.ssh/id
-          echo "${{ secrets.DOCKER_PRIVATE_KEY }}" >~/.ssh/id
-          # Use well-known public keys for the host to prevent middlemen.
-          echo "${{ secrets.DOCKER_KNOWN_HOSTS }}" >~/.ssh/known_hosts
-          # Configure host with ServerAliveInterval to ensure that the client
-          # stays alive even when the server is busy emitting nothing.
-          # ServerAliveCountMax ensures that server responds to these pings
-          # within ~5 minutes.
-          (
-            echo "Host linkerd-docker"
-            echo "    User github"
-            echo "    Hostname ${{ secrets.DOCKER_ADDRESS }}"
-            echo "    IdentityFile ~/.ssh/id"
-            echo "    BatchMode yes"
-            echo "    ServerAliveInterval 60"
-            echo "    ServerAliveCountMax 5"
-          ) >~/.ssh/config
-          # Confirm that the SSH configuration works.
-          ssh linkerd-docker docker version
-
-      - name: Docker (Origin)
-        if: "!github.event.pull_request.head.repo.fork"
-        env:
-          DOCKER_HOST: "ssh://linkerd-docker"
-        run: |
-          export DOCKER_TAG="proxy-ci:$(dd bs=64 count=1 if=/dev/urandom status=none | tr -dc 'a-zA-Z0-9')"
-          make docker
-          docker image rm -f "$DOCKER_TAG"
-
-      - name: Docker (Fork)
+      - name: Docker
         if: github.event.pull_request.head.repo.fork
-        run: make docker
+        run: DOCKER_UNOPTIMIZED=1 make docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,54 @@
+# syntax=docker/dockerfile:experimental
+
 # Proxy build and runtime
 #
 # This is intended **DEVELOPMENT ONLY**, i.e. so that proxy developers can
 # easily test the proxy in the context of the larger `linkerd2` project.
 #
-# When PROXY_UNOPTIMIZED is set and not empty, unoptimized rust artifacts are produced.
-# This reduces build time and produces binaries with debug symbols, at the expense of
-# runtime performance.
+# This Dockerfile requires expirmental features to be enabled in both the
+# Docker client and daemon. You MUST use buildkit to build this image. The
+# simplest way to do this is to set the `DOCKER_BUILDKIT` environment variable:
+#
+#     :; DOCKER_BUILDKIT=1 docker build .
+#
+# Alternatively, you can use `buildx`, which supports more complicated build
+# configurations:
+#
+#     :; docker buildx build . --load
 
-# rather than updating this manually, run update-rust-version.sh
+# Please make changes via update-rust-version.sh
 ARG RUST_IMAGE=rust:1.41.0-buster
-ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-20.2.2
+
+# Use an arbitrary ~recent edge release image to get the proxy
+# identity-initializing wrapper.
+ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-20.4.1
+
+# When set, causes the proxy to be compiled in development mode.
 ARG PROXY_UNOPTIMIZED
 
-## Builds the proxy as incrementally as possible.
+# Controls what features are enabled in the proxy. This is typically empty but
+# may be set to `mock-orig-dst` for profiling builds.
+ARG PROXY_FEATURES
+
+# Build the proxy, leveraging (new, experimental) cache mounting.
+#
+# See: https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/experimental.md#run---mounttypecache
 FROM $RUST_IMAGE as build
-
 WORKDIR /usr/src/linkerd2-proxy
-
 COPY . .
-RUN cargo fetch --locked
-RUN if [ -n "$PROXY_UNOPTIMIZED" ]; \
-    then \
-    cargo build -p linkerd2-proxy --bin linkerd2-proxy --frozen && \
-    mv target/debug/linkerd2-proxy target/linkerd2-proxy ; \
+RUN --mount=type=cache,target=target \
+    --mount=type=cache,from=rust:1.41.0-buster,source=/usr/local/cargo,target=/usr/local/cargo \
+    mkdir -p /out && \
+    if [ -n "$PROXY_UNOPTIMIZED" ]; then \
+      (cd linkerd2-proxy && cargo build --locked --features="$PROXY_FEATURES") && \
+      mv target/debug/linkerd2-proxy /out/linkerd2-proxy ; \
     else \
-    cargo build -p linkerd2-proxy --bin linkerd2-proxy --frozen --release && \
-    mv target/release/linkerd2-proxy target/linkerd2-proxy ; \
+      (cd linkerd2-proxy && cargo build --locked --release --features="$PROXY_FEATURES") && \
+      mv target/release/linkerd2-proxy /out/linkerd2-proxy ; \
     fi
-
 
 ## Install the proxy binary into the base runtime image.
 FROM $RUNTIME_IMAGE as runtime
 WORKDIR /linkerd
-COPY --from=build /usr/src/linkerd2-proxy/target/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy
+COPY --from=build /out/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy
 ENV LINKERD2_PROXY_LOG=warn,linkerd2_proxy=info

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ RUN --mount=type=cache,target=target \
 FROM $RUNTIME_IMAGE as runtime
 WORKDIR /linkerd
 COPY --from=build /out/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy
-ENV LINKERD2_PROXY_LOG=warn,linkerd2_proxy=info
+ENV LINKERD2_PROXY_LOG=warn,linkerd=info

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ clean-profile:
 
 .PHONY: docker
 docker: Dockerfile Cargo.lock
-	$(DOCKER_BUILD) .
+	DOCKER_BUILDKIT=1 $(DOCKER_BUILD) .
 
 .PHONY: all
 all: build test

--- a/update-rust-version.sh
+++ b/update-rust-version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
 

--- a/update-rust-version.sh
+++ b/update-rust-version.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -eu
 
@@ -7,10 +7,14 @@ if [ $# -ne 1 ]; then
     exit 64
 fi
 
-VERSION=$1
+VERSION="$1"
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' ; then
+    echo "Expected M.N.P; got '$VERSION'" >&2
+    exit 64
+fi
 
 echo "$VERSION" > rust-toolchain
-sed -i'' -e "s/RUST_IMAGE=.*/RUST_IMAGE=rust:$VERSION-buster/" Dockerfile
+sed -i'' -Ee "s/rust:[0-9]+\.[0-9]+\.[0-9]+/rust:$VERSION/" Dockerfile
 
 find .github -name \*.yml \
-    -exec sed -i'' -e "s|docker://rust:.*|docker://rust:$VERSION-buster|" '{}' \;
+    -exec sed -i'' -Ee "s|docker://rust:[0-9]+\.[0-9]+\.[0-9]+|docker://rust:$VERSION|" '{}' \;


### PR DESCRIPTION
Our docker builds do not permit caching of dependencies or intermediate
build artifacts. However, Docker's new (experimental) buildkit features
add this functionality. I've been using this configuration locally for
some time, and it seems generaly useful enough to promote (especially
since this Dockerfile is only intended for development).

This change also untroduces the `PROXY_FEATURES` build-arg so that the
Dockerfile can be used to support profiling builds.

Furthermore, the `update-rust-versions.sh` script has been updated to
check versions and be more permissive about how it replaces versions in
the Dockerfile.

--

@linkerd/proxy-maintainers please verify that you're able to use this workflow, as documented in the Dockerfile.