### PR TITLE
trace-context: Simplify implementation with async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,7 @@ dependencies = [
  "hex",
  "http 0.2.1",
  "linkerd2-error",
+ "linkerd2-stack",
  "pin-project",
  "rand 0.7.2",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,7 +1540,6 @@ dependencies = [
  "http 0.2.1",
  "linkerd2-error",
  "linkerd2-stack",
- "pin-project",
  "rand 0.7.2",
  "tokio",
  "tower",

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -23,7 +23,7 @@ pub use linkerd2_router as router;
 pub use linkerd2_service_profiles as profiles;
 pub use linkerd2_stack_metrics as stack_metrics;
 pub use linkerd2_stack_tracing as stack_tracing;
-pub use linkerd2_trace_context::TraceContextLayer;
+pub use linkerd2_trace_context::TraceContext;
 
 mod addr_match;
 pub mod admin;

--- a/linkerd/app/core/src/spans.rs
+++ b/linkerd/app/core/src/spans.rs
@@ -70,7 +70,7 @@ impl SpanConverter {
         }
         for (k, v) in span.labels.drain() {
             attributes.insert(
-                k,
+                k.to_string(),
                 oc::AttributeValue {
                     value: Some(oc::attribute_value::Value::StringValue(truncatable(v))),
                 },

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -26,7 +26,7 @@ use linkerd2_app_core::{
     spans::SpanConverter,
     svc::{self},
     transport::{self, io, listen, tls},
-    Error, NameAddr, NameMatch, ProxyMetrics, TraceContextLayer, DST_OVERRIDE_HEADER,
+    Error, NameAddr, NameMatch, ProxyMetrics, TraceContext, DST_OVERRIDE_HEADER,
 };
 use std::{collections::HashMap, time::Duration};
 use tokio::{net::TcpStream, sync::mpsc};
@@ -210,7 +210,7 @@ impl Config {
             .push(tap_layer)
             // Records metrics for each `Target`.
             .push(metrics.http_endpoint.into_layer::<classify::Response>())
-            .push_on_response(TraceContextLayer::new(
+            .push_on_response(TraceContext::layer(
                 span_sink
                     .clone()
                     .map(|span_sink| SpanConverter::client(span_sink, trace_labels())),
@@ -338,7 +338,7 @@ impl Config {
             // Synthesizes responses for proxy errors.
             .push(errors::layer());
 
-        let http_server_observability = svc::layers().push(TraceContextLayer::new(
+        let http_server_observability = svc::layers().push(TraceContext::layer(
             span_sink.map(|span_sink| SpanConverter::server(span_sink, trace_labels())),
         ));
 

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -32,3 +32,4 @@ pub use self::request_filter::{FilterRequest, RequestFilter};
 pub use self::result::ResultService;
 pub use self::switch::{MakeSwitch, Switch};
 pub use self::switch_ready::{NewSwitchReady, SwitchReady};
+pub use tower::util::Either;

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -14,7 +14,6 @@ http = "0.2"
 linkerd2-error = { path = "../error" }
 linkerd2-stack = { path = "../stack" }
 rand = { version = "0.7", features = ["small_rng"] }
-tower = { version = "0.3", default-features = false }
+tower = { version = "0.3", default-features = false, features = ["util"] }
 tracing = "0.1.2"
 tokio = {version = "0.2", features = ["sync"]}
-pin-project = "0.4"

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -12,6 +12,7 @@ futures = "0.3"
 hex = "0.3.2"
 http = "0.2"
 linkerd2-error = { path = "../error" }
+linkerd2-stack = { path = "../stack" }
 rand = { version = "0.7", features = ["small_rng"] }
 tower = { version = "0.3", default-features = false }
 tracing = "0.1.2"

--- a/linkerd/trace-context/src/layer.rs
+++ b/linkerd/trace-context/src/layer.rs
@@ -35,34 +35,31 @@ impl<K: Clone, S> TraceContext<K, S> {
         })
     }
 
-    fn request_labels<B>(req: &http::Request<B>) -> HashMap<String, String> {
-        let mut labels = HashMap::new();
-        labels.insert("http.method".to_string(), format!("{}", req.method()));
+    fn request_labels<B>(req: &http::Request<B>) -> HashMap<&'static str, String> {
+        let mut labels = HashMap::with_capacity(5);
+        labels.insert("http.method", format!("{}", req.method()));
         let path = req
             .uri()
             .path_and_query()
             .map(|pq| pq.as_str().to_owned())
             .unwrap_or_default();
-        labels.insert("http.path".to_string(), path);
+        labels.insert("http.path", path);
         if let Some(authority) = req.uri().authority() {
-            labels.insert("http.authority".to_string(), authority.as_str().to_string());
+            labels.insert("http.authority", authority.as_str().to_string());
         }
         if let Some(host) = req.headers().get("host") {
             if let Ok(host) = host.to_str() {
-                labels.insert("http.host".to_string(), host.to_string());
+                labels.insert("http.host", host.to_string());
             }
         }
         labels
     }
 
     fn add_response_labels<B>(
-        mut labels: HashMap<String, String>,
+        mut labels: HashMap<&'static str, String>,
         rsp: &http::Response<B>,
-    ) -> HashMap<String, String> {
-        labels.insert(
-            "http.status_code".to_string(),
-            rsp.status().as_str().to_string(),
-        );
+    ) -> HashMap<&'static str, String> {
+        labels.insert("http.status_code", rsp.status().as_str().to_string());
         labels
     }
 }

--- a/linkerd/trace-context/src/layer.rs
+++ b/linkerd/trace-context/src/layer.rs
@@ -1,171 +1,131 @@
-use super::{propagation, Span, SpanSink};
-use futures::{ready, TryFuture};
-use pin_project::pin_project;
-use std::collections::HashMap;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use std::time::SystemTime;
-use tracing::{trace, warn};
+use crate::{propagation, Span, SpanSink};
+use futures::{prelude::*, ready};
+use linkerd2_error::Error;
+use linkerd2_stack::{layer, Either};
+use std::{
+    collections::HashMap,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::SystemTime,
+};
+use tracing::{debug, info, trace};
 
 /// A layer that adds distributed tracing instrumentation.
 ///
-/// This layer reads the `traceparent` HTTP header from the request.  If this
+/// This layer reads the `traceparent` HTTP header from the request. If this
 /// header is absent, the request is fowarded unmodified.  If the header is
 /// present, a new span will be started in the current trace by creating a new
 /// random span id setting it into the `traceparent` header before forwarding
-/// the request.  If the sampled bit of the header was set, we emit metadata
+/// the request. If the sampled bit of the header was set, we emit metadata
 /// about the span to the given SpanSink when the span is complete, i.e. when
 /// we receive the response.
 #[derive(Clone, Debug)]
-pub struct TraceContextLayer<S> {
-    sink: Option<S>,
-}
-
-#[derive(Clone, Debug)]
-pub struct TraceContext<Svc, S> {
-    inner: Svc,
-    sink: Option<S>,
-}
-
-#[pin_project]
-pub struct ResponseFuture<F, S> {
-    trace: Option<(Span, S)>,
-    #[pin]
-    inner: F,
-}
-
-// === impl TraceContextLayer ===
-
-impl<S> TraceContextLayer<S> {
-    pub fn new(sink: Option<S>) -> Self {
-        Self { sink }
-    }
-}
-
-impl<Svc, S> tower::layer::Layer<Svc> for TraceContextLayer<S>
-where
-    S: Clone,
-{
-    type Service = TraceContext<Svc, S>;
-
-    fn layer(&self, inner: Svc) -> Self::Service {
-        Self::Service {
-            inner,
-            sink: self.sink.clone(),
-        }
-    }
+pub struct TraceContext<K, S> {
+    inner: S,
+    sink: Option<K>,
 }
 
 // === impl TraceContext ===
 
-impl<Svc, B1, B2, S> tower::Service<http::Request<B1>> for TraceContext<Svc, S>
-where
-    Svc: tower::Service<http::Request<B1>, Response = http::Response<B2>>,
-    S: SpanSink + Clone,
-{
-    type Response = Svc::Response;
-    type Error = Svc::Error;
-    type Future = ResponseFuture<Svc::Future, S>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Svc::Error>> {
-        self.inner.poll_ready(cx)
+impl<K: Clone, S> TraceContext<K, S> {
+    pub fn layer(sink: Option<K>) -> impl layer::Layer<S, Service = TraceContext<K, S>> + Clone {
+        layer::mk(move |inner| TraceContext {
+            inner,
+            sink: sink.clone(),
+        })
     }
 
-    fn call(&mut self, mut request: http::Request<B1>) -> Self::Future {
-        let sink = match &self.sink {
-            Some(sink) => sink.clone(),
-            None => {
-                return ResponseFuture {
-                    trace: None,
-                    inner: self.inner.call(request),
+    fn request_labels<B>(req: &http::Request<B>) -> HashMap<String, String> {
+        let mut labels = HashMap::new();
+        labels.insert("http.method".to_string(), format!("{}", req.method()));
+        let path = req
+            .uri()
+            .path_and_query()
+            .map(|pq| pq.as_str().to_owned())
+            .unwrap_or_default();
+        labels.insert("http.path".to_string(), path);
+        if let Some(authority) = req.uri().authority() {
+            labels.insert("http.authority".to_string(), authority.as_str().to_string());
+        }
+        if let Some(host) = req.headers().get("host") {
+            if let Ok(host) = host.to_str() {
+                labels.insert("http.host".to_string(), host.to_string());
+            }
+        }
+        labels
+    }
+
+    fn add_response_labels<B>(
+        mut labels: HashMap<String, String>,
+        rsp: &http::Response<B>,
+    ) -> HashMap<String, String> {
+        labels.insert(
+            "http.status_code".to_string(),
+            rsp.status().as_str().to_string(),
+        );
+        labels
+    }
+}
+
+impl<K, S, ReqB, RspB> tower::Service<http::Request<ReqB>> for TraceContext<K, S>
+where
+    S: tower::Service<http::Request<ReqB>, Response = http::Response<RspB>>,
+    S::Error: Into<Error> + Send,
+    S::Future: Send + 'static,
+    K: SpanSink + Clone + Send + 'static,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = Either<
+        S::Future,
+        Pin<Box<dyn Future<Output = Result<S::Response, S::Error>> + Send + 'static>>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        Poll::Ready(ready!(self.inner.poll_ready(cx)).map_err(Into::into))
+    }
+
+    fn call(&mut self, mut req: http::Request<ReqB>) -> Self::Future {
+        if let Some(sink) = self.sink.as_ref() {
+            if let Some(context) = propagation::unpack_trace_context(&req) {
+                // Update the trace ID if the request set one and the proxy is configured to emit
+                // spans.
+                let span_id = propagation::increment_span_id(&mut req, &context);
+                debug!(?span_id, sampled = context.is_sampled());
+
+                if context.is_sampled() {
+                    // If the request has been marked for sampling, record its metadata.
+                    let start = SystemTime::now();
+                    let req_labels = Self::request_labels(&req);
+                    let mut sink = sink.clone();
+                    let span_name = req
+                        .uri()
+                        .path_and_query()
+                        .map(|pq| pq.as_str().to_owned())
+                        .unwrap_or_default();
+                    return Either::B(Box::pin(self.inner.call(req).map_ok(move |rsp| {
+                        // Emit the completed span with the response metadtata.
+                        let span = Span {
+                            span_id,
+                            trace_id: context.trace_id,
+                            parent_id: context.parent_id,
+                            span_name,
+                            start,
+                            end: SystemTime::now(),
+                            labels: Self::add_response_labels(req_labels, &rsp),
+                        };
+                        trace!(?span);
+                        if let Err(error) = sink.try_send(span) {
+                            info!(%error, "Span dropped");
+                        }
+                        rsp
+                    })));
                 }
             }
-        };
-
-        let trace_context = propagation::unpack_trace_context(&request);
-        let mut span = None;
-
-        if let Some(context) = trace_context {
-            trace!(message = "got trace context", ?context);
-            let span_id = propagation::increment_span_id(&mut request, &context);
-            // If we plan to sample this span, we need to record span metadata
-            // from the request before dispatching it to inner.
-            if context.is_sampled() {
-                trace!(message = "span will be sampled", ?span_id);
-                let path = request
-                    .uri()
-                    .path_and_query()
-                    .map(|pq| pq.as_str().to_owned());
-                let mut labels = HashMap::new();
-                request_labels(&mut labels, &request);
-                span = Some(Span {
-                    trace_id: context.trace_id,
-                    span_id,
-                    parent_id: context.parent_id,
-                    span_name: path.unwrap_or_default(),
-                    start: SystemTime::now(),
-                    // End time will be updated when the span completes.
-                    end: SystemTime::UNIX_EPOCH,
-                    labels,
-                });
-            }
         }
 
-        let f = self.inner.call(request);
-
-        ResponseFuture {
-            trace: span.map(|span| (span, sink)),
-            inner: f,
-        }
+        // If there's no tracing to be done, just pass on the request to the inner service.
+        Either::A(self.inner.call(req))
     }
-}
-
-// === impl SpanFuture ===
-
-impl<F, S, B2> Future for ResponseFuture<F, S>
-where
-    F: TryFuture<Ok = http::Response<B2>>,
-    S: SpanSink,
-{
-    type Output = Result<F::Ok, F::Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        let inner = ready!(this.inner.try_poll(cx))?;
-        if let Some((mut span, mut sink)) = this.trace.take() {
-            span.end = SystemTime::now();
-            response_labels(&mut span.labels, &inner);
-            trace!(message = "emitting span", ?span);
-            if let Err(error) = sink.try_send(span) {
-                warn!(message = "span dropped", %error);
-            }
-        }
-        Poll::Ready(Ok(inner))
-    }
-}
-
-fn request_labels<Body>(labels: &mut HashMap<String, String>, req: &http::Request<Body>) {
-    labels.insert("http.method".to_string(), format!("{}", req.method()));
-    let path = req
-        .uri()
-        .path_and_query()
-        .map(|pq| pq.as_str().to_owned())
-        .unwrap_or_default();
-    labels.insert("http.path".to_string(), path);
-    if let Some(authority) = req.uri().authority() {
-        labels.insert("http.authority".to_string(), authority.as_str().to_string());
-    }
-    if let Some(host) = req.headers().get("host") {
-        if let Ok(host) = host.to_str() {
-            labels.insert("http.host".to_string(), host.to_string());
-        }
-    }
-}
-
-fn response_labels<Body>(labels: &mut HashMap<String, String>, rsp: &http::Response<Body>) {
-    labels.insert(
-        "http.status_code".to_string(),
-        rsp.status().as_str().to_string(),
-    );
 }

--- a/linkerd/trace-context/src/layer.rs
+++ b/linkerd/trace-context/src/layer.rs
@@ -101,7 +101,7 @@ where
                         .map(|pq| pq.as_str().to_owned())
                         .unwrap_or_default();
                     return Either::Right(Box::pin(self.inner.call(req).map_ok(move |rsp| {
-                        // Emit the completed span with the response metadtata.
+                        // Emit the completed span with the response metadata.
                         let span = Span {
                             span_id,
                             trace_id: context.trace_id,

--- a/linkerd/trace-context/src/lib.rs
+++ b/linkerd/trace-context/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
 
+pub use self::layer::TraceContext;
 use bytes::Bytes;
 use linkerd2_error::Error;
 use rand::Rng;
@@ -11,8 +12,6 @@ use tokio::sync::mpsc;
 
 pub mod layer;
 mod propagation;
-
-pub use layer::{TraceContext, TraceContextLayer};
 
 const SPAN_ID_LEN: usize = 8;
 

--- a/linkerd/trace-context/src/lib.rs
+++ b/linkerd/trace-context/src/lib.rs
@@ -32,7 +32,7 @@ pub struct Span {
     pub span_name: String,
     pub start: SystemTime,
     pub end: SystemTime,
-    pub labels: HashMap<String, String>,
+    pub labels: HashMap<&'static str, String>,
 }
 
 pub trait SpanSink {

--- a/linkerd/trace-context/src/propagation.rs
+++ b/linkerd/trace-context/src/propagation.rs
@@ -1,6 +1,7 @@
-use super::{Error, Flags, Id, InsufficientBytes};
+use crate::{Flags, Id, InsufficientBytes};
 use bytes::Bytes;
 use http::header::HeaderValue;
+use linkerd2_error::Error;
 use rand::{rngs::SmallRng, SeedableRng};
 use std::convert::TryInto;
 use std::fmt;


### PR DESCRIPTION
TraceContext relies on some older idioms like a manual future
implementaton.

This change replaces the `TraceContextLayer` type with a
`TraceContext::layer` function and the `ResponseFuture` implementation
with an (optionally) boxed response future. The response future is boxed
only when tracing is active.

No functional changes/