### PR TITLE
remove & deny warnings; cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1019,7 +1019,7 @@ dependencies = [
  "tower 0.3.1",
  "tower-grpc",
  "tracing",
- "tracing-futures 0.1.0",
+ "tracing-futures 0.2.4",
  "tracing-subscriber",
  "webpki",
 ]
@@ -1070,7 +1070,7 @@ dependencies = [
  "tower 0.3.1",
  "tower-test",
  "tracing",
- "tracing-futures 0.1.0",
+ "tracing-futures 0.2.4",
 ]
 
 [[package]]
@@ -1084,7 +1084,7 @@ dependencies = [
  "tokio 0.2.21",
  "tower 0.3.1",
  "tracing",
- "tracing-futures 0.1.0",
+ "tracing-futures 0.2.4",
 ]
 
 [[package]]
@@ -1113,7 +1113,7 @@ dependencies = [
  "tokio 0.2.21",
  "tower 0.3.1",
  "tracing",
- "tracing-futures 0.1.0",
+ "tracing-futures 0.2.4",
  "trust-dns-resolver",
 ]
 
@@ -1425,7 +1425,7 @@ dependencies = [
  "tower 0.3.1",
  "tower-test",
  "tracing",
- "tracing-futures 0.1.0",
+ "tracing-futures 0.2.4",
 ]
 
 [[package]]
@@ -1455,7 +1455,7 @@ dependencies = [
  "tokio 0.2.21",
  "tower 0.3.1",
  "tracing",
- "tracing-futures 0.1.0",
+ "tracing-futures 0.2.4",
  "try-lock",
 ]
 
@@ -1515,7 +1515,7 @@ dependencies = [
  "tonic",
  "tower 0.3.1",
  "tracing",
- "tracing-futures 0.1.0",
+ "tracing-futures 0.2.4",
 ]
 
 [[package]]
