### PR TITLE
remove git deps on hyper and h2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,8 +489,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.5"
-source = "git+https://github.com/hyperium/h2?rev=d3b9f1e36aadc1a7a6804e2f8e86d3fe4a244b4f#d3b9f1e36aadc1a7a6804e2f8e86d3fe4a244b4f"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -571,14 +572,15 @@ checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 
 [[package]]
 name = "hyper"
-version = "0.13.6"
-source = "git+https://github.com/hyperium/hyper?rev=9832aef9eeaeff8979354d5de04b8706ff79a233#9832aef9eeaeff8979354d5de04b8706ff79a233"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
 dependencies = [
  "bytes 0.5.4",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.2.5",
+ "h2 0.2.6",
  "http 0.2.1",
  "http-body",
  "httparse",
@@ -740,7 +742,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
- "h2 0.2.5",
+ "h2 0.2.6",
  "http 0.2.1",
  "http-body",
  "hyper",
@@ -879,7 +881,7 @@ dependencies = [
  "bytes 0.5.4",
  "flate2",
  "futures 0.3.5",
- "h2 0.2.5",
+ "h2 0.2.6",
  "http 0.2.1",
  "http-body",
  "hyper",
@@ -1174,7 +1176,7 @@ name = "linkerd2-proxy-api"
 version = "0.1.13"
 source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.13#f9a95345ef44c3d6f22559442e35f07e0af477e2"
 dependencies = [
- "h2 0.2.5",
+ "h2 0.2.6",
  "http 0.2.1",
  "prost",
  "prost-types",
@@ -1250,7 +1252,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.5.4",
  "futures 0.3.5",
- "h2 0.2.5",
+ "h2 0.2.6",
  "http 0.2.1",
  "http-body",
  "httparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,3 @@ debug = false
 [patch.crates-io]
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.21" }
 tower = { version = "0.3", git = "https://github.com/tower-rs/tower", rev = "8752a3811788e94670c62dc0acbc9613207931b1"}
-# Un-patch after h2 v0.2.6 is published
-h2 = { git = "https://github.com/hyperium/h2", rev = "d3b9f1e36aadc1a7a6804e2f8e86d3fe4a244b4f"} 
-# Un-patch after hyper v0.13.7 is published
-hyper = { version = "0.13", git = "https://github.com/hyperium/hyper", rev = "9832aef9eeaeff8979354d5de04b8706ff79a233"}

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 futures = "0.3"
 http = "0.2"
-hyper = "0.13"
+hyper = "0.13.7"
 pin-project = "0.4"
 tower = { version = "0.3", default-features = false, features = ["load"]}
 tokio = { version = "0.2", features = ["macros"]}

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -33,9 +33,9 @@ tracing-futures = { version = "0.2", features = ["std-future"]}
 
 [dev-dependencies]
 bytes = "0.5"
-h2 = "0.2"
+h2 = "0.2.6"
 http = "0.2"
-hyper = "0.13"
+hyper = "0.13.7"
 linkerd2-metrics = { path = "../metrics", features = ["test_util"] }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.13", features = ["arbitrary"] }
 net2 = "0.2"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -19,7 +19,7 @@ async-trait = "0.1"
 bytes = "0.5"
 http = "0.2"
 http-body = "0.3"
-hyper = "0.13"
+hyper = "0.13.7"
 futures = "0.3"
 indexmap = "1.0"
 linkerd2-addr = { path = "../../addr" }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -20,10 +20,10 @@ nyi = []
 [dependencies]
 bytes = "0.5"
 futures = "0.3" 
-h2 = "0.2"
+h2 = "0.2.6"
 http = "0.2"
 http-body = "0.3"
-hyper = "0.13"
+hyper = "0.13.7"
 linkerd2-app = { path = "..", features = ["mock-orig-dst"] }
 linkerd2-app-core = { path = "../core", features = ["mock-orig-dst"] }
 linkerd2-metrics = { path = "../../metrics", features = ["test_util"] }

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3"
 h2 = "0.1"
 http = "0.2"
 http-body = "0.3"
-hyper = "0.13.0"
+hyper = "0.13.7"
 indexmap = "1.0"
 linkerd2-error = { path  = "../error" }
 linkerd2-http-classify = { path  = "../http-classify" }

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -13,7 +13,7 @@ test_util = []
 deflate = { version = "0.7.18", features = ["gzip"] }
 futures = "0.3"
 http = "0.2"
-hyper = "0.13"
+hyper = "0.13.7"
 indexmap = "1.0"
 tracing = "0.1.2"
 

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -13,11 +13,11 @@ This should probably be decomposed into smaller, decoupled crates.
 [dependencies]
 bytes = "0.5"
 futures = { package = "futures", version = "0.3" }
-h2 = "0.2"
+h2 = "0.2.6"
 http = "0.2"
 http-body = "0.3"
 httparse = "1.2"
-hyper = "0.13"
+hyper = "0.13.7"
 hyper-balance = { path  = "../../../hyper-balance" }
 indexmap = "1.0"
 linkerd2-addr = { path  = "../../addr" }

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 bytes = "0.5"
 http = "0.2"
-hyper = "0.13"
+hyper = "0.13.7"
 futures = "0.3"
 indexmap = "1.0"
 ipnet = "2.0"


### PR DESCRIPTION
The versions we were waiting for (`hyper` 0.13.7 and `h2` 0.2.6) have
now been released, so we can remove the patches and Git dependencies :D