### PR TITLE
Replace ExtractAuthority with CanOverrideAuthority

### DIFF
--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -6,7 +6,7 @@ use linkerd2_app_core::{
     profiles,
     proxy::{
         api_resolve::{Metadata, ProtocolHint},
-        http::overwrite_authority::ExtractAuthority,
+        http::overwrite_authority::CanOverrideAuthority,
         http::{self, identity_from_header, Settings},
         identity,
         resolve::map_endpoint::MapEndpoint,
@@ -297,9 +297,9 @@ impl MapEndpoint<Concrete<http::Settings>, Metadata> for FromMetadata {
     }
 }
 
-impl ExtractAuthority<Target<HttpEndpoint>> for FromMetadata {
-    fn extract(&self, target: &Target<HttpEndpoint>) -> Option<Authority> {
-        target.inner.metadata.authority_override().cloned()
+impl CanOverrideAuthority for Target<HttpEndpoint> {
+    fn override_authority(&self) -> Option<Authority> {
+        self.inner.metadata.authority_override().cloned()
     }
 }
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -157,7 +157,7 @@ impl Config {
                     }))
                     .push(observability.clone())
                     .push(identity_headers.clone())
-                    .push(http::overwrite_authority::layer(endpoint::FromMetadata,  vec![HOST.as_str(), CANONICAL_DST_HEADER]))
+                    .push(http::overwrite_authority::Layer::new(vec![HOST.as_str(), CANONICAL_DST_HEADER]))
                     // Ensures that the request's URI is in the proper form.
                     .push(http::normalize_uri::layer())
                     // Upgrades HTTP/1 requests to be transported over HTTP/2 connections.


### PR DESCRIPTION
The extractor pattern is useful when we need to use additional
configuration or when we don't control the type over which we're
extracting a value (like an http::Request). But in the case of authority
overrides, we have all of the information we need on the target type.

This change replaces the ExtractAuthority strategy with a
CanOverrideAuthority trait that must be implemented by targets.

I've also modified logging to be at the debug level (request
modification seems useful to observe when debugging), and I've renamed
some variables to match the tracing output.

I think, as a follow up, I'd prefer that we call this module
`override_authority` (rather than "overwrite"), as this matches the
naming in the controller/API.

I've also moved `layer => Layer::new`, which is the newer idiom we're
targetting.