### PR TITLE
metrics: add peer identities to all TLS metric labels

### DIFF
--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -87,7 +87,7 @@ impl FmtLabels for TlsStatus {
                 write!(f, "tls=\"no_identity\",no_tls_reason=\"{}\"", why)
             }
             Conditional::Some(ref id) => {
-                write!(f, "tls=\"true\"")?;
+                write!(f, "tls=\"true\",")?;
                 id.fmt_labels(f)
             }
         }

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -49,7 +49,7 @@ impl TlsStatus {
     }
 
     pub fn server(id: tls::PeerIdentity) -> Self {
-        Self(id.map(TlsId::ClientId))
+        Self(id.map(TlsId::ServerId))
     }
 }
 

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -1,5 +1,5 @@
 use super::tls;
-pub use crate::metric_labels::{Direction, EndpointLabels};
+pub use crate::metric_labels::{Direction, EndpointLabels, TlsId};
 use linkerd2_conditional::Conditional;
 use linkerd2_metrics::FmtLabels;
 use std::fmt;
@@ -15,10 +15,16 @@ pub enum Key {
     Connect(EndpointLabels),
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct TlsStatus(tls::Conditional<()>);
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct TlsStatus(tls::Conditional<TlsId>);
 
 // === impl Key ===
+
+impl Key {
+    pub fn accept(direction: Direction, id: tls::PeerIdentity) -> Self {
+        Self::Accept(direction, TlsStatus::client(id))
+    }
+}
 
 impl FmtLabels for Key {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -37,36 +43,53 @@ impl FmtLabels for Key {
 
 // === impl TlsStatus ===
 
-impl<T> From<tls::Conditional<T>> for TlsStatus {
-    fn from(inner: tls::Conditional<T>) -> Self {
-        TlsStatus(inner.map(|_| ()))
+impl TlsStatus {
+    pub fn client(id: tls::PeerIdentity) -> Self {
+        Self(id.map(TlsId::ClientId))
+    }
+
+    pub fn server(id: tls::PeerIdentity) -> Self {
+        Self(id.map(TlsId::ClientId))
     }
 }
 
-impl Into<tls::Conditional<()>> for TlsStatus {
-    fn into(self) -> tls::Conditional<()> {
-        self.0
+impl From<tls::Conditional<TlsId>> for TlsStatus {
+    fn from(inner: tls::Conditional<TlsId>) -> Self {
+        TlsStatus(inner)
+    }
+}
+
+impl Into<tls::PeerIdentity> for TlsStatus {
+    fn into(self) -> tls::PeerIdentity {
+        self.0.map(|id| match id {
+            TlsId::ClientId(id) => id,
+            TlsId::ServerId(id) => id,
+        })
     }
 }
 
 impl fmt::Display for TlsStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
-            Conditional::Some(()) => write!(f, "true"),
-            Conditional::None(r) => fmt::Display::fmt(&r, f),
+            Conditional::Some(_) => write!(f, "true"),
+            Conditional::None(ref r) => fmt::Display::fmt(&r, f),
         }
     }
 }
 
 impl FmtLabels for TlsStatus {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Self(Conditional::None(tls::ReasonForNoPeerName::LocalIdentityDisabled)) = self {
-            return write!(f, "tls=\"disabled\"");
+        match self.0 {
+            Conditional::None(tls::ReasonForNoPeerName::LocalIdentityDisabled) => {
+                write!(f, "tls=\"disabled\"")
+            }
+            Conditional::None(ref why) => {
+                write!(f, "tls=\"no_identity\",no_tls_reason=\"{}\"", why)
+            }
+            Conditional::Some(ref id) => {
+                write!(f, "tls=\"true\"")?;
+                id.fmt_labels(f)
+            }
         }
-        if let Self(Conditional::None(why)) = self {
-            return write!(f, "tls=\"no_identity\",no_tls_reason=\"{}\"", why);
-        }
-
-        write!(f, "tls=\"{}\"", self)
     }
 }

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -137,7 +137,10 @@ impl Into<metric_labels::EndpointLabels> for Target {
         metric_labels::EndpointLabels {
             authority: self.dst.name_addr().map(|d| d.as_http_authority()),
             direction: metric_labels::Direction::In,
-            tls_id: self.tls_client_id.map(metric_labels::TlsId::ClientId),
+            tls_id: self
+                .tls_client_id
+                .map(metric_labels::TlsId::ClientId)
+                .into(),
             labels: None,
         }
     }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -471,9 +471,9 @@ impl transport::metrics::TransportLabels<listen::Addrs> for TransportLabels {
     type Labels = transport::labels::Key;
 
     fn transport_labels(&self, _: &listen::Addrs) -> Self::Labels {
-        transport::labels::Key::Accept(
+        transport::labels::Key::accept(
             transport::labels::Direction::In,
-            tls::Conditional::<()>::None(tls::ReasonForNoPeerName::PortSkipped).into(),
+            tls::Conditional::None(tls::ReasonForNoPeerName::PortSkipped),
         )
     }
 }
@@ -482,9 +482,9 @@ impl transport::metrics::TransportLabels<tls::accept::Meta> for TransportLabels 
     type Labels = transport::labels::Key;
 
     fn transport_labels(&self, target: &tls::accept::Meta) -> Self::Labels {
-        transport::labels::Key::Accept(
+        transport::labels::Key::accept(
             transport::labels::Direction::In,
-            target.peer_identity.as_ref().into(),
+            target.peer_identity.clone(),
         )
     }
 }

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use linkerd2_app_core::{
     dst,
     metric_labels,
-    metric_labels::{prefix_labels, EndpointLabels},
+    metric_labels::{prefix_labels, EndpointLabels, TlsStatus},
     profiles,
     proxy::{
         api_resolve::{Metadata, ProtocolHint},
@@ -314,11 +314,11 @@ impl CanOverrideAuthority for HttpEndpoint {
 
 impl Into<EndpointLabels> for HttpEndpoint {
     fn into(self) -> EndpointLabels {
-        use linkerd2_app_core::metric_labels::{Direction, TlsId};
+        use linkerd2_app_core::metric_labels::Direction;
         EndpointLabels {
             authority: Some(self.concrete.logical.dst.to_http_authority()),
             direction: Direction::Out,
-            tls_id: self.identity.as_ref().map(|id| TlsId::ServerId(id.clone())),
+            tls_id: TlsStatus::server(self.identity.clone()),
             labels: prefix_labels("dst", self.metadata.labels().into_iter()),
         }
     }
@@ -357,12 +357,12 @@ impl tls::HasPeerIdentity for TcpEndpoint {
 
 impl Into<EndpointLabels> for TcpEndpoint {
     fn into(self) -> EndpointLabels {
-        use linkerd2_app_core::metric_labels::{Direction, TlsId};
+        use linkerd2_app_core::metric_labels::Direction;
         EndpointLabels {
             authority: Some(self.dst.to_http_authority()),
             direction: Direction::Out,
             labels: self.labels,
-            tls_id: self.identity.as_ref().map(|id| TlsId::ServerId(id.clone())),
+            tls_id: TlsStatus::server(self.identity),
         }
     }
 }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -577,8 +577,9 @@ impl transport::metrics::TransportLabels<listen::Addrs> for TransportLabels {
     type Labels = transport::labels::Key;
 
     fn transport_labels(&self, _: &listen::Addrs) -> Self::Labels {
-        const NO_TLS: tls::Conditional<()> = Conditional::None(tls::ReasonForNoPeerName::Loopback);
-        transport::labels::Key::Accept(transport::labels::Direction::Out, NO_TLS.into())
+        const NO_TLS: tls::Conditional<identity::Name> =
+            Conditional::None(tls::ReasonForNoPeerName::Loopback);
+        transport::labels::Key::accept(transport::labels::Direction::Out, NO_TLS.into())
     }
 }
 


### PR DESCRIPTION
In order to have `linkerd edges` return non-empty values for a raw TCP
connection's `CLIENT_ID`, the proxy's `tcp_open_total` metric needs to
include the `client_id` label for inbound connections, like the
`request_total` metrics for http connections does.

This PR changes the `TlsStatus` metric label type to include a peer
identity in the `Conditional::Some` case, rather than `()`. This means
that all metrics with TLS labels will now include the peer identity as
a label.

I've manually verified that this works by running Linkerd locally and
scraping the metrics:

For example, here's an excerpt from Grafana:
```
tcp_open_total{peer="src",direction="inbound",tls="no_identity",no_tls_reason="no_tls_from_remote"} 44
tcp_open_total{peer="dst",direction="inbound",tls="no_identity",no_tls_reason="loopback"} 2
tcp_open_total{peer="src",direction="inbound",tls="true",client_id="linkerd-prometheus.linkerd.serviceaccount.identity.linkerd.cluster.local"}
1
```
And from Prometheus
```
tcp_open_total{peer="dst",authority="10.42.0.25:4191",direction="outbound",dst_control_plane_ns="linkerd",dst_deployment="linkerd-grafana",dst_namespace="linkerd",dst_pod="linkerd-grafana-65597cf467-vq456",dst_pod_template_hash="65597cf467",dst_serviceaccount="linkerd-grafana",tls="true",server_id="linkerd-grafana.linkerd.serviceaccount.identity.linkerd.cluster.local"} 1
tcp_open_total{peer="dst",authority="10.42.0.25:3000",direction="outbound",dst_control_plane_ns="linkerd",dst_deployment="linkerd-grafana",dst_namespace="linkerd",dst_pod="linkerd-grafana-65597cf467-vq456",dst_pod_template_hash="65597cf467",dst_serviceaccount="linkerd-grafana",tls="true",server_id="linkerd-grafana.linkerd.serviceaccount.identity.linkerd.cluster.local"} 1
```

I'd like to have automated tests for this, but I'd prefer to not have to
write them in the integration style, and use the isolated mock service
style instead. So, tests can be added once #658 lands.

Refs: linkerd/linkerd2#4999
Fixes: linkerd/linkerd2#5031