### PR TITLE
outbound: Use profile to inform protocol detection

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -23,7 +23,6 @@ pub struct ProxyConfig {
     pub connect: ConnectConfig,
     pub buffer_capacity: usize,
     pub cache_max_idle_age: Duration,
-    pub disable_protocol_detection_for_ports: crate::SkipByPort,
     pub dispatch_timeout: Duration,
     pub max_in_flight_requests: usize,
     pub detect_protocol_timeout: Duration,

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -113,21 +113,3 @@ pub struct ProxyMetrics {
     pub stack: StackMetrics,
     pub transport: transport::Metrics,
 }
-
-#[derive(Clone, Debug, Default)]
-pub struct SkipByPort(std::sync::Arc<indexmap::IndexSet<u16>>);
-
-impl From<indexmap::IndexSet<u16>> for SkipByPort {
-    fn from(ports: indexmap::IndexSet<u16>) -> Self {
-        SkipByPort(ports.into())
-    }
-}
-
-impl<T> linkerd2_stack::Switch<T> for SkipByPort
-where
-    for<'t> &'t T: Into<std::net::SocketAddr>,
-{
-    fn use_primary(&self, addrs: &T) -> bool {
-        !self.0.contains(&addrs.into().port())
-    }
-}

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -24,7 +24,6 @@ pub struct Proxy {
     outbound_server: Option<server::Listening>,
 
     inbound_disable_ports_protocol_detection: Option<Vec<u16>>,
-    outbound_disable_ports_protocol_detection: Option<Vec<u16>>,
 
     shutdown_signal: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
 }
@@ -60,7 +59,6 @@ impl Proxy {
             outbound_server: None,
 
             inbound_disable_ports_protocol_detection: None,
-            outbound_disable_ports_protocol_detection: None,
             shutdown_signal: None,
         }
     }
@@ -122,11 +120,6 @@ impl Proxy {
 
     pub fn disable_inbound_ports_protocol_detection(mut self, ports: Vec<u16>) -> Self {
         self.inbound_disable_ports_protocol_detection = Some(ports);
-        self
-    }
-
-    pub fn disable_outbound_ports_protocol_detection(mut self, ports: Vec<u16>) -> Self {
-        self.outbound_disable_ports_protocol_detection = Some(ports);
         self
     }
 
@@ -287,17 +280,6 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
         );
     }
 
-    if let Some(ports) = proxy.outbound_disable_ports_protocol_detection {
-        let ports = ports
-            .into_iter()
-            .map(|p| p.to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-        env.put(
-            app::env::ENV_OUTBOUND_PORTS_DISABLE_PROTOCOL_DETECTION,
-            ports,
-        );
-    }
     if !env.contains_key(app::env::ENV_DESTINATION_PROFILE_NETWORKS) {
         // If the test has not already overridden the destination search
         // networks, make sure that localhost works.

--- a/linkerd/app/outbound/src/tests.rs
+++ b/linkerd/app/outbound/src/tests.rs
@@ -45,7 +45,6 @@ fn default_config(orig_dst: SocketAddr) -> Config {
             },
             buffer_capacity: 10_000,
             cache_max_idle_age: Duration::from_secs(60),
-            disable_protocol_detection_for_ports: Default::default(),
             dispatch_timeout: Duration::from_secs(3),
             max_in_flight_requests: 10_000,
             detect_protocol_timeout: Duration::from_secs(3),

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -118,8 +118,6 @@ pub const ENV_INBOUND_GATEWAY_SUFFIXES: &str = "LINKERD2_PROXY_INBOUND_GATEWAY_S
 // has a port in the provided list.
 pub const ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION: &str =
     "LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION";
-pub const ENV_OUTBOUND_PORTS_DISABLE_PROTOCOL_DETECTION: &str =
-    "LINKERD2_PROXY_OUTBOUND_PORTS_DISABLE_PROTOCOL_DETECTION";
 
 pub const ENV_INBOUND_PORTS_REQUIRE_IDENTITY: &str =
     "LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_IDENTITY";
@@ -246,11 +244,6 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let inbound_disable_ports = parse(
         strings,
         ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION,
-        parse_port_set,
-    );
-    let outbound_disable_ports = parse(
-        strings,
-        ENV_OUTBOUND_PORTS_DISABLE_PROTOCOL_DETECTION,
         parse_port_set,
     );
 
@@ -381,9 +374,6 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             proxy: ProxyConfig {
                 server,
                 connect,
-                disable_protocol_detection_for_ports: outbound_disable_ports?
-                    .unwrap_or_else(|| default_disable_ports_protocol_detection())
-                    .into(),
                 cache_max_idle_age: outbound_cache_max_idle_age?
                     .unwrap_or(DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE),
                 buffer_capacity,
@@ -440,9 +430,6 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             proxy: ProxyConfig {
                 server,
                 connect,
-                disable_protocol_detection_for_ports: inbound_disable_ports?
-                    .unwrap_or_else(|| default_disable_ports_protocol_detection())
-                    .into(),
                 cache_max_idle_age: inbound_cache_max_idle_age?
                     .unwrap_or(DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE),
                 buffer_capacity,
@@ -454,6 +441,9 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             require_identity_for_inbound_ports: require_identity_for_inbound_ports.into(),
             profile_idle_timeout: dst_profile_idle_timeout?
                 .unwrap_or(DEFAULT_DESTINATION_PROFILE_IDLE_TIMEOUT),
+            disable_protocol_detection_for_ports: inbound_disable_ports?
+                .unwrap_or_else(|| default_disable_ports_protocol_detection())
+                .into(),
         }
     };
 

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -245,6 +245,7 @@ where
                     name,
                     http_routes,
                     targets,
+                    opaque_protocol: proto.opaque_protocol,
                 }
             })
         });

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -24,6 +24,7 @@ pub struct Profile {
     pub name: Option<Name>,
     pub http_routes: Vec<(self::http::RequestMatch, self::http::Route)>,
     pub targets: Vec<Target>,
+    pub opaque_protocol: bool,
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
The outbound proxy skips protocol detection when the target port is in a
configured list. But there's nothing that actually sets this
configuration currently. Now that we lookup profiles before protocol
detection, we can use the profile response to provide a more granular
per-endpoint hint.

This change stops honoring the
`LINKERD2_PROXY_OUTBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` environment
variable. Service profiles are now used exclusively to determine whether
protocol detection should be skipped for outbound connections.