### PR TITLE
trace: update tracing-subscriber to 0.2.8; add spans to JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,9 +35,9 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi 0.3.8",
 ]
@@ -2743,9 +2743,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72c8cf3ec4ed69fef614d011a5ae4274537a8a8c59133558029bd731eb71659"
+checksum = "cafe899b943f5433c6cab468d75a17ea92948fe9fe60b00f41e13d5e0d4fd054"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -73,7 +73,7 @@ tracing-log = "0.1"
 pin-project = "0.4"
 
 [dependencies.tracing-subscriber]
-version = "0.2.7"
+version = "0.2.8"
 # we don't need `chrono` time formatting
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "ansi", "json", "parking_lot"]

--- a/linkerd/app/core/src/trace.rs
+++ b/linkerd/app/core/src/trace.rs
@@ -56,7 +56,7 @@ pub fn with_filter_and_format(
 
     match format.as_ref().to_uppercase().as_ref() {
         "JSON" => {
-            let builder = builder.json().with_filter_reloading();
+            let builder = builder.json().with_span_list(true).with_filter_reloading();
             let handle = LevelHandle::Json(builder.reload_handle());
             let dispatch = Dispatch::new(builder.finish());
             (dispatch, handle)


### PR DESCRIPTION
This branch updates the `tracing-subscriber` crate to version 0.2.8,
which adds support for serializing the complete span context with the
JSON formatter, the way the text log subscriber does.

Also, it includes @Pothulapati's change to print thread IDs, which will
be useful for debugging the multithreaded runtime.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>