### PR TITLE
proxy-http: Remove unneeded boilerplate

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -34,7 +34,7 @@ impl fmt::Display for ControlAddr {
 }
 
 type BalanceBody =
-    http::balance::PendingUntilFirstDataBody<tower::load::peak_ewma::Handle, http::glue::Body>;
+    http::balance::PendingUntilFirstDataBody<tower::load::peak_ewma::Handle, hyper::Body>;
 
 type RspBody = linkerd2_http_metrics::requests::ResponseBody<BalanceBody, classify::Eos>;
 

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -53,9 +53,9 @@ impl Into<SocketAddr> for HttpEndpoint {
     }
 }
 
-impl http::settings::HasSettings for HttpEndpoint {
-    fn http_settings(&self) -> http::Settings {
-        self.settings
+impl AsRef<http::Settings> for HttpEndpoint {
+    fn as_ref(&self) -> &http::Settings {
+        &self.settings
     }
 }
 
@@ -135,9 +135,9 @@ impl http::normalize_uri::ShouldNormalizeUri for Target {
     }
 }
 
-impl http::settings::HasSettings for Target {
-    fn http_settings(&self) -> http::Settings {
-        self.http_settings
+impl AsRef<http::Settings> for Target {
+    fn as_ref(&self) -> &http::Settings {
+        &self.http_settings
     }
 }
 

--- a/linkerd/app/outbound/src/orig_proto_upgrade.rs
+++ b/linkerd/app/outbound/src/orig_proto_upgrade.rs
@@ -1,7 +1,4 @@
-use crate::proxy::http::{
-    orig_proto,
-    settings::{HasSettings, Settings},
-};
+use crate::proxy::http::{orig_proto, settings::Settings};
 use crate::svc::stack;
 use crate::{HttpEndpoint, Target};
 use futures::{ready, TryFuture};
@@ -56,7 +53,7 @@ where
             return Either::B(self.inner.new_service(endpoint));
         }
 
-        let was_absolute = endpoint.http_settings().was_absolute_form();
+        let was_absolute = endpoint.inner.settings.was_absolute_form();
         trace!(
             header = %orig_proto::L5D_ORIG_PROTO,
             was_absolute,
@@ -84,7 +81,7 @@ where
     fn call(&mut self, mut endpoint: Target<HttpEndpoint>) -> Self::Future {
         let can_upgrade = endpoint.inner.can_use_orig_proto();
 
-        let was_absolute = endpoint.http_settings().was_absolute_form();
+        let was_absolute = endpoint.inner.settings.was_absolute_form();
 
         if can_upgrade {
             trace!(

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -207,9 +207,17 @@ where
                         .instrument(span.clone()),
                 )
             }
-            Client::Http2(ref mut h2) => {
-                Box::pin(h2.call(req).err_into::<Error>().instrument(span.clone()))
-            }
+            Client::Http2(ref mut h2) => Box::pin(
+                h2.call(req)
+                    .map_ok(|rsp| {
+                        rsp.map(|b| Body {
+                            body: Some(b),
+                            upgrade: None,
+                        })
+                    })
+                    .err_into::<Error>()
+                    .instrument(span.clone()),
+            ),
         }
     }
 }

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -1,22 +1,19 @@
 use super::glue::{Body, HyperConnect};
 use super::upgrade::{Http11Upgrade, HttpConnect};
-use super::{
-    h1, h2,
-    settings::{HasSettings, Settings},
-    trace,
-};
-use futures::{ready, TryFuture};
+use super::{h1, h2, settings::Settings, trace};
+use futures::prelude::*;
 use http;
 use hyper;
 use linkerd2_error::Error;
-use pin_project::pin_project;
-use std::future::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::{
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use tower::ServiceExt;
 use tracing::{debug, debug_span, trace};
-use tracing_futures::{Instrument, Instrumented};
+use tracing_futures::Instrument;
 
 /// Configures an HTTP client that uses a `C`-typed connector
 #[derive(Debug)]
@@ -25,29 +22,11 @@ pub struct MakeClientLayer<B> {
     _marker: PhantomData<fn() -> B>,
 }
 
-type HyperMakeClient<C, T, B> = hyper::Client<HyperConnect<C, T>, B>;
-
 /// A `MakeService` that can speak either HTTP/1 or HTTP/2.
 pub struct MakeClient<C, B> {
     connect: C,
     h2_settings: crate::h2::Settings,
-    _marker: PhantomData<fn() -> B>,
-}
-
-/// A `Future` returned from `MakeClient::new_service()`.
-#[pin_project(project = MakeFutureProj)]
-pub enum MakeFuture<C, T, B>
-where
-    B: hyper::body::HttpBody + Send + 'static,
-    B::Data: Send,
-    B::Error: Into<Error> + Send + Sync,
-    C: tower::make::MakeConnection<T> + 'static,
-    C::Error: Into<Error>,
-    C::Connection: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
-    C::Future: Send + 'static,
-{
-    Http1(Option<HyperMakeClient<C, T, B>>),
-    Http2(#[pin] tower::util::Oneshot<h2::Connect<C, B>, T>),
+    _marker: PhantomData<fn(B)>,
 }
 
 /// The `Service` yielded by `MakeClient::new_service()`.
@@ -56,19 +35,8 @@ where
     B: hyper::body::HttpBody + 'static,
     C: tower::make::MakeConnection<T> + 'static,
 {
-    Http1(HyperMakeClient<C, T, B>),
+    Http1(hyper::Client<HyperConnect<C, T>, B>),
     Http2(h2::Connection<B>),
-}
-
-#[pin_project(project = ClientFutureProj)]
-pub enum ClientFuture {
-    Http1 {
-        #[pin]
-        future: Instrumented<hyper::client::ResponseFuture>,
-        upgrade: Option<Http11Upgrade>,
-        is_http_connect: bool,
-    },
-    Http2(#[pin] Instrumented<h2::ResponseFuture>),
 }
 
 // === impl MakeClientLayer ===
@@ -91,10 +59,7 @@ impl<B> Clone for MakeClientLayer<B> {
     }
 }
 
-impl<C, B> tower::layer::Layer<C> for MakeClientLayer<B>
-// where
-// B: hyper::body::HttpBody + Send + 'static,
-{
+impl<C, B> tower::layer::Layer<C> for MakeClientLayer<B> {
     type Service = MakeClient<C, B>;
 
     fn layer(&self, connect: C) -> Self::Service {
@@ -114,48 +79,59 @@ where
     C::Future: Unpin + Send + 'static,
     C::Error: Into<Error>,
     C::Connection: Unpin + Send + 'static,
-    T: HasSettings + Clone + Send + Sync + 'static,
+    T: AsRef<Settings> + Clone + Send + Sync + 'static,
     B: hyper::body::HttpBody + Send + 'static,
     B::Data: Send,
     B::Error: Into<Error> + Send + Sync,
 {
     type Response = Client<C, T, B>;
     type Error = Error;
-    type Future = MakeFuture<C, T, B>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.connect.poll_ready(cx).map_err(Into::into)
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, target: T) -> Self::Future {
         trace!("Building HTTP client");
         let connect = self.connect.clone();
-        match target.http_settings() {
-            Settings::Http1 {
-                keep_alive,
-                wants_h1_upgrade: _,
-                was_absolute_form,
-            } => {
-                let mut h1 = hyper::Client::builder();
-                let h1 = if !keep_alive {
-                    // disable hyper's connection pooling by setting the maximum
-                    // number of idle connections to 0.
-                    h1.pool_max_idle_per_host(0)
-                } else {
-                    &mut h1
+        let h2_settings = self.h2_settings.clone();
+
+        Box::pin(async move {
+            match *target.as_ref() {
+                Settings::Http1 {
+                    keep_alive,
+                    wants_h1_upgrade: _,
+                    was_absolute_form,
+                } => {
+                    let mut h1 = hyper::Client::builder();
+                    let h1 = if !keep_alive {
+                        // disable hyper's connection pooling by setting the maximum
+                        // number of idle connections to 0.
+                        h1.pool_max_idle_per_host(0)
+                    } else {
+                        &mut h1
+                    }
+                    // hyper should only try to automatically
+                    // set the host if the request was in absolute_form
+                    .executor(trace::Executor::new())
+                    .set_host(was_absolute_form)
+                    .build(HyperConnect::new(
+                        connect,
+                        target,
+                        was_absolute_form,
+                    ));
+                    Ok(Client::Http1(h1))
                 }
-                // hyper should only try to automatically
-                // set the host if the request was in absolute_form
-                .executor(trace::Executor::new())
-                .set_host(was_absolute_form)
-                .build(HyperConnect::new(connect, target, was_absolute_form));
-                MakeFuture::Http1(Some(h1))
+                Settings::Http2 => {
+                    let h2 = h2::Connect::new(connect, h2_settings)
+                        .oneshot(target)
+                        .await?;
+                    Ok(Client::Http2(h2))
+                }
             }
-            Settings::Http2 => {
-                let h2 = h2::Connect::new(connect, self.h2_settings.clone()).oneshot(target);
-                MakeFuture::Http2(h2)
-            }
-        }
+        })
     }
 }
 
@@ -166,32 +142,6 @@ impl<C: Clone, B> Clone for MakeClient<C, B> {
             h2_settings: self.h2_settings,
             _marker: self._marker,
         }
-    }
-}
-
-// === impl MakeFuture ===
-
-impl<C, T, B> Future for MakeFuture<C, T, B>
-where
-    C: tower::make::MakeConnection<T> + Unpin + Send + Sync + 'static,
-    C::Connection: Unpin + Send + 'static,
-    C::Future: Send + 'static,
-    C::Error: Into<Error>,
-    B: hyper::body::HttpBody + Send + 'static,
-    B::Data: Send,
-    B::Error: Into<Error> + Send + Sync,
-{
-    type Output = Result<Client<C, T, B>, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let svc = match self.project() {
-            MakeFutureProj::Http1(h1) => Client::Http1(h1.take().expect("polled after ready")),
-            MakeFutureProj::Http2(h2) => {
-                let svc = ready!(h2.poll(cx))?;
-                Client::Http2(svc)
-            }
-        };
-        Poll::Ready(Ok(svc))
     }
 }
 
@@ -210,7 +160,8 @@ where
 {
     type Response = http::Response<Body>;
     type Error = Error;
-    type Future = ClientFuture;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match *self {
@@ -232,50 +183,33 @@ where
         match *self {
             Client::Http1(ref h1) => {
                 let upgrade = req.extensions_mut().remove::<Http11Upgrade>();
-                let is_http_connect = if upgrade.is_some() {
-                    req.method() == &http::Method::CONNECT
-                } else {
-                    false
-                };
-                ClientFuture::Http1 {
-                    future: h1.request(req).instrument(span.clone()),
-                    upgrade,
-                    is_http_connect,
-                }
+                let is_http_connect = req.method() == &http::Method::CONNECT;
+                Box::pin(
+                    h1.request(req)
+                        .map_ok(move |mut rsp| {
+                            if is_http_connect {
+                                debug_assert!(upgrade.is_some());
+                                rsp.extensions_mut().insert(HttpConnect);
+                            }
+
+                            if h1::is_upgrade(&rsp) {
+                                trace!("client response is HTTP/1.1 upgrade");
+                            } else {
+                                h1::strip_connection_headers(rsp.headers_mut());
+                            }
+
+                            rsp.map(|b| Body {
+                                body: Some(b),
+                                upgrade,
+                            })
+                        })
+                        .err_into::<Error>()
+                        .instrument(span.clone()),
+                )
             }
-            Client::Http2(ref mut h2) => ClientFuture::Http2(h2.call(req).instrument(span.clone())),
-        }
-    }
-}
-
-// === impl ClientFuture ===
-
-impl Future for ClientFuture {
-    type Output = Result<http::Response<Body>, Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.project() {
-            ClientFutureProj::Http1 {
-                future,
-                upgrade,
-                is_http_connect,
-            } => {
-                let mut res = ready!(future.try_poll(cx))?.map(|b| Body {
-                    body: Some(b),
-                    upgrade: upgrade.take(),
-                });
-                if *is_http_connect {
-                    res.extensions_mut().insert(HttpConnect);
-                }
-
-                if h1::is_upgrade(&res) {
-                    trace!("client response is HTTP/1.1 upgrade");
-                } else {
-                    h1::strip_connection_headers(res.headers_mut());
-                }
-                Poll::Ready(Ok(res))
+            Client::Http2(ref mut h2) => {
+                Box::pin(h2.call(req).err_into::<Error>().instrument(span.clone()))
             }
-            ClientFutureProj::Http2(f) => f.poll(cx).map_err(Into::into),
         }
     }
 }

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -30,11 +30,7 @@ pub struct MakeClient<C, B> {
 }
 
 /// The `Service` yielded by `MakeClient::new_service()`.
-pub enum Client<C, T, B>
-where
-    B: hyper::body::HttpBody + 'static,
-    C: tower::make::MakeConnection<T> + 'static,
-{
+pub enum Client<C, T, B> {
     Http1(hyper::Client<HyperConnect<C, T>, B>),
     Http2(h2::Connection<B>),
 }

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -1,5 +1,5 @@
-use crate::{trace, Body};
-use futures::{future, prelude::*};
+use crate::trace;
+use futures::prelude::*;
 use http;
 use hyper::{
     body::HttpBody,
@@ -120,12 +120,9 @@ where
     B::Data: Send,
     B::Error: Into<Error> + Send + Sync,
 {
-    type Response = http::Response<Body>;
+    type Response = http::Response<hyper::Body>;
     type Error = hyper::Error;
-    type Future = future::MapOk<
-        conn::ResponseFuture,
-        fn(http::Response<hyper::Body>) -> http::Response<Body>,
-    >;
+    type Future = conn::ResponseFuture;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.tx.poll_ready(cx).map_err(From::from)
@@ -146,11 +143,6 @@ where
             *req.version_mut() = http::Version::HTTP_11;
         }
 
-        self.tx.send_request(req).map_ok(|rsp| {
-            rsp.map(|body| Body {
-                body: Some(body),
-                upgrade: None,
-            })
-        })
+        self.tx.send_request(req)
     }
 }


### PR DESCRIPTION
There's a lot of needless boilerplate around the HTTP client, mostly due
to manual future implementations. These have been converted to boxed
futures.

Furthermore, the HasSettings trait has been eliminated, in favor of
AsRef.