### PR TITLE
port `linkerd2-proxy-error::recover` and `linkerd2-proxy-resolve` to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ version = "0.1.0"
 name = "linkerd2-error"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.26",
+ "futures 0.3.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,12 +1362,12 @@ dependencies = [
 name = "linkerd2-proxy-resolve"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.26",
+ "futures 0.3.4",
  "indexmap",
  "linkerd2-error",
  "linkerd2-proxy-core",
  "pin-project",
- "tokio 0.1.22",
+ "tokio 0.2.20",
  "tower 0.3.1",
  "tracing",
 ]

--- a/linkerd/error/Cargo.toml
+++ b/linkerd/error/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.1"
+futures = "0.3"

--- a/linkerd/error/src/recover.rs
+++ b/linkerd/error/src/recover.rs
@@ -1,10 +1,10 @@
 use super::{Error, Never};
-use futures::{stream, Stream};
+use futures::stream::{self, TryStream};
 
 /// An error recovery strategy.
 pub trait Recover<E: Into<Error> = Error> {
     type Error: Into<Error>;
-    type Backoff: Stream<Item = (), Error = Self::Error>;
+    type Backoff: TryStream<Ok = (), Error = Self::Error>;
 
     /// Given an E-typed error, determine if the error is recoverable.
     ///
@@ -25,7 +25,7 @@ pub struct Immediately(());
 impl<E, B, F> Recover<E> for F
 where
     E: Into<Error>,
-    B: Stream<Item = ()>,
+    B: TryStream<Ok = ()>,
     B::Error: Into<Error>,
     F: Fn(E) -> Result<B, E>,
 {
@@ -47,17 +47,17 @@ impl Immediately {
 
 impl<E: Into<Error>> Recover<E> for Immediately {
     type Error = Never;
-    type Backoff = stream::IterOk<Immediately, Never>;
+    type Backoff = stream::Iter<Immediately>;
 
     fn recover(&self, _: E) -> Result<Self::Backoff, E> {
-        Ok(stream::iter_ok(Immediately(())))
+        Ok(stream::iter(Immediately(())))
     }
 }
 
 impl Iterator for Immediately {
-    type Item = ();
+    type Item = Result<(), Never>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        Some(())
+        Some(Ok(()))
     }
 }

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -9,7 +9,7 @@ Core interfaces needed to implement proxy components
 """
 
 [dependencies]
-futures = {package = "futures", version = "0.3" }
+futures = "0.3"
 linkerd2-error = { path = "../../error" }
 tokio = "0.2"
 tower = {version = "0.3", default-features = false }

--- a/linkerd/proxy/core/src/resolve.rs
+++ b/linkerd/proxy/core/src/resolve.rs
@@ -32,6 +32,16 @@ pub trait Resolution {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<Update<Self::Endpoint>, Self::Error>>;
+
+    fn poll_unpin(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Update<Self::Endpoint>, Self::Error>>
+    where
+        Self: Unpin,
+    {
+        Pin::new(self).poll(cx)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/linkerd/proxy/resolve/Cargo.toml
+++ b/linkerd/proxy/resolve/Cargo.toml
@@ -9,11 +9,11 @@ Utilities for working with `Resolve` implementations
 """
 
 [dependencies]
-futures = "0.1"
+futures = "0.3"
 linkerd2-error = { path = "../../error" }
 linkerd2-proxy-core = { path = "../core" }
 indexmap = "1.0"
-tokio = "0.1"
+tokio = "0.2"
 tracing = "0.1"
 pin-project = "0.4"
 

--- a/linkerd/proxy/resolve/src/map_endpoint.rs
+++ b/linkerd/proxy/resolve/src/map_endpoint.rs
@@ -1,136 +1,148 @@
-// //! A middleware that wraps `Resolutions`, modifying their endpoint type.
+//! A middleware that wraps `Resolutions`, modifying their endpoint type.
 
-// use futures::{try_ready, Async, Future, Poll};
-// use linkerd2_proxy_core::resolve;
-// use std::net::SocketAddr;
+use futures::{ready, TryFuture};
+use linkerd2_proxy_core::resolve;
+use pin_project::pin_project;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
-// pub trait MapEndpoint<Target, In> {
-//     type Out;
-//     fn map_endpoint(&self, target: &Target, addr: SocketAddr, in_ep: In) -> Self::Out;
-// }
+pub trait MapEndpoint<Target, In> {
+    type Out;
+    fn map_endpoint(&self, target: &Target, addr: SocketAddr, in_ep: In) -> Self::Out;
+}
 
-// #[derive(Clone, Debug)]
-// pub struct Resolve<M, R> {
-//     resolve: R,
-//     map: M,
-// }
+#[derive(Clone, Debug)]
+pub struct Resolve<M, R> {
+    resolve: R,
+    map: M,
+}
 
-// #[derive(Debug)]
-// pub struct ResolveFuture<T, F, M> {
-//     future: F,
-//     target: Option<T>,
-//     map: Option<M>,
-// }
+#[pin_project]
+#[derive(Debug)]
+pub struct ResolveFuture<T, F, M> {
+    #[pin]
+    future: F,
+    target: Option<T>,
+    map: Option<M>,
+}
 
-// #[derive(Clone, Debug)]
-// pub struct Resolution<T, M, R> {
-//     resolution: R,
-//     target: T,
-//     map: M,
-// }
+#[pin_project]
+#[derive(Clone, Debug)]
+pub struct Resolution<T, M, R> {
+    #[pin]
+    resolution: R,
+    target: T,
+    map: M,
+}
 
-// // === impl Resolve ===
+// === impl Resolve ===
 
-// impl<M, R> Resolve<M, R> {
-//     pub fn new<T>(map: M, resolve: R) -> Self
-//     where
-//         Self: resolve::Resolve<T>,
-//     {
-//         Self { resolve, map }
-//     }
-// }
+impl<M, R> Resolve<M, R> {
+    pub fn new<T>(map: M, resolve: R) -> Self
+    where
+        Self: resolve::Resolve<T>,
+    {
+        Self { resolve, map }
+    }
+}
 
-// impl<T, M, R> tower::Service<T> for Resolve<M, R>
-// where
-//     T: Clone,
-//     R: resolve::Resolve<T>,
-//     M: MapEndpoint<T, R::Endpoint> + Clone,
-// {
-//     type Response = Resolution<T, M, R::Resolution>;
-//     type Error = R::Error;
-//     type Future = ResolveFuture<T, R::Future, M>;
+impl<T, M, R> tower::Service<T> for Resolve<M, R>
+where
+    T: Clone,
+    R: resolve::Resolve<T>,
+    M: MapEndpoint<T, R::Endpoint> + Clone,
+{
+    type Response = Resolution<T, M, R::Resolution>;
+    type Error = R::Error;
+    type Future = ResolveFuture<T, R::Future, M>;
 
-//     #[inline]
-//     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-//         self.resolve.poll_ready()
-//     }
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.resolve.poll_ready(cx)
+    }
 
-//     #[inline]
-//     fn call(&mut self, target: T) -> Self::Future {
-//         let future = self.resolve.resolve(target.clone());
-//         Self::Future {
-//             future,
-//             target: Some(target),
-//             map: Some(self.map.clone()),
-//         }
-//     }
-// }
+    #[inline]
+    fn call(&mut self, target: T) -> Self::Future {
+        let future = self.resolve.resolve(target.clone());
+        Self::Future {
+            future,
+            target: Some(target),
+            map: Some(self.map.clone()),
+        }
+    }
+}
 
-// // === impl ResolveFuture ===
+// === impl ResolveFuture ===
 
-// impl<T, F, M> Future for ResolveFuture<T, F, M>
-// where
-//     F: Future,
-//     F::Item: resolve::Resolution,
-//     M: MapEndpoint<T, <F::Item as resolve::Resolution>::Endpoint>,
-// {
-//     type Item = Resolution<T, M, F::Item>;
-//     type Error = F::Error;
+impl<T, F, M> Future for ResolveFuture<T, F, M>
+where
+    F: TryFuture,
+    F::Ok: resolve::Resolution,
+    M: MapEndpoint<T, <F::Ok as resolve::Resolution>::Endpoint>,
+{
+    type Output = Result<Resolution<T, M, F::Ok>, F::Error>;
 
-//     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-//         let resolution = try_ready!(self.future.poll());
-//         let target = self.target.take().expect("polled after ready");
-//         let map = self.map.take().expect("polled after ready");
-//         Ok(Async::Ready(Resolution {
-//             resolution,
-//             target,
-//             map,
-//         }))
-//     }
-// }
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let resolution = ready!(this.future.try_poll(cx))?;
+        let target = this.target.take().expect("polled after ready");
+        let map = this.map.take().expect("polled after ready");
+        Poll::Ready(Ok(Resolution {
+            resolution,
+            target,
+            map,
+        }))
+    }
+}
 
