### PR TITLE
Handle GRPC body errors

### DIFF
--- a/linkerd/app/core/src/errors.rs
+++ b/linkerd/app/core/src/errors.rs
@@ -71,10 +71,7 @@ where
                         let error = error.into();
                         let mut error_trailers = http::HeaderMap::new();
                         let code = set_grpc_status(&error, &mut error_trailers);
-                        warn!(
-                            "Handling body error: {:?} with grpc status {:?}",
-                            error, code
-                        );
+                        debug!(%error, grpc.status = ?code, "Handling gRPC stream failure");
                         *trailers = Some(error_trailers);
                         Ok(Async::Ready(None))
                     }

--- a/linkerd/app/core/src/errors.rs
+++ b/linkerd/app/core/src/errors.rs
@@ -90,6 +90,7 @@ where
             },
         }
     }
+
     fn is_end_stream(&self) -> bool {
         match self {
             Self::NonGrpc(inner) => inner.is_end_stream(),


### PR DESCRIPTION
This branch modifies the `Respond` trait by allowing it to modify the response's body. In errors responder, we wrap the body of the response to allow it to set the GRPC status on trailers in case we get errors when calling `poll_data` on the body. 

Fixes https://github.com/linkerd/linkerd2/issues/4262
Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>