### PR TITLE
Update tower to tower-rs/tower@ad348d8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,7 +2669,7 @@ dependencies = [
 [[package]]
 name = "tower"
 version = "0.3.1"
-source = "git+https://github.com/tower-rs/tower?rev=8752a3811788e94670c62dc0acbc9613207931b1#8752a3811788e94670c62dc0acbc9613207931b1"
+source = "git+https://github.com/tower-rs/tower?rev=ad348d8#ad348d8ee5106f21b87155d2a0e8e18b90bd6b73"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2678,7 +2678,7 @@ dependencies = [
  "rand 0.7.2",
  "slab",
  "tokio",
- "tower-layer 0.3.0 (git+https://github.com/tower-rs/tower?rev=8752a3811788e94670c62dc0acbc9613207931b1)",
+ "tower-layer 0.3.0 (git+https://github.com/tower-rs/tower?rev=ad348d8)",
  "tower-service",
  "tracing",
 ]
@@ -2686,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "tower-layer"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower?rev=8752a3811788e94670c62dc0acbc9613207931b1#8752a3811788e94670c62dc0acbc9613207931b1"
+source = "git+https://github.com/tower-rs/tower?rev=ad348d8#ad348d8ee5106f21b87155d2a0e8e18b90bd6b73"
 
 [[package]]
 name = "tower-layer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,4 @@ debug = false
 
 [patch.crates-io]
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.21" }
-tower = { version = "0.3", git = "https://github.com/tower-rs/tower", rev = "8752a3811788e94670c62dc0acbc9613207931b1"}
+tower = { version = "0.3", git = "https://github.com/tower-rs/tower", rev = "ad348d8" }

--- a/linkerd/proxy/http/src/balance.rs
+++ b/linkerd/proxy/http/src/balance.rs
@@ -58,6 +58,6 @@ where
     fn layer(&self, discover: D) -> Self::Service {
         let instrument = PendingUntilFirstData::default();
         let loaded = PeakEwmaDiscover::new(discover, self.default_rtt, self.decay, instrument);
-        Balance::new(loaded, self.rng.clone())
+        Balance::from_rng(loaded, self.rng.clone()).expect("RNG must be valid")
     }
 }


### PR DESCRIPTION
We need tower-rs/tower@ad348d8 for an upcoming change. This PR updates
the tower dependency in anticipation of this change. The `Balance`
constructor has changed.