-// // === impl Resolution ===
+// === impl Resolution ===
 
-// impl<T, M, R> resolve::Resolution for Resolution<T, M, R>
-// where
-//     R: resolve::Resolution,
-//     M: MapEndpoint<T, R::Endpoint>,
-// {
-//     type Endpoint = M::Out;
-//     type Error = R::Error;
+impl<T, M, R> resolve::Resolution for Resolution<T, M, R>
+where
+    R: resolve::Resolution,
+    M: MapEndpoint<T, R::Endpoint>,
+{
+    type Endpoint = M::Out;
+    type Error = R::Error;
 
-//     fn poll(&mut self) -> Poll<resolve::Update<M::Out>, Self::Error> {
-//         let update = match try_ready!(self.resolution.poll()) {
-//             resolve::Update::Add(eps) => resolve::Update::Add(
-//                 eps.into_iter()
-//                     .map(|(a, ep)| {
-//                         let ep = self.map.map_endpoint(&self.target, a, ep);
-//                         (a, ep)
-//                     })
-//                     .collect(),
-//             ),
-//             resolve::Update::Remove(addrs) => resolve::Update::Remove(addrs),
-//             resolve::Update::DoesNotExist => resolve::Update::DoesNotExist,
-//             resolve::Update::Empty => resolve::Update::Empty,
-//         };
-//         Ok(update.into())
-//     }
-// }
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<resolve::Update<M::Out>, Self::Error>> {
+        let this = self.project();
+        let update = match ready!(this.resolution.poll(cx))? {
+            resolve::Update::Add(eps) => resolve::Update::Add(
+                eps.into_iter()
+                    .map(|(a, ep)| {
+                        let ep = this.map.map_endpoint(&this.target, a, ep);
+                        (a, ep)
+                    })
+                    .collect(),
+            ),
+            resolve::Update::Remove(addrs) => resolve::Update::Remove(addrs),
+            resolve::Update::DoesNotExist => resolve::Update::DoesNotExist,
+            resolve::Update::Empty => resolve::Update::Empty,
+        };
+        Poll::Ready(Ok(update))
+    }
+}
 
-// // === impl MapEndpoint ===
+// === impl MapEndpoint ===
 
-// impl<T, N> MapEndpoint<T, N> for () {
-//     type Out = N;
+impl<T, N> MapEndpoint<T, N> for () {
+    type Out = N;
 
-//     fn map_endpoint(&self, _: &T, _: SocketAddr, ep: N) -> Self::Out {
-//         ep
-//     }
-// }
+    fn map_endpoint(&self, _: &T, _: SocketAddr, ep: N) -> Self::Out {
+        ep
+    }
+}
 
-// impl<T, In, Out, F: Fn(&T, SocketAddr, In) -> Out> MapEndpoint<T, In> for F {
-//     type Out = Out;
+impl<T, In, Out, F: Fn(&T, SocketAddr, In) -> Out> MapEndpoint<T, In> for F {
+    type Out = Out;
 
-//     fn map_endpoint(&self, target: &T, addr: SocketAddr, ep: In) -> Self::Out {
-//         (self)(target, addr, ep)
-//     }
-// }
+    fn map_endpoint(&self, target: &T, addr: SocketAddr, ep: In) -> Self::Out {
+        (self)(target, addr, ep)
+    }
+}

