### PR TITLE
fix concurrency-limit layer not being Send

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ dependencies = [
  "indexmap",
  "log",
  "slab",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-util",
 ]
 
@@ -686,7 +686,7 @@ dependencies = [
  "net2",
  "pin-project",
  "time",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower-service 0.3.0",
  "want 0.3.0",
 ]
@@ -699,7 +699,7 @@ dependencies = [
  "http 0.2.1",
  "hyper 0.13.5",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-test",
  "tower 0.3.1",
 ]
@@ -844,7 +844,7 @@ dependencies = [
  "ring",
  "rustls",
  "tokio 0.1.22",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-compat",
  "tokio-connect",
  "tokio-current-thread",
@@ -917,7 +917,7 @@ dependencies = [
  "rand 0.7.2",
  "regex 1.0.0",
  "tokio 0.1.22",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-compat",
  "tokio-timer",
  "tonic",
@@ -977,7 +977,7 @@ dependencies = [
  "rustls",
  "task-compat",
  "tokio 0.1.22",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-compat",
  "tokio-connect",
  "tokio-rustls",
@@ -1031,7 +1031,7 @@ dependencies = [
  "futures 0.3.4",
  "linkerd2-error",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-test",
  "tower 0.3.1",
  "tower-test",
@@ -1047,7 +1047,7 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-lock",
  "linkerd2-stack",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower 0.3.1",
  "tracing",
  "tracing-futures 0.1.0",
@@ -1059,7 +1059,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.4",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower 0.3.1",
  "tracing",
 ]
@@ -1076,7 +1076,7 @@ dependencies = [
  "linkerd2-dns-name",
  "linkerd2-stack",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower 0.3.1",
  "tracing",
  "tracing-futures 0.1.0",
@@ -1098,7 +1098,7 @@ dependencies = [
  "futures 0.3.4",
  "linkerd2-error",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-test",
 ]
 
@@ -1109,7 +1109,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tracing",
 ]
 
@@ -1152,7 +1152,7 @@ dependencies = [
  "pin-project",
  "quickcheck",
  "rand 0.7.2",
- "tokio 0.2.20",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -1220,7 +1220,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.4",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-rustls",
  "tokio-test",
 ]
@@ -1232,7 +1232,7 @@ dependencies = [
  "futures 0.3.4",
  "linkerd2-error",
  "rand 0.7.2",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-test",
  "tower 0.3.1",
  "tower-test",
@@ -1351,7 +1351,7 @@ dependencies = [
  "futures 0.3.4",
  "linkerd2-error",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower 0.3.1",
  "tracing-futures 0.2.4",
 ]
@@ -1365,7 +1365,7 @@ dependencies = [
  "linkerd2-io",
  "linkerd2-proxy-core",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower 0.3.1",
 ]
 
@@ -1378,7 +1378,7 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-proxy-core",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-test",
  "tower 0.3.1",
  "tower-test",
@@ -1413,7 +1413,7 @@ dependencies = [
  "rand 0.7.2",
  "task-compat",
  "tokio 0.1.22",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-connect",
  "tokio-timer",
  "tower 0.3.1",
@@ -1446,7 +1446,7 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-proxy-core",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower 0.3.1",
  "tracing",
 ]
@@ -1488,7 +1488,7 @@ dependencies = [
  "linkerd2-duplex",
  "linkerd2-error",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower 0.3.1",
 ]
 
@@ -1514,7 +1514,7 @@ dependencies = [
  "ring",
  "rustls",
  "task-compat",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-compat",
  "tokio-rustls",
  "tokio-util",
@@ -1616,7 +1616,7 @@ dependencies = [
  "futures 0.3.4",
  "linkerd2-error",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower 0.3.1",
 ]
 
@@ -1659,7 +1659,7 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-stack",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-connect",
  "tokio-test",
  "tower 0.3.1",
@@ -2719,8 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.20"
-source = "git+https://github.com/tokio-rs/tokio?rev=45773c56413267cbcf9d5e7877e8dc4afc1e5b07#45773c56413267cbcf9d5e7877e8dc4afc1e5b07"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -2769,7 +2770,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-current-thread",
  "tokio-executor",
  "tokio-reactor",
@@ -2830,7 +2831,8 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "0.2.5"
-source = "git+https://github.com/tokio-rs/tokio?rev=45773c56413267cbcf9d5e7877e8dc4afc1e5b07#45773c56413267cbcf9d5e7877e8dc4afc1e5b07"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.2",
@@ -2864,7 +2866,7 @@ checksum = "4adb8b3e5f86b707f1b54e7c15b6de52617a823608ccda98a15d3a24222f265a"
 dependencies = [
  "futures-core",
  "rustls",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "webpki",
 ]
 
@@ -2916,7 +2918,7 @@ checksum = "ed0049c119b6d505c4447f5c64873636c7af6c75ab0d45fd9f618d82acb8016d"
 dependencies = [
  "bytes 0.5.4",
  "futures-core",
- "tokio 0.2.20",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -2992,7 +2994,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio 0.2.20",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -3060,7 +3062,7 @@ dependencies = [
  "pin-project",
  "rand 0.7.2",
  "slab",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower-layer 0.3.0 (git+https://github.com/tower-rs/tower?rev=8752a3811788e94670c62dc0acbc9613207931b1)",
  "tower-service 0.3.0",
  "tracing",
@@ -3203,7 +3205,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
 dependencies = [
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tower-service 0.3.0",
 ]
 
@@ -3277,7 +3279,7 @@ checksum = "9ba4bbc2c1e4a8543c30d4c13a4c8314ed72d6e07581910f665aa13fde0153c8"
 dependencies = [
  "futures-util",
  "pin-project",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-test",
  "tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.3.0",
@@ -3419,7 +3421,7 @@ dependencies = [
  "rand 0.7.2",
  "smallvec 1.2.0",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "url",
 ]
 
@@ -3439,7 +3441,7 @@ dependencies = [
  "resolv-conf",
  "smallvec 1.2.0",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "trust-dns-proto",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,4 +68,3 @@ webpki = { git = "https://github.com/seanmonstar/webpki", branch = "cert-dns-nam
 # backport danburkert/prost#268 to `prost` 0.5 temporarily.
 prost = { git = "https://github.com/linkerd/prost", branch = "v0.5.x" }
 tower = { version = "0.3", git = "https://github.com/tower-rs/tower", rev = "8752a3811788e94670c62dc0acbc9613207931b1"}
-tokio = { version = "0.2", git = "https://github.com/tokio-rs/tokio", rev = "45773c56413267cbcf9d5e7877e8dc4afc1e5b07"}

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -231,7 +231,7 @@ impl Config {
                 // Downgrades the protocol if upgraded by an outbound proxy.
                 .push(svc::layer::mk(orig_proto::Downgrade::new))
                 // Limits the number of in-flight requests.
-                // .push_concurrency_limit(max_in_flight_requests)
+                .push_concurrency_limit(max_in_flight_requests)
                 // Eagerly fail requests when the proxy is out of capacity for a
                 // dispatch_timeout.
                 .push_failfast(dispatch_timeout)

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -420,7 +420,7 @@ impl Config {
                 // Eagerly fail requests when the proxy is out of capacity for a
                 // dispatch_timeout.
                 .push_failfast(dispatch_timeout)
-                .push(metrics.http_errors)
+                // .push(metrics.http_errors)
                 // Synthesizes responses for proxy errors.
                 // .push(errors::layer())
                 // Initiates OpenCensus tracing.
@@ -440,7 +440,7 @@ impl Config {
 
                 // // Used by tap.
                 // .push_http_insert_target()
-                // .push_on_response(http_admit_request)
+                .push_on_response(http_admit_request)
                 .push_on_response(metrics.stack.layer(stack_labels("source")))
                 .instrument(
                     |src: &tls::accept::Meta| {

--- a/linkerd/concurrency-limit/Cargo.toml
+++ b/linkerd/concurrency-limit/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 futures = "0.3"
-tokio = { version = "0.2.19", features = ["sync"] }
+tokio = { version = "0.2.21", features = ["sync"] }
 tower = { version = "0.3", default-features = false }
 tracing = "0.1"
 pin-project = "0.4"

--- a/linkerd/concurrency-limit/src/lib.rs
+++ b/linkerd/concurrency-limit/src/lib.rs
@@ -30,7 +30,7 @@ pub struct ConcurrencyLimit<T> {
 }
 
 enum State {
-    Waiting(Pin<Box<dyn Future<Output = OwnedSemaphorePermit> + 'static>>),
+    Waiting(Pin<Box<dyn Future<Output = OwnedSemaphorePermit> + Send + 'static>>),
     Ready(OwnedSemaphorePermit),
     Empty,
 }


### PR DESCRIPTION
The `linkerd2-concurrency-limit` service was inadvertently not `Send`,
because it failed to bound the wrapped future trait object with `Send`.
This means that we couldn't actually use it in the inbound or outbound
stack, because other layers require the service to be `Send`.

This branch adds the missing `Send` bound, and removes the patch that
pinned Tokio to a Git revision, since `OwnedSemaphorePermit` is now in a
published Tokio release. Additionally, I've actually put back the
concurrency-limit layers now that they don't break everything any more.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>