### PR TITLE
Add build arg for skipping identity wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,16 @@ RUN --mount=type=cache,target=target \
 
 ## Install the proxy binary into the base runtime image.
 FROM $RUNTIME_IMAGE as runtime
+
+# When set, causes the proxy to remove the identity wrapper responsible for
+# CSR and key generation.
+ARG SKIP_IDENTITY_WRAPPER
+
 WORKDIR /linkerd
 COPY --from=build /out/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy
 ENV LINKERD2_PROXY_LOG=warn,linkerd=info
+RUN if [ -n "$SKIP_IDENTITY_WRAPPER" ] ; then \
+  rm -f /usr/bin/linkerd2-proxy-run && \
+  ln /usr/lib/linkerd/linkerd2-proxy /usr/bin/linkerd2-proxy-run ; \
+  fi
 # Inherits the ENTRYPOINT from the runtime image.


### PR DESCRIPTION
## Motivation

The proxy identity-initializing wrapper is responsible for generating a CSR and
key for the proxy upon startup. These files (located in `end-entity/`) are used
by the proxy for establishing identity.

When mocking identity, we'd like to be able to provide a pre-generated CSR and
key so that we can expect certain certificates in the Signed certificate
request.

Therefore, when building a proxy to be used with mock identity there should be a
way to remove this wrapper so that the identity files are not overwritten.

## Solution

Introduce a new `SKIP_IDENTITY_WRAPPER` build-arg that when set, removes the
proxy identity-initializing script that is run at starup.

The use of it below will build a proxy with the `mock-orig-dst` feature and skip
identity generation.

```
:; docker buildx build . --build-arg PROXY_FEATURES=mock-orig-dst --build-arg SKIP_IDENTITY_WRAPPER=1 --load --tag=kevinlbuoyant/l2-proxy:proxy-identity-v1
```

I have confirmed this works with the changes in olix0r/l2-proxy-harness#2.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
