### PR TITLE
port `drain` to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1203,6 +1203,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
  "futures 0.1.26",
+ "futures 0.3.4",
  "h2",
  "http",
  "http-body",
@@ -1221,6 +1222,7 @@ dependencies = [
  "linkerd2-timeout",
  "rand 0.7.2",
  "tokio 0.1.22",
+ "tokio 0.2.17",
  "tokio-connect",
  "tokio-timer",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,7 +413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.1",
+ "proc-macro2 1.0.10",
  "quote 1.0.2",
  "syn 1.0.5",
 ]
@@ -718,7 +718,7 @@ dependencies = [
  "ring",
  "rustls",
  "tokio 0.1.22",
- "tokio 0.2.13",
+ "tokio 0.2.17",
  "tokio-compat",
  "tokio-connect",
  "tokio-current-thread",
@@ -954,8 +954,11 @@ dependencies = [
 name = "linkerd2-drain"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.26",
+ "futures 0.3.4",
  "linkerd2-error",
+ "pin-project",
+ "tokio 0.2.17",
+ "tokio-test",
 ]
 
 [[package]]
@@ -1750,7 +1753,7 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385322a45f2ecf3410c68d2a549a4a2685e8051d0f278e39743ff4e451cb9b3f"
 dependencies = [
- "proc-macro2 1.0.1",
+ "proc-macro2 1.0.10",
  "quote 1.0.2",
  "syn 1.0.5",
 ]
@@ -1796,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.1"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
+checksum = "df246d292ff63439fea9bc8c0a270bed0e390d5ebd4db4ba15aba81111b5abe3"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
@@ -1895,7 +1898,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 dependencies = [
- "proc-macro2 1.0.1",
+ "proc-macro2 1.0.10",
 ]
 
 [[package]]
@@ -2311,7 +2314,7 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 dependencies = [
- "proc-macro2 1.0.1",
+ "proc-macro2 1.0.10",
  "quote 1.0.2",
  "unicode-xid 0.2.0",
 ]
@@ -2408,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.13"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa5e81d6bc4e67fe889d5783bd2a128ab2e0cfa487e0be16b6a8d177b101616"
+checksum = "39fb9142eb6e9cc37f4f29144e62618440b149a138eee01a7bbe9b9226aaf17c"
 dependencies = [
  "bytes 0.5.3",
  "fnv",
@@ -2420,6 +2423,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "slab",
+ "tokio-macros",
 ]
 
 [[package]]
@@ -2454,7 +2458,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "tokio 0.2.13",
+ "tokio 0.2.17",
  "tokio-current-thread",
  "tokio-executor",
  "tokio-reactor",
@@ -2510,6 +2514,17 @@ dependencies = [
  "bytes 0.4.11",
  "futures 0.1.26",
  "log",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.2",
+ "syn 1.0.5",
 ]
 
 [[package]]
@@ -2583,6 +2598,17 @@ dependencies = [
  "mio",
  "tokio-io",
  "tokio-reactor",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cf9705471976fa5fc6817d3fbc9c4ff9696a6647af0e5c1870c81ca7445b05"
+dependencies = [
+ "bytes 0.5.3",
+ "futures-core",
+ "tokio 0.2.17",
 ]
 
 [[package]]
@@ -3128,7 +3154,7 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.1",
+ "proc-macro2 1.0.10",
  "quote 1.0.2",
  "syn 1.0.5",
  "wasm-bindgen-shared",
@@ -3150,7 +3176,7 @@ version = "0.2.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a433d89ecdb9f77d46fcf00c8cf9f3467b7de9954d8710c175f61e2e245bb0e"
 dependencies = [
- "proc-macro2 1.0.1",
+ "proc-macro2 1.0.10",
  "quote 1.0.2",
  "syn 1.0.5",
  "wasm-bindgen-backend",
@@ -3172,7 +3198,7 @@ dependencies = [
  "failure",
  "heck",
  "log",
- "proc-macro2 1.0.1",
+ "proc-macro2 1.0.10",
  "quote 1.0.2",
  "syn 1.0.5",
  "wasm-bindgen-backend",

--- a/linkerd/drain/Cargo.toml
+++ b/linkerd/drain/Cargo.toml
@@ -6,5 +6,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.1"
 linkerd2-error = { path = "../error" }
+tokio = {version = "0.2.17", features = ["sync", "macros"]}
+pin-project = "0.4"
+futures = "0.3"
+
+[dev-dependencies]
+tokio-test = "0.2"

--- a/linkerd/drain/src/lib.rs
+++ b/linkerd/drain/src/lib.rs
@@ -1,10 +1,12 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use futures::future::Shared;
-use futures::sync::{mpsc, oneshot};
-use futures::{try_ready, Async, Future, Poll, Stream};
+use futures::{future::Shared, FutureExt, TryFutureExt};
 use linkerd2_error::Never;
-use std::mem;
+use pin_project::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::sync::{mpsc, oneshot};
 
 /// Creates a drain channel.
 ///
@@ -17,7 +19,7 @@ pub fn channel() -> (Signal, Watch) {
         Signal { drained_rx, tx },
         Watch {
             drained_tx,
-            rx: rx.shared(),
+            rx: rx.map_err((|_| ()) as fn(_) -> _).shared(),
         },
     )
 }
@@ -35,28 +37,23 @@ pub struct Signal {
 /// Watch for a drain command.
 ///
 /// This wraps another future and callback to be called when drain is triggered.
+#[pin_project]
 #[derive(Clone, Debug)]
 pub struct Watch {
+    #[pin]
     drained_tx: mpsc::Sender<Never>,
-    rx: Shared<oneshot::Receiver<()>>,
-}
-
-/// The wrapped watching `Future`.
-#[derive(Debug)]
-pub struct Watching<A, F> {
-    future: A,
-    state: State<F>,
-    watch: Watch,
-}
-
-#[derive(Debug)]
-enum State<F> {
-    Watch(F),
-    Draining,
+    rx: Shared<
+        futures::future::MapErr<
+            oneshot::Receiver<()>,
+            fn(tokio::sync::oneshot::error::RecvError) -> (),
+        >,
+    >,
 }
 
 /// A future that resolves when all `Watch`ers have been dropped (drained).
+#[pin_project]
 pub struct Drained {
+    #[pin]
     drained_rx: mpsc::Receiver<Never>,
 }
 
@@ -83,47 +80,16 @@ impl Watch {
     ///
     /// The callback receives a mutable reference to the original future, and
     /// should be used to trigger any shutdown process for it.
-    pub fn watch<A, F>(self, future: A, on_drain: F) -> Watching<A, F>
+    pub async fn watch<A, F>(self, mut future: A, on_drain: F) -> A::Output
     where
-        A: Future,
+        A: Future + Unpin,
         F: FnOnce(&mut A),
     {
-        Watching {
-            future,
-            state: State::Watch(on_drain),
-            watch: self,
-        }
-    }
-}
-
-// ===== impl Watching =====
-
-impl<A, F> Future for Watching<A, F>
-where
-    A: Future,
-    F: FnOnce(&mut A),
-{
-    type Item = A::Item;
-    type Error = A::Error;
-
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        loop {
-            match mem::replace(&mut self.state, State::Draining) {
-                State::Watch(on_drain) => {
-                    match self.watch.rx.poll() {
-                        Ok(Async::Ready(_)) | Err(_) => {
-                            // Drain has been triggered!
-                            on_drain(&mut self.future);
-                        }
-                        Ok(Async::NotReady) => {
-                            self.state = State::Watch(on_drain);
-                            return self.future.poll();
-                        }
-                    }
-                }
-                State::Draining => {
-                    return self.future.poll();
-                }
+        tokio::select! {
+            res = &mut future => res,
+            _ = self.rx => {
+                on_drain(&mut future);
+                (&mut future).await
             }
         }
     }
@@ -132,13 +98,12 @@ where
 // ===== impl Drained =====
 
 impl Future for Drained {
-    type Item = ();
-    type Error = ();
+    type Output = ();
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match try_ready!(self.drained_rx.poll()) {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match futures::ready!(self.project().drained_rx.poll_recv(cx)) {
             Some(never) => match never {},
-            None => Ok(Async::Ready(())),
+            None => Poll::Ready(()),
         }
     }
 }
@@ -146,121 +111,114 @@ impl Future for Drained {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::{future, Async, Future, Poll};
-
+    use std::sync::{
+        atomic::{AtomicBool, AtomicUsize, Ordering::Relaxed},
+        Arc,
+    };
+    use tokio_test::{assert_pending, assert_ready, task};
     struct TestMe {
-        draining: bool,
-        finished: bool,
-        poll_cnt: usize,
+        draining: AtomicBool,
+        finished: AtomicBool,
+        poll_cnt: AtomicUsize,
     }
 
-    impl Future for TestMe {
-        type Item = ();
-        type Error = ();
+    struct TestMeFut(Arc<TestMe>);
 
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            self.poll_cnt += 1;
-            if self.finished {
-                Ok(Async::Ready(()))
+    impl Future for TestMeFut {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = self.as_ref();
+            this.0.poll_cnt.fetch_add(1, Relaxed);
+            if this.0.finished.load(Relaxed) {
+                Poll::Ready(())
             } else {
-                Ok(Async::NotReady)
+                Poll::Pending
             }
         }
     }
 
     #[test]
     fn watch() {
-        future::lazy(|| {
-            let (tx, rx) = channel();
-            let fut = TestMe {
-                draining: false,
-                finished: false,
-                poll_cnt: 0,
-            };
+        let (tx, rx) = channel();
+        let fut = Arc::new(TestMe {
+            draining: AtomicBool::new(false),
+            finished: AtomicBool::new(false),
+            poll_cnt: AtomicUsize::new(0),
+        });
 
-            let mut watch = rx.watch(fut, |fut| {
-                fut.draining = true;
-            });
+        let mut watch = task::spawn(rx.watch(TestMeFut(fut.clone()), |fut| {
+            fut.0.draining.store(true, Relaxed)
+        }));
 
-            assert_eq!(watch.future.poll_cnt, 0);
+        assert_eq!(fut.poll_cnt.load(Relaxed), 0);
 
-            // First poll should poll the inner future
-            assert!(watch.poll().unwrap().is_not_ready());
-            assert_eq!(watch.future.poll_cnt, 1);
+        // First poll should poll the inner future, 1);
+        assert_pending!(watch.poll());
+        assert_eq!(fut.poll_cnt.load(Relaxed), 1);
 
-            // Second poll should poll the inner future again
-            assert!(watch.poll().unwrap().is_not_ready());
-            assert_eq!(watch.future.poll_cnt, 2);
+        // Second poll should poll the inner future again
+        assert_pending!(watch.poll());
+        assert_eq!(fut.poll_cnt.load(Relaxed), 2);
 
-            let mut draining = tx.drain();
-            // Drain signaled, but needs another poll to be noticed.
-            assert!(!watch.future.draining);
-            assert_eq!(watch.future.poll_cnt, 2);
+        let mut draining = task::spawn(tx.drain());
+        // Drain signaled, but needs another poll to be noticed.
+        assert!(!fut.draining.load(Relaxed));
+        assert_eq!(fut.poll_cnt.load(Relaxed), 2);
 
-            // Now, poll after drain has been signaled.
-            assert!(watch.poll().unwrap().is_not_ready());
-            assert_eq!(watch.future.poll_cnt, 3);
-            assert!(watch.future.draining);
+        // Now, poll after drain has been signaled.
+        assert_pending!(watch.poll());
+        assert!(fut.draining.load(Relaxed));
+        assert_eq!(fut.poll_cnt.load(Relaxed), 3);
 
-            // Draining is not ready until watcher completes
-            assert!(draining.poll().unwrap().is_not_ready());
+        // Draining is not ready until watcher completes
+        assert_pending!(draining.poll());
 
-            // Finishing up the watch future
-            watch.future.finished = true;
-            assert!(watch.poll().unwrap().is_ready());
-            assert_eq!(watch.future.poll_cnt, 4);
-            drop(watch);
+        // Finishing up the watch future
+        fut.finished.store(true, Relaxed);
+        assert_ready!(watch.poll());
+        assert_eq!(fut.poll_cnt.load(Relaxed), 4);
+        drop(watch);
 
-            assert!(draining.poll().unwrap().is_ready());
-
-            Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        assert_ready!(draining.poll());
     }
 
     #[test]
     fn watch_clones() {
-        future::lazy(|| {
-            let (tx, rx) = channel();
+        let (tx, rx) = channel();
+        let fut1 = Arc::new(TestMe {
+            draining: AtomicBool::new(false),
+            finished: AtomicBool::new(false),
+            poll_cnt: AtomicUsize::new(0),
+        });
+        let fut2 = Arc::new(TestMe {
+            draining: AtomicBool::new(false),
+            finished: AtomicBool::new(false),
+            poll_cnt: AtomicUsize::new(0),
+        });
 
-            let fut1 = TestMe {
-                draining: false,
-                finished: false,
-                poll_cnt: 0,
-            };
-            let fut2 = TestMe {
-                draining: false,
-                finished: false,
-                poll_cnt: 0,
-            };
+        let watch1 = task::spawn(rx.clone().watch(TestMeFut(fut1.clone()), |fut| {
+            fut.0.draining.store(true, Relaxed)
+        }));
 
-            let watch1 = rx.clone().watch(fut1, |fut| {
-                fut.draining = true;
-            });
-            let watch2 = rx.watch(fut2, |fut| {
-                fut.draining = true;
-            });
+        let watch2 = task::spawn(rx.clone().watch(TestMeFut(fut2.clone()), |fut| {
+            fut.0.draining.store(true, Relaxed)
+        }));
 
-            let mut draining = tx.drain();
+        let mut draining = task::spawn(tx.drain());
 
-            // Still 2 outstanding watchers
-            assert!(draining.poll().unwrap().is_not_ready());
+        // Still 2 outstanding watchers
+        assert_pending!(draining.poll());
 
-            // drop 1 for whatever reason
-            drop(watch1);
+        // drop 1 for whatever reason
+        drop(watch1);
 
-            // Still not ready, 1 other watcher still pending
-            assert!(draining.poll().unwrap().is_not_ready());
+        // Still not ready, 1 other watcher still pending
+        assert_pending!(draining.poll());
 
-            drop(watch2);
+        drop(watch2);
 
-            // Now all watchers are gone, draining is complete
-            assert!(draining.poll().unwrap().is_ready());
-
-            Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        // Now all watchers are gone, draining is complete
+        assert_ready!(draining.poll())
     }
 }

--- a/linkerd/drain/src/lib.rs
+++ b/linkerd/drain/src/lib.rs
@@ -93,6 +93,23 @@ impl Watch {
             }
         }
     }
+
+    /// Wrap a future to count it against the completion of the `Drained`
+    /// future that corresponds to this `Watch`.
+    ///
+    /// Unlike `Watch::watch`, this method does not take a callback that is
+    /// triggered on drain; the wrapped future will simply be allowed to
+    /// complete. However, like `Watch::watch`, the `Drained` future returned
+    /// by calling `drain` on the corresponding `Signal` will not complete until
+    /// the wrapped future finishes.
+    pub async fn with<A>(self, future: A) -> A::Output
+    where
+        A: Future,
+    {
+        let res = future.await;
+        drop(self);
+        res
+    }
 }
 
 // ===== impl Drained =====

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -13,6 +13,7 @@ This should probably be decomposed into smaller, decoupled crates.
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
+futures_03 = { package = "futures", version = "0.3", features = ["compat"]}
 h2 = "0.1"
 http = "0.1"
 http-body = "0.1"
@@ -31,6 +32,7 @@ linkerd2-stack = { path  = "../../stack" }
 linkerd2-timeout = { path  = "../../timeout" }
 rand = "0.7"
 tokio = "0.1"
+tokio_02 = { package = "tokio", version = "0.2" }
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-timer = "0.2"   # for tokio_timer::clock
 tower = "0.1"
@@ -40,5 +42,5 @@ tower-load = { git = "https://github.com/tower-rs/tower" }
 tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 tower-util = "0.1"
 tracing = "0.1.9"
-tracing-futures = "0.1"
+tracing-futures = { version = "0.1", features = ["std-future"] }
 try-lock = "0.2"

--- a/linkerd/proxy/http/src/upgrade.rs
+++ b/linkerd/proxy/http/src/upgrade.rs
@@ -4,6 +4,7 @@ use futures::{
     future::{self, Either},
     Future, Poll,
 };
+use futures_03::compat::Future01CompatExt;
 use hyper::upgrade::OnUpgrade;
 use linkerd2_drain as drain;
 use linkerd2_duplex::Duplex;
@@ -148,11 +149,11 @@ impl Drop for Inner {
             // There's nothing to do when drain is signaled, we just have to hope
             // the sockets finish soon. However, the drain signal still needs to
             // 'watch' the TCP future so that the process doesn't close early.
-            tokio::spawn(
+            tokio_02::spawn(
                 self.upgrade_drain_signal
                     .take()
                     .expect("only taken in drop")
-                    .watch(both_upgrades, |_| ())
+                    .watch(both_upgrades.compat(), |_| ())
                     .in_current_span(),
             );
         } else {

--- a/linkerd/proxy/http/src/upgrade.rs
+++ b/linkerd/proxy/http/src/upgrade.rs
@@ -157,7 +157,7 @@ impl Drop for Inner {
                 self.upgrade_drain_signal
                     .take()
                     .expect("only taken in drop")
-                    .with(both_upgrades)
+                    .after(both_upgrades)
                     .in_current_span(),
             );
         } else {

--- a/linkerd/proxy/http/src/upgrade.rs
+++ b/linkerd/proxy/http/src/upgrade.rs
@@ -133,19 +133,23 @@ impl Drop for Inner {
         if let (Some(server), Some(client)) = (server, client) {
             trace!("HTTP/1.1 upgrade has both halves");
 
-            let server_upgrade = server.map_err(|e| debug!("server HTTP upgrade error: {}", e));
+            let server_upgrade = server
+                .map_err(|e| debug!("server HTTP upgrade error: {}", e))
+                .compat();
 
-            let client_upgrade = client.map_err(|e| debug!("client HTTP upgrade error: {}", e));
+            let client_upgrade = client
+                .map_err(|e| debug!("client HTTP upgrade error: {}", e))
+                .compat();
 
-            let both_upgrades =
-                server_upgrade
-                    .join(client_upgrade)
-                    .and_then(|(server_conn, client_conn)| {
-                        trace!("HTTP upgrade successful");
-                        Duplex::new(server_conn, client_conn)
-                            .map_err(|e| info!("tcp duplex error: {}", e))
-                    });
-
+            let both_upgrades = async move {
+                let (server_conn, client_conn) =
+                    tokio_02::try_join!(server_upgrade, client_upgrade)?;
+                trace!("HTTP upgrade successful");
+                if let Err(e) = Duplex::new(server_conn, client_conn).compat().await {
+                    info!("tcp duplex error: {}", e)
+                }
+                Ok::<(), ()>(())
+            };
             // There's nothing to do when drain is signaled, we just have to hope
             // the sockets finish soon. However, the drain signal still needs to
             // 'watch' the TCP future so that the process doesn't close early.
@@ -153,7 +157,7 @@ impl Drop for Inner {
                 self.upgrade_drain_signal
                     .take()
                     .expect("only taken in drop")
-                    .watch(both_upgrades.compat(), |_| ())
+                    .with(both_upgrades)
                     .in_current_span(),
             );
         } else {


### PR DESCRIPTION
This updates the `drain` crate to use std::future.

Note that because Tokio 0.2's `spawn` returns a `JoinHandle` that may
be used to await a task's completion, we can probably simplify the 
"waiting for tasks to drain" logic a bit. I didn't do that because I wanted
to do as close to a strict translation as possible, without adding possible
changes in behavior. Also, we are currently still using the compat runtime's
0.1-style spawning.