### PR TITLE
dns: Run DNS resolutions on the main runtime

### DIFF
--- a/linkerd/app/core/src/dns.rs
+++ b/linkerd/app/core/src/dns.rs
@@ -11,16 +11,15 @@ pub struct Config {
 
 pub struct Dns {
     pub resolver: Resolver,
-    pub task: Task,
 }
 
 // === impl Config ===
 
 impl Config {
     pub fn build(self) -> Dns {
-        let (resolver, task) =
+        let resolver =
             Resolver::from_system_config_with(&self).expect("system DNS config must be valid");
-        Dns { resolver, task }
+        Dns { resolver }
     }
 }
 

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -57,7 +57,6 @@ pub struct Config {
 pub struct App {
     admin: admin::Admin,
     drain: drain::Signal,
-    dns: dns::Task,
     dst: ControlAddr,
     identity: identity::Identity,
     inbound_addr: SocketAddr,
@@ -223,7 +222,6 @@ impl Config {
             admin,
             dst: dst_addr,
             drain: drain_tx,
-            dns: dns.task,
             identity,
             inbound_addr,
             oc_collector,
@@ -283,7 +281,6 @@ impl App {
         let App {
             admin,
             drain,
-            dns,
             identity,
             oc_collector,
             start_proxy,
@@ -339,9 +336,6 @@ impl App {
                         } else {
                             admin.latch.release()
                         }
-
-                        // Spawn the DNS resolver background task.
-                        tokio::spawn(dns.instrument(info_span!("dns")));
 
                         if let tap::Tap::Enabled {
                             registry, serve, ..


### PR DESCRIPTION
DNS resolutions are run on the admin runtime. This requires an
unnecessary layer of indirection around the resolver, including an MPSC.

Now that we allow the main runtime to use more than one thread, it's
preferable to do this discovery on the main runtime and we can simplify
the implementation.