### PR TITLE
outbound: Make discovery error detection generic

### DIFF
--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -598,11 +598,13 @@ impl From<Error> for DiscoveryError {
 }
 
 fn is_discovery_rejected(err: &Error) -> bool {
-    tracing::trace!(?err, "is_discovery_rejected");
-
-    if let Some(e) = err.downcast_ref::<svc::buffer::error::ServiceError>() {
-        return is_discovery_rejected(e.inner());
+    fn is_rejected(err: &(dyn std::error::Error + 'static)) -> bool {
+        err.is::<DiscoveryRejected>()
+            || err.is::<profiles::InvalidProfileAddr>()
+            || err.source().map(is_rejected).unwrap_or(false)
     }
 
-    err.is::<DiscoveryRejected>() || err.is::<profiles::InvalidProfileAddr>()
+    let rejected = is_rejected(&**err);
+    tracing::debug!(rejected, %err);
+    rejected
 }


### PR DESCRIPTION
The outbound proxy handles discovery rejection error with a fallback
router. The current implementation does not allow for middlewares
to wrap errors in a general fashion.

This change updates the `is_discovery_rejecte` function to examine
aribitrary error types to determine if the underlying error matches the
known types.