### PR TITLE
Makefile: Use STRIP variable with strip as default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ ifndef PACKAGE_VERSION
 	PACKAGE_VERSION = $(shell git rev-parse --short HEAD)
 endif
 
+STRIP ?= strip
 PROFILING = profiling
 TARGET_BIN = $(TARGET)/linkerd2-proxy
 PKG_ROOT = $(TARGET)/package
@@ -43,7 +44,7 @@ $(PKG_ROOT)/$(PKG): $(TARGET_BIN)
 	mkdir -p $(PKG_BASE)/bin
 	cp LICENSE $(PKG_BASE)
 	cp $(TARGET_BIN) $(PKG_BASE)/bin/linkerd2-proxy
-	strip $(PKG_BASE)/bin/linkerd2-proxy
+	$(STRIP) $(PKG_BASE)/bin/linkerd2-proxy
 ifdef CARGO_DEBUG
 	if which objcopy >/dev/null ; then \
 		objcopy $(TARGET_BIN) $(PKG_BASE)/linkerd2-proxy.obj ; \


### PR DESCRIPTION
If we run make in a cross-compile environment where the strip binary we
want to use is something else than strip, it is useful to have a STRIP
variable in the Makefile. If STRIP is not set, the default value is the
common strip.
