### PR TITLE
prepare to update the proxy to use std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 dependencies = [
- "memchr 2.0.1",
+ "memchr 2.3.3",
 ]
 
 [[package]]
@@ -349,10 +349,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62941eff9507c8177d448bd83a44d9b9760856e184081d8cd79ba9f03dd24981"
 
 [[package]]
-name = "futures-core"
-version = "0.3.1"
+name = "futures"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79564c427afefab1dfb3298535b21eda083ef7935b4f0ecbfcb121f0aec10866"
+checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
 
 [[package]]
 name = "futures-cpupool"
@@ -360,33 +385,68 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "num_cpus",
 ]
 
 [[package]]
-name = "futures-sink"
-version = "0.3.1"
+name = "futures-executor"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171be33efae63c2d59e6dbba34186fe0d6394fb378069a76dfd80fdcffd43c16"
+checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.1",
+ "quote 1.0.2",
+ "syn 1.0.5",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bae52d6b29cf440e298856fec3965ee6fa71b06aa7495178615953fd669e5f9"
+checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
 
 [[package]]
 name = "futures-util"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0d66274fb76985d3c62c886d1da7ac4c0903a8c9f754e8fe0f35a6a6cc39e76"
+checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
 dependencies = [
- "futures",
+ "futures 0.1.26",
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr 2.3.3",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
  "slab",
 ]
 
@@ -420,7 +480,7 @@ dependencies = [
  "byteorder",
  "bytes 0.4.11",
  "fnv",
- "futures",
+ "futures 0.1.26",
  "http",
  "indexmap",
  "log",
@@ -472,7 +532,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "http",
  "tokio-buf",
 ]
@@ -490,7 +550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "898a87371a3999b2f731b9af636cd76aa20de10e69c2daf3e71388326b619fe0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "futures-cpupool",
  "h2",
  "http",
