### PR TITLE
http: Lazily build http/tcp stacks

### DIFF
--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -114,6 +114,12 @@ pub(super) fn route((route, logical): (profiles::http::Route, Logical)) -> dst::
 
 // === impl Target ===
 
+impl Into<Addr> for &'_ Target {
+    fn into(self) -> Addr {
+        self.dst.clone()
+    }
+}
+
 impl AsRef<Addr> for Target {
     fn as_ref(&self) -> &Addr {
         &self.dst

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -364,7 +364,8 @@ impl Config {
                     .box_http_response(),
             )
             .instrument(|_: &_| debug_span!("source"))
-            .check_new_service::<tls::accept::Meta, http::Request<_>>()
+            .push_map_target(|(_, accept): (http::Version, tls::accept::Meta)| accept)
+            .check_new_service::<(http::Version, tls::accept::Meta), http::Request<_>>()
             .into_inner();
 
         svc::stack(http::DetectHttp::new(

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -86,6 +86,18 @@ impl Into<SocketAddr> for &'_ TcpLogical {
     }
 }
 
+impl Into<Addr> for &'_ TcpLogical {
+    fn into(self) -> Addr {
+        self.addr.into()
+    }
+}
+
+impl std::fmt::Display for TcpLogical {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.addr.fmt(f)
+    }
+}
+
 // === impl HttpAccept ===
 
 impl From<(http::Version, TcpLogical)> for HttpAccept {
@@ -114,6 +126,12 @@ impl From<(Addr, Profile)> for HttpConcrete {
 impl AsRef<Addr> for HttpConcrete {
     fn as_ref(&self) -> &Addr {
         &self.dst
+    }
+}
+
+impl Into<Addr> for &'_ HttpConcrete {
+    fn into(self) -> Addr {
+        self.dst.clone()
     }
 }
 
@@ -150,6 +168,12 @@ impl<'t> From<&'t HttpLogical> for http::header::HeaderValue {
 impl Into<SocketAddr> for HttpLogical {
     fn into(self) -> SocketAddr {
         self.orig_dst
+    }
+}
+
+impl Into<Addr> for &'_ HttpLogical {
+    fn into(self) -> Addr {
+        self.dst.clone()
     }
 }
 

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -238,8 +238,8 @@ impl Into<http::client::Settings> for &'_ HttpEndpoint {
 }
 
 impl tap::Inspect for HttpEndpoint {
-    fn src_addr<B>(&self, req: &http::Request<B>) -> Option<SocketAddr> {
-        req.extensions().get::<listen::Addrs>().map(|s| s.peer())
+    fn src_addr<B>(&self, _: &http::Request<B>) -> Option<SocketAddr> {
+        None
     }
 
     fn src_tls<'a, B>(

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -23,8 +23,8 @@ pub struct FromMetadata;
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct HttpAccept {
-    orig_dst: SocketAddr,
-    version: http::Version,
+    pub orig_dst: SocketAddr,
+    pub version: http::Version,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -507,6 +507,7 @@ impl Config {
             )
             .push_on_response(
                 svc::layers()
+                    .push_failfast(dispatch_timeout)
                     .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age),
             )
             .check_new::<endpoint::TcpLogical>()

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -501,8 +501,8 @@ impl Config {
         // Load balances TCP streams that cannot be decoded as HTTP.
         let tcp_balance = svc::stack(self.build_tcp_balance(tcp_connect, resolve))
             .push_fallback_with_predicate(
-                svc::stack(tcp_forward.clone())
-                    .check_new::<TcpEndpoint>()
+                tcp_forward
+                    .clone()
                     .push_map_target(TcpEndpoint::from)
                     .into_inner(),
                 is_discovery_rejected,
@@ -531,10 +531,7 @@ impl Config {
         svc::stack(svc::stack::MakeSwitch::new(
             skip_detect.clone(),
             http,
-            tcp_forward
-                .check_new::<TcpEndpoint>()
-                .push_map_target(TcpEndpoint::from)
-                .into_inner(),
+            tcp_forward.push_map_target(TcpEndpoint::from).into_inner(),
         ))
         .cache(
             svc::layers().push_on_response(

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -120,7 +120,7 @@ impl Config {
             .push_on_response(
                 svc::layers()
                     .push(tcp::balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
-                .push(svc::layer::mk(tcp::Forward::new))
+                    .push(svc::layer::mk(tcp::Forward::new))
             )
             .into_new_service()
             .check_new_service::<endpoint::TcpLogical, I>()

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -116,10 +116,12 @@ impl Config {
                 endpoint::FromMetadata,
                 resolve,
             )))
-            .check_service::<endpoint::TcpLogical>()
-            .push_on_response(svc::layers().push(tcp::balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
-            .push(svc::layer::mk(tcp::Forward::new)))
-            .check_make_service::<endpoint::TcpLogical, I>()
+            .push(discover::buffer(1_000, self.proxy.cache_max_idle_age))
+            .push_on_response(
+                svc::layers()
+                    .push(tcp::balance::layer(EWMA_DEFAULT_RTT, EWMA_DECAY))
+                .push(svc::layer::mk(tcp::Forward::new))
+            )
             .into_new_service()
             .check_new_service::<endpoint::TcpLogical, I>()
     }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -477,8 +477,6 @@ impl Config {
             .push_timeout(dispatch_timeout)
             .push(router::Layer::new(LogicalPerRequest::from))
             .check_new_service::<endpoint::HttpAccept, http::Request<_>>()
-            // Used by tap.
-            //FIXME .push_http_insert_target()
             .push_on_response(
                 svc::layers()
                     .push(http_admit_request)
@@ -486,9 +484,7 @@ impl Config {
                     .box_http_request()
                     .box_http_response(),
             )
-            .check_new_service::<endpoint::HttpAccept, http::Request<_>>()
             .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
-            .check_new_service::<endpoint::HttpAccept, http::Request<_>>()
             .instrument(|_: &_| debug_span!("source"))
             .push_map_target(endpoint::HttpAccept::from)
             .check_new_service::<(http::Version, endpoint::TcpLogical), http::Request<_>>()

--- a/linkerd/app/outbound/src/tests.rs
+++ b/linkerd/app/outbound/src/tests.rs
@@ -1,7 +1,7 @@
-use crate::Config;
+use crate::{endpoint::TcpLogical, Config};
 use futures::prelude::*;
 use linkerd2_app_core::{
-    config, exp_backoff, proxy::http::h2, svc::NewService, transport::listen, Addr, Error,
+    config, exp_backoff, proxy::http::h2, svc::NewService, transport::listen, Error,
 };
 use linkerd2_app_test as test_support;
 use std::{net::SocketAddr, time::Duration};
@@ -48,6 +48,7 @@ async fn plaintext_tcp() {
     // ports or anything. These will just be used so that the proxy has a socket
     // address to resolve, etc.
     let target_addr = SocketAddr::new([0, 0, 0, 0].into(), 666);
+    let logical = TcpLogical { addr: target_addr };
 
     let cfg = default_config(target_addr);
 
@@ -64,7 +65,7 @@ async fn plaintext_tcp() {
     // Configure the mock destination resolver to just give us a single endpoint
     // for the target, which always exists and has no metadata.
     let resolver = test_support::resolver().endpoint_exists(
-        Addr::from(target_addr),
+        logical.clone(),
         target_addr,
         test_support::resolver::Metadata::empty(),
     );
@@ -72,7 +73,7 @@ async fn plaintext_tcp() {
     // Build the outbound TCP balancer stack.
     let forward = cfg
         .build_tcp_balance(connect, resolver)
-        .new_service(target_addr);
+        .new_service(logical);
 
     forward
         .oneshot(client_io)

--- a/linkerd/app/src/dst/permit.rs
+++ b/linkerd/app/src/dst/permit.rs
@@ -51,12 +51,12 @@ impl<E> Clone for PermitConfiguredDsts<E> {
 impl<T, E> request_filter::RequestFilter<T> for PermitConfiguredDsts<E>
 where
     E: Into<Error> + From<Addr>,
-    T: AsRef<Addr>,
+    for<'t> &'t T: Into<Addr>,
 {
     type Error = E;
 
     fn filter(&self, t: T) -> Result<T, Self::Error> {
-        let addr = t.as_ref();
+        let addr = (&t).into();
         let permitted = match addr {
             Addr::Name(ref name) => self
                 .name_suffixes

--- a/linkerd/proxy/http/src/detect.rs
+++ b/linkerd/proxy/http/src/detect.rs
@@ -199,13 +199,10 @@ where
                 let tcp = if let Some(svc) = self.tcp.clone() {
                     svc
                 } else {
-                    let svc = self
-                        .new_tcp
-                        .new_service(self.target.clone());
+                    let svc = self.new_tcp.new_service(self.target.clone());
                     self.tcp = Some(svc.clone());
                     svc
                 };
-
 
                 Box::pin(
                     self.drain.clone().ignore_signal().release_after(

--- a/linkerd/proxy/http/src/detect.rs
+++ b/linkerd/proxy/http/src/detect.rs
@@ -69,7 +69,6 @@ impl<F, H> DetectHttp<F, H> {
 
 impl<T, F, H> NewService<T> for DetectHttp<F, H>
 where
-    T: Clone,
     F: NewService<T> + Clone,
     H: NewService<(HttpVersion, T)> + Clone,
 {

--- a/linkerd/proxy/http/src/version.rs
+++ b/linkerd/proxy/http/src/version.rs
@@ -62,11 +62,23 @@ impl Version {
     }
 }
 
+// A convenience for tracing contexts.
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Http1 => write!(f, "http/1.x"),
+            Self::H2 => write!(f, "h2"),
+        }
+    }
+}
+
 impl std::fmt::Display for Unsupported {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Unsupported HTTP version")
     }
 }
+
+impl std::error::Error for Unsupported {}
 
 #[cfg(test)]
 #[test]

--- a/linkerd/stack/src/switch.rs
+++ b/linkerd/stack/src/switch.rs
@@ -13,6 +13,7 @@ pub trait Switch<T> {
 
 /// Makes either the primary or fallback stack, as determined by an `S`-typed
 /// `Switch`.
+#[derive(Clone, Debug)]
 pub struct MakeSwitch<S, P, F> {
     switch: S,
     primary: P,


### PR DESCRIPTION
Currently, the `DetectHttp` layer always builds both HTTP and TCP
stacks, even though only one is needed. Furthermore, we lose the
information about which protocol was detected--it's never passed into
the http stack (and instead must be inferred from individual requests).

This change modifies the `DetectHttp` layer to only build inner services
as needed, after the protocol has been detected.

Furthermore, outbound caching has been moved up from the tcp balancer to
wrap the HTTP detection layer. This was necessary so that the tcp
balancer could be built instantaneously as a NewService while still
being cloneable. This means that, for each outbound target ip:port, we
will reuse HTTP and TCP stacks.

However, HTTP routing remains dependent on per-request metadata. This is
expected to change in a followup.