### PR TITLE
outbound: Explicitly ignore the source address for tap

### DIFF
--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -172,7 +172,7 @@ impl Into<http::client::Settings> for &'_ HttpEndpoint {
 }
 
 impl tap::Inspect for HttpEndpoint {
-    fn src_addr<B>(&self, req: &http::Request<B>) -> Option<SocketAddr> {
+    fn src_addr<B>(&self, _: &http::Request<B>) -> Option<SocketAddr> {
         None
     }
 

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -173,7 +173,7 @@ impl Into<http::client::Settings> for &'_ HttpEndpoint {
 
 impl tap::Inspect for HttpEndpoint {
     fn src_addr<B>(&self, req: &http::Request<B>) -> Option<SocketAddr> {
-        req.extensions().get::<listen::Addrs>().map(|s| s.peer())
+        None
     }
 
     fn src_tls<'a, B>(

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -477,8 +477,6 @@ impl Config {
             .push_timeout(dispatch_timeout)
             .push(router::Layer::new(LogicalPerRequest::from))
             .check_new_service::<listen::Addrs, http::Request<_>>()
-            // Used by tap.
-            .push_http_insert_target()
             .push_on_response(
                 svc::layers()
                     .push(http_admit_request)


### PR DESCRIPTION
For outbound requests, the src address is always an ephemeral port on
localhost, which isn't particularly valuable. Futhermore, as we add
caching outside of HTTP detection, this becomes annoying to track.

This changes the outbound stack to always use a `None` src addr.