### PR TITLE
add feature-flagged support for multi-threaded Tokio runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1177,6 +1177,7 @@ dependencies = [
  "linkerd2-app",
  "linkerd2-signal",
  "mimalloc",
+ "num_cpus",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 
 [[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2490,7 @@ dependencies = [
  "memchr 2.3.3",
  "mio",
  "mio-uds",
+ "num_cpus",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,8 @@ FROM $RUST_IMAGE as build
 ARG PROXY_UNOPTIMIZED
 
 # Controls what features are enabled in the proxy. This is typically empty but
-# may be set to `mock-orig-dst` for profiling builds.
+# may be set to `mock-orig-dst` for profiling builds, or to `multithreaded` to
+# enable the multithreaded Tokio runtime.
 ARG PROXY_FEATURES
 
 RUN --mount=type=cache,target=/var/lib/apt/lists \

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -125,7 +125,7 @@ impl Config {
             .push_map_response(BoxedIo::new) // Ensures the transport propagates shutdown properly.
             // Limits the time we wait for a connection to be established.
             .push_timeout(self.proxy.connect.timeout)
-            .push(metrics.transport.layer_connect(TransportLabels))
+            // .push(metrics.transport.layer_connect(TransportLabels))
             .into_inner()
     }
 
@@ -198,8 +198,8 @@ impl Config {
         let http_target_observability = svc::layers()
             // Registers the stack to be tapped.
             .push(tap_layer)
-            // Records metrics for each `Target`.
-            .push(metrics.http_endpoint.into_layer::<classify::Response>())
+            // // Records metrics for each `Target`.
+            // .push(metrics.http_endpoint.into_layer::<classify::Response>())
             .push_on_response(TraceContextLayer::new(
                 span_sink
                     .clone()
@@ -210,8 +210,8 @@ impl Config {
             // Sets the route as a request extension so that it can be used
             // by tap.
             .push_http_insert_target()
-            // Records per-route metrics.
-            .push(metrics.http_route.into_layer::<classify::Response>())
+            // // Records per-route metrics.
+            // .push(metrics.http_route.into_layer::<classify::Response>())
             // Sets the per-route response classifier as a request
             // extension.
             .push(classify::Layer::new())
@@ -233,8 +233,7 @@ impl Config {
                         // fail requests.
                         .push_failfast(dispatch_timeout)
                         // Shares the service, ensuring discovery errors are propagated.
-                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
-                        .push(metrics.stack.layer(stack_labels("target"))),
+                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age), // .push(metrics.stack.layer(stack_labels("target"))),
                 ),
             )
             .spawn_buffer(buffer_capacity)
@@ -262,8 +261,7 @@ impl Config {
                         // fail requests.
                         .push_failfast(dispatch_timeout)
                         // Shares the service, ensuring discovery errors are propagated.
-                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
-                        .push(metrics.stack.layer(stack_labels("profile"))),
+                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age), // .push(metrics.stack.layer(stack_labels("profile"))),
                 ),
             )
             .spawn_buffer(buffer_capacity)
@@ -358,7 +356,7 @@ impl Config {
             // Eagerly fail requests when the proxy is out of capacity for a
             // dispatch_timeout.
             .push_failfast(dispatch_timeout)
-            .push(metrics.http_errors)
+            // .push(metrics.http_errors)
             // Synthesizes responses for proxy errors.
             .push(errors::layer());
 
@@ -392,7 +390,7 @@ impl Config {
                     .push(http_strip_headers)
                     .push(http_admit_request)
                     .push(http_server_observability)
-                    .push(metrics.stack.layer(stack_labels("source")))
+                    // .push(metrics.stack.layer(stack_labels("source")))
                     .box_http_request()
                     .box_http_response(),
             )
@@ -416,7 +414,7 @@ impl Config {
                 disable_protocol_detection_for_ports.clone(),
             )))
             .push(admit::AdmitLayer::new(require_identity_for_inbound_ports))
-            .push(metrics.transport.layer_accept(TransportLabels))
+            // .push(metrics.transport.layer_accept(TransportLabels))
             // Terminates inbound mTLS from other outbound proxies.
             .push(detect::AcceptLayer::new(tls::DetectTls::new(
                 local_identity,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -3,7 +3,7 @@
 //! The inbound proxy is responsible for terminating traffic from other network
 //! endpoints inbound to the local application.
 
-// #![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 
 pub use self::endpoint::{
     HttpEndpoint, Profile, ProfileTarget, RequestTarget, Target, TcpEndpoint,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -184,7 +184,7 @@ impl Config {
             ..
         } = self.clone();
 
-        // let prevent_loop = prevent_loop.into();
+        let prevent_loop = prevent_loop.into();
 
         // Creates HTTP clients for each inbound port & HTTP settings.
         let http_endpoint = svc::stack(tcp_connect)
@@ -281,16 +281,16 @@ impl Config {
             //     http_target_cache
             //         .push_on_response(svc::layers().box_http_response().box_http_request()),
             // )
-            // // If the traffic is targeted at the inbound port, send it through
-            // // the loopback service (i.e. as a gateway). This is done before
-            // // caching so that the loopback stack can determine whether it
-            // // should cache or not.
-            // .push(admit::AdmitLayer::new(prevent_loop))
-            // .push_fallback_on_error::<prevent_loop::LoopPrevented, _>(
-            //     svc::stack(http_loopback)
-            //         .push_on_response(svc::layers().box_http_request())
-            //         .into_inner(),
-            // )
+            // If the traffic is targeted at the inbound port, send it through
+            // the loopback service (i.e. as a gateway). This is done before
+            // caching so that the loopback stack can determine whether it
+            // should cache or not.
+            .push(admit::AdmitLayer::new(prevent_loop))
+            .push_fallback_on_error::<prevent_loop::LoopPrevented, _>(
+                svc::stack(http_loopback)
+                    .push_on_response(svc::layers().box_http_request())
+                    .into_inner(),
+            )
             .check_service::<Target>()
             .into_inner()
     }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -350,18 +350,18 @@ impl Config {
         //     .push(strip_header::request::layer(L5D_CLIENT_ID))
         //     .push(strip_header::response::layer(L5D_SERVER_ID));
 
-        // // Handles requests as they are initially received by the proxy.
-        // let http_admit_request = svc::layers()
-        //     // Downgrades the protocol if upgraded by an outbound proxy.
-        //     .push(svc::layer::mk(orig_proto::Downgrade::new))
-        //     // Limits the number of in-flight requests.
-        //     .push_concurrency_limit(max_in_flight_requests)
-        //     // Eagerly fail requests when the proxy is out of capacity for a
-        //     // dispatch_timeout.
-        //     .push_failfast(dispatch_timeout)
-        //     .push(metrics.http_errors)
-        //     // Synthesizes responses for proxy errors.
-        //     .push(errors::layer());
+        // Handles requests as they are initially received by the proxy.
+        let http_admit_request = svc::layers()
+            // Downgrades the protocol if upgraded by an outbound proxy.
+            // .push(svc::layer::mk(orig_proto::Downgrade::new))
+            // Limits the number of in-flight requests.
+            .push_concurrency_limit(max_in_flight_requests)
+            // Eagerly fail requests when the proxy is out of capacity for a
+            // dispatch_timeout.
+            // .push_failfast(dispatch_timeout)
+            // .push(metrics.http_errors)
+            // Synthesizes responses for proxy errors.
+            .push(errors::layer());
 
         // let http_server_observability = svc::layers()
         //     .push(TraceContextLayer::new(span_sink.map(|span_sink| {
@@ -390,7 +390,7 @@ impl Config {
             .push_on_response(
                 svc::layers()
                     // .push(http_strip_headers)
-                    // .push(http_admit_request)
+                    .push(http_admit_request)
                     // .push(http_server_observability)
                     .push(metrics.stack.layer(stack_labels("source")))
                     .box_http_request()

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -363,12 +363,12 @@ impl Config {
             // Synthesizes responses for proxy errors.
             .push(errors::layer());
 
-        // let http_server_observability = svc::layers()
-        //     .push(TraceContextLayer::new(span_sink.map(|span_sink| {
-        //         SpanConverter::server(span_sink, trace_labels())
-        //     })))
-        //     // Tracks proxy handletime.
-        //     .push(metrics.http_handle_time.layer());
+        let http_server_observability = svc::layers()
+            // .push(TraceContextLayer::new(span_sink.map(|span_sink| {
+            //     SpanConverter::server(span_sink, trace_labels())
+            // })))
+            // Tracks proxy handletime.
+            .push(metrics.http_handle_time.layer());
 
         let http_server = svc::stack(http_router)
             // // Ensures that the built service is ready before it is returned
@@ -391,7 +391,7 @@ impl Config {
                 svc::layers()
                     // .push(http_strip_headers)
                     .push(http_admit_request)
-                    // .push(http_server_observability)
+                    .push(http_server_observability)
                     .push(metrics.stack.layer(stack_labels("source")))
                     .box_http_request()
                     .box_http_response(),

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -125,7 +125,7 @@ impl Config {
             .push_map_response(BoxedIo::new) // Ensures the transport propagates shutdown properly.
             // Limits the time we wait for a connection to be established.
             .push_timeout(self.proxy.connect.timeout)
-            // .push(metrics.transport.layer_connect(TransportLabels))
+            .push(metrics.transport.layer_connect(TransportLabels))
             .into_inner()
     }
 
@@ -198,8 +198,8 @@ impl Config {
         let http_target_observability = svc::layers()
             // Registers the stack to be tapped.
             .push(tap_layer)
-            // // Records metrics for each `Target`.
-            // .push(metrics.http_endpoint.into_layer::<classify::Response>())
+            // Records metrics for each `Target`.
+            .push(metrics.http_endpoint.into_layer::<classify::Response>())
             .push_on_response(TraceContextLayer::new(
                 span_sink
                     .clone()
@@ -210,8 +210,8 @@ impl Config {
             // Sets the route as a request extension so that it can be used
             // by tap.
             .push_http_insert_target()
-            // // Records per-route metrics.
-            // .push(metrics.http_route.into_layer::<classify::Response>())
+            // Records per-route metrics.
+            .push(metrics.http_route.into_layer::<classify::Response>())
             // Sets the per-route response classifier as a request
             // extension.
             .push(classify::Layer::new())
@@ -233,7 +233,8 @@ impl Config {
                         // fail requests.
                         .push_failfast(dispatch_timeout)
                         // Shares the service, ensuring discovery errors are propagated.
-                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age), // .push(metrics.stack.layer(stack_labels("target"))),
+                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
+                        .push(metrics.stack.layer(stack_labels("target"))),
                 ),
             )
             .spawn_buffer(buffer_capacity)
@@ -261,7 +262,8 @@ impl Config {
                         // fail requests.
                         .push_failfast(dispatch_timeout)
                         // Shares the service, ensuring discovery errors are propagated.
-                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age), // .push(metrics.stack.layer(stack_labels("profile"))),
+                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
+                        .push(metrics.stack.layer(stack_labels("profile"))),
                 ),
             )
             .spawn_buffer(buffer_capacity)
@@ -356,7 +358,7 @@ impl Config {
             // Eagerly fail requests when the proxy is out of capacity for a
             // dispatch_timeout.
             .push_failfast(dispatch_timeout)
-            // .push(metrics.http_errors)
+            .push(metrics.http_errors)
             // Synthesizes responses for proxy errors.
             .push(errors::layer());
 
@@ -390,7 +392,7 @@ impl Config {
                     .push(http_strip_headers)
                     .push(http_admit_request)
                     .push(http_server_observability)
-                    // .push(metrics.stack.layer(stack_labels("source")))
+                    .push(metrics.stack.layer(stack_labels("source")))
                     .box_http_request()
                     .box_http_response(),
             )
@@ -414,7 +416,7 @@ impl Config {
                 disable_protocol_detection_for_ports.clone(),
             )))
             .push(admit::AdmitLayer::new(require_identity_for_inbound_ports))
-            // .push(metrics.transport.layer_accept(TransportLabels))
+            .push(metrics.transport.layer_accept(TransportLabels))
             // Terminates inbound mTLS from other outbound proxies.
             .push(detect::AcceptLayer::new(tls::DetectTls::new(
                 local_identity,

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -82,7 +82,7 @@ impl Config {
             .push(tls::client::ConnectLayer::new(local_identity))
             // Limits the time we wait for a connection to be established.
             .push_timeout(self.proxy.connect.timeout)
-            .push(metrics.transport.layer_connect(TransportLabels))
+            // .push(metrics.transport.layer_connect(TransportLabels))
             .into_inner()
     }
 
@@ -113,8 +113,7 @@ impl Config {
                         .push_spawn_buffer_with_idle_timeout(
                             self.proxy.buffer_capacity,
                             self.proxy.cache_max_idle_age,
-                        )
-                        .push(metrics.layer(stack_labels("refine"))),
+                        ), // .push(metrics.layer(stack_labels("refine"))),
                 ),
             )
             .spawn_buffer(self.proxy.buffer_capacity)
@@ -160,7 +159,7 @@ impl Config {
         // export.
         let observability = svc::layers()
             .push(tap_layer.clone())
-            .push(metrics.http_endpoint.into_layer::<classify::Response>())
+            // .push(metrics.http_endpoint.into_layer::<classify::Response>())
             .push_on_response(TraceContextLayer::new(
                 span_sink
                     .clone()
@@ -275,7 +274,7 @@ impl Config {
             .check_make_service::<Target<HttpEndpoint>, http::Request<http::boxed::Payload>>()
             .push_on_response(
                 svc::layers()
-                    .push(metrics.stack.layer(stack_labels("balance.endpoint")))
+                    // .push(metrics.stack.layer(stack_labels("balance.endpoint")))
                     .box_http_request(),
             )
             .push_spawn_ready()
@@ -290,8 +289,7 @@ impl Config {
                         // requests.
                         .push_failfast(dispatch_timeout)
                         // Shares the balancer, ensuring discovery errors are propagated.
-                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
-                        .push(metrics.stack.layer(stack_labels("balance"))),
+                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age), // .push(metrics.stack.layer(stack_labels("balance"))),
                 ),
             )
             .spawn_buffer(buffer_capacity)
@@ -314,7 +312,7 @@ impl Config {
                             // Shares the balancer, ensuring discovery errors are propagated.
                             .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
                             .box_http_request()
-                            .push(metrics.stack.layer(stack_labels("forward.endpoint"))),
+                            // .push(metrics.stack.layer(stack_labels("forward.endpoint"))),
                     ),
             )
             .spawn_buffer(buffer_capacity)
@@ -344,15 +342,15 @@ impl Config {
 
         let http_profile_route_proxy = svc::proxies()
             .check_new_clone_service::<dst::Route>()
-            .push(metrics.http_route_actual.into_layer::<classify::Response>())
+            // .push(metrics.http_route_actual.into_layer::<classify::Response>())
             // Sets an optional retry policy.
             .push(retry::layer(metrics.http_route_retry))
             .check_new_clone_service::<dst::Route>()
             // Sets an optional request timeout.
             .push(http::MakeTimeoutLayer::default())
             .check_new_clone_service::<dst::Route>()
-            // Records per-route metrics.
-            .push(metrics.http_route.into_layer::<classify::Response>())
+            // // Records per-route metrics.
+            // .push(metrics.http_route.into_layer::<classify::Response>())
             .check_new_clone_service::<dst::Route>()
             // Sets the per-route response classifier as a request
             // extension.
@@ -389,8 +387,7 @@ impl Config {
                         // fail requests.
                         .push_failfast(dispatch_timeout)
                         // Shares the service, ensuring discovery errors are propagated.
-                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
-                        .push(metrics.stack.layer(stack_labels("profile"))),
+                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age), // .push(metrics.stack.layer(stack_labels("profile"))),
                 ),
             )
             .spawn_buffer(buffer_capacity)
@@ -520,7 +517,7 @@ impl Config {
             .push_on_response(
                  svc::layers()
                     .push(http_admit_request)
-                    .push(metrics.stack.layer(stack_labels("source")))
+                    // .push(metrics.stack.layer(stack_labels("source")))
                     .box_http_request()
                     .box_http_response()
             )
@@ -545,7 +542,7 @@ impl Config {
             .push(detect::AcceptLayer::new(DetectHttp::new(
                 disable_protocol_detection_for_ports.clone(),
             )))
-            .push(metrics.transport.layer_accept(TransportLabels))
+            // .push(metrics.transport.layer_accept(TransportLabels))
             // The local application never establishes mTLS with the proxy, so don't try to
             // terminate TLS, just annotate with the connection with the reason.
             .push(detect::AcceptLayer::new(tls::DetectTls::new(

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -3,7 +3,7 @@
 //! The outound proxy is responsible for routing traffic from the local
 //! application to external network endpoints.
 
-// #![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 
 pub use self::endpoint::{
     Concrete, HttpEndpoint, Logical, LogicalPerRequest, Profile, ProfilePerTarget, Target,

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -342,96 +342,88 @@ impl Config {
             )
             .check_service::<Concrete<HttpEndpoint>>();
 
-        // let http_profile_route_proxy = svc::proxies()
-        //     .check_new_clone_service::<dst::Route>()
-        //     .push(metrics.http_route_actual.into_layer::<classify::Response>())
-        //     // Sets an optional retry policy.
-        //     .push(retry::layer(metrics.http_route_retry))
-        //     .check_new_clone_service::<dst::Route>()
-        //     // Sets an optional request timeout.
-        //     .push(http::MakeTimeoutLayer::default())
-        //     .check_new_clone_service::<dst::Route>()
-        //     // Records per-route metrics.
-        //     .push(metrics.http_route.into_layer::<classify::Response>())
-        //     .check_new_clone_service::<dst::Route>()
-        //     // Sets the per-route response classifier as a request
-        //     // extension.
-        //     .push(classify::Layer::new())
-        //     .check_new_clone_service::<dst::Route>();
+        let http_profile_route_proxy = svc::proxies()
+            .check_new_clone_service::<dst::Route>()
+            .push(metrics.http_route_actual.into_layer::<classify::Response>())
+            // Sets an optional retry policy.
+            .push(retry::layer(metrics.http_route_retry))
+            .check_new_clone_service::<dst::Route>()
+            // Sets an optional request timeout.
+            .push(http::MakeTimeoutLayer::default())
+            .check_new_clone_service::<dst::Route>()
+            // Records per-route metrics.
+            .push(metrics.http_route.into_layer::<classify::Response>())
+            .check_new_clone_service::<dst::Route>()
+            // Sets the per-route response classifier as a request
+            // extension.
+            .push(classify::Layer::new())
+            .check_new_clone_service::<dst::Route>();
 
-        // // Routes `Logical` targets to a cached `Profile` stack, i.e. so that profile
-        // // resolutions are shared even as the type of request may vary.
-        // let http_logical_profile_cache = http_concrete
-        //     .clone()
-        //     .push_on_response(svc::layers().box_http_request())
-        //     .check_service::<Concrete<HttpEndpoint>>()
-        //     // Provides route configuration. The profile service operates
-        //     // over `Concret` services. When overrides are in play, the
-        //     // Concrete destination may be overridden.
-        //     .push(profiles::Layer::with_overrides(
-        //         profiles_client,
-        //         http_profile_route_proxy.into_inner(),
-        //     ))
-        //     .check_make_service::<Profile, Concrete<HttpEndpoint>>()
-        //     // Use the `Logical` target as a `Concrete` target. It may be
-        //     // overridden by the profile layer.
-        //     .push_on_response(
-        //         svc::layers().push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
-        //             addr: inner.addr.clone(),
-        //             inner,
-        //         }),
-        //     )
-        //     .into_new_service()
-        //     .cache(
-        //         svc::layers().push_on_response(
-        //             svc::layers()
-        //                 // If the service has been unavailable for an extended time, eagerly
-        //                 // fail requests.
-        //                 .push_failfast(dispatch_timeout)
-        //                 // Shares the service, ensuring discovery errors are propagated.
-        //                 .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
-        //                 .push(metrics.stack.layer(stack_labels("profile"))),
-        //         ),
-        //     )
-        //     .spawn_buffer(buffer_capacity)
-        //     .instrument(|_: &Profile| info_span!("profile"))
-        //     .check_make_service::<Profile, Logical<HttpEndpoint>>()
-        //     .push(router::Layer::new(|()| ProfilePerTarget))
-        //     .check_new_service_routes::<(), Logical<HttpEndpoint>>()
-        //     .new_service(());
+        // Routes `Logical` targets to a cached `Profile` stack, i.e. so that profile
+        // resolutions are shared even as the type of request may vary.
+        let http_logical_profile_cache = http_concrete
+            .clone()
+            .push_on_response(svc::layers().box_http_request())
+            .check_service::<Concrete<HttpEndpoint>>()
+            // Provides route configuration. The profile service operates
+            // over `Concret` services. When overrides are in play, the
+            // Concrete destination may be overridden.
+            .push(profiles::Layer::with_overrides(
+                profiles_client,
+                http_profile_route_proxy.into_inner(),
+            ))
+            .check_make_service::<Profile, Concrete<HttpEndpoint>>()
+            // Use the `Logical` target as a `Concrete` target. It may be
+            // overridden by the profile layer.
+            .push_on_response(
+                svc::layers().push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
+                    addr: inner.addr.clone(),
+                    inner,
+                }),
+            )
+            .into_new_service()
+            .cache(
+                svc::layers().push_on_response(
+                    svc::layers()
+                        // If the service has been unavailable for an extended time, eagerly
+                        // fail requests.
+                        .push_failfast(dispatch_timeout)
+                        // Shares the service, ensuring discovery errors are propagated.
+                        .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
+                        .push(metrics.stack.layer(stack_labels("profile"))),
+                ),
+            )
+            .spawn_buffer(buffer_capacity)
+            .instrument(|_: &Profile| info_span!("profile"))
+            .check_make_service::<Profile, Logical<HttpEndpoint>>()
+            .push(router::Layer::new(|()| ProfilePerTarget))
+            .check_new_service_routes::<(), Logical<HttpEndpoint>>()
+            .new_service(());
 
         // Routes requests to their logical target.
-        svc::stack(http_concrete)
-            .push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
-                addr: inner.addr.clone(),
-                inner,
-            })
-            .push_on_response(svc::layers().box_http_response().box_http_request())
-            .check_service::<Logical<HttpEndpoint>>()
-            // .into_inner()
-            // svc::stack(http_logical_profile_cache)
+        svc::stack(http_logical_profile_cache)
             .check_service::<Logical<HttpEndpoint>>()
             .push_on_response(svc::layers().box_http_response())
             .push_make_ready()
-            //     .push_fallback_with_predicate(
-            //         http_concrete
-            //             .push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
-            //                 addr: inner.addr.clone(),
-            //                 inner,
-            //             })
-            //             .push_on_response(svc::layers().box_http_response().box_http_request())
-            //             .check_service::<Logical<HttpEndpoint>>()
-            //             .into_inner(),
-            //         is_discovery_rejected,
-            //     )
+            .push_fallback_with_predicate(
+                http_concrete
+                    .push_map_target(|inner: Logical<HttpEndpoint>| Concrete {
+                        addr: inner.addr.clone(),
+                        inner,
+                    })
+                    .push_on_response(svc::layers().box_http_response().box_http_request())
+                    .check_service::<Logical<HttpEndpoint>>()
+                    .into_inner(),
+                is_discovery_rejected,
+            )
             .check_service::<Logical<HttpEndpoint>>()
-            // .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
-            // .push_on_response(
-            //     // Strips headers that may be set by this proxy.
-            //     svc::layers()
-            //         .push(http::strip_header::request::layer(L5D_CLIENT_ID))
-            //         .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
-            // )
+            .push(http::header_from_target::layer(CANONICAL_DST_HEADER))
+            .push_on_response(
+                // Strips headers that may be set by this proxy.
+                svc::layers()
+                    .push(http::strip_header::request::layer(L5D_CLIENT_ID))
+                    .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER)),
+            )
             // Sets the canonical-dst header on all outbound requests.
             .check_service::<Logical<HttpEndpoint>>()
             .instrument(|logical: &Logical<_>| info_span!("logical", addr = %logical.addr))
@@ -498,18 +490,18 @@ impl Config {
             .push(svc::layer::mk(tcp::Forward::new));
 
         let http_admit_request = svc::layers()
-            // // Limits the number of in-flight requests.
-            // .push_concurrency_limit(max_in_flight_requests)
-            // // Eagerly fail requests when the proxy is out of capacity for a
-            // // dispatch_timeout.
-            // .push_failfast(dispatch_timeout)
-            // .push(metrics.http_errors.clone())
-            // // Synthesizes responses for proxy errors.
-            // .push(errors::layer())
-            // // Initiates OpenCensus tracing.
-            // .push(TraceContextLayer::new(span_sink.clone().map(|span_sink| {
-            //     SpanConverter::server(span_sink, trace_labels())
-            // })))
+            // Limits the number of in-flight requests.
+            .push_concurrency_limit(max_in_flight_requests)
+            // Eagerly fail requests when the proxy is out of capacity for a
+            // dispatch_timeout.
+            .push_failfast(dispatch_timeout)
+            .push(metrics.http_errors.clone())
+            // Synthesizes responses for proxy errors.
+            .push(errors::layer())
+            // Initiates OpenCensus tracing.
+            .push(TraceContextLayer::new(span_sink.clone().map(|span_sink| {
+                SpanConverter::server(span_sink, trace_labels())
+            })))
             // // Tracks proxy handletime.
             // .push(metrics.clone().http_handle_time.layer())
             ;
@@ -523,8 +515,8 @@ impl Config {
             .push_timeout(dispatch_timeout)
             .push(router::Layer::new(LogicalPerRequest::from))
             .check_new_service::<tls::accept::Meta>()
-            // // Used by tap.
-            // .push_http_insert_target()
+            // Used by tap.
+            .push_http_insert_target()
             .push_on_response(
                  svc::layers()
                     .push(http_admit_request)

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -14,5 +14,5 @@ futures = { version = "0.3", features = ["compat"] }
 mimalloc = { version = "0.1.19", optional = true }
 linkerd2-app = { path = "../linkerd/app" }
 linkerd2-signal = { path = "../linkerd/signal" }
-tokio = { version = "0.2", features = ["rt-core"] }
+tokio = { version = "0.2", features = ["rt-threaded"] }
 tracing = "0.1"

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -8,11 +8,13 @@ description = "The main proxy executable"
 
 [features]
 mock-orig-dst  = ["linkerd2-app/mock-orig-dst"]
+multicore = ["tokio/rt-threaded", "num_cpus"]
 
 [dependencies]
 futures = { version = "0.3", features = ["compat"] }
 mimalloc = { version = "0.1.19", optional = true }
+num_cpus = { version = "1", optional = true }
 linkerd2-app = { path = "../linkerd/app" }
 linkerd2-signal = { path = "../linkerd/signal" }
-tokio = { version = "0.2", features = ["rt-threaded"] }
+tokio = { version = "0.2", features = ["rt-core", "time", "io-driver"] }
 tracing = "0.1"

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -12,8 +12,9 @@ pub use tracing::{debug, error, info, warn};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[tokio::main(threaded_scheduler)]
-async fn main() {
+mod rt;
+
+fn main() {
     let trace = trace::init();
 
     // Load configuration from the environment without binding ports.
@@ -26,51 +27,55 @@ async fn main() {
         }
     };
 
-    let app = match async move { config.build(trace?).await }.await {
-        Ok(app) => app,
-        Err(e) => {
-            eprintln!("Initialization failure: {}", e);
-            std::process::exit(1);
+    rt::build().block_on(async move {
+        let app = match async move { config.build(trace?).await }.await {
+            Ok(app) => app,
+            Err(e) => {
+                eprintln!("Initialization failure: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+        info!("Admin interface on {}", app.admin_addr());
+        info!("Inbound interface on {}", app.inbound_addr());
+        info!("Outbound interface on {}", app.outbound_addr());
+
+        match app.tap_addr() {
+            None => info!("Tap DISABLED"),
+            Some(addr) => info!("Tap interface on {}", addr),
         }
-    };
 
-    info!("Admin interface on {}", app.admin_addr());
-    info!("Inbound interface on {}", app.inbound_addr());
-    info!("Outbound interface on {}", app.outbound_addr());
-
-    match app.tap_addr() {
-        None => info!("Tap DISABLED"),
-        Some(addr) => info!("Tap interface on {}", addr),
-    }
-
-    match app.local_identity() {
-        None => warn!("Identity is DISABLED"),
-        Some(identity) => {
-            info!("Local identity is {}", identity.name());
-            let addr = app.identity_addr().expect("must have identity addr");
-            match addr.identity.value() {
-                None => info!("Identity verified via {}", addr.addr),
-                Some(identity) => {
-                    info!("Identity verified via {} ({})", addr.addr, identity);
+        match app.local_identity() {
+            None => warn!("Identity is DISABLED"),
+            Some(identity) => {
+                info!("Local identity is {}", identity.name());
+                let addr = app.identity_addr().expect("must have identity addr");
+                match addr.identity.value() {
+                    None => info!("Identity verified via {}", addr.addr),
+                    Some(identity) => {
+                        info!("Identity verified via {} ({})", addr.addr, identity);
+                    }
                 }
             }
         }
-    }
 
-    let dst_addr = app.dst_addr();
-    match dst_addr.identity.value() {
-        None => info!("Destinations resolved via {}", dst_addr.addr),
-        Some(identity) => info!("Destinations resolved via {} ({})", dst_addr.addr, identity),
-    }
-
-    if let Some(oc) = app.opencensus_addr() {
-        match oc.identity.value() {
-            None => info!("OpenCensus tracing collector at {}", oc.addr),
-            Some(identity) => info!("OpenCensus tracing collector at {} ({})", oc.addr, identity),
+        let dst_addr = app.dst_addr();
+        match dst_addr.identity.value() {
+            None => info!("Destinations resolved via {}", dst_addr.addr),
+            Some(identity) => info!("Destinations resolved via {} ({})", dst_addr.addr, identity),
         }
-    }
 
-    let drain = app.spawn();
-    signal::shutdown().await;
-    drain.drain().await;
+        if let Some(oc) = app.opencensus_addr() {
+            match oc.identity.value() {
+                None => info!("OpenCensus tracing collector at {}", oc.addr),
+                Some(identity) => {
+                    info!("OpenCensus tracing collector at {} ({})", oc.addr, identity)
+                }
+            }
+        }
+
+        let drain = app.spawn();
+        signal::shutdown().await;
+        drain.drain().await;
+    });
 }

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -12,7 +12,7 @@ pub use tracing::{debug, error, info, warn};
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[tokio::main(basic_scheduler)]
+#[tokio::main(threaded_scheduler)]
 async fn main() {
     let trace = trace::init();
 

--- a/linkerd2-proxy/src/rt.rs
+++ b/linkerd2-proxy/src/rt.rs
@@ -1,0 +1,31 @@
+use tokio::runtime::{self, Runtime};
+
+#[cfg(feature = "multicore")]
+pub(crate) fn build() -> Runtime {
+    let builder = runtime::Builder::new()
+        .enable_all()
+        .thread_name("linkerd2-proxy-worker");
+    let num_cpus = num_cpus::get();
+    if num_cpus > 2 {
+        builder
+            .threaded_scheduler()
+            .core_threads(num_cpus - 1) // Save 1 core for the admin runtime.
+            .build()
+            .expect("failed to build multithreaded runtime!")
+    } else {
+        builder
+            .basic_scheduler()
+            .build()
+            .expect("failed to build single-threaded runtime!")
+    }
+}
+
+#[cfg(not(feature = "multicore"))]
+pub(crate) fn build() -> Runtime {
+    runtime::Builder::new()
+        .enable_all()
+        .thread_name("linkerd2-proxy-worker")
+        .basic_scheduler()
+        .build()
+        .expect("failed to build single-threaded runtime!")
+}


### PR DESCRIPTION
This branch enables feature-flagged support for using Tokio's
multithreaded runtime when the proxy is given more than two CPU cores to
run on. The proxy's understanding of the system's number of CPUs
reflects cgroups limits, so docker CPU limits are taken into
consideration. 

The multithreaded runtime offers significantly better performance under
load when multiple CPU cores are available. Here's benchmark results
from a run on my 24-thread Ryzen 3900X system, where the proxy, the load
generator, and the test server were all given 8 cores:

```
eliza on noctis in ~
:; nproc --all
24
``` 
![Screenshot_20200730_162805](https://user-images.githubusercontent.com/2796466/88987330-6df03500-d28a-11ea-958a-b13047ee4e48.png)


Note that the locking in multiple metrics layers doesn't really seem
to have a big impact, as shown by the run with metrics disabled. There 
might be some improvement in high tails from further optimizations to
the metrics code, though.

If only a single core is available to run a worker on, we will construct
Tokio's `basic_scheduler`, rather than a `threaded_scheduler` with a
single worker thread. This is because there is some overhead introduced
by the threaded scheduler, which results in worse performance when only
1 core is available:

![Screenshot_20200730_152202](https://user-images.githubusercontent.com/2796466/88987345-75174300-d28a-11ea-968f-1bf56c692983.png)


I'd like to fix this upstream in Tokio, by having `Runtime::new()` and 
the macros intelligently select the basic scheduler when only 1 core 
is available, but this works for now.

Finally, a bug in the handle time metrics layer results in a deadlock
when used with the multithreaded runtime. Therefore, I've disabled this
metric for now --- my understanding is that nothing consumes it at the
moment. If it's needed, we can fix the bug and put it back.