### PR TITLE
Print build diagnostics in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,16 +35,20 @@ ARG PROXY_UNOPTIMIZED
 # may be set to `mock-orig-dst` for profiling builds.
 ARG PROXY_FEATURES
 
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+    --mount=type=cache,target=/var/tmp \
+    apt update && apt install -y time
+
 WORKDIR /usr/src/linkerd2-proxy
 COPY . .
 RUN --mount=type=cache,target=target \
     --mount=type=cache,from=rust:1.44.1-buster,source=/usr/local/cargo,target=/usr/local/cargo \
     mkdir -p /out && \
     if [ -n "$PROXY_UNOPTIMIZED" ]; then \
-      (cd linkerd2-proxy && cargo build --locked --features="$PROXY_FEATURES") && \
+      (cd linkerd2-proxy && /usr/bin/time -v cargo build --locked --features="$PROXY_FEATURES") && \
       mv target/debug/linkerd2-proxy /out/linkerd2-proxy ; \
     else \
-      (cd linkerd2-proxy && cargo build --locked --release --features="$PROXY_FEATURES") && \
+      (cd linkerd2-proxy && /usr/bin/time -v cargo build --locked --release --features="$PROXY_FEATURES") && \
       mv target/release/linkerd2-proxy /out/linkerd2-proxy ; \
     fi
 


### PR DESCRIPTION
This change modifies the development dockerfile to wrap build commands
with `/usr/bin/time -v` so that we get diagnostic information (like the
RSS of the build process).