### PR TITLE
outbound: Split HTTP endpoint builder

### DIFF
--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -163,14 +163,19 @@ impl Config {
 
             let refine = outbound.build_dns_refine(resolver, &outbound_metrics.stack);
 
-            let outbound_http = outbound.build_http_router(
+            let outbound_http_endpoint = outbound.build_http_endpoint(
                 outbound_addr.port(),
                 outbound_connect.clone(),
-                dst.resolve,
-                dst.profiles.clone(),
                 tap_layer.clone(),
                 outbound_metrics.clone(),
                 oc_span_sink.clone(),
+            );
+
+            let outbound_http = outbound.build_http_router(
+                outbound_http_endpoint,
+                dst.resolve,
+                dst.profiles.clone(),
+                outbound_metrics.clone(),
             );
 
             tokio::spawn(


### PR DESCRIPTION
This change follows on the refactor in d7b86b01 by splitting the
outbound HTTP endpoint stack into its own constructor in order to
modularize the proxy stacks. The response body is boxed in order to hide
the stack's details (with regard to metrics, tracing, etc).

There is no functional change.