### PR TITLE
update retries to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,11 +1551,10 @@ dependencies = [
 name = "linkerd2-retry"
 version = "0.1.0"
 dependencies = [
- "bytes 0.4.11",
- "futures 0.1.26",
  "linkerd2-error",
  "linkerd2-stack",
- "tower 0.1.1",
+ "pin-project",
+ "tower 0.3.1",
  "tower-util",
  "tracing",
 ]

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -37,7 +37,7 @@ pub mod errors;
 // pub mod handle_time;
 pub mod metric_labels;
 pub mod proxy;
-// pub mod retry;
+pub mod retry;
 pub mod serve;
 pub mod spans;
 pub mod svc;

--- a/linkerd/app/core/src/retry.rs
+++ b/linkerd/app/core/src/retry.rs
@@ -1,12 +1,12 @@
 use super::classify;
 use super::dst::Route;
-use super::handle_time;
+// use super::handle_time;
 use super::http_metrics::retries::Handle;
 use super::transport::tls;
 use super::HttpRouteRetry;
 use crate::profiles;
-use futures::future;
-use hyper::body::Payload;
+use futures_03::future;
+use hyper::body::HttpBody;
 use linkerd2_http_classify::{Classify, ClassifyEos, ClassifyResponse};
 use linkerd2_retry::NewRetryLayer;
 use std::marker::PhantomData;
@@ -70,7 +70,7 @@ impl<C, A, B, E> linkerd2_retry::Policy<http::Request<A>, http::Response<B>, E> 
 where
     C: CloneRequest<http::Request<A>>,
 {
-    type Future = future::FutureResult<Self, ()>;
+    type Future = future::Ready<Self>;
 
     fn retry(
         &self,
@@ -97,7 +97,7 @@ where
             return None;
         }
 
-        Some(future::ok(self.clone()))
+        Some(future::ready(self.clone()))
     }
 
     fn clone_request(&self, req: &http::Request<A>) -> Option<http::Request<A>> {
@@ -116,7 +116,7 @@ impl<C> Clone for Retry<C> {
     }
 }
 
-impl<B: Default + Payload> CloneRequest<http::Request<B>> for () {
+impl<B: Default + HttpBody> CloneRequest<http::Request<B>> for () {
     fn clone_request(req: &http::Request<B>) -> Option<http::Request<B>> {
         if !req.body().is_end_stream() {
             return None;
@@ -132,10 +132,10 @@ impl<B: Default + Payload> CloneRequest<http::Request<B>> for () {
             clone.extensions_mut().insert(ext.clone());
         }
 
-        // Count retries toward the request's total handle time.
-        if let Some(ext) = req.extensions().get::<handle_time::Tracker>() {
-            clone.extensions_mut().insert(ext.clone());
-        }
+        // // Count retries toward the request's total handle time.
+        // if let Some(ext) = req.extensions().get::<handle_time::Tracker>() {
+        //     clone.extensions_mut().insert(ext.clone());
+        // }
 
         Some(clone)
     }

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -133,7 +133,6 @@ macro_rules! profile_test {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn retry_if_profile_allows() {
     profile_test! {
         routes: [
@@ -150,7 +149,6 @@ fn retry_if_profile_allows() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn retry_uses_budget() {
     profile_test! {
         routes: [
@@ -301,7 +299,6 @@ fn ignores_invalid_retry_budget_negative_ratio() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http2_failures_dont_leak_connection_window() {
     profile_test! {
         http: http2,

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -247,7 +247,6 @@ fn does_not_retry_if_missing_retry_budget() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn ignores_invalid_retry_budget_ttl() {
     profile_test! {
         routes: [

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -14,35 +14,19 @@ use futures::future;
 use linkerd2_app_core::{
     classify,
     config::{ProxyConfig, ServerConfig},
-    dns,
-    drain,
-    dst,
-    errors,
-    metric_labels,
+    dns, drain, dst, errors, metric_labels,
     opencensus::proto::trace::v1 as oc,
     profiles,
     proxy::{
         self, core::resolve::Resolve, detect::DetectProtocolLayer, discover, http, identity,
         resolve::map_endpoint, server::ProtocolDetect, tap, tcp, Server,
     },
-    reconnect,
-    // retry,
-    router,
-    serve,
+    reconnect, retry, router, serve,
     spans::SpanConverter,
     svc::{self, NewService},
     transport::{self, tls},
-    Conditional,
-    DiscoveryRejected,
-    Error,
-    ProxyMetrics,
-    TraceContextLayer,
-    CANONICAL_DST_HEADER,
-    DST_OVERRIDE_HEADER,
-    L5D_CLIENT_ID,
-    L5D_REMOTE_IP,
-    L5D_REQUIRE_ID,
-    L5D_SERVER_ID,
+    Conditional, DiscoveryRejected, Error, ProxyMetrics, TraceContextLayer, CANONICAL_DST_HEADER,
+    DST_OVERRIDE_HEADER, L5D_CLIENT_ID, L5D_REMOTE_IP, L5D_REQUIRE_ID, L5D_SERVER_ID,
 };
 use std::collections::HashMap;
 use std::future::Future;
@@ -287,7 +271,7 @@ impl Config {
                 .check_new_clone_service::<dst::Route>()
                 .push(metrics.http_route_actual.into_layer::<classify::Response>())
                 // Sets an optional retry policy.
-                // .push(retry::layer(metrics.http_route_retry))
+                .push(retry::layer(metrics.http_route_retry))
                 .check_new_clone_service::<dst::Route>()
                 // Sets an optional request timeout.
                 .push(http::MakeTimeoutLayer::default())

--- a/linkerd/retry/Cargo.toml
+++ b/linkerd/retry/Cargo.toml
@@ -6,10 +6,9 @@ edition = "2018"
 publish = false
 
 [dependencies]
-bytes = "0.4"
-futures = "0.1"
 linkerd2-error = { path  = "../error" }
 linkerd2-stack = { path  = "../stack" }
-tower = "0.1"
+tower = { version = "0.3", default-features = false, features = ["util"] }
 tower-util = "0.1"
 tracing = "0.1.9"
+pin-project = "0.4"

--- a/linkerd/retry/src/lib.rs
+++ b/linkerd/retry/src/lib.rs
@@ -1,128 +1,133 @@
-// #![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 
-// use futures::{Future, Poll};
-// use linkerd2_error::Error;
-// use linkerd2_stack::{NewService, Proxy, ProxyService};
-// pub use tower::retry::{budget::Budget, Policy};
-// use tower::util::{Oneshot, ServiceExt};
-// use tracing::trace;
+use linkerd2_error::Error;
+use linkerd2_stack::{NewService, Proxy, ProxyService};
+use pin_project::{pin_project, project};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+pub use tower::retry::{budget::Budget, Policy};
+use tower::util::{Oneshot, ServiceExt};
+use tracing::trace;
 
-// /// A strategy for obtaining per-target retry polices.
-// pub trait NewPolicy<T> {
-//     type Policy;
+/// A strategy for obtaining per-target retry polices.
+pub trait NewPolicy<T> {
+    type Policy;
 
-//     fn new_policy(&self, target: &T) -> Option<Self::Policy>;
-// }
+    fn new_policy(&self, target: &T) -> Option<Self::Policy>;
+}
 
-// /// A layer that applies per-target retry polcies.
-// ///
-// /// Composes `NewService`s that produce a `Proxy`.
-// #[derive(Clone, Debug)]
-// pub struct NewRetryLayer<P> {
-//     new_policy: P,
-// }
+/// A layer that applies per-target retry polcies.
+///
+/// Composes `NewService`s that produce a `Proxy`.
+#[derive(Clone, Debug)]
+pub struct NewRetryLayer<P> {
+    new_policy: P,
+}
 
-// #[derive(Clone, Debug)]
-// pub struct NewRetry<P, N> {
-//     new_policy: P,
-//     inner: N,
-// }
+#[derive(Clone, Debug)]
+pub struct NewRetry<P, N> {
+    new_policy: P,
+    inner: N,
+}
 
-// #[derive(Clone, Debug)]
-// pub struct Retry<P, S> {
-//     policy: Option<P>,
-//     inner: S,
-// }
+#[derive(Clone, Debug)]
+pub struct Retry<P, S> {
+    policy: Option<P>,
+    inner: S,
+}
 
-// pub enum ResponseFuture<R, P, S, Req>
-// where
-//     R: tower::retry::Policy<Req, P::Response, Error> + Clone,
-//     P: Proxy<Req, S> + Clone,
-//     S: tower::Service<P::Request> + Clone,
-//     S::Error: Into<Error>,
-// {
-//     Disabled(P::Future),
-//     Retry(Oneshot<tower::retry::Retry<R, ProxyService<P, S>>, Req>),
-// }
+#[pin_project]
+pub enum ResponseFuture<R, P, S, Req>
+where
+    R: tower::retry::Policy<Req, P::Response, Error> + Clone,
+    P: Proxy<Req, S> + Clone,
+    S: tower::Service<P::Request> + Clone,
+    S::Error: Into<Error>,
+{
+    Disabled(#[pin] P::Future),
+    Retry(#[pin] Oneshot<tower::retry::Retry<R, ProxyService<P, S>>, Req>),
+}
 
-// // === impl NewRetryLayer ===
+// === impl NewRetryLayer ===
 
-// impl<P> NewRetryLayer<P> {
-//     pub fn new(new_policy: P) -> Self {
-//         Self { new_policy }
-//     }
-// }
+impl<P> NewRetryLayer<P> {
+    pub fn new(new_policy: P) -> Self {
+        Self { new_policy }
+    }
+}
 
-// impl<P: Clone, N> tower::layer::Layer<N> for NewRetryLayer<P> {
-//     type Service = NewRetry<P, N>;
+impl<P: Clone, N> tower::layer::Layer<N> for NewRetryLayer<P> {
+    type Service = NewRetry<P, N>;
 
-//     fn layer(&self, inner: N) -> Self::Service {
-//         Self::Service {
-//             inner,
-//             new_policy: self.new_policy.clone(),
-//         }
-//     }
-// }
+    fn layer(&self, inner: N) -> Self::Service {
+        Self::Service {
+            inner,
+            new_policy: self.new_policy.clone(),
+        }
+    }
+}
 
-// // === impl NewRetry ===
+// === impl NewRetry ===
 
-// impl<T, N, P> NewService<T> for NewRetry<P, N>
-// where
-//     N: NewService<T>,
-//     P: NewPolicy<T>,
-// {
-//     type Service = Retry<P::Policy, N::Service>;
+impl<T, N, P> NewService<T> for NewRetry<P, N>
+where
+    N: NewService<T>,
+    P: NewPolicy<T>,
+{
+    type Service = Retry<P::Policy, N::Service>;
 
-//     fn new_service(&self, target: T) -> Self::Service {
-//         // Determine if there is a retry policy for the given target.
-//         let policy = self.new_policy.new_policy(&target);
+    fn new_service(&self, target: T) -> Self::Service {
+        // Determine if there is a retry policy for the given target.
+        let policy = self.new_policy.new_policy(&target);
 
-//         let inner = self.inner.new_service(target);
-//         Retry { policy, inner }
-//     }
-// }
+        let inner = self.inner.new_service(target);
+        Retry { policy, inner }
+    }
+}
 
-// // === impl Retry ===
+// === impl Retry ===
 
-// impl<R, P, Req, S> Proxy<Req, S> for Retry<R, P>
-// where
-//     R: tower::retry::Policy<Req, P::Response, Error> + Clone,
-//     P: Proxy<Req, S> + Clone,
-//     S: tower::Service<P::Request> + Clone,
-//     S::Error: Into<Error>,
-// {
-//     type Request = P::Request;
-//     type Response = P::Response;
-//     type Error = Error;
-//     type Future = ResponseFuture<R, P, S, Req>;
+impl<R, P, Req, S> Proxy<Req, S> for Retry<R, P>
+where
+    R: tower::retry::Policy<Req, P::Response, Error> + Clone,
+    P: Proxy<Req, S> + Clone,
+    S: tower::Service<P::Request> + Clone,
+    S::Error: Into<Error>,
+{
+    type Request = P::Request;
+    type Response = P::Response;
+    type Error = Error;
+    type Future = ResponseFuture<R, P, S, Req>;
 
-//     fn proxy(&self, svc: &mut S, req: Req) -> Self::Future {
-//         trace!(retryable = %self.policy.is_some());
+    fn proxy(&self, svc: &mut S, req: Req) -> Self::Future {
+        trace!(retryable = %self.policy.is_some());
 
-//         if let Some(policy) = self.policy.as_ref() {
-//             let inner = self.inner.clone().wrap_service(svc.clone());
-//             let retry = tower::retry::Retry::new(policy.clone(), inner);
-//             return ResponseFuture::Retry(retry.oneshot(req));
-//         }
+        if let Some(policy) = self.policy.as_ref() {
+            let inner = self.inner.clone().wrap_service(svc.clone());
+            let retry = tower::retry::Retry::new(policy.clone(), inner);
+            return ResponseFuture::Retry(retry.oneshot(req));
+        }
 
-//         ResponseFuture::Disabled(self.inner.proxy(svc, req))
-//     }
-// }
+        ResponseFuture::Disabled(self.inner.proxy(svc, req))
+    }
+}
 
-// impl<R, P, S, Req> Future for ResponseFuture<R, P, S, Req>
-// where
-//     R: tower::retry::Policy<Req, P::Response, Error> + Clone,
-//     P: Proxy<Req, S> + Clone,
-//     S: tower::Service<P::Request> + Clone,
-//     S::Error: Into<Error>,
-// {
-//     type Item = P::Response;
-//     type Error = Error;
+impl<R, P, S, Req> Future for ResponseFuture<R, P, S, Req>
+where
+    R: tower::retry::Policy<Req, P::Response, Error> + Clone,
+    P: Proxy<Req, S> + Clone,
+    S: tower::Service<P::Request> + Clone,
+    S::Error: Into<Error>,
+{
+    type Output = Result<P::Response, Error>;
 
-//     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-//         match self {
-//             ResponseFuture::Disabled(ref mut f) => f.poll().map_err(Into::into),
-//             ResponseFuture::Retry(ref mut f) => f.poll().map_err(Into::into),
-//         }
-//     }
-// }
+    #[project]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        #[project]
+        match self.project() {
+            ResponseFuture::Disabled(f) => f.poll(cx).map_err(Into::into),
+            ResponseFuture::Retry(f) => f.poll(cx).map_err(Into::into),
+        }
+    }
+}


### PR DESCRIPTION
This branch updates the proxy's retry implementation to work with
`std::future`. Retries in service profiles now work correctly!

Again, nothing too out of the ordinary to see here. 

Depends on #537 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>