### PR TITLE
outbound: Unify TCP & HTTP target types

### DIFF
--- a/linkerd/app/gateway/src/make.rs
+++ b/linkerd/app/gateway/src/make.rs
@@ -53,8 +53,8 @@ where
         // Create an outbound target using the resolved IP & name.
         let svc = self.outbound.new_service(outbound::HttpLogical {
             profile,
-            version: http_version,
             orig_dst: self.default_addr,
+            protocol: http_version,
         });
 
         Gateway::new(svc, dst, source_id, local_id)

--- a/linkerd/app/outbound/src/allow_discovery.rs
+++ b/linkerd/app/outbound/src/allow_discovery.rs
@@ -1,4 +1,4 @@
-use crate::endpoint::{HttpConcrete, TcpAccept, TcpConcrete};
+use crate::endpoint::{Accept, Concrete};
 use linkerd2_app_core::{discovery_rejected, svc::stack::FilterRequest, Addr, Error, IpMatch};
 use std::net::SocketAddr;
 
@@ -6,35 +6,24 @@ use std::net::SocketAddr;
 pub struct AllowProfile(pub IpMatch);
 
 #[derive(Clone, Debug)]
-pub struct AllowTcpResolve;
+pub struct AllowResolve;
 
-#[derive(Copy, Clone, Debug)]
-pub struct AllowHttpResolve;
-
-impl FilterRequest<TcpAccept> for AllowProfile {
+impl FilterRequest<Accept> for AllowProfile {
     type Request = SocketAddr;
 
-    fn filter(&self, target: TcpAccept) -> Result<SocketAddr, Error> {
-        if self.0.matches(target.addr.ip()) {
-            Ok(target.addr)
+    fn filter(&self, Accept { orig_dst }: Accept) -> Result<SocketAddr, Error> {
+        if self.0.matches(orig_dst.ip()) {
+            Ok(orig_dst)
         } else {
             Err(discovery_rejected().into())
         }
     }
 }
 
-impl FilterRequest<HttpConcrete> for AllowHttpResolve {
+impl<P> FilterRequest<Concrete<P>> for AllowResolve {
     type Request = Addr;
 
-    fn filter(&self, target: HttpConcrete) -> Result<Addr, Error> {
-        target.resolve.ok_or_else(|| discovery_rejected().into())
-    }
-}
-
-impl FilterRequest<TcpConcrete> for AllowTcpResolve {
-    type Request = Addr;
-
-    fn filter(&self, target: TcpConcrete) -> Result<Addr, Error> {
+    fn filter(&self, target: Concrete<P>) -> Result<Addr, Error> {
         target.resolve.ok_or_else(|| discovery_rejected().into())
     }
 }

--- a/linkerd/app/outbound/src/tests.rs
+++ b/linkerd/app/outbound/src/tests.rs
@@ -64,8 +64,9 @@ async fn plaintext_tcp() {
     let target_addr = SocketAddr::new([0, 0, 0, 0].into(), 666);
     let concrete = TcpConcrete {
         logical: TcpLogical {
-            addr: target_addr,
+            orig_dst: target_addr,
             profile: Some(profile()),
+            protocol: (),
         },
         resolve: Some(target_addr.into()),
     };
@@ -110,8 +111,9 @@ async fn tls_when_hinted() {
     let tls_addr = SocketAddr::new([0, 0, 0, 0].into(), 5550);
     let tls_concrete = TcpConcrete {
         logical: TcpLogical {
-            addr: tls_addr,
+            orig_dst: tls_addr,
             profile: Some(profile()),
+            protocol: (),
         },
         resolve: Some(tls_addr.into()),
     };
@@ -119,8 +121,9 @@ async fn tls_when_hinted() {
     let plain_addr = SocketAddr::new([0, 0, 0, 0].into(), 5551);
     let plain_concrete = TcpConcrete {
         logical: TcpLogical {
-            addr: plain_addr,
+            orig_dst: plain_addr,
             profile: Some(profile()),
+            protocol: (),
         },
         resolve: Some(plain_addr.into()),
     };


### PR DESCRIPTION
We have target types like `{Http,Tcp}{Logical,Concrete,Endpoint}` that
differ only superficially between the HTTP and TCP variants. This
results in unnecessary, duplicate trait impls.

This change consolidates these targets as `Logical`, `Concrete`, and
`Endpoint`, all of which are generic over the protocol type. We provide
`Tcp*` and `Http*` trait aliases as a shorthand and compatibility.