### PR TITLE
Update the accept stack to use NewService

### DIFF
--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -1,8 +1,9 @@
+use crate::svc;
 use futures::prelude::*;
 use linkerd2_error::Error;
 use linkerd2_proxy_transport::listen::Addrs;
 use tower::util::ServiceExt;
-use tracing::{debug, error, info, info_span};
+use tracing::{debug, info, info_span};
 use tracing_futures::Instrument;
 
 /// Spawns a task that binds an `L`-typed listener with an `A`-typed
@@ -16,10 +17,8 @@ pub async fn serve<M, A, I>(
 ) -> Result<(), Error>
 where
     I: Send + 'static,
-    M: tower::Service<Addrs, Response = A>,
-    M::Error: Into<Error>,
-    M::Future: Send + 'static,
-    A: tower::Service<I, Response = ()> + Send,
+    M: svc::NewService<Addrs, Service = A>,
+    A: tower::Service<I, Response = ()> + Send + 'static,
     A::Error: Into<Error>,
     A::Future: Send + 'static,
 {
@@ -43,22 +42,14 @@ where
                     //
                     // This allows the service to propagate errors and to exert backpressure on the
                     // listener. It also avoids a `Clone` requirement.
-                    let accept = make_accept
-                        .ready_and()
-                        .err_into::<Error>()
-                        .instrument(span.clone())
-                        .await?
-                        .call(addrs);
+                    let accept = make_accept.new_service(addrs);
 
                     // Dispatch all of the work for a given connection onto a connection-specific task.
                     tokio::spawn(
                         async move {
-                            match accept.err_into::<Error>().await {
-                                Err(error) => error!(%error, "Failed to dispatch connection"),
-                                Ok(accept) => match accept.oneshot(io).err_into::<Error>().await {
-                                    Ok(()) => debug!("Connection closed"),
-                                    Err(error) => info!(%error, "Connection closed"),
-                                },
+                            match accept.oneshot(io).err_into::<Error>().await {
+                                Ok(()) => debug!("Connection closed"),
+                                Err(error) => info!(%error, "Connection closed"),
                             }
                         }
                         .instrument(span),

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -12,7 +12,7 @@ use tracing_futures::Instrument;
 /// The task is driven until shutdown is signaled.
 pub async fn serve<M, A, I>(
     listen: impl Stream<Item = std::io::Result<(Addrs, I)>>,
-    mut make_accept: M,
+    mut new_accept: M,
     shutdown: impl Future,
 ) -> Result<(), Error>
 where
@@ -38,11 +38,7 @@ where
                         target.addr = %addrs.target_addr(),
                     );
 
-                    // Ready the service before dispatching the request to it.
-                    //
-                    // This allows the service to propagate errors and to exert backpressure on the
-                    // listener. It also avoids a `Clone` requirement.
-                    let accept = make_accept.new_service(addrs);
+                    let accept = new_accept.new_service(addrs);
 
                     // Dispatch all of the work for a given connection onto a connection-specific task.
                     tokio::spawn(

--- a/linkerd/app/src/tap.rs
+++ b/linkerd/app/src/tap.rs
@@ -1,4 +1,4 @@
-use futures::{future, prelude::*};
+use futures::prelude::*;
 use indexmap::IndexSet;
 use linkerd2_app_core::{
     config::ServerConfig,
@@ -6,7 +6,7 @@ use linkerd2_app_core::{
     proxy::{identity, tap},
     serve,
     transport::{io, tls},
-    Error, Never,
+    Error,
 };
 use std::net::SocketAddr;
 use std::pin::Pin;
@@ -55,15 +55,15 @@ impl Config {
                     tap::AcceptPermittedClients::new(permitted_peer_identities.into(), server);
                 let accept = tls::DetectTls::new(
                     identity,
-                    service_fn(move |meta: tls::accept::Meta| {
+                    move |meta: tls::accept::Meta| {
                         let service = service.clone();
-                        future::ok::<_, Never>(service_fn(move |io: io::BoxedIo| {
+                        service_fn(move |io: io::BoxedIo| {
                             let fut = service.clone().oneshot((meta.clone(), io));
                             Box::pin(async move {
                                 fut.err_into::<Error>().await?.err_into::<Error>().await
                             })
-                        }))
-                    }),
+                        })
+                    },
                     std::time::Duration::from_secs(1),
                 );
 

--- a/linkerd/proxy/transport/src/tls/accept.rs
+++ b/linkerd/proxy/transport/src/tls/accept.rs
@@ -4,9 +4,9 @@ use crate::listen::Addrs;
 use bytes::BytesMut;
 use futures::prelude::*;
 use linkerd2_dns_name as dns;
-use linkerd2_error::{Error, Never};
+use linkerd2_error::Error;
 use linkerd2_identity as identity;
-use linkerd2_stack::layer;
+use linkerd2_stack::{layer, NewService};
 pub use rustls::ServerConfig as Config;
 use std::{
     pin::Pin,
@@ -87,36 +87,27 @@ impl<I: HasConfig, M> DetectTls<I, M> {
     }
 }
 
-impl<I: HasConfig, M> tower::Service<Addrs> for DetectTls<I, M>
+impl<I, M> NewService<Addrs> for DetectTls<I, M>
 where
-    I: Clone,
-    M: tower::Service<Meta> + Clone,
+    I: HasConfig + Clone,
+    M: NewService<Meta> + Clone,
 {
-    type Response = AcceptTls<I, M>;
-    type Error = Never;
-    type Future = future::Ready<Result<AcceptTls<I, M>, Never>>;
+    type Service = AcceptTls<I, M>;
 
-    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // The `accept` is cloned into the response future, so its readiness isn't important.
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, addrs: Addrs) -> Self::Future {
-        future::ok(AcceptTls {
+    fn new_service(&mut self, addrs: Addrs) -> Self::Service {
+        AcceptTls {
             addrs,
             local_identity: self.local_identity.clone(),
             inner: self.inner.clone(),
             timeout: self.timeout,
-        })
+        }
     }
 }
 
 impl<I: HasConfig, M, A> tower::Service<TcpStream> for AcceptTls<I, M>
 where
-    M: tower::Service<Meta, Response = A> + Clone + Send + 'static,
-    M::Error: Into<Error>,
-    M::Future: Send,
-    A: tower::Service<BoxedIo, Response = ()> + Send,
+    M: NewService<Meta, Service = A> + Clone + Send + 'static,
+    A: tower::Service<BoxedIo, Response = ()> + Send + 'static,
     A::Error: Into<Error>,
     A::Future: Send,
 {
@@ -130,7 +121,7 @@ where
 
     fn call(&mut self, tcp: TcpStream) -> Self::Future {
         let addrs = self.addrs.clone();
-        let make = self.inner.clone();
+        let mut make = self.inner.clone();
 
         match self.local_identity.as_ref() {
             Conditional::Some(local) => {
@@ -149,27 +140,18 @@ where
                         peer_identity,
                         addrs,
                     };
-                    make.oneshot(meta)
-                        .err_into::<Error>()
-                        .await?
-                        .oneshot(io)
-                        .err_into::<Error>()
-                        .await
+                    make.new_service(meta).oneshot(io).err_into::<Error>().await
                 })
             }
 
-            Conditional::None(reason) => Box::pin(async move {
+            Conditional::None(reason) => {
                 let meta = Meta {
                     peer_identity: Conditional::None(reason),
                     addrs,
                 };
-                make.oneshot(meta)
-                    .err_into::<Error>()
-                    .await?
-                    .oneshot(BoxedIo::new(tcp))
-                    .err_into::<Error>()
-                    .await
-            }),
+                let svc = make.new_service(meta);
+                Box::pin(svc.oneshot(BoxedIo::new(tcp)).err_into::<Error>())
+            }
         }
     }
 }

--- a/linkerd/proxy/transport/src/tls/accept.rs
+++ b/linkerd/proxy/transport/src/tls/accept.rs
@@ -121,7 +121,7 @@ where
 
     fn call(&mut self, tcp: TcpStream) -> Self::Future {
         let addrs = self.addrs.clone();
-        let mut make = self.inner.clone();
+        let mut new_accept = self.inner.clone();
 
         match self.local_identity.as_ref() {
             Conditional::Some(local) => {
@@ -140,7 +140,11 @@ where
                         peer_identity,
                         addrs,
                     };
-                    make.new_service(meta).oneshot(io).err_into::<Error>().await
+                    new_accept
+                        .new_service(meta)
+                        .oneshot(io)
+                        .err_into::<Error>()
+                        .await
                 })
             }
 
@@ -149,7 +153,7 @@ where
                     peer_identity: Conditional::None(reason),
                     addrs,
                 };
