### PR TITLE
outbound: test profile search nets filtering

### DIFF
--- a/linkerd/app/outbound/src/tests/tcp.rs
+++ b/linkerd/app/outbound/src/tests/tcp.rs
@@ -338,7 +338,7 @@ async fn no_profiles_when_outside_search_nets() {
     let id_name = linkerd2_identity::Name::from_hostname(
         b"foo.ns1.serviceaccount.identity.linkerd.cluster.local",
     )
-    .expect("hostname is valid");
+    .expect("hostname is invalid");
     let id_name2 = id_name.clone();
 
     // Build a mock "connector" that returns the upstream "server" IO.


### PR DESCRIPTION
This PR adds a new test asserting that service profiles are only
resolved for original destination IPs within the specified search
networks. Also, I updated the existing tests so that the mock connectors
for endpoints which are expected to be plaintext actually assert that no
server identity was provided.