### PR TITLE
turn outbound back into a proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ dependencies = [
  "tokio-io",
  "tokio-rustls",
  "tonic",
- "tower 0.1.1",
+ "tower 0.3.1",
  "tracing",
  "tracing-futures 0.1.0",
  "webpki",
@@ -1299,19 +1299,6 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.12"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/tonic#b7dc966731ffc1223d2cde4472686ae2c7bb05d6"
-dependencies = [
- "h2 0.2.4",
- "http 0.2.1",
- "prost 0.6.1",
- "prost-types 0.6.1",
- "tonic",
- "tonic-build",
-]
-
-[[package]]
-name = "linkerd2-proxy-api"
-version = "0.1.12"
 source = "git+https://github.com/linkerd/linkerd2-proxy-api#59d91c1d8787f907fbab2de5ca844c25e7aeb9f7"
 dependencies = [
  "bytes 0.4.11",
@@ -1327,6 +1314,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkerd2-proxy-api"
+version = "0.1.12"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=8b400dee750671b41cb24dcea23e5cceb6188301#8b400dee750671b41cb24dcea23e5cceb6188301"
+dependencies = [
+ "h2 0.2.4",
+ "http 0.2.1",
+ "prost 0.6.1",
+ "prost-types 0.6.1",
+ "tonic",
+ "tonic-build",
+]
+
+[[package]]
 name = "linkerd2-proxy-api-resolve"
 version = "0.1.0"
 dependencies = [
@@ -1335,7 +1335,7 @@ dependencies = [
  "http-body 0.3.1",
  "indexmap",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?branch=eliza/tonic)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=8b400dee750671b41cb24dcea23e5cceb6188301)",
  "linkerd2-proxy-core",
  "pin-project",
  "prost 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,7 +1316,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.12"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=8b400dee750671b41cb24dcea23e5cceb6188301#8b400dee750671b41cb24dcea23e5cceb6188301"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=c2dba642c7301b5b562c75fd6e2bd0a12ec763e8#c2dba642c7301b5b562c75fd6e2bd0a12ec763e8"
 dependencies = [
  "h2 0.2.4",
  "http 0.2.1",
@@ -1335,7 +1335,7 @@ dependencies = [
  "http-body 0.3.1",
  "indexmap",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=8b400dee750671b41cb24dcea23e5cceb6188301)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=c2dba642c7301b5b562c75fd6e2bd0a12ec763e8)",
  "linkerd2-proxy-core",
  "pin-project",
  "prost 0.6.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,8 +1540,10 @@ dependencies = [
 name = "linkerd2-request-filter"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.26",
- "tower 0.1.1",
+ "futures 0.3.4",
+ "linkerd2-error",
+ "pin-project",
+ "tower 0.3.1",
  "tracing",
 ]
 

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -31,7 +31,7 @@ futures_03 = { package = "futures", version = "0.3" }
 tokio-compat = "0.1"
 tokio_02 = {package = "tokio", version = "0.2", features = ["rt-util"] }
 http-body = "0.3"
-
+tower = "0.3"
 
 [dev-dependencies]
 bytes = "0.5"
@@ -48,5 +48,5 @@ tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-io = "0.1.6"
 tokio-current-thread = "0.1.4"
 tokio-rustls = "0.13"
-tower = "0.1"
+# tower = "0.1"
 webpki = "=0.21.0"

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -48,5 +48,4 @@ tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-io = "0.1.6"
 tokio-current-thread = "0.1.4"
 tokio-rustls = "0.13"
-# tower = "0.1"
 webpki = "=0.21.0"

--- a/linkerd/app/core/src/proxy/server.rs
+++ b/linkerd/app/core/src/proxy/server.rs
@@ -141,7 +141,7 @@ where
         + 'static,
     <H::Service as Service<http::Request<Body>>>::Future: Send + 'static,
     B: hyper::body::HttpBody + Default + Send + 'static,
-    B::Error: std::error::Error + Send + Sync + 'static,
+    B::Error: Into<Error>,
     B::Data: Send + 'static,
 {
     type Response = Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'static>>;

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -8,7 +8,6 @@ macro_rules! generate_tests {
         use linkerd2_proxy_api as pb;
 
         #[test]
-        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_asks_controller_api() {
             let _ = trace_init();
             let srv = $make_server().route("/", "hello").route("/bye", "bye").run();
@@ -25,7 +24,6 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_reconnects_if_controller_stream_ends() {
             let _ = trace_init();
 
@@ -88,7 +86,6 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_falls_back_to_orig_dst_when_outside_search_path() {
             let _ = trace_init();
 
@@ -107,7 +104,6 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_falls_back_to_orig_dst_after_invalid_argument() {
             let _ = trace_init();
 
@@ -208,7 +204,6 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_asks_controller_without_orig_dst() {
             let _ = TestEnv::new();
 

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -6,7 +6,6 @@ use std::error::Error as _;
 use std::sync::mpsc;
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn outbound_http1() {
     let _ = trace_init();
 
@@ -22,7 +21,6 @@ fn outbound_http1() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn inbound_http1() {
     let _ = trace_init();
 
@@ -629,7 +627,6 @@ macro_rules! http1_tests {
         }
 
         #[tokio::test]
-        #[cfg_attr(not(feature = "nyi"), ignore)]
         async fn http1_request_with_body_chunked() {
             let _ = trace_init();
 
@@ -742,7 +739,6 @@ macro_rules! http1_tests {
         }
 
         #[test]
-        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn http1_bodyless_responses() {
             let _ = trace_init();
 
@@ -805,7 +801,6 @@ macro_rules! http1_tests {
         }
 
         #[tokio::test]
-        #[cfg_attr(not(feature = "nyi"), ignore)]
         async fn http1_head_responses() {
             let _ = trace_init();
 
@@ -840,7 +835,6 @@ macro_rules! http1_tests {
         }
 
         #[tokio::test]
-        #[cfg_attr(not(feature = "nyi"), ignore)]
         async fn http1_response_end_of_file() {
             let _ = trace_init();
 
@@ -990,7 +984,6 @@ fn http10_without_host() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http1_one_connection_per_host() {
     let _ = trace_init();
 
@@ -1037,7 +1030,6 @@ fn http1_one_connection_per_host() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http1_requests_without_host_have_unique_connections() {
     let _ = trace_init();
 
@@ -1164,7 +1156,6 @@ async fn http2_request_without_authority() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 async fn http2_rst_stream_is_propagated() {
     let _ = trace_init();
 

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -72,15 +72,15 @@ impl<T> std::fmt::Display for Target<T> {
     }
 }
 
-impl<T> http::canonicalize::Target for Target<T> {
-    fn addr(&self) -> &Addr {
-        &self.addr
-    }
+// impl<T> http::canonicalize::Target for Target<T> {
+//     fn addr(&self) -> &Addr {
+//         &self.addr
+//     }
 
-    fn addr_mut(&mut self) -> &mut Addr {
-        &mut self.addr
-    }
-}
+//     fn addr_mut(&mut self) -> &mut Addr {
+//         &mut self.addr
+//     }
+// }
 
 impl<'t, T> From<&'t Target<T>> for ::http::header::HeaderValue {
     fn from(target: &'t Target<T>) -> Self {

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -342,17 +342,17 @@ impl tls::HasPeerIdentity for TcpEndpoint {
     }
 }
 
-// impl Into<EndpointLabels> for TcpEndpoint {
-//     fn into(self) -> EndpointLabels {
-//         use linkerd2_app_core::metric_labels::{Direction, TlsId};
-//         EndpointLabels {
-//             direction: Direction::Out,
-//             tls_id: self.identity.as_ref().map(|id| TlsId::ServerId(id.clone())),
-//             authority: None,
-//             labels: None,
-//         }
-//     }
-// }
+impl Into<EndpointLabels> for TcpEndpoint {
+    fn into(self) -> EndpointLabels {
+        use linkerd2_app_core::metric_labels::{Direction, TlsId};
+        EndpointLabels {
+            direction: Direction::Out,
+            tls_id: self.identity.as_ref().map(|id| TlsId::ServerId(id.clone())),
+            authority: None,
+            labels: None,
+        }
+    }
+}
 
 // === impl LogicalPerRequest ===
 

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -1,23 +1,20 @@
 use crate::http::uri::Authority;
 use indexmap::IndexMap;
 use linkerd2_app_core::{
-    // dst,
-    // metric_labels,
-    // metric_labels::{prefix_labels, EndpointLabels},
+    dst, metric_labels,
+    metric_labels::{prefix_labels, EndpointLabels},
     profiles,
     proxy::{
         api_resolve::{Metadata, ProtocolHint},
         // http::override_authority::CanOverrideAuthority,
         http::{self, identity_from_header, Settings},
         identity,
-        // resolve::map_endpoint::MapEndpoint,
+        resolve::map_endpoint::MapEndpoint,
         tap,
     },
     router,
     transport::{connect, tls},
-    Addr,
-    Conditional,
-    L5D_REQUIRE_ID,
+    Addr, Conditional, L5D_REQUIRE_ID,
 };
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -75,15 +72,15 @@ impl<T> std::fmt::Display for Target<T> {
     }
 }
 
-// impl<T> http::canonicalize::Target for Target<T> {
-//     fn addr(&self) -> &Addr {
-//         &self.addr
-//     }
+impl<T> http::canonicalize::Target for Target<T> {
+    fn addr(&self) -> &Addr {
+        &self.addr
+    }
 
-//     fn addr_mut(&mut self) -> &mut Addr {
-//         &mut self.addr
-//     }
-// }
+    fn addr_mut(&mut self) -> &mut Addr {
+        &mut self.addr
+    }
+}
 
 impl<'t, T> From<&'t Target<T>> for ::http::header::HeaderValue {
     fn from(target: &'t Target<T>) -> Self {
@@ -269,36 +266,36 @@ impl http::settings::HasSettings for HttpEndpoint {
 //     }
 // }
 
-// impl MapEndpoint<Concrete<http::Settings>, Metadata> for FromMetadata {
-//     type Out = Target<HttpEndpoint>;
+impl MapEndpoint<Concrete<http::Settings>, Metadata> for FromMetadata {
+    type Out = Target<HttpEndpoint>;
 
-//     fn map_endpoint(
-//         &self,
-//         concrete: &Concrete<http::Settings>,
-//         addr: SocketAddr,
-//         metadata: Metadata,
-//     ) -> Self::Out {
-//         tracing::trace!(%addr, ?metadata, "Resolved endpoint");
-//         let identity = metadata
-//             .identity()
-//             .cloned()
-//             .map(Conditional::Some)
-//             .unwrap_or_else(|| {
-//                 Conditional::None(tls::ReasonForNoPeerName::NotProvidedByServiceDiscovery.into())
-//             });
+    fn map_endpoint(
+        &self,
+        concrete: &Concrete<http::Settings>,
+        addr: SocketAddr,
+        metadata: Metadata,
+    ) -> Self::Out {
+        tracing::trace!(%addr, ?metadata, "Resolved endpoint");
+        let identity = metadata
+            .identity()
+            .cloned()
+            .map(Conditional::Some)
+            .unwrap_or_else(|| {
+                Conditional::None(tls::ReasonForNoPeerName::NotProvidedByServiceDiscovery.into())
+            });
 
-//         Target {
-//             // Use the logical addr for the target.
-//             addr: concrete.inner.addr.clone(),
-//             inner: HttpEndpoint {
-//                 addr,
-//                 identity,
-//                 metadata,
-//                 settings: concrete.inner.inner,
-//             },
-//         }
-//     }
-// }
+        Target {
+            // Use the logical addr for the target.
+            addr: concrete.inner.addr.clone(),
+            inner: HttpEndpoint {
+                addr,
+                identity,
+                metadata,
+                settings: concrete.inner.inner,
+            },
+        }
+    }
+}
 
 // impl CanOverrideAuthority for Target<HttpEndpoint> {
 //     fn override_authority(&self) -> Option<Authority> {
@@ -306,21 +303,21 @@ impl http::settings::HasSettings for HttpEndpoint {
 //     }
 // }
 
-// impl Into<EndpointLabels> for Target<HttpEndpoint> {
-//     fn into(self) -> EndpointLabels {
-//         use linkerd2_app_core::metric_labels::{Direction, TlsId};
-//         EndpointLabels {
-//             authority: Some(self.addr.to_http_authority()),
-//             direction: Direction::Out,
-//             tls_id: self
-//                 .inner
-//                 .identity
-//                 .as_ref()
-//                 .map(|id| TlsId::ServerId(id.clone())),
-//             labels: prefix_labels("dst", self.inner.metadata.labels().into_iter()),
-//         }
-//     }
-// }
+impl Into<EndpointLabels> for Target<HttpEndpoint> {
+    fn into(self) -> EndpointLabels {
+        use linkerd2_app_core::metric_labels::{Direction, TlsId};
+        EndpointLabels {
+            authority: Some(self.addr.to_http_authority()),
+            direction: Direction::Out,
+            tls_id: self
+                .inner
+                .identity
+                .as_ref()
+                .map(|id| TlsId::ServerId(id.clone())),
+            labels: prefix_labels("dst", self.inner.metadata.labels().into_iter()),
+        }
+    }
+}
 
 // === impl TcpEndpoint ===
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -211,7 +211,7 @@ impl Config {
                 .push_on_response(
                     svc::layers()
                         .push(metrics.stack.layer(stack_labels("balance.endpoint")))
-                        .box_http_request()
+                        .box_http_request(),
                 )
                 .push_spawn_ready()
                 .check_service::<Target<HttpEndpoint>>()
@@ -230,14 +230,12 @@ impl Config {
                             .push_failfast(dispatch_timeout)
                             // Shares the balancer, ensuring discovery errors are propagated.
                             .push_spawn_buffer(buffer_capacity)
-                            .push(metrics.stack.layer(stack_labels("balance")))
-
+                            .push(metrics.stack.layer(stack_labels("balance"))),
                     ),
                 )
                 .instrument(|c: &Concrete<http::Settings>| info_span!("balance", addr = %c.addr))
                 // Ensure that buffers don't hold the cache's lock in poll_ready.
-                .push_oneshot()
-                ;
+                .push_oneshot();
 
             // Caches clients that bypass discovery/balancing.
             //
@@ -399,20 +397,20 @@ impl Config {
                 })
                 .push_on_response(svc::layers().box_http_response().box_http_request())
                 .check_service::<Logical<HttpEndpoint>>()
-            //     .check_service::<Logical<HttpEndpoint>>()
-            //     // Sets the canonical-dst header on all outbound requests.
-            //     .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
-            //     // Strips headers that may be set by this proxy.
-            //     .push(http::canonicalize::Layer::new(
-            //         dns_refine_cache,
-            //         canonicalize_timeout,
-            //     ))
-            //     .push_on_response(
-            //         // Strips headers that may be set by this proxy.
-            //         svc::layers()
-            //             .push(http::strip_header::request::layer(L5D_CLIENT_ID))
-            //             .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
-            //     )
+                //     .check_service::<Logical<HttpEndpoint>>()
+                //     // Sets the canonical-dst header on all outbound requests.
+                //     .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
+                //     // Strips headers that may be set by this proxy.
+                //     .push(http::canonicalize::Layer::new(
+                //         dns_refine_cache,
+                //         canonicalize_timeout,
+                //     ))
+                //     .push_on_response(
+                //         // Strips headers that may be set by this proxy.
+                //         svc::layers()
+                //             .push(http::strip_header::request::layer(L5D_CLIENT_ID))
+                //             .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
+                //     )
                 .check_service::<Logical<HttpEndpoint>>()
                 .instrument(|logical: &Logical<_>| info_span!("logical", addr = %logical.addr));
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -95,8 +95,8 @@ impl Config {
             + Send
             + Sync
             + 'static,
-        R::Future: Send,
-        R::Resolution: Send,
+        R::Future: Unpin + Send,
+        R::Resolution: Unpin + Send,
         // P: profiles::GetRoutes<Profile> + Clone + Send + 'static,
         // P::Future: Send,
     {
@@ -210,230 +210,235 @@ impl Config {
                 .push_on_response(
                     svc::layers()
                         .push(metrics.stack.layer(stack_labels("balance.endpoint")))
-                        .box_http_request(),
+                        .box_http_request()
                 )
                 .push_spawn_ready()
                 .check_service::<Target<HttpEndpoint>>()
                 .push(discover)
                 .push_on_response(http::balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
                 .into_new_service()
+                .check_new_send_and_static()
                 .cache(
                     svc::layers().push_on_response(
                         svc::layers()
-                            // If the balancer has been ready & unused for `cache_max_idle_age`,
-                            // fail the balancer.
-                            .push_idle_timeout(cache_max_idle_age)
+                            // // If the balancer has been ready & unused for `cache_max_idle_age`,
+                            // // fail the balancer.
+                            // .push_idle_timeout(cache_max_idle_age)
                             // If the balancer has been empty/unavailable for 10s, eagerly fail
                             // requests.
                             .push_failfast(dispatch_timeout)
                             // Shares the balancer, ensuring discovery errors are propagated.
                             .push_spawn_buffer(buffer_capacity)
-                            .push(metrics.stack.layer(stack_labels("balance"))),
+                            .push(metrics.stack.layer(stack_labels("balance")))
+
                     ),
                 )
                 .instrument(|c: &Concrete<http::Settings>| info_span!("balance", addr = %c.addr))
                 // Ensure that buffers don't hold the cache's lock in poll_ready.
+                .push_oneshot()
+                ;
+
+            // Caches clients that bypass discovery/balancing.
+            //
+            // This is effectively the same as the endpoint stack; but the client layer captures the
+            // requst body type (via PhantomData), so the stack cannot be shared directly.
+            let http_forward_cache = http_endpoint
+                .check_make_service::<Target<HttpEndpoint>, http::Request<http::boxed::Payload>>()
+                .into_new_service()
+                .cache(
+                    svc::layers()
+                        .push_on_response(
+                            svc::layers()
+                                // If the endpoint has been unavailable for an extended time, eagerly
+                                // fail requests.
+                                .push_failfast(dispatch_timeout)
+                                // Shares the balancer, ensuring discovery errors are propagated.
+                                .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
+                                // .box_http_request()
+                                .push(metrics.stack.layer(stack_labels("forward.endpoint"))),
+                        ),
+                )
+                .instrument(|endpoint: &Target<HttpEndpoint>| {
+                    info_span!("forward", peer.addr = %endpoint.addr, peer.id = ?endpoint.inner.identity)
+                })
+                .push_map_target(|t: Concrete<HttpEndpoint>| Target {
+                    addr: t.addr.into(),
+                    inner: t.inner.inner,
+                })
+                .check_service::<Concrete<HttpEndpoint>>()
+                // Ensure that buffers don't hold the cache's lock in poll_ready.
                 .push_oneshot();
 
-            // // Caches clients that bypass discovery/balancing.
-            // //
-            // // This is effectively the same as the endpoint stack; but the client layer captures the
-            // // requst body type (via PhantomData), so the stack cannot be shared directly.
-            // let http_forward_cache = http_endpoint
-            //     .check_make_service::<Target<HttpEndpoint>, http::Request<http::boxed::Payload>>()
-            //     .into_new_service()
-            //     .cache(
-            //         svc::layers()
-            //             .push_on_response(
-            //                 svc::layers()
-            //                     // If the endpoint has been unavailable for an extended time, eagerly
-            //                     // fail requests.
-            //                     .push_failfast(dispatch_timeout)
-            //                     // Shares the balancer, ensuring discovery errors are propagated.
-            //                     .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
-            //                     .box_http_request()
-            //                     .push(metrics.stack.layer(stack_labels("forward.endpoint"))),
-            //             ),
-            //     )
-            //     .instrument(|endpoint: &Target<HttpEndpoint>| {
-            //         info_span!("forward", peer.addr = %endpoint.addr, peer.id = ?endpoint.inner.identity)
-            //     })
-            //     .push_map_target(|t: Concrete<HttpEndpoint>| Target {
-            //         addr: t.addr.into(),
-            //         inner: t.inner.inner,
-            //     })
-            //     .check_service::<Concrete<HttpEndpoint>>()
-            //     // Ensure that buffers don't hold the cache's lock in poll_ready.
-            //     .push_oneshot();
+            // If the balancer fails to be created, i.e., because it is unresolvable, fall back to
+            // using a router that dispatches request to the application-selected original destination.
+            let http_concrete = http_balancer
+                .push_map_target(|c: Concrete<HttpEndpoint>| c.map(|l| l.map(|e| e.settings)))
+                .check_service::<Concrete<HttpEndpoint>>()
+                .push_on_response(svc::layers().box_http_response())
+                .push_make_ready()
+                .push_fallback_with_predicate(
+                    http_forward_cache
+                        .push_on_response(svc::layers().box_http_response())
+                        .into_inner(),
+                    is_discovery_rejected,
+                )
+                .check_service::<Concrete<HttpEndpoint>>();
 
-            // // If the balancer fails to be created, i.e., because it is unresolvable, fall back to
-            // // using a router that dispatches request to the application-selected original destination.
-            // let http_concrete = http_balancer
-            //     .push_map_target(|c: Concrete<HttpEndpoint>| c.map(|l| l.map(|e| e.settings)))
-            //     .check_service::<Concrete<HttpEndpoint>>()
-            //     .push_on_response(svc::layers().box_http_response())
-            //     .push_make_ready()
-            //     .push_fallback_with_predicate(
-            //         http_forward_cache
-            //             .push_on_response(svc::layers().box_http_response())
-            //             .into_inner(),
-            //         is_discovery_rejected,
-            //     )
-            //     .check_service::<Concrete<HttpEndpoint>>();
+            let http_profile_route_proxy = svc::proxies()
+                .check_new_clone_service::<dst::Route>()
+                .push(metrics.http_route_actual.into_layer::<classify::Response>())
+                // Sets an optional retry policy.
+                // .push(retry::layer(metrics.http_route_retry))
+                .check_new_clone_service::<dst::Route>()
+                // Sets an optional request timeout.
+                .push(http::MakeTimeoutLayer::default())
+                .check_new_clone_service::<dst::Route>()
+                // Records per-route metrics.
+                .push(metrics.http_route.into_layer::<classify::Response>())
+                .check_new_clone_service::<dst::Route>()
+                // Sets the per-route response classifier as a request
+                // extension.
+                .push(classify::Layer::new())
+                .check_new_clone_service::<dst::Route>();
 
-            // let http_profile_route_proxy = svc::proxies()
-            //     .check_new_clone_service::<dst::Route>()
-            //     .push(metrics.http_route_actual.into_layer::<classify::Response>())
-            //     // Sets an optional retry policy.
-            //     .push(retry::layer(metrics.http_route_retry))
-            //     .check_new_clone_service::<dst::Route>()
-            //     // Sets an optional request timeout.
-            //     .push(http::MakeTimeoutLayer::default())
-            //     .check_new_clone_service::<dst::Route>()
-            //     // Records per-route metrics.
-            //     .push(metrics.http_route.into_layer::<classify::Response>())
-            //     .check_new_clone_service::<dst::Route>()
-            //     // Sets the per-route response classifier as a request
-            //     // extension.
-            //     .push(classify::Layer::new())
-            //     .check_new_clone_service::<dst::Route>();
+            // Routes `Logical` targets to a cached `Profile` stack, i.e. so that profile
+            // resolutions are shared even as the type of request may vary.
+            let http_logical_profile_cache = http_concrete
+                .clone()
+                // .push_on_response(svc::layers().box_http_request())
+                // .check_service::<Concrete<HttpEndpoint>>()
+                // // // Provides route configuration. The profile service operates
+                // // // over `Concret` services. When overrides are in play, the
+                // // // Concrete destination may be overridden.
+                // // .push(profiles::Layer::with_overrides(
+                // //     profiles_client,
+                // //     http_profile_route_proxy.into_inner(),
+                // // ))
+                // .check_make_service::<Profile, Concrete<HttpEndpoint>>()
+                // // Use the `Logical` target as a `Concrete` target. It may be
+                // // overridden by the profile layer.
+                // .push_on_response(
+                //     svc::layers().push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
+                //         addr: inner.addr.clone(),
+                //         inner,
+                //     }),
+                // )
+                // .into_new_service()
+                // .cache(
+                //     svc::layers().push_on_response(
+                //         svc::layers()
+                //             // If the service has been unavailable for an extended time, eagerly
+                //             // fail requests.
+                //             .push_failfast(dispatch_timeout)
+                //             // Shares the service, ensuring discovery errors are propagated.
+                //             .push_spawn_buffer_with_idle_timeout(
+                //                 buffer_capacity,
+                //                 cache_max_idle_age,
+                //             )
+                //             .push(metrics.stack.layer(stack_labels("profile"))),
+                //     ),
+                // )
+                // .instrument(|_: &Profile| info_span!("profile"))
+                // // Ensures that the cache isn't locked when polling readiness.
+                // .push_oneshot()
+                // .check_make_service::<Profile, Logical<HttpEndpoint>>()
+                // .push(router::Layer::new(|()| ProfilePerTarget))
+                // .check_new_service_routes::<(), Logical<HttpEndpoint>>()
+                // .new_service(());
+                ;
 
-            // // Routes `Logical` targets to a cached `Profile` stack, i.e. so that profile
-            // // resolutions are shared even as the type of request may vary.
-            // let http_logical_profile_cache = http_concrete
-            //     .clone()
-            //     .push_on_response(svc::layers().box_http_request())
-            //     .check_service::<Concrete<HttpEndpoint>>()
-            //     // Provides route configuration. The profile service operates
-            //     // over `Concret` services. When overrides are in play, the
-            //     // Concrete destination may be overridden.
-            //     .push(profiles::Layer::with_overrides(
-            //         profiles_client,
-            //         http_profile_route_proxy.into_inner(),
-            //     ))
-            //     .check_make_service::<Profile, Concrete<HttpEndpoint>>()
-            //     // Use the `Logical` target as a `Concrete` target. It may be
-            //     // overridden by the profile layer.
-            //     .push_on_response(
-            //         svc::layers().push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
-            //             addr: inner.addr.clone(),
-            //             inner,
-            //         }),
-            //     )
-            //     .into_new_service()
-            //     .cache(
-            //         svc::layers().push_on_response(
-            //             svc::layers()
-            //                 // If the service has been unavailable for an extended time, eagerly
-            //                 // fail requests.
-            //                 .push_failfast(dispatch_timeout)
-            //                 // Shares the service, ensuring discovery errors are propagated.
-            //                 .push_spawn_buffer_with_idle_timeout(
-            //                     buffer_capacity,
-            //                     cache_max_idle_age,
-            //                 )
-            //                 .push(metrics.stack.layer(stack_labels("profile"))),
-            //         ),
-            //     )
-            //     .instrument(|_: &Profile| info_span!("profile"))
-            //     // Ensures that the cache isn't locked when polling readiness.
-            //     .push_oneshot()
-            //     .check_make_service::<Profile, Logical<HttpEndpoint>>()
-            //     .push(router::Layer::new(|()| ProfilePerTarget))
-            //     .check_new_service_routes::<(), Logical<HttpEndpoint>>()
-            //     .new_service(());
+            // Caches DNS refinements from relative names to canonical names.
+            //
+            // For example, a client may send requests to `foo` or `foo.ns`; and the canonical form
+            // of these names is `foo.ns.svc.cluster.local
+            let dns_refine_cache = svc::stack(dns_resolver.into_make_refine())
+                .cache(
+                    svc::layers().push_on_response(
+                        svc::layers()
+                            // If the service has been unavailable for an extended time, eagerly
+                            // fail requests.
+                            .push_failfast(dispatch_timeout)
+                            // Shares the service, ensuring discovery errors are propagated.
+                            .push_spawn_buffer_with_idle_timeout(
+                                buffer_capacity,
+                                cache_max_idle_age,
+                            )
+                            .push(metrics.stack.layer(stack_labels("canonicalize"))),
+                    ),
+                )
+                .instrument(|name: &dns::Name| info_span!("canonicalize", %name))
+                // Obtains the service, advances the state of the resolution
+                .push(svc::make_response::Layer)
+                // Ensures that the cache isn't locked when polling readiness.
+                .push_oneshot()
+                .check_service_response::<dns::Name, dns::Name>()
+                .into_inner();
 
-            // // Caches DNS refinements from relative names to canonical names.
-            // //
-            // // For example, a client may send requests to `foo` or `foo.ns`; and the canonical form
-            // // of these names is `foo.ns.svc.cluster.local
-            // let dns_refine_cache = svc::stack(dns_resolver.into_make_refine())
-            //     .cache(
-            //         svc::layers().push_on_response(
-            //             svc::layers()
-            //                 // If the service has been unavailable for an extended time, eagerly
-            //                 // fail requests.
-            //                 .push_failfast(dispatch_timeout)
-            //                 // Shares the service, ensuring discovery errors are propagated.
-            //                 .push_spawn_buffer_with_idle_timeout(
-            //                     buffer_capacity,
-            //                     cache_max_idle_age,
-            //                 )
-            //                 .push(metrics.stack.layer(stack_labels("canonicalize"))),
-            //         ),
-            //     )
-            //     .instrument(|name: &dns::Name| info_span!("canonicalize", %name))
-            //     // Obtains the service, advances the state of the resolution
-            //     .push(svc::make_response::Layer)
-            //     // Ensures that the cache isn't locked when polling readiness.
-            //     .push_oneshot()
-            //     .check_service_response::<dns::Name, dns::Name>()
-            //     .into_inner();
+            // Routes requests to their logical target.
+            let http_logical_router = svc::stack(http_logical_profile_cache)
+                // .check_service::<Logical<HttpEndpoint>>()
+                .push_on_response(svc::layers().box_http_response())
+                .push_make_ready()
+                .push_fallback_with_predicate(
+                    http_concrete
+                        .push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
+                            addr: inner.addr.clone(),
+                            inner,
+                        })
+                        .push_on_response(svc::layers().box_http_response().box_http_request())
+                        // .check_service::<Logical<HttpEndpoint>>()
+                        .into_inner(),
+                    is_discovery_rejected,
+                )
+                // .check_service::<Logical<HttpEndpoint>>()
+                // Sets the canonical-dst header on all outbound requests.
+                // .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
+                // Strips headers that may be set by this proxy.
+                // .push(http::canonicalize::Layer::new(
+                //     dns_refine_cache,
+                //     canonicalize_timeout,
+                // ))
+                .push_on_response(
+                    // Strips headers that may be set by this proxy.
+                    svc::layers()
+                        // .push(http::strip_header::request::layer(L5D_CLIENT_ID))
+                        // .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
+                )
+                // .check_service::<Logical<HttpEndpoint>>()
+                .instrument(|logical: &Logical<_>| info_span!("logical", addr = %logical.addr));
 
-            // // Routes requests to their logical target.
-            // let http_logical_router = svc::stack(http_logical_profile_cache)
-            //     .check_service::<Logical<HttpEndpoint>>()
-            //     .push_on_response(svc::layers().box_http_response())
-            //     .push_make_ready()
-            //     .push_fallback_with_predicate(
-            //         http_concrete
-            //             .push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
-            //                 addr: inner.addr.clone(),
-            //                 inner,
-            //             })
-            //             .push_on_response(svc::layers().box_http_response().box_http_request())
-            //             .check_service::<Logical<HttpEndpoint>>()
-            //             .into_inner(),
-            //         is_discovery_rejected,
-            //     )
-            //     .check_service::<Logical<HttpEndpoint>>()
-            //     // Sets the canonical-dst header on all outbound requests.
-            //     .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
-            //     // Strips headers that may be set by this proxy.
-            //     .push(http::canonicalize::Layer::new(
-            //         dns_refine_cache,
-            //         canonicalize_timeout,
-            //     ))
-            //     .push_on_response(
-            //         // Strips headers that may be set by this proxy.
-            //         svc::layers()
-            //             .push(http::strip_header::request::layer(L5D_CLIENT_ID))
-            //             .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
-            //     )
-            //     .check_service::<Logical<HttpEndpoint>>()
-            //     .instrument(|logical: &Logical<_>| info_span!("logical", addr = %logical.addr));
+            let http_admit_request = svc::layers()
+                // Limits the number of in-flight requests.
+                .push_concurrency_limit(max_in_flight_requests)
+                // Eagerly fail requests when the proxy is out of capacity for a
+                // dispatch_timeout.
+                .push_failfast(dispatch_timeout)
+                .push(metrics.http_errors)
+                // Synthesizes responses for proxy errors.
+                // .push(errors::layer())s
+                // Initiates OpenCensus tracing.
+                .push(TraceContextLayer::new(span_sink.map(|span_sink| {
+                    SpanConverter::server(span_sink, trace_labels())
+                })))
+                // Tracks proxy handletime.
+                // .push(metrics.http_handle_time.layer())
+                ;
 
-            // let http_admit_request = svc::layers()
-            //     // Limits the number of in-flight requests.
-            //     .push_concurrency_limit(max_in_flight_requests)
-            //     // Eagerly fail requests when the proxy is out of capacity for a
-            //     // dispatch_timeout.
-            //     .push_failfast(dispatch_timeout)
-            //     .push(metrics.http_errors)
-            //     // Synthesizes responses for proxy errors.
-            //     .push(errors::layer())
-            //     // Initiates OpenCensus tracing.
-            //     .push(TraceContextLayer::new(span_sink.map(|span_sink| {
-            //         SpanConverter::server(span_sink, trace_labels())
-            //     })))
-            //     // Tracks proxy handletime.
-            //     .push(metrics.http_handle_time.layer());
-
-            // let http_server = http_logical_router
-            //     .check_service::<Logical<HttpEndpoint>>()
-            //     .push_make_ready()
-            //     .push_timeout(dispatch_timeout)
-            //     .push(router::Layer::new(LogicalPerRequest::from))
-            //     // Used by tap.
-            //     .push_http_insert_target()
-            //     .push_on_response(http_admit_request)
-            //     .push_on_response(metrics.stack.layer(stack_labels("source")))
-            //     .instrument(
-            //         |src: &tls::accept::Meta| {
-            //             info_span!("source", target.addr = %src.addrs.target_addr())
-            //         },
-            //     )
-            //     .check_new_service::<tls::accept::Meta>();
+            let http_server = http_logical_router
+                // .check_service::<Logical<HttpEndpoint>>()
+                .push_make_ready()
+                .push_timeout(dispatch_timeout)
+                .push(router::Layer::new(LogicalPerRequest::from))
+                // // Used by tap.
+                // .push_http_insert_target()
+                .push_on_response(http_admit_request)
+                .push_on_response(metrics.stack.layer(stack_labels("source")))
+                .instrument(
+                    |src: &tls::accept::Meta| {
+                        info_span!("source", target.addr = %src.addrs.target_addr())
+                    },
+                )
+                .check_new_service::<tls::accept::Meta>();
 
             let http_server = |_| {
                 tower::service_fn(move |_: http::Request<_>| async {

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -81,7 +81,7 @@ impl Config {
     pub fn build<R, P>(
         self,
         local_identity: tls::Conditional<identity::Local>,
-        // resolve: R,
+        resolve: R,
         dns_resolver: dns::Resolver,
         // profiles_client: P,
         // tap_layer: tap::Layer,
@@ -250,6 +250,8 @@ where
             //                     .push_failfast(dispatch_timeout)
             //                     // Shares the balancer, ensuring discovery errors are propagated.
             //                     .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
+            //                     .box_http_request()
+            //                     .push(metrics.stack.layer(stack_labels("forward.endpoint"))),
             //             ),
             //     )
             //     .instrument(|endpoint: &Target<HttpEndpoint>| {
@@ -259,7 +261,178 @@ where
             //         addr: t.addr.into(),
             //         inner: t.inner.inner,
             //     })
-            // };
+            //     .check_service::<Concrete<HttpEndpoint>>()
+            //     // Ensure that buffers don't hold the cache's lock in poll_ready.
+            //     .push_oneshot();
+
+            // // If the balancer fails to be created, i.e., because it is unresolvable, fall back to
+            // // using a router that dispatches request to the application-selected original destination.
+            // let http_concrete = http_balancer
+            //     .push_map_target(|c: Concrete<HttpEndpoint>| c.map(|l| l.map(|e| e.settings)))
+            //     .check_service::<Concrete<HttpEndpoint>>()
+            //     .push_on_response(svc::layers().box_http_response())
+            //     .push_make_ready()
+            //     .push_fallback_with_predicate(
+            //         http_forward_cache
+            //             .push_on_response(svc::layers().box_http_response())
+            //             .into_inner(),
+            //         is_discovery_rejected,
+            //     )
+            //     .check_service::<Concrete<HttpEndpoint>>();
+
+            // let http_profile_route_proxy = svc::proxies()
+            //     .check_new_clone_service::<dst::Route>()
+            //     .push(metrics.http_route_actual.into_layer::<classify::Response>())
+            //     // Sets an optional retry policy.
+            //     .push(retry::layer(metrics.http_route_retry))
+            //     .check_new_clone_service::<dst::Route>()
+            //     // Sets an optional request timeout.
+            //     .push(http::MakeTimeoutLayer::default())
+            //     .check_new_clone_service::<dst::Route>()
+            //     // Records per-route metrics.
+            //     .push(metrics.http_route.into_layer::<classify::Response>())
+            //     .check_new_clone_service::<dst::Route>()
+            //     // Sets the per-route response classifier as a request
+            //     // extension.
+            //     .push(classify::Layer::new())
+            //     .check_new_clone_service::<dst::Route>();
+
+            // // Routes `Logical` targets to a cached `Profile` stack, i.e. so that profile
+            // // resolutions are shared even as the type of request may vary.
+            // let http_logical_profile_cache = http_concrete
+            //     .clone()
+            //     .push_on_response(svc::layers().box_http_request())
+            //     .check_service::<Concrete<HttpEndpoint>>()
+            //     // Provides route configuration. The profile service operates
+            //     // over `Concret` services. When overrides are in play, the
+            //     // Concrete destination may be overridden.
+            //     .push(profiles::Layer::with_overrides(
+            //         profiles_client,
+            //         http_profile_route_proxy.into_inner(),
+            //     ))
+            //     .check_make_service::<Profile, Concrete<HttpEndpoint>>()
+            //     // Use the `Logical` target as a `Concrete` target. It may be
+            //     // overridden by the profile layer.
+            //     .push_on_response(
+            //         svc::layers().push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
+            //             addr: inner.addr.clone(),
+            //             inner,
+            //         }),
+            //     )
+            //     .into_new_service()
+            //     .cache(
+            //         svc::layers().push_on_response(
+            //             svc::layers()
+            //                 // If the service has been unavailable for an extended time, eagerly
+            //                 // fail requests.
+            //                 .push_failfast(dispatch_timeout)
+            //                 // Shares the service, ensuring discovery errors are propagated.
+            //                 .push_spawn_buffer_with_idle_timeout(
+            //                     buffer_capacity,
+            //                     cache_max_idle_age,
+            //                 )
+            //                 .push(metrics.stack.layer(stack_labels("profile"))),
+            //         ),
+            //     )
+            //     .instrument(|_: &Profile| info_span!("profile"))
+            //     // Ensures that the cache isn't locked when polling readiness.
+            //     .push_oneshot()
+            //     .check_make_service::<Profile, Logical<HttpEndpoint>>()
+            //     .push(router::Layer::new(|()| ProfilePerTarget))
+            //     .check_new_service_routes::<(), Logical<HttpEndpoint>>()
+            //     .new_service(());
+
+            // // Caches DNS refinements from relative names to canonical names.
+            // //
+            // // For example, a client may send requests to `foo` or `foo.ns`; and the canonical form
+            // // of these names is `foo.ns.svc.cluster.local
+            // let dns_refine_cache = svc::stack(dns_resolver.into_make_refine())
+            //     .cache(
+            //         svc::layers().push_on_response(
+            //             svc::layers()
+            //                 // If the service has been unavailable for an extended time, eagerly
+            //                 // fail requests.
+            //                 .push_failfast(dispatch_timeout)
+            //                 // Shares the service, ensuring discovery errors are propagated.
+            //                 .push_spawn_buffer_with_idle_timeout(
+            //                     buffer_capacity,
+            //                     cache_max_idle_age,
+            //                 )
+            //                 .push(metrics.stack.layer(stack_labels("canonicalize"))),
+            //         ),
+            //     )
+            //     .instrument(|name: &dns::Name| info_span!("canonicalize", %name))
+            //     // Obtains the service, advances the state of the resolution
+            //     .push(svc::make_response::Layer)
+            //     // Ensures that the cache isn't locked when polling readiness.
+            //     .push_oneshot()
+            //     .check_service_response::<dns::Name, dns::Name>()
+            //     .into_inner();
+
+            // // Routes requests to their logical target.
+            // let http_logical_router = svc::stack(http_logical_profile_cache)
+            //     .check_service::<Logical<HttpEndpoint>>()
+            //     .push_on_response(svc::layers().box_http_response())
+            //     .push_make_ready()
+            //     .push_fallback_with_predicate(
+            //         http_concrete
+            //             .push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
+            //                 addr: inner.addr.clone(),
+            //                 inner,
+            //             })
+            //             .push_on_response(svc::layers().box_http_response().box_http_request())
+            //             .check_service::<Logical<HttpEndpoint>>()
+            //             .into_inner(),
+            //         is_discovery_rejected,
+            //     )
+            //     .check_service::<Logical<HttpEndpoint>>()
+            //     // Sets the canonical-dst header on all outbound requests.
+            //     .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
+            //     // Strips headers that may be set by this proxy.
+            //     .push(http::canonicalize::Layer::new(
+            //         dns_refine_cache,
+            //         canonicalize_timeout,
+            //     ))
+            //     .push_on_response(
+            //         // Strips headers that may be set by this proxy.
+            //         svc::layers()
+            //             .push(http::strip_header::request::layer(L5D_CLIENT_ID))
+            //             .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
+            //     )
+            //     .check_service::<Logical<HttpEndpoint>>()
+            //     .instrument(|logical: &Logical<_>| info_span!("logical", addr = %logical.addr));
+
+            // let http_admit_request = svc::layers()
+            //     // Limits the number of in-flight requests.
+            //     .push_concurrency_limit(max_in_flight_requests)
+            //     // Eagerly fail requests when the proxy is out of capacity for a
+            //     // dispatch_timeout.
+            //     .push_failfast(dispatch_timeout)
+            //     .push(metrics.http_errors)
+            //     // Synthesizes responses for proxy errors.
+            //     .push(errors::layer())
+            //     // Initiates OpenCensus tracing.
+            //     .push(TraceContextLayer::new(span_sink.map(|span_sink| {
+            //         SpanConverter::server(span_sink, trace_labels())
+            //     })))
+            //     // Tracks proxy handletime.
+            //     .push(metrics.http_handle_time.layer());
+
+            // let http_server = http_logical_router
+            //     .check_service::<Logical<HttpEndpoint>>()
+            //     .push_make_ready()
+            //     .push_timeout(dispatch_timeout)
+            //     .push(router::Layer::new(LogicalPerRequest::from))
+            //     // Used by tap.
+            //     .push_http_insert_target()
+            //     .push_on_response(http_admit_request)
+            //     .push_on_response(metrics.stack.layer(stack_labels("source")))
+            //     .instrument(
+            //         |src: &tls::accept::Meta| {
+            //             info_span!("source", target.addr = %src.addrs.target_addr())
+            //         },
+            //     )
+            //     .check_new_service::<tls::accept::Meta>();
 
             let http_server = |_| {
                 tower::service_fn(move |_: http::Request<_>| async {

--- a/linkerd/app/src/dst/resolve.rs
+++ b/linkerd/app/src/dst/resolve.rs
@@ -3,7 +3,10 @@ use ipnet::{Contains, IpNet};
 use linkerd2_app_core::{
     dns::Suffix,
     exp_backoff::{ExponentialBackoff, ExponentialBackoffStream},
-    proxy::{api_resolve as api, resolve::{self, recover}},
+    proxy::{
+        api_resolve as api,
+        resolve::{self, recover},
+    },
     request_filter, Addr, DiscoveryRejected, Error, Recover,
 };
 use linkerd2_app_outbound::Target;

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -184,11 +184,12 @@ impl Config {
             // let oc = oc_collector.span_sink();
             info_span!("outbound").in_scope(move || {
                 outbound.build::<_, ()>(
-                    identity, 
+                    identity,
                     dst.resolve,
-                    dns,      // dst.profiles,
+                    dns, // dst.profiles,
                     //tap,
-                    metrics, None, //oc,
+                    metrics,
+                    None, //oc,
                     drain_rx,
                 )
             })?

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -183,8 +183,9 @@ impl Config {
             let metrics = metrics.outbound;
             // let oc = oc_collector.span_sink();
             info_span!("outbound").in_scope(move || {
-                outbound.build::<(), ()>(
-                    identity, // dst.resolve,
+                outbound.build(
+                    identity, 
+                    dst.resolve,
                     dns,      // dst.profiles,
                     //tap,
                     metrics, None, //oc,

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -183,7 +183,7 @@ impl Config {
             let metrics = metrics.outbound;
             // let oc = oc_collector.span_sink();
             info_span!("outbound").in_scope(move || {
-                outbound.build(
+                outbound.build::<_, ()>(
                     identity, 
                     dst.resolve,
                     dns,      // dst.profiles,

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -11,7 +11,7 @@ Implements the Resolve trait using the proxy's gRPC API
 [dependencies]
 futures = "0.3"
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "eliza/tonic" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "8b400dee750671b41cb24dcea23e5cceb6188301" }
 linkerd2-proxy-core = { path = "../core" }
 prost = "0.6"
 http = "0.2"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -11,7 +11,7 @@ Implements the Resolve trait using the proxy's gRPC API
 [dependencies]
 futures = "0.3"
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "8b400dee750671b41cb24dcea23e5cceb6188301" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "c2dba642c7301b5b562c75fd6e2bd0a12ec763e8" }
 linkerd2-proxy-core = { path = "../core" }
 prost = "0.6"
 http = "0.2"

--- a/linkerd/proxy/resolve/src/lib.rs
+++ b/linkerd/proxy/resolve/src/lib.rs
@@ -2,3 +2,5 @@
 
 pub mod map_endpoint;
 pub mod recover;
+pub mod make_unpin;
+pub use make_unpin::make_unpin;

--- a/linkerd/proxy/resolve/src/lib.rs
+++ b/linkerd/proxy/resolve/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
 
+pub mod make_unpin;
 pub mod map_endpoint;
 pub mod recover;
-pub mod make_unpin;
 pub use make_unpin::make_unpin;

--- a/linkerd/proxy/resolve/src/make_unpin.rs
+++ b/linkerd/proxy/resolve/src/make_unpin.rs
@@ -1,0 +1,64 @@
+
+use linkerd2_proxy_core::resolve::{Resolution, self, Update};
+use std::pin::Pin;
+use std::task::{Poll, Context};
+use std::future::Future;
+use futures::TryFuture;
+use pin_project::pin_project;
+
+pub fn make_unpin<R>(r: R) -> Resolve<R> {
+    Resolve(r)
+}
+
+#[derive(Clone)]
+pub struct Resolve<T>(T);
+
+#[pin_project]
+pub struct MakeUnpin<T>(Pin<Box<T>>);
+
+impl<T, S> tower::Service<T> for Resolve<S>
+where
+    S: resolve::Resolve<T>,
+{
+    type Response = MakeUnpin<S::Resolution>;
+    type Error = S::Error;
+    type Future = MakeUnpin<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.0.poll_ready(cx)
+    }
+
+    fn call(&mut self, target: T) -> Self::Future {
+        MakeUnpin::new(self.0.resolve(target))
+    }
+}
+
+
+impl<T> MakeUnpin<T> {
+    fn new(t: T) -> Self {
+        Self(Box::pin(t))
+    }
+}
+
+impl<T: Resolution> Resolution for MakeUnpin<T> {
+    type Endpoint = T::Endpoint;
+    type Error = T::Error;
+
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Update<Self::Endpoint>, Self::Error>> {
+        self.project().0.as_mut().as_mut().poll(cx)
+    }
+}
+
+impl<T: TryFuture> Future for MakeUnpin<T> {
+    type Output = Result<MakeUnpin<T::Ok>, T::Error>;
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Self::Output> {
+        let res = futures::ready!(Pin::as_mut(self.project().0).try_poll(cx))?;
+        Poll::Ready(Ok(MakeUnpin::new(res)))
+    }
+}

--- a/linkerd/proxy/resolve/src/recover.rs
+++ b/linkerd/proxy/resolve/src/recover.rs
@@ -75,7 +75,12 @@ enum State<F, R: resolve::Resolution, B> {
 
 // === impl Resolve ===
 
-impl<E, R> Resolve<E, R> {
+impl<E, R> Resolve<E, R> 
+where
+R: Clone,
+E: Recover + Clone,
+E::Backoff: Unpin,
+{
     pub fn new(recover: E, resolve: R) -> Self {
         Self { resolve, recover }
     }

--- a/linkerd/proxy/resolve/src/recover.rs
+++ b/linkerd/proxy/resolve/src/recover.rs
@@ -75,12 +75,7 @@ enum State<F, R: resolve::Resolution, B> {
 
 // === impl Resolve ===
 
-impl<E, R> Resolve<E, R> 
-where
-R: Clone,
-E: Recover + Clone,
-E::Backoff: Unpin,
-{
+impl<E, R> Resolve<E, R> {
     pub fn new(recover: E, resolve: R) -> Self {
         Self { resolve, recover }
     }

--- a/linkerd/request-filter/Cargo.toml
+++ b/linkerd/request-filter/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.1"
-tower = "0.1"
+futures = "0.3"
+tower = { version = "0.3", default-features = false }
 tracing = "0.1"
+linkerd2-error = { path = "../error" }
+pin-project = "0.4"

--- a/linkerd/request-filter/src/lib.rs
+++ b/linkerd/request-filter/src/lib.rs
@@ -3,11 +3,11 @@
 
 #![deny(warnings, rust_2018_idioms)]
 
-use std::future::Future;
-use std::task::{Poll, Context};
-use std::pin::Pin;
 use linkerd2_error::Error;
-use pin_project::{project, pin_project};
+use pin_project::{pin_project, project};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 pub trait RequestFilter<T> {
     type Error: Into<Error>;

--- a/linkerd/request-filter/src/lib.rs
+++ b/linkerd/request-filter/src/lib.rs
@@ -3,9 +3,11 @@
 
 #![deny(warnings, rust_2018_idioms)]
 
-use futures::{Future, Poll};
-
-pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+use std::future::Future;
+use std::task::{Poll, Context};
+use std::pin::Pin;
+use linkerd2_error::Error;
+use pin_project::{project, pin_project};
 
 pub trait RequestFilter<T> {
     type Error: Into<Error>;
@@ -19,9 +21,10 @@ pub struct Service<I, S> {
     service: S,
 }
 
+#[pin_project]
 #[derive(Debug)]
 pub enum ResponseFuture<F> {
-    Future(F),
+    Future(#[pin] F),
     Rejected(Option<Error>),
 }
 
@@ -44,8 +47,8 @@ where
     type Future = ResponseFuture<S::Future>;
 
     #[inline]
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.service.poll_ready().map_err(Into::into)
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx).map_err(Into::into)
     }
 
     fn call(&mut self, request: T) -> Self::Future {
@@ -65,18 +68,19 @@ where
 
 // === impl ResponseFuture ===
 
-impl<F> Future for ResponseFuture<F>
+impl<F, T, E> Future for ResponseFuture<F>
 where
-    F: Future,
-    F::Error: Into<Error>,
+    F: Future<Output = Result<T, E>>,
+    E: Into<Error>,
 {
-    type Item = F::Item;
-    type Error = Error;
+    type Output = Result<T, Error>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self {
-            ResponseFuture::Future(ref mut f) => f.poll().map_err(Into::into),
-            ResponseFuture::Rejected(ref mut e) => Err(e.take().unwrap()),
+    #[project]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        #[project]
+        match self.project() {
+            ResponseFuture::Future(f) => f.poll(cx).map(|r| r.map_err(Into::into)),
+            ResponseFuture::Rejected(e) => Poll::Ready(Err(e.take().unwrap())),
         }
     }
 }


### PR DESCRIPTION
This branch turns the outbound side of the proxy back into a real proxy,
similarly to what #516 did for the inbound side. Getting outbound to
work again was somewhat more complex, since the outbound side also
requires the load balancer (and, therefore, discovery). In order to get
this all working, it was also necessary to update the
`linkerd2-request-filter` crate (which was quite trivial), as it's
necessary for the resolver to work, and to make some changes in the
resolver so that all trait bounds were satisfied.

In addition, now that both inbound and outbound work, we're now able
to re-enable a large amount of the integration tests in the 
`transparency` and `discovery` modules. Some of these tests are still
disabled, as they either depend on service profiles, HTTP upgrades and
orig-proto, or header maniuplation, all of which have yet to be 
updated.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>