### PR TITLE
profiles: Expose the fully_qualified_name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,6 +1500,7 @@ dependencies = [
  "http-body",
  "indexmap",
  "linkerd2-addr",
+ "linkerd2-dns-name",
  "linkerd2-error",
  "linkerd2-proxy-api",
  "linkerd2-stack",

--- a/linkerd/dns/name/src/name.rs
+++ b/linkerd/dns/name/src/name.rs
@@ -104,5 +104,6 @@ mod tests {
             )
         }
         assert!(Name::try_from(".".as_bytes()).is_err());
+        assert!(Name::try_from("".as_bytes()).is_err());
     }
 }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -15,6 +15,7 @@ http = "0.2"
 http-body = "0.3"
 indexmap = "1.0"
 linkerd2-addr = { path  = "../addr" }
+linkerd2-dns-name = { path  = "../dns/name" }
 linkerd2-error = { path  = "../error" }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.14" }
 linkerd2-stack = { path  = "../stack" }

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -8,14 +8,18 @@ use linkerd2_error::{Error, Recover};
 use linkerd2_proxy_api::destination as api;
 use pin_project::pin_project;
 use regex::Regex;
-use std::convert::TryInto;
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::Duration;
-use tokio::sync::watch;
-use tokio::time::{self, Delay};
+use std::{
+    convert::{TryFrom, TryInto},
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+use tokio::{
+    sync::watch,
+    time::{self, Delay},
+};
 use tonic::{
     self as grpc,
     body::{Body, BoxBody},
@@ -24,7 +28,6 @@ use tonic::{
 use tower::retry::budget::Budget;
 use tracing::{debug, error, info, info_span, trace, warn};
 use tracing_futures::Instrument;
-use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]
 pub struct Client<S, R> {

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -3,6 +3,7 @@ use api::destination_client::DestinationClient;
 use futures::{future, prelude::*, ready, select_biased};
 use http_body::Body as HttpBody;
 use linkerd2_addr::Addr;
+use linkerd2_dns_name::Name;
 use linkerd2_error::{Error, Recover};
 use linkerd2_proxy_api::destination as api;
 use pin_project::pin_project;
@@ -23,6 +24,7 @@ use tonic::{
 use tower::retry::budget::Budget;
 use tracing::{debug, error, info, info_span, trace, warn};
 use tracing_futures::Instrument;
+use std::convert::TryFrom;
 
 #[derive(Clone, Debug)]
 pub struct Client<S, R> {
@@ -111,7 +113,7 @@ where
 
 impl<T, S, R> tower::Service<T> for Client<S, R>
 where
-    T: AsRef<Addr>,
+    T: ToString,
     S: GrpcService<BoxBody> + Clone + Send + 'static,
     S::ResponseBody: Send,
     <S::ResponseBody as Body>::Data: Send,
@@ -130,18 +132,9 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, dst: T) -> Self::Future {
-        let path = dst.as_ref().to_string();
-
-        let service = {
-            // In case the ready service holds resources, pass it into the
-            // response and use a new clone for the client.
-            let s = self.service.clone();
-            std::mem::replace(&mut self.service, s)
-        };
-
+    fn call(&mut self, t: T) -> Self::Future {
         let request = api::GetDestination {
-            path,
+            path: t.to_string(),
             context_token: self.context_token.clone(),
             ..Default::default()
         };
@@ -149,8 +142,8 @@ where
         let timeout = time::delay_for(self.initial_timeout);
 
         let inner = Inner {
-            service,
             request,
+            service: self.service.clone(),
             recover: self.recover.clone(),
             state: State::Disconnected { backoff: None },
         };
@@ -255,6 +248,7 @@ where
         let profile = ready!(rx.poll_next(cx)).map(|res| {
             res.map(|proto| {
                 debug!("profile received: {:?}", proto);
+                let name = Name::try_from(proto.fully_qualified_name.as_bytes()).ok();
                 let retry_budget = proto.retry_budget.and_then(convert_retry_budget);
                 let http_routes = proto
                     .routes
@@ -267,6 +261,7 @@ where
                     .filter_map(convert_dst_override)
                     .collect();
                 Profile {
+                    name,
                     http_routes,
                     targets,
                 }

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 
 use linkerd2_addr::Addr;
+use linkerd2_dns_name::Name;
 use linkerd2_error::Error;
 use std::{
     future::Future,
@@ -19,6 +20,7 @@ pub type Receiver = tokio::sync::watch::Receiver<Profile>;
 
 #[derive(Clone, Debug, Default)]
 pub struct Profile {
+    pub name: Option<Name>,
     pub http_routes: Vec<(self::http::RequestMatch, self::http::Route)>,
     pub targets: Vec<Target>,
 }


### PR DESCRIPTION
Service profiles may include an optional service name, which is
especially useful if the profile is resolved by IP. This change attempts
to parse this value as a DNS name. If the default (empty) name is
returned, no name is exposed.