### PR TITLE
remove deprecated pin-project attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1835,18 +1835,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.9"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f6a7f5eee6292c559c793430c55c00aea9d3b3d1905e855806ca4d7253426a2"
+checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.9"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8988430ce790d8682672117bc06dda364c0be32d3abd738234f19f3240bad99a"
+checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.2",

--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -10,7 +10,7 @@ use opencensus_proto::agent::trace::v1::{
     trace_service_client::TraceServiceClient, ExportTraceServiceRequest, ExportTraceServiceResponse,
 };
 use opencensus_proto::trace::v1::Span;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 use std::convert::TryInto;
 use std::future::Future;
 use std::pin::Pin;
@@ -167,7 +167,6 @@ where
 {
     type Output = ();
 
-    #[project]
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
             let this = self.as_mut().project();

--- a/linkerd/proxy/resolve/src/recover.rs
+++ b/linkerd/proxy/resolve/src/recover.rs
@@ -4,7 +4,7 @@ use futures::{ready, stream::TryStreamExt, FutureExt};
 use indexmap::IndexMap;
 use linkerd2_error::{Error, Recover};
 use linkerd2_proxy_core::resolve::{self, Resolution as _, Update};
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 use std::future::Future;
 use std::net::SocketAddr;
 use std::pin::Pin;
@@ -21,7 +21,7 @@ pub struct ResolveFuture<T, E: Recover, R: resolve::Resolve<T>> {
     inner: Option<Inner<T, E, R>>,
 }
 
-#[pin_project]
+#[pin_project(project = ResolutionProj)]
 pub struct Resolution<T, E: Recover, R: resolve::Resolve<T>> {
     inner: Inner<T, E, R>,
     cache: IndexMap<SocketAddr, R::Endpoint>,
@@ -225,8 +225,7 @@ where
     }
 }
 
-#[project]
-impl<T, E, R> Resolution<T, E, R>
+impl<T, E, R> ResolutionProj<'_, T, E, R>
 where
     T: Clone,
     R: resolve::Resolve<T>,

--- a/linkerd/proxy/tap/src/daemon.rs
+++ b/linkerd/proxy/tap/src/daemon.rs
@@ -1,6 +1,6 @@
 use super::iface::Tap;
 use futures::{ready, Stream};
-use pin_project::{pin_project};
+use pin_project::pin_project;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/linkerd/proxy/tap/src/service.rs
+++ b/linkerd/proxy/tap/src/service.rs
@@ -5,7 +5,7 @@ use http;
 use hyper::body::HttpBody;
 use linkerd2_proxy_http::HasH2Reason;
 use linkerd2_stack::NewService;
-use pin_project::{pin_project, pinned_drop, project};
+use pin_project::{pin_project, pinned_drop};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -48,7 +48,7 @@ pub struct ResponseFuture<F, T> {
 }
 
 // A `Body` instrumented with taps.
-#[pin_project(PinnedDrop)]
+#[pin_project(PinnedDrop, project = BodyProj)]
 #[derive(Debug)]
 pub struct Body<B, T>
 where
@@ -313,8 +313,7 @@ where
     }
 }
 
-#[project]
-impl<B, T> Body<B, T>
+impl<B, T> BodyProj<'_, B, T>
 where
     B: HttpBody,
     B::Error: HasH2Reason,


### PR DESCRIPTION
The `#[project]` attribute is now deprecated.

See https://github.com/taiki-e/pin-project/releases/tag/v0.4.21