-                let svc = make.new_service(meta);
+                let svc = new_accept.new_service(meta);
                 Box::pin(svc.oneshot(BoxedIo::new(tcp)).err_into::<Error>())
             }
         }

--- a/linkerd/stack/src/switch.rs
+++ b/linkerd/stack/src/switch.rs
@@ -37,6 +37,23 @@ impl<S, P, F> MakeSwitch<S, P, F> {
     }
 }
 
+impl<T, S, P, F> super::NewService<T> for MakeSwitch<S, P, F>
+where
+    S: Switch<T>,
+    P: super::NewService<T>,
+    F: super::NewService<T>,
+{
+    type Service = tower::util::Either<P::Service, F::Service>;
+
+    fn new_service(&mut self, target: T) -> Self::Service {
+        if self.switch.use_primary(&target) {
+            tower::util::Either::A(self.primary.new_service(target))
+        } else {
+            tower::util::Either::B(self.fallback.new_service(target))
+        }
+    }
+}
+
 impl<T, S, P, F> tower::Service<T> for MakeSwitch<S, P, F>
 where
     S: Switch<T>,


### PR DESCRIPTION
This change modifies `serve` to take a `NewService` instead of a
`MakeService`. Services specific to the accept stack have been
updated as well

`DetectHttp` has been updated to work as either a `MakeService` or
`NewService` -- the asynchronous version is still needed by the outbound
proxy (until caching is changed).

`DetectTls` is now purely a `NewService`.