### PR TITLE
feat: add json log format as an option

### DIFF
--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -79,7 +79,7 @@ tracing-log = "0.1"
 version = "0.2.1"
 # we don't need `chrono` time formatting
 default-features = false
-features = ["env-filter", "fmt", "smallvec", "tracing-log", "ansi"]
+features = ["env-filter", "fmt", "smallvec", "tracing-log", "ansi", "json"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -47,12 +47,11 @@ pub fn with_filter_and_format(
     format: impl AsRef<str>,
 ) -> (Dispatch, LevelHandle) {
     let filter = filter.as_ref();
-    let format = format.as_ref();
 
     // Set up the subscriber
     let start_time = clock::now();
 
-    match format {
+    match format.as_ref().to_uppercase().as_ref() {
         "JSON" => {
             let builder = FmtSubscriber::builder()
                 .json()

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -10,6 +10,9 @@ use tracing_subscriber::{
 const ENV_LOG_LEVEL: &str = "LINKERD2_PROXY_LOG";
 const ENV_LOG_FORMAT: &str = "LINKERD2_PROXY_LOG_FORMAT";
 
+const DEFAULT_LOG_LEVEL: &str = "warn,linkerd2_proxy=info";
+const DEFAULT_LOG_FORMAT: &str = "PLAIN";
+
 type JsonFormatter = Formatter<format::JsonFields, format::Format<format::Json, Uptime>>;
 type PlainFormatter = Formatter<format::DefaultFields, format::Format<format::Full, Uptime>>;
 
@@ -26,8 +29,8 @@ pub enum LevelHandle {
 /// Initialize tracing and logging with the value of the `ENV_LOG`
 /// environment variable as the verbosity-level filter.
 pub fn init() -> Result<LevelHandle, Error> {
-    let log_level = env::var(ENV_LOG_LEVEL).unwrap_or_default();
-    let log_format = env::var(ENV_LOG_FORMAT).unwrap_or_default();
+    let log_level = env::var(ENV_LOG_LEVEL).unwrap_or(DEFAULT_LOG_LEVEL.to_string());
+    let log_format = env::var(ENV_LOG_FORMAT).unwrap_or(DEFAULT_LOG_FORMAT.to_string());
 
     let (dispatch, handle) = with_filter_and_format(log_level, log_format);
 

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -18,12 +18,8 @@ type PlainFormatter = Formatter<format::DefaultFields, format::Format<format::Fu
 
 #[derive(Clone)]
 pub enum LevelHandle {
-    Json {
-        inner: reload::Handle<EnvFilter, JsonFormatter>,
-    },
-    Plain {
-        inner: reload::Handle<EnvFilter, PlainFormatter>,
-    },
+    Json(reload::Handle<EnvFilter, JsonFormatter>),
+    Plain(reload::Handle<EnvFilter, PlainFormatter>),
 }
 
 /// Initialize tracing and logging with the value of the `ENV_LOG`

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -50,7 +50,6 @@ pub fn with_filter_and_format(
     format: impl AsRef<str>,
 ) -> (Dispatch, LevelHandle) {
     let filter = filter.as_ref();
-    let format = format.as_ref();
 
     // Set up the subscriber
     let start_time = clock::now();

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -58,8 +58,7 @@ pub fn with_filter_and_format(
                 .json()
                 .with_timer(Uptime { start_time })
                 .with_env_filter(filter)
-                .with_filter_reloading()
-                .with_ansi(cfg!(test));
+                .with_filter_reloading();
 
             let handle = LevelHandle::Json {
                 inner: builder.reload_handle(),
@@ -71,10 +70,10 @@ pub fn with_filter_and_format(
         }
         "PLAIN" | _ => {
             let builder = FmtSubscriber::builder()
+                .with_ansi(cfg!(test))
                 .with_timer(Uptime { start_time })
                 .with_env_filter(filter)
-                .with_filter_reloading()
-                .with_ansi(cfg!(test));
+                .with_filter_reloading();
 
             let handle = LevelHandle::Plain {
                 inner: builder.reload_handle(),

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -51,35 +51,25 @@ pub fn with_filter_and_format(
     // Set up the subscriber
     let start_time = clock::now();
 
+    let builder = FmtSubscriber::builder()
+        .with_timer(Uptime { start_time })
+        .with_env_filter(filter);
+
     match format.as_ref().to_uppercase().as_ref() {
         "JSON" => {
-            let builder = FmtSubscriber::builder()
-                .json()
-                .with_timer(Uptime { start_time })
-                .with_env_filter(filter)
-                .with_filter_reloading();
-
+            let builder = builder.json().with_filter_reloading();
             let handle = LevelHandle::Json {
                 inner: builder.reload_handle(),
             };
-
             let dispatch = Dispatch::new(builder.finish());
-
             (dispatch, handle)
         }
         "PLAIN" | _ => {
-            let builder = FmtSubscriber::builder()
-                .with_ansi(cfg!(test))
-                .with_timer(Uptime { start_time })
-                .with_env_filter(filter)
-                .with_filter_reloading();
-
+            let builder = builder.with_ansi(cfg!(test)).with_filter_reloading();
             let handle = LevelHandle::Plain {
                 inner: builder.reload_handle(),
             };
-
             let dispatch = Dispatch::new(builder.finish());
-
             (dispatch, handle)
         }
     }

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -50,6 +50,7 @@ pub fn with_filter_and_format(
     format: impl AsRef<str>,
 ) -> (Dispatch, LevelHandle) {
     let filter = filter.as_ref();
+    let format = format.as_ref();
 
     // Set up the subscriber
     let start_time = clock::now();

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -104,10 +104,10 @@ impl LevelHandle {
 
     pub fn current(&self) -> Result<String, Error> {
         match self {
-            Self::Json(with_current) => with_current
+            Self::Json(handle) => handle
                 .with_current(|f| format!("{}", f))
                 .map_err(Into::into),
-            Self::Plain(with_current) => with_current
+            Self::Plain(handle) => handle
                 .with_current(|f| format!("{}", f))
                 .map_err(Into::into),
         }
@@ -117,7 +117,7 @@ impl LevelHandle {
 impl fmt::Debug for LevelHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Json(with_current) => with_current
+            Self::Json(handle) => handle
                 .with_current(|c| {
                     f.debug_struct("LevelHandle")
                         .field("current", &format_args!("{}", c))
@@ -128,7 +128,7 @@ impl fmt::Debug for LevelHandle {
                         .field("current", &format_args!("{}", e))
                         .finish()
                 }),
-            Self::Plain(with_current) => with_current
+            Self::Plain(handle) => handle
                 .with_current(|c| {
                     f.debug_struct("LevelHandle")
                         .field("current", &format_args!("{}", c))

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -10,19 +10,16 @@ use tracing_subscriber::{
 const ENV_LOG_LEVEL: &str = "LINKERD2_PROXY_LOG";
 const ENV_LOG_FORMAT: &str = "LINKERD2_PROXY_LOG_FORMAT";
 
+type JsonFormatter = Formatter<format::JsonFields, format::Format<format::Json, Uptime>>;
+type PlainFormatter = Formatter<format::DefaultFields, format::Format<format::Full, Uptime>>;
+
 #[derive(Clone)]
 pub enum LevelHandle {
     Json {
-        inner: reload::Handle<
-            EnvFilter,
-            Formatter<format::JsonFields, format::Format<format::Json, Uptime>>,
-        >,
+        inner: reload::Handle<EnvFilter, JsonFormatter>,
     },
     Plain {
-        inner: reload::Handle<
-            EnvFilter,
-            Formatter<format::DefaultFields, format::Format<format::Full, Uptime>>,
-        >,
+        inner: reload::Handle<EnvFilter, PlainFormatter>,
     },
 }
 

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -39,15 +39,17 @@ const DEFAULT_LOG: &'static str = "error,\
 
 pub fn trace_init() -> (Dispatch, app::core::trace::LevelHandle) {
     use std::env;
-    let log = env::var("LINKERD2_PROXY_LOG")
+    let log_level = env::var("LINKERD2_PROXY_LOG")
         .or_else(|_| env::var("RUST_LOG"))
         .unwrap_or_else(|_| DEFAULT_LOG.to_owned());
-    env::set_var("RUST_LOG", &log);
-    env::set_var("LINKERD2_PROXY_LOG", &log);
+    env::set_var("RUST_LOG", &log_level);
+    env::set_var("LINKERD2_PROXY_LOG", &log_level);
+    let log_format = env::var("LINKERD2_PROXY_LOG_FORMAT").unwrap_or_else(|_| "PLAIN".to_string());
+    env::set_var("LINKERD2_PROXY_LOG_FORMAT", &log_format);
     // This may fail, since the global log compat layer may have been
     // initialized by another test.
     let _ = app::core::trace::init_log_compat();
-    app::core::trace::with_filter(&log)
+    app::core::trace::with_filter_and_format(&log_level, &log_format)
 }
 
 /// Retry an assertion up to a specified number of times, waiting


### PR DESCRIPTION
JSON logs can be easily parsed in logging sinks such as Elasticsearch. 

resolves https://github.com/linkerd/linkerd2/issues/2491

cc @hawkw 

Please bare with me as this is my first PR in Rust, unless you count a message change. :)

Could you please break down the anatomy of the following line:

https://github.com/linkerd/linkerd2-proxy/blob/610309ebc240494426f9169000c46da9d5fe9647/linkerd/app/core/src/trace.rs#L12
 