### PR TITLE
gateway: Return errors instead of responses

### DIFF
--- a/linkerd/app/core/src/errors.rs
+++ b/linkerd/app/core/src/errors.rs
@@ -386,7 +386,7 @@ impl HttpError {
     pub fn identity_required(message: &'static str) -> Self {
         Self {
             message,
-            http: http::StatusCode::PROXY_AUTHENTICATION_REQUIRED,
+            http: http::StatusCode::FORBIDDEN,
             grpc: Code::Unauthenticated,
             reason: Reason::IdentityRequired,
         }

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -1,6 +1,6 @@
 use futures::{future, Future, Poll};
 use linkerd2_app_core::proxy::{http, identity};
-use linkerd2_app_core::{dns, NameAddr};
+use linkerd2_app_core::{dns, errors::HttpError, Error, NameAddr};
 
 #[derive(Clone, Debug)]
 pub(crate) enum Gateway<O> {
@@ -36,16 +36,16 @@ impl<B, O> tower::Service<http::Request<B>> for Gateway<O>
 where
     B: http::Payload + 'static,
     O: tower::Service<http::Request<B>, Response = http::Response<http::boxed::Payload>>,
-    O::Error: Send + 'static,
+    O::Error: Into<Error> + 'static,
     O::Future: Send + 'static,
 {
     type Response = O::Response;
-    type Error = O::Error;
+    type Error = Error;
     type Future = Box<dyn Future<Item = Self::Response, Error = Self::Error> + Send + 'static>;
 
     fn poll_ready(&mut self) -> Poll<(), Self::Error> {
         match self {
-            Self::Outbound { outbound, .. } => outbound.poll_ready(),
+            Self::Outbound { outbound, .. } => outbound.poll_ready().map_err(Into::into),
             _ => Ok(().into()),
         }
     }
@@ -63,27 +63,13 @@ where
                     headers = ?request.headers(),
                     "Passing request to outbound"
                 );
-                Box::new(outbound.call(request))
+                Box::new(outbound.call(request).map_err(Into::into))
             }
-            Self::NoAuthority => {
-                tracing::info!("No authority");
-                Box::new(future::ok(forbidden()))
-            }
-            Self::NoIdentity => {
-                tracing::info!("No identity");
-                Box::new(future::ok(forbidden()))
-            }
-            Self::BadDomain(dst) => {
-                tracing::info!(%dst, "Bad domain");
-                Box::new(future::ok(forbidden()))
-            }
+            Self::NoAuthority => Box::new(future::err(HttpError::not_found("no authority").into())),
+            Self::NoIdentity => Box::new(future::err(
+                HttpError::identity_required("no identity").into(),
+            )),
+            Self::BadDomain(..) => Box::new(future::err(HttpError::not_found("bad domain").into())),
         }
     }
-}
-
-fn forbidden<B: Default>() -> http::Response<B> {
-    http::Response::builder()
-        .status(http::StatusCode::FORBIDDEN)
-        .body(Default::default())
-        .unwrap()
 }


### PR DESCRIPTION
This ensures that error metrics are recorded and that logging is emitted
uniformly. This also ensures that gRPC requests don't get HTTP error
responses.