### PR TITLE
update identity service client to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,14 +1425,15 @@ dependencies = [
 name = "linkerd2-proxy-identity"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.26",
+ "futures 0.3.4",
+ "http-body 0.3.1",
  "linkerd2-error",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=c2dba642c7301b5b562c75fd6e2bd0a12ec763e8)",
  "linkerd2-proxy-transport",
- "tokio 0.1.22",
- "tokio-timer",
- "tower-grpc",
+ "pin-project",
+ "tokio 0.2.21",
+ "tonic",
  "tracing",
 ]
 

--- a/linkerd/app/integration/tests/identity.rs
+++ b/linkerd/app/integration/tests/identity.rs
@@ -1,5 +1,4 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "1586225"]
 
 use linkerd2_app_integration::*;
 use std::{
@@ -11,7 +10,6 @@ use std::{
 };
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn nonblocking_identity_detection() {
     let _ = trace_init();
 
@@ -114,7 +112,6 @@ macro_rules! generate_tls_reject_test {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http1_accepts_tls_after_identity_is_certified() {
     generate_tls_accept_test! {
        client_non_tls:  client::http1,
@@ -128,7 +125,6 @@ fn http1_rejects_tls_before_identity_is_certified() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http2_accepts_tls_after_identity_is_certified() {
     generate_tls_accept_test! {
        client_non_tls:  client::http2,
@@ -194,7 +190,6 @@ fn http2_outbound_tls_works_before_identity_is_certified() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn ready() {
     let _ = trace_init();
     let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
@@ -228,7 +223,6 @@ fn ready() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 async fn refresh() {
     let _ = trace_init();
     let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";

--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -1,4 +1,3 @@
-use futures::{future, Future};
 pub use linkerd2_app_core::proxy::identity::{
     certify, Crt, CrtKey, Csr, InvalidName, Key, Local, Name, TokenSource, TrustAnchors,
 };
@@ -10,6 +9,8 @@ use linkerd2_app_core::{
     transport::tls,
     ControlHttpMetrics as Metrics, Error, Never,
 };
+use std::future::Future;
+use std::pin::Pin;
 use tracing::debug;
 
 #[derive(Clone, Debug)]
@@ -30,7 +31,7 @@ pub enum Identity {
     },
 }
 
-pub type Task = Box<dyn Future<Item = (), Error = Never> + Send + 'static>;
+pub type Task = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
 pub type LocalIdentity = tls::Conditional<Local>;
 
@@ -42,31 +43,30 @@ impl Config {
                 let (local, crt_store) = Local::new(&certify);
 
                 let addr = control.addr;
-                // let svc = svc::connect(control.connect.keepalive)
-                //     .push(tls::ConnectLayer::new(tls::Conditional::Some(
-                //         certify.trust_anchors.clone(),
-                //     )))
-                //     .push_timeout(control.connect.timeout)
-                //     .push(control::client::layer())
-                //     .push(control::resolve::layer(dns))
-                //     .push(reconnect::layer({
-                //         let backoff = control.connect.backoff;
-                //         move |_| Ok(backoff.stream())
-                //     }))
-                //     .push(metrics.into_layer::<classify::Response>())
-                //     .push_on_response(proxy::grpc::req_body_as_payload::layer())
-                //     .push(control::add_origin::Layer::new())
-                //     .into_new_service()
-                //     .new_service(addr.clone());
+                let svc = svc::connect(control.connect.keepalive)
+                    .push(tls::ConnectLayer::new(tls::Conditional::Some(
+                        certify.trust_anchors.clone(),
+                    )))
+                    .push_timeout(control.connect.timeout)
+                    .push(control::client::layer())
+                    .push(control::resolve::layer(dns))
+                    .push(reconnect::layer({
+                        let backoff = control.connect.backoff;
+                        move |_| Ok(backoff.stream())
+                    }))
+                    .push(metrics.into_layer::<classify::Response>())
+                    .push_on_response(proxy::grpc::req_body_as_payload::layer())
+                    .push(control::add_origin::Layer::new())
+                    .into_new_service()
+                    .new_service(addr.clone());
 
                 // Save to be spawned on an auxiliary runtime.
                 let task = {
                     let addr = addr.clone();
-                    Box::new(future::lazy(move || {
+                    Box::pin(async move {
                         debug!(peer.addr = ?addr, "running");
-                        // certify::Daemon::new(certify, crt_store, svc)
-                        Ok(())
-                    }))
+                        certify::daemon(certify, crt_store, svc).await
+                    })
                 };
 
                 Ok(Identity::Enabled { addr, local, task })

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.1"
+futures = "0.3"
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.12" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "c2dba642c7301b5b562c75fd6e2bd0a12ec763e8" }
 linkerd2-proxy-transport = { path = "../transport" }
-tokio = "0.1.14"
-tokio-timer = "0.2"
-tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
+tokio = { version = "0.2", features = ["time", "sync"] }
+tonic = { version = "0.2", default-features = false }
 tracing = "0.1.9"
-
+http-body = "0.3"
+pin-project = "0.4"


### PR DESCRIPTION
This branch updates the identity service client to use `std::future` and
async/await. Since the identity refresh daemon code ended up being
somewhat tricky to make work with stack pinning, I opted to just replace
it with a new async/await implementation instead.

I've also re-enabled all the identity integration tests.