### PR TITLE
trace: roll `tracing` and `tracing-subscriber` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2706,9 +2706,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41f40ed0e162c911ac6fcb53ecdc8134c46905fdbbae8c50add462a538b495f"
+checksum = "f0aae59226cf195d8e74d4b34beae1859257efb4e5fed3f147d2dc2c7d372178"
 dependencies = [
  "cfg-if",
  "log",
@@ -2718,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99bbad0de3fd923c9c3232ead88510b783e5a4d16a6154adffa3d53308de984c"
+checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.2",
@@ -2729,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
+checksum = "b2734b5a028fa697686f16c6d18c2c6a3c7e41513f9a213abb6754c4acb3c8d7"
 dependencies = [
  "lazy_static",
 ]
@@ -2769,9 +2769,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafe899b943f5433c6cab468d75a17ea92948fe9fe60b00f41e13d5e0d4fd054"
+checksum = "f7b33f8b2ef2ab0c3778c12646d9c42a24f7772bee4cdafc72199644a9f58fdc"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2733,7 +2733,6 @@ name = "tracing"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0aae59226cf195d8e74d4b34beae1859257efb4e5fed3f147d2dc2c7d372178"
-
 dependencies = [
  "cfg-if",
  "log",

--- a/linkerd/admit/Cargo.toml
+++ b/linkerd/admit/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 futures = "0.3"
 linkerd2-error = { path = "../error" }
 tower = { version = "0.3", default-features = false, features = ["util"] }
-tracing = "0.1"
+tracing = "0.1.18"

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -28,7 +28,7 @@ regex = "1.0.0"
 tokio = { version = "0.2", features = ["rt-util"] }
 tonic = { version = "0.2", default-features = false, features = ["prost"] }
 tower = "0.3"
-tracing = "0.1.9"
+tracing = "0.1.18"
 tracing-futures = { version = "0.2", features = ["std-future"]}
 
 [dev-dependencies]

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -67,7 +67,7 @@ tokio = { version = "0.2", features = ["macros", "sync", "parking_lot"]}
 tokio-timer = "0.2"
 tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 tonic = { version = "0.2", default-features = false, features = ["prost"] }
-tracing = "0.1.9"
+tracing = "0.1.18"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 tracing-log = "0.1"
 pin-project = "0.4"

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -13,7 +13,7 @@ linkerd2-app-core = { path = "../core" }
 linkerd2-app-inbound = { path = "../inbound" }
 linkerd2-app-outbound = { path = "../outbound" }
 tower = { version = "0.3", default-features = false }
-tracing = "0.1"
+tracing = "0.1.18"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -15,7 +15,7 @@ futures = { version = "0.3" }
 indexmap = "1.0"
 linkerd2-app-core = { path = "../core" }
 tokio = { version = "0.2", features = ["sync"] }
-tracing = "0.1.9"
+tracing = "0.1.18"
 
 [dependencies.tower]
 version = "0.3"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -37,9 +37,9 @@ tokio = { version = "0.2", features = ["io-util", "net", "rt-core"]}
 tokio-rustls = "0.13"
 tower = { version = "0.3", default-features = false} 
 tonic = { version = "0.2", default-features = false }
-tracing = "0.1.9"
+tracing = "0.1.18"
 tracing-futures = { version = "0.2", features = ["std-future"] }
-tracing-subscriber = "0.2.7"
+tracing-subscriber = "0.2.10"
 webpki = "0.21.0"
 
 [dev-dependencies]

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -39,11 +39,10 @@ tower = { version = "0.3", default-features = false}
 tonic = { version = "0.2", default-features = false }
 tracing = "0.1.18"
 tracing-futures = { version = "0.2", features = ["std-future"] }
-tracing-subscriber = "0.2.10"
 webpki = "0.21.0"
 
 [dependencies.tracing-subscriber]
-version = "0.2.8"
+version = "0.2.10"
 # we don't need `chrono` time formatting or ANSI colored output
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot"]

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -17,7 +17,7 @@ linkerd2-app-core = { path = "../core" }
 linkerd2-identity = { path = "../../identity" }
 linkerd2-retry = { path = "../../retry" }
 tokio = { version = "0.2", features = ["sync"]}
-tracing = "0.1.9"
+tracing = "0.1.18"
 pin-project = "0.4"
 
 [dependencies.tower]

--- a/linkerd/buffer/Cargo.toml
+++ b/linkerd/buffer/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3"
 linkerd2-error = { path = "../error" }
 tokio = { version = "0.2", features = ["sync", "stream", "time", "macros"] }
 tower = { version = "0.3", default_features = false, features = ["util"] }
-tracing = "0.1"
+tracing = "0.1.18"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -11,4 +11,4 @@ linkerd2-error = { path = "../error" }
 linkerd2-stack = { path = "../stack" }
 tokio = "0.2"
 tower = { version = "0.3", default-features = false, features = ["util"] }
-tracing = "0.1"
+tracing = "0.1.18"

--- a/linkerd/concurrency-limit/Cargo.toml
+++ b/linkerd/concurrency-limit/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 futures = "0.3"
 tokio = { version = "0.2.21", features = ["sync"] }
 tower = { version = "0.3", default-features = false }
-tracing = "0.1"
+tracing = "0.1.18"
 pin-project = "0.4"

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3"
 linkerd2-dns-name = { path = "./name" }
 linkerd2-stack = { path = "../stack" }
 tower = "0.3"
-tracing = "0.1"
+tracing = "0.1.18"
 tracing-futures = "0.2"
 tokio = { version = "0.2", features = ["rt-core", "sync"] }
 pin-project = "0.4"

--- a/linkerd/duplex/Cargo.toml
+++ b/linkerd/duplex/Cargo.toml
@@ -10,4 +10,4 @@ bytes = "0.5"
 futures = "0.3"
 tokio = { version = "0.2", features = ["io-util"] }
 pin-project = "0.4"
-tracing = "0.1"
+tracing = "0.1.18"

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -17,7 +17,7 @@ linkerd2-error = { path  = "../error" }
 linkerd2-http-classify = { path  = "../http-classify" }
 linkerd2-metrics = { path  = "../metrics" }
 linkerd2-stack = { path  = "../stack" } 
-tracing = "0.1.9"
+tracing = "0.1.18"
 pin-project = "0.4"
 
 [dependencies.tower]

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -13,7 +13,7 @@ linkerd2-stack = { path = "../stack" }
 opencensus-proto = { path = "../../opencensus-proto" }
 tokio = "0.2"
 tonic = { version = "0.2", default-features = false, features = ["prost", "codegen"] }
-tracing = "0.1"
+tracing = "0.1.18"
 pin-project = "0.4"
 http = "0.2"
 http-body = "0.3"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -19,5 +19,5 @@ http-body = "0.3"
 tonic = { version = "0.2", default-features = false }
 indexmap = "1.0"
 tower = { version = "0.3", default-features = false }
-tracing = "0.1"
+tracing = "0.1.18"
 pin-project = "0.4"

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -15,7 +15,7 @@ linkerd2-error = { path = "../../error" }
 linkerd2-proxy-core = { path = "../core" }
 indexmap = "1.0"
 tokio = { version = "0.2", features = ["sync", "time", "stream"] }
-tracing = "0.1"
+tracing = "0.1.18"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -32,7 +32,7 @@ linkerd2-timeout = { path  = "../../timeout" }
 rand = "0.7"
 tokio = { version = "0.2", features = ["time", "rt-core"] }
 tower = { version = "0.3", default-features = false, features = ["balance", "load", "discover"] }
-tracing = "0.1.9"
+tracing = "0.1.18"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 try-lock = "0.2"
 pin-project = "0.4"

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -13,6 +13,6 @@ linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", ta
 linkerd2-proxy-transport = { path = "../transport" }
 tokio = { version = "0.2", features = ["time", "sync"] }
 tonic = { version = "0.2", default-features = false }
-tracing = "0.1.9"
+tracing = "0.1.18"
 http-body = "0.3"
 pin-project = "0.4"

--- a/linkerd/proxy/resolve/Cargo.toml
+++ b/linkerd/proxy/resolve/Cargo.toml
@@ -14,7 +14,7 @@ linkerd2-error = { path = "../../error" }
 linkerd2-proxy-core = { path = "../core" }
 indexmap = "1.0"
 tokio = "0.2"
-tracing = "0.1"
+tracing = "0.1.18"
 pin-project = "0.4"
 
 [dependencies.tower]

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -24,7 +24,7 @@ rand = { version = "0.7", features = ["small_rng"] }
 tokio = { version = "0.2", features = ["time"]}
 tower = {version = "0.3", default-features = false }
 tonic = { version = "0.2", default-features = false }
-tracing = "0.1.9"
+tracing = "0.1.18"
 tracing-futures = "0.2"
 pin-project = "0.4"
 

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -33,7 +33,7 @@ ring = "0.16"
 rustls = "0.17"
 tokio = { version = "0.2", features = ["net", "io-util"]}
 tokio-rustls = "0.13"
-tracing = "0.1.9"
+tracing = "0.1.18"
 webpki = "0.21"
 untrusted = "0.7"
 pin-project = "0.4"
@@ -52,6 +52,6 @@ libc = "0.2"
 
 [dev-dependencies]
 linkerd2-identity = { path = "../../identity", features = ["test-util"] }
-tracing-subscriber = "0.2.1"
+tracing-subscriber = "0.2.10"
 tower = { version = "0.3", default-features = false, features = ["util"] }
 tracing-futures = { version = "0.2", features = ["std-future"] }

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 linkerd2-error = { path = "../error" }
 futures = "0.3"
 tower = { version = "0.3", default-features = false }
-tracing = "0.1"
+tracing = "0.1.18"
 pin-project = "0.4"

--- a/linkerd/request-filter/Cargo.toml
+++ b/linkerd/request-filter/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 futures = "0.3"
 tower = { version = "0.3", default-features = false }
-tracing = "0.1"
+tracing = "0.1.18"
 linkerd2-error = { path = "../error" }
 pin-project = "0.4"

--- a/linkerd/retry/Cargo.toml
+++ b/linkerd/retry/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 linkerd2-error = { path  = "../error" }
 linkerd2-stack = { path  = "../stack" }
 tower = { version = "0.3", default-features = false, features = ["retry", "util"] }
-tracing = "0.1.9"
+tracing = "0.1.18"
 pin-project = "0.4"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -23,7 +23,7 @@ rand = { version = "0.7", features = ["small_rng"] }
 regex = "1.0.0"
 tokio = { version = "0.2", features = ["macros", "sync", "time"] }
 tonic = { version = "0.2", default-features = false }
-tracing = "0.1.9"
+tracing = "0.1.18"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 

--- a/linkerd/signal/Cargo.toml
+++ b/linkerd/signal/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 tokio = { version = "0.2", features = ["macros", "signal"] }
-tracing = "0.1"
+tracing = "0.1.18"

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 futures = "0.3"
 linkerd2-error = { path = "../../error" }
 linkerd2-stack = { path = ".." }
-tracing = "0.1"
+tracing = "0.1.18"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 

--- a/linkerd/timeout/Cargo.toml
+++ b/linkerd/timeout/Cargo.toml
@@ -10,7 +10,7 @@ futures = { version = "0.3", features = ["compat"] }
 linkerd2-error = { path = "../error" }
 linkerd2-stack = { path = "../stack" }
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
-tracing = "0.1"
+tracing = "0.1.18"
 pin-project = "0.4"
 tokio = { version = "0.2", features = ["time"] }
 

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -18,4 +18,4 @@ num_cpus = { version = "1", optional = true }
 linkerd2-app = { path = "../linkerd/app" }
 linkerd2-signal = { path = "../linkerd/signal" }
 tokio = { version = "0.2", features = ["rt-core", "time", "io-driver"] }
-tracing = "0.1"
+tracing = "0.1.18"


### PR DESCRIPTION
This picks up upstream changes tokio-rs/tracing#853,
tokio-rs/tracing#868, and tokio-rs/tracing#869 which improve performance
in some use cases. The overhead removed by these changes may already be
amortized enough in the proxy that it's not a problem, but it seems
worth picking up regardless.