@@ -1555,7 +1555,7 @@ dependencies = [
  "tokio-util",
  "tower 0.3.1",
  "tracing",
- "tracing-futures 0.1.0",
+ "tracing-futures 0.2.4",
  "tracing-subscriber",
  "untrusted",
  "webpki",
@@ -1631,7 +1631,7 @@ dependencies = [
  "tonic",
  "tower 0.3.1",
  "tracing",
- "tracing-futures 0.1.0",
+ "tracing-futures 0.2.4",
 ]
 
 [[package]]
@@ -1673,7 +1673,7 @@ dependencies = [
  "pin-project",
  "tower 0.3.1",
  "tracing",
- "tracing-futures 0.1.0",
+ "tracing-futures 0.2.4",
 ]
 
 [[package]]

--- a/linkerd/app/core/src/admin/mod.rs
+++ b/linkerd/app/core/src/admin/mod.rs
@@ -133,7 +133,6 @@ fn rsp(status: StatusCode, body: impl Into<Body>) -> Response<Body> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures::compat::Future01CompatExt;
     use http::method::Method;
     use std::time::Duration;
     use tokio::time::timeout;

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -7,7 +7,7 @@
 //! - Tap
 //! - Metric labeling
 #![type_length_limit = "1586225"]
-// #![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 
 pub use linkerd2_addr::{self as addr, Addr, NameAddr};
 pub use linkerd2_admit as admit;

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -3,7 +3,7 @@
 //! The inbound proxy is responsible for terminating traffic from other network
 //! endpoints inbound to the local application.
 
-// #![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 
 pub use self::endpoint::{
     HttpEndpoint, Profile, ProfileTarget, RequestTarget, Target, TcpEndpoint,

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -49,7 +49,7 @@ tower_01 = { package = "tower", version = "0.1" }
 tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 tonic = { version = "0.2", default-features = false }
 tracing = "0.1.9"
-tracing-futures = "0.1"
+tracing-futures = { version = "0.2", features = ["std-future"] }
 tracing-subscriber = "0.2.5"
 webpki = "=0.21.0"
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -3,7 +3,7 @@
 //! The outound proxy is responsible for routing traffic from the local
 //! application to external network endpoints.
 
-// #![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 
 pub use self::endpoint::{
     Concrete, HttpEndpoint, Logical, LogicalPerRequest, Profile, ProfilePerTarget, Target,

--- a/linkerd/buffer/Cargo.toml
+++ b/linkerd/buffer/Cargo.toml
@@ -11,7 +11,7 @@ linkerd2-error = { path = "../error" }
 tokio = { version = "0.2", features = ["sync", "stream", "time", "macros"] }
 tower = { version = "0.3", default_features = false, features = ["util"] }
 tracing = "0.1"
-tracing-futures = { version = "0.1", features = ["std-future"] }
+tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 
 [dev-dependencies]

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -13,4 +13,4 @@ linkerd2-stack = { path = "../stack" }
 tokio = "0.2"
 tower = { version = "0.3", default-features = false, features = ["util"] }
 tracing = "0.1"
-tracing-futures = "0.1"
+tracing-futures = "0.2"

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -11,7 +11,7 @@ linkerd2-dns-name = { path = "./name" }
 linkerd2-stack = { path = "../stack" }
 tower = "0.3"
 tracing = "0.1"
-tracing-futures = "0.1"
+tracing-futures = "0.2"
 tokio = { version = "0.2", features = ["rt-core"] }
 pin-project = "0.4"
 

--- a/linkerd/proxy/api-resolve/src/lib.rs
+++ b/linkerd/proxy/api-resolve/src/lib.rs
@@ -1,4 +1,4 @@
-// #![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 
 use linkerd2_identity as identity;
 use linkerd2_proxy_api as api;

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -16,7 +16,7 @@ linkerd2-proxy-core = { path = "../core" }
 indexmap = "1.0"
 tokio = { version = "0.2", features = ["sync", "time", "stream"] }
 tracing = "0.1"
-tracing-futures = { version = "0.1", features = ["std-future"] }
+tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 
 [dependencies.tower]

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -33,6 +33,6 @@ rand = "0.7"
 tokio = { version = "0.2", features = ["time", "rt-core"] }
 tower = { version = "0.3", default-features = false, features = ["balance", "load", "discover"] }
 tracing = "0.1.9"
-tracing-futures = { version = "0.1", features = ["std-future"] }
+tracing-futures = { version = "0.2", features = ["std-future"] }
 try-lock = "0.2"
 pin-project = "0.4"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "0.2", features = ["time"]}
 tower = {version = "0.3", default-features = false }
 tonic = { version = "0.2", default-features = false }
 tracing = "0.1.9"
-tracing-futures = "0.1"
+tracing-futures = "0.2"
 pin-project = "0.4"
 
 [dev-dependencies]

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -51,4 +51,4 @@ libc = "0.2"
 linkerd2-identity = { path = "../../identity", features = ["test-util"] }
 tracing-subscriber = "0.2.1"
 tower = { version = "0.3", default-features = false, features = ["util"] }
-tracing-futures = { version = "0.1", features = ["std-future"] }
+tracing-futures = { version = "0.2", features = ["std-future"] }

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -1,4 +1,4 @@
-// #![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 #![type_length_limit = "1586225"]
 
 use std::time::Duration;

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -24,7 +24,7 @@ regex = "1.0.0"
 tokio = { version = "0.2", features = ["time", "sync"] }
 tonic = { version = "0.2", default-features = false }
 tracing = "0.1.9"
-tracing-futures = { version = "0.1", features = ["std-future"] }
+tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 
 [dependencies.tower]

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3"
 linkerd2-error = { path = "../../error" }
 linkerd2-stack = { path = ".." }
 tracing = "0.1"
-tracing-futures = { version = "0.1", features = ["std-future"] }
+tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 
 [dependencies.tower]

--- a/linkerd/trace-context/src/lib.rs
+++ b/linkerd/trace-context/src/lib.rs
@@ -1,4 +1,4 @@
-// #![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 
 use bytes::Bytes;
 use linkerd2_error::Error;


### PR DESCRIPTION
This PR removes a few remaining compiler warnings from
`master-tokio-0.2` and re-adds `deny` attributes for warnings. Also,
I've updated all crates to consistently use `tracing-futures` v0.2
(previously, some crates were on 0.2 while others were still on 0.1).