### PR TITLE
fix missing clone impl for MakeSwitch

### DIFF
--- a/linkerd/stack/src/switch.rs
+++ b/linkerd/stack/src/switch.rs
@@ -13,6 +13,7 @@ pub trait Switch<T> {
 
 /// Makes either the primary or fallback stack, as determined by an `S`-typed
 /// `Switch`.
+#[derive(Clone)]
 pub struct MakeSwitch<S, P, F> {
     switch: S,
     primary: P,


### PR DESCRIPTION
The cache requires the service type to be `Clone`, but 
`MakeSwitch` doesn't implement `Clone`, even when all
of its constituents services do. We can add a derive to 
fix this, and now everything compiles.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>