### PR TITLE
Add loop detection to inbound & TCP forwarding

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -37,11 +37,14 @@ use tokio::sync::mpsc;
 use tracing::{info, info_span};
 
 mod endpoint;
+mod prevent_loop;
 mod require_identity_for_ports;
 #[allow(dead_code)] // TODO #2597
 mod set_client_id_on_req;
 #[allow(dead_code)] // TODO #2597
 mod set_remote_ip_on_req;
+
+use self::prevent_loop::PreventLoop;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -87,6 +90,8 @@ impl Config {
         let listen = bind.bind().map_err(Error::from)?;
         let listen_addr = listen.listen_addr();
 
+        let prevent_loop = PreventLoop::new(listen_addr.port());
+
         // The stack is served lazily since some layers (notably buffer) spawn
         // tasks from their constructor. This helps to ensure that tasks are
         // spawned on the same runtime as the proxy.
@@ -101,6 +106,7 @@ impl Config {
             // Forwards TCP streams that cannot be decoded as HTTP.
             let tcp_forward = tcp_connect
                 .clone()
+                .push(admit::AdmitLayer::new(prevent_loop))
                 .push_map_target(|meta: tls::accept::Meta| {
                     TcpEndpoint::from(meta.addrs.target_addr())
                 })
@@ -140,6 +146,7 @@ impl Config {
             // An HTTP client is created for each target via the endpoint stack.
             let http_target_cache = http_endpoint
                 .push_map_target(HttpEndpoint::from)
+                .push(admit::AdmitLayer::new(prevent_loop))
                 // Normalizes the URI, i.e. if it was originally in
                 // absolute-form on the outbound side.
                 .push(normalize_uri::layer())

--- a/linkerd/app/inbound/src/prevent_loop.rs
+++ b/linkerd/app/inbound/src/prevent_loop.rs
@@ -1,4 +1,4 @@
-use super::endpoint::{HttpEndpoint, Target, TcpEndpoint};
+use super::endpoint::{Target, TcpEndpoint};
 use linkerd2_app_core::admit;
 
 /// A connection policy that drops
@@ -18,12 +18,12 @@ impl PreventLoop {
     }
 }
 
-impl admit::Admit<Target<HttpEndpoint>> for PreventLoop {
+impl admit::Admit<Target> for PreventLoop {
     type Error = LoopPrevented;
 
-    fn admit(&mut self, ep: &Target<HttpEndpoint>) -> Result<(), Self::Error> {
-        tracing::debug!(addr = %ep.inner.addr, self.port);
-        if ep.inner.addr.ip().is_loopback() && ep.inner.addr.port() == self.port {
+    fn admit(&mut self, ep: &Target) -> Result<(), Self::Error> {
+        tracing::debug!(addr = %ep.addr, self.port);
+        if ep.addr.port() == self.port {
             return Err(LoopPrevented { port: self.port });
         }
 
@@ -35,8 +35,8 @@ impl admit::Admit<TcpEndpoint> for PreventLoop {
     type Error = LoopPrevented;
 
     fn admit(&mut self, ep: &TcpEndpoint) -> Result<(), Self::Error> {
-        tracing::debug!(addr = %ep.addr, self.port);
-        if ep.addr.ip().is_loopback() && ep.addr.port() == self.port {
+        tracing::debug!(port = %ep.port, self.port);
+        if ep.port == self.port {
             return Err(LoopPrevented { port: self.port });
         }
 
@@ -48,7 +48,7 @@ impl std::fmt::Display for LoopPrevented {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "outbound requests must not target localhost:{}",
+            "inboudn requests must not target localhost:{}",
             self.port
         )
     }

--- a/linkerd/app/inbound/src/prevent_loop.rs
+++ b/linkerd/app/inbound/src/prevent_loop.rs
@@ -48,7 +48,7 @@ impl std::fmt::Display for LoopPrevented {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "inboudn requests must not target localhost:{}",
+            "inbound requests must not target localhost:{}",
             self.port
         )
     }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -119,6 +119,7 @@ impl Config {
             // Forwards TCP streams that cannot be decoded as HTTP.
             let tcp_forward = tcp_connect
                 .clone()
+                .push(admit::AdmitLayer::new(PreventLoop::new(listen_addr.port())))
                 .push_map_target(|meta: tls::accept::Meta| {
                     TcpEndpoint::from(meta.addrs.target_addr())
                 })


### PR DESCRIPTION
e77fe181 introduced loop detection to the outbound HTTP proxy. This
change extends this behavior to the inbound HTTP proxy and the TCP
proxy for both inbound and outbound. This helps ensure malicious
requests can't consume proxy resources.