### PR TITLE
discover: Allow resolution streams to terminate

### DIFF
--- a/linkerd/proxy/discover/src/buffer.rs
+++ b/linkerd/proxy/discover/src/buffer.rs
@@ -48,9 +48,6 @@ pub struct Daemon<D: discover::Discover> {
     watchdog_timeout: Duration,
 }
 
-#[derive(Clone, Debug)]
-pub struct Lost(());
-
 impl<M> Buffer<M> {
     pub fn new(capacity: usize, watchdog_timeout: Duration, inner: M) -> Self {
         Self {
@@ -208,15 +205,7 @@ impl<K: std::hash::Hash + Eq, S> Stream for Discover<K, S> {
         return match self.project().rx.poll_next(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Some(change)) => Poll::Ready(Some(Ok(change))),
-            Poll::Ready(None) => Poll::Ready(Some(Err(Lost(()).into()))),
+            Poll::Ready(None) => Poll::Ready(None),
         };
     }
 }
-
-impl std::fmt::Display for Lost {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "discovery task failed")
-    }
-}
-
-impl std::error::Error for Lost {}

--- a/linkerd/proxy/discover/src/make_endpoint.rs
+++ b/linkerd/proxy/discover/src/make_endpoint.rs
@@ -133,7 +133,7 @@ where
                     })))
                 }
 
-                None => continue,
+                None => return Poll::Ready(None),
             }
         }
     }


### PR DESCRIPTION
In 571f4cba we accidentally introduced a busy-loop on resolution stream
termination; and, furthermore, the buffer layer returns an error when
the inner stream terminates.

This change alters both of these to gracefully propagate stream
termination.