### PR TITLE
Simplify orig_proto_upgrade

### DIFF
--- a/linkerd/app/outbound/src/orig_proto_upgrade.rs
+++ b/linkerd/app/outbound/src/orig_proto_upgrade.rs
@@ -1,4 +1,7 @@
-use crate::proxy::http::{orig_proto, settings::Settings};
+use crate::proxy::http::{
+    orig_proto,
+    settings::{HasSettings, Settings},
+};
 use crate::svc::stack;
 use crate::{HttpEndpoint, Target};
 use futures::{try_ready, Future, Poll};
@@ -47,9 +50,7 @@ where
             return Either::B(self.inner.new_service(endpoint));
         }
 
-        let was_absolute = endpoint.inner.metadata.authority_override().is_some()
-            || endpoint.inner.settings.was_absolute_form();
-
+        let was_absolute = endpoint.http_settings().was_absolute_form();
         trace!(
             header = %orig_proto::L5D_ORIG_PROTO,
             was_absolute,
@@ -77,8 +78,7 @@ where
     fn call(&mut self, mut endpoint: Target<HttpEndpoint>) -> Self::Future {
         let can_upgrade = endpoint.inner.can_use_orig_proto();
 
-        let was_absolute = endpoint.inner.metadata.authority_override().is_some()
-            || endpoint.inner.settings.was_absolute_form();
+        let was_absolute = endpoint.http_settings().was_absolute_form();
 
         if can_upgrade {
             trace!(


### PR DESCRIPTION
OrigProtoUpgrade shouldn't have to know about authority overrides. This
change uses the `HasSettings` implementation on endpoint to hide this
detail.