### PR TITLE
 update require_identity_on_endpoint to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,9 +994,9 @@ dependencies = [
 name = "linkerd2-app-outbound"
 version = "0.1.0"
 dependencies = [
- "bytes 0.4.11",
+ "bytes 0.5.4",
  "futures 0.3.4",
- "http 0.1.21",
+ "http 0.2.1",
  "indexmap",
  "linkerd2-app-core",
  "linkerd2-identity",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -9,8 +9,8 @@ Configures and runs the outbound proxy
 """
 
 [dependencies]
-bytes = "0.4"
-http = "0.1"
+bytes = "0.5"
+http = "0.2"
 futures = "0.3"
 indexmap = "1.0"
 linkerd2-app-core = { path = "../core" }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -42,10 +42,10 @@ use tracing::info_span;
 // mod add_server_id_on_rsp;
 mod endpoint;
 mod orig_proto_upgrade;
-// mod require_identity_on_endpoint;
+mod require_identity_on_endpoint;
 
 use self::orig_proto_upgrade::OrigProtoUpgradeLayer;
-// use self::require_identity_on_endpoint::MakeRequireIdentityLayer;
+use self::require_identity_on_endpoint::MakeRequireIdentityLayer;
 
 const EWMA_DEFAULT_RTT: Duration = Duration::from_millis(30);
 const EWMA_DECAY: Duration = Duration::from_secs(10);
@@ -147,8 +147,7 @@ impl Config {
                             .push(http::strip_header::response::layer(L5D_SERVER_ID))
                             .push(http::strip_header::request::layer(L5D_REQUIRE_ID)),
                     )
-                    // .push(MakeRequireIdentityLayer::new())
-                    ;
+                    .push(MakeRequireIdentityLayer::new());
 
                 tcp_connect
                     .clone()


### PR DESCRIPTION
This branch updates the `require_identity_on_endpoint` module in
`linkerd2-app-outbound` to `std::future`. 

The tests for this functionality
(`require_id_header::http2::disco_client_connects_to_tls_server` and
`require_id_header::http1::disco_client_connects_to_tls_server`) now
pass; however, they had already been re-enabled (they are tagged as
flaky).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>