### PR TITLE
tracing: Elide redundant info in tracing contexts

### DIFF
--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -36,6 +36,7 @@ where
                     let span = info_span!(
                         "accept",
                         peer.addr = %addrs.peer(),
+                        target.adr = %addrs.target_addr(),
                     );
 
                     // Ready the service before dispatching the request to it.

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -200,26 +200,12 @@ impl stack_tracing::GetSpan<()> for Target {
 
         match self.http_version {
             http::Version::H2 => match self.dst.name_addr() {
-                None => info_span!(
-                    "http2",
-                    port = %self.socket_addr.port(),
-                ),
-                Some(name) => info_span!(
-                    "http2",
-                    %name,
-                    port = %self.socket_addr.port(),
-                ),
+                None => info_span!("http2"),
+                Some(name) => info_span!("http2", %name),
             },
             http::Version::Http1 => match self.dst.name_addr() {
-                None => info_span!(
-                    "http1",
-                    port = %self.socket_addr.port(),
-                ),
-                Some(name) => info_span!(
-                    "http1",
-                    %name,
-                    port = %self.socket_addr.port(),
-                ),
+                None => info_span!("http1"),
+                Some(name) => info_span!("http1", %name),
             },
         }
     }

--- a/linkerd/proxy/http/src/detect.rs
+++ b/linkerd/proxy/http/src/detect.rs
@@ -17,7 +17,7 @@ use std::{
     time::Duration,
 };
 use tower::{util::ServiceExt, Service};
-use tracing::{info_span, trace};
+use tracing::{debug, info_span, trace};
 use tracing_futures::Instrument;
 
 type Server = hyper::server::conn::Http<trace::Executor>;
@@ -155,6 +155,7 @@ where
 
         let timeout = tokio::time::delay_for(self.timeout);
         Box::pin(async move {
+            trace!("Detecting");
             let (version, io) = tokio::select! {
                 res = HttpVersion::detect(io) => { res? }
                 () = timeout => {
@@ -164,7 +165,7 @@ where
 
             match version {
                 Some(HttpVersion::Http1) => {
-                    trace!("Handling as HTTP");
+                    debug!("Handling as HTTP");
                     // Enable support for HTTP upgrades (CONNECT and websockets).
                     let http = upgrade::Service::new(http, drain.clone());
                     let conn = server
@@ -179,7 +180,7 @@ where
                 }
 
                 Some(HttpVersion::H2) => {
-                    trace!("Handling as H2");
+                    debug!("Handling as H2");
                     let conn = server
                         .http2_only(true)
                         .serve_connection(io, HyperServerSvc::new(http));
@@ -191,7 +192,7 @@ where
                 }
 
                 None => {
-                    trace!("Forwarding TCP");
+                    debug!("Forwarding TCP");
                     let release = drain.ignore_signal();
                     tcp.oneshot(io).err_into::<Error>().await?;
                     drop(release);


### PR DESCRIPTION
The tracing context includes redundnant information, particularly about
the traffic target.

This change modifies the accept stack to include both the source peer and
target addresses in the `accept` context; and the target address has
been removed from intermediate contexts, many of which can be moved to
the debug level now.