### PR TITLE
update linkerd2-error-metrics to std::future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,10 +1154,11 @@ dependencies = [
 name = "linkerd2-error-metrics"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.26",
+ "futures 0.3.4",
  "indexmap",
  "linkerd2-metrics",
- "tower 0.1.1",
+ "pin-project",
+ "tower 0.3.1",
 ]
 
 [[package]]

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -360,7 +360,7 @@ impl Config {
             // Eagerly fail requests when the proxy is out of capacity for a
             // dispatch_timeout.
             .push_failfast(dispatch_timeout)
-            //.push(metrics.http_errors)
+            .push(metrics.http_errors)
             // Synthesizes responses for proxy errors.
             .push(errors::layer());
 

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "256"]
-#![type_length_limit = "16287993"]
+#![type_length_limit = "16289823"]
 
 mod test_env;
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -473,7 +473,7 @@ impl Config {
             // Eagerly fail requests when the proxy is out of capacity for a
             // dispatch_timeout.
             .push_failfast(dispatch_timeout)
-            //.push(metrics.http_errors.clone())
+            .push(metrics.http_errors.clone())
             // Synthesizes responses for proxy errors.
             .push(errors::layer())
             // Initiates OpenCensus tracing.

--- a/linkerd/error-metrics/Cargo.toml
+++ b/linkerd/error-metrics/Cargo.toml
@@ -7,7 +7,8 @@ publish = false
 
 
 [dependencies]
-futures = "0.1"
+futures = "0.3"
 indexmap = "1.0"
 linkerd2-metrics = { path = "../metrics" }
-tower = "0.1"
+tower = { version = "0.3", default-features = false }
+pin-project = "0.4"

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -2,7 +2,7 @@
 
 #![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "256"]
-#![type_length_limit = "16287993"]
+#![type_length_limit = "16289823"]
 
 use futures::compat::Future01CompatExt;
 use linkerd2_app::{trace, Config};


### PR DESCRIPTION
Looks like the `linkerd2-error-metrics` crate was never updated to
`std::future`. This branch takes care of that and adds back the HTTP
error metrics layers.

This should be a pretty trivial review.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>