### PR TITLE
Move HTTP detection & server into linkerd2_proxy_http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
 name = "linkerd2-proxy-http"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "bytes 0.5.4",
  "futures 0.3.5",
  "h2 0.2.6",
@@ -1290,6 +1291,9 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-http-box",
  "linkerd2-identity",
+ "linkerd2-proxy-core",
+ "linkerd2-proxy-detect",
+ "linkerd2-proxy-transport",
  "linkerd2-stack",
  "linkerd2-timeout",
  "pin-project",

--- a/linkerd/app/core/src/proxy/mod.rs
+++ b/linkerd/app/core/src/proxy/mod.rs
@@ -4,16 +4,8 @@ pub use linkerd2_proxy_api_resolve as api_resolve;
 pub use linkerd2_proxy_core as core;
 pub use linkerd2_proxy_detect as detect;
 pub use linkerd2_proxy_discover as discover;
-pub use linkerd2_proxy_http::{
-    self as http,
-    // TODO(eliza): port
-    // grpc
-};
+pub use linkerd2_proxy_http as http;
 pub use linkerd2_proxy_identity as identity;
 pub use linkerd2_proxy_resolve as resolve;
 pub use linkerd2_proxy_tap as tap;
 pub use linkerd2_proxy_tcp as tcp;
-
-pub mod server;
-
-pub use self::server::ServeHttp;

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -19,9 +19,7 @@ use linkerd2_app_core::{
     proxy::{
         detect,
         http::{self, normalize_uri, orig_proto, strip_header},
-        identity,
-        server::{DetectHttp, ServeHttp},
-        tap, tcp,
+        identity, tap, tcp,
     },
     reconnect, router, serve,
     spans::SpanConverter,
@@ -404,7 +402,7 @@ impl Config {
                 )
             });
 
-        let tcp_server = ServeHttp::new(
+        let tcp_server = http::ServeHttp::new(
             http_server.into_inner(),
             h2_settings,
             tcp_forward.into_inner(),
@@ -412,7 +410,7 @@ impl Config {
         );
 
         let tcp_detect = svc::stack(tcp_server)
-            .push(detect::AcceptLayer::new(DetectHttp::new(
+            .push(detect::AcceptLayer::new(http::DetectHttp::new(
                 disable_protocol_detection_for_ports.clone(),
             )))
             .push(admit::AdmitLayer::new(require_identity_for_inbound_ports))

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -18,8 +18,8 @@ use linkerd2_app_core::{
     opencensus::proto::trace::v1 as oc,
     profiles,
     proxy::{
-        self, core::resolve::Resolve, detect, discover, http, identity, resolve::map_endpoint,
-        server::DetectHttp, tap, tcp, ServeHttp,
+        self, core::resolve::Resolve, detect, discover, http, identity, resolve::map_endpoint, tap,
+        tcp,
     },
     reconnect, retry, router, serve,
     spans::SpanConverter,
@@ -531,7 +531,7 @@ impl Config {
             )
             .check_new_service::<tls::accept::Meta>();
 
-        let tcp_server = ServeHttp::new(
+        let tcp_server = http::ServeHttp::new(
             http_server.into_inner(),
             h2_settings,
             tcp_forward.into_inner(),
@@ -542,7 +542,7 @@ impl Config {
             Conditional::None(tls::ReasonForNoPeerName::Loopback);
 
         let tcp_detect = svc::stack(tcp_server)
-            .push(detect::AcceptLayer::new(DetectHttp::new(
+            .push(detect::AcceptLayer::new(http::DetectHttp::new(
                 disable_protocol_detection_for_ports.clone(),
             )))
             .push(metrics.transport.layer_accept(TransportLabels))

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -11,6 +11,7 @@ This should probably be decomposed into smaller, decoupled crates.
 """
 
 [dependencies]
+async-trait = "0.1"
 bytes = "0.5"
 futures = { package = "futures", version = "0.3" }
 h2 = "0.2.6"
@@ -27,6 +28,9 @@ linkerd2-duplex = { path  = "../../duplex" }
 linkerd2-error = { path  = "../../error" }
 linkerd2-http-box = { path  = "../../http-box" }
 linkerd2-identity = { path  = "../../identity" }
+linkerd2-proxy-core = { path  = "../core" }
+linkerd2-proxy-detect = { path  = "../detect" }
+linkerd2-proxy-transport = { path  = "../transport" }
 linkerd2-stack = { path  = "../../stack" }
 linkerd2-timeout = { path  = "../../timeout" }
 rand = "0.7"

--- a/linkerd/proxy/http/src/detect.rs
+++ b/linkerd/proxy/http/src/detect.rs
@@ -1,27 +1,27 @@
-use crate::proxy::http::{
-    self,
+use crate::Error;
+use crate::{
+    self as http,
     glue::{Body, HyperServerSvc},
     h2::Settings as H2Settings,
     trace, upgrade, Version as HttpVersion,
 };
-use crate::transport::{
+use async_trait::async_trait;
+use futures::prelude::*;
+use hyper;
+use indexmap::IndexSet;
+use linkerd2_drain as drain;
+use linkerd2_proxy_core::Accept;
+use linkerd2_proxy_detect as detect;
+use linkerd2_proxy_transport::{
     io::{self, BoxedIo, Peekable},
     tls,
 };
-use crate::{
-    drain,
-    proxy::{core::Accept, detect},
-    svc::{NewService, Service, ServiceExt},
-    Error,
-};
-use async_trait::async_trait;
-use futures::TryFutureExt;
-use hyper;
-use indexmap::IndexSet;
+use linkerd2_stack::NewService;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use tower::{util::ServiceExt, Service};
 use tracing::{info_span, trace};
 use tracing_futures::Instrument;
 

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -8,6 +8,7 @@ pub mod add_header;
 pub mod balance;
 pub mod canonicalize;
 pub mod client;
+pub mod detect;
 pub mod glue;
 pub mod h1;
 pub mod h2;
@@ -25,6 +26,7 @@ mod version;
 
 pub use self::{
     client::MakeClientLayer,
+    detect::{DetectHttp, ServeHttp},
     glue::{Body, HyperServerSvc},
     settings::Settings,
     timeout::MakeTimeoutLayer,


### PR DESCRIPTION
In preparation for upcoming simplifications, this moves the HTTP
detection/serving logic into the linkerd2_proxy_http crate.