### PR TITLE
Make FailFast cloneable

### DIFF
--- a/linkerd/timeout/src/failfast.rs
+++ b/linkerd/timeout/src/failfast.rs
@@ -60,6 +60,23 @@ impl<S> tower::layer::Layer<S> for FailFastLayer {
 
 // === impl FailFast ===
 
+impl<S> Clone for FailFast<S>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        // When cloning failfast, we can't preserve the waiting state, so each
+        // clone will have to detect its own failfast. Pracitically, this means
+        // that each connection will have to wait for a timeout before
+        // triggerring failfast.
+        Self {
+            inner: self.inner.clone(),
+            max_unavailable: self.max_unavailable.clone(),
+            state: State::Open,
+        }
+    }
+}
+
 impl<S, T> tower::Service<T> for FailFast<S>
 where
     S: tower::Service<T>,

--- a/linkerd/timeout/src/failfast.rs
+++ b/linkerd/timeout/src/failfast.rs
@@ -66,9 +66,9 @@ where
 {
     fn clone(&self) -> Self {
         // When cloning failfast, we can't preserve the waiting state, so each
-        // clone will have to detect its own failfast. Pracitically, this means
+        // clone will have to detect its own failfast. Practically, this means
         // that each connection will have to wait for a timeout before
-        // triggerring failfast.
+        // triggering failfast.
         Self {
             inner: self.inner.clone(),
             max_unavailable: self.max_unavailable.clone(),


### PR DESCRIPTION
Currently, the FailFast middleware is not cloneable, as it maintains
state including a timeout future.

This change modifies FailFast to implement Clone. When the module is
cloned, it reverts to the open state.

This has no impact on the current proxy, but when the stack gets cloned
(as required by an upcoming change), this will have the effect that
connections do not share failfast state. This seems better than adding a
Lock or Buffer just to accomodate this.