### PR TITLE
cache: Implement NewService

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -44,7 +44,7 @@ pub struct IdentityProxy(());
 
 impl<T> NewService<T> for IdentityProxy {
     type Service = ();
-    fn new_service(&self, _: T) -> Self::Service {
+    fn new_service(&mut self, _: T) -> Self::Service {
         ()
     }
 }
@@ -389,7 +389,7 @@ where
 {
     type Service = N::Service;
 
-    fn new_service(&self, t: T) -> Self::Service {
+    fn new_service(&mut self, t: T) -> Self::Service {
         self.0.new_service(t)
     }
 }

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -180,11 +180,11 @@ impl<S> Stack<S> {
         self.push(stack::new_service::FromMakeServiceLayer::default())
     }
 
-    pub fn into_make<T>(self) -> Stack<stack::new_service::IntoMakeService<S>>
+    pub fn into_make_service<T>(self) -> Stack<stack::new_service::IntoMakeService<S>>
     where
         S: NewService<T>,
     {
-        Stack(self.0.into_make_service())
+        Stack(stack::new_service::IntoMakeService::new(self.0))
     }
 
     pub fn push_make_ready<Req>(self) -> Stack<stack::MakeReady<S, Req>> {

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -180,6 +180,13 @@ impl<S> Stack<S> {
         self.push(stack::new_service::FromMakeServiceLayer::default())
     }
 
+    pub fn into_make<T>(self) -> Stack<stack::new_service::IntoMakeService<S>>
+    where
+        S: NewService<T>,
+    {
+        Stack(self.0.into_make_service())
+    }
+
     pub fn push_make_ready<Req>(self) -> Stack<stack::MakeReady<S, Req>> {
         self.push(stack::MakeReadyLayer::new())
     }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -257,6 +257,7 @@ impl Config {
                         .box_http_response(),
                 ),
             )
+            .into_make()
             .spawn_buffer(buffer_capacity)
             .instrument(|_: &Target| debug_span!("profile"))
             .check_make_service::<Target, http::Request<_>>();
@@ -271,6 +272,7 @@ impl Config {
                         .box_http_response(),
                 ),
             )
+            .into_make()
             .spawn_buffer(buffer_capacity)
             .instrument(|_: &Target| debug_span!("forward"))
             .check_make_service::<Target, http::Request<http::boxed::Payload>>();

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -21,7 +21,7 @@ use linkerd2_app_core::{
     },
     reconnect, router,
     spans::SpanConverter,
-    svc::{self, NewService},
+    svc::{self},
     transport::{self, io, listen, tls},
     Error, ProxyMetrics, TraceContextLayer, DST_OVERRIDE_HEADER,
 };
@@ -257,7 +257,7 @@ impl Config {
                         .box_http_response(),
                 ),
             )
-            .into_make()
+            .into_make_service()
             .spawn_buffer(buffer_capacity)
             .instrument(|_: &Target| debug_span!("profile"))
             .check_make_service::<Target, http::Request<_>>();
@@ -272,7 +272,7 @@ impl Config {
                         .box_http_response(),
                 ),
             )
-            .into_make()
+            .into_make_service()
             .spawn_buffer(buffer_capacity)
             .instrument(|_: &Target| debug_span!("forward"))
             .check_make_service::<Target, http::Request<http::boxed::Payload>>();
@@ -388,8 +388,8 @@ impl Config {
             )
             .instrument(|_: &_| debug_span!("source"))
             .check_new_service::<tls::accept::Meta, http::Request<_>>()
-            .into_inner()
-            .into_make_service();
+            .into_make_service()
+            .into_inner();
 
         DetectHttp::new(
             h2_settings,

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -18,7 +18,7 @@ use linkerd2_app_core::{
     },
     reconnect, retry, router,
     spans::SpanConverter,
-    svc::{self, NewService},
+    svc::{self},
     transport::{self, listen, tls},
     Addr, Conditional, DiscoveryRejected, Error, Never, ProxyMetrics, StackMetrics,
     TraceContextLayer, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER, L5D_REQUIRE_ID,
@@ -139,7 +139,7 @@ impl Config {
                         .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
                 ),
             )
-            .into_make()
+            .into_make_service()
             .spawn_buffer(buffer_capacity)
             .push_make_ready()
             .instrument(|_: &_| info_span!("tcp"))
@@ -177,7 +177,7 @@ impl Config {
                         .push(metrics.layer(stack_labels("refine"))),
                 ),
             )
