### PR TITLE
make shutdowns less graceless

### DIFF
--- a/linkerd/app/integration/tests/shutdown.rs
+++ b/linkerd/app/integration/tests/shutdown.rs
@@ -4,7 +4,6 @@
 use linkerd2_app_integration::*;
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn h2_goaways_connections() {
     let _ = trace_init();
 
@@ -22,7 +21,6 @@ fn h2_goaways_connections() {
 }
 
 #[tokio::test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 async fn h2_exercise_goaways_connections() {
     let _ = trace_init();
 
@@ -67,7 +65,6 @@ async fn h2_exercise_goaways_connections() {
 }
 
 #[test]
-#[cfg_attr(not(feature = "nyi"), ignore)]
 fn http1_closes_idle_connections() {
     use std::cell::RefCell;
     let _ = trace_init();


### PR DESCRIPTION
Although the `Drain` type which powers the proxy's graceful shutdown
machinery was updated in #482, we were not actually triggering graceful
shutdowns. This is because the Hyper `ConnectionFuture` was wrapped in a
compatibility adapter which did not allow access to the inner future so
that we could call the `graceful_shutdown` method on it. When we updated
to the `std::future` version of Hyper, the graceful shutdown code was
not re-enabled.

This branch puts back the call to `ConnectionFuture::graceful_shutdown`.
It also re-enables the shutdown integration tests, which pass now.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>