### PR TITLE
tracing: Set contexts in new_service/make_service

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -365,9 +365,7 @@ impl Config {
                     .box_http_response(),
             )
             .push_map_target(|(_, accept): (http::Version, tls::accept::Meta)| accept)
-            .instrument(
-                |(version, _): &(http::Version, tls::accept::Meta)| info_span!("http", %version),
-            )
+            .instrument(|(v, _): &(http::Version, tls::accept::Meta)| info_span!("http", %v))
             .check_new_service::<(http::Version, tls::accept::Meta), http::Request<_>>()
             .into_inner();
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -382,6 +382,7 @@ impl Config {
                         .push(metrics.stack.layer(stack_labels("logical"))),
                 ),
             )
+            .instrument(|logical: &HttpLogical| info_span!("logical", dst = %logical.dst))
             .into_make_service()
             .spawn_buffer(buffer_capacity)
             .check_make_service::<HttpLogical, http::Request<_>>()
@@ -389,7 +390,6 @@ impl Config {
             // Strips headers that may be set by this proxy.
             .push_on_response(http::strip_header::request::layer(DST_OVERRIDE_HEADER))
             .check_make_service_clone::<HttpLogical, http::Request<B>>()
-            .instrument(|logical: &HttpLogical| info_span!("logical", dst = %logical.dst))
             .into_inner()
     }
 
@@ -487,7 +487,7 @@ impl Config {
                     .box_http_response(),
             )
             .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
-            .instrument(|a: &endpoint::HttpAccept| info_span!("http", v=%a.version))
+            .instrument(|a: &endpoint::HttpAccept| info_span!("http", v = %a.version))
             .push_map_target(endpoint::HttpAccept::from)
             .check_new_service::<(http::Version, endpoint::TcpLogical), http::Request<_>>()
             .into_inner();

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -487,7 +487,7 @@ impl Config {
                     .box_http_response(),
             )
             .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
-            .instrument(|a: &endpoint::HttpAccept| info_span!("http", version=%a.version))
+            .instrument(|a: &endpoint::HttpAccept| info_span!("http", v=%a.version))
             .push_map_target(endpoint::HttpAccept::from)
             .check_new_service::<(http::Version, endpoint::TcpLogical), http::Request<_>>()
             .into_inner();

--- a/linkerd/proxy/http/src/version.rs
+++ b/linkerd/proxy/http/src/version.rs
@@ -66,7 +66,7 @@ impl Version {
 impl std::fmt::Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Http1 => write!(f, "http/1.x"),
+            Self::Http1 => write!(f, "1.x"),
             Self::H2 => write!(f, "h2"),
         }
     }

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -88,11 +88,10 @@ where
     type Future = Instrument<M::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        trace!("make ready");
         let ready = self.make.poll_ready(cx);
         match ready {
-            Poll::Pending => trace!(ready = false),
-            Poll::Ready(ref res) => trace!(ready = true, ok = res.is_ok()),
+            Poll::Pending => trace!(ready = false, "make"),
+            Poll::Ready(ref res) => trace!(ready = true, ok = res.is_ok(), "make"),
         }
         ready
     }
@@ -167,11 +166,10 @@ where
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let _enter = self.span.enter();
 
-        trace!("ready");
         let ready = self.inner.poll_ready(cx);
         match ready {
-            Poll::Pending => trace!(ready = false),
-            Poll::Ready(ref res) => trace!(ready = true, ok = res.is_ok()),
+            Poll::Pending => trace!(ready = false, "service"),
+            Poll::Ready(ref res) => trace!(ready = true, ok = res.is_ok(), "service"),
         }
         ready
     }
@@ -179,7 +177,7 @@ where
     fn call(&mut self, request: Req) -> Self::Future {
         let _enter = self.span.enter();
 
-        trace!(?request, "call");
+        trace!(?request, "service");
         self.inner.call(request).instrument(self.span.clone())
     }
 }

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -63,23 +63,23 @@ impl<G: Clone, M> tower::layer::Layer<M> for InstrumentMakeLayer<G> {
 
 impl<T, G, N> NewService<T> for InstrumentMake<G, N>
 where
-    T: std::fmt::Debug,
     G: GetSpan<T>,
     N: NewService<T>,
 {
     type Service = Instrument<N::Service>;
 
     fn new_service(&mut self, target: T) -> Self::Service {
-        trace!(?target, "new_service");
         let span = self.get_span.get_span(&target);
-        let inner = span.in_scope(move || self.make.new_service(target));
+        let inner = span.in_scope(move || {
+            trace!("new");
+            self.make.new_service(target)
+        });
         Instrument { inner, span }
     }
 }
 
 impl<T, G, M> tower::Service<T> for InstrumentMake<G, M>
 where
-    T: std::fmt::Debug,
     G: GetSpan<T>,
     M: tower::Service<T>,
 {
@@ -88,16 +88,21 @@ where
     type Future = Instrument<M::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        trace!("poll_ready");
+        trace!("make ready");
         let ready = self.make.poll_ready(cx);
-        trace!(ready = ready.is_ready());
+        match ready {
+            Poll::Pending => trace!(ready = false),
+            Poll::Ready(ref res) => trace!(ready = true, ok = res.is_ok()),
+        }
         ready
     }
 
     fn call(&mut self, target: T) -> Self::Future {
-        trace!(?target, "make_service");
         let span = self.get_span.get_span(&target);
-        let inner = span.in_scope(|| self.make.call(target));
+        let inner = span.in_scope(|| {
+            trace!("make");
+            self.make.call(target)
+        });
         Instrument { inner, span }
     }
 }
@@ -162,9 +167,12 @@ where
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         let _enter = self.span.enter();
 
-        trace!("poll ready");
+        trace!("ready");
         let ready = self.inner.poll_ready(cx);
-        trace!(ready = ready.is_ready());
+        match ready {
+            Poll::Pending => trace!(ready = false),
+            Poll::Ready(ref res) => trace!(ready = true, ok = res.is_ok()),
+        }
         ready
     }
 


### PR DESCRIPTION
* Modify stack-tracing to set contexts on the initial new_service/make_service invocation (and not just the resulting future/service)
* Tighten up the HTTP context. `http{version=http/1.x}` was verbose and redundant