### PR TITLE
integration: fix missing traces

### DIFF
--- a/linkerd/app/integration/src/client.rs
+++ b/linkerd/app/integration/src/client.rs
@@ -210,8 +210,7 @@ fn run(addr: SocketAddr, version: Run, tls: Option<TlsConfig>) -> (Sender, Runni
     ::std::thread::Builder::new()
         .name(tname)
         .spawn(move || {
-            let (subscriber, _) = trace_subscriber();
-            let _subscriber = subscriber.set_default();
+            let _trace = trace_init();
             tracing::info!("support client running");
 
             let mut runtime = tokio::runtime::Builder::new()

--- a/linkerd/app/integration/src/client.rs
+++ b/linkerd/app/integration/src/client.rs
@@ -210,7 +210,7 @@ fn run(addr: SocketAddr, version: Run, tls: Option<TlsConfig>) -> (Sender, Runni
     ::std::thread::Builder::new()
         .name(tname)
         .spawn(move || {
-            let (subscriber, _) = trace_init();
+            let (subscriber, _) = trace_subscriber();
             let _subscriber = subscriber.set_default();
             tracing::info!("support client running");
 

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -329,7 +329,7 @@ where
     let (listening_tx, listening_rx) = futures_01::sync::oneshot::channel();
     let mut listening_tx = Some(listening_tx);
 
-    let (trace, _) = trace_init();
+    let (trace, _) = trace_subscriber();
     std::thread::Builder::new()
         .name(name.into())
         .spawn(move || {

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -59,7 +59,7 @@ pub fn trace_subscriber() -> (Dispatch, app::core::trace::LevelHandle) {
     app::core::trace::with_filter_and_format(&log_level, &log_format)
 }
 
-pub fn trace_init() -> tracing::dispatcher::DefaultGuard { 
+pub fn trace_init() -> tracing::dispatcher::DefaultGuard {
     let (d, _) = trace_subscriber();
     tracing::dispatcher::set_default(&d)
 }

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -44,7 +44,7 @@ const DEFAULT_LOG: &'static str = "error,\
                                    linkerd2_proxy_http=off,\
                                    linkerd2_proxy_transport=off";
 
-pub fn trace_init() -> (Dispatch, app::core::trace::LevelHandle) {
+pub fn trace_subscriber() -> (Dispatch, app::core::trace::LevelHandle) {
     use std::env;
     let log_level = env::var("LINKERD2_PROXY_LOG")
         .or_else(|_| env::var("RUST_LOG"))
@@ -57,6 +57,11 @@ pub fn trace_init() -> (Dispatch, app::core::trace::LevelHandle) {
     // initialized by another test.
     let _ = app::core::trace::init_log_compat();
     app::core::trace::with_filter_and_format(&log_level, &log_format)
+}
+
+pub fn trace_init() -> tracing::dispatcher::DefaultGuard { 
+    let (d, _) = trace_subscriber();
+    tracing::dispatcher::set_default(&d)
 }
 
 /// Retry an assertion up to a specified number of times, waiting

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -236,7 +236,7 @@ fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
     }
 
     let config = app::env::parse_config(&env).unwrap();
-    let (trace, trace_handle) = super::trace_init();
+    let (trace, trace_handle) = super::trace_subscriber();
 
     let (running_tx, running_rx) = oneshot::channel();
     let (tx, mut rx) = shutdown_signal();

--- a/linkerd/app/integration/src/server.rs
+++ b/linkerd/app/integration/src/server.rs
@@ -183,8 +183,7 @@ impl Server {
         ::std::thread::Builder::new()
             .name(tname)
             .spawn(move || {
-                let (subscriber, _) = trace_init();
-                let _subscriber = subscriber.set_default();
+                let _trace = trace_init();
                 tracing::info!("support server running");
                 let mut new_svc = NewSvc(Arc::new(self.routes));
                 let mut http =

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -9,7 +9,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_asks_controller_api() {
-            let _trace = trace_init();;
+            let _trace = trace_init();
             let srv = $make_server().route("/", "hello").route("/bye", "bye").run();
 
             let ctrl = controller::new();
@@ -25,7 +25,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_reconnects_if_controller_stream_ends() {
-            let _trace = trace_init();;
+            let _trace = trace_init();
 
             let srv = $make_server().route("/recon", "nect").run();
 
@@ -52,7 +52,7 @@ macro_rules! generate_tests {
 
         fn outbound_fails_fast(up: pb::destination::Update) {
             use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
-            let _trace = trace_init();;
+            let _trace = trace_init();
 
             let did_not_fall_back = Arc::new(AtomicBool::new(true));
             let did_not_fall_back2 = did_not_fall_back.clone();
@@ -85,7 +85,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_falls_back_to_orig_dst_when_outside_search_path() {
-            let _trace = trace_init();;
+            let _trace = trace_init();
 
             let srv = $make_server().route("/", "hello from my great website").run();
 
@@ -103,7 +103,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_falls_back_to_orig_dst_after_invalid_argument() {
-            let _trace = trace_init();;
+            let _trace = trace_init();
 
             let srv = $make_server().route("/", "hello").run();
 
@@ -270,7 +270,7 @@ macro_rules! generate_tests {
 
             #[test]
             fn outbound_should_strip() {
-                let _trace = trace_init();;
+                let _trace = trace_init();
                 let header = HeaderValue::from_static(IP_1);
 
                 let srv = $make_server().route_fn("/strip", |_req| {
@@ -290,7 +290,7 @@ macro_rules! generate_tests {
 
             #[test]
             fn inbound_should_strip() {
-                let _trace = trace_init();;
+                let _trace = trace_init();
                 let header = HeaderValue::from_static(IP_1);
 
                 let srv = $make_server().route_fn("/strip", move |req| {
@@ -310,7 +310,7 @@ macro_rules! generate_tests {
             #[test]
             #[ignore] // #2597
             fn outbound_should_set() {
-                let _trace = trace_init();;
+                let _trace = trace_init();
                 let header = HeaderValue::from_static(IP_2);
 
                 let srv = $make_server().route("/set", "hello").run();
@@ -328,7 +328,7 @@ macro_rules! generate_tests {
             #[test]
             #[ignore] // #2597
             fn inbound_should_set() {
-                let _trace = trace_init();;
+                let _trace = trace_init();
 
                 let header = HeaderValue::from_static(IP_2);
 
@@ -366,7 +366,7 @@ macro_rules! generate_tests {
 
             impl Fixture {
                 fn new() -> Fixture {
-                    let _trace = trace_init();;
+                    let _trace = trace_init();
 
                     let foo_reqs = Arc::new(AtomicUsize::new(0));
                     let foo_reqs2 = foo_reqs.clone();

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -9,7 +9,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_asks_controller_api() {
-            let _ = trace_init();
+            let _trace = trace_init();;
             let srv = $make_server().route("/", "hello").route("/bye", "bye").run();
 
             let ctrl = controller::new();
@@ -25,7 +25,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_reconnects_if_controller_stream_ends() {
-            let _ = trace_init();
+            let _trace = trace_init();;
 
             let srv = $make_server().route("/recon", "nect").run();
 
@@ -52,7 +52,7 @@ macro_rules! generate_tests {
 
         fn outbound_fails_fast(up: pb::destination::Update) {
             use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
-            let _ = trace_init();
+            let _trace = trace_init();;
 
             let did_not_fall_back = Arc::new(AtomicBool::new(true));
             let did_not_fall_back2 = did_not_fall_back.clone();
@@ -85,7 +85,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_falls_back_to_orig_dst_when_outside_search_path() {
-            let _ = trace_init();
+            let _trace = trace_init();;
 
             let srv = $make_server().route("/", "hello from my great website").run();
 
@@ -103,7 +103,7 @@ macro_rules! generate_tests {
 
         #[test]
         fn outbound_falls_back_to_orig_dst_after_invalid_argument() {
-            let _ = trace_init();
+            let _trace = trace_init();;
 
             let srv = $make_server().route("/", "hello").run();
 
@@ -270,7 +270,7 @@ macro_rules! generate_tests {
 
             #[test]
             fn outbound_should_strip() {
-                let _ = trace_init();
+                let _trace = trace_init();;
                 let header = HeaderValue::from_static(IP_1);
 
                 let srv = $make_server().route_fn("/strip", |_req| {
@@ -290,7 +290,7 @@ macro_rules! generate_tests {
 
             #[test]
             fn inbound_should_strip() {
-                let _ = trace_init();
+                let _trace = trace_init();;
                 let header = HeaderValue::from_static(IP_1);
 
                 let srv = $make_server().route_fn("/strip", move |req| {
@@ -310,7 +310,7 @@ macro_rules! generate_tests {
             #[test]
             #[ignore] // #2597
             fn outbound_should_set() {
-                let _ = trace_init();
+                let _trace = trace_init();;
                 let header = HeaderValue::from_static(IP_2);
 
                 let srv = $make_server().route("/set", "hello").run();
@@ -328,7 +328,7 @@ macro_rules! generate_tests {
             #[test]
             #[ignore] // #2597
             fn inbound_should_set() {
-                let _ = trace_init();
+                let _trace = trace_init();;
 
                 let header = HeaderValue::from_static(IP_2);
 
@@ -366,7 +366,7 @@ macro_rules! generate_tests {
 
             impl Fixture {
                 fn new() -> Fixture {
-                    let _ = trace_init();
+                    let _trace = trace_init();;
 
                     let foo_reqs = Arc::new(AtomicUsize::new(0));
                     let foo_reqs2 = foo_reqs.clone();
@@ -591,7 +591,7 @@ mod http2 {
     #[tokio::test]
     async fn outbound_balancer_waits_for_ready_endpoint() {
         // See https://github.com/linkerd/linkerd2/issues/2550
-        let _ = trace_init();
+        let _trace = trace_init();
 
         let srv1 = server::http2()
             .route("/", "hello")
@@ -663,7 +663,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn outbound_http1() {
-        let _ = trace_init();
+        let _trace = trace_init();
 
         // Instead of a second proxy, this mocked h2 server will be the target.
         let srv = server::http2()
@@ -692,7 +692,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn inbound_http1() {
-        let _ = trace_init();
+        let _trace = trace_init();
 
         let srv = server::http1()
             .route_fn("/h1", |req| {
@@ -724,7 +724,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn inbound_should_strip_l5d_client_id() {
-        let _ = trace_init();
+        let _trace = trace_init();
 
         let srv = server::http1()
             .route_fn("/stripped", |req| {
@@ -750,7 +750,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn outbound_should_strip_l5d_client_id() {
-        let _ = trace_init();
+        let _trace = trace_init();
 
         let srv = server::http1()
             .route_fn("/stripped", |req| {
@@ -777,7 +777,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn inbound_should_strip_l5d_server_id() {
-        let _ = trace_init();
+        let _trace = trace_init();
 
         let srv = server::http1()
             .route_fn("/strip-me", |_req| {
@@ -806,7 +806,7 @@ mod proxy_to_proxy {
 
     #[test]
     fn outbound_should_strip_l5d_server_id() {
-        let _ = trace_init();
+        let _trace = trace_init();
 
         let srv = server::http1()
             .route_fn("/strip-me", |_req| {
@@ -832,7 +832,7 @@ mod proxy_to_proxy {
 
     macro_rules! generate_l5d_tls_id_test {
         (server: $make_server:path, client: $make_client:path) => {
-            let _ = trace_init();
+            let _trace = trace_init();
             let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
             let id_env = identity::Identity::new("foo-ns1", id.to_string());
 

--- a/linkerd/app/integration/tests/identity.rs
+++ b/linkerd/app/integration/tests/identity.rs
@@ -11,7 +11,7 @@ use std::{
 
 #[test]
 fn nonblocking_identity_detection() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let identity::Identity {
@@ -47,7 +47,7 @@ fn nonblocking_identity_detection() {
 
 macro_rules! generate_tls_accept_test {
     ( client_non_tls: $make_client_non_tls:path, client_tls: $make_client_tls:path) => {
-        let _ = trace_init();
+        let _trace = trace_init();
         let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
         let id_svc = identity::Identity::new("foo-ns1", id.to_string());
         let proxy = proxy::new()
@@ -80,7 +80,7 @@ macro_rules! generate_tls_accept_test {
 
 macro_rules! generate_tls_reject_test {
     ( client: $make_client:path) => {
-        let _ = trace_init();
+        let _trace = trace_init();
         let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
         let identity::Identity {
             env,
@@ -139,7 +139,7 @@ fn http2_rejects_tls_before_identity_is_certified() {
 
 macro_rules! generate_outbound_tls_accept_not_cert_identity_test {
     (server: $make_server:path, client: $make_client:path) => {
-        let _ = trace_init();
+        let _trace = trace_init();
         let proxy_id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
         let app_id = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";
 
@@ -191,7 +191,7 @@ fn http2_outbound_tls_works_before_identity_is_certified() {
 
 #[test]
 fn ready() {
-    let _ = trace_init();
+    let _trace = trace_init();
     let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let identity::Identity {
         env,
@@ -224,7 +224,7 @@ fn ready() {
 
 #[tokio::test]
 async fn refresh() {
-    let _ = trace_init();
+    let _trace = trace_init();
     let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let identity::Identity {
         mut env,
@@ -278,7 +278,7 @@ mod require_id_header {
             #[test]
             #[cfg_attr(not(feature = "flaky_tests"), ignore)]
             fn orig_dst_client_connects_to_tls_server() {
-                let _ = trace_init();
+                let _trace = trace_init();
 
                 let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
                 let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
@@ -335,7 +335,7 @@ mod require_id_header {
             #[test]
             #[cfg_attr(not(feature = "flaky_tests"), ignore)]
             fn disco_client_connects_to_tls_server() {
-                let _ = trace_init();
+                let _trace = trace_init();
 
                 let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
                 let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());
@@ -403,7 +403,7 @@ mod require_id_header {
             #[test]
             #[cfg_attr(not(feature = "flaky_tests"), ignore)]
             fn orig_dst_client_cannot_connect_to_plaintext_server() {
-                let _ = trace_init();
+                let _trace = trace_init();
 
                 let proxy_name = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
                 let proxy_identity = identity::Identity::new("foo-ns1", proxy_name.to_string());

--- a/linkerd/app/integration/tests/profile_dst_overrides.rs
+++ b/linkerd/app/integration/tests/profile_dst_overrides.rs
@@ -64,7 +64,7 @@ fn wait_for_profile_stage(client: &client::Client, metrics: &client::Client, sta
 
 #[test]
 fn add_a_dst_override() {
-    let _ = trace_init();
+    let _trace = trace_init();
     let ctrl = controller::new_unordered();
 
     let apex = "apex";
@@ -109,7 +109,7 @@ fn add_a_dst_override() {
 
 #[test]
 fn add_multiple_dst_overrides() {
-    let _ = trace_init();
+    let _trace = trace_init();
     let ctrl = controller::new_unordered();
 
     let apex = "apex";
@@ -165,7 +165,7 @@ fn add_multiple_dst_overrides() {
 
 #[test]
 fn set_a_dst_override_weight_to_zero() {
-    let _ = trace_init();
+    let _trace = trace_init();
     let ctrl = controller::new_unordered();
 
     let apex = "apex";
@@ -230,7 +230,7 @@ fn set_a_dst_override_weight_to_zero() {
 
 #[test]
 fn set_all_dst_override_weights_to_zero() {
-    let _ = trace_init();
+    let _trace = trace_init();
     let ctrl = controller::new_unordered();
 
     let apex = "apex";
@@ -297,7 +297,7 @@ fn set_all_dst_override_weights_to_zero() {
 
 #[test]
 fn remove_a_dst_override() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let apex = "apex";
     let apex_svc = Service::new(apex);

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -23,7 +23,7 @@ macro_rules! profile_test {
         }
     };
     (http: $http:ident, routes: [$($route:expr),+], budget: $budget:expr, with_client: $with_client:expr, with_metrics: $with_metrics:expr) => {
-        let _trace = trace_init();;
+        let _trace = trace_init();
 
         let counter = AtomicUsize::new(0);
         let counter2 = AtomicUsize::new(0);

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -23,7 +23,7 @@ macro_rules! profile_test {
         }
     };
     (http: $http:ident, routes: [$($route:expr),+], budget: $budget:expr, with_client: $with_client:expr, with_metrics: $with_metrics:expr) => {
-        let _ = trace_init();
+        let _trace = trace_init();;
 
         let counter = AtomicUsize::new(0);
         let counter2 = AtomicUsize::new(0);

--- a/linkerd/app/integration/tests/shutdown.rs
+++ b/linkerd/app/integration/tests/shutdown.rs
@@ -5,7 +5,7 @@ use linkerd2_app_integration::*;
 
 #[test]
 fn h2_goaways_connections() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let (shdn, rx) = shutdown_signal();
 
@@ -22,7 +22,7 @@ fn h2_goaways_connections() {
 
 #[tokio::test]
 async fn h2_exercise_goaways_connections() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     const RESPONSE_SIZE: usize = 1024 * 16;
     const NUM_REQUESTS: usize = 50;
@@ -67,7 +67,7 @@ async fn h2_exercise_goaways_connections() {
 #[test]
 fn http1_closes_idle_connections() {
     use std::cell::RefCell;
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let (shdn, rx) = shutdown_signal();
 
@@ -94,7 +94,7 @@ fn http1_closes_idle_connections() {
 
 #[test]
 fn tcp_waits_for_proxies_to_close() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let (shdn, rx) = shutdown_signal();
     let msg1 = "custom tcp hello";

--- a/linkerd/app/integration/tests/tap.rs
+++ b/linkerd/app/integration/tests/tap.rs
@@ -7,7 +7,7 @@ use std::time::SystemTime;
 
 #[test]
 fn tap_enabled_when_identity_enabled() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let identity = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let identity_env = identity::Identity::new("foo-ns1", identity.to_string());
@@ -21,7 +21,7 @@ fn tap_enabled_when_identity_enabled() {
 
 #[test]
 fn tap_disabled_when_identity_disabled() {
-    let _ = trace_init();
+    let _trace = trace_init();
     let proxy = proxy::new().disable_identity().run();
 
     assert!(proxy.tap.is_none())
@@ -29,7 +29,7 @@ fn tap_disabled_when_identity_disabled() {
 
 #[test]
 fn can_disable_tap() {
-    let _ = trace_init();
+    let _trace = trace_init();
     let mut env = TestEnv::new();
     env.put(app::env::ENV_TAP_DISABLED, "true".to_owned());
 
@@ -40,7 +40,7 @@ fn can_disable_tap() {
 
 #[tokio::test]
 async fn rejects_incorrect_identity_when_identity_is_expected() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let identity = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
     let identity_env = identity::Identity::new("foo-ns1", identity.to_string());
@@ -75,7 +75,7 @@ async fn rejects_incorrect_identity_when_identity_is_expected() {
 #[tokio::test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 async fn inbound_http1() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     // Setup server proxy authority and identity
     let srv_proxy_authority = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
@@ -151,7 +151,7 @@ async fn inbound_http1() {
 
 #[tokio::test]
 async fn grpc_headers_end() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     // Setup server proxy authority and identity
     let srv_proxy_authority = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";

--- a/linkerd/app/integration/tests/telemetry.rs
+++ b/linkerd/app/integration/tests/telemetry.rs
@@ -113,7 +113,7 @@ impl TcpFixture {
 
 #[test]
 fn metrics_endpoint_inbound_request_count() {
-    let _ = trace_init();
+    let _trace = trace_init();
     let Fixture {
         client,
         metrics,
@@ -133,7 +133,7 @@ fn metrics_endpoint_inbound_request_count() {
 
 #[test]
 fn metrics_endpoint_outbound_request_count() {
-    let _ = trace_init();
+    let _trace = trace_init();
     let Fixture {
         client,
         metrics,
@@ -218,7 +218,7 @@ mod response_classification {
 
     #[test]
     fn inbound_http() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let Fixture {
             client,
             metrics,
@@ -247,7 +247,7 @@ mod response_classification {
 
     #[test]
     fn outbound_http() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let Fixture {
             client,
             metrics,
@@ -287,7 +287,7 @@ mod response_classification {
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn metrics_endpoint_inbound_response_latency() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     info!("running test server");
     let srv = server::new()
@@ -366,7 +366,7 @@ fn metrics_endpoint_inbound_response_latency() {
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn metrics_endpoint_outbound_response_latency() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     info!("running test server");
     let srv = server::new()
@@ -469,7 +469,7 @@ mod outbound_dst_labels {
 
     #[test]
     fn multiple_addr_labels() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let (
             Fixture {
                 client,
@@ -500,7 +500,7 @@ mod outbound_dst_labels {
 
     #[test]
     fn multiple_addrset_labels() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let (
             Fixture {
                 client,
@@ -531,7 +531,7 @@ mod outbound_dst_labels {
 
     #[test]
     fn labeled_addr_and_addrset() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let (
             Fixture {
                 client,
@@ -567,7 +567,7 @@ mod outbound_dst_labels {
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn controller_updates_addr_labels() {
-        let _ = trace_init();
+        let _trace = trace_init();
         info!("running test server");
 
         let (
@@ -631,7 +631,7 @@ mod outbound_dst_labels {
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn controller_updates_set_labels() {
-        let _ = trace_init();
+        let _trace = trace_init();
         info!("running test server");
         let (
             Fixture {
@@ -689,7 +689,7 @@ mod outbound_dst_labels {
 #[test]
 fn metrics_have_no_double_commas() {
     // Test for regressions to linkerd/linkerd2#600.
-    let _ = trace_init();
+    let _trace = trace_init();
 
     info!("running test server");
     let inbound_srv = server::new().route("/hey", "hello").run();
@@ -743,7 +743,7 @@ mod transport {
 
     #[test]
     fn inbound_http_accept() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let Fixture {
             client,
             metrics,
@@ -782,7 +782,7 @@ mod transport {
 
     #[test]
     fn inbound_http_connect() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let Fixture {
             client,
             metrics,
@@ -810,7 +810,7 @@ mod transport {
 
     #[test]
     fn outbound_http_accept() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let Fixture {
             client,
             metrics,
@@ -847,7 +847,7 @@ mod transport {
 
     #[test]
     fn outbound_http_connect() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let Fixture {
             client,
             metrics,
@@ -871,7 +871,7 @@ mod transport {
 
     #[test]
     fn inbound_tcp_connect() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -889,7 +889,7 @@ mod transport {
     #[test]
     #[cfg(macos)]
     fn inbound_tcp_connect_err() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let srv = tcp::server()
             .accept_fut(move |sock| {
                 drop(sock);
@@ -919,7 +919,7 @@ mod transport {
     #[test]
     #[cfg(macos)]
     fn outbound_tcp_connect_err() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let srv = tcp::server()
             .accept_fut(move |sock| {
                 drop(sock);
@@ -946,7 +946,7 @@ mod transport {
 
     #[test]
     fn inbound_tcp_accept() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -989,7 +989,7 @@ mod transport {
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn inbound_tcp_duration() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1028,7 +1028,7 @@ mod transport {
 
     #[test]
     fn inbound_tcp_write_bytes_total() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1056,7 +1056,7 @@ mod transport {
 
     #[test]
     fn inbound_tcp_read_bytes_total() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1084,7 +1084,7 @@ mod transport {
 
     #[test]
     fn outbound_tcp_connect() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1101,7 +1101,7 @@ mod transport {
 
     #[test]
     fn outbound_tcp_accept() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1139,7 +1139,7 @@ mod transport {
     #[test]
     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     fn outbound_tcp_duration() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1178,7 +1178,7 @@ mod transport {
 
     #[test]
     fn outbound_tcp_write_bytes_total() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1206,7 +1206,7 @@ mod transport {
 
     #[test]
     fn outbound_tcp_read_bytes_total() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1234,7 +1234,7 @@ mod transport {
 
     #[test]
     fn outbound_tcp_open_connections() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let TcpFixture {
             client,
             metrics,
@@ -1272,7 +1272,7 @@ mod transport {
 
     #[test]
     fn outbound_http_tcp_open_connections() {
-        let _ = trace_init();
+        let _trace = trace_init();
         let Fixture {
             client,
             metrics,
@@ -1313,7 +1313,7 @@ mod transport {
 // linkerd/linkerd2#613
 #[tokio::test]
 async fn metrics_compression() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let Fixture {
         client,

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc;
 
 #[test]
 fn outbound_http1() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let srv = server::http1().route("/", "hello h1").run();
     let ctrl = controller::new();
@@ -22,7 +22,7 @@ fn outbound_http1() {
 
 #[test]
 fn inbound_http1() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let srv = server::http1().route("/", "hello h1").run();
     let ctrl = controller::new();
@@ -38,7 +38,7 @@ fn inbound_http1() {
 
 #[test]
 fn outbound_tcp() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let msg1 = "custom tcp hello";
     let msg2 = "custom tcp bye";
@@ -61,7 +61,7 @@ fn outbound_tcp() {
 
 #[test]
 fn inbound_tcp() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let msg1 = "custom tcp hello";
     let msg2 = "custom tcp bye";
@@ -85,7 +85,7 @@ fn inbound_tcp() {
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn loop_outbound_http1() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let listen_addr = SocketAddr::from(([127, 0, 0, 1], 10751));
 
@@ -103,7 +103,7 @@ fn loop_outbound_http1() {
 #[test]
 #[cfg_attr(not(feature = "flaky_tests"), ignore)]
 fn loop_inbound_http1() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let listen_addr = SocketAddr::from(([127, 0, 0, 1], 10752));
 
@@ -121,7 +121,7 @@ fn loop_inbound_http1() {
 fn test_server_speaks_first(env: TestEnv) {
     const TIMEOUT: Duration = Duration::from_secs(5);
 
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let msg1 = "custom tcp server starts";
     let msg2 = "custom tcp client second";
@@ -210,7 +210,7 @@ fn tcp_server_first_tls() {
 fn tcp_connections_close_if_client_closes() {
     use std::sync::mpsc;
 
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let msg1 = "custom tcp hello";
     let msg2 = "custom tcp bye";
@@ -256,7 +256,7 @@ macro_rules! http1_tests {
     (proxy: $proxy:expr) => {
         #[test]
         fn inbound_http1() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let srv = server::http1().route("/", "hello h1").run();
             let proxy = $proxy(srv);
@@ -267,7 +267,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_removes_connection_headers() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", |req| {
@@ -305,7 +305,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http10_with_host() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let host = "transparency.test.svc.cluster.local";
             let srv = server::http1()
@@ -334,7 +334,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http11_absolute_uri_differs_from_host() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             // We shouldn't touch the URI or the Host, just pass directly as we got.
             let auth = "transparency.test.svc.cluster.local";
@@ -362,7 +362,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http11_upgrades() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             // To simplify things for this test, we just use the test TCP
             // client and server to do an HTTP upgrade.
@@ -438,7 +438,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn l5d_orig_proto_header_isnt_leaked() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", |req| {
@@ -458,7 +458,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http11_upgrade_h2_stripped() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             // If an `h2` upgrade over HTTP/1.1 were to go by the proxy,
             // and it succeeded, there would an h2 connection, but it would
@@ -497,7 +497,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http11_connect() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             // To simplify things for this test, we just use the test TCP
             // client and server to do an HTTP CONNECT.
@@ -572,7 +572,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http11_connect_bad_requests() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let srv = server::tcp()
                 .accept(move |_sock| -> Vec<u8> {
@@ -632,7 +632,7 @@ macro_rules! http1_tests {
 
         #[tokio::test]
         async fn http1_request_with_body_content_length() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", |req| {
@@ -656,7 +656,7 @@ macro_rules! http1_tests {
 
         #[tokio::test]
         async fn http1_request_with_body_chunked() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let srv = server::http1()
                 .route_async("/", |req| async move {
@@ -701,7 +701,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_requests_without_body_doesnt_add_transfer_encoding() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", |req| {
@@ -731,7 +731,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_content_length_zero_is_preserved() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", |req| {
@@ -767,7 +767,7 @@ macro_rules! http1_tests {
 
         #[test]
         fn http1_bodyless_responses() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let req_status_header = "x-test-status-requested";
 
@@ -829,7 +829,7 @@ macro_rules! http1_tests {
 
         #[tokio::test]
         async fn http1_head_responses() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             let srv = server::http1()
                 .route_fn("/", move |req| {
@@ -863,7 +863,7 @@ macro_rules! http1_tests {
 
         #[tokio::test]
         async fn http1_response_end_of_file() {
-            let _ = trace_init();
+            let _trace = trace_init();
 
             // test both http/1.0 and 1.1
             let srv = server::tcp()
@@ -980,7 +980,7 @@ mod proxy_to_proxy {
 fn http10_without_host() {
     // Without a host or authority, there's no way to route this test,
     // so its not part of the proxy_to_proxy set.
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let srv = server::http1()
         .route_fn("/", move |req| {
@@ -1012,7 +1012,7 @@ fn http10_without_host() {
 
 #[test]
 fn http1_one_connection_per_host() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let srv = server::http1()
         .route("/body", "hello hosts")
@@ -1058,7 +1058,7 @@ fn http1_one_connection_per_host() {
 
 #[test]
 fn http1_requests_without_host_have_unique_connections() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let srv = server::http1().route("/", "unique hosts").run();
     let proxy = proxy::new().inbound(srv).run();
@@ -1117,7 +1117,7 @@ fn http1_requests_without_host_have_unique_connections() {
 
 #[tokio::test]
 async fn retry_reconnect_errors() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     // Used to delay `listen` in the server, to force connection refused errors.
     let (tx, rx) = oneshot::channel::<()>();
@@ -1148,7 +1148,7 @@ async fn retry_reconnect_errors() {
 
 #[tokio::test]
 async fn http2_request_without_authority() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let srv = server::http2()
         .route_fn("/", |req| {
@@ -1186,7 +1186,7 @@ async fn http2_request_without_authority() {
 
 #[tokio::test]
 async fn http2_rst_stream_is_propagated() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     let reason = h2::Reason::ENHANCE_YOUR_CALM;
 
@@ -1212,7 +1212,7 @@ async fn http2_rst_stream_is_propagated() {
 
 #[tokio::test]
 async fn http1_orig_proto_does_not_propagate_rst_stream() {
-    let _ = trace_init();
+    let _trace = trace_init();
 
     // Use a custom http2 server to "act" as an inbound proxy so we
     // can trigger a RST_STREAM.


### PR DESCRIPTION
Currently, there are a couple of issues that prevent traces emitted by
the proxy's integration tests from being reported correctly. Many of our
tests begin with:

```rust
let _ = trace_init();
```

This doesn't _actually_ do what we want, for two reasons:

* `trace_init` doesn't actually set a trace subscriber as the default,
  it just _constructs_ one,
* `let _` drops the value _immediately_.

So, this code is constructing a subscriber and then immediately dropping
it, which does nothing.

In practice, we mostly don't notice this, since the test support
servers, clients, and proxy run in separate threads with their _own_
trace subscribers, which are set up correctly, and very few of the tests
themselves actually emit traces. So even though this does the wrong
thing, everything basically works. However, if the dedicated test
support threads are removed and the test support stuff moved to spawned
tasks in the test functions, all the traces go away.

This PR fixes that by making `trace_init` actually set a default
subscriber, adding a new `trace_subscriber` function that just
constructs the subscriber and level handle (which is necessary to run a
test proxy), and changing the tests so they don't drop their guards
until the test ends.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>