### PR TITLE
outbound: remove required identity from `HttpLogical`

### DIFF
--- a/linkerd/app/gateway/src/make.rs
+++ b/linkerd/app/gateway/src/make.rs
@@ -121,7 +121,6 @@ where
                         dst: dst_name.clone().into(),
                         orig_dst: dst_addr,
                         version: http_version,
-                        require_identity: None,
                     };
 
                     let svc = outbound.call(endpoint).await.map_err(Into::into)?;

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -1,20 +1,22 @@
 use crate::http::uri::Authority;
 use indexmap::IndexMap;
 use linkerd2_app_core::{
-    dst, metric_labels,
+    dst,
+    metric_labels,
     metric_labels::{prefix_labels, EndpointLabels},
     profiles,
     proxy::{
         api_resolve::{Metadata, ProtocolHint},
         http::override_authority::CanOverrideAuthority,
-        http::{self, identity_from_header},
+        http::{self},
         identity,
         resolve::map_endpoint::MapEndpoint,
         tap,
     },
     router,
     transport::{listen, tls},
-    Addr, Conditional, L5D_REQUIRE_ID,
+    Addr,
+    Conditional, //L5D_REQUIRE_ID,
 };
 use std::{net::SocketAddr, sync::Arc};
 
@@ -32,7 +34,6 @@ pub struct HttpLogical {
     pub dst: Addr,
     pub orig_dst: SocketAddr,
     pub version: http::Version,
-    pub require_identity: Option<identity::Name>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -196,15 +197,9 @@ impl From<HttpLogical> for HttpEndpoint {
         Self {
             addr: logical.orig_dst,
             settings: logical.version.into(),
-            identity: logical
-                .require_identity
-                .clone()
-                .map(Conditional::Some)
-                .unwrap_or_else(|| {
-                    Conditional::None(
-                        tls::ReasonForNoPeerName::NotProvidedByServiceDiscovery.into(),
-                    )
-                }),
+            identity: Conditional::None(
+                tls::ReasonForNoPeerName::NotProvidedByServiceDiscovery.into(),
+            ),
             concrete: logical.into(),
             metadata: Metadata::empty(),
         }
@@ -285,11 +280,8 @@ impl MapEndpoint<HttpConcrete, Metadata> for FromMetadata {
         metadata: Metadata,
     ) -> Self::Out {
         tracing::trace!(%addr, ?metadata, ?concrete, "Resolved endpoint");
-        let identity = concrete
-            .logical
-            .require_identity
-            .as_ref()
-            .or_else(|| metadata.identity())
+        let identity = metadata
+            .identity()
             .cloned()
             .map(Conditional::Some)
             .unwrap_or_else(|| {
@@ -443,12 +435,9 @@ impl<B> router::Recognize<http::Request<B>> for LogicalPerRequest {
 
         tracing::debug!(headers = ?req.headers(), uri = %req.uri(), dst = %dst, version = ?req.version(), "Setting target for request");
 
-        let require_identity = identity_from_header(req, L5D_REQUIRE_ID);
-
         HttpLogical {
             dst,
             orig_dst: self.0.orig_dst,
-            require_identity,
             version: self.0.version,
         }
     }


### PR DESCRIPTION
Presently, the proxy extracts the required identity from the
`l5d-required-identity` header into the `HttpLogical` target type when
it is present, and builds endpoint stacks which require that identity.
This was previously necessary because service discovery couldn't be
performed for pod IPs, only for authorities. However, this is no longer
the case, and we can now just use the identity returned by service
discovery for these stacks. This means the required identity can be
removed from the `HttpLogical` target, and identities in `HttpEndpoint`
targets are only provided by the destination metadata.

Fixes linkerd/linkerd2#5029