### PR TITLE
metrics: Coerce targets to metric labels by-reference

### DIFF
--- a/linkerd/app/core/src/metric_labels.rs
+++ b/linkerd/app/core/src/metric_labels.rs
@@ -50,8 +50,8 @@ struct Authority<'a>(&'a http::uri::Authority);
 
 // === impl CtlLabels ===
 
-impl<'c> From<&'c control::ControlAddr> for ControlLabels {
-    fn from(c: &'c control::ControlAddr) -> Self {
+impl From<&'_ control::ControlAddr> for ControlLabels {
+    fn from(c: &'_ control::ControlAddr) -> Self {
         ControlLabels {
             addr: c.addr.clone(),
             tls_status: c.identity.clone().map(|id| TlsId::ServerId(id)).into(),
@@ -70,8 +70,8 @@ impl FmtLabels for ControlLabels {
 
 // === impl RouteLabels ===
 
-impl<'t> From<&'t dst::Route> for RouteLabels {
-    fn from(r: &'t dst::Route) -> Self {
+impl From<&'_ dst::Route> for RouteLabels {
+    fn from(r: &'_ dst::Route) -> Self {
         Self {
             target: r.target.clone(),
             direction: r.direction,

--- a/linkerd/app/core/src/metric_labels.rs
+++ b/linkerd/app/core/src/metric_labels.rs
@@ -50,11 +50,11 @@ struct Authority<'a>(&'a http::uri::Authority);
 
 // === impl CtlLabels ===
 
-impl From<control::ControlAddr> for ControlLabels {
-    fn from(c: control::ControlAddr) -> Self {
+impl<'c> From<&'c control::ControlAddr> for ControlLabels {
+    fn from(c: &'c control::ControlAddr) -> Self {
         ControlLabels {
             addr: c.addr.clone(),
-            tls_status: c.identity.map(|id| TlsId::ServerId(id)).into(),
+            tls_status: c.identity.clone().map(|id| TlsId::ServerId(id)).into(),
         }
     }
 }
@@ -70,12 +70,12 @@ impl FmtLabels for ControlLabels {
 
 // === impl RouteLabels ===
 
-impl From<dst::Route> for RouteLabels {
-    fn from(r: dst::Route) -> Self {
+impl<'t> From<&'t dst::Route> for RouteLabels {
+    fn from(r: &'t dst::Route) -> Self {
         Self {
-            target: r.target,
+            target: r.target.clone(),
             direction: r.direction,
-            labels: prefix_labels("rt", r.route.labels().as_ref().into_iter()),
+            labels: prefix_labels("rt", r.route.labels().iter()),
         }
     }
 }

--- a/linkerd/app/core/src/retry.rs
+++ b/linkerd/app/core/src/retry.rs
@@ -56,7 +56,7 @@ impl<C> linkerd2_retry::NewPolicy<Route> for NewRetry<C> {
     fn new_policy(&self, route: &Route) -> Option<Self::Policy> {
         let retries = route.route.retries().cloned()?;
 
-        let metrics = self.metrics.get_handle(route.clone());
+        let metrics = self.metrics.get_handle(route);
         Some(Retry {
             metrics,
             budget: retries.budget().clone(),

--- a/linkerd/http-metrics/src/requests/layer.rs
+++ b/linkerd/http-metrics/src/requests/layer.rs
@@ -162,7 +162,7 @@ where
 
 impl<T, M, K, C> NewService<T> for MakeSvc<M, K, C>
 where
-    T: Clone + Debug + Into<K>,
+    for<'t> &'t T: Into<K>,
     K: Hash + Eq,
     M: NewService<T>,
     C: ClassifyResponse + Default + Send + Sync + 'static,
@@ -174,7 +174,7 @@ where
         let metrics = match self.registry.lock() {
             Ok(mut r) => Some(
                 r.by_target
-                    .entry(target.clone().into())
+                    .entry((&target).into())
                     .or_insert_with(|| Arc::new(Mutex::new(Metrics::default())))
                     .clone(),
             ),
@@ -193,7 +193,7 @@ where
 
 impl<T, M, K, C> tower::Service<T> for MakeSvc<M, K, C>
 where
-    T: Clone + Debug + Into<K>,
+    for<'t> &'t T: Into<K>,
     K: Hash + Eq,
     M: tower::Service<T>,
     C: ClassifyResponse + Default + Send + Sync + 'static,
@@ -211,7 +211,7 @@ where
         let metrics = match self.registry.lock() {
             Ok(mut r) => Some(
                 r.by_target
-                    .entry(target.clone().into())
+                    .entry((&target).into())
                     .or_insert_with(|| Arc::new(Mutex::new(Metrics::default())))
                     .clone(),
             ),


### PR DESCRIPTION
The `TransportLabels` trait & types serve no real purpose and can be
better-expressed via `Into`.

This change replaces the `TransportLabels` trait with an `Into`
constraint.  Furthermore, HTTP metrics have been updated to coerce the
target by-reference, without cloning the whole target.