### PR TITLE
Remove the IntoAbsForm trait

### DIFF
--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -51,8 +51,8 @@ impl connect::ConnectAddr for HttpEndpoint {
 }
 
 impl http::settings::HasSettings for HttpEndpoint {
-    fn http_settings(&self) -> &http::Settings {
-        &self.settings
+    fn http_settings(&self) -> http::Settings {
+        self.settings
     }
 }
 
@@ -149,8 +149,8 @@ impl http::normalize_uri::ShouldNormalizeUri for Target {
 }
 
 impl http::settings::HasSettings for Target {
-    fn http_settings(&self) -> &http::Settings {
-        &self.http_settings
+    fn http_settings(&self) -> http::Settings {
+        self.http_settings
     }
 }
 

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -6,7 +6,7 @@ use linkerd2_app_core::{
     profiles,
     proxy::{
         api_resolve::{Metadata, ProtocolHint},
-        http::overwrite_authority::ExtractAuthority,
+        http::overwrite_authority::CanOverrideAuthority,
         http::{self, identity_from_header, Settings},
         identity,
         resolve::map_endpoint::MapEndpoint,
@@ -297,9 +297,9 @@ impl MapEndpoint<Concrete<http::Settings>, Metadata> for FromMetadata {
     }
 }
 
-impl ExtractAuthority<Target<HttpEndpoint>> for FromMetadata {
-    fn extract(&self, target: &Target<HttpEndpoint>) -> Option<Authority> {
-        target.inner.metadata.authority_override().cloned()
+impl CanOverrideAuthority for Target<HttpEndpoint> {
+    fn override_authority(&self) -> Option<Authority> {
+        self.inner.metadata.authority_override().cloned()
     }
 }
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -157,7 +157,7 @@ impl Config {
                     }))
                     .push(observability.clone())
                     .push(identity_headers.clone())
-                    .push(http::overwrite_authority::layer(endpoint::FromMetadata,  vec![HOST.as_str(), CANONICAL_DST_HEADER]))
+                    .push(http::overwrite_authority::Layer::new(vec![HOST.as_str(), CANONICAL_DST_HEADER]))
                     // Ensures that the request's URI is in the proper form.
                     .push(http::normalize_uri::layer())
                     // Upgrades HTTP/1 requests to be transported over HTTP/2 connections.

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -120,7 +120,7 @@ where
     fn call(&mut self, target: T) -> Self::Future {
         trace!("Building HTTP client");
         let connect = self.connect.clone();
-        match *target.http_settings() {
+        match target.http_settings() {
             Settings::Http1 {
                 keep_alive,
                 wants_h1_upgrade: _,

--- a/linkerd/proxy/http/src/settings.rs
+++ b/linkerd/proxy/http/src/settings.rs
@@ -20,12 +20,12 @@ pub enum Settings {
 }
 
 pub trait HasSettings {
-    fn http_settings(&self) -> &Settings;
+    fn http_settings(&self) -> Settings;
 }
 
 impl HasSettings for Settings {
-    fn http_settings(&self) -> &Settings {
-        self
+    fn http_settings(&self) -> Settings {
+        *self
     }
 }
 


### PR DESCRIPTION
@zaharidichev What do you think of this?

This change modifies the `HasSettings` trait to return a `Settings`
(rather than a reference). The `Settings` type is a simple type with a
few bools, so it's safe to copy freely.

This enables us to implement `HasSettings` for `http::HttpEndpoint` by
overriding the `was_absolute_from` when appropriate without having to
introduce an additional trait