### PR TITLE
port stack to std::future

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -102,9 +102,9 @@ impl<L> Layers<L> {
     //     self.push(timeout::ProbeReadyLayer::new(interval))
     // }
 
-    // pub fn push_on_response<U>(self, layer: U) -> Layers<Pair<L, stack::OnResponseLayer<U>>> {
-    //     self.push(stack::OnResponseLayer::new(layer))
-    // }
+    pub fn push_on_response<U>(self, layer: U) -> Layers<Pair<L, stack::OnResponseLayer<U>>> {
+        self.push(stack::OnResponseLayer::new(layer))
+    }
 
     pub fn push_spawn_ready(self) -> Layers<Pair<L, SpawnReadyLayer>> {
         self.push(SpawnReadyLayer::new())
@@ -114,9 +114,9 @@ impl<L> Layers<L> {
         self.push(concurrency_limit::Layer::new(max))
     }
 
-    // pub fn push_make_ready<Req>(self) -> Layers<Pair<L, stack::MakeReadyLayer<Req>>> {
-    //     self.push(stack::MakeReadyLayer::new())
-    // }
+    pub fn push_make_ready<Req>(self) -> Layers<Pair<L, stack::MakeReadyLayer<Req>>> {
+        self.push(stack::MakeReadyLayer::new())
+    }
 
     pub fn push_map_response<R: Clone>(
         self,
@@ -144,9 +144,9 @@ impl<L> Layers<L> {
         self.push(http::boxed::response::Layer::new())
     }
 
-    // pub fn push_oneshot(self) -> Layers<Pair<L, stack::OneshotLayer>> {
-    //     self.push(stack::OneshotLayer::new())
-    // }
+    pub fn push_oneshot(self) -> Layers<Pair<L, stack::OneshotLayer>> {
+        self.push(stack::OneshotLayer::new())
+    }
 
     pub fn push_instrument<G: Clone>(self, get_span: G) -> Layers<Pair<L, InstrumentMakeLayer<G>>> {
         self.push(InstrumentMakeLayer::new(get_span))
@@ -187,9 +187,9 @@ impl<S> Stack<S> {
     //     self.push(stack::new_service::FromMakeServiceLayer::default())
     // }
 
-    // pub fn push_make_ready<Req>(self) -> Stack<stack::MakeReady<S, Req>> {
-    //     self.push(stack::MakeReadyLayer::new())
-    // }
+    pub fn push_make_ready<Req>(self) -> Stack<stack::MakeReady<S, Req>> {
+        self.push(stack::MakeReadyLayer::new())
+    }
 
     // /// Buffer requests when when the next layer is out of capacity.
     // pub fn spawn_buffer<Req>(self, capacity: usize) -> Stack<buffer::Buffer<Req, S::Future>>
@@ -239,9 +239,9 @@ impl<S> Stack<S> {
     //     self.push(timeout::ProbeReadyLayer::new(interval))
     // }
 
-    // pub fn push_oneshot(self) -> Stack<stack::Oneshot<S>> {
-    //     self.push(stack::OneshotLayer::new())
-    // }
+    pub fn push_oneshot(self) -> Stack<stack::Oneshot<S>> {
+        self.push(stack::OneshotLayer::new())
+    }
 
     pub fn push_map_response<R: Clone>(self, map_response: R) -> Stack<stack::MapResponse<S, R>> {
         self.push(stack::MapResponseLayer::new(map_response))
@@ -261,21 +261,21 @@ impl<S> Stack<S> {
     //     self.push(cache::CacheLayer::new(track))
     // }
 
-    // pub fn push_fallback<F: Clone>(self, fallback: F) -> Stack<stack::Fallback<S, F>> {
-    //     self.push(stack::FallbackLayer::new(fallback))
-    // }
+    pub fn push_fallback<F: Clone>(self, fallback: F) -> Stack<stack::Fallback<S, F>> {
+        self.push(stack::FallbackLayer::new(fallback))
+    }
 
-    // pub fn push_fallback_with_predicate<F, P>(
-    //     self,
-    //     fallback: F,
-    //     predicate: P,
-    // ) -> Stack<stack::Fallback<S, F, P>>
-    // where
-    //     F: Clone,
-    //     P: Fn(&Error) -> bool + Clone,
-    // {
-    //     self.push(stack::FallbackLayer::new(fallback).with_predicate(predicate))
-    // }
+    pub fn push_fallback_with_predicate<F, P>(
+        self,
+        fallback: F,
+        predicate: P,
+    ) -> Stack<stack::Fallback<S, F, P>>
+    where
+        F: Clone,
+        P: Fn(&Error) -> bool + Clone,
+    {
+        self.push(stack::FallbackLayer::new(fallback).with_predicate(predicate))
+    }
 
     // pub fn boxed<A>(self) -> Stack<boxed::BoxService<A, S::Response>>
     // where

--- a/linkerd/stack/src/fallback.rs
+++ b/linkerd/stack/src/fallback.rs
@@ -1,9 +1,11 @@
 //! A middleware that may retry a request in a fallback service.
-
-use futures::{Future, Poll};
+use futures::TryFuture;
 use linkerd2_error::Error;
+use pin_project::{pin_project, project};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use tower::util::{Either, Oneshot, ServiceExt};
-
 /// A Layer that augments the underlying service with a fallback service.
 ///
 /// If the future returned by the primary service fails with an error matching a
@@ -21,13 +23,21 @@ pub struct Fallback<I, F, P = fn(&Error) -> bool> {
     predicate: P,
 }
 
-pub enum MakeFuture<A, B, P> {
+#[pin_project]
+pub struct MakeFuture<A, B, P> {
+    #[pin]
+    state: State<A, B, P>,
+}
+
+#[pin_project]
+enum State<A, B, P> {
     A {
+        #[pin]
         primary: A,
         fallback: Option<B>,
         predicate: P,
     },
-    B(B),
+    B(#[pin] B),
 }
 
 // === impl FallbackLayer ===
@@ -95,15 +105,17 @@ where
     type Error = Error;
     type Future = MakeFuture<A::Future, Oneshot<B, T>, P>;
 
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.inner.poll_ready().map_err(Into::into)
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
     }
 
     fn call(&mut self, target: T) -> Self::Future {
-        MakeFuture::A {
-            primary: self.inner.call(target.clone()),
-            fallback: Some(self.fallback.clone().oneshot(target)),
-            predicate: self.predicate.clone(),
+        MakeFuture {
+            state: State::A {
+                primary: self.inner.call(target.clone()),
+                fallback: Some(self.fallback.clone().oneshot(target)),
+                predicate: self.predicate.clone(),
+            },
         }
     }
 }
@@ -112,34 +124,39 @@ where
 
 impl<A, B, P> Future for MakeFuture<A, B, P>
 where
-    A: Future,
+    A: TryFuture,
     A::Error: Into<Error>,
-    B: Future,
+    B: TryFuture,
     B::Error: Into<Error>,
     P: Fn(&Error) -> bool,
 {
-    type Item = Either<A::Item, B::Item>;
-    type Error = Error;
+    type Output = Result<Either<A::Ok, B::Ok>, Error>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    #[project]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
         loop {
-            *self = match self {
-                MakeFuture::A {
-                    ref mut primary,
-                    ref mut fallback,
-                    ref predicate,
-                } => match primary.poll() {
-                    Ok(ok) => return Ok(ok.map(Either::A)),
+            #[project]
+            match this.state.as_mut().project() {
+                State::A {
+                    primary,
+                    fallback,
+                    predicate,
+                } => match futures::ready!(primary.try_poll(cx)) {
+                    Ok(ok) => return Poll::Ready(Ok(Either::A(ok))),
                     Err(e) => {
                         let error = e.into();
                         if !(predicate)(&error) {
-                            return Err(error);
+                            return Poll::Ready(Err(error));
                         }
-                        MakeFuture::B(fallback.take().unwrap())
+                        this.state.set(State::B(fallback.take().unwrap()));
                     }
                 },
-                MakeFuture::B(ref mut b) => {
-                    return b.poll().map(|ok| ok.map(Either::B)).map_err(Into::into);
+                State::B(b) => {
+                    return b
+                        .try_poll(cx)
+                        .map(|ok| ok.map(Either::B))
+                        .map_err(Into::into);
                 }
             };
         }

--- a/linkerd/stack/src/fallback.rs
+++ b/linkerd/stack/src/fallback.rs
@@ -149,7 +149,8 @@ where
                         if !(predicate)(&error) {
                             return Poll::Ready(Err(error));
                         }
-                        this.state.set(State::B(fallback.take().unwrap()));
+                        let fallback = fallback.take().unwrap();
+                        this.state.set(State::B(fallback));
                     }
                 },
                 State::B(b) => {

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -10,7 +10,7 @@ pub mod map_response;
 pub mod map_target;
 pub mod new_service;
 pub mod on_response;
-// mod oneshot;
+mod oneshot;
 mod proxy;
 
 // pub use self::fallback::{Fallback, FallbackLayer};
@@ -20,5 +20,5 @@ pub use self::map_response::{MapResponse, MapResponseLayer};
 pub use self::map_target::{MapTarget, MapTargetLayer, MapTargetService};
 pub use self::new_service::NewService;
 pub use self::on_response::{OnResponse, OnResponseLayer};
-// pub use self::oneshot::{Oneshot, OneshotLayer};
+pub use self::oneshot::{Oneshot, OneshotLayer};
 pub use self::proxy::{Proxy, ProxyService};

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(warnings, rust_2018_idioms)]
 
-// pub mod fallback;
+pub mod fallback;
 mod future_service;
 pub mod layer;
 pub mod make_ready;
@@ -13,7 +13,7 @@ pub mod on_response;
 mod oneshot;
 mod proxy;
 
-// pub use self::fallback::{Fallback, FallbackLayer};
+pub use self::fallback::{Fallback, FallbackLayer};
 pub use self::future_service::FutureService;
 pub use self::make_ready::{MakeReady, MakeReadyLayer};
 pub use self::map_response::{MapResponse, MapResponseLayer};

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -9,7 +9,7 @@ pub mod layer;
 pub mod map_response;
 pub mod map_target;
 pub mod new_service;
-// pub mod on_response;
+pub mod on_response;
 // mod oneshot;
 mod proxy;
 
@@ -19,6 +19,6 @@ pub use self::future_service::FutureService;
 pub use self::map_response::{MapResponse, MapResponseLayer};
 pub use self::map_target::{MapTarget, MapTargetLayer, MapTargetService};
 pub use self::new_service::NewService;
-// pub use self::on_response::{OnResponse, OnResponseLayer};
+pub use self::on_response::{OnResponse, OnResponseLayer};
 // pub use self::oneshot::{Oneshot, OneshotLayer};
 pub use self::proxy::{Proxy, ProxyService};

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -5,7 +5,7 @@
 // pub mod fallback;
 mod future_service;
 pub mod layer;
-// pub mod make_ready;
+pub mod make_ready;
 pub mod map_response;
 pub mod map_target;
 pub mod new_service;
@@ -15,7 +15,7 @@ mod proxy;
 
 // pub use self::fallback::{Fallback, FallbackLayer};
 pub use self::future_service::FutureService;
-// pub use self::make_ready::{MakeReady, MakeReadyLayer};
+pub use self::make_ready::{MakeReady, MakeReadyLayer};
 pub use self::map_response::{MapResponse, MapResponseLayer};
 pub use self::map_target::{MapTarget, MapTargetLayer, MapTargetService};
 pub use self::new_service::NewService;

--- a/linkerd/stack/src/make_ready.rs
+++ b/linkerd/stack/src/make_ready.rs
@@ -98,7 +98,7 @@ where
                 State::Ready(svc) => {
                     let _ = ready!(svc.as_mut().expect("polled after ready!").poll_ready(cx))
                         .map_err(Into::into)?;
-                    return Poll::Ready(Ok(svc.expect("polled after ready!")));
+                    return Poll::Ready(Ok(svc.take().expect("polled after ready!")));
                 }
             }
         }

--- a/linkerd/stack/src/on_response.rs
+++ b/linkerd/stack/src/on_response.rs
@@ -61,7 +61,7 @@ where
     type Future = OnResponse<L, M::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready()
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, target: T) -> Self::Future {
@@ -82,7 +82,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let inner = ready!(self.inner.try_poll(cx))?;
-        Ok(self.layer.layer(inner).into())
+        let inner = ready!(this.inner.try_poll(cx))?;
+        Poll::Ready(Ok(this.layer.layer(inner).into()))
     }
 }

--- a/linkerd/stack/src/oneshot.rs
+++ b/linkerd/stack/src/oneshot.rs
@@ -1,4 +1,4 @@
-use futures::Poll;
+use std::task::{Context, Poll};
 
 #[derive(Copy, Clone, Debug)]
 pub struct OneshotLayer(());
@@ -32,8 +32,8 @@ where
     type Error = S::Error;
     type Future = tower::util::Oneshot<S, Req>;
 
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        Ok(().into())
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, req: Req) -> Self::Future {

--- a/linkerd/stack/src/oneshot.rs
+++ b/linkerd/stack/src/oneshot.rs
@@ -32,7 +32,7 @@ where
     type Error = S::Error;
     type Future = tower::util::Oneshot<S, Req>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 


### PR DESCRIPTION
This branch ports the `linkerd2-stack` crate to use Tower 0.3 and
`std::future` and tokio 0.2's timers. I've also re-enabled the
`push_*` methods for layers exported by that crate.

This change should be pretty straightforward to read, as it's fairly
mechanical in nature. I've basically just changed the code to account
for the new APIs, but the implementation should be quite similar.