### PR TITLE
update http-box to tower 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1020,10 +1020,11 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
  "futures 0.1.26",
+ "futures 0.3.4",
  "http",
  "hyper",
  "linkerd2-error",
- "tower 0.1.1",
+ "tower 0.3.1",
 ]
 
 [[package]]

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -288,17 +288,17 @@ impl<S> Stack<S> {
     //     self.push(boxed::Layer::new())
     // }
 
-    // pub fn box_http_request<B>(self) -> Stack<http::boxed::BoxRequest<S, B>>
-    // where
-    //     B: hyper::body::Payload<Data = http::boxed::Data, Error = Error> + 'static,
-    //     S: tower::Service<http::Request<http::boxed::Payload>>,
-    // {
-    //     self.push(http::boxed::request::Layer::new())
-    // }
+    pub fn box_http_request<B>(self) -> Stack<http::boxed::BoxRequest<S, B>>
+    where
+        B: hyper::body::Payload<Data = http::boxed::Data, Error = Error> + 'static,
+        S: tower::Service<http::Request<http::boxed::Payload>>,
+    {
+        self.push(http::boxed::request::Layer::new())
+    }
 
-    // pub fn box_http_response(self) -> Stack<http::boxed::BoxResponse<S>> {
-    //     self.push(http::boxed::response::Layer::new())
-    // }
+    pub fn box_http_response(self) -> Stack<http::boxed::BoxResponse<S>> {
+        self.push(http::boxed::response::Layer::new())
+    }
 
     /// Validates that this stack serves T-typed targets.
     pub fn check_new_service<T>(self) -> Self

--- a/linkerd/http-box/Cargo.toml
+++ b/linkerd/http-box/Cargo.toml
@@ -8,7 +8,8 @@ publish = false
 [dependencies]
 bytes = "0.4"
 futures = "0.1"
+futures_03 = {package = "futures", version = "0.3"}
 http = "0.1"
 hyper = "0.12"
 linkerd2-error = { path = "../error" }
-tower = "0.1"
+tower = {version = "0.3", default-features = false }

--- a/linkerd/http-box/src/request.rs
+++ b/linkerd/http-box/src/request.rs
@@ -1,7 +1,7 @@
 //! A middleware that boxes HTTP request bodies.
 
 use crate::Payload;
-use futures::Poll;
+use std::task::{Context, Poll};
 
 #[derive(Debug)]
 pub struct Layer<B>(std::marker::PhantomData<fn(B)>);
@@ -52,8 +52,8 @@ where
     type Error = S::Error;
     type Future = S::Future;
 
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.0.poll_ready()
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.0.poll_ready(cx)
     }
 
     fn call(&mut self, req: http::Request<B>) -> Self::Future {

--- a/linkerd/http-box/src/response.rs
+++ b/linkerd/http-box/src/response.rs
@@ -1,8 +1,9 @@
 //! A middleware that boxes HTTP response bodies.
 
 use crate::Payload;
-use futures::{future, Future, Poll};
+use futures_03::{future, TryFutureExt};
 use linkerd2_error::Error;
+use std::task::{Context, Poll};
 
 #[derive(Copy, Clone, Debug)]
 pub struct Layer(());
@@ -32,13 +33,13 @@ where
 {
     type Response = http::Response<Payload>;
     type Error = S::Error;
-    type Future = future::Map<S::Future, fn(S::Response) -> Self::Response>;
+    type Future = future::MapOk<S::Future, fn(S::Response) -> Self::Response>;
 
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.0.poll_ready()
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.0.poll_ready(cx)
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        self.0.call(req).map(|rsp| rsp.map(Payload::new))
+        self.0.call(req).map_ok(|rsp| rsp.map(Payload::new))
     }
 }


### PR DESCRIPTION
This does **not** update the payload module to `std::future`, since we
are still on the futures 0.1 version of Hyper. It only updates the
`tower-service` impls.

This will be necessary to bring back the HTTP clients.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>