### PR TITLE
inbound: Fix URI normalization for orig-proto requests

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -354,7 +354,6 @@ impl Config {
             // Used by tap.
             .push_http_insert_target()
             .check_new_service::<TcpAccept, http::Request<_>>()
-            .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
             .push_on_response(
                 svc::layers()
                     .push(http_admit_request)
@@ -363,8 +362,9 @@ impl Config {
                     .box_http_request()
                     .box_http_response(),
             )
-            .push_map_target(|(_, accept): (http::Version, TcpAccept)| accept)
-            .instrument(|(v, _): &(http::Version, TcpAccept)| info_span!("http", %v))
+            .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
+            .push_map_target(|(_, accept): (_, TcpAccept)| accept)
+            .instrument(|(v, _): &(http::Version, _)| info_span!("http", %v))
             .check_new_service::<(http::Version, TcpAccept), http::Request<_>>()
             .into_inner();
 

--- a/linkerd/app/integration/src/tests/orig_proto.rs
+++ b/linkerd/app/integration/src/tests/orig_proto.rs
@@ -48,6 +48,10 @@ async fn inbound_http1() {
         .route_fn("/h1", |req| {
             assert_eq!(req.version(), http::Version::HTTP_11);
             assert!(
+                req.uri().scheme().is_none(),
+                "request must not be in absolute form"
+            );
+            assert!(
                 !req.headers().contains_key("l5d-orig-proto"),
                 "h1 server shouldn't receive l5d-orig-proto header"
             );


### PR DESCRIPTION
linkerd/linkerd2#5069 reports that proxied requests can incorrectly
end up in the absolute-form. This happens because URI normalization is
applied after protocol downgrade (where the absolute-form is annotated
explicitly).

This change improves the inbound orig-proto test to detect this bug and
fixes it by performing normalization before protocol downgrade so that
the downgrade layer's behavior is not overridden.