### PR TITLE
Control plane load balancing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,6 +1000,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.5",
  "linkerd2-dns-name",
+ "linkerd2-error",
  "linkerd2-stack",
  "pin-project",
  "tokio",
@@ -1264,6 +1265,7 @@ dependencies = [
 name = "linkerd2-proxy-dns-resolve"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "futures 0.3.5",
  "linkerd2-addr",
  "linkerd2-dns",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,7 +998,6 @@ version = "0.1.0"
 name = "linkerd2-dns"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "futures 0.3.5",
  "linkerd2-dns-name",
  "linkerd2-stack",
@@ -1265,7 +1264,6 @@ dependencies = [
 name = "linkerd2-proxy-dns-resolve"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "futures 0.3.5",
  "linkerd2-addr",
  "linkerd2-dns",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,6 @@ dependencies = [
 name = "linkerd2-proxy-dns-resolve"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "futures 0.3.5",
  "linkerd2-addr",
  "linkerd2-dns",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,6 +1274,7 @@ dependencies = [
  "tokio-test",
  "tower",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -7,6 +7,12 @@ pub struct ControlAddr {
     pub identity: crate::transport::tls::PeerIdentity,
 }
 
+impl Into<Addr> for ControlAddr {
+    fn into(self) -> Addr {
+        self.addr
+    }
+}
+
 impl fmt::Display for ControlAddr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.addr, f)
@@ -145,122 +151,25 @@ pub mod add_origin {
     }
 }
 
-pub mod dns_resolve {
-    use super::{client::Target, ControlAddr};
-    use async_stream::try_stream;
-    use futures::future::{self, Either};
-    use futures::prelude::*;
-    use linkerd2_addr::{Addr, NameAddr};
-    use linkerd2_error::Error;
-    use linkerd2_proxy_core::resolve::Update;
-    use linkerd2_proxy_transport::tls::PeerIdentity;
-    use pin_project::pin_project;
+pub mod resolve {
+    use crate::{
+        dns,
+        proxy::{dns_resolve::DnsResolve, resolve::map_endpoint},
+    };
     use std::net::SocketAddr;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
 
-    type UpdatesStream = Pin<Box<dyn Stream<Item = Result<Update<Target>, Error>> + Send + Sync>>;
-
-    #[derive(Clone)]
-    pub struct Resolve<S> {
-        inner: S,
+    pub fn new(dns: dns::Resolver) -> map_endpoint::Resolve<IntoTarget, DnsResolve> {
+        map_endpoint::Resolve::new(IntoTarget(()), DnsResolve::new(dns))
     }
 
-    #[pin_project]
-    pub struct MakeFuture<S: tower::Service<NameAddr>> {
-        #[pin]
-        inner: S::Future,
-        identity: PeerIdentity,
-    }
+    #[derive(Copy, Clone, Debug)]
+    pub struct IntoTarget(());
 
-    // === impl Resolve ===
+    impl map_endpoint::MapEndpoint<super::ControlAddr, ()> for IntoTarget {
+        type Out = super::client::Target;
 
-    impl<S> Resolve<S> {
-        pub fn new(inner: S) -> Self {
-            Self { inner }
-        }
-
-        // should yield the socket address once
-        // and keep on yielding Pending forever.
-        pub fn resolve_once_stream(&self, sa: SocketAddr, identity: PeerIdentity) -> UpdatesStream {
-            Box::pin(try_stream! {
-                let update = Update::Add(vec![(sa, Target::new(sa, identity))]);
-                tracing::debug!(?update, "resolved once");
-                yield update;
-                future::pending::<Update<Target>>().await;
-            })
-        }
-    }
-
-    impl<S, T> tower::Service<ControlAddr> for Resolve<S>
-    where
-        T: Clone,
-        S: tower::Service<NameAddr>,
-        S::Response: Stream<Item = Result<Update<T>, Error>> + Send + Sync + 'static,
-        S::Error: Into<Error> + Send + Sync,
-        S::Future: Send + Sync,
-    {
-        type Response = UpdatesStream;
-        type Error = S::Error;
-        type Future = Either<MakeFuture<S>, future::Ready<Result<Self::Response, S::Error>>>;
-
-        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-            self.inner.poll_ready(cx)
-        }
-
-        fn call(&mut self, target: ControlAddr) -> Self::Future {
-            match target.addr {
-                Addr::Name(na) if na.is_localhost() => {
-                    let local_sa = format!("127.0.0.1:{}", na.port()).parse().unwrap();
-                    Either::Right(future::ok(
-                        self.resolve_once_stream(local_sa, target.identity),
-                    ))
-                }
-                Addr::Name(na) => Either::Left(MakeFuture {
-                    inner: self.inner.call(na),
-                    identity: target.identity,
-                }),
-                Addr::Socket(sa) => {
-                    Either::Right(future::ok(self.resolve_once_stream(sa, target.identity)))
-                }
-            }
-        }
-    }
-
-    // === impl MakeFuture ===
-
-    impl<S, T> Future for MakeFuture<S>
-    where
-        T: Clone,
-        S: tower::Service<NameAddr>,
-        S::Response: Stream<Item = Result<Update<T>, Error>> + Send + Sync + 'static,
-        S::Error: Into<Error> + Send + Sync,
-        S::Future: Send + Sync,
-    {
-        type Output = Result<UpdatesStream, S::Error>;
-
-        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            let this = self.project();
-            let identity = this.identity.clone();
-            let stream = futures::ready!(this.inner.poll(cx))?;
-            Poll::Ready(Ok(Box::pin(stream.map_ok(move |update| {
-                match update {
-                    Update::Add(adds) => Update::Add(
-                        adds.clone()
-                            .into_iter()
-                            .map(|(sa, _)| (sa, Target::new(sa, identity.clone())))
-                            .collect(),
-                    ),
-                    Update::Reset(eps) => Update::Reset(
-                        eps.clone()
-                            .into_iter()
-                            .map(|(sa, _)| (sa, Target::new(sa, identity.clone())))
-                            .collect(),
-                    ),
-                    Update::Remove(removes) => Update::Remove(removes),
-                    Update::DoesNotExist => Update::DoesNotExist,
-                }
-            }))))
+        fn map_endpoint(&self, control: &super::ControlAddr, addr: SocketAddr, _: ()) -> Self::Out {
+            super::client::Target::new(addr, control.identity.clone())
         }
     }
 }
@@ -270,17 +179,19 @@ pub mod client {
     use crate::transport::{connect, tls};
     use crate::{proxy::http, svc};
     use linkerd2_proxy_http::h2::Settings as H2Settings;
-    use std::net::SocketAddr;
-    use std::task::{Context, Poll};
+    use std::{
+        net::SocketAddr,
+        task::{Context, Poll},
+    };
 
     #[derive(Clone, Hash, Debug, Eq, PartialEq)]
     pub struct Target {
-        pub(super) addr: SocketAddr,
-        pub(super) server_name: tls::PeerIdentity,
+        addr: SocketAddr,
+        server_name: tls::PeerIdentity,
     }
 
     impl Target {
-        pub fn new(addr: SocketAddr, server_name: tls::PeerIdentity) -> Self {
+        pub(super) fn new(addr: SocketAddr, server_name: tls::PeerIdentity) -> Self {
             Self { addr, server_name }
         }
     }

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -111,7 +111,7 @@ pub mod add_origin {
         }
     }
 
-    // === impl Resolve ===
+    // === impl MakeFuture ===
 
     impl<F, B> Future for MakeFuture<F, B>
     where

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -192,10 +192,11 @@ pub mod dns_resolve {
         }
     }
 
-    impl<S> tower::Service<ControlAddr> for Resolve<S>
+    impl<S, T> tower::Service<ControlAddr> for Resolve<S>
     where
+        T: Clone,
         S: tower::Service<NameAddr>,
-        S::Response: Stream<Item = Result<Update<SocketAddr>, Error>> + Send + Sync + 'static,
+        S::Response: Stream<Item = Result<Update<T>, Error>> + Send + Sync + 'static,
         S::Error: Into<Error> + Send + Sync,
         S::Future: Send + Sync,
     {
@@ -228,10 +229,11 @@ pub mod dns_resolve {
 
     // === impl MakeFuture ===
 
-    impl<S> Future for MakeFuture<S>
+    impl<S, T> Future for MakeFuture<S>
     where
+        T: Clone,
         S: tower::Service<NameAddr>,
-        S::Response: Stream<Item = Result<Update<SocketAddr>, Error>> + Send + Sync + 'static,
+        S::Response: Stream<Item = Result<Update<T>, Error>> + Send + Sync + 'static,
         S::Error: Into<Error> + Send + Sync,
         S::Future: Send + Sync,
     {

--- a/linkerd/app/core/src/dns.rs
+++ b/linkerd/app/core/src/dns.rs
@@ -11,16 +11,15 @@ pub struct Config {
 
 pub struct Dns {
     pub resolver: Resolver,
-    pub task: Task,
 }
 
 // === impl Config ===
 
 impl Config {
     pub fn build(self) -> Dns {
-        let (resolver, task) =
+        let resolver =
             Resolver::from_system_config_with(&self).expect("system DNS config must be valid");
-        Dns { resolver, task }
+        Dns { resolver }
     }
 }
 

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -6,9 +6,8 @@
 //! - Admin interfaces
 //! - Tap
 //! - Metric labeling
-#![type_length_limit = "1586225"]
+
 #![deny(warnings, rust_2018_idioms)]
-#![recursion_limit = "512"]
 
 pub use linkerd2_addr::{self as addr, Addr, NameAddr};
 pub use linkerd2_admit as admit;

--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -6,7 +6,7 @@ use linkerd2_app_core::{
     config::{ControlAddr, ControlConfig},
     control, dns,
     exp_backoff::{ExponentialBackoff, ExponentialBackoffStream},
-    proxy::{discover, dns_resolve::DnsResolve, http},
+    proxy::{discover, http},
     reconnect,
     svc::{self, NewService},
     transport::tls,
@@ -53,14 +53,13 @@ impl Config {
                 let (local, crt_store) = Local::new(&certify);
 
                 let addr = control.addr;
-                let control_dns_resolve = control::dns_resolve::Resolve::new(DnsResolve::new(dns));
                 let svc = svc::connect(control.connect.keepalive)
                     .push(tls::ConnectLayer::new(tls::Conditional::Some(
                         certify.trust_anchors.clone(),
                     )))
                     .push_timeout(control.connect.timeout)
                     .push(control::client::layer())
-                    .push(discover::resolve(control_dns_resolve))
+                    .push(discover::resolve(control::resolve::new(dns)))
                     .push_on_response(http::balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
                     .push(reconnect::layer(Recover(control.connect.backoff)))
                     .push(metrics.into_layer::<classify::Response>())

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -61,7 +61,6 @@ pub struct Config {
 pub struct App {
     admin: admin::Admin,
     drain: drain::Signal,
-    dns: dns::Task,
     dst: ControlAddr,
     identity: identity::Identity,
     inbound_addr: SocketAddr,
@@ -230,7 +229,6 @@ impl Config {
             admin,
             dst: dst_addr,
             drain: drain_tx,
-            dns: dns.task,
             identity,
             inbound_addr,
             oc_collector,
@@ -290,7 +288,6 @@ impl App {
         let App {
             admin,
             drain,
-            dns,
             identity,
             oc_collector,
             start_proxy,
@@ -346,9 +343,6 @@ impl App {
                         } else {
                             admin.latch.release()
                         }
-
-                        // Spawn the DNS resolver background task.
-                        tokio::spawn(dns.instrument(info_span!("dns")));
 
                         if let tap::Tap::Enabled {
                             registry, serve, ..

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -1,6 +1,6 @@
 //! Configures and executes the proxy
 #![recursion_limit = "256"]
-//#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 
 pub mod admin;
 pub mod dst;

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -1,5 +1,5 @@
 //! Configures and executes the proxy
-#![recursion_limit = "256"]
+
 #![deny(warnings, rust_2018_idioms)]
 
 pub mod admin;

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-async-stream = "0.2.1"
 futures = "0.3"
 linkerd2-dns-name = { path = "./name" }
 linkerd2-stack = { path = "../stack" }

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 futures = "0.3"
 linkerd2-dns-name = { path = "./name" }
+linkerd2-error = { path = "../error" }
 linkerd2-stack = { path = "../stack" }
 tower = "0.3"
 tracing = "0.1.19"

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -65,7 +65,7 @@ impl Resolver {
 
     /// Resolves a name to a set of addresses, preferring SRV records to normal A
     /// record lookups.
-    pub async fn resolve_addr(
+    pub async fn resolve_addrs(
         &self,
         name: &Name,
         default_port: u16,
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn test_dns_name_parsing() {
-        // Stack sure `dns::Name`'s validation isn't too strict. It is
+        // Make sure `dns::Name`'s validation isn't too strict. It is
         // implemented in terms of `webpki::DNSName` which has many more tests
         // at https://github.com/briansmith/webpki/blob/master/tests/dns_name_tests.rs.
 

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
-#![recursion_limit = "512"]
+
 mod refine;
 
 pub use self::refine::{MakeRefine, Refine};

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -166,7 +166,7 @@ impl Resolver {
             .map_err(|_| Error::InvalidSRVRecord(srv.clone()))
     }
 
-    pub fn resolve_service_ips(
+    pub fn resolve_service_addrs(
         &self,
         svc: &Name,
     ) -> impl Stream<Item = Result<Vec<net::SocketAddr>, Error>> {

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -9,12 +9,13 @@ Service Dns Resolutions for the proxy
 """
 
 [dependencies]
+async-stream = "0.2"
 futures = "0.3"
 linkerd2-error = { path  = "../../error" }
 linkerd2-addr = { path = "../../addr" }
 linkerd2-dns = { path = "../../dns" }
 linkerd2-proxy-core = { path = "../core" }
-tokio = "0.2"
+tokio = { version = "0.2", features = ["stream", "sync"] }
 tracing = "0.1.9"
 
 [dependencies.tower]

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -9,7 +9,6 @@ Service Dns Resolutions for the proxy
 """
 
 [dependencies]
-async-stream = "0.2.1"
 futures = "0.3"
 linkerd2-error = { path  = "../../error" }
 linkerd2-addr = { path = "../../addr" }

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -16,6 +16,7 @@ linkerd2-dns = { path = "../../dns" }
 linkerd2-proxy-core = { path = "../core" }
 tokio = { version = "0.2", features = ["stream", "sync"] }
 tracing = "0.1.9"
+tracing-futures = "0.2"
 
 [dependencies.tower]
 version = "0.3"

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -9,7 +9,6 @@ Service Dns Resolutions for the proxy
 """
 
 [dependencies]
-async-stream = "0.2"
 futures = "0.3"
 linkerd2-error = { path  = "../../error" }
 linkerd2-addr = { path = "../../addr" }

--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -62,7 +62,7 @@ async fn resolution(dns: dns::Resolver, na: NameAddr) -> Result<UpdateStream, Er
 
     // Don't return a stream before the initial resolution completes. Then,
     // spawn a task to drive the continued resolution.
-    let (addrs, expiry) = dns.resolve_addr(na.name(), na.port()).await?;
+    let (addrs, expiry) = dns.resolve_addrs(na.name(), na.port()).await?;
     tokio::spawn(async move {
         let eps = addrs.into_iter().map(|a| (a, ())).collect();
         if tx.send(Ok(Update::Reset(eps))).await.is_err() {
@@ -72,7 +72,7 @@ async fn resolution(dns: dns::Resolver, na: NameAddr) -> Result<UpdateStream, Er
         expiry.await;
 
         loop {
-            match dns.resolve_addr(na.name(), na.port()).await {
+            match dns.resolve_addrs(na.name(), na.port()).await {
                 Ok((addrs, expiry)) => {
                     let eps = addrs.into_iter().map(|a| (a, ())).collect();
                     if tx.send(Ok(Update::Reset(eps))).await.is_err() {

--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -44,7 +44,7 @@ impl<T: Into<Addr>> tower::Service<T> for DnsResolve {
                 future::ok(Box::pin(stream))
             }
             Addr::Name(na) => {
-                let resolve = self.dns.resolve_service_ips(na.name());
+                let resolve = self.dns.resolve_service_addrs(na.name());
                 let stream = try_stream! {
                     tokio::pin!(resolve);
                     while let Some(addrs) = resolve.next().await {

--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -3,13 +3,17 @@
 use futures::{future, prelude::*, stream};
 use linkerd2_addr::Addr;
 use linkerd2_dns as dns;
+use linkerd2_error::Error;
 use linkerd2_proxy_core::resolve::Update;
 use std::{
     net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
 };
+use tokio::sync::mpsc;
+use tracing::debug;
 
+/// A Resolver that attempts to lookup
 #[derive(Clone)]
 pub struct DnsResolve {
     dns: linkerd2_dns::Resolver,
@@ -21,36 +25,105 @@ impl DnsResolve {
     }
 }
 
-type UpdatesStream =
-    Pin<Box<dyn Stream<Item = Result<Update<()>, dns::Error>> + Send + Sync + 'static>>;
+type UpdateStream = Pin<Box<dyn Stream<Item = Result<Update<()>, Error>> + Send + Sync + 'static>>;
 
 impl<T: Into<Addr>> tower::Service<T> for DnsResolve {
-    type Response = UpdatesStream;
-    type Error = dns::Error;
-    type Future = future::Ready<Result<Self::Response, Self::Error>>;
+    type Response = UpdateStream;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<UpdateStream, Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, target: T) -> Self::Future {
-        match target.into() {
+        let addr = match target.into() {
             Addr::Name(na) if na.is_localhost() => {
-                let sa = SocketAddr::from(([127, 0, 0, 1], na.port()));
-                let eps = vec![(sa, ())];
-                future::ok(Box::pin(stream::iter(Some(Ok(Update::Reset(eps))))))
+                SocketAddr::from(([127, 0, 0, 1], na.port())).into()
             }
-            Addr::Name(na) => {
-                let resolve = self.dns.resolve_service_addrs(na.name().clone());
-                let updates = resolve.map_ok(|addrs| {
-                    let eps = addrs.into_iter().map(|a| (a, ())).collect();
-                    Update::Reset(eps)
-                });
-                future::ok(Box::pin(updates))
-            }
+            addr => addr,
+        };
+
+        match addr {
             Addr::Socket(sa) => {
                 let eps = vec![(sa, ())];
-                future::ok(Box::pin(stream::iter(Some(Ok(Update::Reset(eps))))))
+                let updates: UpdateStream = Box::pin(stream::iter(Some(Ok(Update::Reset(eps)))));
+                Box::pin(future::ok(updates))
+            }
+            Addr::Name(na) => {
+                let dns = self.dns.clone();
+                Box::pin(async move {
+                    let (mut tx, rx) = mpsc::channel::<Result<Update<()>, Error>>(1);
+
+                    // First, try to resolve the name via SRV records.
+                    match dns.resolve_srv(na.name().clone()).await {
+                        Ok((addrs, expiry)) => {
+                            tokio::spawn(async move {
+                                let eps = addrs.into_iter().map(|a| (a, ())).collect();
+                                if tx.send(Ok(Update::Reset(eps))).await.is_err() {
+                                    return;
+                                }
+                                expiry.await;
+                                loop {
+                                    match dns.resolve_srv(na.name().clone()).await {
+                                        Ok((addrs, expiry)) => {
+                                            let eps = addrs.into_iter().map(|a| (a, ())).collect();
+                                            if tx.send(Ok(Update::Reset(eps))).await.is_err() {
+                                                return;
+                                            }
+                                            expiry.await;
+                                        }
+                                        Err(e) => {
+                                            let _ = tx.send(Err(e)).await;
+                                            return;
+                                        }
+                                    }
+                                }
+                            });
+                        }
+
+                        // If the initial SRV resolution failed because we
+                        // couldn't parse out IPs from the response, try falling
+                        // back to normal-old A records.
+                        Err(e) if e.is::<dns::InvalidSrv>() => {
+                            let port = na.port();
+                            let (ips, expiry) = dns.resolve_a(na.name().clone()).await?;
+
+                            tokio::spawn(async move {
+                                let eps = ips
+                                    .into_iter()
+                                    .map(|i| (SocketAddr::new(i, port), ()))
+                                    .collect();
+                                if tx.send(Ok(Update::Reset(eps))).await.is_err() {
+                                    return;
+                                }
+                                expiry.await;
+                                loop {
+                                    match dns.resolve_a(na.name().clone()).await {
+                                        Ok((ips, expiry)) => {
+                                            let eps = ips
+                                                .into_iter()
+                                                .map(|i| (SocketAddr::new(i, port), ()))
+                                                .collect();
+                                            if tx.send(Ok(Update::Reset(eps))).await.is_err() {
+                                                return;
+                                            }
+                                            expiry.await;
+                                        }
+                                        Err(e) => {
+                                            let _ = tx.send(Err(e.into())).await;
+                                            return;
+                                        }
+                                    }
+                                }
+                            });
+                        }
+                        Err(e) => return Err(e),
+                    }
+
+                    let updates: UpdateStream = Box::pin(rx);
+                    Ok(updates)
+                })
             }
         }
     }

--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -1,17 +1,14 @@
-#![recursion_limit = "512"]
+//#![recursion_limit = "512"]
+#![deny(warnings, rust_2018_idioms)]
 
 use async_stream::try_stream;
-use futures::future;
-use futures::pin_mut;
-use futures::prelude::*;
+use futures::{future, prelude::*};
 use linkerd2_addr::NameAddr;
 use linkerd2_dns as dns;
 use linkerd2_error::Error;
 use linkerd2_proxy_core::resolve::Update;
-use std::net::SocketAddr;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tracing::debug;
 
 #[derive(Clone)]
 pub struct DnsResolve {
@@ -24,8 +21,7 @@ impl DnsResolve {
     }
 }
 
-type UpdatesStream =
-    Pin<Box<dyn Stream<Item = Result<Update<SocketAddr>, Error>> + Send + Sync + 'static>>;
+type UpdatesStream = Pin<Box<dyn Stream<Item = Result<Update<()>, Error>> + Send + Sync + 'static>>;
 
 impl tower::Service<NameAddr> for DnsResolve {
     type Response = UpdatesStream;
@@ -37,120 +33,14 @@ impl tower::Service<NameAddr> for DnsResolve {
     }
 
     fn call(&mut self, target: NameAddr) -> Self::Future {
-        futures::future::ok(Box::pin(resolution_stream(
-            self.dns.resolve_service_ips(target.name()),
-        )))
-    }
-}
-
-pub fn diff_targets(
-    old_targets: &Vec<SocketAddr>,
-    new_targets: &Vec<SocketAddr>,
-) -> (Vec<SocketAddr>, Vec<SocketAddr>) {
-    let mut adds = Vec::default();
-    let mut removes = Vec::default();
-
-    for new_target in new_targets {
-        if !old_targets.contains(new_target) {
-            adds.push(new_target.clone())
-        }
-    }
-
-    for old_target in old_targets {
-        if !new_targets.contains(old_target) {
-            removes.push(old_target.clone())
-        }
-    }
-
-    (adds, removes)
-}
-
-pub fn resolution_stream<S>(input: S) -> impl Stream<Item = Result<Update<SocketAddr>, Error>>
-where
-    S: futures::stream::Stream<Item = Result<Vec<SocketAddr>, dns::Error>>,
-    S: Send + 'static,
-{
-    try_stream! {
-        pin_mut!(input);
-        let mut current: Vec<SocketAddr> = Vec::new();
-        while let Some(result) = input.next().await {
-            let result = result?;
-            if result.is_empty() {
-                current.clear();
-                yield Update::Reset(Vec::new());
+        let resolve = self.dns.resolve_service_ips(target.name());
+        let stream = try_stream! {
+            tokio::pin!(resolve);
+            while let Some(addrs) = resolve.next().await {
+                let addrs = addrs?;
+                yield Update::Reset(addrs.into_iter().map(|a| (a, ())).collect());
             }
-
-            let (adds, removes) = diff_targets(&current, &result);
-            debug!(?adds, ?removes, "resolved");
-            if !adds.is_empty() {
-                let adds = adds.into_iter().map(|addr| (addr, addr)).collect();
-                yield Update::Add(adds);
-            }
-
-            if !removes.is_empty() {
-                yield Update::Remove(removes);
-            }
-            current.clear();
-            current.extend(result);
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tokio::sync::mpsc;
-    use tokio_test::{assert_pending, assert_ready_eq, task};
-
-    #[tokio::test]
-    async fn yields_add() {
-        let (mut tx, rx1) = mpsc::channel(10);
-
-        let mut stream = task::spawn(resolution_stream(rx1).map_err(|_| ()));
-
-        let sa = "127.0.0.1:8080".parse().unwrap();
-        assert_pending!(stream.poll_next());
-        tx.send(Ok(vec![sa])).await.unwrap();
-        assert_ready_eq!(stream.poll_next(), Some(Ok(Update::Add(vec![(sa, sa)]))));
-    }
-
-    #[tokio::test]
-    async fn yields_remove() {
-        let (mut tx, rx1) = mpsc::channel(10);
-
-        let mut stream = task::spawn(resolution_stream(rx1).map_err(|_| ()));
-
-        let sa_1 = "127.0.0.1:8080".parse().unwrap();
-        let sa_2 = "127.0.0.2:8080".parse().unwrap();
-
-        tx.send(Ok(vec![sa_1])).await.unwrap();
-        assert_ready_eq!(
-            stream.poll_next(),
-            Some(Ok(Update::Add(vec![(sa_1, sa_1)])))
-        );
-        tx.send(Ok(vec![sa_2])).await.unwrap();
-        assert_ready_eq!(
-            stream.poll_next(),
-            Some(Ok(Update::Add(vec![(sa_2, sa_2)])))
-        );
-        assert_ready_eq!(stream.poll_next(), Some(Ok(Update::Remove(vec![sa_1]))));
-    }
-
-    #[tokio::test]
-    async fn yields_empty() {
-        let (mut tx, rx1) = mpsc::channel(10);
-
-        let mut stream = task::spawn(resolution_stream(rx1).map_err(|_| ()));
-
-        let sa_1 = "127.0.0.1:8080".parse().unwrap();
-        let sa_2 = "127.0.0.2:8080".parse().unwrap();
-
-        tx.send(Ok(vec![sa_1, sa_2])).await.unwrap();
-        assert_ready_eq!(
-            stream.poll_next(),
-            Some(Ok(Update::Add(vec![(sa_1, sa_1), (sa_2, sa_2)])))
-        );
-        tx.send(Ok(vec![])).await.unwrap();
-        assert_ready_eq!(stream.poll_next(), Some(Ok(Update::Reset(vec![]))));
+        };
+        future::ok(Box::pin(stream))
     }
 }

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -1,7 +1,6 @@
 //! The main entrypoint for the proxy.
 
 #![deny(warnings, rust_2018_idioms)]
-#![recursion_limit = "256"]
 #![type_length_limit = "16289823"]
 
 use linkerd2_app::{trace, Config};


### PR DESCRIPTION
```
commit 6057920256be10d5a55aef38424d0c224dd033b1 (HEAD -> ver/dns-srv, origin/ver/dns-srv)
Merge: b3808cc5 bff503e7
Author: Oliver Gould <ver@buoyant.io>
Date:   Tue Aug 25 01:29:59 2020 +0000

    Merge branch 'ver/dns-fg' into ver/dns-srv
    
    This merge removes some try_stream! uses to satisfy `Unpin`
    requirements.

commit bff503e74b5ea4798a81fc343ea649cd84e19397 (origin/ver/dns-fg, ver/dns-fg)
Author: Oliver Gould <ver@buoyant.io>
Date:   Tue Aug 25 00:17:24 2020 +0000

    dns: Run DNS resolutions on the main runtime
    
    DNS resolutions are run on the admin runtime. This requires an
    unnecessary layer of indirection around the resolver, including an MPSC.
    
    Now that we allow the main runtime to use more than one thread, it's
    preferable to do this discovery on the main runtime and we can simplify
    the implementation.

commit b3808cc55b4f5f8e2d6209661a203dee75744d2f
Author: Oliver Gould <ver@buoyant.io>
Date:   Tue Aug 25 00:04:29 2020 +0000

    lookup_service_ips => lookup_service_addrs

commit 2f3e7c43c6f0a0f31640535aa2e684d4c62d528e
Author: Oliver Gould <ver@buoyant.io>
Date:   Mon Aug 24 23:59:09 2020 +0000

    undo unnecessarty change

commit 9154fcdc60d9679f6187f7eb500856ca75edd7a3
Author: Oliver Gould <ver@buoyant.io>
Date:   Mon Aug 24 23:49:59 2020 +0000

    Use map_endpoint to build control client targets

commit 16d5014ef3ff0b901b81e2854e1a1d57648b1c5c
Author: Oliver Gould <ver@buoyant.io>
Date:   Mon Aug 24 23:03:57 2020 +0000

    undo errant change

commit 7c9e529fc18c56468dc20a308d70c327db411ca3
Author: Oliver Gould <ver@buoyant.io>
Date:   Mon Aug 24 23:01:39 2020 +0000

    dns-resolve: Always use resets
    
    There's no reason that we have to maintain the resolution state now that
    we have a Reset type.
    
    Furthermore, we can use a unit endpoint type, since it is ignored.

```