--- a/linkerd/proxy/resolve/src/map_endpoint.rs
+++ b/linkerd/proxy/resolve/src/map_endpoint.rs
@@ -113,14 +113,15 @@ where
     ) -> Poll<Result<resolve::Update<M::Out>, Self::Error>> {
         let this = self.project();
         let update = match ready!(this.resolution.poll(cx))? {
-            resolve::Update::Add(eps) => resolve::Update::Add(
-                eps.into_iter()
-                    .map(|(a, ep)| {
-                        let ep = this.map.map_endpoint(&this.target, a, ep);
-                        (a, ep)
-                    })
-                    .collect(),
-            ),
+            resolve::Update::Add(eps) => {
+                let mut update = Vec::new();
+                for (a, ep) in eps.into_iter() {
+                    let ep = this.map.map_endpoint(&this.target, a, ep);
+                    update.push((a, ep));
+                }
+
+                resolve::Update::Add(update)
+            }
             resolve::Update::Remove(addrs) => resolve::Update::Remove(addrs),
             resolve::Update::DoesNotExist => resolve::Update::DoesNotExist,
             resolve::Update::Empty => resolve::Update::Empty,

--- a/linkerd/proxy/resolve/src/recover.rs
+++ b/linkerd/proxy/resolve/src/recover.rs
@@ -1,12 +1,11 @@
 //! A middleware that recovers a resolution after some failures.
 
-use futures::{ready, Stream};
+use futures::{ready, stream::TryStreamExt};
 use indexmap::IndexMap;
 use linkerd2_error::{Error, Recover};
-use linkerd2_proxy_core::resolve::{self, Resolution as _, Update};
+use linkerd2_proxy_core::resolve::{self, Update};
 use pin_project::{pin_project, project};
 use std::future::Future;
-use std::net::SocketAddr;
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -25,6 +24,7 @@ pub struct ResolveFuture<T, E: Recover, R: resolve::Resolve<T>> {
 
 #[pin_project]
 pub struct Resolution<T, E: Recover, R: resolve::Resolve<T>> {
+    #[pin]
     inner: Inner<T, E, R>,
     cache: IndexMap<SocketAddr, R::Endpoint>,
     reconcile: Option<Update<R::Endpoint>>,
@@ -33,7 +33,6 @@ pub struct Resolution<T, E: Recover, R: resolve::Resolve<T>> {
 #[pin_project]
 struct Inner<T, E: Recover, R: resolve::Resolve<T>> {
     target: T,
-    #[pin]
     resolve: R,
     recover: E,
     #[pin]
@@ -48,35 +47,31 @@ struct Cache<T> {
 #[pin_project]
 enum State<F, R: resolve::Resolution, B> {
     Disconnected {
-        #[pin]
         backoff: Option<B>,
     },
     Connecting {
         #[pin]
         future: F,
-        #[pin]
-        backoff: Option<B>,
-    },
-    // XXX This state shouldn't be necessary, but we need it to pass tests(!)
-    // that don't properly mimic the go server's behavior. See
-    // linkerd/linkerd2#3362.
-    Pending {
-        #[pin]
-        resolution: Option<R>,
-        #[pin]
         backoff: Option<B>,
     },
     Connected {
         #[pin]
         resolution: R,
-        initial: Option<Update<R::Endpoint>>,
+        inner: Connected<B, R::Endpoint>,
     },
     Recover {
         error: Option<Error>,
-        #[pin]
         backoff: Option<B>,
     },
-    Backoff(#[pin] Option<B>),
+    Backoff(Option<B>),
+}
+
+enum Connected<B, E> {
+    // XXX This state shouldn't be necessary, but we need it to pass tests(!)
+    // that don't properly mimic the go server's behavior. See
+    // linkerd/linkerd2#3362.
+    Pending { backoff: Option<B> },
+    Connected { initial: Option<Update<E>> },
 }
 
 // === impl Resolve ===
@@ -93,14 +88,15 @@ where
     R: resolve::Resolve<T> + Clone,
     R::Endpoint: Clone + PartialEq,
     E: Recover + Clone,
+    E::Backoff: Unpin,
 {
     type Response = Resolution<T, E, R>;
     type Error = Error;
     type Future = ResolveFuture<T, E, R>;
 
     #[inline]
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.resolve.poll_ready().map_err(Into::into)
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.resolve.poll_ready(cx).map_err(Into::into)
     }
 
     #[inline]
@@ -129,20 +125,21 @@ where
     R: resolve::Resolve<T>,
     R::Endpoint: Clone + PartialEq,
     E: Recover,
+    E::Backoff: Unpin,
 {
-    type Item = Resolution<T, E, R>;
-    type Error = Error;
+    type Output = Result<Resolution<T, E, R>, Error>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
         // Wait until the resolution is connected.
-        try_ready!(self
+        ready!(this
             .inner
-            .as_mut()
+            .as_pin_mut()
             .expect("polled after complete")
-            .poll_connected());
-
-        Ok(Async::Ready(Resolution {
-            inner: self.inner.take().expect("polled after complete"),
+            .poll_connected(cx))?;
+        let inner = this.inner.take().expect("polled after complete");
+        Poll::Ready(Ok(Resolution {
+            inner,
             cache: IndexMap::default(),
             //cache: Cache::default(),
             reconcile: None,
@@ -158,63 +155,87 @@ where
     R: resolve::Resolve<T>,
     R::Endpoint: Clone + PartialEq,
     E: Recover,
+    E::Backoff: Unpin,
 {
     type Endpoint = R::Endpoint;
     type Error = Error;
 
-    fn poll(&mut self) -> Poll<Update<Self::Endpoint>, Self::Error> {
+    #[project]
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Update<Self::Endpoint>, Self::Error>> {
+        let mut this = self.project();
         loop {
             // If a reconciliation update is buffered (i.e. after
             // reconcile_after_reconnect), process it immediately.
-            if let Some(update) = self.reconcile.take() {
-                self.update_active(&update);
-                return Ok(update.into());
+            if let Some(update) = this.reconcile.take() {
+                this.update_active(&update);
+                return Poll::Ready(Ok(update));
             }
 
-            if let State::Connected {
-                ref mut resolution,
-                ref mut initial,
-            } = self.inner.state
-            {
-                // XXX Due to linkerd/linkerd2#3362, errors can't be discovered
-                // eagerly, so we must potentially read the first update to be
-                // sure it didn't fail. If that's the case, then reconcile the
-                // cache against the initial update.
-                if let Some(initial) = initial.take() {
-                    // The initial state afer a reconnect may be identitical to
-                    // the prior state, and so there may be no updates to
-                    // advertise.
-                    if let Some((update, reconcile)) = reconcile_after_connect(&self.cache, initial)
+            #[project]
+            match this.inner.as_mut().project().state.project() {
+                State::Connected {
+                    inner: Connected::Pending { .. },
+                    ..
+                } => continue,
+                _ => {}
+            };
+            #[project]
+            match this.inner.as_mut().project().state.project() {
+                State::Connected { resolution, inner } => {
+                    let initial = if let Connected::Connected { initial } =
+                        std::mem::replace(inner, Connected::Connected { initial: None })
                     {
-                        self.reconcile = reconcile;
-                        self.update_active(&update);
-                        return Ok(update.into());
+                        initial
+                    } else {
+                        continue;
+                    };
+                    // XXX Due to linkerd/linkerd2#3362, errors can't be discovered
+                    // eagerly, so we must potentially read the first update to be
+                    // sure it didn't fail. If that's the case, then reconcile the
+                    // cache against the initial update.
+                    if let Some(initial) = initial {
+                        // The initial state afer a reconnect may be identitical to
+                        // the prior state, and so there may be no updates to
+                        // advertise.
+                        if let Some((update, reconcile)) =
+                            reconcile_after_connect(&this.cache, initial)
+                        {
+                            *this.reconcile = reconcile;
+                            this.update_active(&update);
+                            return Poll::Ready(Ok(update));
+                        }
                     }
-                }
 
-                // Process the resolution stream, updating the cache.
-                //
-                // Attempt recovery/backoff if the resolution fails.
-                match resolve::Resolution::poll(resolution) {
-                    Ok(Async::NotReady) => return Ok(Async::NotReady),
-                    Ok(Async::Ready(update)) => {
-                        self.update_active(&update);
-                        return Ok(update.into());
-                    }
-                    Err(e) => {
-                        self.inner.state = State::Recover {
-                            error: Some(e.into()),
-                            backoff: None,
-                        };
+                    // Process the resolution stream, updating the cache.
+                    //
+                    // Attempt recovery/backoff if the resolution fails.
+                    match ready!(resolution.poll(cx)) {
+                        Ok(update) => {
+                            this.update_active(&update);
+                            return Poll::Ready(Ok(update));
+                        }
+                        Err(e) => {
+                            this.inner.as_mut().project().state.set(State::Recover {
+                                error: Some(e.into()),
+                                backoff: None,
+                            });
+                        }
                     }
                 }
+                // XXX(eliza): note that this match was originally an `if let`,
+                // but that doesn't work with `#[project]` for some kinda reason
+                _ => {}
             }
 
-            try_ready!(self.inner.poll_connected());
+            ready!(this.inner.as_mut().poll_connected(cx))?;
         }
     }
 }
 
+#[project]
 impl<T, E, R> Resolution<T, E, R>
 where
     T: Clone,
@@ -247,93 +268,97 @@ where
     R: resolve::Resolve<T>,
     R::Endpoint: Clone + PartialEq,
     E: Recover,
+    E::Backoff: Unpin,
 {
     /// Drives the state forward until its connected.
-    fn poll_connected(&mut self) -> Poll<(), Error> {
+    #[project]
+    fn poll_connected(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        let mut this = self.project();
         loop {
-            self.state = match self.state {
+            #[project]
+            match this.state.as_mut().project() {
                 // When disconnected, start connecting.
                 //
                 // If we're recovering from a previous failure, we retain the
                 // backoff in case this connection attempt fails.
-                State::Disconnected { ref mut backoff } => {
+                State::Disconnected { backoff } => {
                     tracing::trace!("connecting");
-                    try_ready!(self.resolve.poll_ready().map_err(Into::into));
-                    let future = self.resolve.resolve(self.target.clone());
-                    State::Connecting {
-                        future,
-                        backoff: backoff.take(),
-                    }
+                    ready!(this.resolve.poll_ready(cx).map_err(Into::into))?;
+                    let future = this.resolve.resolve(this.target.clone());
+                    let backoff = backoff.take();
+                    this.state.set(State::Connecting { future, backoff });
                 }
 
-                State::Connecting {
-                    ref mut future,
-                    ref mut backoff,
-                } => match future.poll() {
-                    Ok(Async::NotReady) => return Ok(Async::NotReady),
-                    Ok(Async::Ready(resolution)) => {
-                        tracing::trace!("pending");
-                        State::Pending {
-                            resolution: Some(resolution),
-                            backoff: backoff.take(),
+                State::Connecting { future, backoff } => {
+                    tokio::pin!(future);
+                    match ready!(future.poll(cx)) {
+                        Ok(resolution) => {
+                            tracing::trace!("pending");
+                            let backoff = backoff.take();
+                            this.state.set(State::Connected {
+                                resolution,
+                                inner: Connected::Pending { backoff },
+                            });
+                        }
+                        Err(e) => {
+                            let backoff = backoff.take();
+                            this.state.set(State::Recover {
+                                error: Some(e.into()),
+                                backoff,
+                            });
                         }
                     }
-                    Err(e) => State::Recover {
-                        error: Some(e.into()),
-                        backoff: backoff.take(),
-                    },
-                },
+                }
 
                 // We've already connected, but haven't yet received an update
                 // (or an error). This state shouldn't exist. See
                 // linkerd/linkerd2#3362.
-                State::Pending {
-                    ref mut resolution,
-                    ref mut backoff,
-                } => match resolution.as_mut().unwrap().poll() {
-                    Ok(Async::NotReady) => return Ok(Async::NotReady),
-                    Err(e) => State::Recover {
-                        error: Some(e.into()),
-                        backoff: backoff.take(),
-                    },
-                    Ok(Async::Ready(initial)) => {
-                        tracing::trace!("connected");
-                        State::Connected {
-                            resolution: resolution.take().unwrap(),
-                            initial: Some(initial),
+                State::Connected { resolution, inner } => match inner {
+                    Connected::Pending { backoff } => {
+                        match ready!(resolve::Resolution::poll(resolution, cx)) {
+                            Err(e) => {
+                                let backoff = backoff.take();
+                                this.state.set(State::Recover {
+                                    error: Some(e.into()),
+                                    backoff,
+                                });
+                            }
+                            Ok(initial) => {
+                                tracing::trace!("connected");
+                                *inner = Connected::Connected {
+                                    initial: Some(initial),
+                                };
+                            }
                         }
                     }
+                    Connected::Connected { .. } => return Poll::Ready(Ok(())),
                 },
-
-                State::Connected { .. } => return Ok(Async::Ready(())),
 
                 // If any stage failed, try to recover. If the error is
                 // recoverable, start (or continue) backing off...
-                State::Recover {
-                    ref mut error,
-                    ref mut backoff,
-                } => {
+                State::Recover { error, backoff } => {
                     let err = error.take().expect("illegal state");
                     tracing::debug!(%err, "recovering");
-                    let new_backoff = self.recover.recover(err)?;
-                    State::Backoff(backoff.take().or(Some(new_backoff)))
+                    let new_backoff = this.recover.recover(err)?;
+                    let backoff = backoff.take();
+                    this.state
+                        .set(State::Backoff(backoff.or(Some(new_backoff))));
                 }
 
-                State::Backoff(ref mut backoff) => {
-                    // If the backoff fails, it's not recoverable.
-                    match backoff
+                State::Backoff(backoff) => {
+                    let unit = ready!(backoff
                         .as_mut()
                         .expect("illegal state")
-                        .poll()
-                        .map_err(Into::into)?
-                    {
-                        Async::NotReady => return Ok(Async::NotReady),
-                        Async::Ready(unit) => {
-                            tracing::trace!("disconnected");
-                            let backoff = if unit.is_some() { backoff.take() } else { None };
-                            State::Disconnected { backoff }
-                        }
-                    }
+                        .try_poll_next_unpin(cx));
+                    tracing::trace!("disconnected");
+                    let backoff = if let Some(unit) = unit {
+                        // If the backoff fails, it's not recoverable.
+                        unit.map_err(Into::into)?;
+                        backoff.take()
+                    } else {
+                        None
+                    };
+                    this.state.set(State::Disconnected { backoff });
                 }
             };
         }

--- a/linkerd/proxy/resolve/src/recover.rs
+++ b/linkerd/proxy/resolve/src/recover.rs
@@ -144,7 +144,6 @@ where
         Poll::Ready(Ok(Resolution {
             inner,
             cache: IndexMap::default(),
-            //cache: Cache::default(),
             reconcile: None,
         }))
     }

--- a/linkerd/proxy/resolve/src/recover.rs
+++ b/linkerd/proxy/resolve/src/recover.rs
@@ -1,487 +1,506 @@
-// //! A middleware that recovers a resolution after some failures.
+//! A middleware that recovers a resolution after some failures.
 
-// use futures::{try_ready, Async, Future, Poll, Stream};
-// use indexmap::IndexMap;
-// use linkerd2_error::{Error, Recover};
-// use linkerd2_proxy_core::resolve::{self, Resolution as _, Update};
-// use std::net::SocketAddr;
+use futures::{ready, Stream};
+use indexmap::IndexMap;
+use linkerd2_error::{Error, Recover};
+use linkerd2_proxy_core::resolve::{self, Resolution as _, Update};
+use pin_project::{pin_project, project};
+use std::future::Future;
+use std::net::SocketAddr;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
-// #[derive(Clone, Debug)]
-// pub struct Resolve<E, R> {
-//     resolve: R,
-//     recover: E,
-// }
+#[derive(Clone, Debug)]
+pub struct Resolve<E, R> {
+    resolve: R,
+    recover: E,
+}
 
-// pub struct ResolveFuture<T, E: Recover, R: resolve::Resolve<T>> {
-//     inner: Option<Inner<T, E, R>>,
-// }
+#[pin_project]
+pub struct ResolveFuture<T, E: Recover, R: resolve::Resolve<T>> {
+    #[pin]
+    inner: Option<Inner<T, E, R>>,
+}
 
-// pub struct Resolution<T, E: Recover, R: resolve::Resolve<T>> {
-//     inner: Inner<T, E, R>,
-//     cache: IndexMap<SocketAddr, R::Endpoint>,
-//     reconcile: Option<Update<R::Endpoint>>,
-// }
+#[pin_project]
+pub struct Resolution<T, E: Recover, R: resolve::Resolve<T>> {
+    inner: Inner<T, E, R>,
+    cache: IndexMap<SocketAddr, R::Endpoint>,
+    reconcile: Option<Update<R::Endpoint>>,
+}
 
-// struct Inner<T, E: Recover, R: resolve::Resolve<T>> {
-//     target: T,
-//     resolve: R,
-//     recover: E,
-//     state: State<R::Future, R::Resolution, E::Backoff>,
-// }
+#[pin_project]
+struct Inner<T, E: Recover, R: resolve::Resolve<T>> {
+    target: T,
+    #[pin]
+    resolve: R,
+    recover: E,
+    #[pin]
+    state: State<R::Future, R::Resolution, E::Backoff>,
+}
 
-// // #[derive(Debug)]
-// // struct Cache<T> {
-// //     active: IndexMap<SocketAddr, T>,
-// // }
+#[derive(Debug)]
+struct Cache<T> {
+    active: IndexMap<SocketAddr, T>,
+}
 
-// enum State<F, R: resolve::Resolution, B> {
-//     Disconnected {
-//         backoff: Option<B>,
-//     },
-//     Connecting {
-//         future: F,
-//         backoff: Option<B>,
-//     },
-//     // XXX This state shouldn't be necessary, but we need it to pass tests(!)
-//     // that don't properly mimic the go server's behavior. See
-//     // linkerd/linkerd2#3362.
-//     Pending {
-//         resolution: Option<R>,
-//         backoff: Option<B>,
-//     },
-//     Connected {
-//         resolution: R,
-//         initial: Option<Update<R::Endpoint>>,
-//     },
-//     Recover {
-//         error: Option<Error>,
-//         backoff: Option<B>,
-//     },
-//     Backoff(Option<B>),
-// }
+#[pin_project]
+enum State<F, R: resolve::Resolution, B> {
+    Disconnected {
+        #[pin]
+        backoff: Option<B>,
+    },
+    Connecting {
+        #[pin]
+        future: F,
+        #[pin]
+        backoff: Option<B>,
+    },
+    // XXX This state shouldn't be necessary, but we need it to pass tests(!)
+    // that don't properly mimic the go server's behavior. See
+    // linkerd/linkerd2#3362.
+    Pending {
+        #[pin]
+        resolution: Option<R>,
+        #[pin]
+        backoff: Option<B>,
+    },
+    Connected {
+        #[pin]
+        resolution: R,
+        initial: Option<Update<R::Endpoint>>,
+    },
+    Recover {
+        error: Option<Error>,
+        #[pin]
+        backoff: Option<B>,
+    },
+    Backoff(#[pin] Option<B>),
+}
 
-// // === impl Resolve ===
+// === impl Resolve ===
 
-// impl<E, R> Resolve<E, R> {
-//     pub fn new(recover: E, resolve: R) -> Self {
-//         Self { resolve, recover }
-//     }
-// }
+impl<E, R> Resolve<E, R> {
+    pub fn new(recover: E, resolve: R) -> Self {
+        Self { resolve, recover }
+    }
+}
 
-// impl<T, E, R> tower::Service<T> for Resolve<E, R>
-// where
-//     T: Clone,
-//     R: resolve::Resolve<T> + Clone,
-//     R::Endpoint: Clone + PartialEq,
-//     E: Recover + Clone,
-// {
-//     type Response = Resolution<T, E, R>;
-//     type Error = Error;
-//     type Future = ResolveFuture<T, E, R>;
+impl<T, E, R> tower::Service<T> for Resolve<E, R>
+where
+    T: Clone,
+    R: resolve::Resolve<T> + Clone,
+    R::Endpoint: Clone + PartialEq,
+    E: Recover + Clone,
+{
+    type Response = Resolution<T, E, R>;
+    type Error = Error;
+    type Future = ResolveFuture<T, E, R>;
 
-//     #[inline]
-//     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-//         self.resolve.poll_ready().map_err(Into::into)
-//     }
+    #[inline]
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.resolve.poll_ready().map_err(Into::into)
+    }
 
-//     #[inline]
-//     fn call(&mut self, target: T) -> Self::Future {
-//         let future = self.resolve.resolve(target.clone());
+    #[inline]
+    fn call(&mut self, target: T) -> Self::Future {
+        let future = self.resolve.resolve(target.clone());
 
-//         Self::Future {
-//             inner: Some(Inner {
-//                 state: State::Connecting {
-//                     future,
-//                     backoff: None,
-//                 },
-//                 target: target.clone(),
-//                 recover: self.recover.clone(),
-//                 resolve: self.resolve.clone(),
-//             }),
-//         }
-//     }
-// }
+        Self::Future {
+            inner: Some(Inner {
+                state: State::Connecting {
+                    future,
+                    backoff: None,
+                },
+                target: target.clone(),
+                recover: self.recover.clone(),
+                resolve: self.resolve.clone(),
+            }),
+        }
+    }
+}
 
-// // === impl ResolveFuture ===
+// === impl ResolveFuture ===
 
-// impl<T, E, R> Future for ResolveFuture<T, E, R>
-// where
-//     T: Clone,
-//     R: resolve::Resolve<T>,
-//     R::Endpoint: Clone + PartialEq,
-//     E: Recover,
-// {
-//     type Item = Resolution<T, E, R>;
-//     type Error = Error;
+impl<T, E, R> Future for ResolveFuture<T, E, R>
+where
+    T: Clone,
+    R: resolve::Resolve<T>,
+    R::Endpoint: Clone + PartialEq,
+    E: Recover,
+{
+    type Item = Resolution<T, E, R>;
+    type Error = Error;
 
-//     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-//         // Wait until the resolution is connected.
-//         try_ready!(self
-//             .inner
-//             .as_mut()
-//             .expect("polled after complete")
-//             .poll_connected());
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        // Wait until the resolution is connected.
+        try_ready!(self
+            .inner
+            .as_mut()
+            .expect("polled after complete")
+            .poll_connected());
 
-//         Ok(Async::Ready(Resolution {
-//             inner: self.inner.take().expect("polled after complete"),
-//             cache: IndexMap::default(),
-//             //cache: Cache::default(),
-//             reconcile: None,
-//         }))
-//     }
-// }
+        Ok(Async::Ready(Resolution {
+            inner: self.inner.take().expect("polled after complete"),
+            cache: IndexMap::default(),
+            //cache: Cache::default(),
+            reconcile: None,
+        }))
+    }
+}
 
-// // === impl Resolution ===
+// === impl Resolution ===
 
-// impl<T, E, R> resolve::Resolution for Resolution<T, E, R>
-// where
-//     T: Clone,
-//     R: resolve::Resolve<T>,
-//     R::Endpoint: Clone + PartialEq,
-//     E: Recover,
-// {
-//     type Endpoint = R::Endpoint;
-//     type Error = Error;
+impl<T, E, R> resolve::Resolution for Resolution<T, E, R>
+where
+    T: Clone,
+    R: resolve::Resolve<T>,
+    R::Endpoint: Clone + PartialEq,
+    E: Recover,
+{
+    type Endpoint = R::Endpoint;
+    type Error = Error;
 
-//     fn poll(&mut self) -> Poll<Update<Self::Endpoint>, Self::Error> {
-//         loop {
-//             // If a reconciliation update is buffered (i.e. after
-//             // reconcile_after_reconnect), process it immediately.
-//             if let Some(update) = self.reconcile.take() {
-//                 self.update_active(&update);
-//                 return Ok(update.into());
-//             }
+    fn poll(&mut self) -> Poll<Update<Self::Endpoint>, Self::Error> {
+        loop {
+            // If a reconciliation update is buffered (i.e. after
+            // reconcile_after_reconnect), process it immediately.
+            if let Some(update) = self.reconcile.take() {
+                self.update_active(&update);
+                return Ok(update.into());
+            }
 
-//             if let State::Connected {
-//                 ref mut resolution,
-//                 ref mut initial,
-//             } = self.inner.state
-//             {
-//                 // XXX Due to linkerd/linkerd2#3362, errors can't be discovered
-//                 // eagerly, so we must potentially read the first update to be
-//                 // sure it didn't fail. If that's the case, then reconcile the
-//                 // cache against the initial update.
-//                 if let Some(initial) = initial.take() {
-//                     // The initial state afer a reconnect may be identitical to
-//                     // the prior state, and so there may be no updates to
-//                     // advertise.
-//                     if let Some((update, reconcile)) = reconcile_after_connect(&self.cache, initial)
-//                     {
-//                         self.reconcile = reconcile;
-//                         self.update_active(&update);
-//                         return Ok(update.into());
-//                     }
-//                 }
+            if let State::Connected {
+                ref mut resolution,
+                ref mut initial,
+            } = self.inner.state
+            {
+                // XXX Due to linkerd/linkerd2#3362, errors can't be discovered
+                // eagerly, so we must potentially read the first update to be
+                // sure it didn't fail. If that's the case, then reconcile the
+                // cache against the initial update.
+                if let Some(initial) = initial.take() {
+                    // The initial state afer a reconnect may be identitical to
+                    // the prior state, and so there may be no updates to
+                    // advertise.
+                    if let Some((update, reconcile)) = reconcile_after_connect(&self.cache, initial)
+                    {
+                        self.reconcile = reconcile;
+                        self.update_active(&update);
+                        return Ok(update.into());
+                    }
+                }
 
-//                 // Process the resolution stream, updating the cache.
-//                 //
-//                 // Attempt recovery/backoff if the resolution fails.
-//                 match resolve::Resolution::poll(resolution) {
-//                     Ok(Async::NotReady) => return Ok(Async::NotReady),
-//                     Ok(Async::Ready(update)) => {
-//                         self.update_active(&update);
-//                         return Ok(update.into());
-//                     }
-//                     Err(e) => {
-//                         self.inner.state = State::Recover {
-//                             error: Some(e.into()),
-//                             backoff: None,
-//                         };
-//                     }
-//                 }
-//             }
+                // Process the resolution stream, updating the cache.
+                //
+                // Attempt recovery/backoff if the resolution fails.
+                match resolve::Resolution::poll(resolution) {
+                    Ok(Async::NotReady) => return Ok(Async::NotReady),
+                    Ok(Async::Ready(update)) => {
+                        self.update_active(&update);
+                        return Ok(update.into());
+                    }
+                    Err(e) => {
+                        self.inner.state = State::Recover {
+                            error: Some(e.into()),
+                            backoff: None,
+                        };
+                    }
+                }
+            }
 
-//             try_ready!(self.inner.poll_connected());
-//         }
-//     }
-// }
+            try_ready!(self.inner.poll_connected());
+        }
+    }
+}
 
-// impl<T, E, R> Resolution<T, E, R>
-// where
-//     T: Clone,
-//     R: resolve::Resolve<T>,
-//     R::Endpoint: Clone + PartialEq,
-//     E: Recover,
-// {
-//     fn update_active(&mut self, update: &Update<R::Endpoint>) {
-//         match update {
-//             Update::Add(ref endpoints) => {
-//                 self.cache.extend(endpoints.clone());
-//             }
-//             Update::Remove(ref addrs) => {
-//                 for addr in addrs.iter() {
-//                     self.cache.remove(addr);
-//                 }
-//             }
-//             Update::DoesNotExist | Update::Empty => {
-//                 self.cache.drain(..);
-//             }
-//         }
-//     }
-// }
+impl<T, E, R> Resolution<T, E, R>
+where
+    T: Clone,
+    R: resolve::Resolve<T>,
+    R::Endpoint: Clone + PartialEq,
+    E: Recover,
+{
+    fn update_active(&mut self, update: &Update<R::Endpoint>) {
+        match update {
+            Update::Add(ref endpoints) => {
+                self.cache.extend(endpoints.clone());
+            }
+            Update::Remove(ref addrs) => {
+                for addr in addrs.iter() {
+                    self.cache.remove(addr);
+                }
+            }
+            Update::DoesNotExist | Update::Empty => {
+                self.cache.drain(..);
+            }
+        }
+    }
+}
 
-// // === impl Inner ===
+// === impl Inner ===
 
-// impl<T, E, R> Inner<T, E, R>
-// where
-//     T: Clone,
-//     R: resolve::Resolve<T>,
-//     R::Endpoint: Clone + PartialEq,
-//     E: Recover,
-// {
-//     /// Drives the state forward until its connected.
-//     fn poll_connected(&mut self) -> Poll<(), Error> {
-//         loop {
-//             self.state = match self.state {
-//                 // When disconnected, start connecting.
-//                 //
-//                 // If we're recovering from a previous failure, we retain the
-//                 // backoff in case this connection attempt fails.
-//                 State::Disconnected { ref mut backoff } => {
-//                     tracing::trace!("connecting");
-//                     try_ready!(self.resolve.poll_ready().map_err(Into::into));
-//                     let future = self.resolve.resolve(self.target.clone());
-//                     State::Connecting {
-//                         future,
-//                         backoff: backoff.take(),
-//                     }
-//                 }
+impl<T, E, R> Inner<T, E, R>
+where
+    T: Clone,
+    R: resolve::Resolve<T>,
+    R::Endpoint: Clone + PartialEq,
+    E: Recover,
+{
+    /// Drives the state forward until its connected.
+    fn poll_connected(&mut self) -> Poll<(), Error> {
+        loop {
+            self.state = match self.state {
+                // When disconnected, start connecting.
+                //
+                // If we're recovering from a previous failure, we retain the
+                // backoff in case this connection attempt fails.
+                State::Disconnected { ref mut backoff } => {
+                    tracing::trace!("connecting");
+                    try_ready!(self.resolve.poll_ready().map_err(Into::into));
+                    let future = self.resolve.resolve(self.target.clone());
+                    State::Connecting {
+                        future,
+                        backoff: backoff.take(),
+                    }
+                }
 
-//                 State::Connecting {
-//                     ref mut future,
-//                     ref mut backoff,
-//                 } => match future.poll() {
-//                     Ok(Async::NotReady) => return Ok(Async::NotReady),
-//                     Ok(Async::Ready(resolution)) => {
-//                         tracing::trace!("pending");
-//                         State::Pending {
-//                             resolution: Some(resolution),
-//                             backoff: backoff.take(),
-//                         }
-//                     }
-//                     Err(e) => State::Recover {
-//                         error: Some(e.into()),
-//                         backoff: backoff.take(),
-//                     },
-//                 },
+                State::Connecting {
+                    ref mut future,
+                    ref mut backoff,
+                } => match future.poll() {
+                    Ok(Async::NotReady) => return Ok(Async::NotReady),
+                    Ok(Async::Ready(resolution)) => {
+                        tracing::trace!("pending");
+                        State::Pending {
+                            resolution: Some(resolution),
+                            backoff: backoff.take(),
+                        }
+                    }
+                    Err(e) => State::Recover {
+                        error: Some(e.into()),
+                        backoff: backoff.take(),
+                    },
+                },
 
-//                 // We've already connected, but haven't yet received an update
-//                 // (or an error). This state shouldn't exist. See
-//                 // linkerd/linkerd2#3362.
-//                 State::Pending {
-//                     ref mut resolution,
-//                     ref mut backoff,
-//                 } => match resolution.as_mut().unwrap().poll() {
-//                     Ok(Async::NotReady) => return Ok(Async::NotReady),
-//                     Err(e) => State::Recover {
-//                         error: Some(e.into()),
-//                         backoff: backoff.take(),
-//                     },
-//                     Ok(Async::Ready(initial)) => {
-//                         tracing::trace!("connected");
-//                         State::Connected {
-//                             resolution: resolution.take().unwrap(),
-//                             initial: Some(initial),
-//                         }
-//                     }
-//                 },
+                // We've already connected, but haven't yet received an update
+                // (or an error). This state shouldn't exist. See
+                // linkerd/linkerd2#3362.
+                State::Pending {
+                    ref mut resolution,
+                    ref mut backoff,
+                } => match resolution.as_mut().unwrap().poll() {
+                    Ok(Async::NotReady) => return Ok(Async::NotReady),
+                    Err(e) => State::Recover {
+                        error: Some(e.into()),
+                        backoff: backoff.take(),
+                    },
+                    Ok(Async::Ready(initial)) => {
+                        tracing::trace!("connected");
+                        State::Connected {
+                            resolution: resolution.take().unwrap(),
+                            initial: Some(initial),
+                        }
+                    }
+                },
 
-//                 State::Connected { .. } => return Ok(Async::Ready(())),
+                State::Connected { .. } => return Ok(Async::Ready(())),
 
-//                 // If any stage failed, try to recover. If the error is
-//                 // recoverable, start (or continue) backing off...
-//                 State::Recover {
-//                     ref mut error,
-//                     ref mut backoff,
-//                 } => {
-//                     let err = error.take().expect("illegal state");
-//                     tracing::debug!(%err, "recovering");
-//                     let new_backoff = self.recover.recover(err)?;
-//                     State::Backoff(backoff.take().or(Some(new_backoff)))
-//                 }
+                // If any stage failed, try to recover. If the error is
+                // recoverable, start (or continue) backing off...
+                State::Recover {
+                    ref mut error,
+                    ref mut backoff,
+                } => {
+                    let err = error.take().expect("illegal state");
+                    tracing::debug!(%err, "recovering");
+                    let new_backoff = self.recover.recover(err)?;
+                    State::Backoff(backoff.take().or(Some(new_backoff)))
+                }
 
-//                 State::Backoff(ref mut backoff) => {
-//                     // If the backoff fails, it's not recoverable.
-//                     match backoff
-//                         .as_mut()
-//                         .expect("illegal state")
-//                         .poll()
-//                         .map_err(Into::into)?
-//                     {
-//                         Async::NotReady => return Ok(Async::NotReady),
-//                         Async::Ready(unit) => {
-//                             tracing::trace!("disconnected");
-//                             let backoff = if unit.is_some() { backoff.take() } else { None };
-//                             State::Disconnected { backoff }
-//                         }
-//                     }
-//                 }
-//             };
-//         }
-//     }
-// }
+                State::Backoff(ref mut backoff) => {
+                    // If the backoff fails, it's not recoverable.
+                    match backoff
+                        .as_mut()
+                        .expect("illegal state")
+                        .poll()
+                        .map_err(Into::into)?
+                    {
+                        Async::NotReady => return Ok(Async::NotReady),
+                        Async::Ready(unit) => {
+                            tracing::trace!("disconnected");
+                            let backoff = if unit.is_some() { backoff.take() } else { None };
+                            State::Disconnected { backoff }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}
 
-// /// Computes the updates needed after a connection is (re-)established.
-// // Raw fn for easier testing.
-// fn reconcile_after_connect<E: PartialEq>(
-//     cache: &IndexMap<SocketAddr, E>,
-//     initial: Update<E>,
-// ) -> Option<(Update<E>, Option<Update<E>>)> {
-//     match initial {
-//         // When the first update after a disconnect is an Add, it should
-//         // contain the new state of the replica set.
-//         Update::Add(endpoints) => {
-//             let mut new_eps = endpoints.into_iter().collect::<IndexMap<_, _>>();
-//             let mut rm_addrs = Vec::with_capacity(cache.len());
-//             for (addr, endpoint) in cache.iter() {
-//                 match new_eps.get(addr) {
-//                     // If the endpoint is in the active set and not in
-//                     // the new set, it needs to be removed.
-//                     None => {
-//                         rm_addrs.push(*addr);
-//                     }
-//                     // If the endpoint is already in the active set,
-//                     // remove it from the new set (to avoid rebuilding
-//                     // services unnecessarily).
-//                     Some(ep) => {
-//                         // The endpoints must be identitical, though.
-//                         if *ep == *endpoint {
-//                             new_eps.remove(addr);
-//                         }
-//                     }
-//                 }
-//             }
-//             let add = if new_eps.is_empty() {
-//                 None
-//             } else {
-//                 Some(Update::Add(new_eps.into_iter().collect()))
-//             };
-//             let rm = if rm_addrs.is_empty() {
-//                 None
-//             } else {
-//                 Some(Update::Remove(rm_addrs))
-//             };
-//             // Advertise adds before removes so that we don't unnecessarily
-//             // empty out a consumer.
-//             match add {
-//                 Some(add) => Some((add, rm)),
-//                 None => rm.map(|rm| (rm, None)),
-//             }
-//         }
-//         // It would be exceptionally odd to get a remove, specifically,
-//         // immediately after a reconnect, but it seems appropriate to
-//         // handle it as Empty.
-//         Update::Remove(..) | Update::Empty => Some((Update::Empty, None)),
-//         Update::DoesNotExist => Some((Update::DoesNotExist, None)),
-//     }
-// }
+/// Computes the updates needed after a connection is (re-)established.
+// Raw fn for easier testing.
+fn reconcile_after_connect<E: PartialEq>(
+    cache: &IndexMap<SocketAddr, E>,
+    initial: Update<E>,
+) -> Option<(Update<E>, Option<Update<E>>)> {
+    match initial {
+        // When the first update after a disconnect is an Add, it should
+        // contain the new state of the replica set.
+        Update::Add(endpoints) => {
+            let mut new_eps = endpoints.into_iter().collect::<IndexMap<_, _>>();
+            let mut rm_addrs = Vec::with_capacity(cache.len());
+            for (addr, endpoint) in cache.iter() {
+                match new_eps.get(addr) {
+                    // If the endpoint is in the active set and not in
+                    // the new set, it needs to be removed.
+                    None => {
+                        rm_addrs.push(*addr);
+                    }
+                    // If the endpoint is already in the active set,
+                    // remove it from the new set (to avoid rebuilding
+                    // services unnecessarily).
+                    Some(ep) => {
+                        // The endpoints must be identitical, though.
+                        if *ep == *endpoint {
+                            new_eps.remove(addr);
+                        }
+                    }
+                }
+            }
+            let add = if new_eps.is_empty() {
+                None
+            } else {
+                Some(Update::Add(new_eps.into_iter().collect()))
+            };
+            let rm = if rm_addrs.is_empty() {
+                None
+            } else {
+                Some(Update::Remove(rm_addrs))
+            };
+            // Advertise adds before removes so that we don't unnecessarily
+            // empty out a consumer.
+            match add {
+                Some(add) => Some((add, rm)),
+                None => rm.map(|rm| (rm, None)),
+            }
+        }
+        // It would be exceptionally odd to get a remove, specifically,
+        // immediately after a reconnect, but it seems appropriate to
+        // handle it as Empty.
+        Update::Remove(..) | Update::Empty => Some((Update::Empty, None)),
+        Update::DoesNotExist => Some((Update::DoesNotExist, None)),
+    }
+}
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-//     pub fn addr0() -> SocketAddr {
-//         ([198, 51, 100, 1], 8080).into()
-//     }
+    pub fn addr0() -> SocketAddr {
+        ([198, 51, 100, 1], 8080).into()
+    }
 
-//     pub fn addr1() -> SocketAddr {
-//         ([198, 51, 100, 2], 8080).into()
-//     }
+    pub fn addr1() -> SocketAddr {
+        ([198, 51, 100, 2], 8080).into()
+    }
 
-//     #[test]
-//     fn reconcile_after_initial_connect() {
-//         let cache = IndexMap::default();
-//         let add = Update::Add(vec![(addr0(), 0), (addr1(), 0)]);
-//         assert_eq!(
-//             reconcile_after_connect(&cache, add.clone()),
-//             Some((add, None)),
-//             "Adds should be passed through initially"
-//         );
-//         assert_eq!(
-//             reconcile_after_connect(&cache, Update::Remove(vec![addr0(), addr1()])),
-//             Some((Update::Empty, None)),
-//             "Removes should be treated as empty"
-//         );
-//         assert_eq!(
-//             reconcile_after_connect(&cache, Update::Empty),
-//             Some((Update::Empty, None)),
-//             "Empties should be passed through"
-//         );
-//         assert_eq!(
-//             reconcile_after_connect(&cache, Update::DoesNotExist),
-//             Some((Update::DoesNotExist, None)),
-//             "DNEs should be passed through"
-//         );
-//     }
+    #[test]
+    fn reconcile_after_initial_connect() {
+        let cache = IndexMap::default();
+        let add = Update::Add(vec![(addr0(), 0), (addr1(), 0)]);
+        assert_eq!(
+            reconcile_after_connect(&cache, add.clone()),
+            Some((add, None)),
+            "Adds should be passed through initially"
+        );
+        assert_eq!(
+            reconcile_after_connect(&cache, Update::Remove(vec![addr0(), addr1()])),
+            Some((Update::Empty, None)),
+            "Removes should be treated as empty"
+        );
+        assert_eq!(
+            reconcile_after_connect(&cache, Update::Empty),
+            Some((Update::Empty, None)),
+            "Empties should be passed through"
+        );
+        assert_eq!(
+            reconcile_after_connect(&cache, Update::DoesNotExist),
+            Some((Update::DoesNotExist, None)),
+            "DNEs should be passed through"
+        );
+    }
 
-//     #[test]
-//     fn reconcile_after_reconnect_dedupes() {
-//         let mut cache = IndexMap::new();
-//         cache.insert(addr0(), 0);
+    #[test]
+    fn reconcile_after_reconnect_dedupes() {
+        let mut cache = IndexMap::new();
+        cache.insert(addr0(), 0);
 
-//         assert_eq!(
-//             reconcile_after_connect(&cache, Update::Add(vec![(addr0(), 0), (addr1(), 0)])),
-//             Some((Update::Add(vec![(addr1(), 0)]), None)),
-//         );
-//     }
+        assert_eq!(
+            reconcile_after_connect(&cache, Update::Add(vec![(addr0(), 0), (addr1(), 0)])),
+            Some((Update::Add(vec![(addr1(), 0)]), None)),
+        );
+    }
 
-//     #[test]
-//     fn reconcile_after_reconnect_updates() {
-//         let mut cache = IndexMap::new();
-//         cache.insert(addr0(), 0);
+    #[test]
+    fn reconcile_after_reconnect_updates() {
+        let mut cache = IndexMap::new();
+        cache.insert(addr0(), 0);
 
-//         assert_eq!(
-//             reconcile_after_connect(&cache, Update::Add(vec![(addr0(), 1), (addr1(), 0)])),
-//             Some((Update::Add(vec![(addr0(), 1), (addr1(), 0)]), None)),
-//         );
-//     }
+        assert_eq!(
+            reconcile_after_connect(&cache, Update::Add(vec![(addr0(), 1), (addr1(), 0)])),
+            Some((Update::Add(vec![(addr0(), 1), (addr1(), 0)]), None)),
+        );
+    }
 
-//     #[test]
-//     fn reconcile_after_reconnect_removes() {
-//         let mut cache = IndexMap::new();
-//         cache.insert(addr0(), 0);
-//         cache.insert(addr1(), 0);
+    #[test]
+    fn reconcile_after_reconnect_removes() {
+        let mut cache = IndexMap::new();
+        cache.insert(addr0(), 0);
+        cache.insert(addr1(), 0);
 
-//         assert_eq!(
-//             reconcile_after_connect(&cache, Update::Add(vec![(addr0(), 0)])),
-//             Some((Update::Remove(vec![addr1()]), None))
-//         );
-//     }
+        assert_eq!(
+            reconcile_after_connect(&cache, Update::Add(vec![(addr0(), 0)])),
+            Some((Update::Remove(vec![addr1()]), None))
+        );
+    }
 
-//     #[test]
-//     fn reconcile_after_reconnect_adds_and_removes() {
-//         let mut cache = IndexMap::new();
-//         cache.insert(addr0(), 0);
-//         cache.insert(addr1(), 0);
+    #[test]
+    fn reconcile_after_reconnect_adds_and_removes() {
+        let mut cache = IndexMap::new();
+        cache.insert(addr0(), 0);
+        cache.insert(addr1(), 0);
 
-//         assert_eq!(
-//             reconcile_after_connect(&cache, Update::Add(vec![(addr0(), 1)])),
-//             Some((
-//                 Update::Add(vec![(addr0(), 1)]),
-//                 Some(Update::Remove(vec![addr1()]))
-//             ))
-//         );
-//     }
+        assert_eq!(
+            reconcile_after_connect(&cache, Update::Add(vec![(addr0(), 1)])),
+            Some((
+                Update::Add(vec![(addr0(), 1)]),
+                Some(Update::Remove(vec![addr1()]))
+            ))
+        );
+    }
 
-//     #[test]
-//     fn reconcile_after_reconnect_passthru() {
-//         let mut cache = IndexMap::default();
-//         cache.insert(addr0(), 0);
+    #[test]
+    fn reconcile_after_reconnect_passthru() {
+        let mut cache = IndexMap::default();
+        cache.insert(addr0(), 0);
 
-//         assert_eq!(
-//             reconcile_after_connect(&cache, Update::Remove(vec![addr1()])),
-//             Some((Update::Empty, None)),
-//             "Removes should be treated as empty"
-//         );
-//         assert_eq!(
-//             reconcile_after_connect(&cache, Update::Empty),
-//             Some((Update::Empty, None)),
-//             "Empties should be passed through"
-//         );
-//         assert_eq!(
-//             reconcile_after_connect(&cache, Update::DoesNotExist),
-//             Some((Update::DoesNotExist, None)),
-//             "DNEs should be passed through"
-//         );
-//     }
-// }
+        assert_eq!(
+            reconcile_after_connect(&cache, Update::Remove(vec![addr1()])),
+            Some((Update::Empty, None)),
+            "Removes should be treated as empty"
+        );
+        assert_eq!(
+            reconcile_after_connect(&cache, Update::Empty),
+            Some((Update::Empty, None)),
+            "Empties should be passed through"
+        );
+        assert_eq!(
+            reconcile_after_connect(&cache, Update::DoesNotExist),
+            Some((Update::DoesNotExist, None)),
+            "DNEs should be passed through"
+        );
+    }
+}

--- a/linkerd/reconnect/src/lib.rs
+++ b/linkerd/reconnect/src/lib.rs
@@ -1,14 +1,14 @@
-//! Conditionally reconnects with a pluggable recovery/backoff strategy.
-#![deny(warnings, rust_2018_idioms)]
+// //! Conditionally reconnects with a pluggable recovery/backoff strategy.
+// #![deny(warnings, rust_2018_idioms)]
 
-use linkerd2_error::Recover;
+// use linkerd2_error::Recover;
 
-mod layer;
-mod service;
+// mod layer;
+// mod service;
 
-pub use self::layer::Layer;
-pub use self::service::Service;
+// pub use self::layer::Layer;
+// pub use self::service::Service;
 
-pub fn layer<R: Recover + Clone>(recover: R) -> Layer<R> {
-    recover.into()
-}
+// pub fn layer<R: Recover + Clone>(recover: R) -> Layer<R> {
+//     recover.into()
+// }

--- a/linkerd/reconnect/src/service.rs
+++ b/linkerd/reconnect/src/service.rs
@@ -1,4 +1,4 @@
-use futures::{future, try_ready, Async, Future, Poll, Stream};
+use futures::{future, try_ready, Async, Future, Poll, TryStream};
 use linkerd2_error::{Error, Recover};
 use tracing;
 
@@ -123,7 +123,7 @@ where
                     let more = try_ready!(backoff
                         .as_mut()
                         .expect("backoff must be set")
-                        .poll()
+                        .try_poll(cx)
                         .map_err(Into::into));
                     State::Disconnected {
                         // Only reuse the backoff if the backoff stream did not complete.


### PR DESCRIPTION
This branch updates the `linkerd2-proxy-resolve` crate to `std::future`.
It also updates the `recover` module in `linkerd2-proxy-error`, which is
a dependency of `resolve`, and `linkerd2-reconnect`, which depends on
`recover` and therefore didn't compile after it was updated.

The `linkerd2-proxy-resolve::recover` code currently only works when the
underlying resolver's resolution and future types are both `Unpin`, and
the backoff type is also `Unpin`. This is because this logic relies a
bit on being able to move these values in and out of `Option`s. I tried
to implement this without requiring these values to be `Unpin`, but the
implementation of the `ResolveFuture`, which drives the resolution until
it's connected and then returns it, was more or less impossible to
translate in its current state. 
 
I suspect that this won't be an issue when updating code that depends on
`recover` — I think the resolutions will probably be `Unpin` without any
intervention from us. If not, we can always either `Box::pin` them, or
try to do a more complete rewrite of this code so that it's refactored
in a way that avoids these issues.

In other cases, we can sometimes just replace code that is difficult to
port to use `async`/`await`. Here, that was not possible, because we are
implementing the `Resolution` trait, rather than a future. We _may_ want
to consider rewriting `Resolution` to be a trait alias for a `Stream`,
so that we can use the `async-stream` crate, but that may have other
downsides, so I decided to not do that just yet.

Hopefully this all makes sense!