### PR TITLE
update controller client to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
  "linkerd2-app-outbound",
  "linkerd2-metrics",
  "linkerd2-opencensus",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "net2",
  "quickcheck",
  "regex 1.0.0",
@@ -849,8 +849,8 @@ dependencies = [
  "tokio-current-thread",
  "tokio-io",
  "tokio-rustls",
+ "tonic",
  "tower 0.1.1",
- "tower-grpc",
  "tracing",
  "tracing-futures 0.1.0",
  "webpki",
@@ -919,9 +919,9 @@ dependencies = [
  "tokio 0.2.20",
  "tokio-compat",
  "tokio-timer",
+ "tonic",
  "tower 0.3.1",
  "tower-balance",
- "tower-grpc",
  "tower-load",
  "tower-request-modifier",
  "tower-spawn-ready",
@@ -1308,6 +1308,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkerd2-proxy-api"
+version = "0.1.12"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api#59d91c1d8787f907fbab2de5ca844c25e7aeb9f7"
+dependencies = [
+ "bytes 0.4.11",
+ "futures 0.1.26",
+ "h2 0.1.26",
+ "http 0.1.21",
+ "prost 0.5.0",
+ "prost-types 0.5.0",
+ "quickcheck",
+ "rand 0.7.2",
+ "tower-grpc",
+ "tower-grpc-build",
+]
+
+[[package]]
 name = "linkerd2-proxy-api-resolve"
 version = "0.1.0"
 dependencies = [
@@ -1395,10 +1412,10 @@ dependencies = [
  "tokio 0.2.20",
  "tokio-connect",
  "tokio-timer",
+ "tonic",
  "tower 0.3.1",
  "tower-balance",
  "tower-discover",
- "tower-grpc",
  "tower-load",
  "tracing",
  "tracing-futures 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,7 @@ dependencies = [
  "linkerd2-app-core",
  "linkerd2-app-inbound",
  "linkerd2-app-outbound",
+ "linkerd2-error",
  "linkerd2-metrics",
  "linkerd2-opencensus",
  "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
@@ -1147,6 +1148,7 @@ name = "linkerd2-exp-backoff"
 version = "0.1.0"
 dependencies = [
  "futures 0.3.4",
+ "linkerd2-error",
  "pin-project",
  "quickcheck",
  "rand 0.7.2",
@@ -1412,7 +1414,6 @@ dependencies = [
  "tokio 0.2.20",
  "tokio-connect",
  "tokio-timer",
- "tonic",
  "tower 0.3.1",
  "tower-balance",
  "tower-discover",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,11 +3200,10 @@ dependencies = [
 [[package]]
 name = "tower-request-modifier"
 version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http#044e0ed5ae8b2e9946233b7cc8fc24471b2d126a"
+source = "git+https://github.com/tower-rs/tower-http#bd7a4654bdc4e2b5363572e9f66b4dbbc7c0e1ea"
 dependencies = [
- "futures 0.1.26",
- "http 0.1.21",
- "tower-service 0.2.0",
+ "http 0.2.1",
+ "tower-service 0.3.0",
 ]
 
 [[package]]

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -23,7 +23,7 @@ linkerd2-app-outbound = { path = "./outbound" }
 linkerd2-opencensus = { path = "../opencensus" }
 regex = "1.0.0"
 tokio = "0.1.14"
-tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
+tonic = { version = "0.2", default-features = false, features = ["prost"] }
 tracing = "0.1.9"
 tracing-futures = { version = "0.1", features = ["std-future"]}
 futures_03 = { package = "futures", version = "0.3" }
@@ -37,7 +37,7 @@ http = "0.2"
 http-body = "0.3"
 hyper = "0.13"
 linkerd2-metrics = { path = "../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.12" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"] }
 net2 = "0.2"
 quickcheck = { version = "0.9", default-features = false }
 ring = "0.16"

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -21,6 +21,7 @@ linkerd2-app-core = { path = "./core" }
 linkerd2-app-inbound = { path = "./inbound" }
 linkerd2-app-outbound = { path = "./outbound" }
 linkerd2-opencensus = { path = "../opencensus" }
+linkerd2-error = { path = "../error" }
 regex = "1.0.0"
 tokio = "0.1.14"
 tonic = { version = "0.2", default-features = false, features = ["prost"] }
@@ -29,12 +30,13 @@ tracing-futures = { version = "0.1", features = ["std-future"]}
 futures_03 = { package = "futures", version = "0.3" }
 tokio-compat = "0.1"
 tokio_02 = {package = "tokio", version = "0.2", features = ["rt-util"] }
+http-body = "0.3"
+
 
 [dev-dependencies]
 bytes = "0.5"
 h2 = "0.2"
 http = "0.2"
-http-body = "0.3"
 hyper = "0.13"
 linkerd2-metrics = { path = "../metrics", features = ["test_util"] }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"] }

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -71,7 +71,7 @@ tower-balance = { git = "https://github.com/tower-rs/tower" }
 tower-load = { git = "https://github.com/tower-rs/tower" }
 tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 tower-spawn-ready = { git = "https://github.com/tower-rs/tower" }
-tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
+tonic = { version = "0.2", default-features = false, features = ["prost"] }
 tracing = "0.1.9"
 tracing-futures = { version = "0.2", features = ["futures-01"] }
 tracing-log = "0.1"

--- a/linkerd/app/core/src/classify.rs
+++ b/linkerd/app/core/src/classify.rs
@@ -6,7 +6,7 @@ pub use linkerd2_http_classify::{CanClassify, Layer};
 use linkerd2_proxy_http::HasH2Reason;
 use linkerd2_timeout::error::ResponseTimeout;
 use std::borrow::Cow;
-use tower_grpc::{self as grpc};
+use tonic as grpc;
 use tracing::trace;
 
 #[derive(Clone, Debug)]

--- a/linkerd/app/core/src/errors.rs
+++ b/linkerd/app/core/src/errors.rs
@@ -10,7 +10,7 @@ use linkerd2_timeout::{error::ResponseTimeout, FailFastError};
 use pin_project::{pin_project, project};
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tower_grpc::{self as grpc, Code};
+use tonic::{self as grpc, Code};
 use tracing::{debug, warn};
 
 pub fn layer() -> respond::RespondLayer<NewRespond> {

--- a/linkerd/app/src/dst/mod.rs
+++ b/linkerd/app/src/dst/mod.rs
@@ -6,7 +6,10 @@ use linkerd2_app_core::{
     dns, profiles, Error,
 };
 use std::time::Duration;
-use tower_grpc::{generic::client::GrpcService, Body, BoxBody};
+use tonic::{
+    body::{Body, BoxBody},
+    client::GrpcService,
+};
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -23,7 +26,7 @@ pub struct Config {
 /// The addr is preserved for logging.
 pub struct Dst<S> {
     pub addr: ControlAddr,
-    pub profiles: profiles::Client<S, resolve::BackoffUnlessInvalidArgument>,
+    // pub profiles: profiles::Client<S, resolve::BackoffUnlessInvalidArgument>,
     pub resolve: resolve::Resolve<S>,
 }
 
@@ -44,18 +47,18 @@ impl Config {
             self.control.connect.backoff,
         );
 
-        let profiles = profiles::Client::new(
-            svc,
-            resolve::BackoffUnlessInvalidArgument::from(self.control.connect.backoff),
-            self.initial_profile_timeout,
-            self.context,
-            self.profile_suffixes,
-        );
+        // let profiles = profiles::Client::new(
+        //     svc,
+        //     resolve::BackoffUnlessInvalidArgument::from(self.control.connect.backoff),
+        //     self.initial_profile_timeout,
+        //     self.context,
+        //     self.profile_suffixes,
+        // );
 
         Ok(Dst {
             addr: self.control.addr,
             resolve,
-            profiles,
+            // profiles,
         })
     }
 }

--- a/linkerd/app/src/dst/mod.rs
+++ b/linkerd/app/src/dst/mod.rs
@@ -1,5 +1,6 @@
 mod resolve;
 
+use http_body::Body as HttpBody;
 use indexmap::IndexSet;
 use linkerd2_app_core::{
     config::{ControlAddr, ControlConfig},
@@ -35,8 +36,10 @@ impl Config {
     pub fn build<S>(self, svc: S) -> Result<Dst<S>, Error>
     where
         S: GrpcService<BoxBody> + Clone + Send + 'static,
+        S::Error: Into<Error> + Send,
         S::ResponseBody: Send,
         <S::ResponseBody as Body>::Data: Send,
+        <S::ResponseBody as HttpBody>::Error: Into<Error> + Send,
         S::Future: Send,
     {
         let resolve = resolve::new(

--- a/linkerd/app/src/dst/resolve.rs
+++ b/linkerd/app/src/dst/resolve.rs
@@ -8,7 +8,11 @@ use linkerd2_app_core::{
 use linkerd2_app_outbound::Target;
 use std::net::IpAddr;
 use std::sync::Arc;
-use tower_grpc::{generic::client::GrpcService, Body, BoxBody, Code, Status};
+use tonic::{
+    body::{Body, BoxBody},
+    client::GrpcService,
+    Code, Status,
+};
 
 pub type Resolve<S> = request_filter::Service<
     PermitConfiguredDsts,

--- a/linkerd/app/src/dst/resolve.rs
+++ b/linkerd/app/src/dst/resolve.rs
@@ -1,3 +1,4 @@
+use http_body::Body as HttpBody;
 use ipnet::{Contains, IpNet};
 use linkerd2_app_core::{
     dns::Suffix,
@@ -6,6 +7,8 @@ use linkerd2_app_core::{
     request_filter, Addr, DiscoveryRejected, Error, Recover,
 };
 use linkerd2_app_outbound::Target;
+use linkerd2_error::Never;
+use std::error;
 use std::net::IpAddr;
 use std::sync::Arc;
 use tonic::{
@@ -28,8 +31,10 @@ pub fn new<S>(
 ) -> Resolve<S>
 where
     S: GrpcService<BoxBody> + Clone + Send + 'static,
+    S::Error: Into<Error> + Send,
     S::ResponseBody: Send,
     <S::ResponseBody as Body>::Data: Send,
+    <S::ResponseBody as HttpBody>::Error: Into<Error> + Send,
     S::Future: Send,
 {
     request_filter::Service::new(
@@ -98,7 +103,7 @@ impl From<ExponentialBackoff> for BackoffUnlessInvalidArgument {
 
 impl Recover<Error> for BackoffUnlessInvalidArgument {
     type Backoff = ExponentialBackoffStream;
-    type Error = <ExponentialBackoffStream as futures::Stream>::Error;
+    type Error = Never;
 
     fn recover(&self, err: Error) -> Result<Self::Backoff, Error> {
         match err.downcast::<Status>() {

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -470,29 +470,29 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         }
     };
 
-    // let dst = {
-    //     let addr = dst_addr?.ok_or(EnvError::NoDestinationAddress)?;
-    //     let connect = if addr.addr.is_loopback() {
-    //         inbound.proxy.connect.clone()
-    //     } else {
-    //         outbound.proxy.connect.clone()
-    //     };
-    //     super::dst::Config {
-    //         context: dst_token?.unwrap_or_default(),
-    //         get_suffixes: dst_get_suffixes?
-    //             .unwrap_or(parse_dns_suffixes(DEFAULT_DESTINATION_GET_SUFFIXES).unwrap()),
-    //         get_networks: dst_get_networks?.unwrap_or_default(),
-    //         profile_suffixes: dst_profile_suffixes?
-    //             .unwrap_or(parse_dns_suffixes(DEFAULT_DESTINATION_PROFILE_SUFFIXES).unwrap()),
-    //         initial_profile_timeout: dst_profile_initial_timeout?
-    //             .unwrap_or(DEFAULT_DESTINATION_PROFILE_INITIAL_TIMEOUT),
-    //         control: ControlConfig {
-    //             addr,
-    //             connect,
-    //             buffer_capacity,
-    //         },
-    //     }
-    // };
+    let dst = {
+        let addr = dst_addr?.ok_or(EnvError::NoDestinationAddress)?;
+        let connect = if addr.addr.is_loopback() {
+            inbound.proxy.connect.clone()
+        } else {
+            outbound.proxy.connect.clone()
+        };
+        super::dst::Config {
+            context: dst_token?.unwrap_or_default(),
+            get_suffixes: dst_get_suffixes?
+                .unwrap_or(parse_dns_suffixes(DEFAULT_DESTINATION_GET_SUFFIXES).unwrap()),
+            get_networks: dst_get_networks?.unwrap_or_default(),
+            profile_suffixes: dst_profile_suffixes?
+                .unwrap_or(parse_dns_suffixes(DEFAULT_DESTINATION_PROFILE_SUFFIXES).unwrap()),
+            initial_profile_timeout: dst_profile_initial_timeout?
+                .unwrap_or(DEFAULT_DESTINATION_PROFILE_INITIAL_TIMEOUT),
+            control: ControlConfig {
+                addr,
+                connect,
+                buffer_capacity,
+            },
+        }
+    };
 
     let admin = super::admin::Config {
         metrics_retain_idle: metrics_retain_idle?.unwrap_or(DEFAULT_METRICS_RETAIN_IDLE),
@@ -574,7 +574,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     Ok(super::Config {
         admin,
         dns,
-        // dst,
+        dst,
         tap,
         // oc_collector,
         identity,

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -126,16 +126,16 @@ impl Config {
                     .push_timeout(dst.control.connect.timeout)
                     .push(control::client::layer())
                     .push(control::resolve::layer(dns))
-                    .push(reconnect::layer({
-                        let backoff = dst.control.connect.backoff;
-                        move |_| Ok(backoff.stream())
-                    }))
+                    // .push(reconnect::layer({
+                    //     let backoff = dst.control.connect.backoff;
+                    //     move |_| Ok(backoff.stream())
+                    // }))
                     .push(metrics.into_layer::<classify::Response>())
                     .push(control::add_origin::Layer::new())
                     .into_new_service()
                     .push_on_response(
                         svc::layers()
-                            .push(grpc::req_body_as_payload::layer())
+                            // .push(grpc::req_body_as_payload::layer())
                             .push_spawn_buffer(dst.control.buffer_capacity),
                     )
                     .new_service(dst.control.addr.clone());
@@ -196,7 +196,7 @@ impl Config {
         Ok(App {
             admin,
             admin_rt,
-            dst: dst_addr,
+            dst,
             drain: drain_tx,
             identity,
             inbound,

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -109,7 +109,7 @@ impl Config {
         let (drain_tx, drain_rx) = drain::channel();
 
         // let tap = info_span!("tap").in_scope(|| tap.build(identity.local(), drain_rx.clone()))?;
-
+        let dst_addr = dst.control.addr.clone();
         let dst = {
             use linkerd2_app_core::{classify, control, reconnect, transport::tls};
 
@@ -196,7 +196,7 @@ impl Config {
         Ok(App {
             admin,
             admin_rt,
-            dst,
+            dst: dst_addr,
             drain: drain_tx,
             identity,
             inbound,
@@ -228,9 +228,9 @@ impl App {
         None
     }
 
-    // pub fn dst_addr(&self) -> &ControlAddr {
-    //     &self.dst
-    // }
+    pub fn dst_addr(&self) -> &ControlAddr {
+        &self.dst
+    }
 
     pub fn local_identity(&self) -> Option<&identity::Local> {
         match self.identity {

--- a/linkerd/exp-backoff/Cargo.toml
+++ b/linkerd/exp-backoff/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 futures = "0.3"
+linkerd2-error = { path = "../error" }
 rand = { version = "0.7", features = ["small_rng"] }
 tokio = { version = "0.2", features = ["time", "stream"]}
 pin-project = "0.4"

--- a/linkerd/exp-backoff/src/lib.rs
+++ b/linkerd/exp-backoff/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
 
+use linkerd2_error::Never;
 use pin_project::pin_project;
 use rand::{rngs::SmallRng, SeedableRng};
 use std::fmt;
@@ -98,9 +99,9 @@ impl ExponentialBackoff {
 }
 
 impl Stream for ExponentialBackoffStream {
-    type Item = ();
+    type Item = Result<(), Never>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<()>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
         loop {
             // If there's an active delay, wait until it's done and then
@@ -110,7 +111,7 @@ impl Stream for ExponentialBackoffStream {
 
                 this.delay.as_mut().set(None);
                 *this.iterations += 1;
-                return Poll::Ready(Some(()));
+                return Poll::Ready(Some(Ok(())));
             }
             if *this.iterations == std::u32::MAX {
                 return Poll::Ready(None);

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -40,7 +40,6 @@ tower = { version = "0.3", default-features = false }
 tower-balance = { git = "https://github.com/tower-rs/tower" }
 tower-discover = "0.1"
 tower-load = { git = "https://github.com/tower-rs/tower" }
-tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 # tower-util = "0.1"
 tracing = "0.1.9"
 tracing-futures = { version = "0.1", features = ["std-future"] }


### PR DESCRIPTION
This branch updates the proxy's control-plane client to use
`std::future` and Tonic. This should unblock updating the outbound proxy
(as it needs service discovery) and bringing back service profiles.