### PR TITLE
Add an `i/o` error label to http metrics (#512)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -821,6 +821,7 @@ dependencies = [
  "linkerd2-dns",
  "linkerd2-drain",
  "linkerd2-duplex",
+ "linkerd2-errno",
  "linkerd2-error",
  "linkerd2-error-metrics",
  "linkerd2-error-respond",
@@ -1052,6 +1053,10 @@ dependencies = [
  "tokio 0.2.20",
  "tracing",
 ]
+
+[[package]]
+name = "linkerd2-errno"
+version = "0.1.0"
 
 [[package]]
 name = "linkerd2-error"
@@ -1409,6 +1414,7 @@ dependencies = [
  "libc",
  "linkerd2-conditional",
  "linkerd2-dns-name",
+ "linkerd2-errno",
  "linkerd2-error",
  "linkerd2-identity",
  "linkerd2-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "linkerd/drain",
     "linkerd/duplex",
     "linkerd/error",
+    "linkerd/errno",
     "linkerd/error-metrics",
     "linkerd/error-respond",
     "linkerd/exp-backoff",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -30,6 +30,7 @@ linkerd2-conditional = { path = "../../conditional" }
 linkerd2-dns = { path = "../../dns" }
 linkerd2-drain = { path = "../../drain" }
 linkerd2-duplex = { path = "../../duplex" }
+linkerd2-errno = { path = "../../errno" }
 linkerd2-error = { path = "../../error" }
 linkerd2-error-metrics = { path = "../../error-metrics" }
 linkerd2-error-respond = { path = "../../error-respond" }

--- a/linkerd/errno/Cargo.toml
+++ b/linkerd/errno/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "linkerd2-errno"
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+edition = "2018"
+publish = false

--- a/linkerd/errno/src/lib.rs
+++ b/linkerd/errno/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(warnings, rust_2018_idioms)]
+
 use std::fmt;
 
 /// Represents a platform-agnostic system error for metrics labels.

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -20,6 +20,7 @@ futures_03 = { package = "futures", version = "0.3", features = ["compat", "io-c
 indexmap = "1.0.0"
 linkerd2-conditional = { path = "../../conditional" }
 linkerd2-dns-name = { path = "../../dns/name" }
+linkerd2-errno = { path = "../../errno" }
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
 linkerd2-io = { path = "../../io" }

--- a/linkerd/proxy/transport/src/metrics/mod.rs
+++ b/linkerd/proxy/transport/src/metrics/mod.rs
@@ -1,5 +1,6 @@
 use futures_03::{ready, TryFuture};
 use indexmap::IndexMap;
+use linkerd2_errno::Errno;
 use linkerd2_metrics::{
     latency, metrics, Counter, FmtLabels, FmtMetric, FmtMetrics, Gauge, Histogram, Metric,
 };
@@ -14,10 +15,9 @@ use std::time::Instant;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::debug;
 
-mod errno;
 mod io;
 
-pub use self::{errno::Errno, io::Io};
+pub use self::io::Io;
 
 metrics! {
     tcp_open_total: Counter { "Total count of opened connections" },


### PR DESCRIPTION
This change modifies HTTP error-labeling to detect I/O errors
and label them explicitly. Previously all I/O errors were reported as
`unexpected`.

Additionally, an `errno` label is included when possible.

Fixes linkerd/linkerd2#4364