-            .into_make()
+            .into_make_service()
             .spawn_buffer(self.proxy.buffer_capacity)
             .instrument(|name: &dns::Name| info_span!("refine", %name))
             // Obtains the service, advances the state of the resolution
@@ -387,7 +387,7 @@ impl Config {
                         .push(metrics.stack.layer(stack_labels("profile"))),
                 ),
             )
-            .into_make()
+            .into_make_service()
             .spawn_buffer(buffer_capacity)
             .push_make_ready()
             .check_make_service::<HttpLogical, http::Request<_>>();
@@ -405,7 +405,7 @@ impl Config {
                         .push(metrics.stack.layer(stack_labels("forward.endpoint"))),
                 ),
             )
-            .into_make()
+            .into_make_service()
             .spawn_buffer(buffer_capacity)
             .instrument(|t: &HttpEndpoint| debug_span!("forward", peer.id = ?t.identity))
             .check_make_service::<HttpEndpoint, http::Request<_>>();
@@ -524,8 +524,8 @@ impl Config {
             .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
             .instrument(|_: &listen::Addrs| debug_span!("source"))
             .check_new_service::<listen::Addrs, http::Request<_>>()
-            .into_inner()
-            .into_make_service();
+            .into_make_service()
+            .into_inner();
 
         let tcp_forward = svc::stack(tcp_connect.clone())
             .push_make_thunk()

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -139,6 +139,7 @@ impl Config {
                         .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
                 ),
             )
+            .into_make()
             .spawn_buffer(buffer_capacity)
             .push_make_ready()
             .instrument(|_: &_| info_span!("tcp"))
@@ -176,6 +177,7 @@ impl Config {
                         .push(metrics.layer(stack_labels("refine"))),
                 ),
             )
+            .into_make()
             .spawn_buffer(self.proxy.buffer_capacity)
             .instrument(|name: &dns::Name| info_span!("refine", %name))
             // Obtains the service, advances the state of the resolution
@@ -385,6 +387,7 @@ impl Config {
                         .push(metrics.stack.layer(stack_labels("profile"))),
                 ),
             )
+            .into_make()
             .spawn_buffer(buffer_capacity)
             .push_make_ready()
             .check_make_service::<HttpLogical, http::Request<_>>();
@@ -402,6 +405,7 @@ impl Config {
                         .push(metrics.stack.layer(stack_labels("forward.endpoint"))),
                 ),
             )
+            .into_make()
             .spawn_buffer(buffer_capacity)
             .instrument(|t: &HttpEndpoint| debug_span!("forward", peer.id = ?t.identity))
             .check_make_service::<HttpEndpoint, http::Request<_>>();

