### PR TITLE
Increase default Dns canonicalize timeout

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -211,7 +211,7 @@ const DEFAULT_OUTBOUND_CONNECT_BACKOFF: ExponentialBackoff = ExponentialBackoff 
     max: Duration::from_millis(500),
     jitter: 0.1,
 };
-const DEFAULT_DNS_CANONICALIZE_TIMEOUT: Duration = Duration::from_millis(100);
+const DEFAULT_DNS_CANONICALIZE_TIMEOUT: Duration = Duration::from_millis(500);
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
 
 const DEFAULT_INITIAL_STREAM_WINDOW_SIZE: u32 = 65_535; // Protocol default


### PR DESCRIPTION
The current default DNS refinement timeout is 100ms. This does not seem to be enough as we can observe refinement timeouts. The result of that is that discovery fails and there is no provided identitiy, resulting in the traffic not being tlsed. 

A repro for this can be found here #4992.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>