### PR TITLE
Eliminate the ConnectAddr trait

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -268,7 +268,7 @@ mod balance {
 
 /// Creates a client suitable for gRPC.
 mod client {
-    use crate::transport::{connect, tls};
+    use crate::transport::tls;
     use crate::{proxy::http, svc};
     use linkerd2_proxy_http::h2::Settings as H2Settings;
     use std::{
@@ -295,8 +295,8 @@ mod client {
 
     // === impl Target ===
 
-    impl connect::ConnectAddr for Target {
-        fn connect_addr(&self) -> SocketAddr {
+    impl Into<SocketAddr> for Target {
+        fn into(self) -> SocketAddr {
             self.addr
         }
     }

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -4,7 +4,7 @@ use linkerd2_app_core::{
     http_request_l5d_override_dst_addr, metric_labels, profiles,
     proxy::{http, identity, tap},
     router, stack_tracing,
-    transport::{connect, listen, tls},
+    transport::{listen, tls},
     Addr, Conditional, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER,
 };
 use std::fmt;
@@ -41,8 +41,8 @@ pub struct ProfileTarget;
 
 // === impl HttpEndpoint ===
 
-impl connect::ConnectAddr for HttpEndpoint {
-    fn connect_addr(&self) -> SocketAddr {
+impl Into<SocketAddr> for HttpEndpoint {
+    fn into(self) -> SocketAddr {
         ([127, 0, 0, 1], self.port).into()
     }
 }
@@ -86,8 +86,8 @@ impl From<tls::accept::Meta> for TcpEndpoint {
     }
 }
 
-impl connect::ConnectAddr for TcpEndpoint {
-    fn connect_addr(&self) -> SocketAddr {
+impl Into<SocketAddr> for TcpEndpoint {
+    fn into(self) -> SocketAddr {
         ([127, 0, 0, 1], self.port).into()
     }
 }

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -13,7 +13,7 @@ use linkerd2_app_core::{
         tap,
     },
     router,
-    transport::{connect, listen, tls},
+    transport::{listen, tls},
     Addr, Conditional, L5D_REQUIRE_ID,
 };
 use std::net::SocketAddr;
@@ -144,9 +144,9 @@ impl<T: tap::Inspect> tap::Inspect for Target<T> {
     }
 }
 
-impl<T: connect::ConnectAddr> connect::ConnectAddr for Target<T> {
-    fn connect_addr(&self) -> SocketAddr {
-        self.inner.connect_addr()
+impl<T: Into<SocketAddr>> Into<SocketAddr> for Target<T> {
+    fn into(self) -> SocketAddr {
+        self.inner.into()
     }
 }
 
@@ -195,8 +195,8 @@ impl tls::HasPeerIdentity for HttpEndpoint {
     }
 }
 
-impl connect::ConnectAddr for HttpEndpoint {
-    fn connect_addr(&self) -> SocketAddr {
+impl Into<SocketAddr> for HttpEndpoint {
+    fn into(self) -> SocketAddr {
         self.addr
     }
 }
@@ -322,8 +322,8 @@ impl From<listen::Addrs> for TcpEndpoint {
     }
 }
 
-impl connect::ConnectAddr for TcpEndpoint {
-    fn connect_addr(&self) -> SocketAddr {
+impl Into<SocketAddr> for TcpEndpoint {
+    fn into(self) -> SocketAddr {
         self.addr
     }
 }

--- a/linkerd/proxy/transport/tests/tls_accept.rs
+++ b/linkerd/proxy/transport/tests/tls_accept.rs
@@ -303,8 +303,8 @@ struct Target(SocketAddr, Conditional<Name>);
 #[derive(Clone)]
 struct ClientTls(CrtKey);
 
-impl connect::ConnectAddr for Target {
-    fn connect_addr(&self) -> SocketAddr {
+impl Into<SocketAddr> for Target {
+    fn into(self) -> SocketAddr {
         self.0
     }
 }


### PR DESCRIPTION
The connect module can use the more standard `Into<SocketAddr>`. No need
for a special trait.