### PR TITLE
Implement profile discovery as a NewService

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -248,7 +248,6 @@ impl Config {
             ))
             .push_map_target(endpoint::Logical::from)
             .push(profiles::discover::layer(profiles_client))
-            .into_new_service()
             .instrument(|_: &Target| debug_span!("profile"))
             .push_on_response(svc::layers().box_http_response())
             .check_new_service::<Target, http::Request<http::boxed::Payload>>();

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -361,7 +361,6 @@ impl Config {
             // Discovers the service profile from the control plane and passes
             // it to inner stack to build the router and traffic split.
             .push(profiles::discover::layer(profiles_client))
-            .into_new_service()
             .check_new_service::<HttpLogical, http::Request<_>>();
 
         // Caches clients that bypass discovery/balancing.


### PR DESCRIPTION
The profile discovery layer is always coerced to a NewService. This
change formalizes this to avoid stack boilerplate.

While we're here, the GetProfile trait has ben simplified to avoid
exposing poll_ready in its public API. Instead, we provide an impl of
Service for GetProfile that does this (though it's not currently
needed).