### PR TITLE
Add `multicore` to default features

### DIFF
--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 description = "The main proxy executable"
 
 [features]
+default = ["multicore"]
 mock-orig-dst  = ["linkerd2-app/mock-orig-dst"]
 multicore = ["tokio/rt-threaded", "num_cpus"]
 

--- a/linkerd2-proxy/src/rt.rs
+++ b/linkerd2-proxy/src/rt.rs
@@ -18,6 +18,7 @@ pub(crate) fn build() -> Runtime {
             .thread_name("proxy")
             .threaded_scheduler()
             .core_threads(num_cpus)
+            .max_threads(num_cpus)
             .build()
             .expect("failed to build threaded runtime!"),
     }
@@ -30,5 +31,5 @@ pub(crate) fn build() -> Runtime {
         .thread_name("proxy")
         .basic_scheduler()
         .build()
-        .expect("failed to build threaded runtime!")
+        .expect("failed to build basic runtime!")
 }

--- a/linkerd2-proxy/src/rt.rs
+++ b/linkerd2-proxy/src/rt.rs
@@ -1,31 +1,34 @@
-use tokio::runtime::{self, Runtime};
+use tokio::runtime::{Builder, Runtime};
 
 #[cfg(feature = "multicore")]
 pub(crate) fn build() -> Runtime {
-    let builder = runtime::Builder::new()
-        .enable_all()
-        .thread_name("linkerd2-proxy-worker");
-    let num_cpus = num_cpus::get();
-    if num_cpus > 2 {
-        builder
-            .threaded_scheduler()
-            .core_threads(num_cpus - 1) // Save 1 core for the admin runtime.
-            .build()
-            .expect("failed to build multithreaded runtime!")
-    } else {
-        builder
+    // The proxy creates an additional admin thread, but it would be wasteful to allocate a whole
+    // core to it; so we let the main runtime consume all cores the process has. The basic scheduler
+    // is used when the threaded scheduler would provide no benefit.
+    match num_cpus::get() {
+        // `0` is unexpected, but it's a wild world out there.
+        0 | 1 => Builder::new()
+            .enable_all()
+            .thread_name("proxy")
             .basic_scheduler()
             .build()
-            .expect("failed to build single-threaded runtime!")
+            .expect("failed to build basic runtime!"),
+        num_cpus => Builder::new()
+            .enable_all()
+            .thread_name("proxy")
+            .threaded_scheduler()
+            .core_threads(num_cpus)
+            .build()
+            .expect("failed to build threaded runtime!"),
     }
 }
 
 #[cfg(not(feature = "multicore"))]
 pub(crate) fn build() -> Runtime {
-    runtime::Builder::new()
+    Builder::new()
         .enable_all()
-        .thread_name("linkerd2-proxy-worker")
+        .thread_name("proxy")
         .basic_scheduler()
         .build()
-        .expect("failed to build single-threaded runtime!")
+        .expect("failed to build threaded runtime!")
 }


### PR DESCRIPTION
We don't have any blockers to using the threaded runtime by default.
This change adds the `multicore` feature flag to the default feature
list.

It also modifies the threaded runtime initialization to use all
available cores.

The thread names have been changed from `linkerd2-proxy-worker` to just
`proxy`, which is more consistent with the `admin` thread name. This
should be unambiguous in the context of the process.