### PR TITLE
Port admit to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkerd2-admit"
+version = "0.1.0"
+dependencies = [
+ "futures 0.3.4",
+ "linkerd2-error",
+ "tower 0.3.1",
+ "tracing",
+]
+
+[[package]]
 name = "linkerd2-app"
 version = "0.1.0"
 dependencies = [
@@ -883,8 +893,8 @@ dependencies = [
  "futures 0.1.26",
  "http 0.2.1",
  "indexmap",
+ "linkerd2-admit",
  "linkerd2-app-core",
- "linkerd2-retry",
  "quickcheck",
  "tokio 0.1.22",
  "tower 0.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "hyper-balance",
     "linkerd/addr",
+    "linkerd/admit",
     "linkerd/app/core",
     "linkerd/app/inbound",
     "linkerd/app/integration",

--- a/linkerd/admit/Cargo.toml
+++ b/linkerd/admit/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "linkerd2-admit"
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+futures = "0.3"
+linkerd2-error = { path = "../error" }
+tower = { version = "0.3", default-features = false, features = ["util"] }
+tracing = "0.1"

--- a/linkerd/admit/src/lib.rs
+++ b/linkerd/admit/src/lib.rs
@@ -1,0 +1,63 @@
+#![deny(warnings, rust_2018_idioms)]
+
+//! A middleware that fails requests by policy.
+
+use futures::{future, TryFutureExt};
+use linkerd2_error::Error;
+use std::task::{Context, Poll};
+
+pub struct AdmitLayer<A>(A);
+
+pub trait Admit<T> {
+    type Error: Into<Error>;
+
+    fn admit(&mut self, target: &T) -> Result<(), Self::Error>;
+}
+
+#[derive(Debug, Clone)]
+pub struct AdmitService<A, S> {
+    admit: A,
+    inner: S,
+}
+
+impl<A> AdmitLayer<A> {
+    pub fn new(admit: A) -> Self {
+        Self(admit)
+    }
+}
+
+impl<A: Clone, S> tower::layer::Layer<S> for AdmitLayer<A> {
+    type Service = AdmitService<A, S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        Self::Service {
+            admit: self.0.clone(),
+            inner,
+        }
+    }
+}
+
+impl<A, T, S> tower::Service<T> for AdmitService<A, S>
+where
+    A: Admit<T>,
+    S: tower::Service<T>,
+    S::Error: Into<Error>,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = future::Either<
+        future::MapErr<S::Future, fn(S::Error) -> Error>,
+        future::Ready<Result<Self::Response, Self::Error>>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, t: T) -> Self::Future {
+        match self.admit.admit(&t) {
+            Ok(()) => future::Either::Left(self.inner.call(t).map_err(Into::into)),
+            Err(e) => future::Either::Right(future::err(e.into())),
+        }
+    }
+}

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -13,8 +13,8 @@ bytes = "0.5"
 http = "0.2"
 futures = "0.1"
 indexmap = "1.0"
+linkerd2-admit = { path = "../../admit" }
 linkerd2-app-core = { path = "../core" }
-linkerd2-retry = { path = "../../retry" }
 tokio = "0.1.14"
 tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 tracing = "0.1.9"

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -8,7 +8,9 @@
 pub use self::endpoint::{
     HttpEndpoint, Profile, ProfileTarget, RequestTarget, Target, TcpEndpoint,
 };
+use self::require_identity_for_ports::RequireIdentityForPorts;
 use futures::future;
+use linkerd2_admit as admit;
 use linkerd2_app_core::{
     // classify,
     config::{ProxyConfig, ServerConfig},
@@ -48,6 +50,7 @@ use tokio::sync::mpsc;
 use tracing::{info, info_span};
 
 mod endpoint;
+mod require_identity_for_ports;
 // #[allow(dead_code)] // TODO #2597
 // mod set_client_id_on_req;
 // #[allow(dead_code)] // TODO #2597
@@ -56,6 +59,7 @@ mod endpoint;
 #[derive(Clone, Debug)]
 pub struct Config {
     pub proxy: ProxyConfig,
+    pub require_identity_for_inbound_ports: RequireIdentityForPorts,
 }
 
 pub struct Inbound {
@@ -90,6 +94,7 @@ impl Config {
                     max_in_flight_requests,
                     detect_protocol_timeout,
                 },
+            require_identity_for_inbound_ports,
         } = self;
 
         let listen = bind.bind().map_err(Error::from)?;
@@ -288,6 +293,7 @@ impl Config {
                 .push(DetectProtocolLayer::new(ProtocolDetect::new(
                     disable_protocol_detection_for_ports.clone(),
                 )))
+                .push(admit::AdmitLayer::new(require_identity_for_inbound_ports))
                 // Terminates inbound mTLS from other outbound proxies.
                 .push(tls::AcceptTls::layer(
                     local_identity,

--- a/linkerd/app/inbound/src/require_identity_for_ports.rs
+++ b/linkerd/app/inbound/src/require_identity_for_ports.rs
@@ -1,0 +1,45 @@
+use indexmap::IndexSet;
+use linkerd2_admit as admit;
+use linkerd2_app_core::transport::tls;
+use std::sync::Arc;
+
+/// A connection policy that drops
+#[derive(Clone, Debug)]
+pub struct RequireIdentityForPorts {
+    ports: Arc<IndexSet<u16>>,
+}
+
+#[derive(Debug)]
+pub struct IdentityRequired(());
+
+impl<T: IntoIterator<Item = u16>> From<T> for RequireIdentityForPorts {
+    fn from(ports: T) -> Self {
+        Self {
+            ports: Arc::new(ports.into_iter().collect()),
+        }
+    }
+}
+
+impl admit::Admit<tls::accept::Connection> for RequireIdentityForPorts {
+    type Error = IdentityRequired;
+
+    fn admit(&mut self, (meta, _): &tls::accept::Connection) -> Result<(), Self::Error> {
+        let port = meta.addrs.target_addr().port();
+        let id_required = self.ports.contains(&port);
+
+        tracing::debug!(%port, peer.id = ?meta.peer_identity, %id_required);
+        if id_required && meta.peer_identity.is_none() {
+            return Err(IdentityRequired(()));
+        }
+
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for IdentityRequired {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "identity required")
+    }
+}
+
+impl std::error::Error for IdentityRequired {}


### PR DESCRIPTION
Fairly simple change to bring in the Admit middleware

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>