### PR TITLE
update handle_time to std::future

### DIFF
--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -34,7 +34,7 @@ pub mod control;
 pub mod dns;
 pub mod dst;
 pub mod errors;
-// pub mod handle_time;
+pub mod handle_time;
 pub mod metric_labels;
 pub mod proxy;
 // pub mod retry;
@@ -91,7 +91,7 @@ pub type StackMetrics = stack_metrics::Registry<metric_labels::StackLabels>;
 
 #[derive(Clone)]
 pub struct ProxyMetrics {
-    // pub http_handle_time: handle_time::Scope,
+    pub http_handle_time: handle_time::Scope,
     pub http_route: HttpRouteMetrics,
     pub http_route_actual: HttpRouteMetrics,
     pub http_route_retry: HttpRouteRetry,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -230,12 +230,12 @@ impl Config {
                 // .push(errors::layer())
                 ;
 
-            // let http_server_observability = svc::layers()
-            //     .push(TraceContextLayer::new(span_sink.map(|span_sink| {
-            //         SpanConverter::server(span_sink, trace_labels())
-            //     })))
-            //     // Tracks proxy handletime.
-            //     .push(metrics.http_handle_time.layer());
+            let http_server_observability = svc::layers()
+                //     .push(TraceContextLayer::new(span_sink.map(|span_sink| {
+                //         SpanConverter::server(span_sink, trace_labels())
+                //     })))
+                // Tracks proxy handletime.
+                .push(metrics.http_handle_time.layer());
 
             let http_server = svc::stack(http_profile_cache)
                 .push_on_response(svc::layers().box_http_response())
@@ -263,7 +263,7 @@ impl Config {
                 .push_http_insert_target()
                 .push_on_response(http_strip_headers)
                 .push_on_response(http_admit_request)
-                // .push_on_response(http_server_observability)
+                .push_on_response(http_server_observability)
                 .push_on_response(metrics.stack.layer(stack_labels("source")))
                 .instrument(|src: &tls::accept::Meta| {
                     info_span!(

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -419,8 +419,7 @@ impl Config {
                 //     SpanConverter::server(span_sink, trace_labels())
                 // })))
                 // Tracks proxy handletime.
-                // .push(metrics.http_handle_time.layer())
-                ;
+                .push(metrics.http_handle_time.layer());
 
             let http_server = http_logical_router
                 .check_service::<Logical<HttpEndpoint>>()

--- a/linkerd/app/src/metrics.rs
+++ b/linkerd/app/src/metrics.rs
@@ -1,17 +1,9 @@
 pub use linkerd2_app_core::{
     classify::Class,
-    errors,
-    // handle_time,
-    http_metrics as metrics,
+    errors, handle_time, http_metrics as metrics,
     metric_labels::{ControlLabels, EndpointLabels, RouteLabels},
     metrics::FmtMetrics,
-    opencensus,
-    proxy,
-    stack_metrics,
-    telemetry,
-    transport,
-    ControlHttpMetrics,
-    ProxyMetrics,
+    opencensus, proxy, stack_metrics, telemetry, transport, ControlHttpMetrics, ProxyMetrics,
 };
 use std::time::{Duration, SystemTime};
 
@@ -61,9 +53,9 @@ impl Metrics {
 
         let http_errors = errors::Metrics::default();
 
-        // let handle_time_report = handle_time::Metrics::new();
-        // let inbound_handle_time = handle_time_report.inbound();
-        // let outbound_handle_time = handle_time_report.outbound();
+        let handle_time_report = handle_time::Metrics::new();
+        let inbound_handle_time = handle_time_report.inbound();
+        let outbound_handle_time = handle_time_report.outbound();
 
         let stack = stack_metrics::Registry::default();
 
@@ -73,7 +65,7 @@ impl Metrics {
 
         let metrics = Metrics {
             inbound: ProxyMetrics {
-                // http_handle_time: inbound_handle_time,
+                http_handle_time: inbound_handle_time,
                 http_endpoint: http_endpoint.clone(),
                 http_route: http_route.clone(),
                 http_route_actual: http_route_actual.clone(),
@@ -83,7 +75,7 @@ impl Metrics {
                 transport: transport.clone(),
             },
             outbound: ProxyMetrics {
-                // http_handle_time: outbound_handle_time,
+                http_handle_time: outbound_handle_time,
                 http_endpoint,
                 http_route,
                 http_route_retry,
@@ -102,7 +94,7 @@ impl Metrics {
             .and_then(retry_report)
             .and_then(actual_report)
             .and_then(control_report)
-            // .and_then(handle_time_report)
+            .and_then(handle_time_report)
             .and_then(transport_report)
             .and_then(opencensus_report)
             .and_then(stack)


### PR DESCRIPTION
This branch updates the proxy handle time metric and puts the layer that
records it back in the stack.

Depends on #541 (for `insert`).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>