--- a/linkerd/app/outbound/src/require_identity_on_endpoint.rs
+++ b/linkerd/app/outbound/src/require_identity_on_endpoint.rs
@@ -61,7 +61,7 @@ where
 {
     type Service = RequireIdentity<M::Service>;
 
-    fn new_service(&self, target: HttpEndpoint) -> Self::Service {
+    fn new_service(&mut self, target: HttpEndpoint) -> Self::Service {
         let peer_identity = target.peer_identity().clone();
         let inner = self.inner.new_service(target);
         RequireIdentity {

--- a/linkerd/cache/benches/cache.rs
+++ b/linkerd/cache/benches/cache.rs
@@ -51,7 +51,7 @@ impl Service<usize> for NeverEvict {
 impl NewService<(usize, Handle)> for NewNeverEvict {
     type Service = NeverEvict;
 
-    fn new_service(&self, target: (usize, Handle)) -> Self::Service {
+    fn new_service(&mut self, target: (usize, Handle)) -> Self::Service {
         NeverEvict {
             val: target.0,
             handle: target.1,
@@ -76,7 +76,7 @@ impl Service<usize> for AlwaysEvict {
 impl NewService<(usize, Handle)> for NewAlwaysEvict {
     type Service = AlwaysEvict;
 
-    fn new_service(&self, target: (usize, Handle)) -> Self::Service {
+    fn new_service(&mut self, target: (usize, Handle)) -> Self::Service {
         AlwaysEvict { val: target.0 }
     }
 }
@@ -98,7 +98,7 @@ impl Service<usize> for SometimesEvict {
 impl NewService<(usize, Handle)> for NewSometimesEvict {
     type Service = SometimesEvict;
 
-    fn new_service(&self, target: (usize, Handle)) -> Self::Service {
+    fn new_service(&mut self, target: (usize, Handle)) -> Self::Service {
         if target.0 % 2 == 0 {
             SometimesEvict {
                 val: target.0,

--- a/linkerd/cache/src/layer.rs
+++ b/linkerd/cache/src/layer.rs
@@ -60,7 +60,7 @@ where
 {
     type Service = <L::Service as NewService<T>>::Service;
 
-    fn new_service(&self, (target, _handle): (T, Handle)) -> Self::Service {
+    fn new_service(&mut self, (target, _handle): (T, Handle)) -> Self::Service {
         let inner = Track {
             _handle,
             inner: self.inner.clone(),
@@ -72,7 +72,7 @@ where
 impl<T, N: NewService<T>> NewService<T> for Track<N> {
     type Service = Track<N::Service>;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         Self::Service {
             _handle: self._handle.clone(),
             inner: self.inner.new_service(target),

--- a/linkerd/dns/src/refine.rs
+++ b/linkerd/dns/src/refine.rs
@@ -38,7 +38,7 @@ enum State {
 impl NewService<Name> for MakeRefine {
     type Service = Refine;
 
-    fn new_service(&self, name: Name) -> Self::Service {
+    fn new_service(&mut self, name: Name) -> Self::Service {
         Refine {
             name,
             state: State::Init,

--- a/linkerd/http-classify/src/layer.rs
+++ b/linkerd/http-classify/src/layer.rs
@@ -36,7 +36,7 @@ where
 {
     type Service = Proxy<T::Classify, N::Service>;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         let classify = target.classify();
         let inner = self.inner.new_service(target);
         Proxy { classify, inner }

--- a/linkerd/http-metrics/src/requests/layer.rs
+++ b/linkerd/http-metrics/src/requests/layer.rs
@@ -170,7 +170,7 @@ where
 {
     type Service = Service<M::Service, C>;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         let metrics = match self.registry.lock() {
             Ok(mut r) => Some(
                 r.by_target

--- a/linkerd/proxy/http/src/header_from_target.rs
+++ b/linkerd/proxy/http/src/header_from_target.rs
@@ -65,7 +65,7 @@ where
 {
     type Service = Service<H, M::Service>;
 
-    fn new_service(&self, t: T) -> Self::Service {
+    fn new_service(&mut self, t: T) -> Self::Service {
         let header = self.header.clone();
         let value = (&t).into();
         let inner = self.inner.new_service(t);

--- a/linkerd/proxy/http/src/insert.rs
+++ b/linkerd/proxy/http/src/insert.rs
@@ -177,7 +177,7 @@ pub mod target {
     {
         type Service = Insert<M::Service, super::ValLazy<T>, T>;
 
-        fn new_service(&self, target: T) -> Self::Service {
+        fn new_service(&mut self, target: T) -> Self::Service {
             let inner = self.0.new_service(target.clone());
             super::Insert::new(inner, super::ValLazy(target))
         }

--- a/linkerd/proxy/http/src/normalize_uri.rs
+++ b/linkerd/proxy/http/src/normalize_uri.rs
@@ -51,7 +51,7 @@ where
 {
     type Service = NormalizeUri<N::Service>;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         let target_addr = (&target).into();
         let inner = self.inner.new_service(target);
         NormalizeUri::new(inner, target_addr)

--- a/linkerd/proxy/http/src/timeout.rs
+++ b/linkerd/proxy/http/src/timeout.rs
@@ -49,7 +49,7 @@ where
 {
     type Service = Timeout<M::Service>;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         match target.timeout() {
             Some(t) => Timeout::new(self.inner.new_service(target), t),
             None => Timeout::passthru(self.inner.new_service(target)),

--- a/linkerd/proxy/tap/src/service.rs
+++ b/linkerd/proxy/tap/src/service.rs
@@ -94,7 +94,7 @@ where
 {
     type Service = Service<M::Service, I, T>;
 
-    fn new_service(&self, target: I) -> Self::Service {
+    fn new_service(&mut self, target: I) -> Self::Service {
         let inspect = target.clone();
         Service {
             inner: self.inner.new_service(target),

--- a/linkerd/retry/src/lib.rs
+++ b/linkerd/retry/src/lib.rs
@@ -77,7 +77,7 @@ where
 {
     type Service = Retry<P::Policy, N::Service>;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         // Determine if there is a retry policy for the given target.
         let policy = self.new_policy.new_policy(&target);
 

--- a/linkerd/router/src/lib.rs
+++ b/linkerd/router/src/lib.rs
@@ -64,7 +64,7 @@ where
 {
     type Service = Router<K::Service, M>;
 
-    fn new_service(&self, t: T) -> Self::Service {
+    fn new_service(&mut self, t: T) -> Self::Service {
         Router {
             recognize: self.new_recgonize.new_service(t),
             make: self.make_route.clone(),

--- a/linkerd/service-profiles/src/discover.rs
+++ b/linkerd/service-profiles/src/discover.rs
@@ -39,7 +39,7 @@ where
     }
 
     fn call(&mut self, target: T) -> Self::Future {
-        let inner = self.inner.clone();
+        let mut inner = self.inner.clone();
         Box::pin(
             self.get_profile
                 .get_profile(target.clone())

--- a/linkerd/service-profiles/src/http/route_request.rs
+++ b/linkerd/service-profiles/src/http/route_request.rs
@@ -60,7 +60,7 @@ where
 {
     type Service = RouteRequest<T, M::Service, N, N::Service>;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         let rx = target.as_ref().clone();
         let inner = self.inner.new_service(target.clone());
         let default = self

--- a/linkerd/service-profiles/src/split.rs
+++ b/linkerd/service-profiles/src/split.rs
@@ -65,7 +65,7 @@ where
 {
     type Service = Split<T, N, S, Req>;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         let rx = target.as_ref().clone();
         Split {
             rx,

--- a/linkerd/stack/src/map_target.rs
+++ b/linkerd/stack/src/map_target.rs
@@ -39,7 +39,7 @@ where
 {
     type Service = S::Service;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         self.inner.new_service(self.map_target.map_target(target))
     }
 }

--- a/linkerd/stack/src/new_service.rs
+++ b/linkerd/stack/src/new_service.rs
@@ -9,13 +9,6 @@ pub trait NewService<T> {
     type Service;
 
     fn new_service(&mut self, target: T) -> Self::Service;
-
-    fn into_make_service(self) -> IntoMakeService<Self>
-    where
-        Self: Sized,
-    {
-        IntoMakeService { new_service: self }
-    }
 }
 
 /// A Layer that modifies inner `MakeService`s to be exposd as a `NewService`.
@@ -67,6 +60,14 @@ where
 
     fn new_service(&mut self, target: T) -> Self::Service {
         FutureService::new(self.make_service.clone().oneshot(target))
+    }
+}
+
+// === impl FromMakeService ===
+
+impl<N> IntoMakeService<N> {
+    pub fn new(new_service: N) -> Self {
+        Self { new_service }
     }
 }
 

--- a/linkerd/stack/src/new_service.rs
+++ b/linkerd/stack/src/new_service.rs
@@ -8,7 +8,7 @@ use tower::util::{Oneshot, ServiceExt};
 pub trait NewService<T> {
     type Service;
 
-    fn new_service(&self, target: T) -> Self::Service;
+    fn new_service(&mut self, target: T) -> Self::Service;
 
     fn into_make_service(self) -> IntoMakeService<Self>
     where
@@ -42,7 +42,7 @@ where
 {
     type Service = S;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         (self)(target)
     }
 }
@@ -65,7 +65,7 @@ where
 {
     type Service = FutureService<Oneshot<S, T>, S::Response>;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         FutureService::new(self.make_service.clone().oneshot(target))
     }
 }

--- a/linkerd/stack/src/on_response.rs
+++ b/linkerd/stack/src/on_response.rs
@@ -46,7 +46,7 @@ where
 {
     type Service = L::Service;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         self.layer.layer(self.inner.new_service(target))
     }
 }

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -69,7 +69,7 @@ where
 {
     type Service = Instrument<N::Service>;
 
-    fn new_service(&self, target: T) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         trace!(?target, "new_service");
         let span = self.get_span.get_span(&target);
         let inner = span.in_scope(move || self.make.new_service(target));


### PR DESCRIPTION
The cache used to implement logic in its `poll_ready`; but this was
changed some time ago. Otherwise, the cache is synchronous and
infallible, much like the `NewService` trait.

This change modifies `NewService` to take a mutable reference, as needed
by the cache; and it modifies the cache to implement `NewService`
instead of `Service`.

The stacks then coerce the cache back into a service (via `into_make`)
to satisfy the buffer's requirements. It is expected that this buffering
will be decoupled from the cache in a followup change.