### PR TITLE
update protocol upgrades to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,16 +995,16 @@ name = "linkerd2-app-outbound"
 version = "0.1.0"
 dependencies = [
  "bytes 0.4.11",
- "futures 0.1.26",
+ "futures 0.3.4",
  "http 0.1.21",
  "indexmap",
  "linkerd2-app-core",
  "linkerd2-identity",
  "linkerd2-retry",
+ "pin-project",
  "quickcheck",
  "tokio 0.1.22",
  "tower 0.3.1",
- "tower-grpc",
  "tracing",
 ]
 

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -11,14 +11,14 @@ Configures and runs the outbound proxy
 [dependencies]
 bytes = "0.4"
 http = "0.1"
-futures = "0.1"
+futures = "0.3"
 indexmap = "1.0"
 linkerd2-app-core = { path = "../core" }
 linkerd2-identity = { path = "../../identity" }
 linkerd2-retry = { path = "../../retry" }
 tokio = "0.1.14"
-tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 tracing = "0.1.9"
+pin-project = "0.4"
 
 [dependencies.tower]
 version = "0.3"

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -183,7 +183,7 @@ impl Config {
                     // Ensures that the request's URI is in the proper form.
                     .push(http::normalize_uri::layer())
                     // Upgrades HTTP/1 requests to be transported over HTTP/2 connections.
-                    
+                    //
                     // This sets headers so that the inbound proxy can downgrade the request
                     // properly.
                     .push(OrigProtoUpgradeLayer::new())

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -57,10 +57,10 @@ use tracing::info_span;
 // #[allow(dead_code)] // TODO #2597
 // mod add_server_id_on_rsp;
 mod endpoint;
-// mod orig_proto_upgrade;
+mod orig_proto_upgrade;
 // mod require_identity_on_endpoint;
 
-// use self::orig_proto_upgrade::OrigProtoUpgradeLayer;
+use self::orig_proto_upgrade::OrigProtoUpgradeLayer;
 // use self::require_identity_on_endpoint::MakeRequireIdentityLayer;
 
 const EWMA_DEFAULT_RTT: Duration = Duration::from_millis(30);
@@ -183,10 +183,10 @@ impl Config {
                     // Ensures that the request's URI is in the proper form.
                     .push(http::normalize_uri::layer())
                     // Upgrades HTTP/1 requests to be transported over HTTP/2 connections.
-                    //
+                    
                     // This sets headers so that the inbound proxy can downgrade the request
                     // properly.
-                    // .push(OrigProtoUpgradeLayer::new())
+                    .push(OrigProtoUpgradeLayer::new())
                     // .check_service::<Target<HttpEndpoint>>()
                     .instrument(|endpoint: &Target<HttpEndpoint>| {
                         info_span!("endpoint", peer.addr = %endpoint.inner.addr)

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -57,10 +57,10 @@ use tracing::info_span;
 // #[allow(dead_code)] // TODO #2597
 // mod add_server_id_on_rsp;
 mod endpoint;
-// mod orig_proto_upgrade;
+mod orig_proto_upgrade;
 // mod require_identity_on_endpoint;
 
-// use self::orig_proto_upgrade::OrigProtoUpgradeLayer;
+use self::orig_proto_upgrade::OrigProtoUpgradeLayer;
 // use self::require_identity_on_endpoint::MakeRequireIdentityLayer;
 
 const EWMA_DEFAULT_RTT: Duration = Duration::from_millis(30);
@@ -173,20 +173,20 @@ impl Config {
                     // HTTP/1.x fallback is supported as needed.
                     .push(http::MakeClientLayer::new(connect.h2_settings))
                     // Re-establishes a connection when the client fails.
-                    .push(reconnect::layer({
-                        let backoff = connect.backoff.clone();
-                        move |_| Ok(backoff.stream())
-                    }))
+                    // .push(reconnect::layer({
+                    //     let backoff = connect.backoff.clone();
+                    //     move |_| Ok(backoff.stream())
+                    // }))
                     .push(observability.clone())
                     .push(identity_headers.clone())
                     // .push(http::override_authority::Layer::new(vec![HOST.as_str(), CANONICAL_DST_HEADER]))
                     // Ensures that the request's URI is in the proper form.
                     .push(http::normalize_uri::layer())
                     // Upgrades HTTP/1 requests to be transported over HTTP/2 connections.
-                    //
+                    
                     // This sets headers so that the inbound proxy can downgrade the request
                     // properly.
-                    // .push(OrigProtoUpgradeLayer::new())
+                    .push(OrigProtoUpgradeLayer::new())
                     // .check_service::<Target<HttpEndpoint>>()
                     .instrument(|endpoint: &Target<HttpEndpoint>| {
                         info_span!("endpoint", peer.addr = %endpoint.inner.addr)
@@ -451,7 +451,7 @@ impl Config {
 
             let tcp_server = Server::new(
                 TransportLabels,
-                metrics.transport,
+                // metrics.transport,
                 tcp_forward.into_inner(),
                 http_server.into_inner(),
                 h2_settings,

--- a/linkerd/app/outbound/src/orig_proto_upgrade.rs
+++ b/linkerd/app/outbound/src/orig_proto_upgrade.rs
@@ -5,12 +5,12 @@ use crate::proxy::http::{
 use crate::svc::stack;
 use crate::{HttpEndpoint, Target};
 use futures::{ready, TryFuture};
-use pin_project::pin_project;
 use std::future::Future;
-use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::pin::Pin;
 use tower::util::Either;
 use tracing::trace;
+use pin_project::pin_project;
 
 #[derive(Clone, Debug, Default)]
 pub struct OrigProtoUpgradeLayer(());
@@ -120,7 +120,7 @@ where
             let upgrade = orig_proto::Upgrade::new(inner, *this.was_absolute);
             Poll::Ready(Ok(Either::A(upgrade)))
         } else {
-            Poll::Ready(Ok(Either::B(inner)))
+           Poll::Ready(Ok(Either::B(inner)))
         }
     }
 }

--- a/linkerd/app/outbound/src/orig_proto_upgrade.rs
+++ b/linkerd/app/outbound/src/orig_proto_upgrade.rs
@@ -5,12 +5,12 @@ use crate::proxy::http::{
 use crate::svc::stack;
 use crate::{HttpEndpoint, Target};
 use futures::{ready, TryFuture};
+use pin_project::pin_project;
 use std::future::Future;
-use std::task::{Context, Poll};
 use std::pin::Pin;
+use std::task::{Context, Poll};
 use tower::util::Either;
 use tracing::trace;
-use pin_project::pin_project;
 
 #[derive(Clone, Debug, Default)]
 pub struct OrigProtoUpgradeLayer(());
@@ -120,7 +120,7 @@ where
             let upgrade = orig_proto::Upgrade::new(inner, *this.was_absolute);
             Poll::Ready(Ok(Either::A(upgrade)))
         } else {
-           Poll::Ready(Ok(Either::B(inner)))
+            Poll::Ready(Ok(Either::B(inner)))
         }
     }
 }

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -15,7 +15,7 @@ pub mod h2;
 // pub mod header_from_target;
 // pub mod insert;
 pub mod normalize_uri;
-// pub mod orig_proto;
+pub mod orig_proto;
 // pub mod override_authority;
 pub mod settings;
 // pub mod strip_header;

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -1,12 +1,12 @@
 use super::h1;
 use futures_03::{future, ready, TryFuture, TryFutureExt};
-use http;
-use http::header::{HeaderValue, TRANSFER_ENCODING};
-use pin_project::pin_project;
+use std::task::{Context, Poll};
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use http;
+use http::header::{HeaderValue, TRANSFER_ENCODING};
 use tracing::{debug, warn};
+use pin_project::pin_project;
 
 pub const L5D_ORIG_PROTO: &str = "l5d-orig-proto";
 

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -1,8 +1,12 @@
 use super::h1;
-use futures::{future, try_ready, Future, Poll};
+use futures_03::{future, ready, TryFuture, TryFutureExt};
+use std::task::{Context, Poll};
+use std::future::Future;
+use std::pin::Pin;
 use http;
 use http::header::{HeaderValue, TRANSFER_ENCODING};
 use tracing::{debug, warn};
+use pin_project::pin_project;
 
 pub const L5D_ORIG_PROTO: &str = "l5d-orig-proto";
 
@@ -39,8 +43,8 @@ where
     type Error = S::Error;
     type Future = UpgradeFuture<S::Future>;
 
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.inner.poll_ready()
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, mut req: http::Request<A>) -> Self::Future {
@@ -77,20 +81,22 @@ where
     }
 }
 
+#[pin_project]
 pub struct UpgradeFuture<F> {
     version: http::Version,
+    #[pin]
     inner: F,
 }
 
 impl<F, B> Future for UpgradeFuture<F>
 where
-    F: Future<Item = http::Response<B>>,
+    F: TryFuture<Ok = http::Response<B>>,
 {
-    type Item = F::Item;
-    type Error = F::Error;
+    type Output = Result<F::Ok, F::Error>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let mut res = try_ready!(self.inner.poll());
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let mut res = ready!(this.inner.try_poll(cx))?;
         let version = res
             .headers_mut()
             .remove(L5D_ORIG_PROTO)
@@ -103,10 +109,10 @@ where
                     None
                 }
             })
-            .unwrap_or(self.version);
+            .unwrap_or(*this.version);
         debug!("Downgrading response to {:?}", version);
         *res.version_mut() = version;
-        Ok(res.into())
+        Poll::Ready(Ok(res.into()))
     }
 }
 
