### PR TITLE
trace: update tracing dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -777,7 +777,7 @@ dependencies = [
  "linkerd2-proxy-api",
  "net2",
  "quickcheck",
- "regex 1.2.1",
+ "regex 1.3.9",
  "ring",
  "rustls",
  "tokio",
@@ -848,7 +848,7 @@ dependencies = [
  "prost-types",
  "quickcheck",
  "rand 0.7.2",
- "regex 1.2.1",
+ "regex 1.3.9",
  "serde_json",
  "tokio",
  "tokio-test",
@@ -1456,7 +1456,7 @@ dependencies = [
  "prost-types",
  "quickcheck",
  "rand 0.7.2",
- "regex 1.2.1",
+ "regex 1.3.9",
  "tokio",
  "tonic",
  "tower",
@@ -2155,14 +2155,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.2.1"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c3d9193984285d544df4a30c23a4e62ead42edf70a4452ceb76dac1ce05c26"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick 0.7.13",
  "memchr 2.3.3",
- "regex-syntax 0.6.11",
- "thread_local 0.3.6",
+ "regex-syntax 0.6.18",
+ "thread_local 1.0.1",
 ]
 
 [[package]]
@@ -2172,7 +2172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 dependencies = [
  "byteorder",
- "regex-syntax 0.6.11",
+ "regex-syntax 0.6.18",
  "utf8-ranges 1.0.0",
 ]
 
@@ -2184,9 +2184,9 @@ checksum = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.11"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
@@ -2456,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "0.3.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
 ]
@@ -2717,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aae59226cf195d8e74d4b34beae1859257efb4e5fed3f147d2dc2c7d372178"
+checksum = "6d79ca061b032d6ce30c660fded31189ca0b9922bf483cd70759f13a2d86786c"
 dependencies = [
  "cfg-if",
  "log",
@@ -2729,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
+checksum = "1fe233f4227389ab7df5b32649239da7ebe0b281824b4e84b342d04d3fd8c25e"
 dependencies = [
  "proc-macro2 1.0.10",
  "quote 1.0.2",
@@ -2740,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2734b5a028fa697686f16c6d18c2c6a3c7e41513f9a213abb6754c4acb3c8d7"
+checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
 dependencies = [
  "lazy_static",
 ]
@@ -2780,20 +2780,21 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b33f8b2ef2ab0c3778c12646d9c42a24f7772bee4cdafc72199644a9f58fdc"
+checksum = "abd165311cc4d7a555ad11cc77a37756df836182db0d81aac908c8184c584f40"
 dependencies = [
  "ansi_term",
  "chrono",
  "lazy_static",
  "matchers",
  "parking_lot",
- "regex 1.2.1",
+ "regex 1.3.9",
  "serde",
  "serde_json",
  "sharded-slab",
  "smallvec",
+ "thread_local 1.0.1",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/linkerd/admit/Cargo.toml
+++ b/linkerd/admit/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 futures = "0.3"
 linkerd2-error = { path = "../error" }
 tower = { version = "0.3", default-features = false, features = ["util"] }
-tracing = "0.1.18"
+tracing = "0.1.19"

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -28,7 +28,7 @@ regex = "1.0.0"
 tokio = { version = "0.2", features = ["rt-util"] }
 tonic = { version = "0.2", default-features = false, features = ["prost"] }
 tower = "0.3"
-tracing = "0.1.18"
+tracing = "0.1.19"
 tracing-futures = { version = "0.2", features = ["std-future"]}
 html-escape = "0.2.5"
 

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -66,7 +66,7 @@ tokio = { version = "0.2.22", features = ["macros", "sync", "parking_lot"]}
 tokio-timer = "0.2"
 tower-request-modifier = { git = "https://github.com/tower-rs/tower-http" }
 tonic = { version = "0.2", default-features = false, features = ["prost"] }
-tracing = "0.1.18"
+tracing = "0.1.19"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 tracing-log = "0.1"
 pin-project = "0.4"
@@ -77,7 +77,7 @@ tokio-trace = { git = "https://github.com/hawkw/tokio-trace", rev = "a8240c5cbb4
 serde_json = "1"
 
 [dependencies.tracing-subscriber]
-version = "0.2.8"
+version = "0.2.11"
 # we don't need `chrono` time formatting or ANSI colored output
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot"]

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -13,7 +13,7 @@ linkerd2-app-core = { path = "../core" }
 linkerd2-app-inbound = { path = "../inbound" }
 linkerd2-app-outbound = { path = "../outbound" }
 tower = { version = "0.3", default-features = false }
-tracing = "0.1.18"
+tracing = "0.1.19"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["rt-core", "macros"] }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -15,7 +15,7 @@ futures = { version = "0.3" }
 indexmap = "1.0"
 linkerd2-app-core = { path = "../core" }
 tokio = { version = "0.2", features = ["sync"] }
-tracing = "0.1.18"
+tracing = "0.1.19"
 
 [dependencies.tower]
 version = "0.3"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -37,12 +37,12 @@ tokio = { version = "0.2", features = ["io-util", "net", "rt-core"]}
 tokio-rustls = "0.13"
 tower = { version = "0.3", default-features = false} 
 tonic = { version = "0.2", default-features = false }
-tracing = "0.1.18"
+tracing = "0.1.19"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 webpki = "0.21.0"
 
 [dependencies.tracing-subscriber]
-version = "0.2.10"
+version = "0.2.11"
 # we don't need `chrono` time formatting or ANSI colored output
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot"]

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -17,7 +17,7 @@ linkerd2-app-core = { path = "../core" }
 linkerd2-identity = { path = "../../identity" }
 linkerd2-retry = { path = "../../retry" }
 tokio = { version = "0.2", features = ["sync"]}
-tracing = "0.1.18"
+tracing = "0.1.19"
 pin-project = "0.4"
 
 [dependencies.tower]

--- a/linkerd/buffer/Cargo.toml
+++ b/linkerd/buffer/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3"
 linkerd2-error = { path = "../error" }
 tokio = { version = "0.2", features = ["sync", "stream", "time", "macros"] }
 tower = { version = "0.3", default_features = false, features = ["util"] }
-tracing = "0.1.18"
+tracing = "0.1.19"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -11,4 +11,4 @@ linkerd2-error = { path = "../error" }
 linkerd2-stack = { path = "../stack" }
 tokio = "0.2"
 tower = { version = "0.3", default-features = false, features = ["util"] }
-tracing = "0.1.18"
+tracing = "0.1.19"

--- a/linkerd/concurrency-limit/Cargo.toml
+++ b/linkerd/concurrency-limit/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 futures = "0.3"
 tokio = { version = "0.2.21", features = ["sync"] }
 tower = { version = "0.3", default-features = false }
-tracing = "0.1.18"
+tracing = "0.1.19"
 pin-project = "0.4"

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -10,7 +10,7 @@ futures = "0.3"
 linkerd2-dns-name = { path = "./name" }
 linkerd2-stack = { path = "../stack" }
 tower = "0.3"
-tracing = "0.1.18"
+tracing = "0.1.19"
 tracing-futures = "0.2"
 tokio = { version = "0.2", features = ["rt-core", "sync"] }
 pin-project = "0.4"

--- a/linkerd/duplex/Cargo.toml
+++ b/linkerd/duplex/Cargo.toml
@@ -10,4 +10,4 @@ bytes = "0.5"
 futures = "0.3"
 tokio = { version = "0.2", features = ["io-util"] }
 pin-project = "0.4"
-tracing = "0.1.18"
+tracing = "0.1.19"

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -17,7 +17,7 @@ linkerd2-error = { path  = "../error" }
 linkerd2-http-classify = { path  = "../http-classify" }
 linkerd2-metrics = { path  = "../metrics" }
 linkerd2-stack = { path  = "../stack" } 
-tracing = "0.1.18"
+tracing = "0.1.19"
 pin-project = "0.4"
 
 [dependencies.tower]

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -13,7 +13,7 @@ linkerd2-stack = { path = "../stack" }
 opencensus-proto = { path = "../../opencensus-proto" }
 tokio = "0.2"
 tonic = { version = "0.2", default-features = false, features = ["prost", "codegen"] }
-tracing = "0.1.18"
+tracing = "0.1.19"
 pin-project = "0.4"
 http = "0.2"
 http-body = "0.3"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -19,5 +19,5 @@ http-body = "0.3"
 tonic = { version = "0.2", default-features = false }
 indexmap = "1.0"
 tower = { version = "0.3", default-features = false }
-tracing = "0.1.18"
+tracing = "0.1.19"
 pin-project = "0.4"

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -15,7 +15,7 @@ linkerd2-error = { path = "../../error" }
 linkerd2-proxy-core = { path = "../core" }
 indexmap = "1.0"
 tokio = { version = "0.2", features = ["sync", "time", "stream"] }
-tracing = "0.1.18"
+tracing = "0.1.19"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -34,7 +34,7 @@ linkerd2-timeout = { path  = "../../timeout" }
 rand = "0.7"
 tokio = { version = "0.2", features = ["time", "rt-core"] }
 tower = { version = "0.3", default-features = false, features = ["balance", "load", "discover"] }
-tracing = "0.1.18"
+tracing = "0.1.19"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 try-lock = "0.2"
 pin-project = "0.4"

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -13,6 +13,6 @@ linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", ta
 linkerd2-proxy-transport = { path = "../transport" }
 tokio = { version = "0.2", features = ["time", "sync"] }
 tonic = { version = "0.2", default-features = false }
-tracing = "0.1.18"
+tracing = "0.1.19"
 http-body = "0.3"
 pin-project = "0.4"

--- a/linkerd/proxy/resolve/Cargo.toml
+++ b/linkerd/proxy/resolve/Cargo.toml
@@ -14,7 +14,7 @@ linkerd2-error = { path = "../../error" }
 linkerd2-proxy-core = { path = "../core" }
 indexmap = "1.0"
 tokio = "0.2"
-tracing = "0.1.18"
+tracing = "0.1.19"
 pin-project = "0.4"
 
 [dependencies.tower]

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -24,7 +24,7 @@ rand = { version = "0.7", features = ["small_rng"] }
 tokio = { version = "0.2", features = ["time"]}
 tower = {version = "0.3", default-features = false }
 tonic = { version = "0.2", default-features = false }
-tracing = "0.1.18"
+tracing = "0.1.19"
 tracing-futures = "0.2"
 pin-project = "0.4"
 

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -32,7 +32,7 @@ ring = "0.16"
 rustls = "0.17"
 tokio = { version = "0.2", features = ["net", "io-util"]}
 tokio-rustls = "0.13"
-tracing = "0.1.18"
+tracing = "0.1.19"
 webpki = "0.21"
 untrusted = "0.7"
 pin-project = "0.4"
@@ -51,6 +51,6 @@ libc = "0.2"
 
 [dev-dependencies]
 linkerd2-identity = { path = "../../identity", features = ["test-util"] }
-tracing-subscriber = "0.2.10"
+tracing-subscriber = "0.2.11"
 tower = { version = "0.3", default-features = false, features = ["util"] }
 tracing-futures = { version = "0.2", features = ["std-future"] }

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 linkerd2-error = { path = "../error" }
 futures = "0.3"
 tower = { version = "0.3", default-features = false }
-tracing = "0.1.18"
+tracing = "0.1.19"
 pin-project = "0.4"

--- a/linkerd/request-filter/Cargo.toml
+++ b/linkerd/request-filter/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 [dependencies]
 futures = "0.3"
 tower = { version = "0.3", default-features = false }
-tracing = "0.1.18"
+tracing = "0.1.19"
 linkerd2-error = { path = "../error" }
 pin-project = "0.4"

--- a/linkerd/retry/Cargo.toml
+++ b/linkerd/retry/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 linkerd2-error = { path  = "../error" }
 linkerd2-stack = { path  = "../stack" }
 tower = { version = "0.3", default-features = false, features = ["retry", "util"] }
-tracing = "0.1.18"
+tracing = "0.1.19"
 pin-project = "0.4"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -23,7 +23,7 @@ rand = { version = "0.7", features = ["small_rng"] }
 regex = "1.0.0"
 tokio = { version = "0.2", features = ["macros", "sync", "time"] }
 tonic = { version = "0.2", default-features = false }
-tracing = "0.1.18"
+tracing = "0.1.19"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 

--- a/linkerd/signal/Cargo.toml
+++ b/linkerd/signal/Cargo.toml
@@ -7,4 +7,4 @@ publish = false
 
 [dependencies]
 tokio = { version = "0.2", features = ["macros", "signal"] }
-tracing = "0.1.18"
+tracing = "0.1.19"

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 futures = "0.3"
 linkerd2-error = { path = "../../error" }
 linkerd2-stack = { path = ".." }
-tracing = "0.1.18"
+tracing = "0.1.19"
 tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 

--- a/linkerd/timeout/Cargo.toml
+++ b/linkerd/timeout/Cargo.toml
@@ -10,7 +10,7 @@ futures = { version = "0.3", features = ["compat"] }
 linkerd2-error = { path = "../error" }
 linkerd2-stack = { path = "../stack" }
 tokio-connect = { git = "https://github.com/carllerche/tokio-connect" }
-tracing = "0.1.18"
+tracing = "0.1.19"
 pin-project = "0.4"
 tokio = { version = "0.2", features = ["time"] }
 

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -18,4 +18,4 @@ num_cpus = { version = "1", optional = true }
 linkerd2-app = { path = "../linkerd/app" }
 linkerd2-signal = { path = "../linkerd/signal" }
 tokio = { version = "0.2", features = ["rt-core", "time", "io-driver"] }
-tracing = "0.1.18"
+tracing = "0.1.19"


### PR DESCRIPTION
This branch makes the following dependency updates:
```
:; cargo update -p tracing -p tracing-core -p tracing-subscriber -p tokio-trace
    Updating crates.io index
    Updating git repository `https://github.com/hawkw/tokio-trace`
    Updating regex v1.2.1 -> v1.3.9
    Updating regex-syntax v0.6.11 -> v0.6.18
    Updating thread_local v0.3.6 -> v1.0.1
    Updating tracing v0.1.18 -> v0.1.19
    Updating tracing-attributes v0.1.9 -> v0.1.10
    Updating tracing-core v0.1.12 -> v0.1.14
    Updating tracing-subscriber v0.2.10 -> v0.2.11
```

In particular, the `tracing-core` update picks up upstream change
tokio-rs/tracing#908, which fixes a bug where filtering would fail to
take the fastest fast path in many cases. This time, there's a slight,
but actually noticeable, latency reduction in the proxy benchmarks:

![Screenshot_20200808_183528](https://user-images.githubusercontent.com/2796466/89925622-8cbec780-dbb8-11ea-8a6f-587ab5075240.png)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>