### PR TITLE
Buffer requests while the service is pending

### DIFF
--- a/linkerd/buffer/src/dispatch.rs
+++ b/linkerd/buffer/src/dispatch.rs
@@ -134,7 +134,6 @@ where
                         let _ = self.ready.broadcast(Ok(Async::Ready(())));
                         self.ready_set = true;
                     }
-                    println!("Ready for requests");
                 }
             }
 

--- a/linkerd/buffer/src/dispatch.rs
+++ b/linkerd/buffer/src/dispatch.rs
@@ -64,7 +64,6 @@ where
     /// requests of the failure.
     fn fail(&mut self, error: impl Into<Error>) {
         let shared = ServiceError(Arc::new(error.into()));
-        println!("Failing {}", shared);
         trace!(%shared, "Inner service failed");
 
         // First, notify services of the readiness change to prevent new requests from

--- a/linkerd/buffer/src/error.rs
+++ b/linkerd/buffer/src/error.rs
@@ -50,7 +50,11 @@ impl<'a> std::fmt::Display for IdleError {
         if secs == 0 {
             write!(fmt, "Service idled out after {}ms", subsec_ms)
         } else {
-            write!(fmt, "Service idled out after {}s", secs as f64 + subsec_ms)
+            write!(
+                fmt,
+                "Service idled out after {}s",
+                secs as f64 + subsec_ms / 1000.0
+            )
         }
     }
 }

--- a/linkerd/buffer/src/lib.rs
+++ b/linkerd/buffer/src/lib.rs
@@ -58,14 +58,13 @@ mod test {
             drop(service.call(()));
 
             handle.send_error(Bad);
-            assert!(dispatch.poll().expect("never fails").is_not_ready());
-            assert_eq!(
-                "bad",
-                service.poll_ready().expect_err("must fail").to_string()
-            );
-
-            drop(service);
             assert!(dispatch.poll().expect("never fails").is_ready());
+            assert!(service
+                .poll_ready()
+                .expect_err("must fail")
+                .source()
+                .unwrap()
+                .is::<Bad>());
 
             Ok::<(), ()>(())
         })

--- a/linkerd/buffer/src/service.rs
+++ b/linkerd/buffer/src/service.rs
@@ -38,7 +38,10 @@ impl<Req, F> Buffer<Req, F> {
         loop {
             match self.ready.poll_ref() {
                 Ok(Async::NotReady) => break,
-                Ok(Async::Ready(Some(_))) => {}
+                Ok(Async::Ready(Some(res))) => match res.as_ref() {
+                    Ok(_) => {}
+                    Err(e) => return Err(e.clone().into()),
+                },
                 Err(_) | Ok(Async::Ready(None)) => return Err(Closed(()).into()),
             }
         }


### PR DESCRIPTION
The buffer uses a watch to advertise readiness to consumers. This is
intended to:

1. Prevent the out service from becoming ready before the inner service
   has initialized.
2. Surface errors to outer services' `poll_ready`.

It, however, currently advertises when the inner service moves into
pending, preventing requests from being admitted to the buffer, and then
basically making consumers race to enter the buffer.

This change also relaxes its use of the ready watch channel, especially
to signal that the task should complete. Instead, the dispatch task
completes as soon as all requests have been processed.