### PR TITLE
update test controllers to std::future/Tonic; remove threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,6 @@ dependencies = [
  "ring",
  "rustls",
  "tokio 0.2.21",
- "tokio-compat",
  "tokio-rustls",
  "tonic",
  "tower",
@@ -2570,7 +2569,6 @@ dependencies = [
  "memchr 2.3.3",
  "mio",
  "mio-uds",
- "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -2587,23 +2585,6 @@ dependencies = [
  "bytes 0.4.11",
  "futures 0.1.26",
  "tokio-io",
-]
-
-[[package]]
-name = "tokio-compat"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "107b625135aa7b9297dd2d99ccd6ca6ab124a5d1230778e159b9095adca4c722"
-dependencies = [
- "futures 0.1.26",
- "futures-core",
- "futures-util",
- "pin-project-lite",
- "tokio 0.2.21",
- "tokio-current-thread",
- "tokio-executor",
- "tokio-reactor",
- "tokio-timer",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1025,6 +1025,7 @@ name = "linkerd2-app-profiling"
 version = "0.1.0"
 dependencies = [
  "linkerd2-app-integration",
+ "tokio 0.2.21",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,7 +166,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 dependencies = [
  "byteorder",
- "either",
  "iovec",
 ]
 
@@ -423,16 +422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
-name = "futures-cpupool"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-dependencies = [
- "futures 0.1.26",
- "num_cpus",
-]
-
-[[package]]
 name = "futures-executor"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,18 +600,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
-dependencies = [
- "bytes 0.4.11",
- "futures 0.1.26",
- "http 0.1.21",
- "tokio-buf",
-]
-
-[[package]]
-name = "http-body"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
@@ -639,36 +616,6 @@ checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
 name = "hyper"
-version = "0.12.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
-dependencies = [
- "bytes 0.4.11",
- "futures 0.1.26",
- "futures-cpupool",
- "h2 0.1.26",
- "http 0.1.21",
- "http-body 0.1.0",
- "httparse",
- "iovec",
- "itoa",
- "log",
- "net2",
- "rustc_version",
- "time",
- "tokio 0.1.22",
- "tokio-buf",
- "tokio-executor",
- "tokio-io",
- "tokio-reactor",
- "tokio-tcp",
- "tokio-threadpool",
- "tokio-timer",
- "want 0.2.0",
-]
-
-[[package]]
-name = "hyper"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96816e1d921eca64d208a85aab4f7798455a8e34229ee5a88c935bdee1b78b14"
@@ -679,7 +626,7 @@ dependencies = [
  "futures-util",
  "h2 0.2.5",
  "http 0.2.1",
- "http-body 0.3.1",
+ "http-body",
  "httparse",
  "itoa",
  "log",
@@ -687,8 +634,8 @@ dependencies = [
  "pin-project",
  "time",
  "tokio 0.2.21",
- "tower-service 0.3.0",
- "want 0.3.0",
+ "tower-service",
+ "want",
 ]
 
 [[package]]
@@ -697,11 +644,11 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.5",
  "http 0.2.1",
- "hyper 0.13.5",
+ "hyper",
  "pin-project",
  "tokio 0.2.21",
  "tokio-test",
- "tower 0.3.1",
+ "tower",
 ]
 
 [[package]]
@@ -820,7 +767,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.5",
  "linkerd2-error",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -832,8 +779,8 @@ dependencies = [
  "futures 0.3.5",
  "h2 0.2.5",
  "http 0.2.1",
- "http-body 0.3.1",
- "hyper 0.13.5",
+ "http-body",
+ "hyper",
  "indexmap",
  "ipnet 1.0.0",
  "linkerd2-app-core",
@@ -855,7 +802,7 @@ dependencies = [
  "tokio-io",
  "tokio-rustls",
  "tonic",
- "tower 0.3.1",
+ "tower",
  "tracing",
  "tracing-futures",
  "webpki",
@@ -869,8 +816,8 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
  "http 0.2.1",
- "http-body 0.3.1",
- "hyper 0.13.5",
+ "http-body",
+ "hyper",
  "indexmap",
  "libc",
  "linkerd2-addr",
@@ -923,7 +870,7 @@ dependencies = [
  "tokio-test",
  "tokio-timer",
  "tonic",
- "tower 0.3.1",
+ "tower",
  "tower-request-modifier",
  "tracing",
  "tracing-futures",
@@ -943,7 +890,7 @@ dependencies = [
  "linkerd2-app-outbound",
  "tokio 0.2.21",
  "tokio-test",
- "tower 0.3.1",
+ "tower",
  "tower-test",
  "tracing",
 ]
@@ -959,7 +906,7 @@ dependencies = [
  "linkerd2-app-core",
  "quickcheck",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -967,18 +914,13 @@ dependencies = [
 name = "linkerd2-app-integration"
 version = "0.1.0"
 dependencies = [
- "bytes 0.4.11",
  "bytes 0.5.4",
  "flate2",
- "futures 0.1.26",
  "futures 0.3.5",
  "h2 0.2.5",
- "http 0.1.21",
  "http 0.2.1",
- "http-body 0.1.0",
- "http-body 0.3.1",
- "hyper 0.12.35",
- "hyper 0.13.5",
+ "http-body",
+ "hyper",
  "linkerd2-app",
  "linkerd2-app-core",
  "linkerd2-metrics",
@@ -988,14 +930,11 @@ dependencies = [
  "regex 0.1.80",
  "ring",
  "rustls",
- "tokio 0.1.22",
  "tokio 0.2.21",
  "tokio-compat",
- "tokio-connect",
  "tokio-rustls",
  "tonic",
- "tower 0.1.1",
- "tower 0.3.1",
+ "tower",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -1016,7 +955,7 @@ dependencies = [
  "pin-project",
  "quickcheck",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1037,7 +976,7 @@ dependencies = [
  "pin-project",
  "tokio 0.2.21",
  "tokio-test",
- "tower 0.3.1",
+ "tower",
  "tower-test",
  "tracing",
  "tracing-futures",
@@ -1052,7 +991,7 @@ dependencies = [
  "linkerd2-lock",
  "linkerd2-stack",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1063,7 +1002,7 @@ dependencies = [
  "futures 0.3.5",
  "pin-project",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1080,7 +1019,7 @@ dependencies = [
  "linkerd2-stack",
  "pin-project",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
  "tracing",
  "tracing-futures",
  "trust-dns-resolver",
@@ -1135,7 +1074,7 @@ dependencies = [
  "indexmap",
  "linkerd2-metrics",
  "pin-project",
- "tower 0.3.1",
+ "tower",
 ]
 
 [[package]]
@@ -1145,7 +1084,7 @@ dependencies = [
  "futures 0.3.5",
  "linkerd2-error",
  "pin-project",
- "tower 0.3.1",
+ "tower",
 ]
 
 [[package]]
@@ -1167,10 +1106,10 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
  "http 0.2.1",
- "http-body 0.3.1",
+ "http-body",
  "linkerd2-error",
  "pin-project",
- "tower 0.3.1",
+ "tower",
 ]
 
 [[package]]
@@ -1180,7 +1119,7 @@ dependencies = [
  "http 0.2.1",
  "linkerd2-error",
  "linkerd2-stack",
- "tower 0.3.1",
+ "tower",
 ]
 
 [[package]]
@@ -1191,8 +1130,8 @@ dependencies = [
  "futures 0.3.5",
  "h2 0.1.26",
  "http 0.2.1",
- "http-body 0.3.1",
- "hyper 0.13.5",
+ "http-body",
+ "hyper",
  "indexmap",
  "linkerd2-error",
  "linkerd2-http-classify",
@@ -1201,7 +1140,7 @@ dependencies = [
  "pin-project",
  "tokio 0.1.22",
  "tokio-timer",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1238,7 +1177,7 @@ dependencies = [
  "rand 0.7.2",
  "tokio 0.2.21",
  "tokio-test",
- "tower 0.3.1",
+ "tower",
  "tower-test",
  "tracing",
  "tracing-futures",
@@ -1253,7 +1192,7 @@ dependencies = [
  "deflate",
  "futures 0.3.5",
  "http 0.2.1",
- "hyper 0.13.5",
+ "hyper",
  "indexmap",
  "quickcheck",
  "tracing",
@@ -1265,7 +1204,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.5",
  "http 0.2.1",
- "http-body 0.3.1",
+ "http-body",
  "linkerd2-error",
  "linkerd2-metrics",
  "linkerd2-stack",
@@ -1273,7 +1212,7 @@ dependencies = [
  "pin-project",
  "tokio 0.2.21",
  "tonic",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1309,7 +1248,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.5",
  "http 0.2.1",
- "http-body 0.3.1",
+ "http-body",
  "indexmap",
  "linkerd2-identity",
  "linkerd2-proxy-api",
@@ -1317,7 +1256,7 @@ dependencies = [
  "pin-project",
  "prost 0.6.1",
  "tonic",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1329,7 +1268,7 @@ dependencies = [
  "linkerd2-error",
  "pin-project",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
  "tracing-futures",
 ]
 
@@ -1343,7 +1282,7 @@ dependencies = [
  "linkerd2-io",
  "linkerd2-proxy-core",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
 ]
 
 [[package]]
@@ -1357,7 +1296,7 @@ dependencies = [
  "pin-project",
  "tokio 0.2.21",
  "tokio-test",
- "tower 0.3.1",
+ "tower",
  "tower-test",
  "tracing",
  "tracing-futures",
@@ -1371,9 +1310,9 @@ dependencies = [
  "futures 0.3.5",
  "h2 0.2.5",
  "http 0.2.1",
- "http-body 0.3.1",
+ "http-body",
  "httparse",
- "hyper 0.13.5",
+ "hyper",
  "hyper-balance",
  "indexmap",
  "linkerd2-addr",
@@ -1388,7 +1327,7 @@ dependencies = [
  "pin-project",
  "rand 0.7.2",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
  "tracing",
  "tracing-futures",
  "try-lock",
@@ -1399,7 +1338,7 @@ name = "linkerd2-proxy-identity"
 version = "0.1.0"
 dependencies = [
  "futures 0.3.5",
- "http-body 0.3.1",
+ "http-body",
  "linkerd2-error",
  "linkerd2-identity",
  "linkerd2-proxy-api",
@@ -1420,7 +1359,7 @@ dependencies = [
  "linkerd2-proxy-core",
  "pin-project",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1431,7 +1370,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
  "http 0.2.1",
- "hyper 0.13.5",
+ "hyper",
  "indexmap",
  "ipnet 2.3.0",
  "linkerd2-conditional",
@@ -1448,7 +1387,7 @@ dependencies = [
  "rand 0.7.2",
  "tokio 0.2.21",
  "tonic",
- "tower 0.3.1",
+ "tower",
  "tracing",
  "tracing-futures",
 ]
@@ -1462,7 +1401,7 @@ dependencies = [
  "linkerd2-error",
  "pin-project",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
 ]
 
 [[package]]
@@ -1488,7 +1427,7 @@ dependencies = [
  "tokio 0.2.21",
  "tokio-rustls",
  "tokio-util",
- "tower 0.3.1",
+ "tower",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -1503,7 +1442,7 @@ dependencies = [
  "futures 0.3.5",
  "linkerd2-error",
  "pin-project",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1514,7 +1453,7 @@ dependencies = [
  "futures 0.3.5",
  "linkerd2-error",
  "pin-project",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1525,7 +1464,7 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-stack",
  "pin-project",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1537,7 +1476,7 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-stack",
  "pin-project",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1548,7 +1487,7 @@ dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
  "http 0.2.1",
- "http-body 0.3.1",
+ "http-body",
  "indexmap",
  "linkerd2-addr",
  "linkerd2-dns",
@@ -1562,7 +1501,7 @@ dependencies = [
  "regex 1.0.0",
  "tokio 0.2.21",
  "tonic",
- "tower 0.3.1",
+ "tower",
  "tracing",
  "tracing-futures",
 ]
@@ -1582,7 +1521,7 @@ dependencies = [
  "futures 0.3.5",
  "linkerd2-error",
  "pin-project",
- "tower 0.3.1",
+ "tower",
 ]
 
 [[package]]
@@ -1591,7 +1530,7 @@ version = "0.1.0"
 dependencies = [
  "indexmap",
  "linkerd2-metrics",
- "tower 0.3.1",
+ "tower",
 ]
 
 [[package]]
@@ -1602,7 +1541,7 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-stack",
  "pin-project",
- "tower 0.3.1",
+ "tower",
  "tracing",
  "tracing-futures",
 ]
@@ -1618,7 +1557,7 @@ dependencies = [
  "tokio 0.2.21",
  "tokio-connect",
  "tokio-test",
- "tower 0.3.1",
+ "tower",
  "tower-test",
  "tracing",
 ]
@@ -1636,7 +1575,7 @@ dependencies = [
  "pin-project",
  "rand 0.7.2",
  "tokio 0.2.21",
- "tower 0.3.1",
+ "tower",
  "tracing",
 ]
 
@@ -1996,8 +1935,10 @@ dependencies = [
 [[package]]
 name = "prost"
 version = "0.5.0"
-source = "git+https://github.com/linkerd/prost?branch=v0.5.x#8875bb9404ed50de20ef51c61bd2eaff5812fb1e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
 dependencies = [
+ "byteorder",
  "bytes 0.4.11",
  "prost-derive 0.5.0",
 ]
@@ -2033,7 +1974,8 @@ dependencies = [
 [[package]]
 name = "prost-derive"
 version = "0.5.0"
-source = "git+https://github.com/linkerd/prost?branch=v0.5.x#8875bb9404ed50de20ef51c61bd2eaff5812fb1e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
 dependencies = [
  "failure",
  "itertools",
@@ -2671,17 +2613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-buf"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "473a45a40e558d6d80e9f60e3d934c32488045def2745488a257e472941e9bce"
-dependencies = [
- "bytes 0.4.11",
- "either",
- "futures 0.1.26",
-]
-
-[[package]]
 name = "tokio-codec"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,14 +2857,14 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 0.2.1",
- "http-body 0.3.1",
+ "http-body",
  "percent-encoding",
  "pin-project",
  "prost 0.6.1",
  "prost-derive 0.6.1",
  "tokio-util",
  "tower-make",
- "tower-service 0.3.0",
+ "tower-service",
  "tracing",
 ]
 
@@ -2951,24 +2882,6 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc72f33b6a72c75c9df0037afce313018bae845f0ec7fdb9201b8768427a917f"
-dependencies = [
- "futures 0.1.26",
- "tower-buffer",
- "tower-discover",
- "tower-layer 0.1.0",
- "tower-limit",
- "tower-load-shed",
- "tower-retry",
- "tower-service 0.2.0",
- "tower-timeout",
- "tower-util",
-]
-
-[[package]]
-name = "tower"
 version = "0.3.1"
 source = "git+https://github.com/tower-rs/tower?rev=8752a3811788e94670c62dc0acbc9613207931b1#8752a3811788e94670c62dc0acbc9613207931b1"
 dependencies = [
@@ -2980,41 +2893,8 @@ dependencies = [
  "slab",
  "tokio 0.2.21",
  "tower-layer 0.3.0 (git+https://github.com/tower-rs/tower?rev=8752a3811788e94670c62dc0acbc9613207931b1)",
- "tower-service 0.3.0",
+ "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-buffer"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c98a7784e6c8ba106bc98d44ed1dbb9c018a8e0322e5e894d365f9020967128"
-dependencies = [
- "futures 0.1.26",
- "tokio-executor",
- "tokio-sync",
- "tower-layer 0.1.0",
- "tower-service 0.2.0",
-]
-
-[[package]]
-name = "tower-discover"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"
-dependencies = [
- "futures 0.1.26",
- "tower-service 0.2.0",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ddf07e10c07dcc8f41da6de036dc66def1a85b70eb8a385159e3908bb258328"
-dependencies = [
- "futures 0.1.26",
- "tower-service 0.2.0",
 ]
 
 [[package]]
@@ -3029,38 +2909,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
 
 [[package]]
-name = "tower-limit"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d990c5b6c0e4e192db8cf3dacaafefe1278962d0ec45dc84421175db32d33f0"
-dependencies = [
- "futures 0.1.26",
- "tokio-sync",
- "tokio-timer",
- "tower-layer 0.1.0",
- "tower-service 0.2.0",
- "tracing",
-]
-
-[[package]]
-name = "tower-load-shed"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04fbaf5bfb63d84204db87b9b2aeec61549613f2bbb8706dcc36f5f3ea8cd769"
-dependencies = [
- "futures 0.1.26",
- "tower-layer 0.1.0",
- "tower-service 0.2.0",
-]
-
-[[package]]
 name = "tower-make"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce50370d644a0364bf4877ffd4f76404156a248d104e2cc234cd391ea5cdc965"
 dependencies = [
  "tokio 0.2.21",
- "tower-service 0.3.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -3069,28 +2924,7 @@ version = "0.1.0"
 source = "git+https://github.com/tower-rs/tower-http#bd7a4654bdc4e2b5363572e9f66b4dbbc7c0e1ea"
 dependencies = [
  "http 0.2.1",
- "tower-service 0.3.0",
-]
-
-[[package]]
-name = "tower-retry"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e80588125061f276ed2a7b0939988b411e570a2dbb2965b1382ef4f71036f7"
-dependencies = [
- "futures 0.1.26",
- "tokio-timer",
- "tower-layer 0.1.0",
- "tower-service 0.2.0",
-]
-
-[[package]]
-name = "tower-service"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc0c98637d23732f8de6dfd16494c9f1559c3b9e20b4a46462c8f9b9e827bfa"
-dependencies = [
- "futures 0.1.26",
+ "tower-service",
 ]
 
 [[package]]
@@ -3110,31 +2944,7 @@ dependencies = [
  "tokio 0.2.21",
  "tokio-test",
  "tower-layer 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.3.0",
-]
-
-[[package]]
-name = "tower-timeout"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa179ec4087589dc67148dc661abce5badc2c3ed4197adc7bd64b39f1f33c31"
-dependencies = [
- "futures 0.1.26",
- "tokio-timer",
- "tower-layer 0.1.0",
- "tower-service 0.2.0",
-]
-
-[[package]]
-name = "tower-util"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4792342fac093db5d2558655055a89a04ca909663467a4310c7739d9f8b64698"
-dependencies = [
- "futures 0.1.26",
- "tokio-io",
- "tower-layer 0.1.0",
- "tower-service 0.2.0",
+ "tower-service",
 ]
 
 [[package]]
@@ -3348,17 +3158,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "want"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
-dependencies = [
- "futures 0.1.26",
- "log",
- "try-lock",
-]
 
 [[package]]
 name = "want"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,15 +218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codegen"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c59e8a9b988977ec3bd61ab380cf1167048817ecd3d6999fac03657f85a609"
-dependencies = [
- "indexmap",
-]
-
-[[package]]
 name = "crc"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,12 +340,6 @@ dependencies = [
  "syn 0.15.29",
  "synstructure",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "fixedbitset"
@@ -858,7 +843,7 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-metrics",
  "linkerd2-opencensus",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
+ "linkerd2-proxy-api",
  "net2",
  "quickcheck",
  "regex 1.0.0",
@@ -907,7 +892,7 @@ dependencies = [
  "linkerd2-lock",
  "linkerd2-metrics",
  "linkerd2-opencensus",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
+ "linkerd2-proxy-api",
  "linkerd2-proxy-api-resolve",
  "linkerd2-proxy-core",
  "linkerd2-proxy-detect",
@@ -997,8 +982,7 @@ dependencies = [
  "linkerd2-app",
  "linkerd2-app-core",
  "linkerd2-metrics",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12)",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
+ "linkerd2-proxy-api",
  "net2",
  "quickcheck",
  "regex 0.1.80",
@@ -1012,7 +996,6 @@ dependencies = [
  "tonic",
  "tower 0.1.1",
  "tower 0.3.1",
- "tower-grpc",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -1306,23 +1289,6 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.12"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12#85f24e80f695378928da985bf9d52af747047e10"
-dependencies = [
- "bytes 0.4.11",
- "futures 0.1.26",
- "h2 0.1.26",
- "http 0.1.21",
- "prost 0.5.0",
- "prost-types 0.5.0",
- "quickcheck",
- "rand 0.7.2",
- "tower-grpc",
- "tower-grpc-build",
-]
-
-[[package]]
-name = "linkerd2-proxy-api"
 version = "0.1.13"
 source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.13#f9a95345ef44c3d6f22559442e35f07e0af477e2"
 dependencies = [
@@ -1345,7 +1311,7 @@ dependencies = [
  "http-body 0.3.1",
  "indexmap",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
+ "linkerd2-proxy-api",
  "linkerd2-proxy-core",
  "pin-project",
  "prost 0.6.1",
@@ -1435,7 +1401,7 @@ dependencies = [
  "http-body 0.3.1",
  "linkerd2-error",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
+ "linkerd2-proxy-api",
  "linkerd2-proxy-transport",
  "pin-project",
  "tokio 0.2.21",
@@ -1470,7 +1436,7 @@ dependencies = [
  "linkerd2-conditional",
  "linkerd2-error",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
+ "linkerd2-proxy-api",
  "linkerd2-proxy-core",
  "linkerd2-proxy-http",
  "linkerd2-proxy-transport",
@@ -1586,7 +1552,7 @@ dependencies = [
  "linkerd2-addr",
  "linkerd2-dns",
  "linkerd2-error",
- "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
+ "linkerd2-proxy-api",
  "linkerd2-stack",
  "pin-project",
  "prost-types 0.6.1",
@@ -1811,12 +1777,6 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
-
-[[package]]
-name = "multimap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
@@ -1938,24 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-
-[[package]]
-name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
-name = "petgraph"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
-dependencies = [
- "fixedbitset 0.1.9",
-]
 
 [[package]]
 name = "petgraph"
@@ -1963,7 +1908,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
 dependencies = [
- "fixedbitset 0.2.0",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -2068,24 +2013,6 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
-dependencies = [
- "bytes 0.4.11",
- "heck",
- "itertools",
- "log",
- "multimap 0.4.0",
- "petgraph 0.4.13",
- "prost 0.5.0",
- "prost-types 0.5.0",
- "tempfile",
- "which 2.0.1",
-]
-
-[[package]]
-name = "prost-build"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
@@ -2094,12 +2021,12 @@ dependencies = [
  "heck",
  "itertools",
  "log",
- "multimap 0.8.1",
- "petgraph 0.5.0",
+ "multimap",
+ "petgraph",
  "prost 0.6.1",
  "prost-types 0.6.1",
  "tempfile",
- "which 3.1.1",
+ "which",
 ]
 
 [[package]]
@@ -2999,7 +2926,7 @@ dependencies = [
  "futures-util",
  "http 0.2.1",
  "http-body 0.3.1",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "pin-project",
  "prost 0.6.1",
  "prost-derive 0.6.1",
@@ -3016,7 +2943,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
 dependencies = [
  "proc-macro2 1.0.10",
- "prost-build 0.6.1",
+ "prost-build",
  "quote 1.0.2",
  "syn 1.0.21",
 ]
@@ -3077,36 +3004,6 @@ checksum = "73a7632286f78164d65d18fd0e570307acde9362489aa5c8c53e6315cc2bde47"
 dependencies = [
  "futures 0.1.26",
  "tower-service 0.2.0",
-]
-
-[[package]]
-name = "tower-grpc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "839c195fd6e4e87442e7a631ea62632799695a3f897949192325a4e509ff4328"
-dependencies = [
- "base64 0.10.1",
- "bytes 0.4.11",
- "futures 0.1.26",
- "h2 0.1.26",
- "http 0.1.21",
- "http-body 0.1.0",
- "log",
- "percent-encoding 1.0.1",
- "prost 0.5.0",
- "tower-service 0.2.0",
- "tower-util",
-]
-
-[[package]]
-name = "tower-grpc-build"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8862053a26bc7b901cf52bca8ae7d4c2e041222673e38f81a475aeb6c82481df"
-dependencies = [
- "codegen",
- "heck",
- "prost-build 0.5.0",
 ]
 
 [[package]]
@@ -3424,7 +3321,7 @@ checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
  "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -3577,16 +3474,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 dependencies = [
  "nom 4.2.3",
-]
-
-[[package]]
-name = "which"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
-dependencies = [
- "failure",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -862,7 +862,7 @@ dependencies = [
  "linkerd2-trace-context",
  "pin-project",
  "procinfo",
- "prost-types 0.5.0",
+ "prost-types",
  "quickcheck",
  "rand 0.7.2",
  "regex 1.0.0",
@@ -1234,8 +1234,8 @@ source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.13#f9a95345
 dependencies = [
  "h2 0.2.5",
  "http 0.2.1",
- "prost 0.6.1",
- "prost-types 0.6.1",
+ "prost",
+ "prost-types",
  "quickcheck",
  "rand 0.7.2",
  "tonic",
@@ -1254,7 +1254,7 @@ dependencies = [
  "linkerd2-proxy-api",
  "linkerd2-proxy-core",
  "pin-project",
- "prost 0.6.1",
+ "prost",
  "tonic",
  "tower",
  "tracing",
@@ -1382,7 +1382,7 @@ dependencies = [
  "linkerd2-proxy-transport",
  "linkerd2-stack",
  "pin-project",
- "prost-types 0.6.1",
+ "prost-types",
  "quickcheck",
  "rand 0.7.2",
  "tokio 0.2.21",
@@ -1495,7 +1495,7 @@ dependencies = [
  "linkerd2-proxy-api",
  "linkerd2-stack",
  "pin-project",
- "prost-types 0.6.1",
+ "prost-types",
  "quickcheck",
  "rand 0.7.2",
  "regex 1.0.0",
@@ -1804,8 +1804,8 @@ name = "opencensus-proto"
 version = "0.1.0"
 dependencies = [
  "bytes 0.5.4",
- "prost 0.6.1",
- "prost-types 0.6.1",
+ "prost",
+ "prost-types",
  "tonic",
  "tonic-build",
 ]
@@ -1934,23 +1934,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
-dependencies = [
- "byteorder",
- "bytes 0.4.11",
- "prost-derive 0.5.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
  "bytes 0.5.4",
- "prost-derive 0.6.1",
+ "prost-derive",
 ]
 
 [[package]]
@@ -1965,23 +1954,10 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost 0.6.1",
- "prost-types 0.6.1",
+ "prost",
+ "prost-types",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
-dependencies = [
- "failure",
- "itertools",
- "proc-macro2 0.4.27",
- "quote 0.6.11",
- "syn 0.15.29",
 ]
 
 [[package]]
@@ -1999,22 +1975,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
-dependencies = [
- "bytes 0.4.11",
- "prost 0.5.0",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
  "bytes 0.5.4",
- "prost 0.6.1",
+ "prost",
 ]
 
 [[package]]
@@ -2860,8 +2826,8 @@ dependencies = [
  "http-body",
  "percent-encoding",
  "pin-project",
- "prost 0.6.1",
- "prost-derive 0.6.1",
+ "prost",
+ "prost-derive",
  "tokio-util",
  "tower-make",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codegen"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34c59e8a9b988977ec3bd61ab380cf1167048817ecd3d6999fac03657f85a609"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
 name = "crc"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +349,12 @@ dependencies = [
  "syn 0.15.29",
  "synstructure",
 ]
+
+[[package]]
+name = "fixedbitset"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "fixedbitset"
@@ -843,7 +858,7 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-metrics",
  "linkerd2-opencensus",
- "linkerd2-proxy-api",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "net2",
  "quickcheck",
  "regex 1.0.0",
@@ -892,7 +907,7 @@ dependencies = [
  "linkerd2-lock",
  "linkerd2-metrics",
  "linkerd2-opencensus",
- "linkerd2-proxy-api",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "linkerd2-proxy-api-resolve",
  "linkerd2-proxy-core",
  "linkerd2-proxy-detect",
@@ -982,7 +997,8 @@ dependencies = [
  "linkerd2-app",
  "linkerd2-app-core",
  "linkerd2-metrics",
- "linkerd2-proxy-api",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12)",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "net2",
  "quickcheck",
  "regex 0.1.80",
@@ -1026,7 +1042,6 @@ name = "linkerd2-app-profiling"
 version = "0.1.0"
 dependencies = [
  "linkerd2-app-integration",
- "tokio 0.2.21",
 ]
 
 [[package]]
@@ -1291,6 +1306,23 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
+version = "0.1.12"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12#85f24e80f695378928da985bf9d52af747047e10"
+dependencies = [
+ "bytes 0.4.11",
+ "futures 0.1.26",
+ "h2 0.1.26",
+ "http 0.1.21",
+ "prost 0.5.0",
+ "prost-types 0.5.0",
+ "quickcheck",
+ "rand 0.7.2",
+ "tower-grpc",
+ "tower-grpc-build",
+]
+
+[[package]]
+name = "linkerd2-proxy-api"
 version = "0.1.13"
 source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.13#f9a95345ef44c3d6f22559442e35f07e0af477e2"
 dependencies = [
@@ -1313,7 +1345,7 @@ dependencies = [
  "http-body 0.3.1",
  "indexmap",
  "linkerd2-identity",
- "linkerd2-proxy-api",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "linkerd2-proxy-core",
  "pin-project",
  "prost 0.6.1",
@@ -1403,7 +1435,7 @@ dependencies = [
  "http-body 0.3.1",
  "linkerd2-error",
  "linkerd2-identity",
- "linkerd2-proxy-api",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "linkerd2-proxy-transport",
  "pin-project",
  "tokio 0.2.21",
@@ -1438,7 +1470,7 @@ dependencies = [
  "linkerd2-conditional",
  "linkerd2-error",
  "linkerd2-identity",
- "linkerd2-proxy-api",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "linkerd2-proxy-core",
  "linkerd2-proxy-http",
  "linkerd2-proxy-transport",
@@ -1554,7 +1586,7 @@ dependencies = [
  "linkerd2-addr",
  "linkerd2-dns",
  "linkerd2-error",
- "linkerd2-proxy-api",
+ "linkerd2-proxy-api 0.1.12 (git+https://github.com/linkerd/linkerd2-proxy-api)",
  "linkerd2-stack",
  "pin-project",
  "prost-types 0.6.1",
@@ -1779,6 +1811,12 @@ dependencies = [
 
 [[package]]
 name = "multimap"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
+
+[[package]]
+name = "multimap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
@@ -1912,11 +1950,20 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+dependencies = [
+ "fixedbitset 0.1.9",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.2.0",
  "indexmap",
 ]
 
@@ -2021,6 +2068,24 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
+dependencies = [
+ "bytes 0.4.11",
+ "heck",
+ "itertools",
+ "log",
+ "multimap 0.4.0",
+ "petgraph 0.4.13",
+ "prost 0.5.0",
+ "prost-types 0.5.0",
+ "tempfile",
+ "which 2.0.1",
+]
+
+[[package]]
+name = "prost-build"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
@@ -2029,12 +2094,12 @@ dependencies = [
  "heck",
  "itertools",
  "log",
- "multimap",
- "petgraph",
+ "multimap 0.8.1",
+ "petgraph 0.5.0",
  "prost 0.6.1",
  "prost-types 0.6.1",
  "tempfile",
- "which",
+ "which 3.1.1",
 ]
 
 [[package]]
@@ -2951,7 +3016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
 dependencies = [
  "proc-macro2 1.0.10",
- "prost-build",
+ "prost-build 0.6.1",
  "quote 1.0.2",
  "syn 1.0.21",
 ]
@@ -3031,6 +3096,17 @@ dependencies = [
  "prost 0.5.0",
  "tower-service 0.2.0",
  "tower-util",
+]
+
+[[package]]
+name = "tower-grpc-build"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8862053a26bc7b901cf52bca8ae7d4c2e041222673e38f81a475aeb6c82481df"
+dependencies = [
+ "codegen",
+ "heck",
+ "prost-build 0.5.0",
 ]
 
 [[package]]
@@ -3501,6 +3577,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 dependencies = [
  "nom 4.2.3",
+]
+
+[[package]]
+name = "which"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
+dependencies = [
+ "failure",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,15 +218,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codegen"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c59e8a9b988977ec3bd61ab380cf1167048817ecd3d6999fac03657f85a609"
-dependencies = [
- "indexmap",
-]
-
-[[package]]
 name = "crc"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,12 +340,6 @@ dependencies = [
  "syn 0.15.29",
  "synstructure",
 ]
-
-[[package]]
-name = "fixedbitset"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 
 [[package]]
 name = "fixedbitset"
@@ -858,7 +843,7 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-metrics",
  "linkerd2-opencensus",
- "linkerd2-proxy-api 0.1.13",
+ "linkerd2-proxy-api",
  "net2",
  "quickcheck",
  "regex 1.0.0",
@@ -907,7 +892,7 @@ dependencies = [
  "linkerd2-lock",
  "linkerd2-metrics",
  "linkerd2-opencensus",
- "linkerd2-proxy-api 0.1.13",
+ "linkerd2-proxy-api",
  "linkerd2-proxy-api-resolve",
  "linkerd2-proxy-core",
  "linkerd2-proxy-detect",
@@ -997,8 +982,7 @@ dependencies = [
  "linkerd2-app",
  "linkerd2-app-core",
  "linkerd2-metrics",
- "linkerd2-proxy-api 0.1.12",
- "linkerd2-proxy-api 0.1.13",
+ "linkerd2-proxy-api",
  "net2",
  "quickcheck",
  "regex 0.1.80",
@@ -1042,6 +1026,7 @@ name = "linkerd2-app-profiling"
 version = "0.1.0"
 dependencies = [
  "linkerd2-app-integration",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -1306,23 +1291,6 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.12"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.12#85f24e80f695378928da985bf9d52af747047e10"
-dependencies = [
- "bytes 0.4.11",
- "futures 0.1.26",
- "h2 0.1.26",
- "http 0.1.21",
- "prost 0.5.0",
- "prost-types 0.5.0",
- "quickcheck",
- "rand 0.7.2",
- "tower-grpc",
- "tower-grpc-build",
-]
-
-[[package]]
-name = "linkerd2-proxy-api"
 version = "0.1.13"
 source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.13#f9a95345ef44c3d6f22559442e35f07e0af477e2"
 dependencies = [
@@ -1345,7 +1313,7 @@ dependencies = [
  "http-body 0.3.1",
  "indexmap",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.13",
+ "linkerd2-proxy-api",
  "linkerd2-proxy-core",
  "pin-project",
  "prost 0.6.1",
@@ -1435,7 +1403,7 @@ dependencies = [
  "http-body 0.3.1",
  "linkerd2-error",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.13",
+ "linkerd2-proxy-api",
  "linkerd2-proxy-transport",
  "pin-project",
  "tokio 0.2.21",
@@ -1470,7 +1438,7 @@ dependencies = [
  "linkerd2-conditional",
  "linkerd2-error",
  "linkerd2-identity",
- "linkerd2-proxy-api 0.1.13",
+ "linkerd2-proxy-api",
  "linkerd2-proxy-core",
  "linkerd2-proxy-http",
  "linkerd2-proxy-transport",
@@ -1586,7 +1554,7 @@ dependencies = [
  "linkerd2-addr",
  "linkerd2-dns",
  "linkerd2-error",
- "linkerd2-proxy-api 0.1.13",
+ "linkerd2-proxy-api",
  "linkerd2-stack",
  "pin-project",
  "prost-types 0.6.1",
@@ -1811,12 +1779,6 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04b9f127583ed176e163fb9ec6f3e793b87e21deedd5734a69386a18a0151"
-
-[[package]]
-name = "multimap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8883adfde9756c1d30b0f519c9b8c502a94b41ac62f696453c37c7fc0a958ce"
@@ -1950,20 +1912,11 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
-dependencies = [
- "fixedbitset 0.1.9",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c127eea4a29ec6c85d153c59dc1213f33ec74cead30fe4730aecc88cc1fd92"
 dependencies = [
- "fixedbitset 0.2.0",
+ "fixedbitset",
  "indexmap",
 ]
 
@@ -2068,24 +2021,6 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
-dependencies = [
- "bytes 0.4.11",
- "heck",
- "itertools",
- "log",
- "multimap 0.4.0",
- "petgraph 0.4.13",
- "prost 0.5.0",
- "prost-types 0.5.0",
- "tempfile",
- "which 2.0.1",
-]
-
-[[package]]
-name = "prost-build"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
@@ -2094,12 +2029,12 @@ dependencies = [
  "heck",
  "itertools",
  "log",
- "multimap 0.8.1",
- "petgraph 0.5.0",
+ "multimap",
+ "petgraph",
  "prost 0.6.1",
  "prost-types 0.6.1",
  "tempfile",
- "which 3.1.1",
+ "which",
 ]
 
 [[package]]
@@ -3016,7 +2951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d8d21cb568e802d77055ab7fcd43f0992206de5028de95c8d3a41118d32e8e"
 dependencies = [
  "proc-macro2 1.0.10",
- "prost-build 0.6.1",
+ "prost-build",
  "quote 1.0.2",
  "syn 1.0.21",
 ]
@@ -3096,17 +3031,6 @@ dependencies = [
  "prost 0.5.0",
  "tower-service 0.2.0",
  "tower-util",
-]
-
-[[package]]
-name = "tower-grpc-build"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8862053a26bc7b901cf52bca8ae7d4c2e041222673e38f81a475aeb6c82481df"
-dependencies = [
- "codegen",
- "heck",
- "prost-build 0.5.0",
 ]
 
 [[package]]
@@ -3577,16 +3501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bb43f70885151e629e2a19ce9e50bd730fd436cfd4b666894c9ce4de9141164"
 dependencies = [
  "nom 4.2.3",
-]
-
-[[package]]
-name = "which"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
-dependencies = [
- "failure",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,4 @@ debug = false
 
 [patch.crates-io]
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.21" }
-# backport danburkert/prost#268 to `prost` 0.5 temporarily.
-prost = { git = "https://github.com/linkerd/prost", branch = "v0.5.x" }
 tower = { version = "0.3", git = "https://github.com/tower-rs/tower", rev = "8752a3811788e94670c62dc0acbc9613207931b1"}

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -97,7 +97,7 @@ procinfo = "0.4.2"
 
 [dev-dependencies]
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.13", features = ["arbitrary"] }
-prost-types = "0.5.0"
+prost-types = "0.6.0"
 quickcheck = { version = "0.9", default-features = false }
 tokio = { version = "0.2", features = ["time"] }
 tokio-test = "0.2"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -23,7 +23,7 @@ bytes = "0.5"
 futures_01 = {package = "futures", version = "0.1"}
 futures = { version = "0.3", features = ["compat"] }
 h2 = "0.2"
-http = "0.2"
+http = "0.2""
 http-body = "0.3"
 http-body_01 = { package = "http-body", version = "0.1"}
 http-01 = { package = "http", version = "0.1"}

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -23,7 +23,7 @@ bytes = "0.5"
 futures_01 = {package = "futures", version = "0.1"}
 futures = { version = "0.3", features = ["compat"] }
 h2 = "0.2"
-http = "0.2""
+http = "0.2"
 http-body = "0.3"
 http-body_01 = { package = "http-body", version = "0.1"}
 http-01 = { package = "http", version = "0.1"}

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -19,7 +19,7 @@ nyi = []
 
 [dependencies]
 bytes = "0.5"
-futures = { version = "0.3", features = ["compat"] }
+futures = "0.3" 
 h2 = "0.2"
 http = "0.2"
 http-body = "0.3"
@@ -35,7 +35,6 @@ ring = "0.16"
 rustls = "0.17"
 tokio = { version = "0.2", features = ["io-util", "net", "rt-core"]}
 tokio-rustls = "0.13"
-tokio-compat = "0.1"
 tower = { version = "0.3", default-features = false} 
 tonic = { version = "0.2", default-features = false }
 tracing = "0.1.9"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -18,17 +18,12 @@ flaky_tests = []
 nyi = []
 
 [dependencies]
-bytes_04 = { package = "bytes", version = "0.4"}
 bytes = "0.5"
-futures_01 = {package = "futures", version = "0.1"}
 futures = { version = "0.3", features = ["compat"] }
 h2 = "0.2"
 http = "0.2"
 http-body = "0.3"
-http-body_01 = { package = "http-body", version = "0.1"}
-http-01 = { package = "http", version = "0.1"}
 hyper = "0.13"
-hyper_012 = { package = "hyper", version = "0.12"}
 linkerd2-app = { path = "..", features = ["mock-orig-dst"] }
 linkerd2-app-core = { path = "../core", features = ["mock-orig-dst"] }
 linkerd2-metrics = { path = "../../metrics", features = ["test_util"] }
@@ -39,12 +34,9 @@ quickcheck = { version = "0.9", default-features = false }
 ring = "0.16"
 rustls = "0.17"
 tokio = { version = "0.2", features = ["io-util", "net", "rt-core"]}
-tokio_01 = { package = "tokio", version = "0.1"}
-tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-rustls = "0.13"
 tokio-compat = "0.1"
 tower = { version = "0.3", default-features = false} 
-tower_01 = { package = "tower", version = "0.1" }
 tonic = { version = "0.2", default-features = false }
 tracing = "0.1.9"
 tracing-futures = { version = "0.2", features = ["std-future"] }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -32,8 +32,7 @@ hyper_012 = { package = "hyper", version = "0.12"}
 linkerd2-app = { path = "..", features = ["mock-orig-dst"] }
 linkerd2-app-core = { path = "../core", features = ["mock-orig-dst"] }
 linkerd2-metrics = { path = "../../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", features = ["arbitrary"], tag = "v0.1.12" }
-linkerd2-proxy-api-tonic = { package = "linkerd2-proxy-api", git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.13", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.13", features = ["arbitrary"] }
 regex = "0.1"
 net2 = "0.2"
 quickcheck = { version = "0.9", default-features = false }
@@ -46,7 +45,6 @@ tokio-rustls = "0.13"
 tokio-compat = "0.1"
 tower = { version = "0.3", default-features = false} 
 tower_01 = { package = "tower", version = "0.1" }
-tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 tonic = { version = "0.2", default-features = false }
 tracing = "0.1.9"
 tracing-futures = { version = "0.2", features = ["std-future"] }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -44,7 +44,7 @@ tokio_01 = { package = "tokio", version = "0.1"}
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
 tokio-rustls = "0.13"
 tokio-compat = "0.1"
-tower = "0.3"
+tower = { version = "0.3", default-features = false} 
 tower_01 = { package = "tower", version = "0.1" }
 tower-grpc = { version = "0.1", default-features = false, features = ["protobuf"] }
 tonic = { version = "0.2", default-features = false }

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 use linkerd2_app_core::proxy::http::trace;
-use linkerd2_proxy_api::destination as pb;
-use linkerd2_proxy_api::net;
+use linkerd2_proxy_api_tonic::destination as pb;
+use linkerd2_proxy_api_tonic::net;
 use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
 use std::ops::{Bound, RangeBounds};

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -1,15 +1,15 @@
 use super::*;
 
-use bytes_04::IntoBuf;
-use futures::TryFutureExt;
-use futures_01::{future, sync};
-use hyper_012::body::Payload;
-use linkerd2_proxy_api::destination as pb;
-use linkerd2_proxy_api::net;
+use linkerd2_app_core::proxy::http::trace;
+use linkerd2_proxy_api_tonic::destination as pb;
+use linkerd2_proxy_api_tonic::net;
 use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
-use std::ops::{Bound, DerefMut, RangeBounds};
+use std::ops::{Bound, RangeBounds};
 use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tonic as grpc;
+use tracing_futures::Instrument;
 
 pub fn new() -> Controller {
     Controller::new()
@@ -25,17 +25,15 @@ pub fn identity() -> identity::Controller {
 
 pub type Labels = HashMap<String, String>;
 
-#[derive(Debug)]
-pub struct DstReceiver(sync::mpsc::UnboundedReceiver<Result<pb::Update, grpc::Status>>);
+pub type DstReceiver = mpsc::UnboundedReceiver<Result<pb::Update, grpc::Status>>;
 
 #[derive(Clone, Debug)]
-pub struct DstSender(sync::mpsc::UnboundedSender<Result<pb::Update, grpc::Status>>);
+pub struct DstSender(mpsc::UnboundedSender<Result<pb::Update, grpc::Status>>);
 
-#[derive(Debug)]
-pub struct ProfileReceiver(sync::mpsc::UnboundedReceiver<pb::DestinationProfile>);
+pub type ProfileReceiver = mpsc::UnboundedReceiver<pb::DestinationProfile>;
 
 #[derive(Clone, Debug)]
-pub struct ProfileSender(sync::mpsc::UnboundedSender<pb::DestinationProfile>);
+pub struct ProfileSender(mpsc::UnboundedSender<pb::DestinationProfile>);
 
 #[derive(Clone, Debug, Default)]
 pub struct Controller {
@@ -46,7 +44,9 @@ pub struct Controller {
 
 pub struct Listening {
     pub addr: SocketAddr,
-    _shutdown: Shutdown,
+    drain: drain::Signal,
+    task: tokio::task::JoinHandle<Result<(), std::io::Error>>,
+    name: &'static str,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -72,7 +72,7 @@ impl Controller {
     }
 
     pub fn destination_tx(&self, dest: &str) -> DstSender {
-        let (tx, rx) = sync::mpsc::unbounded();
+        let (tx, rx) = mpsc::unbounded_channel();
         let path = if dest.contains(":") {
             dest.to_owned()
         } else {
@@ -85,7 +85,7 @@ impl Controller {
         self.expect_dst_calls
             .lock()
             .unwrap()
-            .push_back(Dst::Call(dst, Ok(DstReceiver(rx))));
+            .push_back(Dst::Call(dst, Ok(rx)));
         DstSender(tx)
     }
 
@@ -115,15 +115,16 @@ impl Controller {
         self.expect_dst_calls.lock().unwrap().push_back(Dst::Done);
     }
 
-    pub fn delay_listen<F>(self, f: F) -> Listening
+    pub async fn delay_listen<F>(self, f: F) -> Listening
     where
-        F: TryFuture<Ok = (), Error = ()> + Send + 'static,
+        F: Future<Output = ()> + Send + 'static,
     {
         run(
-            pb::server::DestinationServer::new(self),
+            pb::destination_server::DestinationServer::new(self),
             "support destination service",
-            Some(Box::new(Box::pin(f.map(|_| Ok(()))).compat())),
+            Some(Box::pin(f)),
         )
+        .await
     }
 
     pub fn profile_tx_default(&self, dest: &str) -> ProfileSender {
@@ -133,7 +134,7 @@ impl Controller {
     }
 
     pub fn profile_tx(&self, dest: &str) -> ProfileSender {
-        let (tx, rx) = sync::mpsc::unbounded();
+        let (tx, rx) = mpsc::unbounded_channel();
         let path = if dest.contains(":") {
             dest.to_owned()
         } else {
@@ -146,21 +147,18 @@ impl Controller {
         self.expect_profile_calls
             .lock()
             .unwrap()
-            .push_back((dst, ProfileReceiver(rx)));
+            .push_back((dst, rx));
         ProfileSender(tx)
     }
 
-    pub fn run(self) -> Listening {
+    pub async fn run(self) -> Listening {
         run(
-            pb::server::DestinationServer::new(self),
+            pb::destination_server::DestinationServer::new(self),
             "support destination service",
             None,
         )
+        .await
     }
-}
-
-fn grpc_internal_code() -> grpc::Status {
-    grpc::Status::new(grpc::Code::Internal, "unit test controller internal error")
 }
 
 fn grpc_no_results() -> grpc::Status {
@@ -177,24 +175,13 @@ fn grpc_unexpected_request() -> grpc::Status {
     )
 }
 
-impl Stream01 for DstReceiver {
-    type Item = pb::Update;
-    type Error = grpc::Status;
-    fn poll(&mut self) -> Poll01<Option<Self::Item>, Self::Error> {
-        match futures_01::try_ready!(self.0.poll().map_err(|_| grpc_internal_code())) {
-            Some(res) => Ok(Async::Ready(Some(res?))),
-            None => Ok(Async::Ready(None)),
-        }
-    }
-}
-
 impl DstSender {
     pub fn send(&self, up: pb::Update) {
-        self.0.unbounded_send(Ok(up)).expect("send dst update")
+        self.0.send(Ok(up)).expect("send dst update")
     }
 
     pub fn send_err(&self, e: grpc::Status) {
-        self.0.unbounded_send(Err(e)).expect("send dst err")
+        self.0.send(Err(e)).expect("send dst err")
     }
 
     pub fn send_addr(&self, addr: SocketAddr) {
@@ -219,25 +206,20 @@ impl DstSender {
     }
 }
 
-impl Stream01 for ProfileReceiver {
-    type Item = pb::DestinationProfile;
-    type Error = grpc::Status;
-    fn poll(&mut self) -> Poll01<Option<Self::Item>, Self::Error> {
-        self.0.poll().map_err(|_| grpc_internal_code())
-    }
-}
-
 impl ProfileSender {
     pub fn send(&self, up: pb::DestinationProfile) {
-        self.0.unbounded_send(up).expect("send profile update")
+        self.0.send(up).expect("send profile update")
     }
 }
 
-impl pb::server::Destination for Controller {
+#[tonic::async_trait]
+impl pb::destination_server::Destination for Controller {
     type GetStream = DstReceiver;
-    type GetFuture = future::FutureResult<grpc::Response<Self::GetStream>, grpc::Status>;
 
-    fn get(&mut self, req: grpc::Request<pb::GetDestination>) -> Self::GetFuture {
+    async fn get(
+        &self,
+        req: grpc::Request<pb::GetDestination>,
+    ) -> Result<grpc::Response<Self::GetStream>, grpc::Status> {
         if let Ok(mut calls) = self.expect_dst_calls.lock() {
             if self.unordered {
                 let mut calls_next: VecDeque<Dst> = VecDeque::new();
@@ -249,8 +231,8 @@ impl pb::server::Destination for Controller {
                         if &dst == req.get_ref() {
                             tracing::info!("found request={:?}", dst);
                             calls_next.extend(calls.drain(..));
-                            *calls.deref_mut() = calls_next;
-                            return future::result(updates.map(grpc::Response::new));
+                            *calls = calls_next;
+                            return updates.map(grpc::Response::new);
                         }
 
                         calls_next.push_back(Dst::Call(dst, updates));
@@ -258,15 +240,15 @@ impl pb::server::Destination for Controller {
                 }
 
                 tracing::warn!("missed request={:?} remaining={:?}", req, calls_next.len());
-                *calls.deref_mut() = calls_next;
-                return future::err(grpc_unexpected_request());
+                *calls = calls_next;
+                return Err(grpc_unexpected_request());
             }
 
             match calls.pop_front() {
                 Some(Dst::Call(dst, updates)) => {
                     if &dst == req.get_ref() {
                         tracing::debug!("found request={:?}", dst);
-                        return future::result(updates.map(grpc::Response::new));
+                        return updates.map(grpc::Response::new);
                     }
 
                     let msg = format!(
@@ -274,7 +256,7 @@ impl pb::server::Destination for Controller {
                         dst, req
                     );
                     calls.push_front(Dst::Call(dst, updates));
-                    return future::err(grpc::Status::new(grpc::Code::Unavailable, msg));
+                    return Err(grpc::Status::new(grpc::Code::Unavailable, msg));
                 }
                 Some(Dst::Done) => {
                     panic!("unit test controller expects no more Destination.Get calls")
@@ -283,103 +265,122 @@ impl pb::server::Destination for Controller {
             }
         }
 
-        future::err(grpc_no_results())
+        Err(grpc_no_results())
     }
 
-    type GetProfileStream = ProfileReceiver;
-    type GetProfileFuture =
-        future::FutureResult<grpc::Response<Self::GetProfileStream>, grpc::Status>;
+    type GetProfileStream =
+        Pin<Box<dyn Stream<Item = Result<pb::DestinationProfile, grpc::Status>> + Send + Sync>>;
 
-    fn get_profile(&mut self, req: grpc::Request<pb::GetDestination>) -> Self::GetProfileFuture {
+    async fn get_profile(
+        &self,
+        req: grpc::Request<pb::GetDestination>,
+    ) -> Result<grpc::Response<Self::GetProfileStream>, grpc::Status> {
         if let Ok(mut calls) = self.expect_profile_calls.lock() {
             if let Some((dst, profile)) = calls.pop_front() {
                 if &dst == req.get_ref() {
-                    return future::ok(grpc::Response::new(profile));
+                    return Ok(grpc::Response::new(Box::pin(profile.map(Ok))));
                 }
 
                 calls.push_front((dst, profile));
-                return future::err(grpc_unexpected_request());
+                return Err(grpc_unexpected_request());
             }
         }
 
-        future::err(grpc_no_results())
+        Err(grpc_no_results())
     }
 }
 
-pub(in crate) fn run<T, B>(
+impl Listening {
+    pub async fn join(self) {
+        let span = tracing::info_span!("join", controller = %self.name, addr = %self.addr);
+        async move {
+            tracing::debug!("shutting down...");
+            self.drain.drain().await;
+            tracing::debug!("drained!");
+
+            tracing::debug!("waiting for task to complete...");
+            match self.task.await {
+                Ok(res) => res.expect("support controller failed"),
+                // If the task panicked, propagate the panic so that the test can
+                // fail nicely.
+                Err(err) if err.is_panic() => {
+                    tracing::error!("support {} panicked!", self.name);
+                    std::panic::resume_unwind(err.into_panic());
+                }
+                // If the task was already canceled, it was probably shut down
+                // explicitly, that's fine.
+                Err(_) => tracing::debug!("support server task already canceled"),
+            }
+
+            tracing::info!("support {} on {} terminated cleanly", self.name, self.addr);
+        }
+        .instrument(span)
+        .await
+    }
+}
+
+pub(in crate) async fn run<T, B>(
     svc: T,
     name: &'static str,
-    delay: Option<Box<dyn Future01<Item = (), Error = ()> + Send>>,
+    delay: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
 ) -> Listening
 where
-    T: tower_01::Service<http_01::Request<tower_grpc::BoxBody>, Response = http_01::Response<B>>,
+    T: tower::Service<http::Request<hyper::body::Body>, Response = http::Response<B>>,
     T: Clone + Send + Sync + 'static,
-    T::Error: ::std::error::Error + Send + Sync,
+    T::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     T::Future: Send,
-    B: grpc::Body + Send + 'static,
+    B: http_body::Body + Send + 'static,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     B::Data: Send + 'static,
 {
-    let (tx, rx) = shutdown_signal();
-
     let addr = SocketAddr::from(([127, 0, 0, 1], 0));
     let listener = net2::TcpBuilder::new_v4().expect("Tcp::new_v4");
     listener.bind(addr).expect("Tcp::bind");
     let addr = listener.local_addr().expect("Tcp::local_addr");
+    let listener = listener.listen(1024).expect("listen");
 
-    let (listening_tx, listening_rx) = futures_01::sync::oneshot::channel();
-    let mut listening_tx = Some(listening_tx);
+    let (listening_tx, listening_rx) = tokio::sync::oneshot::channel();
+    let (drain_signal, drain) = drain::channel();
+    let task = tokio::spawn(
+        cancelable(drain.clone(), async move {
+            let mut listener = tokio::net::TcpListener::from_std(listener)?;
+            let mut listening_tx = Some(listening_tx);
 
-    let (trace, _) = trace_subscriber();
-    std::thread::Builder::new()
-        .name(name.into())
-        .spawn(move || {
-            tracing::dispatcher::with_default(&trace, move || {
-                if let Some(delay) = delay {
-                    let _ = listening_tx.take().unwrap().send(());
-                    delay.wait().expect("support server delay wait");
-                }
-                let mut runtime = runtime::current_thread::Runtime::new().expect("support runtime");
+            if let Some(delay) = delay {
+                let _ = listening_tx.take().unwrap().send(());
+                delay.await;
+            }
 
-                let listener = listener.listen(1024).expect("Tcp::listen");
-                let bind = tokio_01::net::TcpListener::from_std(
-                    listener,
-                    &tokio_01::reactor::Handle::default(),
-                )
-                .expect("from_std");
+            if let Some(listening_tx) = listening_tx {
+                let _ = listening_tx.send(());
+            }
 
-                if let Some(listening_tx) = listening_tx {
-                    let _ = listening_tx.send(());
-                }
-
-                let name = name.clone();
-                let serve = hyper_012::Server::builder(bind.incoming())
-                    .http2_only(true)
-                    .serve(move || {
-                        let svc = Mutex::new(svc.clone());
-                        hyper_012::service::service_fn(move |req| {
-                            let req = req.map(|body| tower_grpc::BoxBody::map_from(body));
-                            svc.lock()
-                                .expect("svc lock")
-                                .call(req)
-                                .map(|res| res.map(GrpcToPayload))
-                        })
-                    })
-                    .map_err(move |e| println!("{} error: {:?}", name, e));
-
-                runtime.spawn(serve);
-                runtime
-                    .block_on(rx.map(|_| Ok::<(), ()>(())).compat())
-                    .expect(name);
-            })
+            let mut http = hyper::server::conn::Http::new().with_executor(trace::Executor::new());
+            http.http2_only(true);
+            loop {
+                let (sock, addr) = listener.accept().await?;
+                let span = tracing::debug_span!("conn", %addr);
+                let serve = http.serve_connection(sock, svc.clone());
+                let f = async move {
+                    serve
+                        .await
+                        .map_err(|error| tracing::error!(%error, "serving connection failed."))?;
+                    Ok::<(), ()>(())
+                };
+                tokio::spawn(cancelable(drain.clone(), f).instrument(span));
+            }
         })
-        .unwrap();
+        .instrument(tracing::info_span!("controller", %name, %addr)),
+    );
 
-    listening_rx.wait().expect("listening_rx");
+    listening_rx.await.expect("listening_rx");
     println!("{} listening; addr={:?}", name, addr);
 
     Listening {
         addr,
-        _shutdown: tx,
+        drain: drain_signal,
+        task,
+        name,
     }
 }
 
@@ -626,29 +627,4 @@ fn octets_to_u64s(octets: [u8; 16]) -> (u64, u64) {
         + (u64::from(octets[14]) << 8)
         + u64::from(octets[15]);
     (first, last)
-}
-
-struct GrpcToPayload<B>(B);
-
-impl<B> Payload for GrpcToPayload<B>
-where
-    B: tower_grpc::Body + Send + 'static,
-    B::Data: Send + 'static,
-    <B::Data as IntoBuf>::Buf: Send + 'static,
-{
-    type Data = <B::Data as IntoBuf>::Buf;
-    type Error = B::Error;
-
-    fn is_end_stream(&self) -> bool {
-        self.0.is_end_stream()
-    }
-
-    fn poll_data(&mut self) -> Poll01<Option<Self::Data>, Self::Error> {
-        let data = futures_01::try_ready!(self.0.poll_data());
-        Ok(data.map(IntoBuf::into_buf).into())
-    }
-
-    fn poll_trailers(&mut self) -> Poll01<Option<http_01::HeaderMap>, Self::Error> {
-        self.0.poll_trailers()
-    }
 }

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -115,7 +115,7 @@ impl Controller {
         self.expect_dst_calls.lock().unwrap().push_back(Dst::Done);
     }
 
-    pub async fn delay_listen<F>(self, f: F) -> Listening
+    pub fn delay_listen<F>(self, f: F) -> Listening
     where
         F: Future<Output = ()> + Send + 'static,
     {
@@ -124,7 +124,6 @@ impl Controller {
             "support destination service",
             Some(Box::pin(f)),
         )
-        .await
     }
 
     pub fn profile_tx_default(&self, dest: &str) -> ProfileSender {
@@ -151,13 +150,12 @@ impl Controller {
         ProfileSender(tx)
     }
 
-    pub async fn run(self) -> Listening {
+    pub fn run(self) -> Listening {
         run(
             pb::destination_server::DestinationServer::new(self),
             "support destination service",
             None,
         )
-        .await
     }
 }
 
@@ -319,7 +317,7 @@ impl Listening {
     }
 }
 
-pub(in crate) async fn run<T, B>(
+pub(in crate) fn run<T, B>(
     svc: T,
     name: &'static str,
     delay: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
@@ -338,21 +336,13 @@ where
     listener.bind(addr).expect("Tcp::bind");
     let addr = listener.local_addr().expect("Tcp::local_addr");
     let listener = listener.listen(1024).expect("listen");
-
-    let (listening_tx, listening_rx) = tokio::sync::oneshot::channel();
     let (drain_signal, drain) = drain::channel();
     let task = tokio::spawn(
         cancelable(drain.clone(), async move {
             let mut listener = tokio::net::TcpListener::from_std(listener)?;
-            let mut listening_tx = Some(listening_tx);
 
             if let Some(delay) = delay {
-                let _ = listening_tx.take().unwrap().send(());
                 delay.await;
-            }
-
-            if let Some(listening_tx) = listening_tx {
-                let _ = listening_tx.send(());
             }
 
             let mut http = hyper::server::conn::Http::new().with_executor(trace::Executor::new());
@@ -373,7 +363,6 @@ where
         .instrument(tracing::info_span!("controller", %name, %addr)),
     );
 
-    listening_rx.await.expect("listening_rx");
     println!("{} listening; addr={:?}", name, addr);
 
     Listening {

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -1,8 +1,8 @@
 use super::*;
 
 use linkerd2_app_core::proxy::http::trace;
-use linkerd2_proxy_api_tonic::destination as pb;
-use linkerd2_proxy_api_tonic::net;
+use linkerd2_proxy_api::destination as pb;
+use linkerd2_proxy_api::net;
 use std::collections::{HashMap, VecDeque};
 use std::net::IpAddr;
 use std::ops::{Bound, RangeBounds};

--- a/linkerd/app/integration/src/identity.rs
+++ b/linkerd/app/integration/src/identity.rs
@@ -207,13 +207,14 @@ impl Controller {
         self
     }
 
-    pub fn run(self) -> controller::Listening {
+    pub async fn run(self) -> controller::Listening {
         println!("running support identity service");
         controller::run(
             pb::identity_server::IdentityServer::new(self),
             "support identity service",
             None,
         )
+        .await
     }
 }
 

--- a/linkerd/app/integration/src/identity.rs
+++ b/linkerd/app/integration/src/identity.rs
@@ -1,5 +1,4 @@
 use super::*;
-use futures_01::{future, Future as Future01};
 use std::{
     collections::VecDeque,
     fs, io,
@@ -8,7 +7,8 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use linkerd2_proxy_api::identity as pb;
+use linkerd2_proxy_api_tonic::identity as pb;
+use tonic as grpc;
 
 pub struct Identity {
     pub env: TestEnv,
@@ -25,8 +25,11 @@ pub struct Controller {
 type Certify = Box<
     dyn FnMut(
             pb::CertifyRequest,
-        ) -> Box<
-            dyn Future01<Item = grpc::Response<pb::CertifyResponse>, Error = grpc::Status> + Send,
+        ) -> Pin<
+            Box<
+                dyn Future<Output = Result<grpc::Response<pb::CertifyResponse>, grpc::Status>>
+                    + Send,
+            >,
         > + Send,
 >;
 
@@ -198,7 +201,7 @@ impl Controller {
             let fut = f(req)
                 .map_ok(grpc::Response::new)
                 .map_err(|e| grpc::Status::new(grpc::Code::Internal, format!("{}", e)));
-            Box::new(Box::pin(fut).compat())
+            Box::pin(fut)
         });
         self.expect_calls.lock().unwrap().push_back(func);
         self
@@ -207,24 +210,32 @@ impl Controller {
     pub fn run(self) -> controller::Listening {
         println!("running support identity service");
         controller::run(
-            pb::server::IdentityServer::new(self),
+            pb::identity_server::IdentityServer::new(self),
             "support identity service",
             None,
         )
     }
 }
 
-impl pb::server::Identity for Controller {
-    type CertifyFuture =
-        Box<dyn Future01<Item = grpc::Response<pb::CertifyResponse>, Error = grpc::Status> + Send>;
-    fn certify(&mut self, req: grpc::Request<pb::CertifyRequest>) -> Self::CertifyFuture {
-        if let Some(mut f) = self.expect_calls.lock().unwrap().pop_front() {
-            return f(req.into_inner());
+#[tonic::async_trait]
+impl pb::identity_server::Identity for Controller {
+    async fn certify(
+        &self,
+        req: grpc::Request<pb::CertifyRequest>,
+    ) -> Result<grpc::Response<pb::CertifyResponse>, grpc::Status> {
+        let f = self
+            .expect_calls
+            .lock()
+            .unwrap()
+            .pop_front()
+            .map(|mut f| f(req.into_inner()));
+        if let Some(f) = f {
+            return f.await;
         }
 
-        Box::new(future::err(grpc::Status::new(
+        Err(grpc::Status::new(
             grpc::Code::Unavailable,
             "unit test identity service has no results",
-        )))
+        ))
     }
 }

--- a/linkerd/app/integration/src/identity.rs
+++ b/linkerd/app/integration/src/identity.rs
@@ -207,14 +207,13 @@ impl Controller {
         self
     }
 
-    pub async fn run(self) -> controller::Listening {
+    pub fn run(self) -> controller::Listening {
         println!("running support identity service");
         controller::run(
             pb::identity_server::IdentityServer::new(self),
             "support identity service",
             None,
         )
-        .await
     }
 }
 

--- a/linkerd/app/integration/src/identity.rs
+++ b/linkerd/app/integration/src/identity.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use linkerd2_proxy_api::identity as pb;
+use linkerd2_proxy_api_tonic::identity as pb;
 use tonic as grpc;
 
 pub struct Identity {

--- a/linkerd/app/integration/src/identity.rs
+++ b/linkerd/app/integration/src/identity.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use linkerd2_proxy_api_tonic::identity as pb;
+use linkerd2_proxy_api::identity as pb;
 use tonic as grpc;
 
 pub struct Identity {

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "256"]
-#![type_length_limit = "2427419"]
+#![type_length_limit = "5554984"]
 
 mod test_env;
 
@@ -27,8 +27,8 @@ pub use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpListener;
 pub use tokio::stream::{Stream, StreamExt};
 pub use tokio::sync::oneshot;
+pub use tonic as grpc;
 pub use tower::Service;
-pub use tower_grpc as grpc;
 pub use tracing::*;
 pub use tracing_subscriber::prelude::*;
 

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -27,8 +27,8 @@ pub use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpListener;
 pub use tokio::stream::{Stream, StreamExt};
 pub use tokio::sync::oneshot;
+pub use tonic as grpc;
 pub use tower::Service;
-pub use tower_grpc as grpc;
 pub use tracing::*;
 pub use tracing_subscriber::prelude::*;
 

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "256"]
-#![type_length_limit = "5554984"]
+#![type_length_limit = "16289823"]
 
 mod test_env;
 

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -27,8 +27,8 @@ pub use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpListener;
 pub use tokio::stream::{Stream, StreamExt};
 pub use tokio::sync::oneshot;
-pub use tonic as grpc;
 pub use tower::Service;
+pub use tower_grpc as grpc;
 pub use tracing::*;
 pub use tracing_subscriber::prelude::*;
 

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "256"]
-#![type_length_limit = "16289823"]
+#![type_length_limit = "2427419"]
 
 mod test_env;
 

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -10,7 +10,6 @@ pub use self::test_env::TestEnv;
 pub use bytes::{Buf, BufMut, Bytes};
 pub use futures::{future, FutureExt, TryFuture, TryFutureExt};
 
-use futures_01::{Async, Future as Future01, Poll as Poll01, Stream as Stream01};
 pub use http::{HeaderMap, Request, Response, StatusCode};
 pub use http_body::Body as HttpBody;
 pub use linkerd2_app as app;
@@ -28,7 +27,6 @@ pub use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpListener;
 pub use tokio::stream::{Stream, StreamExt};
 pub use tokio::sync::oneshot;
-use tokio_compat::runtime::{self};
 pub use tower::Service;
 pub use tower_grpc as grpc;
 pub use tracing::*;

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -310,9 +310,9 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
                 let span = info_span!("proxy", test = %thread_name());
                 let _enter = span.enter();
 
-                tokio_compat::runtime::current_thread::Runtime::new()
+                tokio::runtime::Runtime::new()
                     .expect("proxy")
-                    .block_on_std(async move {
+                    .block_on(async move {
                         let main = config.build(trace_handle).await.expect("config");
 
                         // slip the running tx into the shutdown future, since the first time

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -141,16 +141,16 @@ impl Proxy {
         self
     }
 
-    pub async fn run(self) -> Listening {
-        self.run_with_test_env(TestEnv::new()).await
+    pub fn run(self) -> Listening {
+        self.run_with_test_env(TestEnv::new())
     }
 
-    pub async fn run_with_test_env(self, env: TestEnv) -> Listening {
-        run(self, env, true).await
+    pub fn run_with_test_env(self, env: TestEnv) -> Listening {
+        run(self, env, true)
     }
 
-    pub async fn run_with_test_env_and_keep_ports(self, env: TestEnv) -> Listening {
-        run(self, env, false).await
+    pub fn run_with_test_env_and_keep_ports(self, env: TestEnv) -> Listening {
+        run(self, env, false)
     }
 }
 
@@ -195,14 +195,14 @@ impl Listening {
     }
 }
 
-async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
+fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
     use app::env::Strings;
 
     let controller = if let Some(controller) = proxy.controller {
         controller
     } else {
         // bummer that the whole function needs to be async just for this...
-        controller::new().run().await
+        controller::new().run()
     };
     let inbound = proxy.inbound;
     let outbound = proxy.outbound;

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -141,16 +141,16 @@ impl Proxy {
         self
     }
 
-    pub fn run(self) -> Listening {
-        self.run_with_test_env(TestEnv::new())
+    pub async fn run(self) -> Listening {
+        self.run_with_test_env(TestEnv::new()).await
     }
 
-    pub fn run_with_test_env(self, env: TestEnv) -> Listening {
-        run(self, env, true)
+    pub async fn run_with_test_env(self, env: TestEnv) -> Listening {
+        run(self, env, true).await
     }
 
-    pub fn run_with_test_env_and_keep_ports(self, env: TestEnv) -> Listening {
-        run(self, env, false)
+    pub async fn run_with_test_env_and_keep_ports(self, env: TestEnv) -> Listening {
+        run(self, env, false).await
     }
 }
 
@@ -195,14 +195,14 @@ impl Listening {
     }
 }
 
-fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
+async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
     use app::env::Strings;
 
     let controller = if let Some(controller) = proxy.controller {
         controller
     } else {
         // bummer that the whole function needs to be async just for this...
-        controller::new().run()
+        controller::new().run().await
     };
     let inbound = proxy.inbound;
     let outbound = proxy.outbound;

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -322,7 +322,7 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
                             main.tap_addr(),
                             identity_addr,
                             main.inbound_addr(),
-                            main.outbound_addr(),
+                            _compat::runtime::current_thread::main.outbound_addr(),
                             main.admin_addr(),
                         );
                         let mut running = Some((running_tx, addrs));
@@ -348,7 +348,7 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
         .expect("spawn");
 
     let (tap_addr, identity_addr, inbound_addr, outbound_addr, metrics_addr) =
-        futures::executor::block_on(running_rx).unwrap();
+        running_rx.await.unwrap();
 
     // printlns will show if the test fails...
     println!(

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -322,7 +322,7 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
                             main.tap_addr(),
                             identity_addr,
                             main.inbound_addr(),
-                            _compat::runtime::current_thread::main.outbound_addr(),
+                            main.outbound_addr(),
                             main.admin_addr(),
                         );
                         let mut running = Some((running_tx, addrs));

--- a/linkerd/app/integration/src/tap.rs
+++ b/linkerd/app/integration/src/tap.rs
@@ -1,7 +1,7 @@
 use super::*;
 use futures::stream;
 use http_body::Body;
-use linkerd2_proxy_api::tap as pb;
+use linkerd2_proxy_api_tonic::tap as pb;
 
 pub fn client(addr: SocketAddr) -> Client {
     let api = pb::tap_client::TapClient::new(SyncSvc(client::http2(addr, "localhost")));

--- a/linkerd/app/integration/src/tap.rs
+++ b/linkerd/app/integration/src/tap.rs
@@ -1,7 +1,7 @@
 use super::*;
 use futures::stream;
 use http_body::Body;
-use linkerd2_proxy_api_tonic::tap as pb;
+use linkerd2_proxy_api::tap as pb;
 
 pub fn client(addr: SocketAddr) -> Client {
     let api = pb::tap_client::TapClient::new(SyncSvc(client::http2(addr, "localhost")));

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -1,5 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "1586225"]
+#![type_length_limit = "2427419"]
 
 use linkerd2_app_integration::*;
 

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "2427419"]
+#![type_length_limit = "16289823"]
+#![recursion_limit = "256"]
 
 use linkerd2_app_integration::*;
 

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -253,7 +253,7 @@ macro_rules! generate_tests {
                 .run().await;
 
             // Used to delay `listen` in the server, to force connection refused errors.
-            let (tx, rx) = oneshot::channel();
+            let (tx, rx) = oneshot::channel::<()>();
 
             let ctrl = controller::new();
             ctrl.profile_tx_default("disco.test.svc.cluster.local");
@@ -263,7 +263,7 @@ macro_rules! generate_tests {
             // but don't drop, to not trigger stream closing reconnects
 
             let proxy = proxy::new()
-                .controller(ctrl.delay_listen(rx.map_err(|_| ())))
+                .controller(ctrl.delay_listen(async move { let _ = rx.await; }))
                 // don't set srv as outbound(), so that SO_ORIGINAL_DST isn't
                 // used as a backup
                 .run_with_test_env(env);

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -16,7 +16,7 @@ macro_rules! generate_tests {
             ctrl.profile_tx_default("disco.test.svc.cluster.local");
             ctrl.destination_tx("disco.test.svc.cluster.local").send_addr(srv.addr);
 
-            let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
+            let proxy = proxy::new().controller(ctrl.run().await).outbound(srv).run().await;
             let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
 
             assert_eq!(client.get("/").await, "hello");
@@ -37,7 +37,7 @@ macro_rules! generate_tests {
             drop(ctrl.destination_tx("disco.test.svc.cluster.local"));
             ctrl.destination_tx("disco.test.svc.cluster.local").send_addr(srv.addr);
 
-            let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
+            let proxy = proxy::new().controller(ctrl.run().await).outbound(srv).run().await;
             let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
 
             assert_eq!(client.get("/recon").await, "nect");
@@ -70,9 +70,9 @@ macro_rules! generate_tests {
             ctrl.destination_tx("disco.test.svc.cluster.local").send(up);
 
             let proxy = proxy::new()
-                .controller(ctrl.run())
+                .controller(ctrl.run().await)
                 .outbound(srv)
-                .run();
+                .run().await;
 
             let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
 
@@ -98,9 +98,9 @@ macro_rules! generate_tests {
             let ctrl = controller::new();
             ctrl.no_more_destinations();
             let proxy = proxy::new()
-                .controller(ctrl.run())
+                .controller(ctrl.run().await)
                 .outbound(srv)
-                .run();
+                .run().await;
 
             let client = $make_client(proxy.outbound, "my-great-websute.net");
 
@@ -126,9 +126,9 @@ macro_rules! generate_tests {
             ctrl.no_more_destinations();
 
             let proxy = proxy::new()
-                .controller(ctrl.run())
+                .controller(ctrl.run().await)
                 .outbound(srv)
-                .run();
+                .run().await;
 
             let client = $make_client(proxy.outbound, NAME);
 
@@ -165,9 +165,9 @@ macro_rules! generate_tests {
             let dst_tx1 = ctrl.destination_tx("initially-exists.ns.svc.cluster.local");
 
             let proxy = proxy::new()
-                .controller(ctrl.run())
+                .controller(ctrl.run().await)
                 .outbound(srv)
-                .run_with_test_env(env);
+                .run_with_test_env(env).await;
 
             let initially_exists =
                 $make_client(proxy.outbound, "initially-exists.ns.svc.cluster.local");
@@ -201,9 +201,10 @@ macro_rules! generate_tests {
                 .destination_tx("disco.test.svc.cluster.local");
 
             let proxy = proxy::new()
-                .controller(ctrl.run())
+                .controller(ctrl.run().await)
                 .outbound(srv)
-                .run_with_test_env(env);
+                .run_with_test_env(env)
+                .await;
 
             let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
             let req = client.request_builder("/");
@@ -231,10 +232,10 @@ macro_rules! generate_tests {
             ctrl.destination_tx("disco.test.svc.cluster.local").send_addr(srv.addr);
 
             let proxy = proxy::new()
-                .controller(ctrl.run())
+                .controller(ctrl.run().await)
                 // don't set srv as outbound(), so that SO_ORIGINAL_DST isn't
                 // used as a backup
-                .run();
+                .run().await;
             let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
 
             assert_eq!(client.get("/").await, "hello");
@@ -263,10 +264,10 @@ macro_rules! generate_tests {
             // but don't drop, to not trigger stream closing reconnects
 
             let proxy = proxy::new()
-                .controller(ctrl.delay_listen(async move { let _ = rx.await; }))
+                .controller(ctrl.delay_listen(async move { let _ = rx.await; }).await)
                 // don't set srv as outbound(), so that SO_ORIGINAL_DST isn't
                 // used as a backup
-                .run_with_test_env(env);
+                .run_with_test_env(env).await;
 
             // Allow the control client to notice a connection error
             tokio::time::delay_for(Duration::from_millis(500)).await;
@@ -304,7 +305,7 @@ macro_rules! generate_tests {
                 let ctrl = controller::new();
                 ctrl.profile_tx_default("disco.test.svc.cluster.local");
                 ctrl.destination_tx("disco.test.svc.cluster.local").send_addr(srv.addr);
-                let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
+                let proxy = proxy::new().controller(ctrl.run().await).outbound(srv).run().await;
                 let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
                 let rsp = client.request(client.request_builder("/strip")).await.unwrap();
 
@@ -324,7 +325,7 @@ macro_rules! generate_tests {
 
                 let ctrl = controller::new();
                 ctrl.profile_tx_default("disco.test.svc.cluster.local");
-                let proxy = proxy::new().controller(ctrl.run()).inbound(srv).run();
+                let proxy = proxy::new().controller(ctrl.run().await).inbound(srv).run().await;
                 let client = $make_client(proxy.inbound, "disco.test.svc.cluster.local");
                 let rsp = client.request(client.request_builder("/strip").header(REMOTE_IP_HEADER, IP_1)).await.unwrap();
 
@@ -344,7 +345,7 @@ macro_rules! generate_tests {
                 let ctrl = controller::new();
                 ctrl.profile_tx_default("disco.test.svc.cluster.local");
                 ctrl.destination_tx("disco.test.svc.cluster.local").send_addr(srv.addr);
-                let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
+                let proxy = proxy::new().controller(ctrl.run().await).outbound(srv).run().await;
                 let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
                 let rsp = client.request(client.request_builder("/set")).await.unwrap();
 
@@ -364,7 +365,7 @@ macro_rules! generate_tests {
                     Response::default()
                 }).run().await;
 
-                let proxy = proxy::new().inbound(srv).run();
+                let proxy = proxy::new().inbound(srv).run().await;
                 let client = $make_client(proxy.inbound, "disco.test.svc.cluster.local");
                 let rsp = client.request(client.request_builder("/set")).await.unwrap();
 
@@ -467,9 +468,9 @@ macro_rules! generate_tests {
                     self.bar_reqs.load(Ordering::Acquire)
                 }
 
-                fn proxy(&mut self) -> proxy::Proxy {
+                async fn proxy(&mut self) -> proxy::Proxy {
                     let ctrl = self.ctrl.take().unwrap();
-                    proxy::new().controller(ctrl.run())
+                    proxy::new().controller(ctrl.run().await)
                 }
             }
 
@@ -485,7 +486,7 @@ macro_rules! generate_tests {
             #[tokio::test]
             async fn outbound_honors_override_header() {
                 let mut fixture = Fixture::new().await;
-                let proxy = fixture.proxy().run();
+                let proxy = fixture.proxy().await.run().await;
 
                 let client = $make_client(proxy.outbound, FOO);
 
@@ -518,7 +519,7 @@ macro_rules! generate_tests {
             #[tokio::test]
             async fn outbound_overrides_profile() {
                 let mut fixture = Fixture::new().await;
-                let proxy = fixture.proxy().run();
+                let proxy = fixture.proxy().await.run().await;
 
                 println!("make client: {}", FOO);
                 let client = $make_client(proxy.outbound, FOO);
@@ -542,9 +543,9 @@ macro_rules! generate_tests {
             #[tokio::test]
             async fn outbound_honors_override_header_with_orig_dst() {
                 let mut fixture = Fixture::new().await;
-                let proxy = fixture.proxy()
+                let proxy = fixture.proxy().await
                     .outbound(fixture.foo())
-                    .run();
+                    .run().await;
 
                 let client = $make_client(proxy.outbound, "foo.test.svc.cluster.local");
 
@@ -578,9 +579,9 @@ macro_rules! generate_tests {
             #[tokio::test]
             async fn inbound_overrides_profile() {
                 let mut fixture = Fixture::new().await;
-                let proxy = fixture.proxy()
+                let proxy = fixture.proxy().await
                     .inbound(fixture.foo())
-                    .run();
+                    .run().await;
 
                 let client = $make_client(proxy.inbound, FOO);
                 let metrics = client::http1(proxy.metrics, "localhost");
@@ -601,9 +602,9 @@ macro_rules! generate_tests {
             #[tokio::test]
             async fn inbound_still_routes_to_orig_dst() {
                 let mut fixture = Fixture::new().await;
-                let proxy = fixture.proxy()
+                let proxy = fixture.proxy().await
                     .inbound(fixture.foo())
-                    .run();
+                    .run().await;
 
                 let client = $make_client(proxy.inbound, "foo.test.svc.cluster.local");
 
@@ -667,7 +668,7 @@ mod http2 {
         // Start by "knowing" the first server...
         dst.send_addr(srv1.addr);
 
-        let proxy = proxy::new().controller(ctrl.run()).run();
+        let proxy = proxy::new().controller(ctrl.run().await).run().await;
         let client = client::http2(proxy.outbound, host);
         let metrics = client::http1(proxy.metrics, "localhost");
 
@@ -740,7 +741,7 @@ mod proxy_to_proxy {
         let dst = ctrl.destination_tx("disco.test.svc.cluster.local");
         dst.send_h2_hinted(srv.addr);
 
-        let proxy = proxy::new().controller(ctrl.run()).run();
+        let proxy = proxy::new().controller(ctrl.run().await).run().await;
 
         let client = client::http1(proxy.outbound, "disco.test.svc.cluster.local");
 
@@ -775,7 +776,11 @@ mod proxy_to_proxy {
         let ctrl = controller::new();
         ctrl.profile_tx_default("disco.test.svc.cluster.local");
 
-        let proxy = proxy::new().controller(ctrl.run()).inbound(srv).run();
+        let proxy = proxy::new()
+            .controller(ctrl.run().await)
+            .inbound(srv)
+            .run()
+            .await;
 
         // This client will be used as a mocked-other-proxy.
         let client = client::http2(proxy.inbound, "disco.test.svc.cluster.local");
@@ -810,7 +815,11 @@ mod proxy_to_proxy {
         let ctrl = controller::new();
         ctrl.profile_tx_default("disco.test.svc.cluster.local");
 
-        let proxy = proxy::new().controller(ctrl.run()).inbound(srv).run();
+        let proxy = proxy::new()
+            .controller(ctrl.run().await)
+            .inbound(srv)
+            .run()
+            .await;
 
         let client = client::http1(proxy.inbound, "disco.test.svc.cluster.local");
 
@@ -844,7 +853,7 @@ mod proxy_to_proxy {
         ctrl.profile_tx_default("disco.test.svc.cluster.local");
         ctrl.destination_tx("disco.test.svc.cluster.local")
             .send_addr(srv.addr);
-        let proxy = proxy::new().controller(ctrl.run()).run();
+        let proxy = proxy::new().controller(ctrl.run().await).run().await;
 
         let client = client::http1(proxy.outbound, "disco.test.svc.cluster.local");
 
@@ -879,7 +888,11 @@ mod proxy_to_proxy {
         let ctrl = controller::new();
         ctrl.profile_tx_default("disco.test.svc.cluster.local");
 
-        let proxy = proxy::new().controller(ctrl.run()).inbound(srv).run();
+        let proxy = proxy::new()
+            .controller(ctrl.run().await)
+            .inbound(srv)
+            .run()
+            .await;
 
         let client = client::http1(proxy.inbound, "disco.test.svc.cluster.local");
 
@@ -913,7 +926,7 @@ mod proxy_to_proxy {
         ctrl.destination_tx("disco.test.svc.cluster.local")
             .send_addr(srv.addr);
         ctrl.profile_tx_default("disco.test.svc.cluster.local");
-        let proxy = proxy::new().controller(ctrl.run()).run();
+        let proxy = proxy::new().controller(ctrl.run().await).run().await;
 
         let client = client::http1(proxy.outbound, "disco.test.svc.cluster.local");
 
@@ -941,17 +954,19 @@ mod proxy_to_proxy {
 
             let in_proxy = proxy::new()
                 .inbound(srv)
-                .identity(id_env.service().run())
-                .run_with_test_env(id_env.env.clone());
+                .identity(id_env.service().run().await)
+                .run_with_test_env(id_env.env.clone())
+                .await;
 
             let ctrl = controller::new();
             let dst = ctrl.destination_tx("disco.test.svc.cluster.local");
             dst.send(controller::destination_add_tls(in_proxy.inbound, id));
 
             let out_proxy = proxy::new()
-                .controller(ctrl.run())
-                .identity(id_env.service().run())
-                .run_with_test_env(id_env.env.clone());
+                .controller(ctrl.run().await)
+                .identity(id_env.service().run().await)
+                .run_with_test_env(id_env.env.clone())
+                .await;
 
             let client = $make_client(out_proxy.outbound, "disco.test.svc.cluster.local");
 

--- a/linkerd/app/integration/tests/discovery.rs
+++ b/linkerd/app/integration/tests/discovery.rs
@@ -16,7 +16,7 @@ macro_rules! generate_tests {
             ctrl.profile_tx_default("disco.test.svc.cluster.local");
             ctrl.destination_tx("disco.test.svc.cluster.local").send_addr(srv.addr);
 
-            let proxy = proxy::new().controller(ctrl.run().await).outbound(srv).run().await;
+            let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
             let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
 
             assert_eq!(client.get("/").await, "hello");
@@ -37,7 +37,7 @@ macro_rules! generate_tests {
             drop(ctrl.destination_tx("disco.test.svc.cluster.local"));
             ctrl.destination_tx("disco.test.svc.cluster.local").send_addr(srv.addr);
 
-            let proxy = proxy::new().controller(ctrl.run().await).outbound(srv).run().await;
+            let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
             let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
 
             assert_eq!(client.get("/recon").await, "nect");
@@ -70,9 +70,9 @@ macro_rules! generate_tests {
             ctrl.destination_tx("disco.test.svc.cluster.local").send(up);
 
             let proxy = proxy::new()
-                .controller(ctrl.run().await)
+                .controller(ctrl.run())
                 .outbound(srv)
-                .run().await;
+                .run();
 
             let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
 
@@ -98,9 +98,9 @@ macro_rules! generate_tests {
             let ctrl = controller::new();
             ctrl.no_more_destinations();
             let proxy = proxy::new()
-                .controller(ctrl.run().await)
+                .controller(ctrl.run())
                 .outbound(srv)
-                .run().await;
+                .run();
 
             let client = $make_client(proxy.outbound, "my-great-websute.net");
 
@@ -126,9 +126,9 @@ macro_rules! generate_tests {
             ctrl.no_more_destinations();
 
             let proxy = proxy::new()
-                .controller(ctrl.run().await)
+                .controller(ctrl.run())
                 .outbound(srv)
-                .run().await;
+                .run();
 
             let client = $make_client(proxy.outbound, NAME);
 
@@ -165,9 +165,9 @@ macro_rules! generate_tests {
             let dst_tx1 = ctrl.destination_tx("initially-exists.ns.svc.cluster.local");
 
             let proxy = proxy::new()
-                .controller(ctrl.run().await)
+                .controller(ctrl.run())
                 .outbound(srv)
-                .run_with_test_env(env).await;
+                .run_with_test_env(env);
 
             let initially_exists =
                 $make_client(proxy.outbound, "initially-exists.ns.svc.cluster.local");
@@ -201,10 +201,9 @@ macro_rules! generate_tests {
                 .destination_tx("disco.test.svc.cluster.local");
 
             let proxy = proxy::new()
-                .controller(ctrl.run().await)
+                .controller(ctrl.run())
                 .outbound(srv)
-                .run_with_test_env(env)
-                .await;
+                .run_with_test_env(env);
 
             let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
             let req = client.request_builder("/");
@@ -232,10 +231,10 @@ macro_rules! generate_tests {
             ctrl.destination_tx("disco.test.svc.cluster.local").send_addr(srv.addr);
 
             let proxy = proxy::new()
-                .controller(ctrl.run().await)
+                .controller(ctrl.run())
                 // don't set srv as outbound(), so that SO_ORIGINAL_DST isn't
                 // used as a backup
-                .run().await;
+                .run();
             let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
 
             assert_eq!(client.get("/").await, "hello");
@@ -254,7 +253,7 @@ macro_rules! generate_tests {
                 .run().await;
 
             // Used to delay `listen` in the server, to force connection refused errors.
-            let (tx, rx) = oneshot::channel::<()>();
+            let (tx, rx) = oneshot::channel();
 
             let ctrl = controller::new();
             ctrl.profile_tx_default("disco.test.svc.cluster.local");
@@ -264,10 +263,10 @@ macro_rules! generate_tests {
             // but don't drop, to not trigger stream closing reconnects
 
             let proxy = proxy::new()
-                .controller(ctrl.delay_listen(async move { let _ = rx.await; }).await)
+                .controller(ctrl.delay_listen(rx.map_err(|_| ())))
                 // don't set srv as outbound(), so that SO_ORIGINAL_DST isn't
                 // used as a backup
-                .run_with_test_env(env).await;
+                .run_with_test_env(env);
 
             // Allow the control client to notice a connection error
             tokio::time::delay_for(Duration::from_millis(500)).await;
@@ -305,7 +304,7 @@ macro_rules! generate_tests {
                 let ctrl = controller::new();
                 ctrl.profile_tx_default("disco.test.svc.cluster.local");
                 ctrl.destination_tx("disco.test.svc.cluster.local").send_addr(srv.addr);
-                let proxy = proxy::new().controller(ctrl.run().await).outbound(srv).run().await;
+                let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
                 let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
                 let rsp = client.request(client.request_builder("/strip")).await.unwrap();
 
@@ -325,7 +324,7 @@ macro_rules! generate_tests {
 
                 let ctrl = controller::new();
                 ctrl.profile_tx_default("disco.test.svc.cluster.local");
-                let proxy = proxy::new().controller(ctrl.run().await).inbound(srv).run().await;
+                let proxy = proxy::new().controller(ctrl.run()).inbound(srv).run();
                 let client = $make_client(proxy.inbound, "disco.test.svc.cluster.local");
                 let rsp = client.request(client.request_builder("/strip").header(REMOTE_IP_HEADER, IP_1)).await.unwrap();
 
@@ -345,7 +344,7 @@ macro_rules! generate_tests {
                 let ctrl = controller::new();
                 ctrl.profile_tx_default("disco.test.svc.cluster.local");
                 ctrl.destination_tx("disco.test.svc.cluster.local").send_addr(srv.addr);
-                let proxy = proxy::new().controller(ctrl.run().await).outbound(srv).run().await;
+                let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
                 let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
                 let rsp = client.request(client.request_builder("/set")).await.unwrap();
 
@@ -365,7 +364,7 @@ macro_rules! generate_tests {
                     Response::default()
                 }).run().await;
 
-                let proxy = proxy::new().inbound(srv).run().await;
+                let proxy = proxy::new().inbound(srv).run();
                 let client = $make_client(proxy.inbound, "disco.test.svc.cluster.local");
                 let rsp = client.request(client.request_builder("/set")).await.unwrap();
 
@@ -468,9 +467,9 @@ macro_rules! generate_tests {
                     self.bar_reqs.load(Ordering::Acquire)
                 }
 
-                async fn proxy(&mut self) -> proxy::Proxy {
+                fn proxy(&mut self) -> proxy::Proxy {
                     let ctrl = self.ctrl.take().unwrap();
-                    proxy::new().controller(ctrl.run().await)
+                    proxy::new().controller(ctrl.run())
                 }
             }
 
@@ -486,7 +485,7 @@ macro_rules! generate_tests {
             #[tokio::test]
             async fn outbound_honors_override_header() {
                 let mut fixture = Fixture::new().await;
-                let proxy = fixture.proxy().await.run().await;
+                let proxy = fixture.proxy().run();
 
                 let client = $make_client(proxy.outbound, FOO);
 
@@ -519,7 +518,7 @@ macro_rules! generate_tests {
             #[tokio::test]
             async fn outbound_overrides_profile() {
                 let mut fixture = Fixture::new().await;
-                let proxy = fixture.proxy().await.run().await;
+                let proxy = fixture.proxy().run();
 
                 println!("make client: {}", FOO);
                 let client = $make_client(proxy.outbound, FOO);
@@ -543,9 +542,9 @@ macro_rules! generate_tests {
             #[tokio::test]
             async fn outbound_honors_override_header_with_orig_dst() {
                 let mut fixture = Fixture::new().await;
-                let proxy = fixture.proxy().await
+                let proxy = fixture.proxy()
                     .outbound(fixture.foo())
-                    .run().await;
+                    .run();
 
                 let client = $make_client(proxy.outbound, "foo.test.svc.cluster.local");
 
@@ -579,9 +578,9 @@ macro_rules! generate_tests {
             #[tokio::test]
             async fn inbound_overrides_profile() {
                 let mut fixture = Fixture::new().await;
-                let proxy = fixture.proxy().await
+                let proxy = fixture.proxy()
                     .inbound(fixture.foo())
-                    .run().await;
+                    .run();
 
                 let client = $make_client(proxy.inbound, FOO);
                 let metrics = client::http1(proxy.metrics, "localhost");
@@ -602,9 +601,9 @@ macro_rules! generate_tests {
             #[tokio::test]
             async fn inbound_still_routes_to_orig_dst() {
                 let mut fixture = Fixture::new().await;
-                let proxy = fixture.proxy().await
+                let proxy = fixture.proxy()
                     .inbound(fixture.foo())
-                    .run().await;
+                    .run();
 
                 let client = $make_client(proxy.inbound, "foo.test.svc.cluster.local");
 
@@ -668,7 +667,7 @@ mod http2 {
         // Start by "knowing" the first server...
         dst.send_addr(srv1.addr);
 
-        let proxy = proxy::new().controller(ctrl.run().await).run().await;
+        let proxy = proxy::new().controller(ctrl.run()).run();
         let client = client::http2(proxy.outbound, host);
         let metrics = client::http1(proxy.metrics, "localhost");
 
@@ -741,7 +740,7 @@ mod proxy_to_proxy {
         let dst = ctrl.destination_tx("disco.test.svc.cluster.local");
         dst.send_h2_hinted(srv.addr);
 
-        let proxy = proxy::new().controller(ctrl.run().await).run().await;
+        let proxy = proxy::new().controller(ctrl.run()).run();
 
         let client = client::http1(proxy.outbound, "disco.test.svc.cluster.local");
 
@@ -776,11 +775,7 @@ mod proxy_to_proxy {
         let ctrl = controller::new();
         ctrl.profile_tx_default("disco.test.svc.cluster.local");
 
-        let proxy = proxy::new()
-            .controller(ctrl.run().await)
-            .inbound(srv)
-            .run()
-            .await;
+        let proxy = proxy::new().controller(ctrl.run()).inbound(srv).run();
 
         // This client will be used as a mocked-other-proxy.
         let client = client::http2(proxy.inbound, "disco.test.svc.cluster.local");
@@ -815,11 +810,7 @@ mod proxy_to_proxy {
         let ctrl = controller::new();
         ctrl.profile_tx_default("disco.test.svc.cluster.local");
 
-        let proxy = proxy::new()
-            .controller(ctrl.run().await)
-            .inbound(srv)
-            .run()
-            .await;
+        let proxy = proxy::new().controller(ctrl.run()).inbound(srv).run();
 
         let client = client::http1(proxy.inbound, "disco.test.svc.cluster.local");
 
@@ -853,7 +844,7 @@ mod proxy_to_proxy {
         ctrl.profile_tx_default("disco.test.svc.cluster.local");
         ctrl.destination_tx("disco.test.svc.cluster.local")
             .send_addr(srv.addr);
-        let proxy = proxy::new().controller(ctrl.run().await).run().await;
+        let proxy = proxy::new().controller(ctrl.run()).run();
 
         let client = client::http1(proxy.outbound, "disco.test.svc.cluster.local");
 
@@ -888,11 +879,7 @@ mod proxy_to_proxy {
         let ctrl = controller::new();
         ctrl.profile_tx_default("disco.test.svc.cluster.local");
 
-        let proxy = proxy::new()
-            .controller(ctrl.run().await)
-            .inbound(srv)
-            .run()
-            .await;
+        let proxy = proxy::new().controller(ctrl.run()).inbound(srv).run();
 
         let client = client::http1(proxy.inbound, "disco.test.svc.cluster.local");
 
@@ -926,7 +913,7 @@ mod proxy_to_proxy {
         ctrl.destination_tx("disco.test.svc.cluster.local")
             .send_addr(srv.addr);
         ctrl.profile_tx_default("disco.test.svc.cluster.local");
-        let proxy = proxy::new().controller(ctrl.run().await).run().await;
+        let proxy = proxy::new().controller(ctrl.run()).run();
 
         let client = client::http1(proxy.outbound, "disco.test.svc.cluster.local");
 
@@ -954,19 +941,17 @@ mod proxy_to_proxy {
 
             let in_proxy = proxy::new()
                 .inbound(srv)
-                .identity(id_env.service().run().await)
-                .run_with_test_env(id_env.env.clone())
-                .await;
+                .identity(id_env.service().run())
+                .run_with_test_env(id_env.env.clone());
 
             let ctrl = controller::new();
             let dst = ctrl.destination_tx("disco.test.svc.cluster.local");
             dst.send(controller::destination_add_tls(in_proxy.inbound, id));
 
             let out_proxy = proxy::new()
-                .controller(ctrl.run().await)
-                .identity(id_env.service().run().await)
-                .run_with_test_env(id_env.env.clone())
-                .await;
+                .controller(ctrl.run())
+                .identity(id_env.service().run())
+                .run_with_test_env(id_env.env.clone());
 
             let client = $make_client(out_proxy.outbound, "disco.test.svc.cluster.local");
 

--- a/linkerd/app/integration/tests/identity.rs
+++ b/linkerd/app/integration/tests/identity.rs
@@ -21,10 +21,7 @@ async fn nonblocking_identity_detection() {
     } = identity::Identity::new("foo-ns1", id.to_string());
     certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
 
-    let id_svc = controller::identity()
-        .certify(move |_| certify_rsp)
-        .run()
-        .await;
+    let id_svc = controller::identity().certify(move |_| certify_rsp).run();
     let proxy = proxy::new().identity(id_svc);
 
     let msg1 = "custom tcp hello";
@@ -37,7 +34,7 @@ async fn nonblocking_identity_detection() {
         .run()
         .await;
 
-    let proxy = proxy.inbound(srv).run_with_test_env(env).await;
+    let proxy = proxy.inbound(srv).run_with_test_env(env);
     let client = client::tcp(proxy.inbound);
 
     // Create an idle connection and then an active connection. Ensure that
@@ -59,9 +56,8 @@ macro_rules! generate_tls_accept_test {
         let id = "foo.ns1.serviceaccount.identity.linkerd.cluster.local";
         let id_svc = identity::Identity::new("foo-ns1", id.to_string());
         let proxy = proxy::new()
-            .identity(id_svc.service().run().await)
-            .run_with_test_env(id_svc.env)
-            .await;
+            .identity(id_svc.service().run())
+            .run_with_test_env(id_svc.env);
 
         println!("non-tls request to {}", proxy.metrics);
         let non_tls_client = $make_client_non_tls(proxy.metrics, "localhost");
@@ -105,12 +101,9 @@ macro_rules! generate_tls_reject_test {
         certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
 
         let (_tx, rx) = oneshot::channel();
-        let id_svc = controller::identity()
-            .certify_async(move |_| rx)
-            .run()
-            .await;
+        let id_svc = controller::identity().certify_async(move |_| rx).run();
 
-        let proxy = proxy::new().identity(id_svc).run_with_test_env(env).await;
+        let proxy = proxy::new().identity(id_svc).run_with_test_env(env);
 
         let client = $make_client(
             proxy.metrics,
@@ -162,10 +155,7 @@ macro_rules! generate_outbound_tls_accept_not_cert_identity_test {
         let proxy_identity = identity::Identity::new("foo-ns1", proxy_id.to_string());
 
         let (_tx, rx) = oneshot::channel();
-        let id_svc = controller::identity()
-            .certify_async(move |_| rx)
-            .run()
-            .await;
+        let id_svc = controller::identity().certify_async(move |_| rx).run();
 
         let app_identity = identity::Identity::new("bar-ns1", app_id.to_string());
         let srv = $make_server(app_identity.server_config)
@@ -176,8 +166,7 @@ macro_rules! generate_outbound_tls_accept_not_cert_identity_test {
         let proxy = proxy::new()
             .outbound(srv)
             .identity(id_svc)
-            .run_with_test_env(proxy_identity.env)
-            .await;
+            .run_with_test_env(proxy_identity.env);
 
         let client = $make_client(
             proxy.outbound,
@@ -225,12 +214,9 @@ async fn ready() {
     certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
 
     let (tx, rx) = oneshot::channel();
-    let id_svc = controller::identity()
-        .certify_async(move |_| rx)
-        .run()
-        .await;
+    let id_svc = controller::identity().certify_async(move |_| rx).run();
 
-    let proxy = proxy::new().identity(id_svc).run_with_test_env(env).await;
+    let proxy = proxy::new().identity(id_svc).run_with_test_env(env);
 
     let client = client::http1(proxy.metrics, "localhost");
 
@@ -283,12 +269,11 @@ async fn refresh() {
             refreshed2.store(true, Ordering::SeqCst);
             rsp
         })
-        .run()
-        .await;
+        .run();
 
     // Disable the minimum bound on when to refresh identity for this test.
     env.put(app::env::ENV_IDENTITY_MIN_REFRESH, "0ms".into());
-    let _proxy = proxy::new().identity(id_svc).run_with_test_env(env).await;
+    let _proxy = proxy::new().identity(id_svc).run_with_test_env(env);
 
     let expiry = expiry_rx.await.expect("wait for expiry");
     let how_long = expiry.duration_since(SystemTime::now()).unwrap();
@@ -326,9 +311,8 @@ mod require_id_header {
                 // Make a proxy that has `proxy_identity` identity
                 let proxy = proxy::new()
                     .outbound(srv)
-                    .identity(proxy_identity.service().run().await)
-                    .run_with_test_env(proxy_identity.env)
-                    .await;
+                    .identity(proxy_identity.service().run())
+                    .run_with_test_env(proxy_identity.env);
 
                 // Make a non-TLS client
                 let client = $make_client(proxy.outbound, app_name);
@@ -394,10 +378,9 @@ mod require_id_header {
                 // Make a proxy that has `proxy_identity` identity and no
                 // SO_ORIGINAL_DST backup
                 let proxy = proxy::new()
-                    .controller(ctrl.run().await)
-                    .identity(proxy_identity.service().run().await)
-                    .run_with_test_env(proxy_identity.env)
-                    .await;
+                    .controller(ctrl.run())
+                    .identity(proxy_identity.service().run())
+                    .run_with_test_env(proxy_identity.env);
 
                 // Make a non-TLS client
                 let client = $make_client(proxy.outbound, "disco.test.svc.cluster.local");
@@ -459,9 +442,8 @@ mod require_id_header {
                 // Make a proxy that has `proxy_identity` identity
                 let proxy = proxy::new()
                     .outbound(srv)
-                    .identity(proxy_identity.service().run().await)
-                    .run_with_test_env(proxy_identity.env)
-                    .await;
+                    .identity(proxy_identity.service().run())
+                    .run_with_test_env(proxy_identity.env);
 
                 // Make a non-TLS client
                 let client = $make_client(proxy.outbound, "localhost");

--- a/linkerd/app/integration/tests/identity.rs
+++ b/linkerd/app/integration/tests/identity.rs
@@ -1,4 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
+#![type_length_limit = "16289823"]
+#![recursion_limit = "256"]
 
 use linkerd2_app_integration::*;
 use std::{

--- a/linkerd/app/integration/tests/profile_dst_overrides.rs
+++ b/linkerd/app/integration/tests/profile_dst_overrides.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "2427419"]
+#![type_length_limit = "16289823"]
+#![recursion_limit = "256"]
 
 use linkerd2_app_integration::*;
 use linkerd2_proxy_api::destination as pb;

--- a/linkerd/app/integration/tests/profile_dst_overrides.rs
+++ b/linkerd/app/integration/tests/profile_dst_overrides.rs
@@ -1,5 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "1586225"]
+#![type_length_limit = "2427419"]
 
 use linkerd2_app_integration::*;
 use linkerd2_proxy_api::destination as pb;

--- a/linkerd/app/integration/tests/profile_dst_overrides.rs
+++ b/linkerd/app/integration/tests/profile_dst_overrides.rs
@@ -79,7 +79,7 @@ async fn add_a_dst_override() {
     ctrl.destination_tx(&leaf_svc.authority())
         .send_addr(leaf_svc.svc.addr);
 
-    let proxy = proxy::new().controller(ctrl.run().await).run().await;
+    let proxy = proxy::new().controller(ctrl.run()).run();
     let client = client::http1(proxy.outbound, apex_svc.authority());
     let metrics = client::http1(proxy.metrics, "localhost");
 
@@ -130,7 +130,7 @@ async fn add_multiple_dst_overrides() {
     let profile_tx = ctrl.profile_tx(&apex_svc.authority());
     profile_tx.send(pb::DestinationProfile::default());
 
-    let proxy = proxy::new().controller(ctrl.run().await).run().await;
+    let proxy = proxy::new().controller(ctrl.run()).run();
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
     let metrics = client::http1(proxy.metrics, "localhost");
@@ -191,7 +191,7 @@ async fn set_a_dst_override_weight_to_zero() {
         ],
     ));
 
-    let proxy = proxy::new().controller(ctrl.run().await).run().await;
+    let proxy = proxy::new().controller(ctrl.run()).run();
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
     let metrics = client::http1(proxy.metrics, "localhost");
@@ -257,7 +257,7 @@ async fn set_all_dst_override_weights_to_zero() {
         ],
     ));
 
-    let proxy = proxy::new().controller(ctrl.run().await).run().await;
+    let proxy = proxy::new().controller(ctrl.run()).run();
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
     let metrics = client::http1(proxy.metrics, "localhost");
@@ -315,7 +315,7 @@ async fn remove_a_dst_override() {
         vec![controller::dst_override(leaf_svc.authority(), 10000)],
     ));
 
-    let proxy = proxy::new().controller(ctrl.run().await).run().await;
+    let proxy = proxy::new().controller(ctrl.run()).run();
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
     let metrics = client::http1(proxy.metrics, "localhost");

--- a/linkerd/app/integration/tests/profile_dst_overrides.rs
+++ b/linkerd/app/integration/tests/profile_dst_overrides.rs
@@ -79,7 +79,7 @@ async fn add_a_dst_override() {
     ctrl.destination_tx(&leaf_svc.authority())
         .send_addr(leaf_svc.svc.addr);
 
-    let proxy = proxy::new().controller(ctrl.run()).run();
+    let proxy = proxy::new().controller(ctrl.run().await).run().await;
     let client = client::http1(proxy.outbound, apex_svc.authority());
     let metrics = client::http1(proxy.metrics, "localhost");
 
@@ -130,7 +130,7 @@ async fn add_multiple_dst_overrides() {
     let profile_tx = ctrl.profile_tx(&apex_svc.authority());
     profile_tx.send(pb::DestinationProfile::default());
 
-    let proxy = proxy::new().controller(ctrl.run()).run();
+    let proxy = proxy::new().controller(ctrl.run().await).run().await;
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
     let metrics = client::http1(proxy.metrics, "localhost");
@@ -191,7 +191,7 @@ async fn set_a_dst_override_weight_to_zero() {
         ],
     ));
 
-    let proxy = proxy::new().controller(ctrl.run()).run();
+    let proxy = proxy::new().controller(ctrl.run().await).run().await;
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
     let metrics = client::http1(proxy.metrics, "localhost");
@@ -257,7 +257,7 @@ async fn set_all_dst_override_weights_to_zero() {
         ],
     ));
 
-    let proxy = proxy::new().controller(ctrl.run()).run();
+    let proxy = proxy::new().controller(ctrl.run().await).run().await;
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
     let metrics = client::http1(proxy.metrics, "localhost");
@@ -315,7 +315,7 @@ async fn remove_a_dst_override() {
         vec![controller::dst_override(leaf_svc.authority(), 10000)],
     ));
 
-    let proxy = proxy::new().controller(ctrl.run()).run();
+    let proxy = proxy::new().controller(ctrl.run().await).run().await;
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
     let metrics = client::http1(proxy.metrics, "localhost");

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -105,11 +105,12 @@ macro_rules! profile_test {
         ];
         profile_tx.send(controller::profile(routes, $budget, vec![]));
 
-        let ctrl = ctrl.run();
+        let ctrl = ctrl.run().await;
         let proxy = proxy::new()
             .controller(ctrl)
             .outbound(srv)
-            .run();
+            .run()
+            .await;
 
         let client = client::$http(proxy.outbound, host);
 

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -105,12 +105,11 @@ macro_rules! profile_test {
         ];
         profile_tx.send(controller::profile(routes, $budget, vec![]));
 
-        let ctrl = ctrl.run().await;
+        let ctrl = ctrl.run();
         let proxy = proxy::new()
             .controller(ctrl)
             .outbound(srv)
-            .run()
-            .await;
+            .run();
 
         let client = client::$http(proxy.outbound, host);
 

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -1,5 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "1586225"]
+#![type_length_limit = "2427419"]
 
 use linkerd2_app_integration::*;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/linkerd/app/integration/tests/profiles.rs
+++ b/linkerd/app/integration/tests/profiles.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "2427419"]
+#![type_length_limit = "16289823"]
+#![recursion_limit = "256"]
 
 use linkerd2_app_integration::*;
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/linkerd/app/integration/tests/shutdown.rs
+++ b/linkerd/app/integration/tests/shutdown.rs
@@ -1,5 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "1586225"]
+#![type_length_limit = "2427419"]
 
 use linkerd2_app_integration::*;
 

--- a/linkerd/app/integration/tests/shutdown.rs
+++ b/linkerd/app/integration/tests/shutdown.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "2427419"]
+#![type_length_limit = "16289823"]
+#![recursion_limit = "256"]
 
 use linkerd2_app_integration::*;
 

--- a/linkerd/app/integration/tests/shutdown.rs
+++ b/linkerd/app/integration/tests/shutdown.rs
@@ -10,7 +10,7 @@ async fn h2_goaways_connections() {
     let (shdn, rx) = shutdown_signal();
 
     let srv = server::http2().route("/", "hello").run().await;
-    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run().await;
+    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run();
     let client = client::http2(proxy.inbound, "shutdown.test.svc.cluster.local");
 
     assert_eq!(client.get("/").await, "hello");
@@ -36,7 +36,7 @@ async fn h2_exercise_goaways_connections() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run().await;
+    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run();
     let client = client::http2(proxy.inbound, "shutdown.test.svc.cluster.local");
 
     let reqs = (0..NUM_REQUESTS)
@@ -89,7 +89,7 @@ async fn http1_closes_idle_connections() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run().await;
+    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run();
     let client = client::http1(proxy.inbound, "shutdown.test.svc.cluster.local");
 
     let res_body = client.get("/").await;
@@ -123,7 +123,7 @@ async fn tcp_waits_for_proxies_to_close() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run().await;
+    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run();
 
     let client = client::tcp(proxy.inbound);
 

--- a/linkerd/app/integration/tests/shutdown.rs
+++ b/linkerd/app/integration/tests/shutdown.rs
@@ -10,7 +10,7 @@ async fn h2_goaways_connections() {
     let (shdn, rx) = shutdown_signal();
 
     let srv = server::http2().route("/", "hello").run().await;
-    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run();
+    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run().await;
     let client = client::http2(proxy.inbound, "shutdown.test.svc.cluster.local");
 
     assert_eq!(client.get("/").await, "hello");
@@ -36,7 +36,7 @@ async fn h2_exercise_goaways_connections() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run();
+    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run().await;
     let client = client::http2(proxy.inbound, "shutdown.test.svc.cluster.local");
 
     let reqs = (0..NUM_REQUESTS)
@@ -89,7 +89,7 @@ async fn http1_closes_idle_connections() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run();
+    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run().await;
     let client = client::http1(proxy.inbound, "shutdown.test.svc.cluster.local");
 
     let res_body = client.get("/").await;
@@ -123,7 +123,7 @@ async fn tcp_waits_for_proxies_to_close() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run();
+    let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run().await;
 
     let client = client::tcp(proxy.inbound);
 

--- a/linkerd/app/integration/tests/tap.rs
+++ b/linkerd/app/integration/tests/tap.rs
@@ -1,5 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "1586225"]
+#![type_length_limit = "2427419"]
 
 use linkerd2_app_integration::tap::TapEventExt;
 use linkerd2_app_integration::*;

--- a/linkerd/app/integration/tests/tap.rs
+++ b/linkerd/app/integration/tests/tap.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "2427419"]
+#![type_length_limit = "16289823"]
+#![recursion_limit = "256"]
 
 use linkerd2_app_integration::tap::TapEventExt;
 use linkerd2_app_integration::*;

--- a/linkerd/app/integration/tests/tap.rs
+++ b/linkerd/app/integration/tests/tap.rs
@@ -13,8 +13,9 @@ async fn tap_enabled_when_identity_enabled() {
     let identity_env = identity::Identity::new("foo-ns1", identity.to_string());
 
     let proxy = proxy::new()
-        .identity(identity_env.service().run())
-        .run_with_test_env(identity_env.env);
+        .identity(identity_env.service().run().await)
+        .run_with_test_env(identity_env.env)
+        .await;
 
     assert!(proxy.tap.is_some())
 }
@@ -22,7 +23,7 @@ async fn tap_enabled_when_identity_enabled() {
 #[tokio::test]
 async fn tap_disabled_when_identity_disabled() {
     let _trace = trace_init();
-    let proxy = proxy::new().disable_identity().run();
+    let proxy = proxy::new().disable_identity().run().await;
 
     assert!(proxy.tap.is_none())
 }
@@ -33,7 +34,7 @@ async fn can_disable_tap() {
     let mut env = TestEnv::new();
     env.put(app::env::ENV_TAP_DISABLED, "true".to_owned());
 
-    let proxy = proxy::new().run_with_test_env(env);
+    let proxy = proxy::new().run_with_test_env(env).await;
 
     assert!(proxy.tap.is_none())
 }
@@ -53,13 +54,15 @@ async fn rejects_incorrect_identity_when_identity_is_expected() {
 
     let in_proxy = proxy::new()
         .inbound(srv)
-        .identity(identity_env.service().run())
-        .run_with_test_env(expected_identity_env);
+        .identity(identity_env.service().run().await)
+        .run_with_test_env(expected_identity_env)
+        .await;
 
     let tap_proxy = proxy::new()
         .outbound_ip(in_proxy.tap.unwrap())
-        .identity(identity_env.service().run())
-        .run_with_test_env(identity_env.env.clone());
+        .identity(identity_env.service().run().await)
+        .run_with_test_env(identity_env.env.clone())
+        .await;
 
     let mut tap = tap::client(tap_proxy.outbound);
     let mut events = tap.observe(tap::observe_request()).await.take(1);
@@ -92,7 +95,10 @@ async fn inbound_http1() {
 
     // Certify server proxy identity
     certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
-    let srv_proxy_identity_svc = controller::identity().certify(move |_| certify_rsp).run();
+    let srv_proxy_identity_svc = controller::identity()
+        .certify(move |_| certify_rsp)
+        .run()
+        .await;
 
     // Add expected tap service identity
     env.put(
@@ -106,13 +112,15 @@ async fn inbound_http1() {
     let srv_proxy = proxy::new()
         .inbound(srv)
         .identity(srv_proxy_identity_svc)
-        .run_with_test_env(env);
+        .run_with_test_env(env)
+        .await;
 
     // Run client proxy with client proxy identity service.
     let client_proxy = proxy::new()
         .outbound_ip(srv_proxy.tap.unwrap())
-        .identity(client_proxy_identity.service().run())
-        .run_with_test_env(client_proxy_identity.env);
+        .identity(client_proxy_identity.service().run().await)
+        .run_with_test_env(client_proxy_identity.env)
+        .await;
 
     // Wait for the server proxy to become ready
     let client = client::http1(srv_proxy.metrics, "localhost");
@@ -168,7 +176,10 @@ async fn grpc_headers_end() {
 
     // Certify server proxy identity
     certify_rsp.valid_until = Some((SystemTime::now() + Duration::from_secs(666)).into());
-    let srv_proxy_identity_svc = controller::identity().certify(move |_| certify_rsp).run();
+    let srv_proxy_identity_svc = controller::identity()
+        .certify(move |_| certify_rsp)
+        .run()
+        .await;
 
     // Add expected tap service identity
     env.put(
@@ -190,13 +201,15 @@ async fn grpc_headers_end() {
     let srv_proxy = proxy::new()
         .inbound(srv)
         .identity(srv_proxy_identity_svc)
-        .run_with_test_env(env);
+        .run_with_test_env(env)
+        .await;
 
     // Run client proxy with client proxy identity service.
     let client_proxy = proxy::new()
         .outbound_ip(srv_proxy.tap.unwrap())
-        .identity(client_proxy_identity.service().run())
-        .run_with_test_env(client_proxy_identity.env);
+        .identity(client_proxy_identity.service().run().await)
+        .run_with_test_env(client_proxy_identity.env)
+        .await;
 
     // Wait for the server proxy to become ready
     let client = client::http2(srv_proxy.metrics, "localhost");

--- a/linkerd/app/integration/tests/telemetry.rs
+++ b/linkerd/app/integration/tests/telemetry.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "2427419"]
+#![type_length_limit = "16289823"]
+#![recursion_limit = "256"]
 // The compiler cannot figure out that the `use linkerd2_app_integration::*`
 // import is actually used, and putting the allow attribute on that import in
 // particular appears to do nothing... T_T

--- a/linkerd/app/integration/tests/telemetry.rs
+++ b/linkerd/app/integration/tests/telemetry.rs
@@ -22,18 +22,22 @@ struct TcpFixture {
 impl Fixture {
     async fn inbound() -> Self {
         info!("running test server");
-        Fixture::inbound_with_server(server::new().route("/", "hello").run().await)
+        Fixture::inbound_with_server(server::new().route("/", "hello").run().await).await
     }
 
     async fn outbound() -> Self {
         info!("running test server");
-        Fixture::outbound_with_server(server::new().route("/", "hello").run().await)
+        Fixture::outbound_with_server(server::new().route("/", "hello").run().await).await
     }
 
-    fn inbound_with_server(srv: server::Listening) -> Self {
+    async fn inbound_with_server(srv: server::Listening) -> Self {
         let ctrl = controller::new();
         ctrl.profile_tx_default("tele.test.svc.cluster.local");
-        let proxy = proxy::new().controller(ctrl.run()).inbound(srv).run();
+        let proxy = proxy::new()
+            .controller(ctrl.run().await)
+            .inbound(srv)
+            .run()
+            .await;
         let metrics = client::http1(proxy.metrics, "localhost");
 
         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
@@ -44,12 +48,16 @@ impl Fixture {
         }
     }
 
-    fn outbound_with_server(srv: server::Listening) -> Self {
+    async fn outbound_with_server(srv: server::Listening) -> Self {
         let ctrl = controller::new();
         ctrl.profile_tx_default("tele.test.svc.cluster.local");
         ctrl.destination_tx("tele.test.svc.cluster.local")
             .send_addr(srv.addr);
-        let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
+        let proxy = proxy::new()
+            .controller(ctrl.run().await)
+            .outbound(srv)
+            .run()
+            .await;
         let metrics = client::http1(proxy.metrics, "localhost");
 
         let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
@@ -82,9 +90,10 @@ impl TcpFixture {
     async fn inbound() -> Self {
         let ctrl = controller::new();
         let proxy = proxy::new()
-            .controller(ctrl.run())
+            .controller(ctrl.run().await)
             .inbound(TcpFixture::server().await)
-            .run();
+            .run()
+            .await;
 
         let client = client::tcp(proxy.inbound);
         let metrics = client::http1(proxy.metrics, "localhost");
@@ -98,9 +107,10 @@ impl TcpFixture {
     async fn outbound() -> Self {
         let ctrl = controller::new();
         let proxy = proxy::new()
-            .controller(ctrl.run())
+            .controller(ctrl.run().await)
             .outbound(TcpFixture::server().await)
-            .run();
+            .run()
+            .await;
 
         let client = client::tcp(proxy.outbound);
         let metrics = client::http1(proxy.metrics, "localhost");
@@ -225,7 +235,7 @@ mod response_classification {
             client,
             metrics,
             proxy: _proxy,
-        } = Fixture::inbound_with_server(make_test_server().await);
+        } = Fixture::inbound_with_server(make_test_server().await).await;
 
         for (i, status) in STATUSES.iter().enumerate() {
             let request = client
@@ -257,7 +267,7 @@ mod response_classification {
             client,
             metrics,
             proxy: _proxy,
-        } = Fixture::outbound_with_server(make_test_server().await);
+        } = Fixture::outbound_with_server(make_test_server().await).await;
 
         for (i, status) in STATUSES.iter().enumerate() {
             let request = client
@@ -308,7 +318,7 @@ async fn metrics_endpoint_inbound_response_latency() {
         client,
         metrics,
         proxy: _proxy,
-    } = Fixture::inbound_with_server(srv);
+    } = Fixture::inbound_with_server(srv).await;
 
     info!("client.get(/hey)");
     assert_eq!(client.get("/hey").await, "hello");
@@ -388,7 +398,7 @@ async fn metrics_endpoint_outbound_response_latency() {
         client,
         metrics,
         proxy: _proxy,
-    } = Fixture::outbound_with_server(srv);
+    } = Fixture::outbound_with_server(srv).await;
 
     info!("client.get(/hey)");
     assert_eq!(client.get("/hey").await, "hello");
@@ -463,7 +473,11 @@ mod outbound_dst_labels {
         let ctrl = controller::new();
         let dst_tx = ctrl.destination_tx(dest);
 
-        let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
+        let proxy = proxy::new()
+            .controller(ctrl.run().await)
+            .outbound(srv)
+            .run()
+            .await;
         let metrics = client::http1(proxy.metrics, "localhost");
 
         let client = client::new(proxy.outbound, dest);
@@ -710,10 +724,11 @@ async fn metrics_have_no_double_commas() {
     ctrl.destination_tx("tele.test.svc.cluster.local")
         .send_addr(outbound_srv.addr);
     let proxy = proxy::new()
-        .controller(ctrl.run())
+        .controller(ctrl.run().await)
         .inbound(inbound_srv)
         .outbound(outbound_srv)
-        .run();
+        .run()
+        .await;
     let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
     let metrics = client::http1(proxy.metrics, "localhost");
 
@@ -907,7 +922,7 @@ mod transport {
             })
             .run()
             .await;
-        let proxy = proxy::new().inbound(srv).run();
+        let proxy = proxy::new().inbound(srv).run().await;
 
         let client = client::tcp(proxy.inbound);
         let metrics = client::http1(proxy.metrics, "localhost");
@@ -936,8 +951,9 @@ mod transport {
                 drop(sock);
                 future::ok(())
             })
-            .run();
-        let proxy = proxy::new().outbound(srv).run();
+            .run()
+            .await;
+        let proxy = proxy::new().outbound(srv).run().await;
 
         let client = client::tcp(proxy.outbound);
         let metrics = client::http1(proxy.metrics, "localhost");

--- a/linkerd/app/integration/tests/telemetry.rs
+++ b/linkerd/app/integration/tests/telemetry.rs
@@ -1,5 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "1586225"]
+#![type_length_limit = "2427419"]
 // The compiler cannot figure out that the `use linkerd2_app_integration::*`
 // import is actually used, and putting the allow attribute on that import in
 // particular appears to do nothing... T_T

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "2427419"]
+#![type_length_limit = "16289823"]
+#![recursion_limit = "256"]
 
 use linkerd2_app_integration::*;
 use std::error::Error as _;

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -1,5 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "1586225"]
+#![type_length_limit = "2427419"]
 
 use linkerd2_app_integration::*;
 use std::error::Error as _;

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -15,7 +15,11 @@ async fn outbound_http1() {
     ctrl.profile_tx_default("transparency.test.svc.cluster.local");
     ctrl.destination_tx("transparency.test.svc.cluster.local")
         .send_addr(srv.addr);
-    let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
+    let proxy = proxy::new()
+        .controller(ctrl.run().await)
+        .outbound(srv)
+        .run()
+        .await;
     let client = client::http1(proxy.outbound, "transparency.test.svc.cluster.local");
 
     assert_eq!(client.get("/").await, "hello h1");
@@ -31,9 +35,10 @@ async fn inbound_http1() {
     let ctrl = controller::new();
     ctrl.profile_tx_default("transparency.test.svc.cluster.local");
     let proxy = proxy::new()
-        .controller(ctrl.run())
+        .controller(ctrl.run().await)
         .inbound_fuzz_addr(srv)
-        .run();
+        .run()
+        .await;
     let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
     assert_eq!(client.get("/").await, "hello h1");
@@ -55,7 +60,7 @@ async fn outbound_tcp() {
         })
         .run()
         .await;
-    let proxy = proxy::new().outbound(srv).run();
+    let proxy = proxy::new().outbound(srv).run().await;
 
     let client = client::tcp(proxy.outbound);
 
@@ -81,7 +86,7 @@ async fn inbound_tcp() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound_fuzz_addr(srv).run();
+    let proxy = proxy::new().inbound_fuzz_addr(srv).run().await;
 
     let client = client::tcp(proxy.inbound);
 
@@ -165,7 +170,8 @@ async fn test_server_speaks_first(env: TestEnv) {
     let proxy = proxy::new()
         .disable_inbound_ports_protocol_detection(vec![srv.addr.port()])
         .inbound(srv)
-        .run_with_test_env(env);
+        .run_with_test_env(env)
+        .await;
 
     let client = client::tcp(proxy.inbound);
 
@@ -257,7 +263,7 @@ async fn tcp_connections_close_if_client_closes() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).run();
+    let proxy = proxy::new().inbound(srv).run().await;
 
     let client = client::tcp(proxy.inbound);
 
@@ -283,7 +289,7 @@ macro_rules! http1_tests {
             let _trace = trace_init();
 
             let srv = server::http1().route("/", "hello h1").run().await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             assert_eq!(client.get("/").await, "hello h1");
@@ -309,7 +315,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let res = client
@@ -353,7 +359,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
             let client = client::http1(proxy.inbound, host);
 
             let res = client
@@ -388,7 +394,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
             let client = client::http1_absolute_uris(proxy.inbound, auth);
 
             let res = client
@@ -461,7 +467,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
 
             let client = client::tcp(proxy.inbound);
 
@@ -499,7 +505,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
 
             let host = "transparency.test.svc.cluster.local";
             let client = client::http1(proxy.inbound, host);
@@ -535,7 +541,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
 
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
@@ -611,7 +617,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
 
             let client = client::tcp(proxy.inbound);
 
@@ -647,7 +653,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
 
             // A TCP client is used since the HTTP client would stop these requests
             // from ever touching the network.
@@ -716,7 +722,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let req = client
@@ -756,7 +762,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let req = client
@@ -801,7 +807,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let methods = &["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"];
@@ -838,7 +844,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let methods = &["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"];
@@ -882,7 +888,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             // https://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -945,7 +951,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let resp = client
@@ -991,7 +997,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv);
+            let proxy = $proxy(srv).await;
 
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
@@ -1045,10 +1051,10 @@ macro_rules! http1_tests {
 mod one_proxy {
     use linkerd2_app_integration::*;
 
-    http1_tests! { proxy: |srv| {
+    http1_tests! { proxy: |srv| async move {
         let ctrl = controller::new();
         ctrl.profile_tx_default("transparency.test.svc.cluster.local");
-        proxy::new().inbound(srv).controller(ctrl.run()).run()
+        proxy::new().inbound(srv).controller(ctrl.run().await).run().await
     }}
 }
 
@@ -1073,10 +1079,10 @@ mod proxy_to_proxy {
         }
     }
 
-    http1_tests! { proxy: |srv| {
+    http1_tests! { proxy: |srv| async move {
         let ctrl = controller::new();
         ctrl.profile_tx_default("transparency.test.svc.cluster.local");
-        let inbound = proxy::new().controller(ctrl.run()).inbound(srv).run();
+        let inbound = proxy::new().controller(ctrl.run().await).inbound(srv).run().await;
 
         let ctrl = controller::new();
         ctrl.profile_tx_default("transparency.test.svc.cluster.local");
@@ -1084,8 +1090,8 @@ mod proxy_to_proxy {
         dst.send_h2_hinted(inbound.inbound);
 
         let outbound = proxy::new()
-            .controller(ctrl.run())
-            .run();
+            .controller(ctrl.run().await)
+            .run().await;
 
         let addr = outbound.outbound;
         ProxyToProxy {
@@ -1115,7 +1121,7 @@ async fn http10_without_host() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).run();
+    let proxy = proxy::new().inbound(srv).run().await;
 
     let client = client::tcp(proxy.inbound);
 
@@ -1145,7 +1151,7 @@ async fn http1_one_connection_per_host() {
         .route("/no-body", "")
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).run();
+    let proxy = proxy::new().inbound(srv).run().await;
 
     let client = client::http1(proxy.inbound, "foo.bar");
 
@@ -1196,7 +1202,7 @@ async fn http1_requests_without_host_have_unique_connections() {
     let _trace = trace_init();
 
     let srv = server::http1().route("/", "unique hosts").run().await;
-    let proxy = proxy::new().inbound(srv).run();
+    let proxy = proxy::new().inbound(srv).run().await;
 
     let client = client::http1(proxy.inbound, "foo.bar");
 
@@ -1275,7 +1281,7 @@ async fn retry_reconnect_errors() {
         .route("/", "hello retry")
         .delay_listen(rx.map(|_| ()))
         .await;
-    let proxy = proxy::new().inbound(srv).run();
+    let proxy = proxy::new().inbound(srv).run().await;
     let client = client::http2(proxy.inbound, "transparency.test.svc.cluster.local");
     let metrics = client::http1(proxy.metrics, "localhost");
 
@@ -1307,7 +1313,7 @@ async fn http2_request_without_authority() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound_fuzz_addr(srv).run();
+    let proxy = proxy::new().inbound_fuzz_addr(srv).run().await;
 
     // Make a single HTTP/2 request without an :authority header.
     //
@@ -1347,7 +1353,7 @@ async fn http2_rst_stream_is_propagated() {
         .route_async("/", move |_req| async move { Err(h2::Error::from(reason)) })
         .run()
         .await;
-    let proxy = proxy::new().inbound_fuzz_addr(srv).run();
+    let proxy = proxy::new().inbound_fuzz_addr(srv).run().await;
     let client = client::http2(proxy.inbound, "transparency.test.svc.cluster.local");
 
     let err: hyper::Error = client
@@ -1381,7 +1387,7 @@ async fn http1_orig_proto_does_not_propagate_rst_stream() {
     let host = "transparency.test.svc.cluster.local";
     let dst = ctrl.destination_tx(host);
     dst.send_h2_hinted(srv.addr);
-    let proxy = proxy::new().controller(ctrl.run()).run();
+    let proxy = proxy::new().controller(ctrl.run().await).run().await;
     let addr = proxy.outbound;
 
     let client = client::http1(addr, host);

--- a/linkerd/app/integration/tests/transparency.rs
+++ b/linkerd/app/integration/tests/transparency.rs
@@ -15,11 +15,7 @@ async fn outbound_http1() {
     ctrl.profile_tx_default("transparency.test.svc.cluster.local");
     ctrl.destination_tx("transparency.test.svc.cluster.local")
         .send_addr(srv.addr);
-    let proxy = proxy::new()
-        .controller(ctrl.run().await)
-        .outbound(srv)
-        .run()
-        .await;
+    let proxy = proxy::new().controller(ctrl.run()).outbound(srv).run();
     let client = client::http1(proxy.outbound, "transparency.test.svc.cluster.local");
 
     assert_eq!(client.get("/").await, "hello h1");
@@ -35,10 +31,9 @@ async fn inbound_http1() {
     let ctrl = controller::new();
     ctrl.profile_tx_default("transparency.test.svc.cluster.local");
     let proxy = proxy::new()
-        .controller(ctrl.run().await)
+        .controller(ctrl.run())
         .inbound_fuzz_addr(srv)
-        .run()
-        .await;
+        .run();
     let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
     assert_eq!(client.get("/").await, "hello h1");
@@ -60,7 +55,7 @@ async fn outbound_tcp() {
         })
         .run()
         .await;
-    let proxy = proxy::new().outbound(srv).run().await;
+    let proxy = proxy::new().outbound(srv).run();
 
     let client = client::tcp(proxy.outbound);
 
@@ -86,7 +81,7 @@ async fn inbound_tcp() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound_fuzz_addr(srv).run().await;
+    let proxy = proxy::new().inbound_fuzz_addr(srv).run();
 
     let client = client::tcp(proxy.inbound);
 
@@ -170,8 +165,7 @@ async fn test_server_speaks_first(env: TestEnv) {
     let proxy = proxy::new()
         .disable_inbound_ports_protocol_detection(vec![srv.addr.port()])
         .inbound(srv)
-        .run_with_test_env(env)
-        .await;
+        .run_with_test_env(env);
 
     let client = client::tcp(proxy.inbound);
 
@@ -263,7 +257,7 @@ async fn tcp_connections_close_if_client_closes() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).run().await;
+    let proxy = proxy::new().inbound(srv).run();
 
     let client = client::tcp(proxy.inbound);
 
@@ -289,7 +283,7 @@ macro_rules! http1_tests {
             let _trace = trace_init();
 
             let srv = server::http1().route("/", "hello h1").run().await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             assert_eq!(client.get("/").await, "hello h1");
@@ -315,7 +309,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let res = client
@@ -359,7 +353,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
             let client = client::http1(proxy.inbound, host);
 
             let res = client
@@ -394,7 +388,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
             let client = client::http1_absolute_uris(proxy.inbound, auth);
 
             let res = client
@@ -467,7 +461,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
 
             let client = client::tcp(proxy.inbound);
 
@@ -505,7 +499,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
 
             let host = "transparency.test.svc.cluster.local";
             let client = client::http1(proxy.inbound, host);
@@ -541,7 +535,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
 
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
@@ -617,7 +611,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
 
             let client = client::tcp(proxy.inbound);
 
@@ -653,7 +647,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
 
             // A TCP client is used since the HTTP client would stop these requests
             // from ever touching the network.
@@ -722,7 +716,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let req = client
@@ -762,7 +756,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let req = client
@@ -807,7 +801,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let methods = &["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"];
@@ -844,7 +838,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let methods = &["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"];
@@ -888,7 +882,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             // https://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -951,7 +945,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let resp = client
@@ -997,7 +991,7 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = $proxy(srv).await;
+            let proxy = $proxy(srv);
 
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
@@ -1051,10 +1045,10 @@ macro_rules! http1_tests {
 mod one_proxy {
     use linkerd2_app_integration::*;
 
-    http1_tests! { proxy: |srv| async move {
+    http1_tests! { proxy: |srv| {
         let ctrl = controller::new();
         ctrl.profile_tx_default("transparency.test.svc.cluster.local");
-        proxy::new().inbound(srv).controller(ctrl.run().await).run().await
+        proxy::new().inbound(srv).controller(ctrl.run()).run()
     }}
 }
 
@@ -1079,10 +1073,10 @@ mod proxy_to_proxy {
         }
     }
 
-    http1_tests! { proxy: |srv| async move {
+    http1_tests! { proxy: |srv| {
         let ctrl = controller::new();
         ctrl.profile_tx_default("transparency.test.svc.cluster.local");
-        let inbound = proxy::new().controller(ctrl.run().await).inbound(srv).run().await;
+        let inbound = proxy::new().controller(ctrl.run()).inbound(srv).run();
 
         let ctrl = controller::new();
         ctrl.profile_tx_default("transparency.test.svc.cluster.local");
@@ -1090,8 +1084,8 @@ mod proxy_to_proxy {
         dst.send_h2_hinted(inbound.inbound);
 
         let outbound = proxy::new()
-            .controller(ctrl.run().await)
-            .run().await;
+            .controller(ctrl.run())
+            .run();
 
         let addr = outbound.outbound;
         ProxyToProxy {
@@ -1121,7 +1115,7 @@ async fn http10_without_host() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).run().await;
+    let proxy = proxy::new().inbound(srv).run();
 
     let client = client::tcp(proxy.inbound);
 
@@ -1151,7 +1145,7 @@ async fn http1_one_connection_per_host() {
         .route("/no-body", "")
         .run()
         .await;
-    let proxy = proxy::new().inbound(srv).run().await;
+    let proxy = proxy::new().inbound(srv).run();
 
     let client = client::http1(proxy.inbound, "foo.bar");
 
@@ -1202,7 +1196,7 @@ async fn http1_requests_without_host_have_unique_connections() {
     let _trace = trace_init();
 
     let srv = server::http1().route("/", "unique hosts").run().await;
-    let proxy = proxy::new().inbound(srv).run().await;
+    let proxy = proxy::new().inbound(srv).run();
 
     let client = client::http1(proxy.inbound, "foo.bar");
 
@@ -1281,7 +1275,7 @@ async fn retry_reconnect_errors() {
         .route("/", "hello retry")
         .delay_listen(rx.map(|_| ()))
         .await;
-    let proxy = proxy::new().inbound(srv).run().await;
+    let proxy = proxy::new().inbound(srv).run();
     let client = client::http2(proxy.inbound, "transparency.test.svc.cluster.local");
     let metrics = client::http1(proxy.metrics, "localhost");
 
@@ -1313,7 +1307,7 @@ async fn http2_request_without_authority() {
         })
         .run()
         .await;
-    let proxy = proxy::new().inbound_fuzz_addr(srv).run().await;
+    let proxy = proxy::new().inbound_fuzz_addr(srv).run();
 
     // Make a single HTTP/2 request without an :authority header.
     //
@@ -1353,7 +1347,7 @@ async fn http2_rst_stream_is_propagated() {
         .route_async("/", move |_req| async move { Err(h2::Error::from(reason)) })
         .run()
         .await;
-    let proxy = proxy::new().inbound_fuzz_addr(srv).run().await;
+    let proxy = proxy::new().inbound_fuzz_addr(srv).run();
     let client = client::http2(proxy.inbound, "transparency.test.svc.cluster.local");
 
     let err: hyper::Error = client
@@ -1387,7 +1381,7 @@ async fn http1_orig_proto_does_not_propagate_rst_stream() {
     let host = "transparency.test.svc.cluster.local";
     let dst = ctrl.destination_tx(host);
     dst.send_h2_hinted(srv.addr);
-    let proxy = proxy::new().controller(ctrl.run().await).run().await;
+    let proxy = proxy::new().controller(ctrl.run()).run();
     let addr = proxy.outbound;
 
     let client = client::http1(addr, host);

--- a/linkerd/app/profiling/Cargo.toml
+++ b/linkerd/app/profiling/Cargo.toml
@@ -13,4 +13,3 @@ for profiling and benchmarking.
 
 [dependencies]
 linkerd2-app-integration = { path = "../integration" }
-tokio = { version = "0.2", features = ["rt-core", "net", "macros"]}

--- a/linkerd/app/profiling/Cargo.toml
+++ b/linkerd/app/profiling/Cargo.toml
@@ -13,3 +13,4 @@ for profiling and benchmarking.
 
 [dependencies]
 linkerd2-app-integration = { path = "../integration" }
+tokio = { version = "0.2", features = ["rt-core", "net", "macros"]}

--- a/linkerd/app/profiling/src/bin/profile.rs
+++ b/linkerd/app/profiling/src/bin/profile.rs
@@ -5,7 +5,8 @@ use std::env;
 use std::io::Read;
 use std::net::{TcpListener, ToSocketAddrs};
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let srv_addr = match env::var_os("PROFILING_SUPPORT_SERVER") {
         Some(srv_addr) => srv_addr,
         None => {
@@ -40,10 +41,11 @@ fn main() {
     );
     env.put(app::env::ENV_ADMIN_LISTEN_ADDR, "0.0.0.0:4191".to_owned());
     let _proxy = proxy::new()
-        .controller(ctrl.run())
+        .controller(ctrl.run().await)
         .outbound(srv)
         .inbound(srv2)
-        .run_with_test_env_and_keep_ports(env);
+        .run_with_test_env_and_keep_ports(env)
+        .await;
     let listener = TcpListener::bind("127.0.0.1:7777").expect("could not bind");
     let (mut stream, _) = listener.accept().expect("did not accept");
     let mut buf = [0];

--- a/linkerd/app/profiling/src/bin/profile.rs
+++ b/linkerd/app/profiling/src/bin/profile.rs
@@ -5,8 +5,7 @@ use std::env;
 use std::io::Read;
 use std::net::{TcpListener, ToSocketAddrs};
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let srv_addr = match env::var_os("PROFILING_SUPPORT_SERVER") {
         Some(srv_addr) => srv_addr,
         None => {
@@ -41,11 +40,10 @@ async fn main() {
     );
     env.put(app::env::ENV_ADMIN_LISTEN_ADDR, "0.0.0.0:4191".to_owned());
     let _proxy = proxy::new()
-        .controller(ctrl.run().await)
+        .controller(ctrl.run())
         .outbound(srv)
         .inbound(srv2)
-        .run_with_test_env_and_keep_ports(env)
-        .await;
+        .run_with_test_env_and_keep_ports(env);
     let listener = TcpListener::bind("127.0.0.1:7777").expect("could not bind");
     let (mut stream, _) = listener.accept().expect("did not accept");
     let mut buf = [0];


### PR DESCRIPTION
This branch updates the test support mock control plane components in
`linkerd2-app-integration` to use `std::future`, Tonic, and Tokio 0.2.
Rather than spawning a separate thread for each control plane componwnr
as we did previously, they are now spawned as tasks on the main test
thread's runtime. As discussed in #580, this _may_ make the tests
slightly less flaky and/or slightly faster on CI.

In order to make this compile I had to increase the type length and
recursion limits for all the test crates. I have no idea why this branch
made this necessary. My guess is that the fact that we have ~12MB type
names now is at least part of the cause of linkerd/linkerd2#4676.

Depends on #580
Closes linkerd/linkerd2#3963

Signed-off-by: Eliza Weisman <eliza@buoyant.io>