### PR TITLE
Adjust metric description.

### DIFF
--- a/linkerd/http-metrics/src/retries.rs
+++ b/linkerd/http-metrics/src/retries.rs
@@ -95,7 +95,7 @@ where
     fn retryable_total(&self) -> Metric<'_, Prefixed<'_, &'static str>, Counter> {
         Metric::new(
             self.prefix_key("retryable_total"),
-            "Total count of retryable HTTP responses that were not retried.",
+            "Total count of retryable HTTP responses.",
         )
     }
 }


### PR DESCRIPTION
The retryable HTTP responses that were not retries are only those with the skipped: no_budget label. Actual retries that occured fall under this metric category.

Signed-off-by: Naseem <naseem@transit.app>