### PR TITLE
dst: Synthesize responses on rejected discovery

### DIFF
--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -99,14 +99,8 @@ pub struct ProxyMetrics {
     pub transport: transport::Metrics,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct DiscoveryRejected(());
-
-impl DiscoveryRejected {
-    pub fn new() -> Self {
-        DiscoveryRejected(())
-    }
-}
 
 impl std::fmt::Display for DiscoveryRejected {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -115,12 +109,6 @@ impl std::fmt::Display for DiscoveryRejected {
 }
 
 impl std::error::Error for DiscoveryRejected {}
-
-impl From<Addr> for DiscoveryRejected {
-    fn from(_: Addr) -> Self {
-        Self::new()
-    }
-}
 
 #[derive(Clone, Debug, Default)]
 pub struct SkipByPort(std::sync::Arc<indexmap::IndexSet<u16>>);

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -100,17 +100,6 @@ pub struct ProxyMetrics {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct DiscoveryRejected(());
-
-impl std::fmt::Display for DiscoveryRejected {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "discovery rejected")
-    }
-}
-
-impl std::error::Error for DiscoveryRejected {}
-
-#[derive(Clone, Debug, Default)]
 pub struct SkipByPort(std::sync::Arc<indexmap::IndexSet<u16>>);
 
 impl From<indexmap::IndexSet<u16>> for SkipByPort {

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -120,6 +120,12 @@ impl AsRef<Addr> for Target {
     }
 }
 
+impl Into<Addr> for &'_ Target {
+    fn into(self) -> Addr {
+        self.dst.clone()
+    }
+}
+
 impl tls::HasPeerIdentity for Target {
     fn peer_identity(&self) -> tls::PeerIdentity {
         Conditional::None(tls::ReasonForNoPeerName::Loopback.into())

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -21,7 +21,7 @@ pub struct Target {
 #[derive(Clone, Debug)]
 pub struct Logical {
     target: Target,
-    profiles: profiles::Receiver,
+    profiles: Option<profiles::Receiver>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -272,14 +272,14 @@ impl From<Logical> for Target {
 
 // === impl Logical ===
 
-impl From<(profiles::Receiver, Target)> for Logical {
-    fn from((profiles, target): (profiles::Receiver, Target)) -> Self {
+impl From<(Option<profiles::Receiver>, Target)> for Logical {
+    fn from((profiles, target): (Option<profiles::Receiver>, Target)) -> Self {
         Self { profiles, target }
     }
 }
 
-impl AsRef<profiles::Receiver> for Logical {
-    fn as_ref(&self) -> &profiles::Receiver {
+impl AsRef<Option<profiles::Receiver>> for Logical {
+    fn as_ref(&self) -> &Option<profiles::Receiver> {
         &self.profiles
     }
 }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -247,15 +247,9 @@ impl Config {
             .push_on_response(svc::layers().box_http_response())
             .check_new_service::<Target, http::Request<http::boxed::Payload>>();
 
-        let forward = target
-            .instrument(|_: &Target| debug_span!("forward"))
-            .check_new_service::<Target, http::Request<http::boxed::Payload>>();
-
         // Attempts to resolve the target as a service profile or, if that
         // fails, skips that stack to forward to the local endpoint.
         profile
-            .push_fallback(forward)
-            .check_new_service::<Target, http::Request<http::boxed::Payload>>()
             // If the traffic is targeted at the inbound port, send it through
             // the loopback service (i.e. as a gateway).
             .push(admit::AdmitLayer::new(prevent_loop))

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -117,6 +117,12 @@ impl AsRef<Addr> for HttpLogical {
     }
 }
 
+impl Into<Addr> for &'_ HttpLogical {
+    fn into(self) -> Addr {
+        self.dst.clone()
+    }
+}
+
 impl AsMut<Addr> for HttpLogical {
     fn as_mut(&mut self) -> &mut Addr {
         &mut self.dst

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -146,7 +146,7 @@ impl From<HttpLogical> for HttpEndpoint {
                     )
                 }),
             concrete: logical.into(),
-            metadata: Metadata::empty(),
+            metadata: Metadata::default(),
         }
     }
 }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -583,9 +583,7 @@ pub fn trace_labels() -> HashMap<String, String> {
 
 fn is_discovery_rejected(err: &Error) -> bool {
     fn is_rejected(err: &(dyn std::error::Error + 'static)) -> bool {
-        err.is::<DiscoveryRejected>()
-            || err.is::<profiles::InvalidProfileAddr>()
-            || err.source().map(is_rejected).unwrap_or(false)
+        err.is::<DiscoveryRejected>() || err.source().map(is_rejected).unwrap_or(false)
     }
 
     let rejected = is_rejected(&**err);

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -297,7 +297,7 @@ impl Config {
             .push(discover::buffer(1_000, cache_max_idle_age));
 
         // Builds a balancer for each concrete destination.
-        let concrete = svc::stack(endpoint.clone())
+        let concrete = svc::stack(endpoint)
             .check_new_service::<HttpEndpoint, http::Request<http::boxed::Payload>>()
             .push_on_response(
                 svc::layers()
@@ -359,23 +359,11 @@ impl Config {
             .push(profiles::discover::layer(profiles_client))
             .check_new_service::<HttpLogical, http::Request<_>>();
 
-        // Caches clients that bypass discovery/balancing.
-        let forward = svc::stack(endpoint)
-            .instrument(|t: &HttpEndpoint| debug_span!("forward", peer.id = ?t.identity))
-            .check_new_service::<HttpEndpoint, http::Request<_>>();
-
         // Attempts to route route request to a logical services that uses
         // control plane for discovery. If the discovery is rejected, the
         // `forward` stack is used instead, bypassing load balancing, etc.
         logical
             .push_on_response(svc::layers().box_http_response())
-            .push_fallback_with_predicate(
-                forward
-                    .push_map_target(HttpEndpoint::from)
-                    .push_on_response(svc::layers().box_http_response().box_http_request())
-                    .into_inner(),
-                is_discovery_rejected,
-            )
             .cache(
                 svc::layers().push_on_response(
                     svc::layers()

--- a/linkerd/app/outbound/src/tests.rs
+++ b/linkerd/app/outbound/src/tests.rs
@@ -1,7 +1,7 @@
-use crate::Config;
+use crate::{Config, endpoint::TcpLogical};
 use futures::prelude::*;
 use linkerd2_app_core::{
-    config, exp_backoff, proxy::http::h2, svc::NewService, transport::listen, Addr, Error,
+    config, exp_backoff, proxy::http::h2, svc::NewService, transport::listen, Error,
 };
 use linkerd2_app_test as test_support;
 use std::{net::SocketAddr, time::Duration};
@@ -64,15 +64,15 @@ async fn plaintext_tcp() {
     // Configure the mock destination resolver to just give us a single endpoint
     // for the target, which always exists and has no metadata.
     let resolver = test_support::resolver().endpoint_exists(
-        Addr::from(target_addr),
+        TcpLogical::from(target_addr),
         target_addr,
-        test_support::resolver::Metadata::empty(),
+        test_support::resolver::Metadata::default(),
     );
 
     // Build the outbound TCP balancer stack.
     let forward = cfg
         .build_tcp_balance(connect, resolver)
-        .new_service(target_addr);
+        .new_service(target_addr.into());
 
     forward
         .oneshot(client_io)

--- a/linkerd/app/outbound/src/tests.rs
+++ b/linkerd/app/outbound/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{Config, endpoint::TcpLogical};
+use crate::{endpoint::TcpLogical, Config};
 use futures::prelude::*;
 use linkerd2_app_core::{
     config, exp_backoff, proxy::http::h2, svc::NewService, transport::listen, Error,

--- a/linkerd/app/src/dst/default_profile.rs
+++ b/linkerd/app/src/dst/default_profile.rs
@@ -1,0 +1,69 @@
+use super::InvalidProfileAddr;
+use futures::prelude::*;
+use linkerd2_app_core::{profiles, svc, Addr, Error};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::sync::watch;
+use tracing::debug;
+
+pub fn layer<S>() -> impl svc::Layer<S, Service = RecoverDefaultProfile<S>> + Clone {
+    svc::layer::mk(|inner| RecoverDefaultProfile { inner })
+}
+
+#[derive(Clone, Debug)]
+pub struct RecoverDefaultProfile<S> {
+    inner: S,
+}
+
+impl<T, S> tower::Service<T> for RecoverDefaultProfile<S>
+where
+    for<'t> &'t T: Into<Addr>,
+    S: tower::Service<T, Response = profiles::Receiver>,
+    S::Error: Into<Error>,
+    S::Future: Send + 'static,
+{
+    type Response = profiles::Receiver;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<profiles::Receiver, Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, dst: T) -> Self::Future {
+        let addr = (&dst).into();
+
+        Box::pin(self.inner.call(dst).or_else(move |e| {
+            let err = e.into();
+            if is_rejected(&*err) {
+                debug!("Handling rejected discovery");
+
+                let (mut tx, rx) = watch::channel(profiles::Profile {
+                    http_routes: vec![],
+                    targets: vec![profiles::Target { addr, weight: 1 }],
+                });
+
+                // Spawn the sender until all receivers are dropped.
+                tokio::spawn(async move { tx.closed().await });
+
+                future::ok(rx)
+            } else {
+                future::err(err)
+            }
+        }))
+    }
+}
+
+fn is_rejected(err: &(dyn std::error::Error + 'static)) -> bool {
+    if err.is::<InvalidProfileAddr>() {
+        return true;
+    }
+
+    if let Some(status) = err.downcast_ref::<tonic::Status>() {
+        return status.code() == tonic::Code::InvalidArgument;
+    }
+
+    err.source().map(is_rejected).unwrap_or(false)
+}

--- a/linkerd/app/src/dst/default_resolve.rs
+++ b/linkerd/app/src/dst/default_resolve.rs
@@ -1,0 +1,66 @@
+use super::Rejected;
+use futures::{future, prelude::*, stream};
+use linkerd2_app_core::{
+    proxy::core::{Resolve, Update},
+    svc,
+};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pub fn layer<S>() -> impl svc::Layer<S, Service = RecoverDefaultResolve<S>> + Clone {
+    svc::layer::mk(RecoverDefaultResolve)
+}
+
+#[derive(Clone, Debug)]
+pub struct RecoverDefaultResolve<S>(S);
+
+impl<T, S> tower::Service<T> for RecoverDefaultResolve<S>
+where
+    for<'t> &'t T: Into<std::net::SocketAddr>,
+    S: Resolve<T>,
+    S::Error: std::error::Error + Send + 'static,
+    S::Endpoint: Default + Send + 'static,
+    S::Resolution: Send + 'static,
+    S::Future: Send + 'static,
+    stream::Once<future::Ready<Result<Update<S::Endpoint>, S::Error>>>:
+        stream::TryStream<Ok = Update<S::Endpoint>, Error = S::Error>,
+{
+    type Response = future::Either<
+        S::Resolution,
+        stream::Once<future::Ready<Result<Update<S::Endpoint>, S::Error>>>,
+    >;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, S::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.0.poll_ready(cx)
+    }
+
+    fn call(&mut self, dst: T) -> Self::Future {
+        let addr = (&dst).into();
+
+        Box::pin(
+            self.0
+                .resolve(dst)
+                .map_ok(future::Either::Left)
+                .or_else(move |err| {
+                    if Rejected::matches(&err) {
+                        tracing::debug!("Handling rejected discovery");
+
+                        let res: stream::Once<
+                            future::Ready<Result<Update<S::Endpoint>, S::Error>>,
+                        > = stream::once(future::ok(Update::Reset(vec![(
+                            addr,
+                            S::Endpoint::default(),
+                        )])));
+                        future::ok(future::Either::Right(res))
+                    } else {
+                        future::err(err)
+                    }
+                }),
+        )
+    }
+}

--- a/linkerd/app/src/dst/mod.rs
+++ b/linkerd/app/src/dst/mod.rs
@@ -1,7 +1,10 @@
 mod default_profile;
+mod default_resolve;
 mod permit;
 mod resolve;
 
+use self::default_profile::RecoverDefaultProfile;
+use self::default_resolve::RecoverDefaultResolve;
 use indexmap::IndexSet;
 use linkerd2_app_core::{
     control, dns, profiles, proxy::identity, request_filter, svc, transport::tls,
@@ -22,22 +25,23 @@ pub struct Config {
     pub initial_profile_timeout: Duration,
 }
 
-#[derive(Clone, Debug, Default)]
-pub struct InvalidProfileAddr(());
+#[derive(Clone, Debug)]
+struct Rejected(());
 
 /// Handles to destination service clients.
 ///
 /// The addr is preserved for logging.
 pub struct Dst {
     pub addr: control::ControlAddr,
-    pub profiles: default_profile::RecoverDefaultProfile<
+    pub profiles: RecoverDefaultProfile<
         request_filter::Service<
-            PermitConfiguredDsts<InvalidProfileAddr>,
+            PermitConfiguredDsts,
             profiles::Client<control::Client<BoxBody>, resolve::BackoffUnlessInvalidArgument>,
         >,
     >,
-    pub resolve:
+    pub resolve: RecoverDefaultResolve<
         request_filter::Service<PermitConfiguredDsts, resolve::Resolve<control::Client<BoxBody>>>,
+    >,
 }
 
 impl Config {
@@ -55,6 +59,7 @@ impl Config {
                 self.get_suffixes,
                 self.get_networks,
             ))
+            .push(default_resolve::layer())
             .into_inner();
 
         let profiles = svc::stack(profiles::Client::new(
@@ -63,10 +68,10 @@ impl Config {
             self.initial_profile_timeout,
             self.context,
         ))
-        .push_request_filter(
-            PermitConfiguredDsts::new(self.profile_suffixes, self.profile_networks)
-                .with_error::<InvalidProfileAddr>(),
-        )
+        .push_request_filter(PermitConfiguredDsts::new(
+            self.profile_suffixes,
+            self.profile_networks,
+        ))
         .push(default_profile::layer())
         .into_inner();
 
@@ -78,10 +83,24 @@ impl Config {
     }
 }
 
-impl std::fmt::Display for InvalidProfileAddr {
+impl std::fmt::Display for Rejected {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "invalid profile addr")
     }
 }
 
-impl std::error::Error for InvalidProfileAddr {}
+impl std::error::Error for Rejected {}
+
+impl Rejected {
+    fn matches(err: &(dyn std::error::Error + 'static)) -> bool {
+        if err.is::<Self>() {
+            return true;
+        }
+
+        if let Some(status) = err.downcast_ref::<tonic::Status>() {
+            return status.code() == tonic::Code::InvalidArgument;
+        }
+
+        err.source().map(Self::matches).unwrap_or(false)
+    }
+}

--- a/linkerd/app/src/dst/mod.rs
+++ b/linkerd/app/src/dst/mod.rs
@@ -1,3 +1,4 @@
+mod default_profile;
 mod permit;
 mod resolve;
 
@@ -21,14 +22,19 @@ pub struct Config {
     pub initial_profile_timeout: Duration,
 }
 
+#[derive(Clone, Debug, Default)]
+pub struct InvalidProfileAddr(());
+
 /// Handles to destination service clients.
 ///
 /// The addr is preserved for logging.
 pub struct Dst {
     pub addr: control::ControlAddr,
-    pub profiles: request_filter::Service<
-        PermitConfiguredDsts<profiles::InvalidProfileAddr>,
-        profiles::Client<control::Client<BoxBody>, resolve::BackoffUnlessInvalidArgument>,
+    pub profiles: default_profile::RecoverDefaultProfile<
+        request_filter::Service<
+            PermitConfiguredDsts<InvalidProfileAddr>,
+            profiles::Client<control::Client<BoxBody>, resolve::BackoffUnlessInvalidArgument>,
+        >,
     >,
     pub resolve:
         request_filter::Service<PermitConfiguredDsts, resolve::Resolve<control::Client<BoxBody>>>,
@@ -59,8 +65,9 @@ impl Config {
         ))
         .push_request_filter(
             PermitConfiguredDsts::new(self.profile_suffixes, self.profile_networks)
-                .with_error::<profiles::InvalidProfileAddr>(),
+                .with_error::<InvalidProfileAddr>(),
         )
+        .push(default_profile::layer())
         .into_inner();
 
         Ok(Dst {
@@ -70,3 +77,11 @@ impl Config {
         })
     }
 }
+
+impl std::fmt::Display for InvalidProfileAddr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid profile addr")
+    }
+}
+
+impl std::error::Error for InvalidProfileAddr {}

--- a/linkerd/app/src/dst/permit.rs
+++ b/linkerd/app/src/dst/permit.rs
@@ -26,10 +26,7 @@ impl PermitConfiguredDsts {
 
     /// Configures the returned error type when the target is outside of the
     /// configured set of destinations.
-    pub fn with_error<E>(self) -> PermitConfiguredDsts<E>
-    where
-        E: Into<Error> + From<Addr>,
-    {
+    pub fn with_error<E>(self) -> PermitConfiguredDsts<E> {
         PermitConfiguredDsts {
             name_suffixes: self.name_suffixes,
             networks: self.networks,
@@ -50,14 +47,13 @@ impl<E> Clone for PermitConfiguredDsts<E> {
 
 impl<T, E> request_filter::RequestFilter<T> for PermitConfiguredDsts<E>
 where
-    E: Into<Error> + From<Addr>,
     T: AsRef<Addr>,
+    E: Into<Error> + Default,
 {
     type Error = E;
 
     fn filter(&self, t: T) -> Result<T, Self::Error> {
-        let addr = t.as_ref();
-        let permitted = match addr {
+        let permitted = match t.as_ref() {
             Addr::Name(ref name) => self
                 .name_suffixes
                 .iter()
@@ -72,7 +68,7 @@ where
         if permitted {
             Ok(t)
         } else {
-            Err(E::from(addr.clone()))
+            Err(E::default())
         }
     }
 }

--- a/linkerd/app/src/dst/permit.rs
+++ b/linkerd/app/src/dst/permit.rs
@@ -24,11 +24,14 @@ impl PermitConfiguredDsts {
     }
 }
 
-impl<T: AsRef<Addr>> request_filter::RequestFilter<T> for PermitConfiguredDsts {
+impl<T> request_filter::RequestFilter<T> for PermitConfiguredDsts
+where
+    for<'t> &'t T: Into<Addr>,
+{
     type Error = Error;
 
     fn filter(&self, t: T) -> Result<T, Self::Error> {
-        let permitted = match t.as_ref() {
+        let permitted = match (&t).into() {
             Addr::Name(ref name) => self
                 .name_suffixes
                 .iter()

--- a/linkerd/app/src/dst/permit.rs
+++ b/linkerd/app/src/dst/permit.rs
@@ -1,13 +1,13 @@
+use super::Rejected;
 use ipnet::{Contains, IpNet};
-use linkerd2_app_core::{dns::Suffix, request_filter, Addr, DiscoveryRejected, Error};
-use std::marker::PhantomData;
+use linkerd2_app_core::{dns::Suffix, request_filter, Addr, Error};
 use std::net::IpAddr;
 use std::sync::Arc;
 
-pub struct PermitConfiguredDsts<E = DiscoveryRejected> {
+#[derive(Clone, Debug)]
+pub struct PermitConfiguredDsts {
     name_suffixes: Arc<Vec<Suffix>>,
     networks: Arc<Vec<IpNet>>,
-    _error: PhantomData<fn(E)>,
 }
 
 // === impl PermitConfiguredDsts ===
@@ -20,37 +20,12 @@ impl PermitConfiguredDsts {
         Self {
             name_suffixes: Arc::new(name_suffixes.into_iter().collect()),
             networks: Arc::new(nets.into_iter().collect()),
-            _error: PhantomData,
-        }
-    }
-
-    /// Configures the returned error type when the target is outside of the
-    /// configured set of destinations.
-    pub fn with_error<E>(self) -> PermitConfiguredDsts<E> {
-        PermitConfiguredDsts {
-            name_suffixes: self.name_suffixes,
-            networks: self.networks,
-            _error: PhantomData,
         }
     }
 }
 
-impl<E> Clone for PermitConfiguredDsts<E> {
-    fn clone(&self) -> Self {
-        Self {
-            name_suffixes: self.name_suffixes.clone(),
-            networks: self.networks.clone(),
-            _error: PhantomData,
-        }
-    }
-}
-
-impl<T, E> request_filter::RequestFilter<T> for PermitConfiguredDsts<E>
-where
-    T: AsRef<Addr>,
-    E: Into<Error> + Default,
-{
-    type Error = E;
+impl<T: AsRef<Addr>> request_filter::RequestFilter<T> for PermitConfiguredDsts {
+    type Error = Error;
 
     fn filter(&self, t: T) -> Result<T, Self::Error> {
         let permitted = match t.as_ref() {
@@ -68,7 +43,7 @@ where
         if permitted {
             Ok(t)
         } else {
-            Err(E::default())
+            Err(Rejected(()).into())
         }
     }
 }

--- a/linkerd/app/src/dst/resolve.rs
+++ b/linkerd/app/src/dst/resolve.rs
@@ -5,7 +5,7 @@ use linkerd2_app_core::{
         api_resolve as api,
         resolve::{self, recover},
     },
-    DiscoveryRejected, Error, Recover,
+    Error, Recover,
 };
 use tonic::{
     body::{Body, BoxBody},
@@ -49,7 +49,7 @@ impl Recover<Error> for BackoffUnlessInvalidArgument {
         match err.downcast::<Status>() {
             Ok(ref status) if status.code() == Code::InvalidArgument => {
                 tracing::debug!(message = "cannot recover", %status);
-                return Err(DiscoveryRejected::default().into());
+                return Err(super::Rejected(()).into());
             }
             Ok(status) => tracing::trace!(message = "recovering", %status),
             Err(error) => tracing::trace!(message = "recovering", %error),

--- a/linkerd/app/src/dst/resolve.rs
+++ b/linkerd/app/src/dst/resolve.rs
@@ -1,4 +1,3 @@
-pub use super::permit::PermitConfiguredDsts;
 use http_body::Body as HttpBody;
 use linkerd2_app_core::{
     exp_backoff::{ExponentialBackoff, ExponentialBackoffStream},

--- a/linkerd/app/src/dst/resolve.rs
+++ b/linkerd/app/src/dst/resolve.rs
@@ -50,7 +50,7 @@ impl Recover<Error> for BackoffUnlessInvalidArgument {
         match err.downcast::<Status>() {
             Ok(ref status) if status.code() == Code::InvalidArgument => {
                 tracing::debug!(message = "cannot recover", %status);
-                return Err(DiscoveryRejected::new().into());
+                return Err(DiscoveryRejected::default().into());
             }
             Ok(status) => tracing::trace!(message = "recovering", %status),
             Err(error) => tracing::trace!(message = "recovering", %error),

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -169,7 +169,7 @@ impl Config {
                     drain_rx.clone().signal(),
                 )
                 .map_err(|e| panic!("outbound failed: {}", e))
-                .instrument(span.clone()),
+                .in_current_span(),
             );
             drop(_enter);
 
@@ -188,9 +188,7 @@ impl Config {
                     inbound.build(
                         inbound_addr,
                         local_identity,
-                        svc::stack(http_gateway)
-                            .push_on_response(svc::layers().box_http_request())
-                            .into_inner(),
+                        svc::stack(http_gateway).into_new_service().into_inner(),
                         dst.profiles,
                         tap_layer,
                         inbound_metrics,
@@ -200,7 +198,7 @@ impl Config {
                     drain_rx.signal(),
                 )
                 .map_err(|e| panic!("inbound failed: {}", e))
-                .instrument(span.clone()),
+                .in_current_span(),
             );
             drop(_enter);
         });

--- a/linkerd/proxy/api-resolve/src/metadata.rs
+++ b/linkerd/proxy/api-resolve/src/metadata.rs
@@ -41,8 +41,8 @@ pub enum ProtocolHint {
 
 // === impl Metadata ===
 
-impl Metadata {
-    pub fn empty() -> Self {
+impl Default for Metadata {
+    fn default() -> Self {
         Self {
             labels: IndexMap::default(),
             protocol_hint: ProtocolHint::Unknown,
@@ -51,7 +51,9 @@ impl Metadata {
             authority_override: None,
         }
     }
+}
 
+impl Metadata {
     pub fn new(
         labels: IndexMap<String, String>,
         protocol_hint: ProtocolHint,

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -118,7 +118,7 @@ where
     R: Recover + Send + Clone + 'static,
     R::Backoff: Unpin + Send,
 {
-    type Response = Receiver;
+    type Response = Option<Receiver>;
     type Error = Error;
     type Future = ProfileFuture<S, R>;
 
@@ -169,7 +169,7 @@ where
     R::Backoff: Unpin,
     R::Backoff: Send,
 {
-    type Output = Result<Receiver, Error>;
+    type Output = Result<Option<Receiver>, Error>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let mut this = self.project();
@@ -218,7 +218,7 @@ where
                                 trace!(?profile, "publishing");
                                 if tx.broadcast(profile).is_err() {
                                     trace!("failed to publish profile");
-                                    return
+                                    return;
                                 }
                             }
                         }
@@ -228,7 +228,7 @@ where
         };
         tokio::spawn(daemon.in_current_span());
 
-        Poll::Ready(Ok(rx))
+        Poll::Ready(Ok(Some(rx)))
     }
 }
 

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -32,9 +32,6 @@ pub struct Client<S, R> {
     context_token: String,
 }
 
-#[derive(Clone, Debug)]
-pub struct InvalidProfileAddr(Addr);
-
 #[pin_project]
 pub struct ProfileFuture<S, R>
 where
@@ -526,25 +523,5 @@ mod tests {
             // simply not panicking is good enough
             true
         }
-    }
-}
-
-impl InvalidProfileAddr {
-    pub fn addr(&self) -> &Addr {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for InvalidProfileAddr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "invalid profile addr: {}", self.0)
-    }
-}
-
-impl std::error::Error for InvalidProfileAddr {}
-
-impl From<Addr> for InvalidProfileAddr {
-    fn from(addr: Addr) -> Self {
-        Self(addr)
     }
 }

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -2,7 +2,7 @@ use crate::{http, Profile, Receiver, Target};
 use api::destination_client::DestinationClient;
 use futures::{future, prelude::*, ready, select_biased};
 use http_body::Body as HttpBody;
-use linkerd2_addr::Addr;
+use linkerd2_addr::{Addr, NameAddr};
 use linkerd2_error::{Error, Recover};
 use linkerd2_proxy_api::destination as api;
 use pin_project::pin_project;
@@ -352,9 +352,9 @@ fn convert_dst_override(orig: api::WeightedDst) -> Option<Target> {
     if orig.weight == 0 {
         return None;
     }
-    let addr = Addr::from_str(orig.authority.as_str()).ok()?;
+    let name = NameAddr::from_str(orig.authority.as_str()).ok()?;
     Some(Target {
-        addr,
+        name,
         weight: orig.weight,
     })
 }

--- a/linkerd/service-profiles/src/discover.rs
+++ b/linkerd/service-profiles/src/discover.rs
@@ -24,7 +24,7 @@ where
     G: GetProfile<T>,
     G::Future: Send + 'static,
     G::Error: Send,
-    M: NewService<(Receiver, T)> + Clone + Send + 'static,
+    M: NewService<(Option<Receiver>, T)> + Clone + Send + 'static,
 {
     type Service = FutureService<
         Pin<Box<dyn Future<Output = Result<M::Service, G::Error>> + Send + 'static>>,

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -13,7 +13,7 @@ pub mod discover;
 pub mod http;
 pub mod split;
 
-pub use self::client::{Client, InvalidProfileAddr};
+pub use self::client::Client;
 
 pub type Receiver = tokio::sync::watch::Receiver<Profile>;
 

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -35,7 +35,7 @@ pub struct GetProfileService<P>(P);
 /// Watches a destination's Profile.
 pub trait GetProfile<T> {
     type Error: Into<Error>;
-    type Future: Future<Output = Result<Receiver, Self::Error>>;
+    type Future: Future<Output = Result<Option<Receiver>, Self::Error>>;
 
     fn get_profile(&mut self, target: T) -> Self::Future;
 
@@ -49,7 +49,7 @@ pub trait GetProfile<T> {
 
 impl<T, S> GetProfile<T> for S
 where
-    S: tower::Service<T, Response = Receiver> + Clone,
+    S: tower::Service<T, Response = Option<Receiver>> + Clone,
     S::Error: Into<Error>,
 {
     type Error = S::Error;
@@ -64,7 +64,7 @@ impl<T, P> tower::Service<T> for GetProfileService<P>
 where
     P: GetProfile<T>,
 {
-    type Response = Receiver;
+    type Response = Option<Receiver>;
     type Error = P::Error;
     type Future = P::Future;
 

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use linkerd2_addr::Addr;
+use linkerd2_addr::NameAddr;
 use linkerd2_error::Error;
 use std::{
     future::Future,
@@ -25,7 +25,7 @@ pub struct Profile {
 
 #[derive(Clone, Debug)]
 pub struct Target {
-    pub addr: Addr,
+    pub name: NameAddr,
     pub weight: u32,
 }
 

--- a/linkerd/service-profiles/src/split.rs
+++ b/linkerd/service-profiles/src/split.rs
@@ -1,7 +1,7 @@
 use crate::{Profile, Receiver, Target};
 use futures::{prelude::*, ready};
 use indexmap::IndexSet;
-use linkerd2_addr::Addr;
+use linkerd2_addr::NameAddr;
 use linkerd2_error::Error;
 use linkerd2_stack::{layer, NewService};
 use rand::distributions::{Distribution, WeightedIndex};
@@ -34,18 +34,21 @@ pub struct NewSplit<N, S, Req> {
 
 #[derive(Debug)]
 pub struct Split<T, N, S, Req> {
-    target: T,
-    rx: Option<Receiver>,
-    new_service: N,
-    rng: SmallRng,
-    inner: Option<Inner>,
-    services: ReadyCache<Addr, S, Req>,
+    inner: Inner<T, N, S, Req>,
 }
 
 #[derive(Debug)]
-struct Inner {
-    distribution: WeightedIndex<u32>,
-    addrs: IndexSet<Addr>,
+enum Inner<T, N, S, Req> {
+    Default(S),
+    Split {
+        rng: SmallRng,
+        rx: Receiver,
+        target: T,
+        new_service: N,
+        distribution: WeightedIndex<u32>,
+        addrs: IndexSet<Option<NameAddr>>,
+        services: ReadyCache<Option<NameAddr>, S, Req>,
+    },
 }
 
 impl<N: Clone, S, Req> Clone for NewSplit<N, S, Req> {
@@ -58,31 +61,63 @@ impl<N: Clone, S, Req> Clone for NewSplit<N, S, Req> {
     }
 }
 
-impl<T, N: Clone, S, Req> NewService<T> for NewSplit<N, S, Req>
+impl<T, N, S, Req> NewService<T> for NewSplit<N, S, Req>
 where
-    T: AsRef<Option<Receiver>>,
+    T: AsRef<Option<Receiver>> + Clone,
+    N: NewService<(Option<NameAddr>, T), Service = S> + Clone,
     S: tower::Service<Req>,
+    S::Error: Into<Error>,
 {
     type Service = Split<T, N, S, Req>;
 
     fn new_service(&mut self, target: T) -> Self::Service {
-        let rx = target.as_ref().clone();
-        Split {
-            rx,
-            target,
-            new_service: self.inner.clone(),
-            rng: self.rng.clone(),
-            inner: None,
-            services: ReadyCache::default(),
-        }
+        let inner = match target.as_ref().clone() {
+            None => Inner::Default(self.inner.new_service((None, target))),
+            Some(rx) => {
+                let targets = rx.borrow().targets.clone();
+                let mut new_service = self.inner.clone();
+
+                let mut addrs = IndexSet::with_capacity(targets.len().max(1));
+                let mut weights = Vec::with_capacity(targets.len().max(1));
+                let mut services = ReadyCache::default();
+
+                // Create an updated distribution and set of services.
+                if targets.len() == 0 {
+                    services.push(None, new_service.new_service((None, target.clone())));
+                    addrs.insert(None);
+                    weights.push(1);
+                } else {
+                    for Target { weight, name } in targets.into_iter() {
+                        services.push(
+                            Some(name.clone()),
+                            new_service.new_service((Some(name.clone()), target.clone())),
+                        );
+                        addrs.insert(Some(name));
+                        weights.push(weight);
+                    }
+                }
+
+                Inner::Split {
+                    rx,
+                    target,
+                    new_service,
+                    services,
+                    addrs,
+                    distribution: WeightedIndex::new(weights).unwrap(),
+                    rng: self.rng.clone(),
+                }
+            }
+        };
+
+        Split { inner }
     }
 }
 
 impl<T, N, S, Req> tower::Service<Req> for Split<T, N, S, Req>
 where
     Req: Send + 'static,
-    T: AsRef<Addr> + Clone,
-    N: NewService<(Addr, T), Service = S> + Clone,
+    T: Clone,
+    N: NewService<(Option<NameAddr>, T), Service = S> + Clone,
     S: tower::Service<Req> + Send + 'static,
     S::Response: Send + 'static,
     S::Error: Into<Error>,
@@ -93,119 +128,92 @@ where
     type Future = Pin<Box<dyn Future<Output = Result<S::Response, Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let mut update = None;
-        if let Some(rx) = self.rx.as_mut() {
-            while let Poll::Ready(Some(up)) = rx.poll_recv_ref(cx) {
-                update = Some(up.clone());
+        match self.inner {
+            Inner::Default(ref mut svc) => svc.poll_ready(cx).map_err(Into::into),
+            Inner::Split {
+                ref mut rx,
+                ref mut services,
+                ref mut addrs,
+                ref mut distribution,
+                ref mut new_service,
+                ref target,
+                ..
+            } => {
+                let mut update = None;
+                while let Poll::Ready(Some(up)) = rx.poll_recv_ref(cx) {
+                    update = Some(up.clone());
+                }
+
+                // Every time the profile updates, rebuild the distribution, reusing
+                // services that existed in the prior state.
+                if let Some(Profile { targets, .. }) = update {
+                    debug!(?targets, "Updating");
+
+                    let mut prior_addrs =
+                        std::mem::replace(addrs, IndexSet::with_capacity(targets.len().max(1)));
+                    let mut weights = Vec::with_capacity(targets.len().max(1));
+
+                    if targets.len() == 0 {
+                        // Reuse the prior services whenever possible.
+                        if !prior_addrs.remove(&None) {
+                            debug!("Creating default target");
+                            let svc = new_service.new_service((None, target.clone()));
+                            services.push(None, svc);
+                        } else {
+                            debug!("Default target already exists");
+                        }
+                        addrs.insert(None);
+                        weights.push(1);
+                    } else {
+                        // Create an updated distribution and set of services.
+                        for Target { weight, name } in targets.into_iter() {
+                            let addr = Some(name.clone());
+                            // Reuse the prior services whenever possible.
+                            if !prior_addrs.remove(&addr) {
+                                debug!(%name, "Creating target");
+                                let svc = new_service.new_service((addr.clone(), target.clone()));
+                                services.push(addr.clone(), svc);
+                            } else {
+                                trace!(%name, "Target already exists");
+                            }
+                            addrs.insert(addr);
+                            weights.push(weight);
+                        }
+                    }
+
+                    *distribution = WeightedIndex::new(weights).unwrap();
+
+                    for addr in prior_addrs.into_iter() {
+                        services.evict(&addr);
+                    }
+                }
+
+                // Wait for all target services to be ready. If any services fail, then
+                // the whole service fails.
+                Poll::Ready(ready!(services.poll_pending(cx)).map_err(Into::into))
             }
         }
-
-        // Every time the profile updates, rebuild the distribution, reusing
-        // services that existed in the prior state.
-        if let Some(Profile { targets, .. }) = update {
-            debug!(?targets, "Updating");
-            self.update_inner(targets);
-        }
-
-        // If, somehow, the watch hasn't been notified at least once, build the
-        // default target. This shouldn't actually be exercised, though.
-        if self.inner.is_none() {
-            self.update_inner(Vec::new());
-        }
-        debug_assert_ne!(self.services.len(), 0);
-
-        // Wait for all target services to be ready. If any services fail, then
-        // the whole service fails.
-        Poll::Ready(ready!(self.services.poll_pending(cx)).map_err(Into::into))
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        let Inner {
-            ref addrs,
-            ref distribution,
-        } = self.inner.as_ref().expect("Called before ready");
-        debug_assert_ne!(addrs.len(), 0, "addrs empty");
-        debug_assert_eq!(self.services.len(), addrs.len());
-
-        let idx = if addrs.len() == 1 {
-            0
-        } else {
-            distribution.sample(&mut self.rng)
-        };
-        let addr = addrs.get_index(idx).expect("invalid index");
-        trace!(%addr, "Dispatching");
-        Box::pin(self.services.call_ready(addr, req).err_into::<Error>())
-    }
-}
-
-impl<T, N, S, Req> Split<T, N, S, Req>
-where
-    Req: Send + 'static,
-    T: AsRef<Addr> + Clone,
-    N: NewService<(Addr, T), Service = S> + Clone,
-    S: tower::Service<Req> + Send + 'static,
-    S::Response: Send + 'static,
-    S::Error: Into<Error>,
-    S::Future: Send,
-{
-    fn update_inner(&mut self, targets: Vec<Target>) {
-        // Clear out the prior state and preserve its services for reuse.
-        let mut prior = self.inner.take().map(|i| i.addrs).unwrap_or_default();
-
-        let mut addrs = IndexSet::with_capacity(targets.len().max(0));
-        let mut weights = Vec::with_capacity(targets.len().max(1));
-        if targets.len() == 0 {
-            // If there were no overrides, build a default backend from the
-            // target.
-            let addr = self.target.as_ref();
-            if !prior.remove(addr) {
-                debug!(%addr, "Creating default target");
-                let svc = self
-                    .new_service
-                    .new_service((addr.clone(), self.target.clone()));
-                self.services.push(addr.clone(), svc);
-            } else {
-                debug!(%addr, "Default target already exists");
-            }
-            addrs.insert(addr.clone());
-            weights.push(1);
-        } else {
-            // Create an updated distribution and set of services.
-            for Target { weight, addr } in targets.into_iter() {
-                // Reuse the prior services whenever possible.
-                if !prior.remove(&addr) {
-                    debug!(%addr, "Creating target");
-                    let svc = self
-                        .new_service
-                        .new_service((addr.clone(), self.target.clone()));
-                    self.services.push(addr.clone(), svc);
+        match self.inner {
+            Inner::Default(ref mut svc) => Box::pin(svc.call(req).err_into::<Error>()),
+            Inner::Split {
+                ref addrs,
+                ref distribution,
+                ref mut services,
+                ref mut rng,
+                ..
+            } => {
+                let idx = if addrs.len() == 1 {
+                    0
                 } else {
-                    debug!(%addr, "Target already exists");
-                }
-                addrs.insert(addr);
-                weights.push(weight);
+                    distribution.sample(rng)
+                };
+                let addr = addrs.get_index(idx).expect("invalid index");
+                trace!(?addr, "Dispatching");
+                Box::pin(services.call_ready(addr, req).err_into::<Error>())
             }
         }
-
-        for addr in prior {
-            self.services.evict(&addr);
-        }
-        if !addrs.contains(self.target.as_ref()) {
-            self.services.evict(self.target.as_ref());
-        }
-
-        debug_assert_ne!(addrs.len(), 0, "addrs empty");
-        debug_assert_eq!(addrs.len(), weights.len(), "addrs does not match weights");
-        // The cache may still contain evicted pending services until the next
-        // poll.
-        debug_assert!(
-            addrs.len() <= self.services.len(),
-            "addrs does not match the number of services"
-        );
-        let distribution = WeightedIndex::new(weights).expect("Split must be valid");
-        self.inner = Some(Inner {
-            addrs,
-            distribution,
-        });
     }
 }


### PR DESCRIPTION
Both the profile and endpoint discovery stacks produce errors when the
resolution cannot be handled, and we handle these errors by falling back
to an alternate stack.

This changes that behavior to synthesize responses in these cases. When
profile resolution is rejected, we create a profile response that
includes the original dst addr as a target. When resolution is rejected,
we create a resolution stream with a single endpoint (again, from the
original dst address).

This can be optimized later (i.e. to overhead of a balancer when we know
we're not talking to a replica set).