### PR TITLE
request-filter: Allow altering request type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1462,7 +1462,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.5",
  "linkerd2-error",
- "pin-project",
+ "linkerd2-stack",
  "tower",
  "tracing",
 ]

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -2,7 +2,7 @@
 
 pub use crate::proxy::http;
 use crate::transport::Connect;
-use crate::{cache, request_filter, Error};
+use crate::{cache, Error};
 pub use linkerd2_buffer as buffer;
 use linkerd2_concurrency_limit as concurrency_limit;
 pub use linkerd2_stack::{self as stack, layer, NewService};
@@ -265,10 +265,6 @@ impl<S> Stack<S> {
         P: Fn(&Error) -> bool + Clone,
     {
         self.push(stack::FallbackLayer::new(fallback).with_predicate(predicate))
-    }
-
-    pub fn push_request_filter<F: Clone>(self, filter: F) -> Stack<request_filter::Service<F, S>> {
-        self.push(request_filter::RequestFilterLayer::new(filter))
     }
 
     // pub fn box_http_request<B>(self) -> Stack<http::boxed::BoxRequest<S, B>>

--- a/linkerd/request-filter/Cargo.toml
+++ b/linkerd/request-filter/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 futures = "0.3"
+linkerd2-error = { path = "../error" }
+linkerd2-stack = { path = "../stack" }
 tower = { version = "0.3", default-features = false }
 tracing = "0.1.19"
-linkerd2-error = { path = "../error" }
-pin-project = "0.4"


### PR DESCRIPTION
The request filter takes ownership of the request but does not support
changing its type. Furthermore, the trait requires that the error type
be named even though it always coerced to an `Error`.

This change cleans up the request-filter module as follows:

- The `RequestFilter` trait is now named `FilterRequest` (traits
  generally are verbs). This type now has a `Request` type attribute
  instead of an `Error` type attribute.
- The `Service` has been renamed to `RequestFilter` and the
  `RequstFilterLayer` type has been eliminated.
- The manual future implementation can be eliminated with `Either`.
- The stack helper has been removed, as it's only used in one place.