### PR TITLE
update linkerd2-proxy-api-resolve to use Tonic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,12 +34,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 dependencies = [
  "nodrop",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.2",
+ "syn 1.0.5",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.2",
+ "syn 1.0.5",
 ]
 
 [[package]]
@@ -309,6 +347,12 @@ name = "fixedbitset"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
+
+[[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
@@ -865,7 +909,7 @@ dependencies = [
  "linkerd2-trace-context",
  "pin-project",
  "procinfo",
- "prost-types",
+ "prost-types 0.5.0",
  "quickcheck",
  "rand 0.7.2",
  "regex 1.0.0",
@@ -1237,8 +1281,8 @@ dependencies = [
  "futures 0.1.26",
  "h2 0.1.26",
  "http 0.1.21",
- "prost",
- "prost-types",
+ "prost 0.5.0",
+ "prost-types 0.5.0",
  "quickcheck",
  "rand 0.7.2",
  "tower-grpc",
@@ -1249,17 +1293,32 @@ dependencies = [
 name = "linkerd2-proxy-api-resolve"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.26",
- "http 0.1.21",
+ "futures 0.3.4",
+ "http 0.2.1",
+ "http-body 0.3.1",
  "indexmap",
  "linkerd2-identity",
- "linkerd2-proxy-api",
+ "linkerd2-proxy-api-tonic",
  "linkerd2-proxy-core",
- "prost",
- "tokio-sync",
- "tower 0.1.1",
- "tower-grpc",
+ "pin-project",
+ "prost 0.6.1",
+ "tokio 0.2.20",
+ "tonic",
+ "tower 0.3.1",
  "tracing",
+]
+
+[[package]]
+name = "linkerd2-proxy-api-tonic"
+version = "0.1.12"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/tonic#e14d830c0635d20739fdb24312a73a7245ec2de6"
+dependencies = [
+ "h2 0.2.4",
+ "http 0.2.1",
+ "prost 0.6.1",
+ "prost-types 0.6.1",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -1390,7 +1449,7 @@ dependencies = [
  "linkerd2-proxy-http",
  "linkerd2-proxy-transport",
  "linkerd2-stack",
- "prost-types",
+ "prost-types 0.5.0",
  "quickcheck",
  "rand 0.7.2",
  "tokio 0.1.22",
@@ -1508,7 +1567,7 @@ dependencies = [
  "linkerd2-proxy-api",
  "linkerd2-stack",
  "linkerd2-test-util",
- "prost-types",
+ "prost-types 0.5.0",
  "quickcheck",
  "rand 0.7.2",
  "regex 1.0.0",
@@ -1738,6 +1797,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
 
 [[package]]
+name = "multimap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
+
+[[package]]
 name = "net2"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,8 +1874,8 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
  "futures 0.1.26",
- "prost",
- "prost-types",
+ "prost 0.5.0",
+ "prost-types 0.5.0",
  "tower-grpc",
  "tower-grpc-build",
 ]
@@ -1848,12 +1913,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
 name = "petgraph"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a7e5234c228fbfa874c86a77f685886127f82e0aef602ad1d48333fcac6ad61"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.1.8",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
+dependencies = [
+ "fixedbitset 0.2.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -1942,7 +2023,17 @@ version = "0.5.0"
 source = "git+https://github.com/linkerd/prost?branch=v0.5.x#8875bb9404ed50de20ef51c61bd2eaff5812fb1e"
 dependencies = [
  "bytes 0.4.11",
- "prost-derive",
+ "prost-derive 0.5.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
+dependencies = [
+ "bytes 0.5.4",
+ "prost-derive 0.6.1",
 ]
 
 [[package]]
@@ -1955,12 +2046,30 @@ dependencies = [
  "heck",
  "itertools",
  "log",
- "multimap",
- "petgraph",
- "prost",
- "prost-types",
+ "multimap 0.4.0",
+ "petgraph 0.4.11",
+ "prost 0.5.0",
+ "prost-types 0.5.0",
  "tempfile",
- "which",
+ "which 2.0.0",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
+dependencies = [
+ "bytes 0.5.4",
+ "heck",
+ "itertools",
+ "log",
+ "multimap 0.8.1",
+ "petgraph 0.5.0",
+ "prost 0.6.1",
+ "prost-types 0.6.1",
+ "tempfile",
+ "which 3.1.1",
 ]
 
 [[package]]
@@ -1976,13 +2085,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2 1.0.10",
+ "quote 1.0.2",
+ "syn 1.0.5",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
 dependencies = [
  "bytes 0.4.11",
- "prost",
+ "prost 0.5.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
+dependencies = [
+ "bytes 0.5.4",
+ "prost 0.6.1",
 ]
 
 [[package]]
@@ -2816,6 +2948,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4afef9ce97ea39593992cf3fa00ff33b1ad5eb07665b31355df63a690e38c736"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.11.0",
+ "bytes 0.5.4",
+ "futures-core",
+ "futures-util",
+ "http 0.2.1",
+ "http-body 0.3.1",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "prost 0.6.1",
+ "prost-derive 0.6.1",
+ "tokio-util",
+ "tower-make",
+ "tower-service 0.3.0",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "prost-build 0.6.1",
+ "quote 1.0.2",
+ "syn 1.0.5",
+]
+
+[[package]]
 name = "tower"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2903,8 +3071,8 @@ dependencies = [
  "http 0.1.21",
  "http-body 0.1.0",
  "log",
- "percent-encoding",
- "prost",
+ "percent-encoding 1.0.1",
+ "prost 0.5.0",
  "tower-service 0.2.0",
  "tower-util",
 ]
@@ -2917,7 +3085,7 @@ checksum = "8862053a26bc7b901cf52bca8ae7d4c2e041222673e38f81a475aeb6c82481df"
 dependencies = [
  "codegen",
  "heck",
- "prost-build",
+ "prost-build 0.5.0",
 ]
 
 [[package]]
@@ -2976,6 +3144,16 @@ dependencies = [
  "futures 0.1.26",
  "tower-layer 0.1.0",
  "tower-service 0.2.0",
+]
+
+[[package]]
+name = "tower-make"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
+dependencies = [
+ "tokio 0.2.20",
+ "tower-service 0.3.0",
 ]
 
 [[package]]
@@ -3278,7 +3456,7 @@ checksum = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 dependencies = [
  "idna",
  "matches",
- "percent-encoding",
+ "percent-encoding 1.0.1",
 ]
 
 [[package]]
@@ -3440,6 +3618,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49c4f580e93079b70ac522e7bdebbe1568c8afa7d8d05ee534ee737ca37d2f51"
 dependencies = [
  "failure",
+ "libc",
+]
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
  "libc",
 ]
 

--- a/linkerd/cache/benches/cache.rs
+++ b/linkerd/cache/benches/cache.rs
@@ -3,7 +3,6 @@ use futures::future;
 use linkerd2_cache::{Cache, Handle};
 use linkerd2_error::Never;
 use linkerd2_stack::NewService;
-use std::future::Future;
 use std::task::{Context, Poll};
 use tower::util::ServiceExt;
 use tower::Service;

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -9,14 +9,16 @@ Implements the Resolve trait using the proxy's gRPC API
 """
 
 [dependencies]
-futures = "0.1"
+futures = "0.3"
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.12" }
+linkerd2-proxy-api-tonic = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "eliza/tonic" }
 linkerd2-proxy-core = { path = "../core" }
-prost = "0.5.0"
-http = "0.1"
-tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
+prost = "0.6"
+http = "0.2"
+http-body = "0.3"
+tonic = { version = "0.2", default-features = false }
 indexmap = "1.0"
-tokio-sync = "0.1"
-tower = "0.1"
+tokio = { version = "0.2", features = ["sync"] }
+tower = {version = "0.3", default-features = false }
 tracing = "0.1"
+pin-project = "0.4"

--- a/linkerd/proxy/api-resolve/src/lib.rs
+++ b/linkerd/proxy/api-resolve/src/lib.rs
@@ -1,7 +1,7 @@
 // #![deny(warnings, rust_2018_idioms)]
 
 use linkerd2_identity as identity;
-use linkerd2_proxy_api as api;
+use linkerd2_proxy_api_tonic as api;
 use linkerd2_proxy_core as core;
 
 mod metadata;

--- a/linkerd/proxy/api-resolve/src/resolve.rs
+++ b/linkerd/proxy/api-resolve/src/resolve.rs
@@ -2,20 +2,33 @@ use crate::api::destination as api;
 use crate::core::resolve::{self, Update};
 use crate::metadata::Metadata;
 use crate::pb;
-use futures::{future, try_ready, Future, Poll, Stream};
+use api::destination_client::DestinationClient;
+use futures::{ready, Stream};
+use http_body::Body as HttpBody;
+use pin_project::pin_project;
+use std::error::Error;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tonic::{
+    self as grpc,
+    body::{Body, BoxBody},
+    client::GrpcService,
+};
 use tower::Service;
-use tower_grpc::{self as grpc, generic::client::GrpcService, Body, BoxBody};
 use tracing::{debug, info, trace};
 
 #[derive(Clone)]
 pub struct Resolve<S> {
-    service: api::client::Destination<S>,
+    service: DestinationClient<S>,
     scheme: String,
     context_token: String,
 }
 
-pub struct Resolution<S: GrpcService<BoxBody>> {
-    inner: grpc::Streaming<api::Update, S::ResponseBody>,
+#[pin_project]
+pub struct Resolution {
+    #[pin]
+    inner: grpc::Streaming<api::Update>,
 }
 
 // === impl Resolver ===
@@ -23,13 +36,15 @@ pub struct Resolution<S: GrpcService<BoxBody>> {
 impl<S> Resolve<S>
 where
     S: GrpcService<BoxBody> + Clone + Send + 'static,
+    S::Error: Into<Box<dyn Error + Send + Sync + 'static>> + Send,
     S::ResponseBody: Send,
     <S::ResponseBody as Body>::Data: Send,
+    <S::ResponseBody as HttpBody>::Error: Into<Box<dyn Error + Send + Sync + 'static>> + Send,
     S::Future: Send,
 {
     pub fn new(svc: S) -> Self {
         Self {
-            service: api::client::Destination::new(svc),
+            service: DestinationClient::new(svc),
             scheme: "".into(),
             context_token: "".into(),
         }
@@ -54,52 +69,53 @@ impl<T, S> Service<T> for Resolve<S>
 where
     T: ToString,
     S: GrpcService<BoxBody> + Clone + Send + 'static,
+    DestinationClient<S>: Service<T, Error = grpc::Status>,
+    S::Error: Into<Box<dyn Error + Send + Sync + 'static>> + Send,
     S::ResponseBody: Send,
     <S::ResponseBody as Body>::Data: Send,
+    <S::ResponseBody as HttpBody>::Error: Into<Box<dyn Error + Send + Sync + 'static>> + Send,
     S::Future: Send,
 {
-    type Response = Resolution<S>;
+    type Response = Resolution;
     type Error = grpc::Status;
-    type Future = future::Map<
-        grpc::client::server_streaming::ResponseFuture<api::Update, S::Future>,
-        fn(grpc::Response<grpc::Streaming<api::Update, S::ResponseBody>>) -> Resolution<S>,
-    >;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.service.poll_ready()
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
     }
 
     fn call(&mut self, target: T) -> Self::Future {
         let path = target.to_string();
-        debug!(dst = %path, context=%self.context_token, "Resolving");
-        self.service
-            .get(grpc::Request::new(api::GetDestination {
-                path,
-                scheme: self.scheme.clone(),
-                context_token: self.context_token.clone(),
-            }))
-            .map(|rsp| {
-                trace!(metadata = ?rsp.metadata());
-                Resolution {
-                    inner: rsp.into_inner(),
-                }
+        debug!(dst = %path, context = %self.context_token, "Resolving");
+        let mut svc = self.service.clone();
+        let req = api::GetDestination {
+            path,
+            scheme: self.scheme.clone(),
+            context_token: self.context_token.clone(),
+        };
+        Box::pin(async move {
+            let rsp = svc.get(grpc::Request::new(req)).await?;
+            trace!(metadata = ?rsp.metadata());
+            Ok(Resolution {
+                inner: rsp.into_inner(),
             })
+        })
     }
 }
 
-// === impl ResolveFuture ===
-/*
-impl<S> resolve::Resolution for Resolution<S>
-where
-    S: GrpcService<BoxBody>,
-{
+impl resolve::Resolution for Resolution {
     type Endpoint = Metadata;
     type Error = grpc::Status;
 
-    fn poll(&mut self) -> Poll<Update<Self::Endpoint>, Self::Error> {
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Update<Self::Endpoint>, Self::Error>> {
+        let mut this = self.project();
         loop {
-            match try_ready!(self.inner.poll()) {
-                Some(api::Update { update }) => match update {
+            match ready!(this.inner.as_mut().poll_next(cx)) {
+                Some(update) => match update?.update {
                     Some(api::update::Update::Add(api::WeightedAddrSet {
                         addrs,
                         metric_labels,
@@ -110,7 +126,7 @@ where
                             .collect::<Vec<_>>();
                         if !addr_metas.is_empty() {
                             debug!(endpoints = %addr_metas.len(), "Add");
-                            return Ok(Update::Add(addr_metas).into());
+                            return Poll::Ready(Ok(Update::Add(addr_metas)));
                         }
                     }
 
@@ -121,7 +137,7 @@ where
                             .collect::<Vec<_>>();
                         if !sock_addrs.is_empty() {
                             debug!(endpoints = %sock_addrs.len(), "Remove");
-                            return Ok(Update::Remove(sock_addrs).into());
+                            return Poll::Ready(Ok(Update::Remove(sock_addrs)));
                         }
                     }
 
@@ -132,14 +148,15 @@ where
                         } else {
                             Update::DoesNotExist
                         };
-                        return Ok(update.into());
+                        return Poll::Ready(Ok(update.into()));
                     }
 
                     None => {} // continue
                 },
-                None => return Err(grpc::Status::new(grpc::Code::Ok, "end of stream")),
+                None => {
+                    return Poll::Ready(Err(grpc::Status::new(grpc::Code::Ok, "end of stream")))
+                }
             };
         }
     }
 }
-*/

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -11,7 +11,7 @@ Core interfaces needed to implement proxy components
 [dependencies]
 futures = "0.3"
 linkerd2-error = { path = "../../error" }
-tokio = "0.2"
-tower = {version = "0.3", default-features = false }
+tokio = { version = "0.2", features = ["rt-core"] }
+tower = { version = "0.3", default-features = false }
 tracing-futures = "0.2"
 pin-project = "0.4"


### PR DESCRIPTION
This branch updates the `linkerd2-proxy-api-resolve` crate to use
`std::future` and Tonic. Getting this to work required some upstream
changes to linkerd/linkerd2-proxy-api#39 to pass different feature flags
to Tonic, but the change here is pretty straigntforward.

Depends on #518 and will be rebased onto `master-tokio-02`
when that branch merges.