### PR TITLE
http2: Use adaptive windows

### DIFF
--- a/linkerd/app/core/src/proxy/server.rs
+++ b/linkerd/app/core/src/proxy/server.rs
@@ -97,7 +97,8 @@ impl<F, H> Server<F, H> {
     pub fn new(forward_tcp: F, make_http: H, h2: H2Settings, drain: drain::Watch) -> Self {
         let mut http = hyper::server::conn::Http::new().with_executor(trace::Executor::new());
 
-        http.http2_initial_stream_window_size(h2.initial_stream_window_size)
+        http.http2_adaptive_window(true)
+            .http2_initial_stream_window_size(h2.initial_stream_window_size)
             .http2_initial_connection_window_size(h2.initial_connection_window_size);
 
         Self {

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -203,9 +203,6 @@ const DEFAULT_OUTBOUND_CONNECT_BACKOFF: ExponentialBackoff = ExponentialBackoff 
 const DEFAULT_DNS_CANONICALIZE_TIMEOUT: Duration = Duration::from_millis(100);
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 
-const DEFAULT_INITIAL_STREAM_WINDOW_SIZE: u32 = 65_535; // Protocol default
-const DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE: u32 = 1048576; // 1MB ~ 16 streams at capacity
-
 // 10_000 is arbitrarily chosen for now...
 const DEFAULT_BUFFER_CAPACITY: usize = 10_000;
 
@@ -339,12 +336,8 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let tap = parse_tap_config(strings, id_disabled);
 
     let h2_settings = h2::Settings {
-        initial_stream_window_size: Some(
-            initial_stream_window_size?.unwrap_or(DEFAULT_INITIAL_STREAM_WINDOW_SIZE),
-        ),
-        initial_connection_window_size: Some(
-            initial_connection_window_size?.unwrap_or(DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE),
-        ),
+        initial_stream_window_size: initial_stream_window_size?,
+        initial_connection_window_size: initial_connection_window_size?,
     };
 
     let buffer_capacity = buffer_capacity?.unwrap_or(DEFAULT_BUFFER_CAPACITY);


### PR DESCRIPTION
This change removes default window sizes and instead enables hyper's
adaptive window support by default. If environment settings are
provided, they override this default behavior, disabling adaptive
windows.