### PR TITLE
update reconnect to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,9 +1530,10 @@ dependencies = [
 name = "linkerd2-reconnect"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.26",
+ "futures 0.3.4",
  "linkerd2-error",
- "tower 0.1.1",
+ "pin-project",
+ "tower 0.3.1",
  "tracing",
 ]
 

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -283,7 +283,7 @@ impl Config {
 
             let tcp_server = Server::new(
                 TransportLabels,
-                // metrics.transport,
+                metrics.transport,
                 tcp_forward.into_inner(),
                 http_server.into_inner(),
                 h2_settings,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -122,10 +122,10 @@ impl Config {
             // Creates HTTP clients for each inbound port & HTTP settings.
             let http_endpoint = tcp_connect
                 .push(http::MakeClientLayer::new(connect.h2_settings))
-                // .push(reconnect::layer({
-                //     let backoff = connect.backoff.clone();
-                //     move |_| Ok(backoff.stream())
-                // }))
+                .push(reconnect::layer({
+                    let backoff = connect.backoff.clone();
+                    move |_| Ok(backoff.stream())
+                }))
                 .check_service::<HttpEndpoint>();
 
             let http_target_observability = svc::layers()

--- a/linkerd/app/integration/src/client.rs
+++ b/linkerd/app/integration/src/client.rs
@@ -132,11 +132,11 @@ impl Client {
             .to_string()
     }
 
-    pub async fn request_async(
+    pub fn request_async(
         &self,
         builder: http::request::Builder,
-    ) -> Result<Response, ClientError> {
-        self.send_req(builder.body(Bytes::new()).unwrap()).await
+    ) -> impl Future<Output = Result<Response, ClientError>> + Send + Sync + 'static {
+        self.send_req(builder.body(Bytes::new()).unwrap())
     }
 
     #[tokio::main]

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -228,7 +228,6 @@ macro_rules! generate_tests {
         }
 
         #[test]
-        #[cfg_attr(not(feature = "nyi"), ignore)]
         fn outbound_error_reconnects_after_backoff() {
             let env = TestEnv::new();
 

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -1089,7 +1089,6 @@ fn http1_requests_without_host_have_unique_connections() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 async fn retry_reconnect_errors() {
     let _ = trace_init();
 
@@ -1108,7 +1107,7 @@ async fn retry_reconnect_errors() {
     // wait until metrics has seen our connection, this can be flaky depending on
     // all the other threads currently running...
     assert_eventually_contains!(
-        metrics.get("/metrics"),
+        metrics.get_async("/metrics").await,
         "tcp_open_total{direction=\"inbound\",peer=\"src\",tls=\"disabled\"} 1"
     );
 

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -1089,6 +1089,8 @@ fn http1_requests_without_host_have_unique_connections() {
 }
 
 #[tokio::test]
+// Re-enable when transport metrics are put back.
+#[cfg_attr(not(feature = "nyi"), ignore)]
 async fn retry_reconnect_errors() {
     let _ = trace_init();
 

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -1089,8 +1089,6 @@ fn http1_requests_without_host_have_unique_connections() {
 }
 
 #[tokio::test]
-// Re-enable when transport metrics are put back.
-#[cfg_attr(not(feature = "nyi"), ignore)]
 async fn retry_reconnect_errors() {
     let _ = trace_init();
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -173,10 +173,10 @@ impl Config {
                     // HTTP/1.x fallback is supported as needed.
                     .push(http::MakeClientLayer::new(connect.h2_settings))
                     // Re-establishes a connection when the client fails.
-                    // .push(reconnect::layer({
-                    //     let backoff = connect.backoff.clone();
-                    //     move |_| Ok(backoff.stream())
-                    // }))
+                    .push(reconnect::layer({
+                        let backoff = connect.backoff.clone();
+                        move |_| Ok(backoff.stream())
+                    }))
                     .push(observability.clone())
                     .push(identity_headers.clone())
                     // .push(http::override_authority::Layer::new(vec![HOST.as_str(), CANONICAL_DST_HEADER]))

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -451,7 +451,7 @@ impl Config {
 
             let tcp_server = Server::new(
                 TransportLabels,
-                // metrics.transport,
+                metrics.transport,
                 tcp_forward.into_inner(),
                 http_server.into_inner(),
                 h2_settings,

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -126,10 +126,10 @@ impl Config {
                     .push_timeout(dst.control.connect.timeout)
                     .push(control::client::layer())
                     .push(control::resolve::layer(dns))
-                    // .push(reconnect::layer({
-                    //     let backoff = dst.control.connect.backoff;
-                    //     move |_| Ok(backoff.stream())
-                    // }))
+                    .push(reconnect::layer({
+                        let backoff = dst.control.connect.backoff;
+                        move |_| Ok(backoff.stream())
+                    }))
                     .push(metrics.into_layer::<classify::Response>())
                     .push(control::add_origin::Layer::new())
                     .into_new_service()

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [dependencies]
 linkerd2-error = { path = "../error" }
-futures = "0.1"
-tower = "0.1"
+futures = "0.3"
+tower = { version = "0.3", default-features = false }
 tracing = "0.1"
+pin-project = "0.4"

--- a/linkerd/reconnect/src/layer.rs
+++ b/linkerd/reconnect/src/layer.rs
@@ -1,7 +1,7 @@
 use super::Service;
 use futures::future;
-use std::task::{Poll, Context};
 use linkerd2_error::{Error, Never, Recover};
+use std::task::{Context, Poll};
 
 #[derive(Clone, Debug)]
 pub struct Layer<R: Recover> {

--- a/linkerd/reconnect/src/lib.rs
+++ b/linkerd/reconnect/src/lib.rs
@@ -1,14 +1,14 @@
-// //! Conditionally reconnects with a pluggable recovery/backoff strategy.
-// #![deny(warnings, rust_2018_idioms)]
+//! Conditionally reconnects with a pluggable recovery/backoff strategy.
+#![deny(warnings, rust_2018_idioms)]
 
-// use linkerd2_error::Recover;
+use linkerd2_error::Recover;
 
-// mod layer;
-// mod service;
+mod layer;
+mod service;
 
-// pub use self::layer::Layer;
-// pub use self::service::Service;
+pub use self::layer::Layer;
+pub use self::service::Service;
 
-// pub fn layer<R: Recover + Clone>(recover: R) -> Layer<R> {
-//     recover.into()
-// }
+pub fn layer<R: Recover + Clone>(recover: R) -> Layer<R> {
+    recover.into()
+}

--- a/linkerd/reconnect/src/service.rs
+++ b/linkerd/reconnect/src/service.rs
@@ -1,7 +1,7 @@
 use futures::{future, ready, TryFuture, TryFutureExt, TryStreamExt};
-use std::task::{Context, Poll};
-use std::pin::Pin;
 use linkerd2_error::{Error, Recover};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 pub struct Service<T, R, M>
 where
@@ -104,7 +104,7 @@ where
                             error: Some(error),
                             backoff: None,
                         }
-                    },
+                    }
                     Ok(ready) => return Poll::Ready(Ok(ready)),
                 },
 
@@ -134,9 +134,7 @@ where
                         None => None,
                     };
 
-                    State::Disconnected {
-                        backoff,
-                    }
+                    State::Disconnected { backoff }
                 }
             }
         }


### PR DESCRIPTION
This branch updates the `reconnect` middleware to `std::future`.
Updating reconnect was pretty straightforward and mechanical, so it
should be easy to review. 

Most of the complexity was actually in getting the test
`retry_reconnect_errors` which exercises this functionality to pass: the
test uses transport metrics to determine when the proxy has actually
accepted a connection from the test client, so that it can advance to
the next state; it was necessary to re-enable transport metrics for this
to work (see PR #530).

Additionally, there was a subtle change in the test-support client's
behavior that needed to be resolved as well: the test relied on
`Client::request_async` *eagerly* causing the test client to connect to
the proxy when called, rather than when the returned future is polled.
Switching `request_async` to an `async fn` broke this property — the
*entire* body of the function, even the synchronous parts, was run only
when the `async fn` future is polled. This means that the connection was
not opened when the test expected it to be, and the subsequent assertion
that it was open always failed.

Therefore, I changed `request_async` back into a synchronous function
returning `impl Future`. This is identical at the callsite (it still
returns something that you can `.await`), but calling the function now
once again eagerly tells the test client background thread to open a
connection. This fixes the test.

Depends on #530.