@@ -517,7 +577,7 @@ dependencies = [
 name = "hyper-balance"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "http",
  "hyper",
  "tower-load",
@@ -638,7 +698,8 @@ name = "linkerd2-app"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
+ "futures 0.3.4",
  "h2",
  "http",
  "http-body",
@@ -657,6 +718,8 @@ dependencies = [
  "ring",
  "rustls",
  "tokio 0.1.22",
+ "tokio 0.2.13",
+ "tokio-compat",
  "tokio-connect",
  "tokio-current-thread",
  "tokio-io",
@@ -673,7 +736,8 @@ name = "linkerd2-app-core"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
+ "futures 0.3.4",
  "http",
  "hyper",
  "indexmap",
@@ -743,7 +807,7 @@ name = "linkerd2-app-inbound"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "http",
  "indexmap",
  "linkerd2-app-core",
@@ -761,7 +825,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
  "flate2",
- "futures",
+ "futures 0.1.26",
  "h2",
  "http",
  "http-body",
@@ -794,7 +858,7 @@ name = "linkerd2-app-outbound"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "http",
  "indexmap",
  "linkerd2-app-core",
@@ -818,7 +882,7 @@ dependencies = [
 name = "linkerd2-box"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "tower",
 ]
@@ -827,7 +891,7 @@ dependencies = [
 name = "linkerd2-buffer"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "tokio 0.1.22",
  "tower",
@@ -840,7 +904,7 @@ dependencies = [
 name = "linkerd2-cache"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "linkerd2-lock",
  "linkerd2-stack",
@@ -854,7 +918,7 @@ dependencies = [
 name = "linkerd2-concurrency-limit"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "tokio-sync",
  "tower",
@@ -869,7 +933,7 @@ version = "0.1.0"
 name = "linkerd2-dns"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-dns-name",
  "linkerd2-stack",
  "tower",
@@ -890,7 +954,7 @@ dependencies = [
 name = "linkerd2-drain"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
 ]
 
@@ -899,7 +963,7 @@ name = "linkerd2-duplex"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "tokio 0.1.22",
  "tracing",
 ]
@@ -908,14 +972,14 @@ dependencies = [
 name = "linkerd2-error"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
 ]
 
 [[package]]
 name = "linkerd2-error-metrics"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "indexmap",
  "linkerd2-metrics",
  "tower",
@@ -925,7 +989,7 @@ dependencies = [
 name = "linkerd2-error-respond"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "tower",
 ]
@@ -934,7 +998,7 @@ dependencies = [
 name = "linkerd2-exp-backoff"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "quickcheck",
  "rand 0.7.2",
  "tokio-timer",
@@ -945,7 +1009,7 @@ name = "linkerd2-http-box"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "http",
  "hyper",
  "linkerd2-error",
@@ -956,7 +1020,7 @@ dependencies = [
 name = "linkerd2-http-classify"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "http",
  "linkerd2-error",
  "linkerd2-stack",
@@ -968,7 +1032,7 @@ name = "linkerd2-http-metrics"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "h2",
  "http",
  "http-body",
@@ -1002,7 +1066,7 @@ name = "linkerd2-io"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "tokio 0.1.22",
  "tokio-rustls",
 ]
@@ -1011,7 +1075,7 @@ dependencies = [
 name = "linkerd2-lock"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "rand 0.7.2",
  "tokio 0.1.22",
@@ -1027,7 +1091,7 @@ name = "linkerd2-metrics"
 version = "0.1.0"
 dependencies = [
  "deflate",
- "futures",
+ "futures 0.1.26",
  "http",
  "hyper",
  "indexmap",
@@ -1039,7 +1103,7 @@ dependencies = [
 name = "linkerd2-opencensus"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "linkerd2-metrics",
  "opencensus-proto",
@@ -1052,7 +1116,7 @@ dependencies = [
 name = "linkerd2-proxy"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-app",
  "linkerd2-signal",
  "tokio-compat",
@@ -1065,7 +1129,7 @@ version = "0.1.12"
 source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12#85f24e80f695378928da985bf9d52af747047e10"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "h2",
  "http",
  "prost",
@@ -1080,7 +1144,7 @@ dependencies = [
 name = "linkerd2-proxy-api-resolve"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "http",
  "indexmap",
  "linkerd2-identity",
@@ -1097,7 +1161,7 @@ dependencies = [
 name = "linkerd2-proxy-core"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "tokio 0.1.22",
  "tower",
@@ -1107,7 +1171,7 @@ dependencies = [
 name = "linkerd2-proxy-detect"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "linkerd2-io",
  "linkerd2-proxy-core",
@@ -1119,7 +1183,7 @@ dependencies = [
 name = "linkerd2-proxy-discover"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "indexmap",
  "linkerd2-error",
  "linkerd2-proxy-core",
@@ -1135,7 +1199,7 @@ name = "linkerd2-proxy-http"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "h2",
  "http",
  "http-body",
@@ -1171,7 +1235,7 @@ dependencies = [
 name = "linkerd2-proxy-identity"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "linkerd2-identity",
  "linkerd2-proxy-api",
@@ -1186,7 +1250,7 @@ dependencies = [
 name = "linkerd2-proxy-resolve"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "indexmap",
  "linkerd2-error",
  "linkerd2-proxy-core",
@@ -1200,7 +1264,7 @@ name = "linkerd2-proxy-tap"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "http",
  "hyper",
  "indexmap",
@@ -1228,7 +1292,7 @@ dependencies = [
 name = "linkerd2-proxy-tcp"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-duplex",
  "linkerd2-error",
  "tokio 0.1.22",
@@ -1240,7 +1304,7 @@ name = "linkerd2-proxy-transport"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "indexmap",
  "libc",
  "linkerd2-conditional",
@@ -1266,7 +1330,7 @@ dependencies = [
 name = "linkerd2-reconnect"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "tower",
  "tracing",
@@ -1276,7 +1340,7 @@ dependencies = [
 name = "linkerd2-request-filter"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tower",
  "tracing",
 ]
@@ -1286,7 +1350,7 @@ name = "linkerd2-retry"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "linkerd2-stack",
  "tower",
@@ -1298,7 +1362,7 @@ dependencies = [
 name = "linkerd2-router"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "linkerd2-stack",
  "tokio-compat",
@@ -1312,7 +1376,7 @@ name = "linkerd2-service-profiles"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "http",
  "indexmap",
  "linkerd2-addr",
@@ -1337,7 +1401,7 @@ dependencies = [
 name = "linkerd2-signal"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-signal",
  "tracing",
 ]
@@ -1346,7 +1410,7 @@ dependencies = [
 name = "linkerd2-stack"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "tower",
 ]
@@ -1355,7 +1419,7 @@ dependencies = [
 name = "linkerd2-stack-metrics"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "indexmap",
  "linkerd2-metrics",
  "tokio 0.1.22",
@@ -1369,7 +1433,7 @@ dependencies = [
 name = "linkerd2-stack-tracing"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "linkerd2-stack",
  "tower",
@@ -1381,7 +1445,7 @@ dependencies = [
 name = "linkerd2-test-util"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio 0.1.22",
  "tokio-compat",
 ]
@@ -1390,7 +1454,7 @@ dependencies = [
 name = "linkerd2-timeout"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "linkerd2-error",
  "linkerd2-stack",
  "tokio 0.1.22",
@@ -1407,7 +1471,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "hex",
  "http",
  "linkerd2-error",
@@ -1469,12 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.0.1"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
-dependencies = [
- "libc",
-]
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memoffset"
@@ -1584,7 +1645,7 @@ version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
- "memchr 2.0.1",
+ "memchr 2.3.3",
  "version_check",
 ]
 
@@ -1626,7 +1687,7 @@ name = "opencensus-proto"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "prost",
  "prost-types",
  "tower-grpc",
@@ -1675,6 +1736,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7804a463a8d9572f13453c516a5faea534a2403d7ced2f0c7e100eeff072772c"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
+dependencies = [
+ "proc-macro2 1.0.1",
+ "quote 1.0.2",
+ "syn 1.0.5",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +1772,18 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
 
 [[package]]
 name = "proc-macro2"
@@ -1997,7 +2090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
 dependencies = [
  "aho-corasick 0.6.4",
- "memchr 2.0.1",
+ "memchr 2.3.3",
  "regex-syntax 0.6.11",
  "thread_local 0.3.5",
  "utf8-ranges 1.0.0",
@@ -2296,7 +2389,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "mio",
  "num_cpus",
  "tokio-codec",
@@ -2337,7 +2430,7 @@ checksum = "473a45a40e558d6d80e9f60e3d934c32488045def2745488a257e472941e9bce"
 dependencies = [
  "bytes 0.4.11",
  "either",
- "futures",
+ "futures 0.1.26",
 ]
 
 [[package]]
@@ -2347,7 +2440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "tokio-io",
 ]
 
@@ -2357,7 +2450,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ae6e8f0b3bf2c9908bd050ec35598ca71990185e5618fa7a2bbd98771c3e53"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "futures-core",
  "futures-util",
  "pin-project-lite",
@@ -2373,7 +2466,7 @@ name = "tokio-connect"
 version = "0.1.0"
 source = "git+https://github.com/carllerche/tokio-connect#f7ad1ca437973d6e24037ac6f7d5ef1013833c0b"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-io",
 ]
 
@@ -2383,7 +2476,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-executor",
 ]
 
@@ -2394,7 +2487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.26",
 ]
 
 [[package]]
@@ -2403,7 +2496,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-io",
  "tokio-threadpool",
 ]
@@ -2415,7 +2508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "log",
 ]
 
@@ -2426,7 +2519,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.26",
  "lazy_static",
  "log",
  "mio",
@@ -2445,7 +2538,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f0ded5b0b8dbb284cf9464ed0f2912e3e8806553d92f95f5e6944c2b8e989d"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "iovec",
  "rustls",
  "tokio-io",
@@ -2458,7 +2551,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6a5bf935a0151cc8899aa806ce6a425bdaec79ed4034de1a1e6bfa247e2def"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "libc",
  "mio",
  "mio-uds",
@@ -2475,7 +2568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 dependencies = [
  "fnv",
- "futures",
+ "futures 0.1.26",
 ]
 
 [[package]]
@@ -2485,7 +2578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9b094851aadd2caf83ba3ad8e8c4ce65a42104f7b94d9e6550023f0407853f"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "iovec",
  "mio",
  "tokio-io",
@@ -2501,7 +2594,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-queue",
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.26",
  "lazy_static",
  "log",
  "num_cpus",
@@ -2516,7 +2609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.26",
  "slab",
  "tokio-executor",
 ]
@@ -2528,7 +2621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "137bda266504893ac4774e0ec4c2108f7ccdbcb7ac8dced6305fe9e4e0b5041a"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "log",
  "mio",
  "tokio-io",
@@ -2542,7 +2635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
 dependencies = [
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "iovec",
  "libc",
  "log",
@@ -2559,7 +2652,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc72f33b6a72c75c9df0037afce313018bae845f0ec7fdb9201b8768427a917f"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tower-buffer",
  "tower-discover",
  "tower-layer",
@@ -2576,7 +2669,7 @@ name = "tower-balance"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#7e55b7fa0b2db4ff36fd90f3700bd628c89951b6"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "indexmap",
  "rand 0.7.2",
  "slab",
@@ -2597,7 +2690,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c98a7784e6c8ba106bc98d44ed1dbb9c018a8e0322e5e894d365f9020967128"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-executor",
  "tokio-sync",
  "tower-layer",
@@ -2610,7 +2703,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tower-service",
 ]
 
@@ -2622,7 +2715,7 @@ checksum = "839c195fd6e4e87442e7a631ea62632799695a3f897949192325a4e509ff4328"
 dependencies = [
  "base64",
  "bytes 0.4.11",
- "futures",
+ "futures 0.1.26",
  "h2",
  "http",
  "http-body",
@@ -2650,7 +2743,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ddf07e10c07dcc8f41da6de036dc66def1a85b70eb8a385159e3908bb258328"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tower-service",
 ]
 
@@ -2660,7 +2753,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d990c5b6c0e4e192db8cf3dacaafefe1278962d0ec45dc84421175db32d33f0"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-sync",
  "tokio-timer",
  "tower-layer",
@@ -2673,7 +2766,7 @@ name = "tower-load"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#7e55b7fa0b2db4ff36fd90f3700bd628c89951b6"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "log",
  "tokio-timer",
  "tower-discover",
@@ -2686,7 +2779,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04fbaf5bfb63d84204db87b9b2aeec61549613f2bbb8706dcc36f5f3ea8cd769"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tower-layer",
  "tower-service",
 ]
@@ -2696,7 +2789,7 @@ name = "tower-ready-cache"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#7e55b7fa0b2db4ff36fd90f3700bd628c89951b6"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "indexmap",
  "log",
  "tokio-sync",
@@ -2709,7 +2802,7 @@ name = "tower-request-modifier"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower-http#044e0ed5ae8b2e9946233b7cc8fc24471b2d126a"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "http",
  "tower-service",
 ]
@@ -2720,7 +2813,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e80588125061f276ed2a7b0939988b411e570a2dbb2965b1382ef4f71036f7"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-timer",
  "tower-layer",
  "tower-service",
@@ -2732,7 +2825,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cc0c98637d23732f8de6dfd16494c9f1559c3b9e20b4a46462c8f9b9e827bfa"
 dependencies = [
- "futures",
+ "futures 0.1.26",
 ]
 
 [[package]]
@@ -2740,7 +2833,7 @@ name = "tower-spawn-ready"
 version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower#7e55b7fa0b2db4ff36fd90f3700bd628c89951b6"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-executor",
  "tokio-sync",
  "tower-layer",
@@ -2754,7 +2847,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99a0b25036e2c58f681a04a5b312e9283d229445ad5e1221a1b7a4630df6fbdf"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-sync",
  "tower-service",
 ]
@@ -2765,7 +2858,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daa179ec4087589dc67148dc661abce5badc2c3ed4197adc7bd64b39f1f33c31"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-timer",
  "tower-layer",
  "tower-service",
@@ -2777,7 +2870,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4792342fac093db5d2558655055a89a04ca909663467a4310c7739d9f8b64698"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "tokio-io",
  "tower-layer",
  "tower-service",
@@ -2822,7 +2915,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d73cd4d483f6a9af4f9f6da37c1c162e1f99017ba708a3042e6e90e54d26e5c"
 dependencies = [
- "futures",
+ "futures 0.1.26",
+ "pin-project",
  "tokio 0.1.22",
  "tracing",
 ]
@@ -2875,7 +2969,7 @@ source = "git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fdd
 dependencies = [
  "byteorder",
  "failure",
- "futures",
+ "futures 0.1.26",
  "idna",
  "lazy_static",
  "log",
@@ -2898,7 +2992,7 @@ source = "git+https://github.com/bluejekyll/trust-dns?rev=7c8a0739dad495bf5a4fdd
 dependencies = [
  "cfg-if",
  "failure",
- "futures",
+ "futures 0.1.26",
  "ipconfig",
  "lazy_static",
  "log",
@@ -3004,7 +3098,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
- "futures",
+ "futures 0.1.26",
  "log",
  "try-lock",
 ]

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -25,7 +25,10 @@ regex = "1.0.0"
 tokio = "0.1.14"
 tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 tracing = "0.1.9"
-tracing-futures = "0.1"
+tracing-futures = { version = "0.1", features = ["std-future"]}
+futures_03 = { package = "futures", version = "0.3" }
+tokio-compat = "0.1"
+tokio_02 = {package = "tokio", version = "0.2", features = ["rt-util"] }
 
 [dev-dependencies]
 bytes = "0.4"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -73,7 +73,7 @@ tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"
 tracing = "0.1.9"
 tracing-futures = "0.1"
 tracing-log = "0.1"
-
+futures_03 = { package = "futures", version = "0.3", features = ["compat"] }
 [dependencies.tracing-subscriber]
 version = "0.2.1"
 # we don't need `chrono` time formatting

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -7,7 +7,7 @@
 //! - Tap
 //! - Metric labeling
 
-#![deny(warnings, rust_2018_idioms)]
+// #![deny(warnings, rust_2018_idioms)]
 
 pub use linkerd2_addr::{self as addr, Addr, NameAddr};
 pub use linkerd2_cache as cache;

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -3,7 +3,7 @@
 //! The inbound proxy is responsible for terminating traffic from other network
 //! endpoints inbound to the local application.
 
-#![deny(warnings, rust_2018_idioms)]
+// #![deny(warnings, rust_2018_idioms)]
 
 pub use self::endpoint::{
     HttpEndpoint, Profile, ProfileTarget, RequestTarget, Target, TcpEndpoint,
@@ -100,177 +100,182 @@ impl Config {
                 })
                 .push(svc::layer::mk(tcp::Forward::new));
 
-            // Creates HTTP clients for each inbound port & HTTP settings.
-            let http_endpoint = tcp_connect
-                .push(http::MakeClientLayer::new(connect.h2_settings))
-                .push(reconnect::layer({
-                    let backoff = connect.backoff.clone();
-                    move |_| Ok(backoff.stream())
-                }))
-                .push_on_response(
-                    svc::layers()
-                        // If the service has been ready & unused for `cache_max_idle_age`,
-                        // fail it.
-                        .push_idle_timeout(cache_max_idle_age)
-                        // If the service has been unavailable for an extend time, eagerly
-                        // fail requests.
-                        .push_failfast(dispatch_timeout)
-                        // Shares the service, ensuring discovery errors are propagated.
-                        .push_spawn_buffer(buffer_capacity),
-                )
-                .check_service::<HttpEndpoint>();
+            // // Creates HTTP clients for each inbound port & HTTP settings.
+            // let http_endpoint = tcp_connect
+            //     .push(http::MakeClientLayer::new(connect.h2_settings))
+            //     .push(reconnect::layer({
+            //         let backoff = connect.backoff.clone();
+            //         move |_| Ok(backoff.stream())
+            //     }))
+            //     .push_on_response(
+            //         svc::layers()
+            //             // If the service has been ready & unused for `cache_max_idle_age`,
+            //             // fail it.
+            //             .push_idle_timeout(cache_max_idle_age)
+            //             // If the service has been unavailable for an extend time, eagerly
+            //             // fail requests.
+            //             .push_failfast(dispatch_timeout)
+            //             // Shares the service, ensuring discovery errors are propagated.
+            //             .push_spawn_buffer(buffer_capacity),
+            //     )
+            //     .check_service::<HttpEndpoint>();
 
-            let http_target_observability = svc::layers()
-                // Registers the stack to be tapped.
-                .push(tap_layer)
-                // Records metrics for each `Target`.
-                .push(metrics.http_endpoint.into_layer::<classify::Response>())
-                .push_on_response(TraceContextLayer::new(
-                    span_sink
-                        .clone()
-                        .map(|span_sink| SpanConverter::client(span_sink, trace_labels())),
-                ));
+            // let http_target_observability = svc::layers()
+            //     // Registers the stack to be tapped.
+            //     .push(tap_layer)
+            //     // Records metrics for each `Target`.
+            //     .push(metrics.http_endpoint.into_layer::<classify::Response>())
+            //     .push_on_response(TraceContextLayer::new(
+            //         span_sink
+            //             .clone()
+            //             .map(|span_sink| SpanConverter::client(span_sink, trace_labels())),
+            //     ));
 
-            let http_profile_route_proxy = svc::proxies()
-                // Sets the route as a request extension so that it can be used
-                // by tap.
-                .push_http_insert_target()
-                // Records per-route metrics.
-                .push(metrics.http_route.into_layer::<classify::Response>())
-                // Sets the per-route response classifier as a request
-                // extension.
-                .push(classify::Layer::new())
-                .check_new_clone_service::<dst::Route>();
+            // let http_profile_route_proxy = svc::proxies()
+            //     // Sets the route as a request extension so that it can be used
+            //     // by tap.
+            //     .push_http_insert_target()
+            //     // Records per-route metrics.
+            //     .push(metrics.http_route.into_layer::<classify::Response>())
+            //     // Sets the per-route response classifier as a request
+            //     // extension.
+            //     .push(classify::Layer::new())
+            //     .check_new_clone_service::<dst::Route>();
 
-            // An HTTP client is created for each target via the endpoint stack.
-            let http_target_cache = http_endpoint
-                .push_map_target(HttpEndpoint::from)
-                // Normalizes the URI, i.e. if it was originally in
-                // absolute-form on the outbound side.
-                .push(normalize_uri::layer())
-                .push(http_target_observability)
-                .into_new_service()
-                .cache(
-                    svc::layers().push_on_response(
-                        svc::layers()
-                            // If the service has been ready & unused for `cache_max_idle_age`,
-                            // fail it.
-                            .push_idle_timeout(cache_max_idle_age)
-                            // If the service has been unavailable for an extend time, eagerly
-                            // fail requests.
-                            .push_failfast(dispatch_timeout)
-                            // Shares the service, ensuring discovery errors are propagated.
-                            .push_spawn_buffer(buffer_capacity)
-                            .push(metrics.stack.layer(stack_labels("target"))),
-                    ),
-                )
-                .instrument(|_: &Target| info_span!("target"))
-                // Prevent the cache's lock from being acquired in poll_ready, ensuring this happens
-                // in the response future. This prevents buffers from holding the cache's lock.
-                .push_oneshot()
-                .check_service::<Target>();
+            // // An HTTP client is created for each target via the endpoint stack.
+            // let http_target_cache = http_endpoint
+            //     .push_map_target(HttpEndpoint::from)
+            //     // Normalizes the URI, i.e. if it was originally in
+            //     // absolute-form on the outbound side.
+            //     .push(normalize_uri::layer())
+            //     .push(http_target_observability)
+            //     .into_new_service()
+            //     .cache(
+            //         svc::layers().push_on_response(
+            //             svc::layers()
+            //                 // If the service has been ready & unused for `cache_max_idle_age`,
+            //                 // fail it.
+            //                 .push_idle_timeout(cache_max_idle_age)
+            //                 // If the service has been unavailable for an extend time, eagerly
+            //                 // fail requests.
+            //                 .push_failfast(dispatch_timeout)
+            //                 // Shares the service, ensuring discovery errors are propagated.
+            //                 .push_spawn_buffer(buffer_capacity)
+            //                 .push(metrics.stack.layer(stack_labels("target"))),
+            //         ),
+            //     )
+            //     .instrument(|_: &Target| info_span!("target"))
+            //     // Prevent the cache's lock from being acquired in poll_ready, ensuring this happens
+            //     // in the response future. This prevents buffers from holding the cache's lock.
+            //     .push_oneshot()
+            //     .check_service::<Target>();
 
-            // Routes targets to a Profile stack, i.e. so that profile
-            // resolutions are shared even as the type of request may vary.
-            let http_profile_cache = http_target_cache
-                .clone()
-                .push_on_response(svc::layers().box_http_request())
-                .check_service::<Target>()
-                // Provides route configuration without pdestination overrides.
-                .push(profiles::Layer::without_overrides(
-                    profiles_client,
-                    http_profile_route_proxy.into_inner(),
-                ))
-                .into_new_service()
-                // Caches profile stacks.
-                .check_new_service_routes::<Profile, Target>()
-                .cache(
-                    svc::layers().push_on_response(
-                        svc::layers()
-                            // If the service has been ready & unused for `cache_max_idle_age`,
-                            // fail it.
-                            .push_idle_timeout(cache_max_idle_age)
-                            // If the service has been unavailable for an extend time, eagerly
-                            // fail requests.
-                            .push_failfast(dispatch_timeout)
-                            // Shares the service, ensuring discovery errors are propagated.
-                            .push_spawn_buffer(buffer_capacity)
-                            .push(metrics.stack.layer(stack_labels("profile"))),
-                    ),
-                )
-                .instrument(|p: &Profile| info_span!("profile", addr = %p.addr()))
-                .check_make_service::<Profile, Target>()
-                // Ensures that cache's lock isn't held in poll_ready.
-                .push_oneshot()
-                .push(router::Layer::new(|()| ProfileTarget))
-                .check_new_service_routes::<(), Target>()
-                .new_service(());
+            // // Routes targets to a Profile stack, i.e. so that profile
+            // // resolutions are shared even as the type of request may vary.
+            // let http_profile_cache = http_target_cache
+            //     .clone()
+            //     .push_on_response(svc::layers().box_http_request())
+            //     .check_service::<Target>()
+            //     // Provides route configuration without pdestination overrides.
+            //     .push(profiles::Layer::without_overrides(
+            //         profiles_client,
+            //         http_profile_route_proxy.into_inner(),
+            //     ))
+            //     .into_new_service()
+            //     // Caches profile stacks.
+            //     .check_new_service_routes::<Profile, Target>()
+            //     .cache(
+            //         svc::layers().push_on_response(
+            //             svc::layers()
+            //                 // If the service has been ready & unused for `cache_max_idle_age`,
+            //                 // fail it.
+            //                 .push_idle_timeout(cache_max_idle_age)
+            //                 // If the service has been unavailable for an extend time, eagerly
+            //                 // fail requests.
+            //                 .push_failfast(dispatch_timeout)
+            //                 // Shares the service, ensuring discovery errors are propagated.
+            //                 .push_spawn_buffer(buffer_capacity)
+            //                 .push(metrics.stack.layer(stack_labels("profile"))),
+            //         ),
+            //     )
+            //     .instrument(|p: &Profile| info_span!("profile", addr = %p.addr()))
+            //     .check_make_service::<Profile, Target>()
+            //     // Ensures that cache's lock isn't held in poll_ready.
+            //     .push_oneshot()
+            //     .push(router::Layer::new(|()| ProfileTarget))
+            //     .check_new_service_routes::<(), Target>()
+            //     .new_service(());
 
-            // Strips headers that may be set by the inbound router.
-            let http_strip_headers = svc::layers()
-                .push(strip_header::request::layer(L5D_REMOTE_IP))
-                .push(strip_header::request::layer(L5D_CLIENT_ID))
-                .push(strip_header::response::layer(L5D_SERVER_ID));
+            // // Strips headers that may be set by the inbound router.
+            // let http_strip_headers = svc::layers()
+            //     .push(strip_header::request::layer(L5D_REMOTE_IP))
+            //     .push(strip_header::request::layer(L5D_CLIENT_ID))
+            //     .push(strip_header::response::layer(L5D_SERVER_ID));
 
-            // Handles requests as they are initially received by the proxy.
-            let http_admit_request = svc::layers()
-                // Downgrades the protocol if upgraded by an outbound proxy.
-                .push(svc::layer::mk(orig_proto::Downgrade::new))
-                // Limits the number of in-flight requests.
-                .push_concurrency_limit(max_in_flight_requests)
-                // Eagerly fail requests when the proxy is out of capacity for some time period.
-                .push_failfast(dispatch_timeout)
-                .push(metrics.http_errors)
-                // Synthesizes responses for proxy errors.
-                .push(errors::layer());
+            // // Handles requests as they are initially received by the proxy.
+            // let http_admit_request = svc::layers()
+            //     // Downgrades the protocol if upgraded by an outbound proxy.
+            //     .push(svc::layer::mk(orig_proto::Downgrade::new))
+            //     // Limits the number of in-flight requests.
+            //     .push_concurrency_limit(max_in_flight_requests)
+            //     // Eagerly fail requests when the proxy is out of capacity for some time period.
+            //     .push_failfast(dispatch_timeout)
+            //     .push(metrics.http_errors)
+            //     // Synthesizes responses for proxy errors.
+            //     .push(errors::layer());
 
-            let http_server_observability = svc::layers()
-                .push(TraceContextLayer::new(span_sink.map(|span_sink| {
-                    SpanConverter::server(span_sink, trace_labels())
-                })))
-                // Tracks proxy handletime.
-                .push(metrics.http_handle_time.layer());
+            // let http_server_observability = svc::layers()
+            //     .push(TraceContextLayer::new(span_sink.map(|span_sink| {
+            //         SpanConverter::server(span_sink, trace_labels())
+            //     })))
+            //     // Tracks proxy handletime.
+            //     .push(metrics.http_handle_time.layer());
 
-            let http_server = svc::stack(http_profile_cache)
-                .push_on_response(svc::layers().box_http_response())
-                .push_make_ready()
-                .push_fallback(
-                    http_target_cache
-                        .push_on_response(svc::layers().box_http_response().box_http_request()),
-                )
-                .check_service::<Target>()
-                // Ensures that the built service is ready before it is returned
-                // to the router to dispatch a request.
-                .push_make_ready()
-                // Limits the amount of time each request waits to obtain a
-                // ready service.
-                .push_timeout(dispatch_timeout)
-                // Removes the override header after it has been used to
-                // determine a reuquest target.
-                .push_on_response(strip_header::request::layer(DST_OVERRIDE_HEADER))
-                // Routes each request to a target, obtains a service for that
-                // target, and dispatches the request.
-                .instrument_from_target()
-                .push(router::Layer::new(RequestTarget::from))
-                .check_new_service::<tls::accept::Meta>()
-                // Used by tap.
-                .push_http_insert_target()
-                .push_on_response(http_strip_headers)
-                .push_on_response(http_admit_request)
-                .push_on_response(http_server_observability)
-                .push_on_response(metrics.stack.layer(stack_labels("source")))
-                .instrument(|src: &tls::accept::Meta| {
-                    info_span!(
-                        "source",
-                        target.addr = %src.addrs.target_addr(),
-                    )
-                });
+            // let http_server = svc::stack(http_profile_cache)
+            //     .push_on_response(svc::layers().box_http_response())
+            //     .push_make_ready()
+            //     .push_fallback(
+            //         http_target_cache
+            //             .push_on_response(svc::layers().box_http_response().box_http_request()),
+            //     )
+            //     .check_service::<Target>()
+            //     // Ensures that the built service is ready before it is returned
+            //     // to the router to dispatch a request.
+            //     .push_make_ready()
+            //     // Limits the amount of time each request waits to obtain a
+            //     // ready service.
+            //     .push_timeout(dispatch_timeout)
+            //     // Removes the override header after it has been used to
+            //     // determine a reuquest target.
+            //     .push_on_response(strip_header::request::layer(DST_OVERRIDE_HEADER))
+            //     // Routes each request to a target, obtains a service for that
+            //     // target, and dispatches the request.
+            //     .instrument_from_target()
+            //     .push(router::Layer::new(RequestTarget::from))
+            //     .check_new_service::<tls::accept::Meta>()
+            //     // Used by tap.
+            //     .push_http_insert_target()
+            //     .push_on_response(http_strip_headers)
+            //     .push_on_response(http_admit_request)
+            //     .push_on_response(http_server_observability)
+            //     .push_on_response(metrics.stack.layer(stack_labels("source")))
+            //     .instrument(|src: &tls::accept::Meta| {
+            //         info_span!(
+            //             "source",
+            //             target.addr = %src.addrs.target_addr(),
+            //         )
+            //     });
+            let http_server = |_| {
+                tower::service_fn(move |_: http::Request<_>| {
+                    future::ok(http::Response::new(http::Body::default()))
+                })
+            };
 
             let tcp_server = Server::new(
                 TransportLabels,
                 metrics.transport,
                 tcp_forward.into_inner(),
-                http_server.into_inner(),
+                http_server, /* .into_inner() */
                 h2_settings,
                 drain.clone(),
                 disable_protocol_detection_for_ports.clone(),

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -14,6 +14,8 @@ a dedicated crate to help the compiler cache dependencies properly.
 [features]
 # Disable to skip certain tests that should not be run on CI.
 flaky_tests = []
+# Enable to run tests for functionality that hasn't been ported to Tokio 0.2
+nyi = []
 
 [dependencies]
 bytes = "0.4"

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -7,7 +7,7 @@ macro_rules! generate_tests {
         use linkerd2_proxy_api as pb;
 
         #[test]
-        #[ignore] // Not yet implemented
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_asks_controller_api() {
             let _ = trace_init();
             let srv = $make_server().route("/", "hello").route("/bye", "bye").run();
@@ -24,7 +24,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[ignore] // Not yet implemented
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_reconnects_if_controller_stream_ends() {
             let _ = trace_init();
 
@@ -42,13 +42,13 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[ignore] // Not yet implemented
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_fails_fast_when_destination_has_no_endpoints() {
             outbound_fails_fast(controller::destination_exists_with_no_endpoints())
         }
 
         #[test]
-        #[ignore] // Not yet implemented
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_fails_fast_when_destination_does_not_exist() {
             outbound_fails_fast(controller::destination_does_not_exist())
         }
@@ -87,7 +87,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[ignore] // Not yet implemented
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_falls_back_to_orig_dst_when_outside_search_path() {
             let _ = trace_init();
 
@@ -106,7 +106,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[ignore] // Not yet implemented
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_falls_back_to_orig_dst_after_invalid_argument() {
             let _ = trace_init();
 
@@ -132,7 +132,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[ignore] // Not yet implemented
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_destinations_reset_on_reconnect_followed_by_empty() {
             outbound_destinations_reset_on_reconnect(
                 controller::destination_exists_with_no_endpoints()
@@ -140,7 +140,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[ignore] // Not yet implemented
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_destinations_reset_on_reconnect_followed_by_dne() {
             outbound_destinations_reset_on_reconnect(
                 controller::destination_does_not_exist()
@@ -207,7 +207,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[ignore] // Not yet implemented
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_asks_controller_without_orig_dst() {
             let _ = TestEnv::new();
 
@@ -232,7 +232,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[ignore] // Not yet implemented
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_error_reconnects_after_backoff() {
             let env = TestEnv::new();
 
@@ -278,7 +278,7 @@ macro_rules! generate_tests {
             const IP_2: &'static str = "127.0.0.1";
 
             #[test]
-            #[ignore] // Not yet implemented
+            #[cfg_attr(not(feature = "nyi"), ignore)]
             fn outbound_should_strip() {
                 let _ = trace_init();
                 let header = HeaderValue::from_static(IP_1);
@@ -299,7 +299,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
-            #[ignore] // Not yet implemented
+            #[cfg_attr(not(feature = "nyi"), ignore)]
             fn inbound_should_strip() {
                 let _ = trace_init();
                 let header = HeaderValue::from_static(IP_1);
@@ -462,7 +462,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
-            #[ignore] // Not yet implemented
+            #[cfg_attr(not(feature = "nyi"), ignore)]
             fn outbound_honors_override_header() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy().run();
@@ -493,7 +493,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
-            #[ignore] // Not yet implemented
+            #[cfg_attr(not(feature = "nyi"), ignore)]
             fn outbound_overrides_profile() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy().run();
@@ -513,7 +513,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
-            #[ignore] // Not yet implemented
+            #[cfg_attr(not(feature = "nyi"), ignore)]
             fn outbound_honors_override_header_with_orig_dst() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy()
@@ -546,7 +546,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
-            #[ignore] // Not yet implemented
+            #[cfg_attr(not(feature = "nyi"), ignore)]
             fn inbound_overrides_profile() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy()
@@ -567,7 +567,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
-            #[ignore] // Not yet implemented
+            #[cfg_attr(not(feature = "nyi"), ignore)]
             fn inbound_still_routes_to_orig_dst() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy()
@@ -609,7 +609,7 @@ mod http2 {
     generate_tests! { server: server::new, client: client::new }
 
     #[test]
-    #[ignore] // Not yet implemented
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_balancer_waits_for_ready_endpoint() {
         // See https://github.com/linkerd/linkerd2/issues/2550
         let _ = trace_init();
@@ -683,7 +683,7 @@ mod proxy_to_proxy {
     use super::*;
 
     #[test]
-    #[ignore] // Not yet implemented
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_http1() {
         let _ = trace_init();
 
@@ -713,7 +713,7 @@ mod proxy_to_proxy {
     }
 
     #[test]
-    #[ignore] // Not yet implemented
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_http1() {
         let _ = trace_init();
 
@@ -746,7 +746,7 @@ mod proxy_to_proxy {
     }
 
     #[test]
-    #[ignore] // Not yet implemented
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_should_strip_l5d_client_id() {
         let _ = trace_init();
 
@@ -773,7 +773,7 @@ mod proxy_to_proxy {
     }
 
     #[test]
-    #[ignore] // Not yet implemented
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_should_strip_l5d_client_id() {
         let _ = trace_init();
 
@@ -801,7 +801,7 @@ mod proxy_to_proxy {
     }
 
     #[test]
-    #[ignore] // Not yet implemented
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_should_strip_l5d_server_id() {
         let _ = trace_init();
 
@@ -831,7 +831,7 @@ mod proxy_to_proxy {
     }
 
     #[test]
-    #[ignore] // Not yet implemented
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_should_strip_l5d_server_id() {
         let _ = trace_init();
 

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -7,6 +7,7 @@ macro_rules! generate_tests {
         use linkerd2_proxy_api as pb;
 
         #[test]
+        #[ignore] // Not yet implemented
         fn outbound_asks_controller_api() {
             let _ = trace_init();
             let srv = $make_server().route("/", "hello").route("/bye", "bye").run();
@@ -23,6 +24,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
+        #[ignore] // Not yet implemented
         fn outbound_reconnects_if_controller_stream_ends() {
             let _ = trace_init();
 
@@ -40,11 +42,13 @@ macro_rules! generate_tests {
         }
 
         #[test]
+        #[ignore] // Not yet implemented
         fn outbound_fails_fast_when_destination_has_no_endpoints() {
             outbound_fails_fast(controller::destination_exists_with_no_endpoints())
         }
 
         #[test]
+        #[ignore] // Not yet implemented
         fn outbound_fails_fast_when_destination_does_not_exist() {
             outbound_fails_fast(controller::destination_does_not_exist())
         }
@@ -83,6 +87,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
+        #[ignore] // Not yet implemented
         fn outbound_falls_back_to_orig_dst_when_outside_search_path() {
             let _ = trace_init();
 
@@ -101,6 +106,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
+        #[ignore] // Not yet implemented
         fn outbound_falls_back_to_orig_dst_after_invalid_argument() {
             let _ = trace_init();
 
@@ -126,6 +132,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
+        #[ignore] // Not yet implemented
         fn outbound_destinations_reset_on_reconnect_followed_by_empty() {
             outbound_destinations_reset_on_reconnect(
                 controller::destination_exists_with_no_endpoints()
@@ -133,6 +140,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
+        #[ignore] // Not yet implemented
         fn outbound_destinations_reset_on_reconnect_followed_by_dne() {
             outbound_destinations_reset_on_reconnect(
                 controller::destination_does_not_exist()
@@ -199,6 +207,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
+        #[ignore] // Not yet implemented
         fn outbound_asks_controller_without_orig_dst() {
             let _ = TestEnv::new();
 
@@ -223,6 +232,7 @@ macro_rules! generate_tests {
         }
 
         #[test]
+        #[ignore] // Not yet implemented
         fn outbound_error_reconnects_after_backoff() {
             let env = TestEnv::new();
 
@@ -268,6 +278,7 @@ macro_rules! generate_tests {
             const IP_2: &'static str = "127.0.0.1";
 
             #[test]
+            #[ignore] // Not yet implemented
             fn outbound_should_strip() {
                 let _ = trace_init();
                 let header = HeaderValue::from_static(IP_1);
@@ -288,6 +299,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
+            #[ignore] // Not yet implemented
             fn inbound_should_strip() {
                 let _ = trace_init();
                 let header = HeaderValue::from_static(IP_1);
@@ -450,6 +462,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
+            #[ignore] // Not yet implemented
             fn outbound_honors_override_header() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy().run();
@@ -480,6 +493,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
+            #[ignore] // Not yet implemented
             fn outbound_overrides_profile() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy().run();
@@ -499,6 +513,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
+            #[ignore] // Not yet implemented
             fn outbound_honors_override_header_with_orig_dst() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy()
@@ -531,6 +546,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
+            #[ignore] // Not yet implemented
             fn inbound_overrides_profile() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy()
@@ -551,6 +567,7 @@ macro_rules! generate_tests {
             }
 
             #[test]
+            #[ignore] // Not yet implemented
             fn inbound_still_routes_to_orig_dst() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy()
@@ -592,6 +609,7 @@ mod http2 {
     generate_tests! { server: server::new, client: client::new }
 
     #[test]
+    #[ignore] // Not yet implemented
     fn outbound_balancer_waits_for_ready_endpoint() {
         // See https://github.com/linkerd/linkerd2/issues/2550
         let _ = trace_init();
@@ -665,6 +683,7 @@ mod proxy_to_proxy {
     use super::*;
 
     #[test]
+    #[ignore] // Not yet implemented
     fn outbound_http1() {
         let _ = trace_init();
 
@@ -694,6 +713,7 @@ mod proxy_to_proxy {
     }
 
     #[test]
+    #[ignore] // Not yet implemented
     fn inbound_http1() {
         let _ = trace_init();
 
@@ -726,6 +746,7 @@ mod proxy_to_proxy {
     }
 
     #[test]
+    #[ignore] // Not yet implemented
     fn inbound_should_strip_l5d_client_id() {
         let _ = trace_init();
 
@@ -752,6 +773,7 @@ mod proxy_to_proxy {
     }
 
     #[test]
+    #[ignore] // Not yet implemented
     fn outbound_should_strip_l5d_client_id() {
         let _ = trace_init();
 
@@ -779,6 +801,7 @@ mod proxy_to_proxy {
     }
 
     #[test]
+    #[ignore] // Not yet implemented
     fn inbound_should_strip_l5d_server_id() {
         let _ = trace_init();
 
@@ -808,6 +831,7 @@ mod proxy_to_proxy {
     }
 
     #[test]
+    #[ignore] // Not yet implemented
     fn outbound_should_strip_l5d_server_id() {
         let _ = trace_init();
 

--- a/linkerd/app/integration/tests/profile_dst_overrides.rs
+++ b/linkerd/app/integration/tests/profile_dst_overrides.rs
@@ -62,6 +62,7 @@ fn wait_for_profile_stage(client: &client::Client, metrics: &client::Client, sta
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn add_a_dst_override() {
     let _ = trace_init();
     let ctrl = controller::new_unordered();
@@ -107,6 +108,7 @@ fn add_a_dst_override() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn add_multiple_dst_overrides() {
     let _ = trace_init();
     let ctrl = controller::new_unordered();
@@ -163,6 +165,7 @@ fn add_multiple_dst_overrides() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn set_a_dst_override_weight_to_zero() {
     let _ = trace_init();
     let ctrl = controller::new_unordered();
@@ -228,6 +231,7 @@ fn set_a_dst_override_weight_to_zero() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn set_all_dst_override_weights_to_zero() {
     let _ = trace_init();
     let ctrl = controller::new_unordered();
@@ -295,6 +299,7 @@ fn set_all_dst_override_weights_to_zero() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn remove_a_dst_override() {
     let _ = trace_init();
 

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -132,6 +132,7 @@ macro_rules! profile_test {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn retry_if_profile_allows() {
     profile_test! {
         routes: [
@@ -148,6 +149,7 @@ fn retry_if_profile_allows() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn retry_uses_budget() {
     profile_test! {
         routes: [
@@ -172,6 +174,7 @@ fn retry_uses_budget() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn does_not_retry_if_request_does_not_match() {
     profile_test! {
         routes: [
@@ -189,6 +192,7 @@ fn does_not_retry_if_request_does_not_match() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn does_not_retry_if_earlier_response_class_is_success() {
     profile_test! {
         routes: [
@@ -208,6 +212,7 @@ fn does_not_retry_if_earlier_response_class_is_success() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn does_not_retry_if_request_has_body() {
     profile_test! {
         routes: [
@@ -229,6 +234,7 @@ fn does_not_retry_if_request_has_body() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn does_not_retry_if_missing_retry_budget() {
     profile_test! {
         routes: [
@@ -246,6 +252,7 @@ fn does_not_retry_if_missing_retry_budget() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn ignores_invalid_retry_budget_ttl() {
     profile_test! {
         routes: [
@@ -263,6 +270,7 @@ fn ignores_invalid_retry_budget_ttl() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn ignores_invalid_retry_budget_ratio() {
     profile_test! {
         routes: [
@@ -280,6 +288,7 @@ fn ignores_invalid_retry_budget_ratio() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn ignores_invalid_retry_budget_negative_ratio() {
     profile_test! {
         routes: [
@@ -297,6 +306,7 @@ fn ignores_invalid_retry_budget_negative_ratio() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http2_failures_dont_leak_connection_window() {
     profile_test! {
         http: http2,
@@ -318,6 +328,7 @@ fn http2_failures_dont_leak_connection_window() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn timeout() {
     profile_test! {
         routes: [

--- a/linkerd/app/integration/tests/shutdown.rs
+++ b/linkerd/app/integration/tests/shutdown.rs
@@ -3,6 +3,7 @@
 use linkerd2_app_integration::*;
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn h2_goaways_connections() {
     let _ = trace_init();
 
@@ -20,6 +21,7 @@ fn h2_goaways_connections() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn h2_exercise_goaways_connections() {
     let _ = trace_init();
 
@@ -65,6 +67,7 @@ fn h2_exercise_goaways_connections() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http1_closes_idle_connections() {
     use std::cell::RefCell;
     let _ = trace_init();

--- a/linkerd/app/integration/tests/tap.rs
+++ b/linkerd/app/integration/tests/tap.rs
@@ -5,6 +5,7 @@ use linkerd2_app_integration::*;
 use std::time::SystemTime;
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn tap_enabled_when_identity_enabled() {
     let _ = trace_init();
 
@@ -19,6 +20,7 @@ fn tap_enabled_when_identity_enabled() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn tap_disabled_when_identity_disabled() {
     let _ = trace_init();
     let proxy = proxy::new().disable_identity().run();
@@ -27,6 +29,7 @@ fn tap_disabled_when_identity_disabled() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn can_disable_tap() {
     let _ = trace_init();
     let mut env = TestEnv::new();
@@ -38,6 +41,7 @@ fn can_disable_tap() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn rejects_incorrect_identity_when_identity_is_expected() {
     let _ = trace_init();
 
@@ -73,7 +77,7 @@ fn rejects_incorrect_identity_when_identity_is_expected() {
 // Flaky: sometimes the admin thread hasn't had a chance to register
 // the Taps before the `client.get` is called.
 #[test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+#[cfg_attr(all(not(feature = "nyi"), not(feature = "flaky_tests")), ignore)]
 fn inbound_http1() {
     let _ = trace_init();
 
@@ -143,6 +147,7 @@ fn inbound_http1() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn grpc_headers_end() {
     let _ = trace_init();
 

--- a/linkerd/app/integration/tests/telemetry.rs
+++ b/linkerd/app/integration/tests/telemetry.rs
@@ -113,6 +113,7 @@ impl TcpFixture {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn metrics_endpoint_inbound_request_count() {
     let _ = trace_init();
     let Fixture {
@@ -133,6 +134,7 @@ fn metrics_endpoint_inbound_request_count() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn metrics_endpoint_outbound_request_count() {
     let _ = trace_init();
     let Fixture {
@@ -218,6 +220,7 @@ mod response_classification {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_http() {
         let _ = trace_init();
         let Fixture {
@@ -247,6 +250,7 @@ mod response_classification {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_http() {
         let _ = trace_init();
         let Fixture {
@@ -286,7 +290,7 @@ mod response_classification {
 // Eventually, we can add some kind of mock timer system for simulating latency
 // more reliably, and re-enable this test.
 #[test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+#[cfg_attr(all(not(feature = "nyi"), not(feature = "flaky_tests")), ignore)]
 fn metrics_endpoint_inbound_response_latency() {
     let _ = trace_init();
 
@@ -365,7 +369,7 @@ fn metrics_endpoint_inbound_response_latency() {
 // Eventually, we can add some kind of mock timer system for simulating latency
 // more reliably, and re-enable this test.
 #[test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+#[cfg_attr(all(not(feature = "nyi"), not(feature = "flaky_tests")), ignore)]
 fn metrics_endpoint_outbound_response_latency() {
     let _ = trace_init();
 
@@ -469,6 +473,7 @@ mod outbound_dst_labels {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn multiple_addr_labels() {
         let _ = trace_init();
         let (
@@ -500,6 +505,7 @@ mod outbound_dst_labels {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn multiple_addrset_labels() {
         let _ = trace_init();
         let (
@@ -531,6 +537,7 @@ mod outbound_dst_labels {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn labeled_addr_and_addrset() {
         let _ = trace_init();
         let (
@@ -566,7 +573,7 @@ mod outbound_dst_labels {
     // the mock controller before the first request has finished.
     // See linkerd/linkerd2#751
     #[test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    #[cfg_attr(all(not(feature = "nyi"), not(feature = "flaky_tests")), ignore)]
     fn controller_updates_addr_labels() {
         let _ = trace_init();
         info!("running test server");
@@ -630,7 +637,7 @@ mod outbound_dst_labels {
     // the mock controller before the first request has finished.
     // See linkerd/linkerd2#751
     #[test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    #[cfg_attr(all(not(feature = "nyi"), not(feature = "flaky_tests")), ignore)]
     fn controller_updates_set_labels() {
         let _ = trace_init();
         info!("running test server");
@@ -688,6 +695,7 @@ mod outbound_dst_labels {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn metrics_have_no_double_commas() {
     // Test for regressions to linkerd/linkerd2#600.
     let _ = trace_init();
@@ -727,6 +735,7 @@ fn metrics_have_no_double_commas() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn metrics_has_start_time() {
     let Fixture {
         metrics,
@@ -743,6 +752,7 @@ mod transport {
     use linkerd2_app_integration::*;
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_http_accept() {
         let _ = trace_init();
         let Fixture {
@@ -782,6 +792,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_http_connect() {
         let _ = trace_init();
         let Fixture {
@@ -810,6 +821,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_http_accept() {
         let _ = trace_init();
         let Fixture {
@@ -847,6 +859,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_http_connect() {
         let _ = trace_init();
         let Fixture {
@@ -871,6 +884,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_tcp_connect() {
         let _ = trace_init();
         let TcpFixture {
@@ -888,6 +902,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     #[cfg(macos)]
     fn inbound_tcp_connect_err() {
         let _ = trace_init();
@@ -918,6 +933,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     #[cfg(macos)]
     fn outbound_tcp_connect_err() {
         let _ = trace_init();
@@ -946,6 +962,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_tcp_accept() {
         let _ = trace_init();
         let TcpFixture {
@@ -988,7 +1005,7 @@ mod transport {
 
     // linkerd/linkerd2#831
     #[test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    #[cfg_attr(all(not(feature = "nyi"), not(feature = "flaky_tests")), ignore)]
     fn inbound_tcp_duration() {
         let _ = trace_init();
         let TcpFixture {
@@ -1028,6 +1045,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_tcp_write_bytes_total() {
         let _ = trace_init();
         let TcpFixture {
@@ -1056,6 +1074,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_tcp_read_bytes_total() {
         let _ = trace_init();
         let TcpFixture {
@@ -1084,6 +1103,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_tcp_connect() {
         let _ = trace_init();
         let TcpFixture {
@@ -1101,6 +1121,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_tcp_accept() {
         let _ = trace_init();
         let TcpFixture {
@@ -1138,7 +1159,7 @@ mod transport {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    #[cfg_attr(all(not(feature = "nyi"), not(feature = "flaky_tests")), ignore)]
     fn outbound_tcp_duration() {
         let _ = trace_init();
         let TcpFixture {
@@ -1178,6 +1199,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_tcp_write_bytes_total() {
         let _ = trace_init();
         let TcpFixture {
@@ -1206,6 +1228,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_tcp_read_bytes_total() {
         let _ = trace_init();
         let TcpFixture {
@@ -1234,6 +1257,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_tcp_open_connections() {
         let _ = trace_init();
         let TcpFixture {
@@ -1272,6 +1296,7 @@ mod transport {
     }
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_http_tcp_open_connections() {
         let _ = trace_init();
         let Fixture {
@@ -1313,6 +1338,7 @@ mod transport {
 
 // linkerd/linkerd2#613
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn metrics_compression() {
     let _ = trace_init();
 

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -5,6 +5,7 @@ use std::error::Error as _;
 use std::sync::mpsc;
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn outbound_http1() {
     let _ = trace_init();
 
@@ -20,6 +21,7 @@ fn outbound_http1() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn inbound_http1() {
     let _ = trace_init();
 
@@ -212,6 +214,7 @@ fn tcp_connections_close_if_client_closes() {
 macro_rules! http1_tests {
     (proxy: $proxy:expr) => {
         #[test]
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn inbound_http1() {
             let _ = trace_init();
 
@@ -318,6 +321,7 @@ macro_rules! http1_tests {
         }
 
         #[test]
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn http11_upgrades() {
             let _ = trace_init();
 
@@ -453,6 +457,7 @@ macro_rules! http1_tests {
         }
 
         #[test]
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn http11_connect() {
             let _ = trace_init();
 
@@ -611,6 +616,7 @@ macro_rules! http1_tests {
         }
 
         #[test]
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn http1_request_with_body_chunked() {
             let _ = trace_init();
 
@@ -648,6 +654,7 @@ macro_rules! http1_tests {
         }
 
         #[test]
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn http1_requests_without_body_doesnt_add_transfer_encoding() {
             let _ = trace_init();
 
@@ -714,6 +721,7 @@ macro_rules! http1_tests {
         }
 
         #[test]
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn http1_bodyless_responses() {
             let _ = trace_init();
 
@@ -776,6 +784,7 @@ macro_rules! http1_tests {
         }
 
         #[test]
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn http1_head_responses() {
             let _ = trace_init();
 
@@ -806,6 +815,7 @@ macro_rules! http1_tests {
         }
 
         #[test]
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn http1_response_end_of_file() {
             let _ = trace_init();
 
@@ -951,6 +961,7 @@ fn http10_without_host() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http1_one_connection_per_host() {
     let _ = trace_init();
 
@@ -997,6 +1008,7 @@ fn http1_one_connection_per_host() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http1_requests_without_host_have_unique_connections() {
     let _ = trace_init();
 
@@ -1127,6 +1139,7 @@ fn http2_request_without_authority() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http2_rst_stream_is_propagated() {
     let _ = trace_init();
 
@@ -1153,6 +1166,7 @@ fn http2_rst_stream_is_propagated() {
 }
 
 #[test]
+#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http1_orig_proto_does_not_propagate_rst_stream() {
     let _ = trace_init();
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -3,7 +3,7 @@
 //! The outound proxy is responsible for routing traffic from the local
 //! application to external network endpoints.
 
-#![deny(warnings, rust_2018_idioms)]
+// #![deny(warnings, rust_2018_idioms)]
 
 pub use self::endpoint::{
     Concrete, HttpEndpoint, Logical, LogicalPerRequest, Profile, ProfilePerTarget, Target,
@@ -120,304 +120,310 @@ impl Config {
                 })
                 .push(svc::layer::mk(tcp::Forward::new));
 
-            // Registers the stack with Tap, Metrics, and OpenCensus tracing
-            // export.
-            let http_endpoint = {
-                let observability = svc::layers()
-                    .push(tap_layer.clone())
-                    .push(metrics.http_endpoint.into_layer::<classify::Response>())
-                    .push_on_response(TraceContextLayer::new(
-                        span_sink
-                            .clone()
-                            .map(|sink| SpanConverter::client(sink, trace_labels())),
-                    ));
+            // // Registers the stack with Tap, Metrics, and OpenCensus tracing
+            // // export.
+            // let http_endpoint = {
+            //     let observability = svc::layers()
+            //         .push(tap_layer.clone())
+            //         .push(metrics.http_endpoint.into_layer::<classify::Response>())
+            //         .push_on_response(TraceContextLayer::new(
+            //             span_sink
+            //                 .clone()
+            //                 .map(|sink| SpanConverter::client(sink, trace_labels())),
+            //         ));
 
-                // Checks the headers to validate that a client-specified required
-                // identity matches the configured identity.
-                let identity_headers = svc::layers()
-                    .push_on_response(
-                        svc::layers()
-                            .push(http::strip_header::response::layer(L5D_REMOTE_IP))
-                            .push(http::strip_header::response::layer(L5D_SERVER_ID))
-                            .push(http::strip_header::request::layer(L5D_REQUIRE_ID)),
-                    )
-                    .push(MakeRequireIdentityLayer::new());
+            //     // Checks the headers to validate that a client-specified required
+            //     // identity matches the configured identity.
+            //     let identity_headers = svc::layers()
+            //         .push_on_response(
+            //             svc::layers()
+            //                 .push(http::strip_header::response::layer(L5D_REMOTE_IP))
+            //                 .push(http::strip_header::response::layer(L5D_SERVER_ID))
+            //                 .push(http::strip_header::request::layer(L5D_REQUIRE_ID)),
+            //         )
+            //         .push(MakeRequireIdentityLayer::new());
 
-                tcp_connect
-                    .clone()
-                    // Initiates an HTTP client on the underlying transport. Prior-knowledge HTTP/2
-                    // is typically used (i.e. when communicating with other proxies); though
-                    // HTTP/1.x fallback is supported as needed.
-                    .push(http::MakeClientLayer::new(connect.h2_settings))
-                    // Re-establishes a connection when the client fails.
-                    .push(reconnect::layer({
-                        let backoff = connect.backoff.clone();
-                        move |_| Ok(backoff.stream())
-                    }))
-                    .push(observability.clone())
-                    .push(identity_headers.clone())
-                    // Ensures that the request's URI is in the proper form.
-                    .push(http::normalize_uri::layer())
-                    // Upgrades HTTP/1 requests to be transported over HTTP/2 connections.
-                    //
-                    // This sets headers so that the inbound proxy can downgrade the request
-                    // properly.
-                    .push(OrigProtoUpgradeLayer::new())
-                    .check_service::<Target<HttpEndpoint>>()
-                    .instrument(|endpoint: &Target<HttpEndpoint>| {
-                        info_span!("endpoint", peer.addr = %endpoint.inner.addr)
-                    })
-            };
+            //     tcp_connect
+            //         .clone()
+            //         // Initiates an HTTP client on the underlying transport. Prior-knowledge HTTP/2
+            //         // is typically used (i.e. when communicating with other proxies); though
+            //         // HTTP/1.x fallback is supported as needed.
+            //         .push(http::MakeClientLayer::new(connect.h2_settings))
+            //         // Re-establishes a connection when the client fails.
+            //         .push(reconnect::layer({
+            //             let backoff = connect.backoff.clone();
+            //             move |_| Ok(backoff.stream())
+            //         }))
+            //         .push(observability.clone())
+            //         .push(identity_headers.clone())
+            //         // Ensures that the request's URI is in the proper form.
+            //         .push(http::normalize_uri::layer())
+            //         // Upgrades HTTP/1 requests to be transported over HTTP/2 connections.
+            //         //
+            //         // This sets headers so that the inbound proxy can downgrade the request
+            //         // properly.
+            //         .push(OrigProtoUpgradeLayer::new())
+            //         .check_service::<Target<HttpEndpoint>>()
+            //         .instrument(|endpoint: &Target<HttpEndpoint>| {
+            //             info_span!("endpoint", peer.addr = %endpoint.inner.addr)
+            //         })
+            // };
 
-            // Resolves each target via the control plane on a background task, buffering results.
-            //
-            // This buffer controls how many discovery updates may be pending/unconsumed by the
-            // balancer before backpressure is applied on the resolution stream. If the buffer is
-            // full for `cache_max_idle_age`, then the resolution task fails.
-            let discover = {
-                const BUFFER_CAPACITY: usize = 1_000;
-                let resolve = map_endpoint::Resolve::new(endpoint::FromMetadata, resolve.clone());
-                discover::Layer::new(BUFFER_CAPACITY, cache_max_idle_age, resolve)
-            };
+            // // Resolves each target via the control plane on a background task, buffering results.
+            // //
+            // // This buffer controls how many discovery updates may be pending/unconsumed by the
+            // // balancer before backpressure is applied on the resolution stream. If the buffer is
+            // // full for `cache_max_idle_age`, then the resolution task fails.
+            // let discover = {
+            //     const BUFFER_CAPACITY: usize = 1_000;
+            //     let resolve = map_endpoint::Resolve::new(endpoint::FromMetadata, resolve.clone());
+            //     discover::Layer::new(BUFFER_CAPACITY, cache_max_idle_age, resolve)
+            // };
 
-            // Builds a balancer for each concrete destination.
-            let http_balancer = http_endpoint
-                .clone()
-                .check_make_service::<Target<HttpEndpoint>, http::Request<http::boxed::Payload>>()
-                .push_on_response(
-                    svc::layers()
-                        .push(metrics.stack.layer(stack_labels("balance.endpoint")))
-                        .box_http_request(),
-                )
-                .push_spawn_ready()
-                .check_service::<Target<HttpEndpoint>>()
-                .push(discover)
-                .push_on_response(http::balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
-                .into_new_service()
-                .cache(
-                    svc::layers().push_on_response(
-                        svc::layers()
-                            // If the balancer has been ready & unused for `cache_max_idle_age`,
-                            // fail the balancer.
-                            .push_idle_timeout(cache_max_idle_age)
-                            // If the balancer has been empty/unavailable for 10s, eagerly fail
-                            // requests.
-                            .push_failfast(dispatch_timeout)
-                            // Shares the balancer, ensuring discovery errors are propagated.
-                            .push_spawn_buffer(buffer_capacity)
-                            .push(metrics.stack.layer(stack_labels("balance"))),
-                    ),
-                )
-                .instrument(|c: &Concrete<http::Settings>| info_span!("balance", addr = %c.addr))
-                // Ensure that buffers don't hold the cache's lock in poll_ready.
-                .push_oneshot();
+            // // Builds a balancer for each concrete destination.
+            // let http_balancer = http_endpoint
+            //     .clone()
+            //     .check_make_service::<Target<HttpEndpoint>, http::Request<http::boxed::Payload>>()
+            //     .push_on_response(
+            //         svc::layers()
+            //             .push(metrics.stack.layer(stack_labels("balance.endpoint")))
+            //             .box_http_request(),
+            //     )
+            //     .push_spawn_ready()
+            //     .check_service::<Target<HttpEndpoint>>()
+            //     .push(discover)
+            //     .push_on_response(http::balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
+            //     .into_new_service()
+            //     .cache(
+            //         svc::layers().push_on_response(
+            //             svc::layers()
+            //                 // If the balancer has been ready & unused for `cache_max_idle_age`,
+            //                 // fail the balancer.
+            //                 .push_idle_timeout(cache_max_idle_age)
+            //                 // If the balancer has been empty/unavailable for 10s, eagerly fail
+            //                 // requests.
+            //                 .push_failfast(dispatch_timeout)
+            //                 // Shares the balancer, ensuring discovery errors are propagated.
+            //                 .push_spawn_buffer(buffer_capacity)
+            //                 .push(metrics.stack.layer(stack_labels("balance"))),
+            //         ),
+            //     )
+            //     .instrument(|c: &Concrete<http::Settings>| info_span!("balance", addr = %c.addr))
+            //     // Ensure that buffers don't hold the cache's lock in poll_ready.
+            //     .push_oneshot();
 
-            // Caches clients that bypass discovery/balancing.
-            //
-            // This is effectively the same as the endpoint stack; but the client layer captures the
-            // requst body type (via PhantomData), so the stack cannot be shared directly.
-            let http_forward_cache = http_endpoint
-                .check_make_service::<Target<HttpEndpoint>, http::Request<http::boxed::Payload>>()
-                .into_new_service()
-                .cache(
-                    svc::layers()
-                        .push_on_response(
-                            svc::layers()
-                                // If the endpoint has been ready & unused for `cache_max_idle_age`,
-                                // fail it.
-                                .push_idle_timeout(cache_max_idle_age)
-                                // If the endpoint has been unavailable for an extend time, eagerly
-                                // fail requests.
-                                .push_failfast(dispatch_timeout)
-                                // Shares the balancer, ensuring discovery errors are propagated.
-                                .push_spawn_buffer(buffer_capacity)
-                                .box_http_request()
-                                .push(metrics.stack.layer(stack_labels("forward.endpoint"))),
-                        ),
-                )
-                .instrument(|endpoint: &Target<HttpEndpoint>| {
-                    info_span!("forward", peer.addr = %endpoint.addr, peer.id = ?endpoint.inner.identity)
+            // // Caches clients that bypass discovery/balancing.
+            // //
+            // // This is effectively the same as the endpoint stack; but the client layer captures the
+            // // requst body type (via PhantomData), so the stack cannot be shared directly.
+            // let http_forward_cache = http_endpoint
+            //     .check_make_service::<Target<HttpEndpoint>, http::Request<http::boxed::Payload>>()
+            //     .into_new_service()
+            //     .cache(
+            //         svc::layers()
+            //             .push_on_response(
+            //                 svc::layers()
+            //                     // If the endpoint has been ready & unused for `cache_max_idle_age`,
+            //                     // fail it.
+            //                     .push_idle_timeout(cache_max_idle_age)
+            //                     // If the endpoint has been unavailable for an extend time, eagerly
+            //                     // fail requests.
+            //                     .push_failfast(dispatch_timeout)
+            //                     // Shares the balancer, ensuring discovery errors are propagated.
+            //                     .push_spawn_buffer(buffer_capacity)
+            //                     .box_http_request()
+            //                     .push(metrics.stack.layer(stack_labels("forward.endpoint"))),
+            //             ),
+            //     )
+            //     .instrument(|endpoint: &Target<HttpEndpoint>| {
+            //         info_span!("forward", peer.addr = %endpoint.addr, peer.id = ?endpoint.inner.identity)
+            //     })
+            //     .push_map_target(|t: Concrete<HttpEndpoint>| Target {
+            //         addr: t.addr.into(),
+            //         inner: t.inner.inner,
+            //     })
+            //     .check_service::<Concrete<HttpEndpoint>>()
+            //     // Ensure that buffers don't hold the cache's lock in poll_ready.
+            //     .push_oneshot();
+
+            // // If the balancer fails to be created, i.e., because it is unresolvable, fall back to
+            // // using a router that dispatches request to the application-selected original destination.
+            // let http_concrete = http_balancer
+            //     .push_map_target(|c: Concrete<HttpEndpoint>| c.map(|l| l.map(|e| e.settings)))
+            //     .check_service::<Concrete<HttpEndpoint>>()
+            //     .push_on_response(svc::layers().box_http_response())
+            //     .push_make_ready()
+            //     .push_fallback_with_predicate(
+            //         http_forward_cache
+            //             .push_on_response(svc::layers().box_http_response())
+            //             .into_inner(),
+            //         is_discovery_rejected,
+            //     )
+            //     .check_service::<Concrete<HttpEndpoint>>();
+
+            // let http_profile_route_proxy = svc::proxies()
+            //     .check_new_clone_service::<dst::Route>()
+            //     .push(metrics.http_route_actual.into_layer::<classify::Response>())
+            //     // Sets an optional retry policy.
+            //     .push(retry::layer(metrics.http_route_retry))
+            //     .check_new_clone_service::<dst::Route>()
+            //     // Sets an optional request timeout.
+            //     .push(http::MakeTimeoutLayer::default())
+            //     .check_new_clone_service::<dst::Route>()
+            //     // Records per-route metrics.
+            //     .push(metrics.http_route.into_layer::<classify::Response>())
+            //     .check_new_clone_service::<dst::Route>()
+            //     // Sets the per-route response classifier as a request
+            //     // extension.
+            //     .push(classify::Layer::new())
+            //     .check_new_clone_service::<dst::Route>();
+
+            // // Routes `Logical` targets to a cached `Profile` stack, i.e. so that profile
+            // // resolutions are shared even as the type of request may vary.
+            // let http_logical_profile_cache = http_concrete
+            //     .clone()
+            //     .push_on_response(svc::layers().box_http_request())
+            //     .check_service::<Concrete<HttpEndpoint>>()
+            //     // Provides route configuration. The profile service operates
+            //     // over `Concret` services. When overrides are in play, the
+            //     // Concrete destination may be overridden.
+            //     .push(profiles::Layer::with_overrides(
+            //         profiles_client,
+            //         http_profile_route_proxy.into_inner(),
+            //     ))
+            //     .check_make_service::<Profile, Concrete<HttpEndpoint>>()
+            //     // Use the `Logical` target as a `Concrete` target. It may be
+            //     // overridden by the profile layer.
+            //     .push_on_response(
+            //         svc::layers().push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
+            //             addr: inner.addr.clone(),
+            //             inner,
+            //         }),
+            //     )
+            //     .into_new_service()
+            //     .cache(
+            //         svc::layers().push_on_response(
+            //             svc::layers()
+            //                 // If the service has been ready & unused for `cache_max_idle_age`,
+            //                 // fail it.
+            //                 .push_idle_timeout(cache_max_idle_age)
+            //                 // If the service has been unavailable for an extend time, eagerly
+            //                 // fail requests.
+            //                 .push_failfast(dispatch_timeout)
+            //                 // Shares the service, ensuring discovery errors are propagated.
+            //                 .push_spawn_buffer(buffer_capacity)
+            //                 .push(metrics.stack.layer(stack_labels("profile"))),
+            //         ),
+            //     )
+            //     .instrument(|_: &Profile| info_span!("profile"))
+            //     // Ensures that the cache isn't locked when polling readiness.
+            //     .push_oneshot()
+            //     .check_make_service::<Profile, Logical<HttpEndpoint>>()
+            //     .push(router::Layer::new(|()| ProfilePerTarget))
+            //     .check_new_service_routes::<(), Logical<HttpEndpoint>>()
+            //     .new_service(());
+
+            // // Caches DNS refinements from relative names to canonical names.
+            // //
+            // // For example, a client may send requests to `foo` or `foo.ns`; and the canonical form
+            // // of these names is `foo.ns.svc.cluster.local
+            // let dns_refine_cache = svc::stack(dns_resolver.into_make_refine())
+            //     .cache(
+            //         svc::layers().push_on_response(
+            //             svc::layers()
+            //                 // If the service has been ready & unused for `cache_max_idle_age`,
+            //                 // fail it.
+            //                 .push_idle_timeout(cache_max_idle_age)
+            //                 // If the service has been unavailable for an extend time, eagerly
+            //                 // fail requests.
+            //                 .push_failfast(dispatch_timeout)
+            //                 // Shares the service, ensuring discovery errors are propagated.
+            //                 .push_spawn_buffer(buffer_capacity)
+            //                 .push(metrics.stack.layer(stack_labels("canonicalize"))),
+            //         ),
+            //     )
+            //     .instrument(|name: &dns::Name| info_span!("canonicalize", %name))
+            //     // Obtains the service, advances the state of the resolution
+            //     .push(svc::make_response::Layer)
+            //     // Ensures that the cache isn't locked when polling readiness.
+            //     .push_oneshot()
+            //     .check_service_response::<dns::Name, dns::Name>()
+            //     .into_inner();
+
+            // // Routes requests to their logical target.
+            // let http_logical_router = svc::stack(http_logical_profile_cache)
+            //     .check_service::<Logical<HttpEndpoint>>()
+            //     .push_on_response(svc::layers().box_http_response())
+            //     .push_make_ready()
+            //     .push_fallback_with_predicate(
+            //         http_concrete
+            //             .push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
+            //                 addr: inner.addr.clone(),
+            //                 inner,
+            //             })
+            //             .push_on_response(svc::layers().box_http_response().box_http_request())
+            //             .check_service::<Logical<HttpEndpoint>>()
+            //             .into_inner(),
+            //         is_discovery_rejected,
+            //     )
+            //     .check_service::<Logical<HttpEndpoint>>()
+            //     // Sets the canonical-dst header on all outbound requests.
+            //     .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
+            //     // Strips headers that may be set by this proxy.
+            //     .push(http::canonicalize::Layer::new(
+            //         dns_refine_cache,
+            //         canonicalize_timeout,
+            //     ))
+            //     .push_on_response(
+            //         // Strips headers that may be set by this proxy.
+            //         svc::layers()
+            //             .push(http::strip_header::request::layer(L5D_CLIENT_ID))
+            //             .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
+            //     )
+            //     .check_service::<Logical<HttpEndpoint>>()
+            //     .instrument(|logical: &Logical<_>| info_span!("logical", addr = %logical.addr));
+
+            // let http_admit_request = svc::layers()
+            //     // Limits the number of in-flight requests.
+            //     .push_concurrency_limit(max_in_flight_requests)
+            //     .push_failfast(dispatch_timeout)
+            //     .push(metrics.http_errors)
+            //     // Synthesizes responses for proxy errors.
+            //     .push(errors::layer())
+            //     // Initiates OpenCensus tracing.
+            //     .push(TraceContextLayer::new(span_sink.map(|span_sink| {
+            //         SpanConverter::server(span_sink, trace_labels())
+            //     })))
+            //     // Tracks proxy handletime.
+            //     .push(metrics.http_handle_time.layer());
+
+            // let http_server = http_logical_router
+            //     .check_service::<Logical<HttpEndpoint>>()
+            //     .push_make_ready()
+            //     .push_timeout(dispatch_timeout)
+            //     .push(router::Layer::new(LogicalPerRequest::from))
+            //     // Used by tap.
+            //     .push_http_insert_target()
+            //     .push_on_response(http_admit_request)
+            //     .push_on_response(metrics.stack.layer(stack_labels("source")))
+            //     .instrument(
+            //         |src: &tls::accept::Meta| {
+            //             info_span!("source", target.addr = %src.addrs.target_addr())
+            //         },
+            //     )
+            //     .check_new_service::<tls::accept::Meta>();
+
+            let http_server = |_| {
+                tower::service_fn(move |_: http::Request<_>| {
+                    future::ok(http::Response::new(http::Body::default()))
                 })
-                .push_map_target(|t: Concrete<HttpEndpoint>| Target {
-                    addr: t.addr.into(),
-                    inner: t.inner.inner,
-                })
-                .check_service::<Concrete<HttpEndpoint>>()
-                // Ensure that buffers don't hold the cache's lock in poll_ready.
-                .push_oneshot();
-
-            // If the balancer fails to be created, i.e., because it is unresolvable, fall back to
-            // using a router that dispatches request to the application-selected original destination.
-            let http_concrete = http_balancer
-                .push_map_target(|c: Concrete<HttpEndpoint>| c.map(|l| l.map(|e| e.settings)))
-                .check_service::<Concrete<HttpEndpoint>>()
-                .push_on_response(svc::layers().box_http_response())
-                .push_make_ready()
-                .push_fallback_with_predicate(
-                    http_forward_cache
-                        .push_on_response(svc::layers().box_http_response())
-                        .into_inner(),
-                    is_discovery_rejected,
-                )
-                .check_service::<Concrete<HttpEndpoint>>();
-
-            let http_profile_route_proxy = svc::proxies()
-                .check_new_clone_service::<dst::Route>()
-                .push(metrics.http_route_actual.into_layer::<classify::Response>())
-                // Sets an optional retry policy.
-                .push(retry::layer(metrics.http_route_retry))
-                .check_new_clone_service::<dst::Route>()
-                // Sets an optional request timeout.
-                .push(http::MakeTimeoutLayer::default())
-                .check_new_clone_service::<dst::Route>()
-                // Records per-route metrics.
-                .push(metrics.http_route.into_layer::<classify::Response>())
-                .check_new_clone_service::<dst::Route>()
-                // Sets the per-route response classifier as a request
-                // extension.
-                .push(classify::Layer::new())
-                .check_new_clone_service::<dst::Route>();
-
-            // Routes `Logical` targets to a cached `Profile` stack, i.e. so that profile
-            // resolutions are shared even as the type of request may vary.
-            let http_logical_profile_cache = http_concrete
-                .clone()
-                .push_on_response(svc::layers().box_http_request())
-                .check_service::<Concrete<HttpEndpoint>>()
-                // Provides route configuration. The profile service operates
-                // over `Concret` services. When overrides are in play, the
-                // Concrete destination may be overridden.
-                .push(profiles::Layer::with_overrides(
-                    profiles_client,
-                    http_profile_route_proxy.into_inner(),
-                ))
-                .check_make_service::<Profile, Concrete<HttpEndpoint>>()
-                // Use the `Logical` target as a `Concrete` target. It may be
-                // overridden by the profile layer.
-                .push_on_response(
-                    svc::layers().push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
-                        addr: inner.addr.clone(),
-                        inner,
-                    }),
-                )
-                .into_new_service()
-                .cache(
-                    svc::layers().push_on_response(
-                        svc::layers()
-                            // If the service has been ready & unused for `cache_max_idle_age`,
-                            // fail it.
-                            .push_idle_timeout(cache_max_idle_age)
-                            // If the service has been unavailable for an extend time, eagerly
-                            // fail requests.
-                            .push_failfast(dispatch_timeout)
-                            // Shares the service, ensuring discovery errors are propagated.
-                            .push_spawn_buffer(buffer_capacity)
-                            .push(metrics.stack.layer(stack_labels("profile"))),
-                    ),
-                )
-                .instrument(|_: &Profile| info_span!("profile"))
-                // Ensures that the cache isn't locked when polling readiness.
-                .push_oneshot()
-                .check_make_service::<Profile, Logical<HttpEndpoint>>()
-                .push(router::Layer::new(|()| ProfilePerTarget))
-                .check_new_service_routes::<(), Logical<HttpEndpoint>>()
-                .new_service(());
-
-            // Caches DNS refinements from relative names to canonical names.
-            //
-            // For example, a client may send requests to `foo` or `foo.ns`; and the canonical form
-            // of these names is `foo.ns.svc.cluster.local
-            let dns_refine_cache = svc::stack(dns_resolver.into_make_refine())
-                .cache(
-                    svc::layers().push_on_response(
-                        svc::layers()
-                            // If the service has been ready & unused for `cache_max_idle_age`,
-                            // fail it.
-                            .push_idle_timeout(cache_max_idle_age)
-                            // If the service has been unavailable for an extend time, eagerly
-                            // fail requests.
-                            .push_failfast(dispatch_timeout)
-                            // Shares the service, ensuring discovery errors are propagated.
-                            .push_spawn_buffer(buffer_capacity)
-                            .push(metrics.stack.layer(stack_labels("canonicalize"))),
-                    ),
-                )
-                .instrument(|name: &dns::Name| info_span!("canonicalize", %name))
-                // Obtains the service, advances the state of the resolution
-                .push(svc::make_response::Layer)
-                // Ensures that the cache isn't locked when polling readiness.
-                .push_oneshot()
-                .check_service_response::<dns::Name, dns::Name>()
-                .into_inner();
-
-            // Routes requests to their logical target.
-            let http_logical_router = svc::stack(http_logical_profile_cache)
-                .check_service::<Logical<HttpEndpoint>>()
-                .push_on_response(svc::layers().box_http_response())
-                .push_make_ready()
-                .push_fallback_with_predicate(
-                    http_concrete
-                        .push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
-                            addr: inner.addr.clone(),
-                            inner,
-                        })
-                        .push_on_response(svc::layers().box_http_response().box_http_request())
-                        .check_service::<Logical<HttpEndpoint>>()
-                        .into_inner(),
-                    is_discovery_rejected,
-                )
-                .check_service::<Logical<HttpEndpoint>>()
-                // Sets the canonical-dst header on all outbound requests.
-                .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
-                // Strips headers that may be set by this proxy.
-                .push(http::canonicalize::Layer::new(
-                    dns_refine_cache,
-                    canonicalize_timeout,
-                ))
-                .push_on_response(
-                    // Strips headers that may be set by this proxy.
-                    svc::layers()
-                        .push(http::strip_header::request::layer(L5D_CLIENT_ID))
-                        .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
-                )
-                .check_service::<Logical<HttpEndpoint>>()
-                .instrument(|logical: &Logical<_>| info_span!("logical", addr = %logical.addr));
-
-            let http_admit_request = svc::layers()
-                // Limits the number of in-flight requests.
-                .push_concurrency_limit(max_in_flight_requests)
-                .push_failfast(dispatch_timeout)
-                .push(metrics.http_errors)
-                // Synthesizes responses for proxy errors.
-                .push(errors::layer())
-                // Initiates OpenCensus tracing.
-                .push(TraceContextLayer::new(span_sink.map(|span_sink| {
-                    SpanConverter::server(span_sink, trace_labels())
-                })))
-                // Tracks proxy handletime.
-                .push(metrics.http_handle_time.layer());
-
-            let http_server = http_logical_router
-                .check_service::<Logical<HttpEndpoint>>()
-                .push_make_ready()
-                .push_timeout(dispatch_timeout)
-                .push(router::Layer::new(LogicalPerRequest::from))
-                // Used by tap.
-                .push_http_insert_target()
-                .push_on_response(http_admit_request)
-                .push_on_response(metrics.stack.layer(stack_labels("source")))
-                .instrument(
-                    |src: &tls::accept::Meta| {
-                        info_span!("source", target.addr = %src.addrs.target_addr())
-                    },
-                )
-                .check_new_service::<tls::accept::Meta>();
+            };
 
             let tcp_server = Server::new(
                 TransportLabels,
                 metrics.transport,
                 tcp_forward.into_inner(),
-                http_server.into_inner(),
+                http_server, /* .into_inner(), */
                 h2_settings,
                 drain.clone(),
                 disable_protocol_detection_for_ports.clone(),


### PR DESCRIPTION
This branch begins a "top-down" update of the proxy to use
`std::future`. I've started by commenting out most of the stack, making
the proxy into a raw TCP forwarder/HTTP server that just always returns
`200 OK <eof>`. Then, I've updated the top-level `serve` function to use
`std::future`. This is pretty mechanical, but we _may_ want to consider
doing some refactoring here in the future.

Currently, most of the integration tests are failing, since they test
functionality that is now commented out. I've added `ignore` attributes
temporarily to disable those tests. However, since we are ignoring the
tests rather than disabling them via conditional compilation, we will
still try to build them, so this ensures we don't accidentally break any
of these tests. There is a feature flag, "nyi", that can be enabled to
run the ignored tests, so that we can test if changes have made any
additional tests pass again. As functionality is re-enabled, we can
re-enable the corresponding tests as well.