### PR TITLE
port stack-metrics to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1527,14 +1527,9 @@ dependencies = [
 name = "linkerd2-stack-metrics"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.26",
  "indexmap",
  "linkerd2-metrics",
- "tokio 0.1.22",
- "tokio-timer",
- "tower 0.1.1",
- "tower-util",
- "tracing",
+ "tower 0.3.1",
 ]
 
 [[package]]

--- a/linkerd/stack/metrics/Cargo.toml
+++ b/linkerd/stack/metrics/Cargo.toml
@@ -6,11 +6,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.1"
 indexmap = "1.0"
 linkerd2-metrics = { path  = "../../metrics" }
-tokio = "0.1"
-tokio-timer = "0.2"   # for tokio_timer::clock
-tower = "0.1"
-tower-util = "0.1"
-tracing = "0.1.9"
+tower = { version = "0.3", default-features = false }


### PR DESCRIPTION
I had forgotten that `linkerd2-stack-metrics` is actually kind of load
bearing: the `TrackServiceLayer` is necessary for powering cache
eviction as well as being used for debugging. It turns out that we need
this to create stacks that work.

This branch ports `linkerd2-stack-metrics` to std::future. This change
was pretty trivial; I just updated to use the new `tower::Service`
trait. I also pruned a bunch of dependencies that this crate wasn't
actually using from the Cargo.toml.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>