### PR TITLE
service-profiles: Cleanup crate organization

### DIFF
--- a/linkerd/app/core/src/classify.rs
+++ b/linkerd/app/core/src/classify.rs
@@ -12,14 +12,14 @@ use tracing::trace;
 #[derive(Clone, Debug)]
 pub enum Request {
     Default,
-    Profile(profiles::ResponseClasses),
+    Profile(profiles::http::ResponseClasses),
 }
 
 #[derive(Clone, Debug)]
 pub enum Response {
     Default,
     Grpc,
-    Profile(profiles::ResponseClasses),
+    Profile(profiles::http::ResponseClasses),
 }
 
 #[derive(Clone, Debug)]
@@ -51,8 +51,8 @@ pub enum SuccessOrFailure {
 
 // === impl Request ===
 
-impl From<profiles::ResponseClasses> for Request {
-    fn from(classes: profiles::ResponseClasses) -> Self {
+impl From<profiles::http::ResponseClasses> for Request {
+    fn from(classes: profiles::http::ResponseClasses) -> Self {
         if classes.is_empty() {
             Request::Default
         } else {
@@ -106,7 +106,7 @@ impl Default for Response {
 impl Response {
     fn match_class<B>(
         rsp: &http::Response<B>,
-        classes: &[profiles::ResponseClass],
+        classes: &[profiles::http::ResponseClass],
     ) -> Option<Class> {
         for class in classes {
             if class.is_match(rsp) {

--- a/linkerd/app/core/src/dst.rs
+++ b/linkerd/app/core/src/dst.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Route {
     pub target: Addr,
-    pub route: profiles::Route,
+    pub route: profiles::http::Route,
     pub direction: super::metric_labels::Direction,
 }
 

--- a/linkerd/app/core/src/retry.rs
+++ b/linkerd/app/core/src/retry.rs
@@ -30,7 +30,7 @@ pub struct NewRetry<C = ()> {
 pub struct Retry<C = ()> {
     metrics: Handle,
     budget: Arc<Budget>,
-    response_classes: profiles::ResponseClasses,
+    response_classes: profiles::http::ResponseClasses,
     _clone_request: PhantomData<C>,
 }
 

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -129,7 +129,7 @@ impl profiles::HasDestination for Profile {
 impl profiles::WithRoute for Profile {
     type Route = dst::Route;
 
-    fn with_route(self, route: profiles::Route) -> Self::Route {
+    fn with_route(self, route: profiles::http::Route) -> Self::Route {
         dst::Route {
             route,
             target: self.0.clone(),

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -66,7 +66,7 @@ impl Config {
             + 'static,
         S::Error: Into<Error>,
         S::Future: Unpin + Send,
-        P: profiles::GetRoutes<Profile> + Unpin + Clone + Send + 'static,
+        P: profiles::GetProfile<Profile> + Unpin + Clone + Send + 'static,
         P::Future: Unpin + Send,
     {
         let tcp_connect = self.build_tcp_connect(&metrics);
@@ -148,7 +148,7 @@ impl Config {
         C::Error: Into<Error>,
         C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
         C::Future: Unpin + Send,
-        P: profiles::GetRoutes<Profile> + Unpin + Clone + Send + 'static,
+        P: profiles::GetProfile<Profile> + Unpin + Clone + Send + 'static,
         P::Future: Unpin + Send,
         // The loopback router processes requests sent to the inbound port.
         L: tower::Service<Target, Response = S> + Unpin + Send + Clone + 'static,

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -439,7 +439,7 @@ impl profiles::HasDestination for Profile {
 impl profiles::WithRoute for Profile {
     type Route = dst::Route;
 
-    fn with_route(self, route: profiles::Route) -> Self::Route {
+    fn with_route(self, route: profiles::http::Route) -> Self::Route {
         dst::Route {
             route,
             target: self.0.clone(),

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -239,7 +239,7 @@ impl Config {
             + 'static,
         R::Future: Unpin + Send,
         R::Resolution: Unpin + Send,
-        P: profiles::GetRoutes<Profile> + Unpin + Clone + Send + 'static,
+        P: profiles::GetProfile<Profile> + Unpin + Clone + Send + 'static,
         P::Future: Unpin + Send,
     {
         let ProxyConfig {

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -1,9 +1,8 @@
-use crate::http as profiles;
+use crate::{http, Profile, Receiver, Target};
 use api::destination_client::DestinationClient;
 use futures::{future, prelude::*, ready, select_biased};
-use http;
 use http_body::Body as HttpBody;
-use linkerd2_addr::{Addr, NameAddr};
+use linkerd2_addr::Addr;
 use linkerd2_error::{Error, Recover};
 use linkerd2_proxy_api::destination as api;
 use pin_project::pin_project;
@@ -32,8 +31,6 @@ pub struct Client<S, R> {
     initial_timeout: Duration,
     context_token: String,
 }
-
-pub type Receiver = watch::Receiver<profiles::Routes>;
 
 #[derive(Clone, Debug)]
 pub struct InvalidProfileAddr(Addr);
@@ -92,7 +89,7 @@ impl<S, R> Client<S, R>
 where
     // These bounds aren't *required* here, they just help detect the problem
     // earlier (as Client::new), instead of when trying to passing a `Client`
-    // to something that wants `impl profiles::GetRoutes`.
+    // to something that wants `impl GetProfile`.
     S: GrpcService<BoxBody> + Clone + Send + 'static,
     S::ResponseBody: Send,
     <S::ResponseBody as Body>::Data: Send,
@@ -195,7 +192,7 @@ where
                 }
 
                 info!("Using default service profile after timeout");
-                profiles::Routes::default()
+                Profile::default()
             }
             Poll::Ready(Ok(profile)) => profile,
         };
@@ -252,25 +249,25 @@ where
     fn poll_rx(
         rx: Pin<&mut grpc::Streaming<api::DestinationProfile>>,
         cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<profiles::Routes, grpc::Status>>> {
+    ) -> Poll<Option<Result<Profile, grpc::Status>>> {
         trace!("poll");
         let profile = ready!(rx.poll_next(cx)).map(|res| {
             res.map(|proto| {
                 debug!("profile received: {:?}", proto);
                 let retry_budget = proto.retry_budget.and_then(convert_retry_budget);
-                let routes = proto
+                let http_routes = proto
                     .routes
                     .into_iter()
                     .filter_map(move |orig| convert_route(orig, retry_budget.as_ref()))
                     .collect();
-                let dst_overrides = proto
+                let targets = proto
                     .dst_overrides
                     .into_iter()
                     .filter_map(convert_dst_override)
                     .collect();
-                profiles::Routes {
-                    routes,
-                    dst_overrides,
+                Profile {
+                    http_routes,
+                    targets,
                 }
             })
         });
@@ -280,7 +277,7 @@ where
     fn poll_profile(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-    ) -> Poll<Result<profiles::Routes, Error>> {
+    ) -> Poll<Result<Profile, Error>> {
         let span = info_span!("poll_profile");
         let _enter = span.enter();
 
@@ -336,14 +333,14 @@ where
 fn convert_route(
     orig: api::Route,
     retry_budget: Option<&Arc<Budget>>,
-) -> Option<(profiles::RequestMatch, profiles::Route)> {
+) -> Option<(http::RequestMatch, http::Route)> {
     let req_match = orig.condition.and_then(convert_req_match)?;
     let rsp_classes = orig
         .response_classes
         .into_iter()
         .filter_map(convert_rsp_class)
         .collect();
-    let mut route = profiles::Route::new(orig.metrics_labels.into_iter(), rsp_classes);
+    let mut route = http::Route::new(orig.metrics_labels.into_iter(), rsp_classes);
     if orig.is_retryable {
         set_route_retry(&mut route, retry_budget);
     }
@@ -353,19 +350,18 @@ fn convert_route(
     Some((req_match, route))
 }
 
-fn convert_dst_override(orig: api::WeightedDst) -> Option<profiles::WeightedAddr> {
+fn convert_dst_override(orig: api::WeightedDst) -> Option<Target> {
     if orig.weight == 0 {
         return None;
     }
-    NameAddr::from_str(orig.authority.as_str())
-        .ok()
-        .map(|addr| profiles::WeightedAddr {
-            addr,
-            weight: orig.weight,
-        })
+    let addr = Addr::from_str(orig.authority.as_str()).ok()?;
+    Some(Target {
+        addr,
+        weight: orig.weight,
+    })
 }
 
-fn set_route_retry(route: &mut profiles::Route, retry_budget: Option<&Arc<Budget>>) {
+fn set_route_retry(route: &mut http::Route, retry_budget: Option<&Arc<Budget>>) {
     let budget = match retry_budget {
         Some(budget) => budget.clone(),
         None => {
@@ -377,7 +373,7 @@ fn set_route_retry(route: &mut profiles::Route, retry_budget: Option<&Arc<Budget
     route.set_retries(budget);
 }
 
-fn set_route_timeout(route: &mut profiles::Route, timeout: Result<Duration, Duration>) {
+fn set_route_timeout(route: &mut http::Route, timeout: Result<Duration, Duration>) {
     match timeout {
         Ok(dur) => {
             route.set_timeout(dur);
@@ -388,19 +384,19 @@ fn set_route_timeout(route: &mut profiles::Route, timeout: Result<Duration, Dura
     }
 }
 
-fn convert_req_match(orig: api::RequestMatch) -> Option<profiles::RequestMatch> {
+fn convert_req_match(orig: api::RequestMatch) -> Option<http::RequestMatch> {
     let m = match orig.r#match? {
         api::request_match::Match::All(ms) => {
             let ms = ms.matches.into_iter().filter_map(convert_req_match);
-            profiles::RequestMatch::All(ms.collect())
+            http::RequestMatch::All(ms.collect())
         }
         api::request_match::Match::Any(ms) => {
             let ms = ms.matches.into_iter().filter_map(convert_req_match);
-            profiles::RequestMatch::Any(ms.collect())
+            http::RequestMatch::Any(ms.collect())
         }
         api::request_match::Match::Not(m) => {
             let m = convert_req_match(*m)?;
-            profiles::RequestMatch::Not(Box::new(m))
+            http::RequestMatch::Not(Box::new(m))
         }
         api::request_match::Match::Path(api::PathMatch { regex }) => {
             let regex = regex.trim();
@@ -413,23 +409,23 @@ fn convert_req_match(orig: api::RequestMatch) -> Option<profiles::RequestMatch> 
                     Regex::new(&re).ok()?
                 }
             };
-            profiles::RequestMatch::Path(re)
+            http::RequestMatch::Path(re)
         }
         api::request_match::Match::Method(mm) => {
             let m = mm.r#type.and_then(|m| (&m).try_into().ok())?;
-            profiles::RequestMatch::Method(m)
+            http::RequestMatch::Method(m)
         }
     };
 
     Some(m)
 }
 
-fn convert_rsp_class(orig: api::ResponseClass) -> Option<profiles::ResponseClass> {
+fn convert_rsp_class(orig: api::ResponseClass) -> Option<http::ResponseClass> {
     let c = orig.condition.and_then(convert_rsp_match)?;
-    Some(profiles::ResponseClass::new(orig.is_failure, c))
+    Some(http::ResponseClass::new(orig.is_failure, c))
 }
 
-fn convert_rsp_match(orig: api::ResponseMatch) -> Option<profiles::ResponseMatch> {
+fn convert_rsp_match(orig: api::ResponseMatch) -> Option<http::ResponseMatch> {
     let m = match orig.r#match? {
         api::response_match::Match::All(ms) => {
             let ms = ms
@@ -440,7 +436,7 @@ fn convert_rsp_match(orig: api::ResponseMatch) -> Option<profiles::ResponseMatch
             if ms.is_empty() {
                 return None;
             }
-            profiles::ResponseMatch::All(ms)
+            http::ResponseMatch::All(ms)
         }
         api::response_match::Match::Any(ms) => {
             let ms = ms
@@ -451,16 +447,16 @@ fn convert_rsp_match(orig: api::ResponseMatch) -> Option<profiles::ResponseMatch
             if ms.is_empty() {
                 return None;
             }
-            profiles::ResponseMatch::Any(ms)
+            http::ResponseMatch::Any(ms)
         }
         api::response_match::Match::Not(m) => {
             let m = convert_rsp_match(*m)?;
-            profiles::ResponseMatch::Not(Box::new(m))
+            http::ResponseMatch::Not(Box::new(m))
         }
         api::response_match::Match::Status(range) => {
-            let min = http::StatusCode::from_u16(range.min as u16).ok()?;
-            let max = http::StatusCode::from_u16(range.max as u16).ok()?;
-            profiles::ResponseMatch::Status { min, max }
+            let min = ::http::StatusCode::from_u16(range.min as u16).ok()?;
+            let max = ::http::StatusCode::from_u16(range.max as u16).ok()?;
+            http::ResponseMatch::Status { min, max }
         }
     };
 

--- a/linkerd/service-profiles/src/http/concrete.rs
+++ b/linkerd/service-profiles/src/http/concrete.rs
@@ -1,6 +1,7 @@
-use super::{OverrideDestination, WeightedAddr};
+use super::OverrideDestination;
+use crate::Target;
 use futures::{future, TryFutureExt};
-use linkerd2_addr::NameAddr;
+use linkerd2_addr::Addr;
 use linkerd2_error::Error;
 use rand::distributions::{Distribution, WeightedIndex};
 use rand::rngs::SmallRng;
@@ -38,10 +39,10 @@ pub struct Update {
 
 #[derive(Clone)]
 enum Routes {
-    Forward(Option<NameAddr>),
+    Forward(Option<Addr>),
     Override {
         distribution: WeightedIndex<u32>,
-        overrides: Vec<NameAddr>,
+        overrides: Vec<Addr>,
     },
 }
 
@@ -125,7 +126,7 @@ impl Update {
             .map_err(|_| error::LostService(()))
     }
 
-    pub fn set_split(&mut self, mut addrs: Vec<WeightedAddr>) -> Result<(), error::LostService> {
+    pub fn set_split(&mut self, mut addrs: Vec<Target>) -> Result<(), error::LostService> {
         let routes = match self.routes {
             Routes::Forward(ref addr) => {
                 if addrs.len() == 1 {

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -1,7 +1,59 @@
 #![deny(warnings, rust_2018_idioms)]
-#![type_length_limit = "1586225"]
-mod client;
-mod http;
 
-pub use self::client::*;
-pub use self::http::*;
+use linkerd2_addr::Addr;
+use linkerd2_error::Error;
+use std::{
+    future::Future,
+    task::{Context, Poll},
+};
+
+mod client;
+pub mod http;
+
+pub use self::client::{Client, InvalidProfileAddr};
+pub use self::http::{HasDestination, Layer, OverrideDestination, WithRoute};
+
+pub type Receiver = tokio::sync::watch::Receiver<Profile>;
+
+#[derive(Clone, Debug, Default)]
+pub struct Profile {
+    pub http_routes: Vec<(http::RequestMatch, http::Route)>,
+    pub targets: Vec<Target>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Target {
+    pub addr: Addr,
+    pub weight: u32,
+}
+
+/// Watches a destination's Profile.
+///
+/// The stream updates with all routes for the given destination. The stream never ends and cannot
+/// fail.
+pub trait GetProfile<T> {
+    type Error: Into<Error>;
+    type Future: Future<Output = Result<Receiver, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>>;
+
+    fn get_routes(&mut self, target: T) -> Self::Future;
+}
+
+impl<T, S> GetProfile<T> for S
+where
+    T: HasDestination,
+    S: tower::Service<Addr, Response = Receiver>,
+    S::Error: Into<Error>,
+{
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        tower::Service::poll_ready(self, cx)
+    }
+
+    fn get_routes(&mut self, target: T) -> Self::Future {
+        tower::Service::call(self, target.destination())
+    }
+}


### PR DESCRIPTION
* Renames `Routes` to `Profile`;
* Renames `GetRoutes` to `GetProfile`;
* Renames `WeightedAddr` to `Target`; and
* Scope `Route` & co within `http` module.