### PR TITLE
profiles: Do not rely on tuples as stack targets

### DIFF
--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -150,7 +150,7 @@ mod test {
             let socket_addr = SocketAddr::from(([127, 0, 0, 1], 4143));
             let target = inbound::Target {
                 socket_addr,
-                logical: dst_name
+                dst: dst_name
                     .map(|n| NameAddr::from_str(n).unwrap().into())
                     .unwrap_or_else(|| socket_addr.into()),
                 http_settings: http::Settings::Http2,

--- a/linkerd/app/gateway/src/make.rs
+++ b/linkerd/app/gateway/src/make.rs
@@ -72,7 +72,7 @@ where
 
     fn call(&mut self, target: inbound::Target) -> Self::Future {
         let inbound::Target {
-            logical,
+            dst,
             http_settings,
             tls_client_id,
             ..
@@ -85,7 +85,7 @@ where
             }
         };
 
-        let orig_dst = match logical.into_name_addr() {
+        let orig_dst = match dst.into_name_addr() {
             Some(n) => n,
             None => {
                 return Box::pin(future::ok(Gateway::NoAuthority));

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -214,7 +214,7 @@ impl Config {
             .check_new_service::<Target, http::Request<http::boxed::Payload>>()
             .push_on_response(svc::layers().box_http_request())
             // The target stack doesn't use the profile resolution, so drop it.
-            .push_map_target(|(_, target): (profiles::Receiver, Target)| target)
+            .push_map_target(endpoint::Target::from)
             .push(profiles::http::route_request::layer(
                 svc::proxies()
                     // Sets the route as a request extension so that it can be used
@@ -226,11 +226,10 @@ impl Config {
                     // extension.
                     .push(classify::Layer::new())
                     .check_new_clone::<dst::Route>()
-                    .push_map_target(|(r, t): (profiles::http::Route, Target)| {
-                        endpoint::route(r, t)
-                    })
+                    .push_map_target(endpoint::route)
                     .into_inner(),
             ))
+            .push_map_target(endpoint::Logical::from)
             .push(profiles::discover::layer(profiles_client))
             .into_new_service()
             .cache(

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -36,9 +36,9 @@ pub struct Target<T> {
 }
 
 #[derive(Clone, Debug)]
-pub struct Profile<T> {
+pub struct Profile {
     pub rx: profiles::Receiver,
-    pub target: Target<T>,
+    pub target: Target<HttpEndpoint>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -55,8 +55,8 @@ pub struct TcpEndpoint {
     pub identity: tls::PeerIdentity,
 }
 
-impl From<(Addr, Profile<HttpEndpoint>)> for Concrete<http::Settings> {
-    fn from((addr, Profile { target, .. }): (Addr, Profile<HttpEndpoint>)) -> Self {
+impl From<(Addr, Profile)> for Concrete<http::Settings> {
+    fn from((addr, Profile { target, .. }): (Addr, Profile)) -> Self {
         Self {
             addr,
             inner: target.map(|e| e.settings),
@@ -421,7 +421,7 @@ impl<B> router::Recognize<http::Request<B>> for LogicalPerRequest {
     }
 }
 
-pub fn route<T>((route, profile): (profiles::http::Route, Profile<T>)) -> dst::Route {
+pub fn route((route, profile): (profiles::http::Route, Profile)) -> dst::Route {
     dst::Route {
         route,
         target: profile.target.addr,
@@ -431,26 +431,26 @@ pub fn route<T>((route, profile): (profiles::http::Route, Profile<T>)) -> dst::R
 
 // === impl Profile ===
 
-impl<T> From<(profiles::Receiver, Target<T>)> for Profile<T> {
-    fn from((rx, target): (profiles::Receiver, Target<T>)) -> Self {
+impl From<(profiles::Receiver, Target<HttpEndpoint>)> for Profile {
+    fn from((rx, target): (profiles::Receiver, Target<HttpEndpoint>)) -> Self {
         Self { rx, target }
     }
 }
 
-impl<T> AsRef<Addr> for Profile<T> {
+impl AsRef<Addr> for Profile {
     fn as_ref(&self) -> &Addr {
         &self.target.addr
     }
 }
 
-impl<T> AsRef<profiles::Receiver> for Profile<T> {
+impl AsRef<profiles::Receiver> for Profile {
     fn as_ref(&self) -> &profiles::Receiver {
         &self.rx
     }
 }
 
-impl<T> From<Profile<T>> for Target<T> {
-    fn from(Profile { target, .. }: Profile<T>) -> Self {
+impl From<Profile> for Target<HttpEndpoint> {
+    fn from(Profile { target, .. }: Profile) -> Self {
         target
     }
 }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -22,7 +22,7 @@ use linkerd2_app_core::{
     spans::SpanConverter,
     svc::{self, NewService},
     transport::{self, listen, tls},
-    Addr, Conditional, DiscoveryRejected, Error, ProxyMetrics, StackMetrics, TraceContextLayer,
+    Conditional, DiscoveryRejected, Error, ProxyMetrics, StackMetrics, TraceContextLayer,
     CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER, L5D_REQUIRE_ID,
 };
 use std::{collections::HashMap, net::IpAddr, time::Duration};

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -291,10 +291,7 @@ impl Config {
         // processed.
         let logical = concrete
             // Uses the split-provided target `Addr` to build a concrete target.
-            .push_map_target(|(addr, l): (Addr, Logical<HttpEndpoint>)| Concrete {
-                addr,
-                inner: l.map(|e| e.settings),
-            })
+            .push_map_target(Concrete::<http::Settings>::from)
             .push(profiles::split::layer())
             // Drives concrete stacks to readiness and makes the split
             // cloneable, as required by the retry middleware.
@@ -311,11 +308,10 @@ impl Config {
                     // Sets the per-route response classifier as a request
                     // extension.
                     .push(classify::Layer::new())
-                    .push_map_target(|(r, l): (profiles::http::Route, Logical<HttpEndpoint>)| {
-                        endpoint::route(r, l)
-                    })
+                    .push_map_target(endpoint::route)
                     .into_inner(),
             ))
+            .push_map_target(endpoint::Profile::from)
             // Discovers the service profile from the control plane and passes
             // it to inner stack to build the router and traffic split.
             .push(profiles::discover::layer(profiles_client))

--- a/linkerd/service-profiles/src/http/route_request.rs
+++ b/linkerd/service-profiles/src/http/route_request.rs
@@ -52,16 +52,17 @@ impl<M: Clone, N: Clone, R> Clone for NewRouteRequest<M, N, R> {
     }
 }
 
-impl<T, M, N> NewService<(Receiver, T)> for NewRouteRequest<M, N, N::Service>
+impl<T, M, N> NewService<T> for NewRouteRequest<M, N, N::Service>
 where
-    T: Clone,
-    M: NewService<(Receiver, T)>,
+    T: AsRef<Receiver> + Clone,
+    M: NewService<T>,
     N: NewService<(Route, T)> + Clone,
 {
     type Service = RouteRequest<T, M::Service, N, N::Service>;
 
-    fn new_service(&self, (rx, target): (Receiver, T)) -> Self::Service {
-        let inner = self.inner.new_service((rx.clone(), target.clone()));
+    fn new_service(&self, target: T) -> Self::Service {
+        let rx = target.as_ref().clone();
+        let inner = self.inner.new_service(target.clone());
         let default = self
             .new_route
             .new_service((self.default.clone(), target.clone()));

--- a/linkerd/service-profiles/src/split.rs
+++ b/linkerd/service-profiles/src/split.rs
@@ -58,13 +58,15 @@ impl<N: Clone, S, Req> Clone for NewSplit<N, S, Req> {
     }
 }
 
-impl<T, N: Clone, S, Req> NewService<(Receiver, T)> for NewSplit<N, S, Req>
+impl<T, N: Clone, S, Req> NewService<T> for NewSplit<N, S, Req>
 where
+    T: AsRef<Receiver>,
     S: tower::Service<Req>,
 {
     type Service = Split<T, N, S, Req>;
 
-    fn new_service(&self, (rx, target): (Receiver, T)) -> Self::Service {
+    fn new_service(&self, target: T) -> Self::Service {
+        let rx = target.as_ref().clone();
         Split {
             rx,
             target,


### PR DESCRIPTION
Using tuples for stack targets (particularly, the input targets of the
route_request and split modules) is a bit brittle.  Instead, we can use
`AsRef` on the target type to access the profile receiver.

This change introduces new target types to be used to satisfy these
traits, and generally cleans up stack construction.