### PR TITLE
Move tls::accept to async/await

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,6 +1353,7 @@ name = "linkerd2-proxy-transport"
 version = "0.1.0"
 dependencies = [
  "async-stream",
+ "async-trait",
  "bytes 0.5.4",
  "futures 0.3.5",
  "indexmap",
@@ -1365,6 +1366,7 @@ dependencies = [
  "linkerd2-io",
  "linkerd2-metrics",
  "linkerd2-proxy-core",
+ "linkerd2-proxy-detect",
  "linkerd2-stack",
  "pin-project",
  "ring",

--- a/linkerd/app/core/src/metric_labels.rs
+++ b/linkerd/app/core/src/metric_labels.rs
@@ -16,7 +16,7 @@ pub struct ControlLabels {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EndpointLabels {
     pub direction: Direction,
-    pub tls_id: Conditional<TlsId, tls::ReasonForNoIdentity>,
+    pub tls_id: Conditional<TlsId, tls::ReasonForNoPeerName>,
     pub authority: Option<http::uri::Authority>,
     pub labels: Option<String>,
 }

--- a/linkerd/app/core/src/proxy/server.rs
+++ b/linkerd/app/core/src/proxy/server.rs
@@ -54,8 +54,9 @@ impl ProtocolDetect {
 }
 
 #[async_trait]
-impl detect::Detect<tls::accept::Meta> for ProtocolDetect {
+impl detect::Detect<tls::accept::Meta, BoxedIo> for ProtocolDetect {
     type Target = Protocol;
+    type Io = BoxedIo;
     type Error = io::Error;
 
     async fn detect(

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -99,6 +99,9 @@ impl fmt::Display for TlsStatus {
 
 impl FmtLabels for TlsStatus {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Self(Conditional::None(tls::ReasonForNoPeerName::LocalIdentityDisabled)) = self {
+            return write!(f, "tls=\"disabled\"");
+        }
         if let Self(Conditional::None(why)) = self {
             return write!(f, "tls=\"no_identity\",no_tls_reason=\"{}\"", why);
         }

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -88,12 +88,6 @@ impl Into<tls::Conditional<()>> for TlsStatus {
     }
 }
 
-impl TlsStatus {
-    pub fn no_tls_reason(&self) -> Option<tls::ReasonForNoIdentity> {
-        self.0.reason()
-    }
-}
-
 impl fmt::Display for TlsStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
@@ -105,7 +99,7 @@ impl fmt::Display for TlsStatus {
 
 impl FmtLabels for TlsStatus {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(tls::ReasonForNoIdentity::NoPeerName(why)) = self.no_tls_reason() {
+        if let Self(Conditional::None(why)) = self {
             return write!(f, "tls=\"no_identity\",no_tls_reason=\"{}\"", why);
         }
 

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -60,7 +60,7 @@ mod test {
 
     #[tokio::test]
     async fn no_identity() {
-        let peer_id = tls::PeerIdentity::None(tls::ReasonForNoPeerName::NotProvidedByRemote.into());
+        let peer_id = tls::PeerIdentity::None(tls::ReasonForNoPeerName::NoPeerIdFromRemote);
         let test = Test {
             peer_id,
             ..Default::default()

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -189,11 +189,11 @@ impl tap::Inspect for Target {
     fn src_tls<'a, B>(
         &self,
         req: &'a http::Request<B>,
-    ) -> Conditional<&'a identity::Name, tls::ReasonForNoIdentity> {
+    ) -> Conditional<&'a identity::Name, tls::ReasonForNoPeerName> {
         req.extensions()
             .get::<tls::accept::Meta>()
             .map(|s| s.peer_identity.as_ref())
-            .unwrap_or_else(|| Conditional::None(tls::ReasonForNoIdentity::Disabled))
+            .unwrap_or_else(|| Conditional::None(tls::ReasonForNoPeerName::LocalIdentityDisabled))
     }
 
     fn dst_addr<B>(&self, _: &http::Request<B>) -> Option<SocketAddr> {
@@ -207,7 +207,7 @@ impl tap::Inspect for Target {
     fn dst_tls<B>(
         &self,
         _: &http::Request<B>,
-    ) -> Conditional<&identity::Name, tls::ReasonForNoIdentity> {
+    ) -> Conditional<&identity::Name, tls::ReasonForNoPeerName> {
         Conditional::None(tls::ReasonForNoPeerName::Loopback.into())
     }
 

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -17,7 +17,7 @@ use linkerd2_app_core::{
     opencensus::proto::trace::v1 as oc,
     profiles,
     proxy::{
-        detect::DetectProtocolLayer,
+        detect,
         http::{self, normalize_uri, orig_proto, strip_header},
         identity,
         server::{Protocol as ServerProtocol, ProtocolDetect, Server},
@@ -412,12 +412,12 @@ impl Config {
         );
 
         let tcp_detect = svc::stack(tcp_server)
-            .push(DetectProtocolLayer::new(ProtocolDetect::new(
+            .push(detect::AcceptLayer::new(ProtocolDetect::new(
                 disable_protocol_detection_for_ports.clone(),
             )))
             .push(admit::AdmitLayer::new(require_identity_for_inbound_ports))
             // Terminates inbound mTLS from other outbound proxies.
-            .push(DetectProtocolLayer::new(tls::DetectTls::new(
+            .push(detect::AcceptLayer::new(tls::DetectTls::new(
                 local_identity,
                 disable_protocol_detection_for_ports,
             )))

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -417,10 +417,10 @@ impl Config {
             )))
             .push(admit::AdmitLayer::new(require_identity_for_inbound_ports))
             // Terminates inbound mTLS from other outbound proxies.
-            .push(tls::AcceptTls::layer(
+            .push(DetectProtocolLayer::new(tls::DetectTls::new(
                 local_identity,
                 disable_protocol_detection_for_ports,
-            ))
+            )))
             // Limits the amount of time that the TCP server spends waiting for TLS handshake &
             // protocol detection. Ensures that connections that never emit data are dropped
             // eventually.

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -128,7 +128,7 @@ impl<T: tap::Inspect> tap::Inspect for Target<T> {
     fn src_tls<'a, B>(
         &self,
         req: &'a http::Request<B>,
-    ) -> Conditional<&'a identity::Name, tls::ReasonForNoIdentity> {
+    ) -> Conditional<&'a identity::Name, tls::ReasonForNoPeerName> {
         self.inner.src_tls(req)
     }
 
@@ -143,7 +143,7 @@ impl<T: tap::Inspect> tap::Inspect for Target<T> {
     fn dst_tls<B>(
         &self,
         req: &http::Request<B>,
-    ) -> Conditional<&identity::Name, tls::ReasonForNoIdentity> {
+    ) -> Conditional<&identity::Name, tls::ReasonForNoPeerName> {
         self.inner.dst_tls(req)
     }
 
@@ -236,7 +236,7 @@ impl tap::Inspect for HttpEndpoint {
     fn src_tls<'a, B>(
         &self,
         _: &'a http::Request<B>,
-    ) -> Conditional<&'a identity::Name, tls::ReasonForNoIdentity> {
+    ) -> Conditional<&'a identity::Name, tls::ReasonForNoPeerName> {
         Conditional::None(tls::ReasonForNoPeerName::Loopback.into())
     }
 
@@ -251,7 +251,7 @@ impl tap::Inspect for HttpEndpoint {
     fn dst_tls<B>(
         &self,
         _: &http::Request<B>,
-    ) -> Conditional<&identity::Name, tls::ReasonForNoIdentity> {
+    ) -> Conditional<&identity::Name, tls::ReasonForNoPeerName> {
         self.identity.as_ref()
     }
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -547,10 +547,10 @@ impl Config {
             )))
             // The local application never establishes mTLS with the proxy, so don't try to
             // terminate TLS, just annotate with the connection with the reason.
-            .push(tls::AcceptTls::layer(
+            .push(DetectProtocolLayer::new(tls::DetectTls::new(
                 no_tls,
                 disable_protocol_detection_for_ports,
-            ))
+            )))
             // Limits the amount of time that the TCP server spends waiting for protocol
             // detection. Ensures that connections that never emit data are dropped eventually.
             .push_timeout(detect_protocol_timeout);

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -18,8 +18,8 @@ use linkerd2_app_core::{
     opencensus::proto::trace::v1 as oc,
     profiles,
     proxy::{
-        self, core::resolve::Resolve, detect::DetectProtocolLayer, discover, http, identity,
-        resolve::map_endpoint, server::ProtocolDetect, tap, tcp, Server,
+        self, core::resolve::Resolve, detect, discover, http, identity, resolve::map_endpoint,
+        server::ProtocolDetect, tap, tcp, Server,
     },
     reconnect, retry, router, serve,
     spans::SpanConverter,
@@ -542,12 +542,12 @@ impl Config {
             Conditional::None(tls::ReasonForNoPeerName::Loopback.into());
 
         let tcp_detect = svc::stack(tcp_server)
-            .push(DetectProtocolLayer::new(ProtocolDetect::new(
+            .push(detect::AcceptLayer::new(ProtocolDetect::new(
                 disable_protocol_detection_for_ports.clone(),
             )))
             // The local application never establishes mTLS with the proxy, so don't try to
             // terminate TLS, just annotate with the connection with the reason.
-            .push(DetectProtocolLayer::new(tls::DetectTls::new(
+            .push(detect::AcceptLayer::new(tls::DetectTls::new(
                 no_tls,
                 disable_protocol_detection_for_ports,
             )))

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -539,7 +539,7 @@ impl Config {
         );
 
         let no_tls: tls::Conditional<identity::Local> =
-            Conditional::None(tls::ReasonForNoPeerName::Loopback.into());
+            Conditional::None(tls::ReasonForNoPeerName::Loopback);
 
         let tcp_detect = svc::stack(tcp_server)
             .push(detect::AcceptLayer::new(ProtocolDetect::new(

--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -1,6 +1,6 @@
 use crate::identity::LocalIdentity;
 use linkerd2_app_core::{
-    admin, config::ServerConfig, drain, metrics::FmtMetrics, proxy::detect::DetectProtocol, serve,
+    admin, config::ServerConfig, drain, metrics::FmtMetrics, proxy::detect, serve,
     trace::LevelHandle, transport::tls, Error,
 };
 use std::net::SocketAddr;
@@ -34,7 +34,7 @@ impl Config {
 
         let (ready, latch) = admin::Readiness::new();
         let admin = admin::Admin::new(report, ready, log_level);
-        let accept = DetectProtocol::new(
+        let accept = detect::Accept::new(
             tls::DetectTls::new(identity, Default::default()),
             admin.into_accept(),
         );

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -890,7 +890,7 @@ pub fn parse_control_addr_disable_identity<S: Strings>(
     base: &str,
 ) -> Result<Option<ControlAddr>, EnvError> {
     let a = parse(strings, &format!("{}_ADDR", base), parse_addr)?;
-    let identity = tls::Conditional::None(tls::ReasonForNoIdentity::Disabled);
+    let identity = tls::Conditional::None(tls::ReasonForNoPeerName::LocalIdentityDisabled);
     Ok(a.map(|addr| ControlAddr { addr, identity }))
 }
 

--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -79,7 +79,9 @@ impl Config {
 impl Identity {
     pub fn local(&self) -> LocalIdentity {
         match self {
-            Identity::Disabled => tls::Conditional::None(tls::ReasonForNoIdentity::Disabled),
+            Identity::Disabled => {
+                tls::Conditional::None(tls::ReasonForNoPeerName::LocalIdentityDisabled)
+            }
             Identity::Enabled { ref local, .. } => tls::Conditional::Some(local.clone()),
         }
     }

--- a/linkerd/app/src/tap.rs
+++ b/linkerd/app/src/tap.rs
@@ -2,7 +2,7 @@ use indexmap::IndexSet;
 use linkerd2_app_core::{
     config::ServerConfig,
     drain,
-    proxy::{identity, tap},
+    proxy::{detect::DetectProtocol, identity, tap},
     serve,
     transport::tls,
     Error,
@@ -49,8 +49,8 @@ impl Config {
             } => {
                 let (listen_addr, listen) = config.bind.bind()?;
 
-                let accept = tls::AcceptTls::new(
-                    identity,
+                let accept = DetectProtocol::new(
+                    tls::DetectTls::new(identity, Default::default()),
                     tap::AcceptPermittedClients::new(permitted_peer_identities.into(), server),
                 );
 

--- a/linkerd/app/src/tap.rs
+++ b/linkerd/app/src/tap.rs
@@ -2,7 +2,7 @@ use indexmap::IndexSet;
 use linkerd2_app_core::{
     config::ServerConfig,
     drain,
-    proxy::{detect::DetectProtocol, identity, tap},
+    proxy::{detect, identity, tap},
     serve,
     transport::tls,
     Error,
@@ -49,7 +49,7 @@ impl Config {
             } => {
                 let (listen_addr, listen) = config.bind.bind()?;
 
-                let accept = DetectProtocol::new(
+                let accept = detect::Accept::new(
                     tls::DetectTls::new(identity, Default::default()),
                     tap::AcceptPermittedClients::new(permitted_peer_identities.into(), server),
                 );

--- a/linkerd/proxy/detect/src/lib.rs
+++ b/linkerd/proxy/detect/src/lib.rs
@@ -21,37 +21,37 @@ pub trait Detect<T, I: AsyncRead + AsyncWrite> {
 }
 
 #[derive(Debug, Clone)]
-pub struct DetectProtocolLayer<D> {
+pub struct AcceptLayer<D> {
     detect: D,
 }
 
 #[derive(Debug, Clone)]
-pub struct DetectProtocol<D, A> {
+pub struct Accept<D, A> {
     detect: D,
     accept: A,
 }
 
-impl<D> DetectProtocolLayer<D> {
+impl<D> AcceptLayer<D> {
     pub fn new(detect: D) -> Self {
         Self { detect }
     }
 }
 
-impl<D: Clone, A> tower::layer::Layer<A> for DetectProtocolLayer<D> {
-    type Service = DetectProtocol<D, A>;
+impl<D: Clone, A> tower::layer::Layer<A> for AcceptLayer<D> {
+    type Service = Accept<D, A>;
 
     fn layer(&self, accept: A) -> Self::Service {
         Self::Service::new(self.detect.clone(), accept)
     }
 }
 
-impl<D: Clone, A> DetectProtocol<D, A> {
+impl<D: Clone, A> Accept<D, A> {
     pub fn new(detect: D, accept: A) -> Self {
         Self { detect, accept }
     }
 }
 
-impl<T, I, D, A> tower::Service<(T, I)> for DetectProtocol<D, A>
+impl<T, I, D, A> tower::Service<(T, I)> for Accept<D, A>
 where
     T: Send + 'static,
     I: AsyncRead + AsyncWrite + Send + 'static,

--- a/linkerd/proxy/detect/src/lib.rs
+++ b/linkerd/proxy/detect/src/lib.rs
@@ -1,20 +1,23 @@
 use async_trait::async_trait;
 use futures::prelude::*;
 use linkerd2_error::Error;
-use linkerd2_io::BoxedIo;
+use linkerd2_io::{AsyncRead, AsyncWrite, BoxedIo};
 use linkerd2_proxy_core as core;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use tower::util::ServiceExt;
 
 /// A strategy for detecting values out of a client transport.
 #[async_trait]
-pub trait Detect<T> {
+pub trait Detect<T, I: AsyncRead + AsyncWrite> {
     type Target;
+    type Io: AsyncRead + AsyncWrite + Send + Unpin;
     type Error: Into<Error>;
 
-    async fn detect(&self, target: T, io: BoxedIo) -> Result<(Self::Target, BoxedIo), Self::Error>;
+    async fn detect(&self, target: T, io: I) -> Result<(Self::Target, Self::Io), Self::Error>;
 }
 
 #[derive(Debug, Clone)]
@@ -38,17 +41,21 @@ impl<D: Clone, A> tower::layer::Layer<A> for DetectProtocolLayer<D> {
     type Service = DetectProtocol<D, A>;
 
     fn layer(&self, accept: A) -> Self::Service {
-        Self::Service {
-            detect: self.detect.clone(),
-            accept,
-        }
+        Self::Service::new(self.detect.clone(), accept)
     }
 }
 
-impl<T, D, A> tower::Service<(T, BoxedIo)> for DetectProtocol<D, A>
+impl<D: Clone, A> DetectProtocol<D, A> {
+    pub fn new(detect: D, accept: A) -> Self {
+        Self { detect, accept }
+    }
+}
+
+impl<T, I, D, A> tower::Service<(T, I)> for DetectProtocol<D, A>
 where
     T: Send + 'static,
-    D: Detect<T> + Clone + Send + 'static,
+    I: AsyncRead + AsyncWrite + Send + 'static,
+    D: Detect<T, I, Io = BoxedIo> + Clone + Send + 'static,
     D::Target: Send,
     A: core::Accept<(D::Target, BoxedIo)> + Send + Clone + 'static,
     A::Future: Send,
@@ -62,7 +69,7 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, (target, io): (T, BoxedIo)) -> Self::Future {
+    fn call(&mut self, (target, io): (T, I)) -> Self::Future {
         let detect = self.detect.clone();
         let mut accept = self.accept.clone().into_service();
         Box::pin(async move {

--- a/linkerd/proxy/tap/src/accept.rs
+++ b/linkerd/proxy/tap/src/accept.rs
@@ -6,9 +6,7 @@ use linkerd2_identity as identity;
 use linkerd2_proxy_api::tap::tap_server::{Tap, TapServer};
 use linkerd2_proxy_http::{trace, HyperServerSvc};
 use linkerd2_proxy_transport::io::BoxedIo;
-use linkerd2_proxy_transport::tls::{
-    accept::Connection, Conditional, ReasonForNoIdentity, ReasonForNoPeerName,
-};
+use linkerd2_proxy_transport::tls::{accept::Connection, Conditional, ReasonForNoPeerName};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -74,7 +72,7 @@ impl Service<Connection> for AcceptPermittedClients {
                     Box::pin(self.serve_unauthenticated(io, format!("Unauthorized peer: {}", peer)))
                 }
             }
-            Conditional::None(ReasonForNoIdentity::NoPeerName(ReasonForNoPeerName::Loopback)) => {
+            Conditional::None(ReasonForNoPeerName::Loopback) => {
                 Box::pin(self.serve_authenticated(io))
             }
             Conditional::None(reason) => {

--- a/linkerd/proxy/tap/src/lib.rs
+++ b/linkerd/proxy/tap/src/lib.rs
@@ -3,7 +3,7 @@ use http;
 use indexmap::IndexMap;
 use linkerd2_conditional::Conditional;
 use linkerd2_identity as identity;
-use linkerd2_proxy_transport::tls::ReasonForNoIdentity;
+use linkerd2_proxy_transport::tls::ReasonForNoPeerName;
 use std::net;
 use std::sync::Arc;
 
@@ -40,7 +40,7 @@ pub trait Inspect {
     fn src_tls<'a, B>(
         &self,
         req: &'a http::Request<B>,
-    ) -> Conditional<&'a identity::Name, ReasonForNoIdentity>;
+    ) -> Conditional<&'a identity::Name, ReasonForNoPeerName>;
 
     fn dst_addr<B>(&self, req: &http::Request<B>) -> Option<net::SocketAddr>;
 
@@ -49,7 +49,7 @@ pub trait Inspect {
     fn dst_tls<B>(
         &self,
         req: &http::Request<B>,
-    ) -> Conditional<&identity::Name, ReasonForNoIdentity>;
+    ) -> Conditional<&identity::Name, ReasonForNoPeerName>;
 
     fn route_labels<B>(&self, req: &http::Request<B>) -> Option<Arc<IndexMap<String, String>>>;
 

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -14,6 +14,7 @@ This should probably be decomposed into smaller, decoupled crates.
 mock-orig-dst  = []
 
 [dependencies]
+async-trait = "0.1"
 async-stream = "0.2.1"
 bytes = "0.5"
 futures = "0.3"
@@ -26,6 +27,7 @@ linkerd2-identity = { path = "../../identity" }
 linkerd2-io = { path = "../../io" }
 linkerd2-metrics = { path = "../../metrics" }
 linkerd2-proxy-core = { path = "../core" }
+linkerd2-proxy-detect = { path = "../detect" }
 linkerd2-stack = { path = "../../stack" }
 ring = "0.16"
 rustls = "0.17"

--- a/linkerd/proxy/transport/src/tls/accept.rs
+++ b/linkerd/proxy/transport/src/tls/accept.rs
@@ -1,22 +1,18 @@
-use super::{conditional_accept, ReasonForNoPeerName};
+use super::{conditional_accept, Conditional, PeerIdentity, ReasonForNoPeerName};
 use crate::io::{BoxedIo, PrefixedIo};
-use crate::listen::{self, Addrs};
+use crate::listen::Addrs;
 use bytes::BytesMut;
 use indexmap::IndexSet;
-use linkerd2_conditional::Conditional;
 use linkerd2_dns_name as dns;
-use linkerd2_error::Error;
 use linkerd2_identity as identity;
-use linkerd2_proxy_core::Accept;
-use linkerd2_stack::layer;
-use pin_project::pin_project;
+use linkerd2_proxy_detect as detect;
 pub use rustls::ServerConfig as Config;
-use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
-use tokio::net::TcpStream;
-use tracing::{debug, trace};
+use tokio::{
+    io::{self, AsyncReadExt},
+    net::TcpStream,
+};
+use tracing::{debug, trace, warn};
 
 pub trait HasConfig {
     fn tls_server_name(&self) -> identity::Name;
@@ -32,272 +28,151 @@ pub fn empty_config() -> Arc<Config> {
 #[derive(Clone, Debug)]
 pub struct Meta {
     // TODO sni name
-    pub peer_identity: super::PeerIdentity,
+    pub peer_identity: PeerIdentity,
     pub addrs: Addrs,
 }
 
 pub type Connection = (Meta, BoxedIo);
 
-#[derive(Clone)]
-pub struct AcceptTls<A: Accept<Connection>, T> {
-    accept: A,
-    tls: super::Conditional<T>,
+#[derive(Clone, Debug)]
+pub struct DetectTls<I> {
+    local_identity: Conditional<I>,
     skip_ports: Arc<IndexSet<u16>>,
 }
 
-#[pin_project]
-pub struct AcceptFuture<A: Accept<Connection>> {
-    #[pin]
-    state: AcceptState<A>,
-}
-
-#[pin_project(project = AcceptStateProj)]
-enum AcceptState<A: Accept<Connection>> {
-    TryTls(Option<TryTls<A>>),
-    TerminateTls(
-        #[pin] tokio_rustls::Accept<PrefixedIo<TcpStream>>,
-        Option<AcceptMeta<A>>,
-    ),
-    ReadyAccept(A, Option<Connection>),
-    Accept(#[pin] A::Future),
-}
-
-pub struct TryTls<A: Accept<Connection>> {
-    meta: AcceptMeta<A>,
-    server_name: identity::Name,
-    config: Arc<Config>,
-    peek_buf: BytesMut,
-    socket: TcpStream,
-}
-
-pub struct AcceptMeta<A: Accept<Connection>> {
-    accept: A,
-    addrs: Addrs,
-}
-
-// === impl Listen ===
-
-impl<A: Accept<Connection>, T: HasConfig> AcceptTls<A, T> {
+impl<I: HasConfig> DetectTls<I> {
     const PEEK_CAPACITY: usize = 8192;
 
-    pub fn new(tls: super::Conditional<T>, accept: A) -> Self {
+    pub fn new(local_identity: Conditional<I>, skip_ports: Arc<IndexSet<u16>>) -> Self {
         Self {
-            accept,
-            tls,
-            skip_ports: Default::default(),
+            local_identity,
+            skip_ports,
         }
-    }
-
-    pub fn with_skip_ports(mut self, skip_ports: Arc<IndexSet<u16>>) -> Self {
-        self.skip_ports = skip_ports;
-        self
-    }
-
-    pub fn layer(
-        tls: super::Conditional<T>,
-        skip_ports: Arc<IndexSet<u16>>,
-    ) -> impl tower::layer::Layer<A, Service = AcceptTls<A, T>>
-    where
-        T: Clone,
-    {
-        layer::mk(move |accept| {
-            AcceptTls::new(tls.clone(), accept).with_skip_ports(skip_ports.clone())
-        })
     }
 }
 
-impl<A, T> tower::Service<listen::Connection> for AcceptTls<A, T>
-where
-    A: Accept<Connection> + Clone,
-    T: HasConfig + Send + 'static,
-{
-    type Response = A::ConnectionFuture;
-    type Error = Error;
-    type Future = AcceptFuture<A>;
+#[async_trait::async_trait]
+impl<I: HasConfig + Send + Sync> detect::Detect<Addrs, TcpStream> for DetectTls<I> {
+    type Target = Meta;
+    type Io = BoxedIo;
+    type Error = io::Error;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.accept
-            .poll_ready(cx)
-            .map(|poll| poll.map_err(Into::into))
-    }
-
-    fn call(&mut self, (addrs, socket): listen::Connection) -> Self::Future {
-        // Protocol detection is disabled for the original port. Return a
-        // new connection without protocol detection.
-        let target_addr = addrs.target_addr();
-
-        match &self.tls {
-            // Tls is disabled. Return a new plaintext connection.
+    async fn detect(&self, addrs: Addrs, mut tcp: TcpStream) -> io::Result<(Meta, BoxedIo)> {
+        let local_id = match self.local_identity.as_ref() {
+            Conditional::Some(local_id) => local_id,
             Conditional::None(reason) => {
-                debug!(%reason, "skipping TLS");
                 let meta = Meta {
+                    peer_identity: Conditional::None(reason),
                     addrs,
-                    peer_identity: Conditional::None(*reason),
                 };
-                let conn = (meta, BoxedIo::new(socket));
-                AcceptFuture::accept(self.accept.accept(conn))
+                return Ok((meta, BoxedIo::new(tcp)));
+            }
+        };
+
+        let port = addrs.target_addr().port();
+        if self.skip_ports.contains(&port) {
+            debug!(%port, "Skipping TLS detection on port");
+            let meta = Meta {
+                peer_identity: Conditional::None(ReasonForNoPeerName::PortSkipped),
+                addrs,
+            };
+            return Ok((meta, BoxedIo::new(tcp)));
+        }
+
+        let no_tls_meta = move |addrs: Addrs| Meta {
+            peer_identity: Conditional::None(ReasonForNoPeerName::NoTlsFromRemote),
+            addrs,
+        };
+
+        // First, try to use MSG_PEEK to read the SNI from the TLS ClientHello.
+        // Because peeked data does not need to be retained, we use a static
+        // buffer to prevent needless heap allocation.
+        //
+        // Anecdotally, the ClientHello sent by Linkerd proxies is <300B. So a
+        // ~500B byte buffer is more than enough.
+        let mut buf = [0u8; 512];
+        let sz = tcp.peek(&mut buf).await?;
+        debug!(sz, "Peeked bytes from TCP stream");
+        match conditional_accept::match_client_hello(&buf, &local_id.tls_server_name()) {
+            conditional_accept::Match::Matched => {
+                trace!("Identified matching SNI via peek");
+                // Terminate the TLS stream.
+                let (peer_identity, tls) = handshake(local_id, tcp).await?;
+                let meta = Meta {
+                    peer_identity,
+                    addrs,
+                };
+                return Ok((meta, BoxedIo::new(tls)));
             }
 
-            // Tls is enabled. Try to accept a Tls handshake.
-            Conditional::Some(tls) => {
-                if self.skip_ports.contains(&target_addr.port()) {
-                    debug!("skipping protocol detection");
+            conditional_accept::Match::NotMatched => {
+                trace!("Not a matching TLS ClientHello");
+                return Ok((no_tls_meta(addrs), BoxedIo::new(tcp)));
+            }
+
+            conditional_accept::Match::Incomplete => {}
+        }
+
+        // Peeking didn't return enough data, so instead we'll allocate more
+        // capacity and try reading data from the socket.
+        debug!("Attempting to buffer TLS ClientHello after incomplete peek");
+        let mut buf = BytesMut::with_capacity(Self::PEEK_CAPACITY);
+        debug!(buf.capacity = %buf.capacity(), "Reading bytes from TCP stream");
+        while tcp.read_buf(&mut buf).await? != 0 {
+            debug!(buf.len = %buf.len(), "Read bytes from TCP stream");
+            match conditional_accept::match_client_hello(buf.as_ref(), &local_id.tls_server_name())
+            {
+                conditional_accept::Match::Matched => {
+                    trace!("Identified matching SNI via buffered read");
+                    // Terminate the TLS stream.
+                    let (peer_identity, tls) =
+                        handshake(local_id, PrefixedIo::new(buf.freeze(), tcp)).await?;
                     let meta = Meta {
-                        peer_identity: Conditional::None(
-                            super::ReasonForNoPeerName::NotHttp.into(),
-                        ),
+                        peer_identity,
                         addrs,
                     };
-                    let conn = (meta, BoxedIo::new(socket));
-                    AcceptFuture::accept(self.accept.accept(conn))
-                } else {
-                    debug!("attempting TLS handshake");
-                    let meta = AcceptMeta {
-                        accept: self.accept.clone(),
-                        addrs,
-                    };
-                    AcceptFuture::try_tls(TryTls {
-                        meta,
-                        socket,
-                        peek_buf: BytesMut::with_capacity(Self::PEEK_CAPACITY),
-                        config: tls.tls_server_config(),
-                        server_name: tls.tls_server_name(),
-                    })
+                    return Ok((meta, BoxedIo::new(tls)));
                 }
-            }
-        }
-    }
-}
 
-impl<A: Accept<Connection>> AcceptFuture<A> {
-    fn accept(f: A::Future) -> Self {
-        Self {
-            state: AcceptState::Accept(f),
-        }
-    }
+                conditional_accept::Match::NotMatched => break,
 
-    fn try_tls(try_tls: TryTls<A>) -> Self {
-        Self {
-            state: AcceptState::TryTls(Some(try_tls)),
-        }
-    }
-}
-
-impl<A: Accept<Connection>> Future for AcceptFuture<A> {
-    type Output = Result<A::ConnectionFuture, Error>;
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.project();
-        loop {
-            match this.state.as_mut().project() {
-                AcceptStateProj::Accept(future) => return future.poll(cx).map_err(Into::into),
-                AcceptStateProj::ReadyAccept(accept, conn) => {
-                    futures::ready!(accept.poll_ready(cx).map_err(Into::into))?;
-                    let conn = accept.accept(conn.take().expect("polled after complete"));
-                    this.state.set(AcceptState::Accept(conn))
-                }
-                AcceptStateProj::TryTls(ref mut try_tls) => {
-                    let match_ = futures::ready!(try_tls
-                        .as_mut()
-                        .expect("polled after complete")
-                        .poll_match_client_hello(cx))?;
-                    match match_ {
-                        conditional_accept::Match::Matched => {
-                            trace!("upgrading accepted connection to TLS");
-                            let TryTls {
-                                meta,
-                                socket,
-                                peek_buf,
-                                config,
-                                ..
-                            } = try_tls.take().expect("polled after complete");
-                            let io = PrefixedIo::new(peek_buf.freeze(), socket);
-                            this.state.set(AcceptState::TerminateTls(
-                                tokio_rustls::TlsAcceptor::from(config).accept(io),
-                                Some(meta),
-                            ));
-                        }
-
-                        conditional_accept::Match::NotMatched => {
-                            trace!("passing through accepted connection without TLS");
-                            let TryTls {
-                                peek_buf,
-                                socket,
-                                meta: AcceptMeta { accept, addrs },
-                                ..
-                            } = try_tls.take().expect("polled after complete");
-                            let meta = Meta {
-                                addrs,
-                                peer_identity: Conditional::None(
-                                    ReasonForNoPeerName::NotProvidedByRemote.into(),
-                                ),
-                            };
-                            let conn = (
-                                meta,
-                                BoxedIo::new(PrefixedIo::new(peek_buf.freeze(), socket)),
-                            );
-                            this.state.set(AcceptState::ReadyAccept(accept, Some(conn)))
-                        }
-
-                        conditional_accept::Match::Incomplete => {
-                            continue;
-                        }
+                conditional_accept::Match::Incomplete => {
+                    if buf.capacity() == 0 {
+                        // If we can't buffer an entire TLS ClientHello, it
+                        // almost definitely wasn't initiated by another proxy,
+                        // at least.
+                        warn!("Buffer insufficient for TLS ClientHello");
+                        break;
                     }
                 }
-                AcceptStateProj::TerminateTls(future, meta) => {
-                    let io = futures::ready!(future.poll(cx))?;
-                    let peer_identity =
-                        client_identity(&io)
-                            .map(Conditional::Some)
-                            .unwrap_or_else(|| {
-                                Conditional::None(super::ReasonForNoIdentity::NoPeerName(
-                                    super::ReasonForNoPeerName::NotProvidedByRemote,
-                                ))
-                            });
-                    trace!(peer.identity=?peer_identity, "accepted TLS connection");
-
-                    let AcceptMeta { accept, addrs } = meta.take().expect("polled after complete");
-                    // FIXME the connection doesn't know about TLS connections
-                    // that don't have a client id.
-                    let meta = Meta {
-                        addrs,
-                        peer_identity,
-                    };
-                    this.state.set(AcceptState::ReadyAccept(
-                        accept,
-                        Some((meta, BoxedIo::new(io))),
-                    ));
-                }
             }
         }
+
+        trace!("Could not read TLS ClientHello via buffering");
+        let io = BoxedIo::new(PrefixedIo::new(buf.freeze(), tcp));
+        Ok((no_tls_meta(addrs), io))
     }
 }
 
-impl<A: Accept<Connection>> TryTls<A> {
-    /// Polls the underlying socket for more data and buffers it.
-    ///
-    /// The buffer is matched for a Tls client hello message.
-    ///
-    /// `NotMatched` is returned if the underlying socket has closed.
-    fn poll_match_client_hello(
-        &mut self,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<conditional_accept::Match, Error>> {
-        use crate::io::AsyncRead;
+async fn handshake<L, T>(
+    local_id: &L,
+    io: T,
+) -> io::Result<(PeerIdentity, tokio_rustls::server::TlsStream<T>)>
+where
+    L: HasConfig,
+    T: io::AsyncRead + io::AsyncWrite + Unpin,
+{
+    let tls = tokio_rustls::TlsAcceptor::from(local_id.tls_server_config())
+        .accept(io)
+        .await?;
 
-        let sz = futures::ready!(Pin::new(&mut self.socket).poll_read_buf(cx, &mut self.peek_buf))?;
-        trace!(%sz, "read");
-        if sz == 0 {
-            // XXX: It is ambiguous whether this is the start of a Tls handshake or not.
-            // For now, resolve the ambiguity in favor of plaintext. TODO: revisit this
-            // when we add support for Tls policy.
-            return Poll::Ready(Ok(conditional_accept::Match::NotMatched.into()));
-        }
+    // Determine the peer's identity, if it exist.
+    let peer_id = client_identity(&tls)
+        .map(Conditional::Some)
+        .unwrap_or_else(|| Conditional::None(ReasonForNoPeerName::NoPeerIdFromRemote));
 
-        let buf = self.peek_buf.as_ref();
-        let m = conditional_accept::match_client_hello(buf, &self.server_name);
-        trace!(sni = %self.server_name, r#match = ?m, "conditional_accept");
-        Poll::Ready(Ok(m.into()))
-    }
+    trace!(peer.identity = ?peer_id, "Accepted TLS connection");
+    Ok((peer_id, tls))
 }
 
 fn client_identity<S>(tls: &tokio_rustls::server::TlsStream<S>) -> Option<identity::Name> {

--- a/linkerd/proxy/transport/tests/tls_accept.rs
+++ b/linkerd/proxy/transport/tests/tls_accept.rs
@@ -29,9 +29,9 @@ use tracing_futures::Instrument;
 #[test]
 fn plaintext() {
     let (client_result, server_result) = run_test(
-        Conditional::None(tls::ReasonForNoIdentity::Disabled),
+        Conditional::None(tls::ReasonForNoPeerName::LocalIdentityDisabled),
         |conn| write_then_read(conn, PING),
-        Conditional::None(tls::ReasonForNoIdentity::Disabled),
+        Conditional::None(tls::ReasonForNoPeerName::LocalIdentityDisabled),
         |(_, conn)| read_then_write(conn, PING.len(), PONG),
     );
     assert_eq!(client_result.is_tls(), false);


### PR DESCRIPTION
The `tls::accept` module can be simplified by moving to async/await.
This presents a few opportunities for improvement:

1. The recently-introduced `Detect` trait is used. This sets up further
   changes to the accept logic, decoupling protocol detection from the
   `Accept` stack/type.
2. The `tls::ReasonForNoIdentity` type has been removed, as it provided
   no value; and the `tls::ReasonForNoPeerName` has been updated with
   additional states.
3. We now avoid having to use `PrefixedIo` in most cases by using
   `TcpStream::peek` with a smaller buffer. The prior behavior is
   retained as a fallback in case peek doesn't return enough data.

This comes at the cost of ~2 additional Boxes per connection; but these
will probably be shaved off in a follow-up as the detection logic
becomes more flexible/dynamic.