### PR TITLE
Unify control plane client construction

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -1,4 +1,3 @@
-pub use super::control::ControlAddr;
 pub use crate::exp_backoff::ExponentialBackoff;
 pub use crate::proxy::http::h2;
 pub use crate::transport::{Bind, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr};
@@ -30,13 +29,6 @@ pub struct ProxyConfig {
     pub dispatch_timeout: Duration,
     pub max_in_flight_requests: usize,
     pub detect_protocol_timeout: Duration,
-}
-
-#[derive(Clone, Debug)]
-pub struct ControlConfig {
-    pub addr: ControlAddr,
-    pub connect: ConnectConfig,
-    pub buffer_capacity: usize,
 }
 
 // === impl ServerConfig ===

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -40,7 +40,7 @@ pub type Client<B> = Buffer<
         linkerd2_http_metrics::requests::ResponseBody<
             http::balance::PendingUntilFirstDataBody<
                 tower::load::peak_ewma::Handle,
-                linkerd2_proxy_http::glue::Body,
+                http::glue::Body,
             >,
             classify::Eos,
         >,

--- a/linkerd/app/src/dst/mod.rs
+++ b/linkerd/app/src/dst/mod.rs
@@ -35,7 +35,6 @@ pub struct Dst {
 }
 
 impl Config {
-    // XXX This is unfortunate -- the service should be built here, but it's annoying to name.
     pub fn build(
         self,
         dns: dns::Resolver,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -1,6 +1,7 @@
 use crate::core::{
     addr,
     config::*,
+    control::{Config as ControlConfig, ControlAddr},
     proxy::http::h2,
     transport::{listen, tls},
     Addr,

--- a/linkerd/http-box/src/payload.rs
+++ b/linkerd/http-box/src/payload.rs
@@ -4,6 +4,7 @@ use linkerd2_error::Error;
 use pin_project::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+
 pub struct Payload {
     inner: Pin<Box<dyn Body<Data = Data, Error = Error> + Send + 'static>>,
 }

--- a/linkerd/http-metrics/src/requests/mod.rs
+++ b/linkerd/http-metrics/src/requests/mod.rs
@@ -11,6 +11,8 @@ use std::time::{Duration, Instant};
 mod layer;
 mod report;
 
+pub use self::layer::ResponseBody;
+
 type SharedRegistry<T, C> = Arc<Mutex<Registry<T, Metrics<C>>>>;
 
 #[derive(Debug)]


### PR DESCRIPTION
We construct three control plane clients. All of the clients are
basically the same (at least with regard to the stack/configuration).
Rather than duplicate this logic throughout the code, we can unify it in
the `control` module (hiding the details of how the client is built).

This change modifies how the OpenCensus collector client is
instantiated. The `SpanExporter` no longer constructs a new client each
time it wishes to initiate a stream, opting to just clone a single
client instead.

This change also fixes reconnect logic for these clients. When the
control client balancer was introduced, the reconnect layer incorrectly
wrapped the balancer (instead of the endpoint). This has been corrected.