### PR TITLE
http: Put normalize_uri back on the stack

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -346,6 +346,7 @@ impl Config {
             // Used by tap.
             .push_http_insert_target()
             .check_new_service::<tls::accept::Meta, http::Request<_>>()
+            .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
             .push_on_response(
                 svc::layers()
                     .push(http_admit_request)

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -523,6 +523,7 @@ impl Config {
                     .box_http_request()
                     .box_http_response(),
             )
+            .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
             .instrument(
                 |addrs: &listen::Addrs| info_span!("source", target.addr = %addrs.target_addr()),
             )

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -14,7 +14,7 @@ pub mod h1;
 pub mod h2;
 pub mod header_from_target;
 pub mod insert;
-mod normalize_uri;
+pub mod normalize_uri;
 pub mod orig_proto;
 pub mod override_authority;
 pub mod strip_header;

--- a/linkerd/proxy/http/src/normalize_uri.rs
+++ b/linkerd/proxy/http/src/normalize_uri.rs
@@ -39,7 +39,7 @@ pub struct NormalizeUri<S> {
 // === impl MakeNormalizeUri ===
 
 impl<N> MakeNormalizeUri<N> {
-    pub(crate) fn new(inner: N) -> Self {
+    pub fn new(inner: N) -> Self {
         Self { inner }
     }
 }


### PR DESCRIPTION
In b59172a, we moved the NormalizeUri logic into the HTTP server, but
this misses downgraded requests.

This change extracts NormalizeUri from the server, putting it back on
the HTTP stack so that it can be applied after `orig_proto::Downgrade`
is applied on the inbound proxy.