### PR TITLE
Remove `Resolution` trait

### DIFF
--- a/linkerd/proxy/api-resolve/src/resolve.rs
+++ b/linkerd/proxy/api-resolve/src/resolve.rs
@@ -149,12 +149,7 @@ impl Stream for Resolution {
 
                     None => {} // continue
                 },
-                None => {
-                    return Poll::Ready(Some(Err(grpc::Status::new(
-                        grpc::Code::Ok,
-                        "end of stream",
-                    ))))
-                }
+                None => return Poll::Ready(None),
             };
         }
     }

--- a/linkerd/proxy/api-resolve/src/resolve.rs
+++ b/linkerd/proxy/api-resolve/src/resolve.rs
@@ -104,14 +104,10 @@ where
     }
 }
 
-impl resolve::Resolution for Resolution {
-    type Endpoint = Metadata;
-    type Error = grpc::Status;
+impl Stream for Resolution {
+    type Item = Result<resolve::Update<Metadata>, grpc::Status>;
 
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<Update<Self::Endpoint>, Self::Error>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
         loop {
             match ready!(this.inner.as_mut().poll_next(cx)) {
@@ -126,7 +122,7 @@ impl resolve::Resolution for Resolution {
                             .collect::<Vec<_>>();
                         if !addr_metas.is_empty() {
                             debug!(endpoints = %addr_metas.len(), "Add");
-                            return Poll::Ready(Ok(Update::Add(addr_metas)));
+                            return Poll::Ready(Some(Ok(Update::Add(addr_metas))));
                         }
                     }
 
@@ -137,7 +133,7 @@ impl resolve::Resolution for Resolution {
                             .collect::<Vec<_>>();
                         if !sock_addrs.is_empty() {
                             debug!(endpoints = %sock_addrs.len(), "Remove");
-                            return Poll::Ready(Ok(Update::Remove(sock_addrs)));
+                            return Poll::Ready(Some(Ok(Update::Remove(sock_addrs))));
                         }
                     }
 
@@ -148,13 +144,16 @@ impl resolve::Resolution for Resolution {
                         } else {
                             Update::DoesNotExist
                         };
-                        return Poll::Ready(Ok(update.into()));
+                        return Poll::Ready(Some(Ok(update.into())));
                     }
 
                     None => {} // continue
                 },
                 None => {
-                    return Poll::Ready(Err(grpc::Status::new(grpc::Code::Ok, "end of stream")))
+                    return Poll::Ready(Some(Err(grpc::Status::new(
+                        grpc::Code::Ok,
+                        "end of stream",
+                    ))))
                 }
             };
         }

--- a/linkerd/proxy/core/src/lib.rs
+++ b/linkerd/proxy/core/src/lib.rs
@@ -2,4 +2,4 @@
 
 pub mod resolve;
 
-pub use self::resolve::{Resolution, Resolve};
+pub use self::{resolve::Resolve, resolve::Update};

--- a/linkerd/proxy/core/src/resolve.rs
+++ b/linkerd/proxy/core/src/resolve.rs
@@ -2,7 +2,6 @@ use futures::stream::TryStream;
 use linkerd2_error::Error;
 use std::future::Future;
 use std::net::SocketAddr;
-use std::pin::Pin;
 use std::task::{Context, Poll};
 
 /// Resolves `T`-typed names/addresses as an infinite stream of `Update<Self::Endpoint>`.
@@ -80,19 +79,3 @@ where
         self.0.resolve(target)
     }
 }
-
-pub trait ResolutionStreamExt<E, T>: TryStream<Ok = Update<E>, Error = T> {
-    fn poll_next_update(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Update<E>, T>> {
-        self.try_poll_next(cx)
-            .map(|result| result.expect("resolution stream never ends"))
-    }
-
-    fn poll_next_update_unpin(&mut self, cx: &mut Context<'_>) -> Poll<Result<Update<E>, T>>
-    where
-        Self: Unpin,
-    {
-        Pin::new(self).poll_next_update(cx)
-    }
-}
-
-impl<E, T, S: TryStream<Ok = Update<E>, Error = T>> ResolutionStreamExt<E, T> for S {}

--- a/linkerd/proxy/core/src/resolve.rs
+++ b/linkerd/proxy/core/src/resolve.rs
@@ -81,8 +81,6 @@ where
     }
 }
 
