### PR TITLE
put back transport metrics

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -283,7 +283,7 @@ impl Config {
 
             let tcp_server = Server::new(
                 TransportLabels,
-                // metrics.transport,
+                metrics.transport,
                 tcp_forward.into_inner(),
                 http_server.into_inner(),
                 h2_settings,

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -451,7 +451,7 @@ impl Config {
 
             let tcp_server = Server::new(
                 TransportLabels,
-                // metrics.transport,
+                metrics.transport,
                 tcp_forward.into_inner(),
                 http_server.into_inner(),
                 h2_settings,


### PR DESCRIPTION
Turns out these _worked_ but i never actually put them back. Whoopsie!

This is necessary for the only integration test that really exercises
reconnects, which relies on these metrics to determine if a connection
exists.

Depends on #526 and will be rebased onto `master-tokio-0.2` when
that branch merges.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>