### PR TITLE
port normalize_uri to std::future

### DIFF
--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -140,23 +140,23 @@ impl Profile {
 
 // // === impl Target ===
 
-// impl http::normalize_uri::ShouldNormalizeUri for Target {
-//     fn should_normalize_uri(&self) -> Option<http::uri::Authority> {
-//         if let http::Settings::Http1 {
-//             was_absolute_form: false,
-//             ..
-//         } = self.http_settings
-//         {
-//             return Some(
-//                 self.dst_name
-//                     .as_ref()
-//                     .map(|dst| dst.as_http_authority())
-//                     .unwrap_or_else(|| Addr::from(self.addr).to_http_authority()),
-//             );
-//         }
-//         None
-//     }
-// }
+impl http::normalize_uri::ShouldNormalizeUri for Target {
+    fn should_normalize_uri(&self) -> Option<http::uri::Authority> {
+        if let http::Settings::Http1 {
+            was_absolute_form: false,
+            ..
+        } = self.http_settings
+        {
+            return Some(
+                self.dst_name
+                    .as_ref()
+                    .map(|dst| dst.as_http_authority())
+                    .unwrap_or_else(|| Addr::from(self.addr).to_http_authority()),
+            );
+        }
+        None
+    }
+}
 
 impl http::settings::HasSettings for Target {
     fn http_settings(&self) -> http::Settings {

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -92,18 +92,18 @@ impl<'t, T> From<&'t Target<T>> for ::http::header::HeaderValue {
     }
 }
 
-// impl<T: http::settings::HasSettings> http::normalize_uri::ShouldNormalizeUri for Target<T> {
-//     fn should_normalize_uri(&self) -> Option<http::uri::Authority> {
-//         if let http::Settings::Http1 {
-//             was_absolute_form: false,
-//             ..
-//         } = self.inner.http_settings()
-//         {
-//             return Some(self.addr.to_http_authority());
-//         }
-//         None
-//     }
-// }
+impl<T: http::settings::HasSettings> http::normalize_uri::ShouldNormalizeUri for Target<T> {
+    fn should_normalize_uri(&self) -> Option<http::uri::Authority> {
+        if let http::Settings::Http1 {
+            was_absolute_form: false,
+            ..
+        } = self.inner.http_settings()
+        {
+            return Some(self.addr.to_http_authority());
+        }
+        None
+    }
+}
 
 // impl<T> profiles::OverrideDestination for Target<T> {
 //     fn dst_mut(&mut self) -> &mut Addr {

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -14,7 +14,7 @@ pub mod h1;
 pub mod h2;
 pub mod header_from_target;
 // pub mod insert;
-// pub mod normalize_uri;
+pub mod normalize_uri;
 // pub mod orig_proto;
 // pub mod override_authority;
 pub mod settings;


### PR DESCRIPTION
It turns out that most of the tests that can be re-enabled as a result
of #516 expect URIs to be normalized.

Therefore, I ported the `normalize_uri` layer to std::future. This is
a pretty mechanical translation.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>