### PR TITLE
fix AcceptHttp being rebuilt for every connection

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -319,6 +319,7 @@ impl Config {
             dispatch_timeout,
             max_in_flight_requests,
             detect_protocol_timeout,
+            buffer_capacity,
             ..
         } = self.proxy.clone();
 
@@ -373,9 +374,11 @@ impl Config {
                 .into_inner(),
             drain.clone(),
         ))
-        .push_on_response(transport::Prefix::layer(
-            http::Version::DETECT_BUFFER_CAPACITY,
-            detect_protocol_timeout,
+        .push_on_response(svc::layers().push_spawn_buffer(buffer_capacity).push(
+            transport::Prefix::layer(
+                http::Version::DETECT_BUFFER_CAPACITY,
+                detect_protocol_timeout,
+            ),
         ))
         .into_inner()
     }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -403,10 +403,11 @@ impl Config {
             endpoint::TcpLogical,
             transport::io::PrefixedIo<transport::metrics::SensorIo<I>>,
         >()
-        .push_on_response(transport::Prefix::layer(
+        .push_on_response(
+            svc::layers().push_spawn_buffer(buffer_capacity).push(transport::Prefix::layer(
             http::Version::DETECT_BUFFER_CAPACITY,
             detect_protocol_timeout,
-        ))
+        )))
         .check_new_service::<endpoint::TcpLogical, transport::metrics::SensorIo<I>>()
         .into_inner();
 


### PR DESCRIPTION
The `AcceptHttp` service is stateful. It builds the underlying HTTP,
HTTP/2, and TCP service stacks lazily the first time they're needed.
This interacts badly with the derived implementation of `Clone`: if it's
cloned before the state is set, the state will only be set for the
clone, rather than for the original instance in the cache. Since
`Prefix` clones and oneshots the underlying service (`AcceptHttp`), this
means that we rebuild the HTTP, HTTP/2, and TCP stacks on every
connection to the same orig dest. This basically breaks caching for
everything other than service profile discovery, causing us to do new
destination discovery for every connection to the same original
destination. Which...isn't great.

This branch fixes this issue by removing the `Clone` impl from
`AcceptHttp` and putting it behind a buffer instead. In the future, it
may be possible to fix this in a nicer way, but this resolves the issue
for now.