### PR TITLE
Introduce a gateway between inbound and outbound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "indexmap",
  "ipnet",
  "linkerd2-app-core",
+ "linkerd2-app-gateway",
  "linkerd2-app-inbound",
  "linkerd2-app-outbound",
  "linkerd2-metrics",
@@ -691,6 +692,21 @@ dependencies = [
  "tracing-futures",
  "tracing-log",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "linkerd2-app-gateway"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "http",
+ "indexmap",
+ "linkerd2-app-core",
+ "linkerd2-app-inbound",
+ "linkerd2-app-outbound",
+ "tokio",
+ "tower",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "linkerd/addr",
     "linkerd/admit",
     "linkerd/app/core",
+    "linkerd/app/gateway",
     "linkerd/app/inbound",
     "linkerd/app/integration",
     "linkerd/app/outbound",

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -18,6 +18,7 @@ futures = "0.1"
 indexmap = "1.0"
 ipnet = "1.0"
 linkerd2-app-core = { path = "./core" }
+linkerd2-app-gateway = { path = "./gateway" }
 linkerd2-app-inbound = { path = "./inbound" }
 linkerd2-app-outbound = { path = "./outbound" }
 linkerd2-opencensus = { path = "../opencensus" }

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "linkerd2-app-gateway"
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+http = "0.1"
+futures = "0.1"
+indexmap = "1.0"
+linkerd2-app-core = { path = "../core" }
+linkerd2-app-inbound = { path = "../inbound" }
+linkerd2-app-outbound = { path = "../outbound" }
+tokio = "0.1"
+tower = "0.1"
+tracing = "0.1"

--- a/linkerd/app/gateway/src/config.rs
+++ b/linkerd/app/gateway/src/config.rs
@@ -23,7 +23,7 @@ impl Config {
         Future = impl Send + 'static,
         Response = impl Send
                        + tower::Service<
-            http::Request<http::glue::HttpBody>,
+            http::Request<http::boxed::Payload>,
             Response = http::Response<http::boxed::Payload>,
             Error = impl Into<Error>,
             Future = impl Send,
@@ -41,7 +41,7 @@ impl Config {
         O::Future: Send + 'static,
         S: Send
             + tower::Service<
-                http::Request<http::glue::HttpBody>,
+                http::Request<http::boxed::Payload>,
                 Response = http::Response<http::boxed::Payload>,
             > + 'static,
         S::Error: Into<Error> + Send + 'static,

--- a/linkerd/app/gateway/src/config.rs
+++ b/linkerd/app/gateway/src/config.rs
@@ -1,4 +1,4 @@
-use super::make::GatewayMake;
+use super::make::MakeGateway;
 use indexmap::IndexSet;
 use linkerd2_app_core::{dns, proxy::http, Error};
 use linkerd2_app_inbound::endpoint as inbound;
@@ -47,6 +47,6 @@ impl Config {
         S::Error: Into<Error> + Send + 'static,
         S::Future: Send,
     {
-        GatewayMake::new(resolve, outbound, self.suffixes.clone())
+        MakeGateway::new(resolve, outbound, self.suffixes.clone())
     }
 }

--- a/linkerd/app/gateway/src/config.rs
+++ b/linkerd/app/gateway/src/config.rs
@@ -1,0 +1,52 @@
+use super::make::GatewayMake;
+use indexmap::IndexSet;
+use linkerd2_app_core::{dns, proxy::http, Error};
+use linkerd2_app_inbound::endpoint as inbound;
+use linkerd2_app_outbound::endpoint as outbound;
+use std::net::IpAddr;
+
+#[derive(Clone, Debug, Default)]
+pub struct Config {
+    pub suffixes: IndexSet<dns::Suffix>,
+}
+
+impl Config {
+    pub fn build<R, O, S>(
+        self,
+        resolve: R,
+        outbound: O,
+    ) -> impl Clone
+           + Send
+           + tower::Service<
+        inbound::Target,
+        Error = impl Into<Error>,
+        Future = impl Send + 'static,
+        Response = impl Send
+                       + tower::Service<
+            http::Request<http::glue::HttpBody>,
+            Response = http::Response<http::boxed::Payload>,
+            Error = impl Into<Error>,
+            Future = impl Send,
+        > + 'static,
+    >
+    where
+        R: tower::Service<dns::Name, Response = (dns::Name, IpAddr)> + Send + Clone,
+        R::Error: Into<Error> + 'static,
+        R::Future: Send + 'static,
+        O: tower::Service<outbound::Logical<outbound::HttpEndpoint>, Response = S>
+            + Send
+            + Clone
+            + 'static,
+        O::Error: Into<Error> + Send + 'static,
+        O::Future: Send + 'static,
+        S: Send
+            + tower::Service<
+                http::Request<http::glue::HttpBody>,
+                Response = http::Response<http::boxed::Payload>,
+            > + 'static,
+        S::Error: Into<Error> + Send + 'static,
+        S::Future: Send,
+    {
+        GatewayMake::new(resolve, outbound, self.suffixes.clone())
+    }
+}

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -9,8 +9,9 @@ pub(crate) enum Gateway<O> {
     NoIdentity,
     BadDomain(dns::Name),
     Outbound {
-        // Source-metadata is available via request extensions set by the
-        // inbound, but we
+        // Other source-metadata is available via request extensions. This is
+        // here mostly as static proof that the innbound connection had
+        // identity.
         source_identity: identity::Name,
         dst_name: NameAddr,
         dst_addr: SocketAddr,

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -16,12 +16,10 @@ pub(crate) enum Gateway<O> {
     },
 }
 
-impl<O> tower::Service<http::Request<http::glue::HttpBody>> for Gateway<O>
+impl<B, O> tower::Service<http::Request<B>> for Gateway<O>
 where
-    O: tower::Service<
-        http::Request<http::glue::HttpBody>,
-        Response = http::Response<http::boxed::Payload>,
-    >,
+    B: http::Payload + 'static,
+    O: tower::Service<http::Request<B>, Response = http::Response<http::boxed::Payload>>,
     O::Error: Send + 'static,
     O::Future: Send + 'static,
 {
@@ -36,7 +34,7 @@ where
         }
     }
 
-    fn call(&mut self, request: http::Request<http::glue::HttpBody>) -> Self::Future {
+    fn call(&mut self, request: http::Request<B>) -> Self::Future {
         match self {
             Self::Forbidden => {
                 let rsp = http::Response::builder()

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -1,0 +1,7 @@
+#![deny(warnings, rust_2018_idioms)]
+
+mod config;
+mod gateway;
+mod make;
+
+pub use self::config::Config;

--- a/linkerd/app/gateway/src/make.rs
+++ b/linkerd/app/gateway/src/make.rs
@@ -1,0 +1,110 @@
+use super::gateway::Gateway;
+use futures::{future, Future, Poll};
+use linkerd2_app_core::proxy::api_resolve::Metadata;
+use linkerd2_app_core::{dns, transport::tls, Error, NameAddr};
+use linkerd2_app_inbound::endpoint as inbound;
+use linkerd2_app_outbound::endpoint as outbound;
+use std::net::IpAddr;
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub(crate) struct GatewayMake<R, O> {
+    suffixes: Arc<Vec<dns::Suffix>>,
+    resolve: R,
+    outbound: O,
+}
+
+impl<R, O> GatewayMake<R, O> {
+    pub fn new(resolve: R, outbound: O, suffixes: impl IntoIterator<Item = dns::Suffix>) -> Self {
+        Self {
+            resolve,
+            outbound,
+            suffixes: Arc::new(suffixes.into_iter().collect()),
+        }
+    }
+}
+
+impl<R, O> tower::Service<inbound::Target> for GatewayMake<R, O>
+where
+    R: tower::Service<dns::Name, Response = (dns::Name, IpAddr)>,
+    R::Error: Into<Error> + 'static,
+    R::Future: Send + 'static,
+    O: tower::Service<outbound::Logical<outbound::HttpEndpoint>> + Send + Clone + 'static,
+    O::Response: Send + 'static,
+    O::Future: Send + 'static,
+    O::Error: Into<Error>,
+{
+    type Response = Gateway<O::Response>;
+    type Error = Error;
+    type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
+
+    fn poll_ready(&mut self) -> Poll<(), Self::Error> {
+        self.resolve.poll_ready().map_err(Into::into)
+    }
+
+    fn call(&mut self, target: inbound::Target) -> Self::Future {
+        let inbound::Target {
+            dst_name,
+            http_settings,
+            tls_client_id,
+            ..
+        } = target;
+
+        let source_identity = match tls_client_id {
+            tls::Conditional::Some(id) => id,
+            tls::Conditional::None(_) => {
+                tracing::warn!("Request from un-meshed connection");
+                return Box::new(future::ok(Gateway::Forbidden));
+            }
+        };
+
+        let orig_dst = match dst_name {
+            Some(n) => n,
+            None => {
+                tracing::warn!("Request has no host/authority");
+                return Box::new(future::ok(Gateway::Forbidden));
+            }
+        };
+
+        let suffixes = self.suffixes.clone();
+        let mut outbound = self.outbound.clone();
+        Box::new(
+            // First, resolve the original name. This determines both the
+            // canonical name as well as an IP that can be used as the outbound
+            // original dst.
+            self.resolve
+                .call(orig_dst.name().clone())
+                .map_err(Into::into)
+                .and_then(move |(name, dst_ip)| {
+                    if !suffixes.iter().any(|s| s.contains(&name)) {
+                        tracing::debug!(%name, "Not in permitted suffixes");
+                        return future::Either::A(future::ok(Gateway::Forbidden));
+                    }
+
+                    // Create an outbound target using the resolved IP & name.
+                    let dst_addr = (dst_ip, orig_dst.port()).into();
+                    let dst_name = NameAddr::new(name, orig_dst.port());
+                    let endpoint = outbound::Logical {
+                        addr: dst_name.clone().into(),
+                        inner: outbound::HttpEndpoint {
+                            addr: dst_addr,
+                            settings: http_settings,
+                            metadata: Metadata::empty(),
+                            identity: tls::PeerIdentity::None(
+                                tls::ReasonForNoPeerName::NotProvidedByServiceDiscovery.into(),
+                            ),
+                        },
+                    };
+
+                    future::Either::B(outbound.call(endpoint).map_err(Into::into).map(
+                        move |outbound| Gateway::Outbound {
+                            dst_addr,
+                            dst_name,
+                            outbound,
+                            source_identity,
+                        },
+                    ))
+                }),
+        )
+    }
+}

--- a/linkerd/app/gateway/src/make.rs
+++ b/linkerd/app/gateway/src/make.rs
@@ -76,6 +76,7 @@ where
                 .and_then(move |(name, dst_ip)| {
                     tracing::debug!(%name, %dst_ip, "Resolved");
                     if !suffixes.iter().any(|s| s.contains(&name)) {
+                        tracing::debug!(%name, ?suffixes, "No matches");
                         return future::Either::A(future::ok(Gateway::BadDomain(name)));
                     }
 

--- a/linkerd/app/gateway/src/make.rs
+++ b/linkerd/app/gateway/src/make.rs
@@ -76,6 +76,7 @@ where
                 .call(orig_dst.name().clone())
                 .map_err(Into::into)
                 .and_then(move |(name, dst_ip)| {
+                    tracing::debug!(%name, %dst_ip, "Resolved");
                     if !suffixes.iter().any(|s| s.contains(&name)) {
                         tracing::debug!(%name, "Not in permitted suffixes");
                         return future::Either::A(future::ok(Gateway::Forbidden));

--- a/linkerd/app/gateway/src/make.rs
+++ b/linkerd/app/gateway/src/make.rs
@@ -8,13 +8,13 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
-pub(crate) struct GatewayMake<R, O> {
+pub(crate) struct MakeGateway<R, O> {
     suffixes: Arc<Vec<dns::Suffix>>,
     resolve: R,
     outbound: O,
 }
 
-impl<R, O> GatewayMake<R, O> {
+impl<R, O> MakeGateway<R, O> {
     pub fn new(resolve: R, outbound: O, suffixes: impl IntoIterator<Item = dns::Suffix>) -> Self {
         Self {
             resolve,
@@ -24,7 +24,7 @@ impl<R, O> GatewayMake<R, O> {
     }
 }
 
-impl<R, O> tower::Service<inbound::Target> for GatewayMake<R, O>
+impl<R, O> tower::Service<inbound::Target> for MakeGateway<R, O>
 where
     R: tower::Service<dns::Name, Response = (dns::Name, IpAddr)>,
     R::Error: Into<Error> + 'static,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -35,7 +35,7 @@ use std::collections::HashMap;
 use tokio::sync::mpsc;
 use tracing::{info, info_span};
 
-mod endpoint;
+pub mod endpoint;
 mod prevent_loop;
 mod require_identity_for_ports;
 #[allow(dead_code)] // TODO #2597
@@ -52,10 +52,11 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn build<P>(
+    pub fn build<L, S, P>(
         self,
         listen: transport::Listen<transport::DefaultOrigDstAddr>,
         local_identity: tls::Conditional<identity::Local>,
+        http_loopback: L,
         profiles_client: P,
         tap_layer: tap::Layer,
         metrics: ProxyMetrics,
@@ -63,6 +64,16 @@ impl Config {
         drain: drain::Watch,
     ) -> serve::Task
     where
+        L: tower::Service<Target, Response = S> + Send + Clone + 'static,
+        L::Error: Into<Error>,
+        L::Future: Send,
+        S: tower::Service<
+                http::Request<http::glue::HttpBody>,
+                Response = http::Response<http::boxed::Payload>,
+            > + Send
+            + 'static,
+        S::Error: Into<Error>,
+        S::Future: Send,
         P: profiles::GetRoutes<Profile> + Clone + Send + 'static,
         P::Future: Send,
     {
@@ -71,6 +82,7 @@ impl Config {
         let http_router = self.build_http_router(
             tcp_connect.clone(),
             prevent_loop,
+            http_loopback,
             profiles_client,
             tap_layer,
             metrics.clone(),
@@ -113,10 +125,11 @@ impl Config {
             .into_inner()
     }
 
-    pub fn build_http_router<C, P>(
+    pub fn build_http_router<C, P, L, S>(
         &self,
         tcp_connect: C,
         prevent_loop: impl Into<PreventLoop>,
+        http_loopback: L,
         profiles_client: P,
         tap_layer: tap::Layer,
         metrics: ProxyMetrics,
@@ -140,6 +153,17 @@ impl Config {
         C::Future: Send,
         P: profiles::GetRoutes<Profile> + Clone + Send + 'static,
         P::Future: Send,
+        // The loopback router processes requests sent to the inbound port.
+        L: tower::Service<Target, Response = S> + Send + Clone + 'static,
+        L::Error: Into<Error>,
+        L::Future: Send,
+        S: tower::Service<
+                http::Request<http::glue::HttpBody>,
+                Response = http::Response<http::boxed::Payload>,
+            > + Send
+            + 'static,
+        S::Error: Into<Error>,
+        S::Future: Send,
     {
         let Config {
             proxy:
@@ -252,6 +276,7 @@ impl Config {
                     .push_on_response(svc::layers().box_http_response().box_http_request()),
             )
             .push(admit::AdmitLayer::new(prevent_loop))
+            .push_fallback_on_error::<prevent_loop::LoopPrevented, L>(http_loopback)
             .check_service::<Target>()
             .into_inner()
     }

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -114,7 +114,7 @@ fn loop_inbound_http1() {
 
     let client = client::http1(listen_addr, listen_addr.to_string());
     let rsp = client.request(client.request_builder("/").method("GET"));
-    assert_eq!(rsp.status(), http::StatusCode::BAD_GATEWAY);
+    assert_eq!(rsp.status(), http::StatusCode::FORBIDDEN);
 }
 
 fn test_server_speaks_first(env: TestEnv) {

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -386,6 +386,7 @@ impl Config {
                 is_discovery_rejected,
             )
             .check_service::<Logical<HttpEndpoint>>()
+            .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
             .push_on_response(
                 // Strips headers that may be set by this proxy.
                 svc::layers()
@@ -393,7 +394,6 @@ impl Config {
                     .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
             )
             // Sets the canonical-dst header on all outbound requests.
-            .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
             .check_service::<Logical<HttpEndpoint>>()
             .instrument(|logical: &Logical<_>| info_span!("logical", addr = %logical.addr))
             .into_inner()

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -469,7 +469,7 @@ impl Config {
 
         let http_server = svc::stack(http_router)
             // Resolve the application-emitted destination via DNS to determine
-            // it's canonical FQDN to use for routing.
+            // its canonical FQDN to use for routing.
             .push(http::canonicalize::Layer::new(refine,
                 canonicalize_timeout,
             ))

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -123,7 +123,7 @@ pub const ENV_DESTINATION_PROFILE_SUFFIXES: &str = "LINKERD2_PROXY_DESTINATION_P
 
 /// Constrains which destination names are permitted.
 ///
-/// If unspecified or empty, no inbound gateway s configured.
+/// If unspecified or empty, no inbound gateway is configured.
 pub const ENV_INBOUND_GATEWAY_SUFFIXES: &str = "LINKERD2_PROXY_INBOUND_GATEWAY_SUFFIXES";
 
 // These *disable* our protocol detection for connections whose SO_ORIGINAL_DST

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -1,5 +1,6 @@
 //! Configures and executes the proxy
 
+#![recursion_limit = "256"]
 #![deny(warnings, rust_2018_idioms)]
 
 pub mod admin;

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -201,7 +201,9 @@ impl Config {
                     .build(
                         inbound_listen,
                         local_identity,
-                        http_gateway,
+                        svc::stack(http_gateway)
+                            .push_on_response(svc::layers().box_http_request())
+                            .into_inner(),
                         dst.profiles,
                         tap_layer.clone(),
                         inbound_metrics,

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -20,6 +20,7 @@ use linkerd2_app_core::{
     svc::{self, NewService},
     Error, Never,
 };
+use linkerd2_app_gateway as gateway;
 use linkerd2_app_inbound as inbound;
 use linkerd2_app_outbound as outbound;
 use std::net::SocketAddr;
@@ -42,6 +43,7 @@ use tracing_futures::Instrument;
 pub struct Config {
     pub outbound: outbound::Config,
     pub inbound: inbound::Config,
+    pub gateway: gateway::Config,
 
     pub dns: dns::Config,
     pub identity: identity::Config,
@@ -82,6 +84,7 @@ impl Config {
             inbound,
             oc_collector,
             outbound,
+            gateway,
             tap,
         } = self;
         debug!("building app");
@@ -167,7 +170,6 @@ impl Config {
                 outbound_addr.port(),
                 outbound_connect.clone(),
                 dst.resolve,
-                refine,
                 dst.profiles.clone(),
                 tap_layer.clone(),
                 outbound_metrics.clone(),
@@ -179,8 +181,11 @@ impl Config {
                     .build_server(
                         outbound_listen,
                         outbound_addr.port(),
+                        svc::stack(refine.clone())
+                            .push_map_response(|(n, _)| n)
+                            .into_inner(),
                         outbound_connect,
-                        outbound_http,
+                        outbound_http.clone(),
                         outbound_metrics,
                         oc_span_sink.clone(),
                         drain_rx.clone(),
@@ -189,11 +194,14 @@ impl Config {
                     .instrument(info_span!("outbound")),
             );
 
+            let http_gateway = gateway.build(refine, outbound_http);
+
             tokio::spawn(
                 inbound
                     .build(
                         inbound_listen,
                         local_identity,
+                        http_gateway,
                         dst.profiles,
                         tap_layer.clone(),
                         inbound_metrics,

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -31,7 +31,7 @@ pub use self::{
     timeout::MakeTimeoutLayer,
     version::Version,
 };
-pub use http::{header, uri, Request, Response};
+pub use http::{header, uri, Request, Response, StatusCode};
 pub use hyper::body::Payload;
 pub use linkerd2_http_box as boxed;
 

--- a/linkerd/timeout/src/failfast.rs
+++ b/linkerd/timeout/src/failfast.rs
@@ -98,7 +98,8 @@ where
             ret => {
                 match self.state {
                     State::Open => {}
-                    _ => debug!("Recovered"),
+                    State::Waiting(_) => trace!("Ready"),
+                    State::FailFast => debug!("Recovered"),
                 }
                 self.state = State::Open;
                 ret.map_err(Into::into)


### PR DESCRIPTION
When the proxy receives inbound requests without an original dst address
(or with a original dst address matching the inbound listener), the
proxy currently fails these requests.

This change modifies the proxy to attempt to accept these requests and
forward them back through the outbound router.

The gateway requires that all requests are received over an mTLS-secured
connection. It also refines the destination through DNS to determine the
canonical-form name as well as an outbound original dst IP. All
gatewayed destinations must have a suffix as set by the
`LINKERD2_PROXY_GATEWAY_SUFFIXES` environment variable.

All requests that do not meet these criteria are failed with a `403
Forbidden` status.