### PR TITLE
release: Use arch-specific paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/package
         with:
           entrypoint: /linkerd/validate-checksec.sh
-          args: /linkerd/expected-checksec.json "target/release/package/linkerd2-proxy-${{ steps.release-tag-meta.outputs.name }}-checksec.json"
+          args: /linkerd/expected-checksec.json "target/x86_64-unknown-linux-gnu/release/package/linkerd2-proxy-${{ steps.release-tag-meta.outputs.name }}-checksec.json"
 
       - name: release
         uses: softprops/action-gh-release@b21b43d
@@ -40,4 +40,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           name: ${{ steps.release-tag-meta.outputs.name }}
-          files: target/release/package/*
+          files:  target/x86_64-unknown-linux-gnu/release/package/*


### PR DESCRIPTION
6166d328 update the Makefile to output binaries in architecture-specific
target directories, but the release action was not updated to reflect
this change.