### PR TITLE
fallback: Unwrap errors recursively

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -264,6 +264,14 @@ impl<S> Stack<S> {
         self.push(stack::FallbackLayer::new(fallback))
     }
 
+    pub fn push_fallback_on_error<E, F>(self, fallback: F) -> Stack<stack::Fallback<S, F>>
+    where
+        F: Clone,
+        E: std::error::Error + 'static,
+    {
+        self.push(stack::FallbackLayer::new(fallback).on_error::<E>())
+    }
+
     pub fn push_fallback_with_predicate<F, P>(
         self,
         fallback: F,

--- a/linkerd/stack/src/fallback.rs
+++ b/linkerd/stack/src/fallback.rs
@@ -59,8 +59,19 @@ impl<B> FallbackLayer<B> {
     where
         E: std::error::Error + 'static,
     {
-        self.with_predicate(|e| e.is::<E>() || e.source().map(|s| s.is::<E>()).unwrap_or(false))
+        self.with_predicate(|e| is_error::<E>(e.as_ref()))
     }
+}
+
+fn is_error<E>(err: &(dyn std::error::Error + 'static)) -> bool
+where
+    E: std::error::Error + 'static,
+{
+    if err.is::<E>() {
+        return true;
+    }
+
+    err.source().map(is_error::<E>).unwrap_or(false)
 }
 
 impl<A, B, P> tower::layer::Layer<A> for FallbackLayer<B, P>


### PR DESCRIPTION
This change modifies the fallback layer to inspect error sources
recursively to determine if the given error type is satisfied.

A stack-helper is also added for this case.