### PR TITLE
update `linkerd2-exp-backoff` to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,10 +1098,11 @@ dependencies = [
 name = "linkerd2-exp-backoff"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.26",
+ "futures 0.3.4",
+ "pin-project",
  "quickcheck",
  "rand 0.7.2",
- "tokio-timer",
+ "tokio 0.2.20",
 ]
 
 [[package]]

--- a/linkerd/exp-backoff/Cargo.toml
+++ b/linkerd/exp-backoff/Cargo.toml
@@ -7,9 +7,10 @@ publish = false
 
 
 [dependencies]
-futures = "0.1"
+futures = "0.3"
 rand = { version = "0.7", features = ["small_rng"] }
-tokio-timer = "0.2.6"
+tokio = { version = "0.2", features = ["time", "stream"]}
+pin-project = "0.4"
 
 [dev-dependencies]
 quickcheck = { version = "0.9", default-features = false }


### PR DESCRIPTION
This is pretty straightforward, but it was necessary to bring
back the destination service client.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>