### PR TITLE
Simplify protocol detection with async/await

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
 name = "linkerd2-app-core"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bytes 0.5.4",
  "futures 0.3.5",
  "http 0.2.1",
@@ -1369,6 +1370,7 @@ dependencies = [
 name = "linkerd2-proxy-detect"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "futures 0.3.5",
  "linkerd2-error",
  "linkerd2-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,7 +1373,6 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-io",
  "linkerd2-proxy-core",
- "pin-project",
  "tokio 0.2.21",
  "tower 0.3.1",
 ]

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -15,6 +15,7 @@ independently of the inbound and outbound proxy logic.
 mock-orig-dst  = ["linkerd2-proxy-transport/mock-orig-dst"]
 
 [dependencies]
+async-trait = "0.1"
 bytes = "0.5"
 http = "0.2"
 http-body = "0.3"

--- a/linkerd/app/core/src/proxy/server.rs
+++ b/linkerd/app/core/src/proxy/server.rs
@@ -1,18 +1,22 @@
+use crate::proxy::http::{
+    glue::{Body, HyperServerSvc},
+    h2::Settings as H2Settings,
+    trace, upgrade, Version as HttpVersion,
+};
+use crate::transport::{
+    self,
+    io::{self, BoxedIo, Peekable},
+    labels::Key as TransportKey,
+    metrics::TransportLabels,
+    tls,
+};
 use crate::{
     drain,
-    proxy::{
-        core::Accept,
-        detect,
-        http::{
-            glue::{Body, HyperServerSvc},
-            h2::Settings as H2Settings,
-            trace, upgrade, Version as HttpVersion,
-        },
-    },
+    proxy::{core::Accept, detect},
     svc::{NewService, Service, ServiceExt},
-    transport::{self, io::BoxedIo, labels::Key as TransportKey, metrics::TransportLabels, tls},
     Error,
 };
+use async_trait::async_trait;
 use futures::TryFutureExt;
 use http;
 use hyper;
@@ -34,35 +38,43 @@ pub type Connection = (Protocol, BoxedIo);
 
 #[derive(Clone, Debug)]
 pub struct ProtocolDetect {
+    capacity: usize,
     skip_ports: Arc<IndexSet<u16>>,
 }
 
 impl ProtocolDetect {
+    const PEEK_CAPACITY: usize = 8192;
+
     pub fn new(skip_ports: Arc<IndexSet<u16>>) -> Self {
-        ProtocolDetect { skip_ports }
+        ProtocolDetect {
+            skip_ports,
+            capacity: Self::PEEK_CAPACITY,
+        }
     }
 }
 
