### PR TITLE
Update strip_header to std::future

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -23,7 +23,7 @@ use linkerd2_app_core::{
     proxy::{
         self,
         detect::DetectProtocolLayer,
-        http::{self, normalize_uri /* orig_proto, strip_header*/},
+        http::{self, normalize_uri /* orig_proto */, strip_header},
         identity,
         server::{Protocol as ServerProtocol, ProtocolDetect, Server},
         tap, tcp,
@@ -221,10 +221,10 @@ impl Config {
                 ;
 
             // Strips headers that may be set by the inbound router.
-            // let http_strip_headers = svc::layers()
-            //     .push(strip_header::request::layer(L5D_REMOTE_IP))
-            //     .push(strip_header::request::layer(L5D_CLIENT_ID))
-            //     .push(strip_header::response::layer(L5D_SERVER_ID));
+            let http_strip_headers = svc::layers()
+                .push(strip_header::request::layer(L5D_REMOTE_IP))
+                .push(strip_header::request::layer(L5D_CLIENT_ID))
+                .push(strip_header::response::layer(L5D_SERVER_ID));
 
             // Handles requests as they are initially received by the proxy.
             let http_admit_request = svc::layers()
@@ -262,7 +262,7 @@ impl Config {
                 .push_timeout(dispatch_timeout)
                 // Removes the override header after it has been used to
                 // determine a reuquest target.
-                // .push_on_response(strip_header::request::layer(DST_OVERRIDE_HEADER))
+                .push_on_response(strip_header::request::layer(DST_OVERRIDE_HEADER))
                 // Routes each request to a target, obtains a service for that
                 // target, and dispatches the request.
                 .instrument_from_target()
@@ -270,7 +270,7 @@ impl Config {
                 .check_new_service::<tls::accept::Meta>()
                 // Used by tap.
                 // .push_http_insert_target()
-                // .push_on_response(http_strip_headers)
+                .push_on_response(http_strip_headers)
                 // .push_on_response(http_admit_request)
                 // .push_on_response(http_server_observability)
                 .push_on_response(metrics.stack.layer(stack_labels("source")))

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -279,7 +279,6 @@ macro_rules! generate_tests {
             const IP_2: &'static str = "127.0.0.1";
 
             #[test]
-            #[cfg_attr(not(feature = "nyi"), ignore)]
             fn outbound_should_strip() {
                 let _ = trace_init();
                 let header = HeaderValue::from_static(IP_1);
@@ -300,7 +299,6 @@ macro_rules! generate_tests {
             }
 
             #[test]
-            #[cfg_attr(not(feature = "nyi"), ignore)]
             fn inbound_should_strip() {
                 let _ = trace_init();
                 let header = HeaderValue::from_static(IP_1);
@@ -566,7 +564,6 @@ macro_rules! generate_tests {
             }
 
             #[tokio::test]
-            #[cfg_attr(not(feature = "nyi"), ignore)]
             async fn inbound_still_routes_to_orig_dst() {
                 let mut fixture = Fixture::new();
                 let proxy = fixture.proxy()
@@ -680,7 +677,6 @@ mod proxy_to_proxy {
     use super::*;
 
     #[test]
-    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_http1() {
         let _ = trace_init();
 
@@ -743,7 +739,6 @@ mod proxy_to_proxy {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_should_strip_l5d_client_id() {
         let _ = trace_init();
 
@@ -770,7 +765,6 @@ mod proxy_to_proxy {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_should_strip_l5d_client_id() {
         let _ = trace_init();
 
@@ -798,7 +792,6 @@ mod proxy_to_proxy {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn inbound_should_strip_l5d_server_id() {
         let _ = trace_init();
 
@@ -828,7 +821,6 @@ mod proxy_to_proxy {
     }
 
     #[test]
-    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_should_strip_l5d_server_id() {
         let _ = trace_init();
 

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -672,6 +672,7 @@ mod proxy_to_proxy {
     use super::*;
 
     #[test]
+    #[cfg_attr(not(feature = "nyi"), ignore)]
     fn outbound_http1() {
         let _ = trace_init();
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -405,12 +405,12 @@ impl Config {
                 //         dns_refine_cache,
                 //         canonicalize_timeout,
                 //     ))
-                //     .push_on_response(
-                //         // Strips headers that may be set by this proxy.
-                //         svc::layers()
-                //             .push(http::strip_header::request::layer(L5D_CLIENT_ID))
-                //             .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
-                //     )
+                .push_on_response(
+                    // Strips headers that may be set by this proxy.
+                    svc::layers()
+                        .push(http::strip_header::request::layer(L5D_CLIENT_ID))
+                        .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
+                )
                 .check_service::<Logical<HttpEndpoint>>()
                 .instrument(|logical: &Logical<_>| info_span!("logical", addr = %logical.addr));
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -155,13 +155,12 @@ where
 
             //     // Checks the headers to validate that a client-specified required
             //     // identity matches the configured identity.
-            //     let identity_headers = svc::layers()
-            //         .push_on_response(
-            //             svc::layers()
-            //                 .push(http::strip_header::response::layer(L5D_REMOTE_IP))
-            //                 .push(http::strip_header::response::layer(L5D_SERVER_ID))
-            //                 .push(http::strip_header::request::layer(L5D_REQUIRE_ID)),
-            //         )
+            let identity_headers = svc::layers().push_on_response(
+                svc::layers()
+                    .push(http::strip_header::response::layer(L5D_REMOTE_IP))
+                    .push(http::strip_header::response::layer(L5D_SERVER_ID))
+                    .push(http::strip_header::request::layer(L5D_REQUIRE_ID)),
+            );
             //         .push(MakeRequireIdentityLayer::new());
 
             //     tcp_connect

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -18,7 +18,7 @@ pub mod normalize_uri;
 // pub mod orig_proto;
 // pub mod override_authority;
 pub mod settings;
-// pub mod strip_header;
+pub mod strip_header;
 pub mod timeout;
 pub mod upgrade;
 mod version;

--- a/linkerd/proxy/http/src/strip_header.rs
+++ b/linkerd/proxy/http/src/strip_header.rs
@@ -157,7 +157,7 @@ pub mod response {
             let this = self.project();
             let mut res = ready!(this.inner.try_poll(cx))?;
             res.headers_mut().remove(this.header.clone());
-            Poll::Ready(Ok(res.into()))
+            Poll::Ready(Ok(res))
         }
     }
 }

--- a/linkerd/proxy/http/src/strip_header.rs
+++ b/linkerd/proxy/http/src/strip_header.rs
@@ -44,10 +44,10 @@ where
 }
 
 pub mod request {
-    use futures::Poll;
     use http;
     use http::header::AsHeaderName;
     use linkerd2_stack::Proxy;
+    use std::task::{Context, Poll};
 
     pub fn layer<H>(header: H) -> super::Layer<H, ReqHeader>
     where
@@ -86,8 +86,8 @@ pub mod request {
         type Error = S::Error;
         type Future = S::Future;
 
-        fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-            self.inner.poll_ready()
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
         }
 
         fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
@@ -98,9 +98,13 @@ pub mod request {
 }
 
 pub mod response {
-    use futures::{try_ready, Future, Poll};
+    use futures_03::{ready, Future, TryFuture};
     use http;
     use http::header::AsHeaderName;
+    use linkerd2_error::Error;
+    use pin_project::pin_project;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
 
     pub fn layer<H>(header: H) -> super::Layer<H, ResHeader>
     where
@@ -113,7 +117,9 @@ pub mod response {
     #[derive(Clone, Debug)]
     pub enum ResHeader {}
 
+    #[pin_project]
     pub struct ResponseFuture<F, H> {
+        #[pin]
         inner: F,
         header: H,
     }
@@ -122,13 +128,14 @@ pub mod response {
     where
         H: AsHeaderName + Clone,
         S: tower::Service<Req, Response = http::Response<B>>,
+        S::Error: Into<Error> + Send + Sync,
     {
         type Response = S::Response;
         type Error = S::Error;
         type Future = ResponseFuture<S::Future, H>;
 
-        fn poll_ready(&mut self) -> Poll<(), Self::Error> {
-            self.inner.poll_ready()
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
         }
 
         fn call(&mut self, req: Req) -> Self::Future {
@@ -141,16 +148,16 @@ pub mod response {
 
     impl<F, H, B> Future for ResponseFuture<F, H>
     where
-        F: Future<Item = http::Response<B>>,
+        F: TryFuture<Ok = http::Response<B>>,
         H: AsHeaderName + Clone,
     {
-        type Item = F::Item;
-        type Error = F::Error;
+        type Output = Result<F::Ok, F::Error>;
 
-        fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-            let mut res = try_ready!(self.inner.poll());
-            res.headers_mut().remove(self.header.clone());
-            Ok(res.into())
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = self.project();
+            let mut res = ready!(this.inner.try_poll(cx))?;
+            res.headers_mut().remove(this.header.clone());
+            Poll::Ready(Ok(res.into()))
         }
     }
 }


### PR DESCRIPTION
This branch updates `proxy::app::strip_header` module to `std::future`. It is a fairly straightforward change!

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>