### PR TITLE
rt: don't reserve a core for the admin runtime admin 

### DIFF
--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -299,7 +299,7 @@ impl App {
         debug!("spawning daemon thread");
         tokio::spawn(future::pending().map(|()| drop(admin_shutdown_tx)));
         std::thread::Builder::new()
-            .name("admin".into())
+            .name("linkerd2-proxy-admin".into())
             .spawn(move || {
                 let mut rt = tokio::runtime::Builder::new()
                     .basic_scheduler()

--- a/linkerd2-proxy/src/rt.rs
+++ b/linkerd2-proxy/src/rt.rs
@@ -6,10 +6,10 @@ pub(crate) fn build() -> Runtime {
         .enable_all()
         .thread_name("linkerd2-proxy-worker");
     let num_cpus = num_cpus::get();
-    if num_cpus > 2 {
+    if num_cpus > 1 {
         builder
             .threaded_scheduler()
-            .core_threads(num_cpus - 1) // Save 1 core for the admin runtime.
+            .core_threads(num_cpus)
             .build()
             .expect("failed to build multithreaded runtime!")
     } else {


### PR DESCRIPTION
As per @olix0r in https://github.com/linkerd/linkerd2-proxy/pull/611#discussion_r463409810:
> I don't think we should dedicate an entire core to the admin thread...
> That's *a lot* of resources for something we shouldn't be doing much
> work on. The real goal of the separate admin runtime is to ensure we
> can still interact with the proxy if, for instance, the main runtime
> isn't healthy. I think we're best off keeping it simple and treating
> it as if the admin thread needs no dedicated resources.

The admin runtime only performs observability work & certifies
identitities, so its load should be pretty light, and it doesn't need to
be actively using a CPU core all the time. The purpose of having a
separate admin runtime  is to continue allowing access to observability
functions even if the rest of the proxy gets into a bad state, *not* to
take load off the main forwarding runtime; the admin thread no longer
performs service discovery lookups (and I think it hasn't for a while).

This branch changes the `rt::build` function in `linkerd2-proxy` so
that, when the multithreaded Tokio runtime feature is enabled, we give
the main forwarding runtime a thread for every available CPU core,
rather than every core minus one. Furthermore, if the feature flag is
enabled, we will now use the multithreaded Tokio scheduler if the 
number of available CPUs is two or more, rather than three or more, 
since we are no longer reserving a thread for the admin runtime.

In order to ensure that the admin runtime is out of the forwarding
path (so that multiple worker threads don't result in a corresponding
increase in admin load), I've moved the DNS resolver background task to
the main runtime. As a potential follow-up, we might want to simplify
the DNS code so that we just spawn resolution tasks directly, rather
than having a DNS daemon task. `trust-dns` no longer requires a 
background task, so its purpose was just to ensure that DNS resolutions
were spawned on the admin thread. 