### PR TITLE
turn inbound proxy back into a proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,7 +1438,6 @@ dependencies = [
  "tokio-compat",
  "tokio-rustls",
  "tokio-util",
- "tower 0.1.1",
  "tower 0.3.1",
  "tracing",
  "tracing-futures 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,7 +1332,6 @@ dependencies = [
  "tokio 0.2.20",
  "tokio-connect",
  "tokio-timer",
- "tower 0.1.1",
  "tower 0.3.1",
  "tower-balance",
  "tower-discover",

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -366,6 +366,17 @@ impl<S> Stack<S> {
         self
     }
 
+    pub fn check_new_send_and_static<M, T, Req>(self) -> Self
+    where
+        S: NewService<T, Service = M>,
+        M: Service<Req> + Send + 'static,
+        M::Response: Send + 'static,
+        M::Error: Into<Error> + Send + Sync,
+        M::Future: Send,
+    {
+        self
+    }
+
     pub fn into_inner(self) -> S {
         self.0
     }

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -254,9 +254,8 @@ impl<S> Stack<S> {
 
     pub fn cache<T, L, U>(self, track: L) -> Stack<cache::Cache<T, cache::layer::NewTrack<L, S>>>
     where
-        T: Eq + std::hash::Hash + 'static,
+        T: Eq + std::hash::Hash + Send + 'static,
         S: NewService<T> + Clone,
-        S::Service: 'static,
         L: tower::layer::Layer<cache::layer::Track<S>> + Clone,
         L::Service: NewService<T, Service = U>,
     {
@@ -310,6 +309,14 @@ impl<S> Stack<S> {
         self
     }
 
+    /// Validates that this stack can be cloned
+    pub fn check_clone(self) -> Self
+    where
+        S: Clone,
+    {
+        self
+    }
+
     pub fn check_new_clone_service<T>(self) -> Self
     where
         S: NewService<T>,
@@ -322,6 +329,15 @@ impl<S> Stack<S> {
     pub fn check_service<T>(self) -> Self
     where
         S: Service<T>,
+    {
+        self
+    }
+
+    /// Validates that this stack serves T-typed targets with `Unpin` futures.
+    pub fn check_service_unpin<T>(self) -> Self
+    where
+        S: Service<T>,
+        S::Future: Unpin,
     {
         self
     }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -23,7 +23,7 @@ use linkerd2_app_core::{
     proxy::{
         self,
         detect::DetectProtocolLayer,
-        http::{self /*, normalize_uri, orig_proto, strip_header*/},
+        http::{self, normalize_uri /* orig_proto, strip_header*/},
         identity,
         server::{Protocol as ServerProtocol, ProtocolDetect, Server},
         tap, tcp,
@@ -155,9 +155,9 @@ impl Config {
             let http_target_cache = http_endpoint
                 .push_map_target(HttpEndpoint::from)
                 .check_service_unpin::<Target>()
-                // // Normalizes the URI, i.e. if it was originally in
-                // // absolute-form on the outbound side.
-                // .push(normalize_uri::layer())
+                // Normalizes the URI, i.e. if it was originally in
+                // absolute-form on the outbound side.
+                .push(normalize_uri::layer())
                 // .push(http_target_observability)
                 .into_new_service()
                 .check_new_service::<Target>()

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -247,12 +247,12 @@ impl Config {
             //     .push(metrics.http_handle_time.layer());
 
             let http_server = svc::stack(http_profile_cache)
-                .push_on_response(svc::layers().box_http_response())
+                // .push_on_response(svc::layers().box_http_response())
                 .push_make_ready()
-                .push_fallback(
-                    http_target_cache
-                        .push_on_response(svc::layers().box_http_response().box_http_request()),
-                )
+                // .push_fallback(
+                //     http_target_cache
+                //         .push_on_response(svc::layers().box_http_response().box_http_request()),
+                // )
                 .check_service::<Target>()
                 // Ensures that the built service is ready before it is returned
                 // to the router to dispatch a request.
@@ -271,7 +271,7 @@ impl Config {
                 // Used by tap.
                 // .push_http_insert_target()
                 // .push_on_response(http_strip_headers)
-                .push_on_response(http_admit_request)
+                // .push_on_response(http_admit_request)
                 // .push_on_response(http_server_observability)
                 .push_on_response(metrics.stack.layer(stack_labels("source")))
                 .instrument(|src: &tls::accept::Meta| {

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -15,8 +15,8 @@ use linkerd2_app_core::{
     // classify,
     config::{ProxyConfig, ServerConfig},
     drain,
-    // dst,
-    // errors,
+    dst,
+    errors,
     metric_labels,
     opencensus::proto::trace::v1 as oc,
     profiles,
@@ -119,14 +119,14 @@ impl Config {
                 })
                 .push(svc::layer::mk(tcp::Forward::new));
 
-            // // Creates HTTP clients for each inbound port & HTTP settings.
-            // let http_endpoint = tcp_connect
-            //     .push(http::MakeClientLayer::new(connect.h2_settings))
-            //     .push(reconnect::layer({
-            //         let backoff = connect.backoff.clone();
-            //         move |_| Ok(backoff.stream())
-            //     }))
-            //     .check_service::<HttpEndpoint>();
+            // Creates HTTP clients for each inbound port & HTTP settings.
+            let http_endpoint = tcp_connect
+                .push(http::MakeClientLayer::new(connect.h2_settings))
+                // .push(reconnect::layer({
+                //     let backoff = connect.backoff.clone();
+                //     move |_| Ok(backoff.stream())
+                // }))
+                .check_service::<HttpEndpoint>();
 
             // let http_target_observability = svc::layers()
             //     // Registers the stack to be tapped.
@@ -150,88 +150,89 @@ impl Config {
             //     .push(classify::Layer::new())
             //     .check_new_clone_service::<dst::Route>();
 
-            // // An HTTP client is created for each target via the endpoint stack.
-            // let http_target_cache = http_endpoint
-            //     .push_map_target(HttpEndpoint::from)
-            //     // Normalizes the URI, i.e. if it was originally in
-            //     // absolute-form on the outbound side.
-            //     .push(normalize_uri::layer())
-            //     .push(http_target_observability)
-            //     .into_new_service()
-            //     .cache(
-            //         svc::layers().push_on_response(
-            //             svc::layers()
-            //                 // If the service has been unavailable for an extended time, eagerly
-            //                 // fail requests.
-            //                 .push_failfast(dispatch_timeout)
-            //                 // Shares the service, ensuring discovery errors are propagated.
-            //                 .push_spawn_buffer_with_idle_timeout(
-            //                     buffer_capacity,
-            //                     cache_max_idle_age,
-            //                 )
-            //                 .push(metrics.stack.layer(stack_labels("target"))),
-            //         ),
-            //     )
-            //     .instrument(|_: &Target| info_span!("target"))
-            //     // Prevent the cache's lock from being acquired in poll_ready, ensuring this happens
-            //     // in the response future. This prevents buffers from holding the cache's lock.
-            //     .push_oneshot()
-            //     .check_service::<Target>();
+            // An HTTP client is created for each target via the endpoint stack.
+            let http_target_cache = http_endpoint
+                .push_map_target(HttpEndpoint::from)
+                // Normalizes the URI, i.e. if it was originally in
+                // absolute-form on the outbound side.
+                // .push(normalize_uri::layer())
+                // .push(http_target_observability)
+                .into_new_service()
+                // .check_new_clone_service::<Target>()
+                .cache(
+                    svc::layers().push_on_response(
+                        svc::layers()
+                            // If the service has been unavailable for an extended time, eagerly
+                            // fail requests.
+                            .push_failfast(dispatch_timeout)
+                            // Shares the service, ensuring discovery errors are propagated.
+                            .push_spawn_buffer_with_idle_timeout(
+                                buffer_capacity,
+                                cache_max_idle_age,
+                            )
+                            .push(metrics.stack.layer(stack_labels("target"))),
+                    ),
+                )
+                // .instrument(|_: &Target| info_span!("target"))
+                // Prevent the cache's lock from being acquired in poll_ready, ensuring this happens
+                // in the response future. This prevents buffers from holding the cache's lock.
+                .push_oneshot()
+                .check_service::<Target>();
 
-            // // Routes targets to a Profile stack, i.e. so that profile
-            // // resolutions are shared even as the type of request may vary.
-            // let http_profile_cache = http_target_cache
-            //     .clone()
-            //     .push_on_response(svc::layers().box_http_request())
-            //     .check_service::<Target>()
-            //     // Provides route configuration without pdestination overrides.
-            //     .push(profiles::Layer::without_overrides(
-            //         profiles_client,
-            //         http_profile_route_proxy.into_inner(),
-            //     ))
-            //     .into_new_service()
-            //     // Caches profile stacks.
-            //     .check_new_service_routes::<Profile, Target>()
-            //     .cache(
-            //         svc::layers().push_on_response(
-            //             svc::layers()
-            //                 // If the service has been unavailable for an extended time, eagerly
-            //                 // fail requests.
-            //                 .push_failfast(dispatch_timeout)
-            //                 // Shares the service, ensuring discovery errors are propagated.
-            //                 .push_spawn_buffer_with_idle_timeout(
-            //                     buffer_capacity,
-            //                     cache_max_idle_age,
-            //                 )
-            //                 .push(metrics.stack.layer(stack_labels("profile"))),
-            //         ),
-            //     )
-            //     .instrument(|p: &Profile| info_span!("profile", addr = %p.addr()))
-            //     .check_make_service::<Profile, Target>()
-            //     // Ensures that cache's lock isn't held in poll_ready.
-            //     .push_oneshot()
-            //     .push(router::Layer::new(|()| ProfileTarget))
-            //     .check_new_service_routes::<(), Target>()
-            //     .new_service(());
+            // Routes targets to a Profile stack, i.e. so that profile
+            // resolutions are shared even as the type of request may vary.
+            let http_profile_cache = http_target_cache
+                .clone()
+                .push_on_response(svc::layers().box_http_request())
+                .check_service::<Target>()
+                // Provides route configuration without pdestination overrides.
+                .push(profiles::Layer::without_overrides(
+                    profiles_client,
+                    http_profile_route_proxy.into_inner(),
+                ))
+                .into_new_service()
+                // Caches profile stacks.
+                .check_new_service_routes::<Profile, Target>()
+                .cache(
+                    svc::layers().push_on_response(
+                        svc::layers()
+                            // If the service has been unavailable for an extended time, eagerly
+                            // fail requests.
+                            .push_failfast(dispatch_timeout)
+                            // Shares the service, ensuring discovery errors are propagated.
+                            .push_spawn_buffer_with_idle_timeout(
+                                buffer_capacity,
+                                cache_max_idle_age,
+                            )
+                            .push(metrics.stack.layer(stack_labels("profile"))),
+                    ),
+                )
+                .instrument(|p: &Profile| info_span!("profile", addr = %p.addr()))
+                .check_make_service::<Profile, Target>()
+                // Ensures that cache's lock isn't held in poll_ready.
+                .push_oneshot()
+                .push(router::Layer::new(|()| ProfileTarget))
+                .check_new_service_routes::<(), Target>()
+                .new_service(());
 
-            // // Strips headers that may be set by the inbound router.
+            // Strips headers that may be set by the inbound router.
             // let http_strip_headers = svc::layers()
             //     .push(strip_header::request::layer(L5D_REMOTE_IP))
             //     .push(strip_header::request::layer(L5D_CLIENT_ID))
             //     .push(strip_header::response::layer(L5D_SERVER_ID));
 
-            // // Handles requests as they are initially received by the proxy.
-            // let http_admit_request = svc::layers()
-            //     // Downgrades the protocol if upgraded by an outbound proxy.
-            //     .push(svc::layer::mk(orig_proto::Downgrade::new))
-            //     // Limits the number of in-flight requests.
-            //     .push_concurrency_limit(max_in_flight_requests)
-            //     // Eagerly fail requests when the proxy is out of capacity for a
-            //     // dispatch_timeout.
-            //     .push_failfast(dispatch_timeout)
-            //     .push(metrics.http_errors)
-            //     // Synthesizes responses for proxy errors.
-            //     .push(errors::layer());
+            // Handles requests as they are initially received by the proxy.
+            let http_admit_request = svc::layers()
+                // Downgrades the protocol if upgraded by an outbound proxy.
+                // .push(svc::layer::mk(orig_proto::Downgrade::new))
+                // Limits the number of in-flight requests.
+                .push_concurrency_limit(max_in_flight_requests)
+                // Eagerly fail requests when the proxy is out of capacity for a
+                // dispatch_timeout.
+                .push_failfast(dispatch_timeout)
+                .push(metrics.http_errors)
+                // Synthesizes responses for proxy errors.
+                .push(errors::layer());
 
             // let http_server_observability = svc::layers()
             //     .push(TraceContextLayer::new(span_sink.map(|span_sink| {
@@ -240,51 +241,46 @@ impl Config {
             //     // Tracks proxy handletime.
             //     .push(metrics.http_handle_time.layer());
 
-            // let http_server = svc::stack(http_profile_cache)
-            //     .push_on_response(svc::layers().box_http_response())
-            //     .push_make_ready()
-            //     .push_fallback(
-            //         http_target_cache
-            //             .push_on_response(svc::layers().box_http_response().box_http_request()),
-            //     )
-            //     .check_service::<Target>()
-            //     // Ensures that the built service is ready before it is returned
-            //     // to the router to dispatch a request.
-            //     .push_make_ready()
-            //     // Limits the amount of time each request waits to obtain a
-            //     // ready service.
-            //     .push_timeout(dispatch_timeout)
-            //     // Removes the override header after it has been used to
-            //     // determine a reuquest target.
-            //     .push_on_response(strip_header::request::layer(DST_OVERRIDE_HEADER))
-            //     // Routes each request to a target, obtains a service for that
-            //     // target, and dispatches the request.
-            //     .instrument_from_target()
-            //     .push(router::Layer::new(RequestTarget::from))
-            //     .check_new_service::<tls::accept::Meta>()
-            //     // Used by tap.
-            //     .push_http_insert_target()
-            //     .push_on_response(http_strip_headers)
-            //     .push_on_response(http_admit_request)
-            //     .push_on_response(http_server_observability)
-            //     .push_on_response(metrics.stack.layer(stack_labels("source")))
-            //     .instrument(|src: &tls::accept::Meta| {
-            //         info_span!(
-            //             "source",
-            //             target.addr = %src.addrs.target_addr(),
-            //         )
-            //     });
-            let http_server = |_| {
-                tower::service_fn(move |_: http::Request<_>| async {
-                    Ok(http::Response::new(http::Body::default()))
-                })
-            };
+            let http_server = svc::stack(http_profile_cache)
+                .push_on_response(svc::layers().box_http_response())
+                .push_make_ready()
+                .push_fallback(
+                    http_target_cache
+                        .push_on_response(svc::layers().box_http_response().box_http_request()),
+                )
+                .check_service::<Target>()
+                // Ensures that the built service is ready before it is returned
+                // to the router to dispatch a request.
+                .push_make_ready()
+                // Limits the amount of time each request waits to obtain a
+                // ready service.
+                .push_timeout(dispatch_timeout)
+                // Removes the override header after it has been used to
+                // determine a reuquest target.
+                .push_on_response(strip_header::request::layer(DST_OVERRIDE_HEADER))
+                // Routes each request to a target, obtains a service for that
+                // target, and dispatches the request.
+                .instrument_from_target()
+                .push(router::Layer::new(RequestTarget::from))
+                .check_new_service::<tls::accept::Meta>()
+                // Used by tap.
+                // .push_http_insert_target()
+                // .push_on_response(http_strip_headers)
+                .push_on_response(http_admit_request)
+                // .push_on_response(http_server_observability)
+                .push_on_response(metrics.stack.layer(stack_labels("source")))
+                .instrument(|src: &tls::accept::Meta| {
+                    info_span!(
+                        "source",
+                        target.addr = %src.addrs.target_addr(),
+                    )
+                });
 
             let tcp_server = Server::new(
                 TransportLabels,
                 // metrics.transport,
                 tcp_forward.into_inner(),
-                http_server, /* .into_inner() */
+                http_server.into_inner(),
                 h2_settings,
                 drain.clone(),
             );

--- a/linkerd/app/integration/src/client.rs
+++ b/linkerd/app/integration/src/client.rs
@@ -319,6 +319,8 @@ impl tower::Service<hyper::Uri> for Conn {
 
 impl hyper::client::connect::Connection for RunningIo {
     fn connected(&self) -> hyper::client::connect::Connected {
+        // Setting `proxy` to true will configure Hyper to use absolute-form
+        // URIs on this connection.
         hyper::client::connect::Connected::new().proxy(self.abs_form)
     }
 }

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -233,6 +233,8 @@ macro_rules! http1_tests {
         }
 
         #[test]
+        // Re-enable when the header-stripping stuff is ported to std::future
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn http1_removes_connection_headers() {
             let _ = trace_init();
 
@@ -425,6 +427,8 @@ macro_rules! http1_tests {
         }
 
         #[test]
+        // Re-enable when the header-stripping stuff is ported to std::future
+        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn http11_upgrade_h2_stripped() {
             let _ = trace_init();
 

--- a/linkerd/buffer/src/service.rs
+++ b/linkerd/buffer/src/service.rs
@@ -61,12 +61,12 @@ impl<Req, F> Buffer<Req, F> {
     }
 }
 
-impl<Req, F> tower::Service<Req> for Buffer<Req, F>
+impl<Req, F, E, T> tower::Service<Req> for Buffer<Req, F>
 where
-    F: TryFuture,
-    F::Error: Into<Error>,
+    F: Future<Output = Result<T, E>>,
+    E: Into<Error>,
 {
-    type Response = F::Ok;
+    type Response = T;
     type Error = Error;
     type Future = ResponseFuture<F>;
 

--- a/linkerd/buffer/src/service.rs
+++ b/linkerd/buffer/src/service.rs
@@ -61,12 +61,12 @@ impl<Req, F> Buffer<Req, F> {
     }
 }
 
-impl<Req, F, E, T> tower::Service<Req> for Buffer<Req, F>
+impl<Req, F> tower::Service<Req> for Buffer<Req, F>
 where
-    F: Future<Output = Result<T, E>>,
-    E: Into<Error>,
+    F: TryFuture,
+    F::Error: Into<Error>,
 {
-    type Response = T;
+    type Response = F::Ok;
     type Error = Error;
     type Future = ResponseFuture<F>;
 

--- a/linkerd/cache/src/layer.rs
+++ b/linkerd/cache/src/layer.rs
@@ -27,7 +27,7 @@ impl<L: Clone, T> Clone for CacheLayer<T, L> {
 
 impl<T, L, N> tower::layer::Layer<N> for CacheLayer<T, L>
 where
-    T: Eq + std::hash::Hash,
+    T: Eq + std::hash::Hash + Send + 'static,
     N: NewService<T> + Clone,
     L: tower::layer::Layer<Track<N>> + Clone,
     L::Service: NewService<T>,

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -34,7 +34,7 @@ type Services<T, S> = HashMap<T, (S, Weak<()>)>;
 
 impl<T, N> Cache<T, N>
 where
-    T: Eq + Hash,
+    T: Eq + Hash + Send + 'static,
     N: NewService<(T, Handle)>,
 {
     pub fn new(new_service: N) -> Self {

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -36,8 +36,7 @@ tokio = "0.1"
 tokio_02 = { package = "tokio", version = "0.2" }
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-timer = "0.2"   # for tokio_timer::clock
-tower = "0.1"
-tower-03 = { package = "tower", version = "0.3" }
+tower = { version = "0.3", default-features = false }
 tower-balance = { git = "https://github.com/tower-rs/tower" }
 tower-discover = "0.1"
 tower-load = { git = "https://github.com/tower-rs/tower" }

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -43,6 +43,7 @@ where
     C: tower::make::MakeConnection<T> + 'static,
     C::Error: Into<Error>,
     C::Connection: tokio_02::io::AsyncRead + tokio_02::io::AsyncWrite + Unpin + Send + 'static,
+    C::Future: Send + 'static,
 {
     Http1(Option<HyperMakeClient<C, T, B>>),
     Http2(#[pin] tower::util::Oneshot<h2::Connect<C, B>, T>),

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -39,7 +39,7 @@ pub enum MakeFuture<C, T, B>
 where
     B: hyper::body::HttpBody + Send + 'static,
     B::Data: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Error> + Send + Sync,
     C: tower::make::MakeConnection<T> + 'static,
     C::Error: Into<Error>,
     C::Connection: tokio_02::io::AsyncRead + tokio_02::io::AsyncWrite + Unpin + Send + 'static,
@@ -80,10 +80,7 @@ impl<B> MakeClientLayer<B> {
     }
 }
 
-impl<B> Clone for MakeClientLayer<B>
-where
-    B: hyper::body::HttpBody + Send + 'static,
-{
+impl<B> Clone for MakeClientLayer<B> {
     fn clone(&self) -> Self {
         Self {
             h2_settings: self.h2_settings,
@@ -93,8 +90,8 @@ where
 }
 
 impl<C, B> tower::layer::Layer<C> for MakeClientLayer<B>
-where
-    B: hyper::body::HttpBody + Send + 'static,
+// where
+// B: hyper::body::HttpBody + Send + 'static,
 {
     type Service = MakeClient<C, B>;
 
@@ -118,7 +115,7 @@ where
     T: HasSettings + Clone + Send + Sync + 'static,
     B: hyper::body::HttpBody + Send + 'static,
     B::Data: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Error> + Send + Sync,
 {
     type Response = Client<C, T, B>;
     type Error = Error;
@@ -179,7 +176,7 @@ where
     C::Error: Into<Error>,
     B: hyper::body::HttpBody + Send + 'static,
     B::Data: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Error> + Send + Sync,
 {
     type Output = Result<Client<C, T, B>, Error>;
 
@@ -208,7 +205,7 @@ where
     T: Clone + Send + Sync + 'static,
     B: hyper::body::HttpBody + Send + 'static,
     B::Data: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Error> + Send + Sync,
 {
     type Response = http::Response<Body>;
     type Error = Error;

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -114,7 +114,7 @@ where
     C: tower::make::MakeConnection<T> + Clone + Unpin + Send + Sync + 'static,
     C::Future: Unpin + Send + 'static,
     C::Error: Into<Error>,
-    C::Connection: hyper::client::connect::Connection + Unpin + Send + 'static,
+    C::Connection: Unpin + Send + 'static,
     T: HasSettings + Clone + Send + Sync + 'static,
     B: hyper::body::HttpBody + Send + 'static,
     B::Data: Send,
@@ -202,7 +202,7 @@ where
 impl<C, T, B> tower::Service<http::Request<B>> for Client<C, T, B>
 where
     C: tower::make::MakeConnection<T> + Clone + Send + Sync + 'static,
-    C::Connection: hyper::client::connect::Connection + Unpin + Send + 'static,
+    C::Connection: Unpin + Send + 'static,
     C::Future: Unpin + Send + 'static,
     C::Error: Into<Error>,
     T: Clone + Send + Sync + 'static,

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -13,7 +13,7 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tower_03::ServiceExt;
+use tower::ServiceExt;
 use tracing::{debug, trace};
 // use tracing_futures::{Instrument, Instrumented};
 
@@ -40,19 +40,19 @@ where
     B: hyper::body::HttpBody + Send + 'static,
     B::Data: Send,
     B::Error: std::error::Error + Send + Sync,
-    C: tower_03::make::MakeConnection<T> + 'static,
+    C: tower::make::MakeConnection<T> + 'static,
     C::Error: Into<Error>,
     C::Connection: tokio_02::io::AsyncRead + tokio_02::io::AsyncWrite + Unpin + Send + 'static,
 {
     Http1(Option<HyperMakeClient<C, T, B>>),
-    Http2(#[pin] tower_03::util::Oneshot<h2::Connect<C, B>, T>),
+    Http2(#[pin] tower::util::Oneshot<h2::Connect<C, B>, T>),
 }
 
 /// The `Service` yielded by `MakeClient::new_service()`.
 pub enum Client<C, T, B>
 where
     B: hyper::body::HttpBody + 'static,
-    C: tower_03::make::MakeConnection<T> + 'static,
+    C: tower::make::MakeConnection<T> + 'static,
 {
     Http1(HyperMakeClient<C, T, B>),
     Http2(h2::Connection<B>),
@@ -109,9 +109,9 @@ where
 
 // === impl MakeClient ===
 
-impl<C, T, B> tower_03::Service<T> for MakeClient<C, B>
+impl<C, T, B> tower::Service<T> for MakeClient<C, B>
 where
-    C: tower_03::make::MakeConnection<T> + Clone + Unpin + Send + Sync + 'static,
+    C: tower::make::MakeConnection<T> + Clone + Unpin + Send + Sync + 'static,
     C::Future: Unpin + Send + 'static,
     C::Error: Into<Error>,
     C::Connection: hyper::client::connect::Connection + Unpin + Send + 'static,
@@ -173,7 +173,7 @@ impl<C: Clone, B> Clone for MakeClient<C, B> {
 
 impl<C, T, B> Future for MakeFuture<C, T, B>
 where
-    C: tower_03::make::MakeConnection<T> + Unpin + Send + Sync + 'static,
+    C: tower::make::MakeConnection<T> + Unpin + Send + Sync + 'static,
     C::Connection: Unpin + Send + 'static,
     C::Future: Send + 'static,
     C::Error: Into<Error>,
@@ -199,9 +199,9 @@ where
 
 // === impl Client ===
 
-impl<C, T, B> tower_03::Service<http::Request<B>> for Client<C, T, B>
+impl<C, T, B> tower::Service<http::Request<B>> for Client<C, T, B>
 where
-    C: tower_03::make::MakeConnection<T> + Clone + Send + Sync + 'static,
+    C: tower::make::MakeConnection<T> + Clone + Send + Sync + 'static,
     C::Connection: hyper::client::connect::Connection + Unpin + Send + 'static,
     C::Future: Unpin + Send + 'static,
     C::Error: Into<Error>,

--- a/linkerd/proxy/http/src/glue.rs
+++ b/linkerd/proxy/http/src/glue.rs
@@ -128,9 +128,9 @@ impl<S> HyperServerSvc<S> {
     }
 }
 
-impl<S, B> tower_03::Service<http::Request<hyper::Body>> for HyperServerSvc<S>
+impl<S, B> tower::Service<http::Request<hyper::Body>> for HyperServerSvc<S>
 where
-    S: tower_03::Service<http::Request<Body>, Response = http::Response<B>>,
+    S: tower::Service<http::Request<Body>, Response = http::Response<B>>,
     S::Error: Into<Error>,
     B: HttpBody,
 {
@@ -162,9 +162,9 @@ impl<C, T> HyperConnect<C, T> {
     }
 }
 
-impl<C, T> tower_03::Service<hyper::Uri> for HyperConnect<C, T>
+impl<C, T> tower::Service<hyper::Uri> for HyperConnect<C, T>
 where
-    C: tower_03::make::MakeConnection<T> + Clone + Send + Sync,
+    C: tower::make::MakeConnection<T> + Clone + Send + Sync,
     C::Error: Into<Error>,
     C::Future: TryFuture<Ok = C::Connection> + Unpin + Send + 'static,
     <C::Future as TryFuture>::Error: Into<Error>,

--- a/linkerd/proxy/http/src/glue.rs
+++ b/linkerd/proxy/http/src/glue.rs
@@ -274,11 +274,8 @@ where
     }
 }
 
-impl<C> hyper_connect::Connection for Connection<C>
-where
-    C: hyper_connect::Connection,
-{
+impl<C> hyper_connect::Connection for Connection<C> {
     fn connected(&self) -> hyper_connect::Connected {
-        self.transport.connected().proxy(self.absolute_form)
+        hyper_connect::Connected::new().proxy(self.absolute_form)
     }
 }

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -39,7 +39,7 @@ where
     F: TryFuture,
     B: HttpBody + Send + 'static,
     B::Data: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Error> + Send + Sync,
     F::Ok: AsyncRead + AsyncWrite + Send + 'static,
 {
     #[pin]
@@ -53,7 +53,7 @@ where
     F: TryFuture,
     B: HttpBody + Send + 'static,
     B::Data: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Error> + Send + Sync,
     F::Ok: AsyncRead + AsyncWrite + Send + 'static,
 {
     Connect(#[pin] F),
@@ -107,7 +107,7 @@ where
     C::Error: Into<Error>,
     B: HttpBody + Send + 'static,
     B::Data: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Error> + Send + Sync,
 {
     type Response = Connection<B>;
     type Error = Error;
@@ -134,7 +134,7 @@ where
     F::Error: Into<Error>,
     B: HttpBody + Send + 'static,
     B::Data: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Error> + Send + Sync,
 {
     type Output = Result<Connection<B>, Error>;
 
@@ -179,7 +179,7 @@ impl<B> tower::Service<http::Request<B>> for Connection<B>
 where
     B: HttpBody + Send + 'static,
     B::Data: Send,
-    B::Error: std::error::Error + Send + Sync,
+    B::Error: Into<Error> + Send + Sync,
 {
     type Response = http::Response<Body>;
     type Error = hyper::Error;

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -100,9 +100,9 @@ impl<C: Clone, B> Clone for Connect<C, B> {
     }
 }
 
-impl<C, B, T> tower_03::Service<T> for Connect<C, B>
+impl<C, B, T> tower::Service<T> for Connect<C, B>
 where
-    C: tower_03::make::MakeConnection<T>,
+    C: tower::make::MakeConnection<T>,
     C::Connection: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     C::Error: Into<Error>,
     B: HttpBody + Send + 'static,
@@ -175,7 +175,7 @@ where
 
 // ===== impl Connection =====
 
-impl<B> tower_03::Service<http::Request<B>> for Connection<B>
+impl<B> tower::Service<http::Request<B>> for Connection<B>
 where
     B: HttpBody + Send + 'static,
     B::Data: Send,

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -12,7 +12,7 @@ pub mod glue;
 // pub mod grpc;
 pub mod h1;
 pub mod h2;
-pub mod header_from_target;
+// pub mod header_from_target;
 // pub mod insert;
 pub mod normalize_uri;
 // pub mod orig_proto;

--- a/linkerd/proxy/http/src/normalize_uri.rs
+++ b/linkerd/proxy/http/src/normalize_uri.rs
@@ -32,7 +32,7 @@ pub struct NormalizeUri<S> {
 
 // === impl Layer ===
 
-pub fn layer<M>() -> impl tower_03::layer::Layer<M, Service = MakeNormalizeUri<M>> + Copy {
+pub fn layer<M>() -> impl tower::layer::Layer<M, Service = MakeNormalizeUri<M>> + Copy {
     layer::mk(|inner| MakeNormalizeUri { inner })
 }
 
@@ -52,10 +52,10 @@ where
     }
 }
 
-impl<T, M> tower_03::Service<T> for MakeNormalizeUri<M>
+impl<T, M> tower::Service<T> for MakeNormalizeUri<M>
 where
     T: ShouldNormalizeUri,
-    M: tower_03::Service<T>,
+    M: tower::Service<T>,
 {
     type Response = NormalizeUri<M::Response>;
     type Error = M::Error;
@@ -92,9 +92,9 @@ impl<F: TryFuture> Future for MakeFuture<F> {
 
 // === impl NormalizeUri ===
 
-impl<S, B> tower_03::Service<http::Request<B>> for NormalizeUri<S>
+impl<S, B> tower::Service<http::Request<B>> for NormalizeUri<S>
 where
-    S: tower_03::Service<http::Request<B>>,
+    S: tower::Service<http::Request<B>>,
 {
     type Response = S::Response;
     type Error = S::Error;

--- a/linkerd/proxy/http/src/timeout.rs
+++ b/linkerd/proxy/http/src/timeout.rs
@@ -57,9 +57,9 @@ where
     }
 }
 
-impl<T, M> tower_03::Service<T> for MakeTimeout<M>
+impl<T, M> tower::Service<T> for MakeTimeout<M>
 where
-    M: tower_03::Service<T>,
+    M: tower::Service<T>,
     T: HasTimeout,
 {
     type Response = Timeout<M::Response>;

--- a/linkerd/proxy/http/src/upgrade.rs
+++ b/linkerd/proxy/http/src/upgrade.rs
@@ -173,9 +173,9 @@ impl<S> Service<S> {
     }
 }
 
-impl<S, B> tower_03::Service<http::Request<Body>> for Service<S>
+impl<S, B> tower::Service<http::Request<Body>> for Service<S>
 where
-    S: tower_03::Service<http::Request<Body>, Response = http::Response<B>>,
+    S: tower::Service<http::Request<Body>, Response = http::Response<B>>,
     B: Default,
 {
     type Response = S::Response;

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "0.2", features = ["net", "io-util"]}
 tokio-compat = "0.1"
 tokio-rustls = "0.13"
 task-compat = "0.1"
-tower_01 = {package = "tower", version = "0.1"}
+# tower_01 = {package = "tower", version = "0.1"}
 tracing = "0.1.9"
 webpki = "0.21"
 untrusted = "0.7"


### PR DESCRIPTION
Now that the HTTP connect- and accept-side machinery has all been
updated to use `std::future`, we can start turning the proxy back
into...a proxy. This branch does so on the inbound side. Much of the
actual functionality (approximately everything not directly required to
actually proxy requests) is still disabled, as a lot of the code still
needs to be updated.

I had to make a few additional changes in order to get the proxy to
compile, primarily to deal with trait bounds on `Service` impls that
were no longer satisfied as a result of changes made to update other
parts of the codebase. I also disabled two more of the  `transparency`
integration tests, both of which tested whether the proxy stripped
connection-level headers from proxied requests. Previously, these were
passing "accidentally" — because the proxy was replaced with a HTTP
server that just responded to every request with an empty 200 OK
response, the headers were, of course, not present. Now that we're
actually proxying requests, these tests fail, because the code for
stripping headers has yet to be updated.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>