### PR TITLE
Test loop detection

### DIFF
--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -79,6 +79,11 @@ impl Proxy {
         self
     }
 
+    pub fn inbound_ip(mut self, s: SocketAddr) -> Self {
+        self.inbound = Some(s);
+        self
+    }
+
     /// Adjust the server's 'addr'. This won't actually re-bind the server,
     /// it will just affect what the proxy think is the so_original_dst.
     ///

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -81,6 +81,42 @@ fn inbound_tcp() {
     assert_eq!(tcp_client.read(), msg2.as_bytes());
 }
 
+#[test]
+#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+fn loop_outbound_http1() {
+    let _ = trace_init();
+
+    let listen_addr = SocketAddr::from(([127, 0, 0, 1], 10751));
+
+    let mut env = TestEnv::new();
+    env.put(app::env::ENV_OUTBOUND_LISTEN_ADDR, listen_addr.to_string());
+    let _proxy = proxy::new()
+        .outbound_ip(listen_addr)
+        .run_with_test_env_and_keep_ports(env);
+
+    let client = client::http1(listen_addr, "some.invalid.example.com");
+    let rsp = client.request(client.request_builder("/").method("GET"));
+    assert_eq!(rsp.status(), http::StatusCode::BAD_GATEWAY);
+}
+
+#[test]
+#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+fn loop_inbound_http1() {
+    let _ = trace_init();
+
+    let listen_addr = SocketAddr::from(([127, 0, 0, 1], 10752));
+
+    let mut env = TestEnv::new();
+    env.put(app::env::ENV_INBOUND_LISTEN_ADDR, listen_addr.to_string());
+    let _proxy = proxy::new()
+        .inbound_ip(listen_addr)
+        .run_with_test_env_and_keep_ports(env);
+
+    let client = client::http1(listen_addr, listen_addr.to_string());
+    let rsp = client.request(client.request_builder("/").method("GET"));
+    assert_eq!(rsp.status(), http::StatusCode::BAD_GATEWAY);
+}
+
 fn test_server_speaks_first(env: TestEnv) {
     const TIMEOUT: Duration = Duration::from_secs(5);
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -103,6 +103,8 @@ impl Config {
         let listen = bind.bind().map_err(Error::from)?;
         let listen_addr = listen.listen_addr();
 
+        let prevent_loop = PreventLoop::new(listen_addr.port());
+
         // The stack is served lazily since caching layers spawn tasks from
         // their constructor. This helps to ensure that tasks are spawned on the
         // same runtime as the proxy.
@@ -119,7 +121,7 @@ impl Config {
             // Forwards TCP streams that cannot be decoded as HTTP.
             let tcp_forward = tcp_connect
                 .clone()
-                .push(admit::AdmitLayer::new(PreventLoop::new(listen_addr.port())))
+                .push(admit::AdmitLayer::new(prevent_loop))
                 .push_map_target(|meta: tls::accept::Meta| {
                     TcpEndpoint::from(meta.addrs.target_addr())
                 })
@@ -159,7 +161,6 @@ impl Config {
                         let backoff = connect.backoff.clone();
                         move |_| Ok(backoff.stream())
                     }))
-                    .push(admit::AdmitLayer::new(PreventLoop::new(listen_addr.port())))
                     .push(observability.clone())
                     .push(identity_headers.clone())
                     .push(http::override_authority::Layer::new(vec![HOST.as_str(), CANONICAL_DST_HEADER]))
@@ -239,6 +240,8 @@ impl Config {
                                 .push(metrics.stack.layer(stack_labels("forward.endpoint"))),
                         ),
                 )
+                // Avoid caching if it would loop.
+                .push(admit::AdmitLayer::new(prevent_loop))
                 .instrument(|endpoint: &Target<HttpEndpoint>| {
                     info_span!("forward", peer.addr = %endpoint.addr, peer.id = ?endpoint.inner.identity)
                 })


### PR DESCRIPTION
This change adds (flakey) tests for loop detection. The tests are flakey
because they require static ports to work properly. (We cannot configure
the original dst port to be the same as the interface port if the
interface port is not known).