### PR TITLE
Undo hardcoded release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: package
         env:
           CARGO_RELEASE: "1"
-          PACKAGE_VERSION: test-0.0.0 # ${{ steps.release-tag-meta.outputs.name }}
+          PACKAGE_VERSION: ${{ steps.release-tag-meta.outputs.name }}
         uses: ./.github/actions/package
         with:
           entrypoint: make


### PR DESCRIPTION
During testing, we set a hardcoded release version, but this was not
undone.

This fixes the release action by restoring the tag-derived version
string.