### PR TITLE
Set a grpc-status of UNAVAILABLE only on io errors

### DIFF
--- a/linkerd/buffer/src/error.rs
+++ b/linkerd/buffer/src/error.rs
@@ -31,4 +31,8 @@ impl std::fmt::Display for ServiceError {
     }
 }
 
-impl std::error::Error for ServiceError {}
+impl std::error::Error for ServiceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&**self.0.as_ref())
+    }
+}

--- a/linkerd/lock/src/error.rs
+++ b/linkerd/lock/src/error.rs
@@ -22,4 +22,8 @@ impl std::fmt::Display for ServiceError {
     }
 }
 
-impl std::error::Error for ServiceError {}
+impl std::error::Error for ServiceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&**self.0.as_ref())
+    }
+}


### PR DESCRIPTION
In #493, we opted to handle all hyper errors as `UNAVAILABLE` for gRPC
messages.

This change modifies the signature of `http_status` & `set_grpc_status`
so that we can unwrap arbitrary inner errors via `Error::source`. This
reduces some unnecessary special-casing and allows us to more-narrowly
target IO errors

Special thanks to @LucioFranco for guiding me in the right direction on this.