### PR TITLE
propagate spans to tasks spawned by Hyper

### DIFF
--- a/linkerd/app/integration/src/server.rs
+++ b/linkerd/app/integration/src/server.rs
@@ -1,6 +1,7 @@
 use super::*;
 use futures::TryFuture;
 use http::Response;
+use linkerd2_app_core::proxy::http::trace;
 use rustls::ServerConfig;
 use std::collections::HashMap;
 use std::future::Future;
@@ -186,7 +187,8 @@ impl Server {
                 let _subscriber = subscriber.set_default();
                 tracing::info!("support server running");
                 let mut new_svc = NewSvc(Arc::new(self.routes));
-                let mut http = hyper::server::conn::Http::new();
+                let mut http =
+                    hyper::server::conn::Http::new().with_executor(trace::Executor::new());
                 match self.version {
                     Run::Http1 => http.http1_only(true),
                     Run::Http2 => http.http2_only(true),

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -3,6 +3,7 @@ use super::upgrade::{Http11Upgrade, HttpConnect};
 use super::{
     h1, h2,
     settings::{HasSettings, Settings},
+    trace,
 };
 use futures::{ready, TryFuture};
 use http;
@@ -145,6 +146,7 @@ where
                 }
                 // hyper should only try to automatically
                 // set the host if the request was in absolute_form
+                .executor(trace::Executor::new())
                 .set_host(was_absolute_form)
                 .build(HyperConnect::new(connect, target, was_absolute_form));
                 MakeFuture::Http1(Some(h1))

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -1,3 +1,4 @@
+use super::trace;
 use super::Body;
 use futures::{ready, TryFuture, TryFutureExt};
 use http;
@@ -156,6 +157,7 @@ where
                         .http2_initial_connection_window_size(
                             this.h2_settings.initial_connection_window_size,
                         )
+                        .executor(trace::Executor::new())
                         .handshake(io)
                         .instrument(info_span!("h2"));
 

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -19,6 +19,7 @@ pub mod override_authority;
 pub mod settings;
 pub mod strip_header;
 pub mod timeout;
+pub mod trace;
 pub mod upgrade;
 mod version;
 

--- a/linkerd/proxy/http/src/trace.rs
+++ b/linkerd/proxy/http/src/trace.rs
@@ -1,0 +1,25 @@
+use std::future::Future;
+use tracing_futures::Instrument;
+
+#[derive(Clone, Debug)]
+pub struct Executor {
+    _p: (),
+}
+
+impl Executor {
+    #[inline]
+    pub fn new() -> Self {
+        Self { _p: () }
+    }
+}
+
+impl<F> hyper::rt::Executor<F> for Executor
+where
+    F: Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    #[inline]
+    fn execute(&self, f: F) {
+        tokio::spawn(f.in_current_span());
+    }
+}


### PR DESCRIPTION
Previously, in the `futures` 0.1 version of the proxy, we provided
`hyper` with a custom executor to propagate `tracing` spans to tasks
spawned by `hyper`. In the process of updating the proxy to
`std::future`, this was removed, meaning that any tasks spawned by hyper
are missing their spans. This makes events recorded by `h2` and so on
hard to debug, especially when many connections are open.

This branch fixes this by adding an implementation of `hyper::Executor`
that propagates the current span when spawning a task.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>