-impl<E, T, S: ?Sized + TryStream<Ok = Update<E>, Error = T>> ResolutionStreamExt<E, T> for S {}
-
 pub trait ResolutionStreamExt<E, T>: TryStream<Ok = Update<E>, Error = T> {
     fn next_update(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Update<E>, T>> {
         self.try_poll_next(cx)
@@ -96,3 +94,5 @@ pub trait ResolutionStreamExt<E, T>: TryStream<Ok = Update<E>, Error = T> {
         Pin::new(self).next_update(cx)
     }
 }
+
+impl<E, T, S: TryStream<Ok = Update<E>, Error = T>> ResolutionStreamExt<E, T> for S {}

--- a/linkerd/proxy/core/src/resolve.rs
+++ b/linkerd/proxy/core/src/resolve.rs
@@ -82,16 +82,16 @@ where
 }
 
 pub trait ResolutionStreamExt<E, T>: TryStream<Ok = Update<E>, Error = T> {
-    fn next_update(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Update<E>, T>> {
+    fn poll_next_update(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Update<E>, T>> {
         self.try_poll_next(cx)
             .map(|result| result.expect("resolution stream never ends"))
     }
 
-    fn next_update_pin(&mut self, cx: &mut Context<'_>) -> Poll<Result<Update<E>, T>>
+    fn poll_next_update_unpin(&mut self, cx: &mut Context<'_>) -> Poll<Result<Update<E>, T>>
     where
         Self: Unpin,
     {
-        Pin::new(self).next_update(cx)
+        Pin::new(self).poll_next_update(cx)
     }
 }
 

--- a/linkerd/proxy/core/src/resolve.rs
+++ b/linkerd/proxy/core/src/resolve.rs
@@ -1,3 +1,4 @@
+use futures::stream::TryStream;
 use linkerd2_error::Error;
 use std::future::Future;
 use std::net::SocketAddr;
@@ -8,7 +9,7 @@ use std::task::{Context, Poll};
 pub trait Resolve<T> {
     type Endpoint;
     type Error: Into<Error>;
-    type Resolution: Resolution<Endpoint = Self::Endpoint>;
+    type Resolution: TryStream<Ok = Update<Self::Endpoint>, Error = Self::Error>;
     type Future: Future<Output = Result<Self::Resolution, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
@@ -20,27 +21,6 @@ pub trait Resolve<T> {
         Self: Sized,
     {
         Service(self)
-    }
-}
-
-/// An infinite stream of endpoint updates.
-pub trait Resolution {
-    type Endpoint;
-    type Error: Into<Error>;
-
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<Update<Self::Endpoint>, Self::Error>>;
-
-    fn poll_unpin(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<Update<Self::Endpoint>, Self::Error>>
-    where
-        Self: Unpin,
-    {
-        Pin::new(self).poll(cx)
     }
 }
 
@@ -57,13 +37,13 @@ pub enum Update<T> {
 
 // === impl Resolve ===
 
-impl<S, T, R> Resolve<T> for S
+impl<S, T, R, E> Resolve<T> for S
 where
     S: tower::Service<T, Response = R>,
     S::Error: Into<Error>,
-    R: Resolution,
+    R: TryStream<Ok = Update<E>, Error = S::Error>,
 {
-    type Endpoint = <R as Resolution>::Endpoint;
+    type Endpoint = E;
     type Error = S::Error;
     type Resolution = S::Response;
     type Future = S::Future;
@@ -98,5 +78,21 @@ where
     #[inline]
     fn call(&mut self, target: T) -> Self::Future {
         self.0.resolve(target)
+    }
+}
+
+impl<E, T, S: ?Sized + TryStream<Ok = Update<E>, Error = T>> ResolutionStreamExt<E, T> for S {}
+
+pub trait ResolutionStreamExt<E, T>: TryStream<Ok = Update<E>, Error = T> {
+    fn next_update(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<Update<E>, T>> {
+        self.try_poll_next(cx)
+            .map(|result| result.expect("resolution stream never ends"))
+    }
+
+    fn next_update_pin(&mut self, cx: &mut Context<'_>) -> Poll<Result<Update<E>, T>>
+    where
+        Self: Unpin,
+    {
+        Pin::new(self).next_update(cx)
     }
 }

--- a/linkerd/proxy/core/src/resolve.rs
+++ b/linkerd/proxy/core/src/resolve.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-/// Resolves `T`-typed names/addresses as a `Resolution`.
+/// Resolves `T`-typed names/addresses as an infinite stream of `Update<Self::Endpoint>`.
 pub trait Resolve<T> {
     type Endpoint;
     type Error: Into<Error>;

--- a/linkerd/proxy/discover/src/from_resolve.rs
+++ b/linkerd/proxy/discover/src/from_resolve.rs
@@ -1,6 +1,6 @@
-use futures::{ready, Stream, TryFuture};
+use futures::{ready, Stream, TryFuture, TryStream};
 use indexmap::IndexSet;
-use linkerd2_proxy_core::resolve::{Resolution, Resolve, Update};
+use linkerd2_proxy_core::resolve::{ResolutionStreamExt, Resolve, Update};
 use pin_project::pin_project;
 use std::collections::VecDeque;
 use std::future::Future;
@@ -10,45 +10,50 @@ use std::task::{Context, Poll};
 use tower::discover::Change;
 
 #[derive(Clone, Debug)]
-pub struct FromResolve<R> {
+pub struct FromResolve<R, E> {
     resolve: R,
+    _marker: std::marker::PhantomData<fn(E)>,
 }
 
 #[pin_project]
 #[derive(Debug)]
-pub struct DiscoverFuture<F> {
+pub struct DiscoverFuture<F, E> {
     #[pin]
     future: F,
+    _marker: std::marker::PhantomData<fn(E)>,
 }
 
 /// Observes an `R`-typed resolution stream, using an `M`-typed endpoint stack to
 /// build a service for each endpoint.
 #[pin_project]
-pub struct Discover<R: Resolution> {
+pub struct Discover<R: TryStream, E> {
     #[pin]
     resolution: R,
     active: IndexSet<SocketAddr>,
-    pending: VecDeque<Change<SocketAddr, R::Endpoint>>,
+    pending: VecDeque<Change<SocketAddr, E>>,
 }
 
 // === impl FromResolve ===
 
-impl<R> FromResolve<R> {
+impl<R, E> FromResolve<R, E> {
     pub fn new<T>(resolve: R) -> Self
     where
         R: Resolve<T>,
     {
-        Self { resolve }
+        Self {
+            resolve,
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 
-impl<T, R> tower::Service<T> for FromResolve<R>
+impl<T, R, E> tower::Service<T> for FromResolve<R, E>
 where
     R: Resolve<T> + Clone,
 {
-    type Response = Discover<R::Resolution>;
+    type Response = Discover<R::Resolution, E>;
     type Error = R::Error;
-    type Future = DiscoverFuture<R::Future>;
+    type Future = DiscoverFuture<R::Future, E>;
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -59,18 +64,19 @@ where
     fn call(&mut self, target: T) -> Self::Future {
         Self::Future {
             future: self.resolve.resolve(target),
+            _marker: std::marker::PhantomData,
         }
     }
 }
 
 // === impl DiscoverFuture ===
 
-impl<F> Future for DiscoverFuture<F>
+impl<F, E> Future for DiscoverFuture<F, E>
 where
     F: TryFuture,
-    F::Ok: Resolution,
+    F::Ok: TryStream,
 {
-    type Output = Result<Discover<F::Ok>, F::Error>;
+    type Output = Result<Discover<F::Ok, E>, F::Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let resolution = ready!(self.project().future.try_poll(cx))?;
@@ -80,7 +86,7 @@ where
 
 // === impl Discover ===
 
-impl<R: Resolution> Discover<R> {
+impl<R: TryStream, E> Discover<R, E> {
     pub fn new(resolution: R) -> Self {
         Self {
             resolution,
@@ -90,8 +96,11 @@ impl<R: Resolution> Discover<R> {
     }
 }
 
-impl<R: Resolution> Stream for Discover<R> {
-    type Item = Result<Change<SocketAddr, R::Endpoint>, R::Error>;
+impl<R, E> Stream for Discover<R, E>
+where
+    R: TryStream<Ok = Update<E>>,
+{
+    type Item = Result<Change<SocketAddr, E>, R::Error>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {
@@ -100,7 +109,7 @@ impl<R: Resolution> Stream for Discover<R> {
                 return Poll::Ready(Some(Ok(change)));
             }
 
-            match ready!(this.resolution.poll(cx))? {
+            match ready!(this.resolution.next_update(cx))? {
                 Update::Add(endpoints) => {
                     for (addr, endpoint) in endpoints.into_iter() {
                         this.active.insert(addr);

--- a/linkerd/proxy/discover/src/from_resolve.rs
+++ b/linkerd/proxy/discover/src/from_resolve.rs
@@ -109,7 +109,7 @@ where
                 return Poll::Ready(Some(Ok(change)));
             }
 
-            match ready!(this.resolution.next_update(cx))? {
+            match ready!(this.resolution.poll_next_update(cx))? {
                 Update::Add(endpoints) => {
                     for (addr, endpoint) in endpoints.into_iter() {
                         this.active.insert(addr);

--- a/linkerd/proxy/discover/src/lib.rs
+++ b/linkerd/proxy/discover/src/lib.rs
@@ -43,7 +43,7 @@ where
     T: fmt::Display,
     R: Resolve<T> + Send + Clone + 'static,
     R::Error: Into<Error>,
-    R::Endpoint: fmt::Debug + Clone + PartialEq + Send,
+    R::Endpoint: fmt::Debug + Clone + PartialEq + Send + 'static,
     R::Resolution: Send + 'static,
     R::Future: Send + 'static,
     M: tower::Service<R::Endpoint> + Clone + Send + 'static,
@@ -51,7 +51,7 @@ where
     M::Response: Send + 'static,
     M::Future: Send + 'static,
 {
-    type Service = Buffer<MakeEndpoint<FromResolve<R>, M>>;
+    type Service = Buffer<MakeEndpoint<FromResolve<R, R::Endpoint>, M>>;
 
     fn layer(&self, make_endpoint: M) -> Self::Service {
         let make_discover =

--- a/linkerd/proxy/resolve/src/map_endpoint.rs
+++ b/linkerd/proxy/resolve/src/map_endpoint.rs
@@ -116,7 +116,7 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
-        let update = match ready!(this.resolution.next_update(cx))? {
+        let update = match ready!(this.resolution.poll_next_update(cx))? {
             resolve::Update::Add(eps) => {
                 let mut update = Vec::new();
                 for (a, ep) in eps.into_iter() {

--- a/linkerd/proxy/resolve/src/recover.rs
+++ b/linkerd/proxy/resolve/src/recover.rs
@@ -200,7 +200,7 @@ where
                     //
                     // Attempt recovery/backoff if the resolution fails.
 
-                    match ready!(resolution.next_update_pin(cx)) {
+                    match ready!(resolution.poll_next_update_unpin(cx)) {
                         Ok(update) => {
                             this.update_active(&update);
                             return Poll::Ready(Some(Ok(update)));
@@ -301,7 +301,7 @@ where
                 } => match ready!(resolution
                     .as_mut()
                     .expect("illegal state")
-                    .next_update_pin(cx))
+                    .poll_next_update_unpin(cx))
                 {
                     Err(e) => State::Recover {
                         error: Some(e.into()),


### PR DESCRIPTION
This PR removes the `Resolution` and replaces it with a `TryStream<Ok = Update<Endpoint>, Error>`.  This will allow us to treat any resolution as a normal `Stream` and as a consequence make it easier to  transition state machine based stream implementations to using `async-stream`. 

In addition a ResolutionStreamExt trait is defined that abstracts away the fact that we expect this stream to never end (i.e. should never return `None`)

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>