### PR TITLE
Recognize NXDomain Errors

### DIFF
--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -101,9 +101,7 @@ impl Resolver {
                 }
                 ResolveErrorKind::Proto(pe) if self.is_nx_domain(&pe) => Ok((
                     vec![],
-                    time::delay_until(Instant::from_std(
-                        std::time::Instant::now() + Self::DEFAULT_TTL,
-                    )),
+                    time::delay_for(Self::DEFAULT_TTL)),
                 )),
 
                 _ => Err(e),
@@ -112,10 +110,10 @@ impl Resolver {
     }
 
     fn is_nx_domain(&self, pe: &error::ProtoError) -> bool {
-        return match pe.kind() {
+        match pe.kind() {
             error::ProtoErrorKind::Message(msg) => *msg == "Nameserver responded with NXDomain",
             _ => false,
-        };
+        }
     }
 
     async fn resolve_srv(&self, name: &Name) -> Result<(Vec<net::SocketAddr>, time::Delay), Error> {
@@ -138,9 +136,7 @@ impl Resolver {
                 }
                 ResolveErrorKind::Proto(pe) if self.is_nx_domain(&pe) => Ok((
                     vec![],
-                    time::delay_until(Instant::from_std(
-                        std::time::Instant::now() + Self::DEFAULT_TTL,
-                    )),
+                    time::delay_for(Self::DEFAULT_TTL)),
                 )),
                 _ => Err(e.into()),
             },

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -30,7 +30,10 @@ pub trait ConfigureResolver {
 struct InvalidSrv(rdata::SRV);
 
 impl Resolver {
-    const DEFAULT_TTL: std::time::Duration = std::time::Duration::from_secs(60);
+    // When the DNS library does not return a TTL, we must assume one to prevent
+    // tight-looping. In practice, default kubernetes configs appear to have a
+    // 5s TTL, so we mirror that default here.
+    const DEFAULT_TTL: std::time::Duration = std::time::Duration::from_secs(5);
 
     /// Construct a new `Resolver` from environment variables and system
     /// configuration.
@@ -93,26 +96,7 @@ impl Resolver {
                 let ips = lookup.iter().collect::<Vec<_>>();
                 Ok((ips, time::delay_until(valid_until)))
             }
-            Err(e) => match e.kind() {
-                ResolveErrorKind::NoRecordsFound { valid_until, .. } => {
-                    let expiry = valid_until
-                        .unwrap_or_else(|| std::time::Instant::now() + Self::DEFAULT_TTL);
-                    Ok((vec![], time::delay_until(Instant::from_std(expiry))))
-                }
-                ResolveErrorKind::Proto(pe) if self.is_nx_domain(&pe) => Ok((
-                    vec![],
-                    time::delay_for(Self::DEFAULT_TTL)),
-                )),
-
-                _ => Err(e),
-            },
-        }
-    }
-
-    fn is_nx_domain(&self, pe: &error::ProtoError) -> bool {
-        match pe.kind() {
-            error::ProtoErrorKind::Message(msg) => *msg == "Nameserver responded with NXDomain",
-            _ => false,
+            Err(e) => Self::handle_error(e),
         }
     }
 
@@ -128,18 +112,32 @@ impl Resolver {
                 debug!(?addrs);
                 Ok((addrs, time::delay_until(valid_until)))
             }
-            Err(e) => match e.kind() {
-                ResolveErrorKind::NoRecordsFound { valid_until, .. } => {
-                    let expiry = valid_until
-                        .unwrap_or_else(|| std::time::Instant::now() + Self::DEFAULT_TTL);
-                    Ok((vec![], time::delay_until(Instant::from_std(expiry))))
-                }
-                ResolveErrorKind::Proto(pe) if self.is_nx_domain(&pe) => Ok((
-                    vec![],
-                    time::delay_for(Self::DEFAULT_TTL)),
-                )),
-                _ => Err(e.into()),
-            },
+            Err(e) => Self::handle_error(e).map_err(Into::into),
+        }
+    }
+
+    fn handle_error<T>(e: ResolveError) -> Result<(Vec<T>, time::Delay), ResolveError> {
+        match e.kind() {
+            ResolveErrorKind::NoRecordsFound { valid_until, .. } => {
+                let expiry =
+                    valid_until.unwrap_or_else(|| std::time::Instant::now() + Self::DEFAULT_TTL);
+                Ok((vec![], time::delay_until(Instant::from_std(expiry))))
+            }
+            ResolveErrorKind::Proto(pe) if Self::is_nx_domain(&pe) => {
+                Ok((vec![], time::delay_for(Self::DEFAULT_TTL)))
+            }
+            _ => Err(e),
+        }
+    }
+
+    // XXX This is a workaround for
+    // https://github.com/bluejekyll/trust-dns/issues/1171.
+    //
+    // It should be removed once this bug is fixed upstream.
+    fn is_nx_domain(pe: &error::ProtoError) -> bool {
+        match pe.kind() {
+            error::ProtoErrorKind::Message(msg) => *msg == "Nameserver responded with NXDomain",
+            _ => false,
         }
     }
 


### PR DESCRIPTION
Unfrotunatelly due to https://github.com/bluejekyll/trust-dns/issues/1171 we can not see NoRecordsFound errors. There is not a stong type we can rely on and therefore we need to read the actual proto message to determine that we have gotten a negative resolution and return an empty list of IPs

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>