### PR TITLE
buffer: Box the inner service's reponse future

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -107,23 +107,25 @@ impl<L> Layers<L> {
     }
 
     /// Buffers requests in an mpsc, spawning the inner service onto a dedicated task.
-    pub fn push_spawn_buffer<Req>(
+    pub fn push_spawn_buffer<Req, Rsp>(
         self,
         capacity: usize,
-    ) -> Layers<Pair<L, buffer::SpawnBufferLayer<Req>>>
+    ) -> Layers<Pair<L, buffer::SpawnBufferLayer<Req, Rsp>>>
     where
         Req: Send + 'static,
+        Rsp: Send + 'static,
     {
         self.push(buffer::SpawnBufferLayer::new(capacity))
     }
 
-    pub fn push_spawn_buffer_with_idle_timeout<Req>(
+    pub fn push_spawn_buffer_with_idle_timeout<Req, Rsp>(
         self,
         capacity: usize,
         idle_timeout: Duration,
-    ) -> Layers<Pair<L, buffer::SpawnBufferLayer<Req>>>
+    ) -> Layers<Pair<L, buffer::SpawnBufferLayer<Req, Rsp>>>
     where
         Req: Send + 'static,
+        Rsp: Send + 'static,
     {
         self.push(buffer::SpawnBufferLayer::new(capacity).with_idle_timeout(idle_timeout))
     }
@@ -220,11 +222,11 @@ impl<S> Stack<S> {
     }
 
     /// Buffer requests when when the next layer is out of capacity.
-    pub fn spawn_buffer<Req>(self, capacity: usize) -> Stack<buffer::Buffer<Req, S::Future>>
+    pub fn spawn_buffer<Req, Rsp>(self, capacity: usize) -> Stack<buffer::Buffer<Req, Rsp>>
     where
         Req: Send + 'static,
-        S: Service<Req> + Send + 'static,
-        S::Response: Send + 'static,
+        Rsp: Send + 'static,
+        S: Service<Req, Response = Rsp> + Send + 'static,
         S::Error: Into<Error> + Send + Sync,
         S::Future: Send,
     {


### PR DESCRIPTION
The buffer middleware is parameterized on the inner service's repsonse
future, which "leaks" the inner service's type to the outer components
(which slows down compilations).

This changes the signature to instead be parameterized by the response
type, boxing the inner service's response future to avoid exposing its
type signature.

Relates to linkerd/linkerd2#4676