### PR TITLE
Update proxy-api dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
  "linkerd2-app-core",
  "linkerd2-metrics",
  "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12)",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=c2dba642c7301b5b562c75fd6e2bd0a12ec763e8)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "net2",
  "quickcheck",
  "regex 0.1.80",
@@ -1324,21 +1324,6 @@ dependencies = [
 name = "linkerd2-proxy-api"
 version = "0.1.12"
 source = "git+https://github.com/linkerd/linkerd2-proxy-api#c442280b7c1e8c5a83d53abe00287aca69129d7c"
-dependencies = [
- "h2 0.2.5",
- "http 0.2.1",
- "prost 0.6.1",
- "prost-types 0.6.1",
- "quickcheck",
- "rand 0.7.2",
- "tonic",
- "tonic-build",
-]
-
-[[package]]
-name = "linkerd2-proxy-api"
-version = "0.1.12"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=c2dba642c7301b5b562c75fd6e2bd0a12ec763e8#c2dba642c7301b5b562c75fd6e2bd0a12ec763e8"
 dependencies = [
  "h2 0.2.5",
  "http 0.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "codegen"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf02acd61125952ee148207cd411f9b73c9e218eab4b901375a82e1a443b6238"
+checksum = "34c59e8a9b988977ec3bd61ab380cf1167048817ecd3d6999fac03657f85a609"
 dependencies = [
  "indexmap",
 ]
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "fixedbitset"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cb8fec437468d86dc7c83ca7cfc933341d561873275f22dd5eedefa63a6478"
+checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "fixedbitset"
@@ -906,7 +906,7 @@ dependencies = [
  "linkerd2-lock",
  "linkerd2-metrics",
  "linkerd2-opencensus",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "linkerd2-proxy-api-resolve",
  "linkerd2-proxy-core",
  "linkerd2-proxy-detect",
@@ -1323,18 +1323,16 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.12"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api#59d91c1d8787f907fbab2de5ca844c25e7aeb9f7"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api#c442280b7c1e8c5a83d53abe00287aca69129d7c"
 dependencies = [
- "bytes 0.4.11",
- "futures 0.1.26",
- "h2 0.1.26",
- "http 0.1.21",
- "prost 0.5.0",
- "prost-types 0.5.0",
+ "h2 0.2.5",
+ "http 0.2.1",
+ "prost 0.6.1",
+ "prost-types 0.6.1",
  "quickcheck",
  "rand 0.7.2",
- "tower-grpc",
- "tower-grpc-build",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
@@ -1361,7 +1359,7 @@ dependencies = [
  "http-body 0.3.1",
  "indexmap",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=c2dba642c7301b5b562c75fd6e2bd0a12ec763e8)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "linkerd2-proxy-core",
  "pin-project",
  "prost 0.6.1",
@@ -1451,7 +1449,7 @@ dependencies = [
  "http-body 0.3.1",
  "linkerd2-error",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=c2dba642c7301b5b562c75fd6e2bd0a12ec763e8)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "linkerd2-proxy-transport",
  "pin-project",
  "tokio 0.2.21",
@@ -1486,7 +1484,7 @@ dependencies = [
  "linkerd2-conditional",
  "linkerd2-error",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=c2dba642c7301b5b562c75fd6e2bd0a12ec763e8)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "linkerd2-proxy-core",
  "linkerd2-proxy-http",
  "linkerd2-proxy-transport",
@@ -1602,7 +1600,7 @@ dependencies = [
  "linkerd2-addr",
  "linkerd2-dns",
  "linkerd2-error",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?rev=c2dba642c7301b5b562c75fd6e2bd0a12ec763e8)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "linkerd2-stack",
  "pin-project",
  "prost-types 0.6.1",
@@ -1966,11 +1964,11 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7e5234c228fbfa874c86a77f685886127f82e0aef602ad1d48333fcac6ad61"
+checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
 dependencies = [
- "fixedbitset 0.1.8",
+ "fixedbitset 0.1.9",
 ]
 
 [[package]]
@@ -2093,11 +2091,11 @@ dependencies = [
  "itertools",
  "log",
  "multimap 0.4.0",
- "petgraph 0.4.11",
+ "petgraph 0.4.13",
  "prost 0.5.0",
  "prost-types 0.5.0",
  "tempfile",
- "which 2.0.0",
+ "which 2.0.1",
 ]
 
 [[package]]
@@ -3597,9 +3595,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49c4f580e93079b70ac522e7bdebbe1568c8afa7d8d05ee534ee737ca37d2f51"
+checksum = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 dependencies = [
  "failure",
  "libc",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -41,7 +41,7 @@ linkerd2-lock = { path = "../../lock" }
 linkerd2-metrics = { path = "../../metrics" }
 linkerd2-opencensus = { path = "../../opencensus" }
 linkerd2-proxy-core = { path = "../../proxy/core" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.12" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api" }
 linkerd2-proxy-api-resolve = { path = "../../proxy/api-resolve" }
 linkerd2-proxy-detect = { path = "../../proxy/detect" }
 linkerd2-proxy-discover = { path = "../../proxy/discover" }
@@ -95,7 +95,7 @@ libc = "0.2"
 procinfo = "0.4.2"
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.12" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"] }
 prost-types = "0.5.0"
 quickcheck = { version = "0.9", default-features = false }
 tokio = { version = "0.2", features = ["time"] }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -33,7 +33,7 @@ linkerd2-app = { path = "..", features = ["mock-orig-dst"] }
 linkerd2-app-core = { path = "../core", features = ["mock-orig-dst"] }
 linkerd2-metrics = { path = "../../metrics", features = ["test_util"] }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.12" }
-linkerd2-proxy-api-tonic = { package = "linkerd2-proxy-api", git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "c2dba642c7301b5b562c75fd6e2bd0a12ec763e8" }
+linkerd2-proxy-api-tonic = { package = "linkerd2-proxy-api", git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"] }
 regex = "0.1"
 net2 = "0.2"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -11,7 +11,7 @@ Implements the Resolve trait using the proxy's gRPC API
 [dependencies]
 futures = "0.3"
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "c2dba642c7301b5b562c75fd6e2bd0a12ec763e8" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api" }
 linkerd2-proxy-core = { path = "../core" }
 prost = "0.6"
 http = "0.2"

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 futures = "0.3"
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "c2dba642c7301b5b562c75fd6e2bd0a12ec763e8" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api" }
 linkerd2-proxy-transport = { path = "../transport" }
 tokio = { version = "0.2", features = ["time", "sync"] }
 tonic = { version = "0.2", default-features = false }

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -16,7 +16,7 @@ linkerd2-conditional = { path = "../../conditional" }
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
 linkerd2-proxy-core = { path = "../core" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "c2dba642c7301b5b562c75fd6e2bd0a12ec763e8" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api" }
 linkerd2-proxy-http = { path = "../http" }
 linkerd2-proxy-transport = { path = "../transport" }
 linkerd2-stack = { path = "../../stack" }
@@ -29,6 +29,6 @@ tracing-futures = "0.2"
 pin-project = "0.4"
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "c2dba642c7301b5b562c75fd6e2bd0a12ec763e8"  }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"] }
 prost-types = "0.6.0"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = "1.0"
 linkerd2-addr = { path  = "../addr" }
 linkerd2-dns = { path  = "../dns" }
 linkerd2-error = { path  = "../error" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "c2dba642c7301b5b562c75fd6e2bd0a12ec763e8"  }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api" }
 linkerd2-stack = { path  = "../stack" }
 rand = { version = "0.7", features = ["small_rng"] }
 regex = "1.0.0"
@@ -38,6 +38,6 @@ features = [
 ]
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], rev = "c2dba642c7301b5b562c75fd6e2bd0a12ec763e8"  }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"] }
 prost-types = "0.6.0"
 quickcheck = { version = "0.9", default-features = false }


### PR DESCRIPTION
Tracks the latest master's tonic upgrade. We'll pin a tagged version on
release.