### PR TITLE
service-profiles: Eliminate the HasDestination trait

### DIFF
--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -147,9 +147,12 @@ mod test {
                 ))
             };
 
+            let socket_addr = SocketAddr::from(([127, 0, 0, 1], 4143));
             let target = inbound::Target {
-                addr: SocketAddr::from(([127, 0, 0, 1], 4143)),
-                dst_name: dst_name.map(|n| NameAddr::from_str(n).unwrap()),
+                socket_addr,
+                logical: dst_name
+                    .map(|n| NameAddr::from_str(n).unwrap().into())
+                    .unwrap_or_else(|| socket_addr.into()),
                 http_settings: http::Settings::Http2,
                 tls_client_id: peer_id,
             };

--- a/linkerd/app/gateway/src/make.rs
+++ b/linkerd/app/gateway/src/make.rs
@@ -118,9 +118,9 @@ where
 
                     // Create an outbound target using the resolved IP & name.
                     let dst_addr = (dst_ip, orig_dst.port()).into();
-                    let dst = NameAddr::new(name, orig_dst.port());
+                    let dst_name = NameAddr::new(name, orig_dst.port());
                     let endpoint = outbound::Logical {
-                        addr: dst.clone().into(),
+                        addr: dst_name.clone().into(),
                         inner: outbound::HttpEndpoint {
                             addr: dst_addr,
                             settings: http_settings,
@@ -132,7 +132,7 @@ where
                     };
 
                     let svc = outbound.call(endpoint).await.map_err(Into::into)?;
-                    Ok(Gateway::new(svc, source_identity, dst, local_identity))
+                    Ok(Gateway::new(svc, source_identity, dst_name, local_identity))
                 })
             }
         }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -258,7 +258,7 @@ impl Config {
                 ),
             )
             .spawn_buffer(buffer_capacity)
-            .instrument(|p: &Profile| info_span!("profile", addr = %p.addr()))
+            .instrument(|p: &Profile| info_span!("profile", addr = %p.as_ref()))
             .check_make_service::<Profile, Target>()
             .push(router::Layer::new(|()| ProfileTarget))
             .check_new_service_routes::<(), Target>()

--- a/linkerd/app/inbound/src/prevent_loop.rs
+++ b/linkerd/app/inbound/src/prevent_loop.rs
@@ -24,8 +24,8 @@ impl admit::Admit<Target> for PreventLoop {
     type Error = LoopPrevented;
 
     fn admit(&mut self, ep: &Target) -> Result<(), Self::Error> {
-        tracing::debug!(addr = %ep.addr, self.port);
-        if ep.addr.port() == self.port {
+        tracing::debug!(addr = %ep.socket_addr, self.port);
+        if ep.socket_addr.port() == self.port {
             return Err(LoopPrevented { port: self.port });
         }
 

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -430,9 +430,9 @@ impl<T> router::Recognize<Target<T>> for ProfilePerTarget {
 
 // === impl Profile ===
 
-impl profiles::HasDestination for Profile {
-    fn destination(&self) -> Addr {
-        self.0.clone()
+impl AsRef<Addr> for Profile {
+    fn as_ref(&self) -> &Addr {
+        &self.0
     }
 }
 

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -112,8 +112,9 @@ where
     }
 }
 
-impl<S, R> tower::Service<Addr> for Client<S, R>
+impl<T, S, R> tower::Service<T> for Client<S, R>
 where
+    T: AsRef<Addr>,
     S: GrpcService<BoxBody> + Clone + Send + 'static,
     S::ResponseBody: Send,
     <S::ResponseBody as Body>::Data: Send,
@@ -132,8 +133,8 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, dst: Addr) -> Self::Future {
-        let path = dst.to_string();
+    fn call(&mut self, dst: T) -> Self::Future {
+        let path = dst.as_ref().to_string();
 
         let service = {
             // In case the ready service holds resources, pass it into the

--- a/linkerd/service-profiles/src/http/mod.rs
+++ b/linkerd/service-profiles/src/http/mod.rs
@@ -50,8 +50,7 @@ pub trait GetRoutes<T> {
 
 impl<T, S> GetRoutes<T> for S
 where
-    T: HasDestination,
-    S: tower::Service<Addr, Response = watch::Receiver<Routes>>,
+    S: tower::Service<T, Response = watch::Receiver<Routes>>,
     S::Error: Into<Error>,
 {
     type Error = S::Error;
@@ -62,7 +61,7 @@ where
     }
 
     fn get_routes(&mut self, target: T) -> Self::Future {
-        tower::Service::call(self, target.destination())
+        tower::Service::call(self, target)
     }
 }
 
@@ -77,12 +76,6 @@ pub trait WithRoute {
 /// changed.
 pub trait OverrideDestination {
     fn dst_mut(&mut self) -> &mut Addr;
-}
-
-/// Implemented by target types that may have a `NameAddr` destination that
-/// can be discovered via `GetRoutes`.
-pub trait HasDestination {
-    fn destination(&self) -> Addr;
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]


### PR DESCRIPTION
The `HasDestination` trait isn't particularly useful, as it's basically
just `AsRef<Addr>`.

This change updates the `GetRoutes` signature to support this; and it
updates the inbound target type to store an `Addr` instead of an
`Option<NameAddr>` (so `Target` will be suitable for this in an upcoming
change).