+#[async_trait]
 impl detect::Detect<tls::accept::Meta> for ProtocolDetect {
     type Target = Protocol;
+    type Error = io::Error;
 
-    fn detect_before_peek(
+    async fn detect(
         &self,
         tls: tls::accept::Meta,
-    ) -> Result<Self::Target, tls::accept::Meta> {
+        io: BoxedIo,
+    ) -> Result<(Self::Target, BoxedIo), Self::Error> {
         let port = tls.addrs.target_addr().port();
         if self.skip_ports.contains(&port) {
-            return Ok(Protocol { tls, http: None });
+            let proto = Protocol { tls, http: None };
+            return Ok::<_, Self::Error>((proto, io));
         }
 
-        Err(tls)
-    }
-
-    fn detect_peeked_prefix(&self, tls: tls::accept::Meta, prefix: &[u8]) -> Self::Target {
-        Protocol {
-            tls,
-            http: HttpVersion::from_prefix(prefix),
-        }
+        // Otherwise, attempt to peek the client connection to determine the protocol.
+        // Currently, we only check for an HTTP prefix.
+        let peek = io.peek(self.capacity).await?;
+        let http = HttpVersion::from_prefix(peek.prefix().as_ref());
+        let proto = Protocol { tls, http };
+        Ok((proto, BoxedIo::new(peek)))
     }
 }
 

--- a/linkerd/app/core/src/proxy/server.rs
+++ b/linkerd/app/core/src/proxy/server.rs
@@ -64,6 +64,8 @@ impl detect::Detect<tls::accept::Meta> for ProtocolDetect {
         io: BoxedIo,
     ) -> Result<(Self::Target, BoxedIo), Self::Error> {
         let port = tls.addrs.target_addr().port();
+
+        // Skip detection if the port is in the configured set.
         if self.skip_ports.contains(&port) {
             let proto = Protocol { tls, http: None };
             return Ok::<_, Self::Error>((proto, io));

--- a/linkerd/io/src/lib.rs
+++ b/linkerd/io/src/lib.rs
@@ -7,8 +7,17 @@ pub use tokio::io::{AsyncRead, AsyncWrite};
 
 pub type Poll<T> = std::task::Poll<Result<T>>;
 
+pub trait Peekable {
+    fn peek(self, capacity: usize) -> Peek<Self>
+    where
+        Self: Sized + internal::Io + Unpin,
+    {
+        Peek::with_capacity(capacity, self)
+    }
+}
+
 mod internal {
-    use super::{AsyncRead, AsyncWrite, Poll};
+    use super::{AsyncRead, AsyncWrite, Peekable, Poll};
     use bytes::{Buf, BufMut};
     use std::pin::Pin;
     use std::task::Context;
@@ -35,6 +44,8 @@ mod internal {
             buf: &mut dyn Buf,
         ) -> Poll<usize>;
     }
+
+    impl<T: Io> Peekable for T {}
 
     impl Io for tokio::net::TcpStream {
         fn poll_write_buf_erased(

--- a/linkerd/io/src/lib.rs
+++ b/linkerd/io/src/lib.rs
@@ -1,23 +1,18 @@
 mod boxed;
 mod peek;
 mod prefixed;
-pub use self::{boxed::BoxedIo, peek::Peek, prefixed::PrefixedIo};
+pub use self::{
+    boxed::BoxedIo,
+    peek::{Peek, Peekable},
+    prefixed::PrefixedIo,
+};
 pub use std::io::{Error, Read, Result, Write};
 pub use tokio::io::{AsyncRead, AsyncWrite};
 
 pub type Poll<T> = std::task::Poll<Result<T>>;
 
-pub trait Peekable {
-    fn peek(self, capacity: usize) -> Peek<Self>
-    where
-        Self: Sized + internal::Io + Unpin,
-    {
-        Peek::with_capacity(capacity, self)
-    }
-}
-
 mod internal {
-    use super::{AsyncRead, AsyncWrite, Peekable, Poll};
+    use super::{AsyncRead, AsyncWrite, Poll};
     use bytes::{Buf, BufMut};
     use std::pin::Pin;
     use std::task::Context;
@@ -44,8 +39,6 @@ mod internal {
             buf: &mut dyn Buf,
         ) -> Poll<usize>;
     }
-
-    impl<T: Io> Peekable for T {}
 
     impl Io for tokio::net::TcpStream {
         fn poll_write_buf_erased(

--- a/linkerd/io/src/peek.rs
+++ b/linkerd/io/src/peek.rs
@@ -1,4 +1,4 @@
-use crate::{AsyncRead, AsyncWrite, PrefixedIo};
+use crate::{internal::Io, AsyncRead, AsyncWrite, PrefixedIo};
 use bytes::BytesMut;
 use pin_project::pin_project;
 use std::future::Future;
@@ -18,6 +18,14 @@ struct Inner<T> {
     #[pin]
     io: T,
 }
+
+pub trait Peekable: Io + Sized + Unpin {
+    fn peek(self, capacity: usize) -> Peek<Self> {
+        Peek::with_capacity(capacity, self)
+    }
+}
+
+impl<I: Io + Sized + Unpin> Peekable for I {}
 
 // === impl Peek ===
 

--- a/linkerd/proxy/detect/Cargo.toml
+++ b/linkerd/proxy/detect/Cargo.toml
@@ -9,6 +9,7 @@ Client stream detection
 """
 
 [dependencies]
+async-trait = "0.1"
 futures = "0.3"
 linkerd2-error = { path = "../../error" }
 linkerd2-io = { path = "../../io" }

--- a/linkerd/proxy/detect/Cargo.toml
+++ b/linkerd/proxy/detect/Cargo.toml
@@ -14,7 +14,6 @@ linkerd2-error = { path = "../../error" }
 linkerd2-io = { path = "../../io" }
 linkerd2-proxy-core = { path = "../core" }
 tokio = "0.2"
-pin-project = "0.4"
 
 [dependencies.tower]
 version = "0.3"

--- a/linkerd/proxy/detect/src/lib.rs
+++ b/linkerd/proxy/detect/src/lib.rs
@@ -1,6 +1,7 @@
+use async_trait::async_trait;
 use futures::prelude::*;
 use linkerd2_error::Error;
-use linkerd2_io::{BoxedIo, Peekable};
+use linkerd2_io::BoxedIo;
 use linkerd2_proxy_core as core;
 use std::future::Future;
 use std::pin::Pin;
@@ -8,40 +9,28 @@ use std::task::{Context, Poll};
 use tower::util::ServiceExt;
 
 /// A strategy for detecting values out of a client transport.
-pub trait Detect<T>: Clone {
+#[async_trait]
+pub trait Detect<T> {
     type Target;
+    type Error: Into<Error>;
 
-    /// If the target can be determined by the target alone (i.e. because it's
-    /// known to be a server-speaks-first target), Otherwise, the target is
-    /// returned as an error.
-    fn detect_before_peek(&self, target: T) -> Result<Self::Target, T>;
-
-    /// If the target could not be determined without peeking, then used the
-    /// peeked prefix to determine the protocol.
-    fn detect_peeked_prefix(&self, target: T, prefix: &[u8]) -> Self::Target;
+    async fn detect(&self, target: T, io: BoxedIo) -> Result<(Self::Target, BoxedIo), Self::Error>;
 }
 
 #[derive(Debug, Clone)]
 pub struct DetectProtocolLayer<D> {
     detect: D,
-    peek_capacity: usize,
 }
 
 #[derive(Debug, Clone)]
 pub struct DetectProtocol<D, A> {
     detect: D,
     accept: A,
-    peek_capacity: usize,
 }
 
 impl<D> DetectProtocolLayer<D> {
-    const DEFAULT_CAPACITY: usize = 8192;
-
     pub fn new(detect: D) -> Self {
-        Self {
-            detect,
-            peek_capacity: Self::DEFAULT_CAPACITY,
-        }
+        Self { detect }
     }
 }
 
@@ -51,7 +40,6 @@ impl<D: Clone, A> tower::layer::Layer<A> for DetectProtocolLayer<D> {
     fn layer(&self, accept: A) -> Self::Service {
         Self::Service {
             detect: self.detect.clone(),
-            peek_capacity: self.peek_capacity,
             accept,
         }
     }
@@ -60,7 +48,7 @@ impl<D: Clone, A> tower::layer::Layer<A> for DetectProtocolLayer<D> {
 impl<T, D, A> tower::Service<(T, BoxedIo)> for DetectProtocol<D, A>
 where
     T: Send + 'static,
-    D: Detect<T> + Send + 'static,
+    D: Detect<T> + Clone + Send + 'static,
     D::Target: Send,
     A: core::listen::Accept<(D::Target, BoxedIo)> + Send + Clone + 'static,
     A::Future: Send,
@@ -76,27 +64,14 @@ where
 
     fn call(&mut self, (target, io): (T, BoxedIo)) -> Self::Future {
         let detect = self.detect.clone();
-        let capacity = self.peek_capacity;
-        let detect = async move {
-            // Try to detect the protocol from the target alone. This allows configuration to
-            // skip prevent tryng to read from the client connection.
-            let target = match detect.detect_before_peek(target) {
-                Ok(detected) => return Ok((detected, io)),
-                Err(t) => t,
-            };
-
-            // Otherwise, attempt to peek the client connection to determine the protocol.
-            let prefixed = io.peek(capacity).await.map_err(Into::<Error>::into)?;
-            let detected = detect.detect_peeked_prefix(target, prefixed.prefix().as_ref());
-            Ok((detected, BoxedIo::new(prefixed)))
-        };
-
         let mut accept = self.accept.clone().into_service();
         Box::pin(async move {
             // Await the service and protocol detection together. If either fails, the other is
             // aborted.
-            let (accept, conn) =
-                futures::try_join!(accept.ready_and().map_err(Into::into), detect)?;
+            let (accept, conn) = futures::try_join!(
+                accept.ready_and().map_err(Into::into),
+                detect.detect(target, io).map_err(Into::into)
+            )?;
 
             accept.call(conn).await.map_err(Into::into)
         })

--- a/linkerd/proxy/detect/src/lib.rs
+++ b/linkerd/proxy/detect/src/lib.rs
@@ -1,10 +1,11 @@
+use futures::prelude::*;
 use linkerd2_error::Error;
-use linkerd2_io::{BoxedIo, Peek};
+use linkerd2_io::{BoxedIo, Peekable};
 use linkerd2_proxy_core as core;
-use pin_project::{pin_project, project};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use tower::util::ServiceExt;
 
 /// A strategy for detecting values out of a client transport.
 pub trait Detect<T>: Clone {
@@ -33,39 +34,6 @@ pub struct DetectProtocol<D, A> {
     peek_capacity: usize,
 }
 
-#[pin_project]
-pub struct AcceptFuture<T, D, A>
-where
-    D: Detect<T>,
-    A: core::listen::Accept<(D::Target, BoxedIo)>,
-{
-    #[pin]
-    state: State<T, D, A>,
-}
-
-#[pin_project]
-enum State<T, D, A>
-where
-    D: Detect<T>,
-    A: core::listen::Accept<(D::Target, BoxedIo)>,
-{
-    Accept(#[pin] A::Future),
-    Detect {
-        detect: D,
-        accept: A,
-        #[pin]
-        inner: PeekAndDetect<T, D>,
-    },
-}
-
-#[pin_project]
-pub enum PeekAndDetect<T, D: Detect<T>> {
-    // Waiting for accept to become ready.
-    Detected(Option<(D::Target, BoxedIo)>),
-    // Waiting for the prefix to be read.
-    Peek(Option<T>, #[pin] Peek<BoxedIo>),
-}
-
 impl<D> DetectProtocolLayer<D> {
     const DEFAULT_CAPACITY: usize = 8192;
 
@@ -91,77 +59,46 @@ impl<D: Clone, A> tower::layer::Layer<A> for DetectProtocolLayer<D> {
 
 impl<T, D, A> tower::Service<(T, BoxedIo)> for DetectProtocol<D, A>
 where
-    D: Detect<T>,
-    A: core::listen::Accept<(D::Target, BoxedIo)> + Clone,
-    D::Target: std::fmt::Debug,
+    T: Send + 'static,
+    D: Detect<T> + Send + 'static,
+    D::Target: Send,
+    A: core::listen::Accept<(D::Target, BoxedIo)> + Send + Clone + 'static,
+    A::Future: Send,
 {
     type Response = A::ConnectionFuture;
     type Error = Error;
-    type Future = AcceptFuture<T, D, A>;
+    type Future = Pin<Box<dyn Future<Output = Result<A::ConnectionFuture, Error>> + Send>>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.accept.poll_ready(cx).map_err(Into::into)
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // The `accept` is cloned into the response future, so its readiness isn't important.
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, (target, io): (T, BoxedIo)) -> Self::Future {
-        match self.detect.detect_before_peek(target) {
-            Ok(detected) => AcceptFuture {
-                state: State::Accept(self.accept.accept((detected, io))),
-            },
-            Err(target) => AcceptFuture {
-                state: State::Detect {
-                    detect: self.detect.clone(),
-                    accept: self.accept.clone(),
-                    inner: PeekAndDetect::Peek(
-                        Some(target),
-                        Peek::with_capacity(self.peek_capacity, io),
-                    ),
-                },
-            },
-        }
-    }
-}
+        let detect = self.detect.clone();
+        let capacity = self.peek_capacity;
+        let detect = async move {
+            // Try to detect the protocol from the target alone. This allows configuration to
+            // skip prevent tryng to read from the client connection.
+            let target = match detect.detect_before_peek(target) {
+                Ok(detected) => return Ok((detected, io)),
+                Err(t) => t,
+            };
 
-impl<T, D, A> Future for AcceptFuture<T, D, A>
-where
-    D: Detect<T>,
-    A: core::listen::Accept<(D::Target, BoxedIo)>,
-    A::Error: Into<Error>,
-{
-    type Output = Result<A::ConnectionFuture, Error>;
+            // Otherwise, attempt to peek the client connection to determine the protocol.
+            let prefixed = io.peek(capacity).await.map_err(Into::<Error>::into)?;
+            let detected = detect.detect_peeked_prefix(target, prefixed.prefix().as_ref());
+            Ok((detected, BoxedIo::new(prefixed)))
+        };
 
-    #[project]
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.project();
-        loop {
-            #[project]
-            match this.state.as_mut().project() {
-                State::Accept(fut) => return fut.poll(cx).map_err(Into::into),
-                State::Detect {
-                    detect,
-                    accept,
-                    mut inner,
-                } =>
-                {
-                    #[project]
-                    match inner.as_mut().project() {
-                        PeekAndDetect::Peek(target, peek) => {
-                            let io = futures::ready!(peek.poll(cx))?;
-                            let target = detect.detect_peeked_prefix(
-                                target.take().expect("polled after complete"),
-                                io.prefix().as_ref(),
-                            );
-                            inner.set(PeekAndDetect::Detected(Some((target, BoxedIo::new(io)))));
-                        }
-                        PeekAndDetect::Detected(io) => {
-                            futures::ready!(accept.poll_ready(cx)).map_err(Into::into)?;
-                            let io = io.take().expect("polled after complete");
-                            let accept = accept.accept(io);
-                            this.state.set(State::Accept(accept));
-                        }
-                    }
-                }
-            }
-        }
+        let mut accept = self.accept.clone().into_service();
+        Box::pin(async move {
+            // Await the service and protocol detection together. If either fails, the other is
+            // aborted.
+            let (accept, conn) =
+                futures::try_join!(accept.ready_and().map_err(Into::into), detect)?;
+
+            accept.call(conn).await.map_err(Into::into)
+        })
     }
 }


### PR DESCRIPTION
The protocol detection middleware is pretty verbose, including a manual
future implementation that manages a complex set of state types.

This can all be simplified with async/await (at the cost of ~2 boxes per connection).