### PR TITLE
fix InvalidProfileAddr not converting into DiscoveryRejected

### DIFF
--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -623,9 +623,7 @@ impl From<Error> for DiscoveryError {
             return inner.clone();
         }
 
-        if orig.is::<DiscoveryRejected>()
-        //  || orig.is::<profiles::InvalidProfileAddr>()
-        {
+        if orig.is::<DiscoveryRejected>() || orig.is::<profiles::InvalidProfileAddr>() {
             return DiscoveryError::DiscoveryRejected;
         }
 


### PR DESCRIPTION
It looks like this error was commented out during the 0.2 update, when
the code that emitted it was broken. It was uncommented in the
`is_discovery_rejected` predicate, but not in the `From` impl for
`DiscoveryError`. This branch fixes that.

I am not sure if anything load-bearing depends on this conversion, but
it should at least fix potentially incorrect logs.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>