@@ -127,10 +133,10 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = future::Map<S::Future, fn(S::Response) -> S::Response>;
+    type Future = future::MapOk<S::Future, fn(S::Response) -> S::Response>;
 
-    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-        self.inner.poll_ready()
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
     }
 
     fn call(&mut self, mut req: http::Request<A>) -> Self::Future {
@@ -160,7 +166,7 @@ where
         let fut = self.inner.call(req);
 
         if upgrade_response {
-            fut.map(|mut res| {
+            fut.map_ok(|mut res| {
                 let orig_proto = if res.version() == http::Version::HTTP_11 {
                     "HTTP/1.1"
                 } else if res.version() == http::Version::HTTP_10 {
@@ -179,7 +185,7 @@ where
                 res
             })
         } else {
-            fut.map(|res| res)
+            fut.map_ok(|res| res)
         }
     }
 }

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -1,12 +1,12 @@
 use super::h1;
 use futures_03::{future, ready, TryFuture, TryFutureExt};
-use std::task::{Context, Poll};
-use std::future::Future;
-use std::pin::Pin;
 use http;
 use http::header::{HeaderValue, TRANSFER_ENCODING};
-use tracing::{debug, warn};
 use pin_project::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tracing::{debug, warn};
 
 pub const L5D_ORIG_PROTO: &str = "l5d-orig-proto";
 


### PR DESCRIPTION
This branch updates the `l5d-orig-proto` upgrade/downgrade code to use
`std::future`, and puts it back in the stack.

It turns out that the integration tests that exercise this don't
actually assert that an upgrade is _performed_ when the hint is sent,
just that sending the hint doesn't _break_ proxy-to-proxy traffic (which
is a bummer, but it's hard to assert that in an integration test). So,
those tests were passing before this branch.

However, I validated that the upgrade is performed by checking the logs:

```
[     0.73767491s] DEBUG proxy{test=main:proxy}:outbound:accept{peer.addr=127.0.0.1:60420}:source{target.addr=127.0.0.1:34913}:logical{addr=transparency.test.svc.cluster.local:80}:balance{addr=transparency.test.svc.cluster.local:80}:endpoint{peer.addr=127.0.0.1:34885}: linkerd2_proxy_transport::connect: Connected local.addr=127.0.0.1:50732 keepalive=None
[     0.73871743s] DEBUG proxy{test=main:proxy}:outbound:accept{peer.addr=127.0.0.1:60420}:source{target.addr=127.0.0.1:34913}:logical{addr=transparency.test.svc.cluster.local:80}:balance{addr=transparency.test.svc.cluster.local:80}:endpoint{peer.addr=127.0.0.1:34885}: linkerd2_proxy_transport::metrics: client connection open
[     0.74886384s] DEBUG proxy{test=main:proxy}:outbound:accept{peer.addr=127.0.0.1:60420}:source{target.addr=127.0.0.1:34913}:logical{addr=transparency.test.svc.cluster.local:80}:balance{addr=transparency.test.svc.cluster.local:80}: linkerd2_timeout::failfast: Recovered
[     0.75516939s] DEBUG proxy{test=main:proxy}:outbound:accept{peer.addr=127.0.0.1:60420}:source{target.addr=127.0.0.1:34913}:logical{addr=transparency.test.svc.cluster.local:80}:balance{addr=transparency.test.svc.cluster.local:80}:endpoint{peer.addr=127.0.0.1:34885}: linkerd2_proxy_http::orig_proto: Upgrading request to HTTP2 from HTTP/1.1
[     0.75671201s] DEBUG proxy{test=main:proxy}:outbound:accept{peer.addr=127.0.0.1:60420}:source{target.addr=127.0.0.1:34913}:logical{addr=transparency.test.svc.cluster.local:80}:balance{addr=transparency.test.svc.cluster.local:80}:endpoint{peer.addr=127.0.0.1:34885}: linkerd2_proxy_http::client: method=POST uri=/ version=HTTP/2.0 headers={"l5d-orig-proto": "HTTP/1.1", "host": "transparency.test.svc.cluster.local"}
[     0.77214679s] DEBUG proxy{test=main:proxy}:outbound:accept{peer.addr=127.0.0.1:60420}:source{target.addr=127.0.0.1:34913}:logical{addr=transparency.test.svc.cluster.local:80}:balance{addr=transparency.test.svc.cluster.local:80}: linkerd2_timeout::failfast: Recovered
[     0.143665402s] DEBUG proxy{test=main:proxy}:inbound:accept{peer.addr=127.0.0.1:50732}:source{target.addr=127.0.0.1:39975}:linkerd2_proxy_http::orig_proto: translating HTTP2 to orig-proto: "HTTP/1.1"
```

Depends on #526