### PR TITLE
gateway: Ensure proper outbound metadata

### DIFF
--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -98,7 +98,7 @@ where
                 if let ::http::Version::HTTP_11 | ::http::Version::HTTP_10 = request.version() {
                     request
                         .headers_mut()
-                        .insert(::http::header::HOST, host_header.clone());
+                        .insert(http::header::HOST, host_header.clone());
                 }
 
                 tracing::debug!(

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -95,10 +95,10 @@ where
                 // was stripped on the peer's outbound proxy. But the request
                 // should have an updated `Host` header now that it's being
                 // routed in the cluster.
-                if let ::http::Version::HTTP_11 | ::http::Version::HTTP_10 = request.version() {
+                if let http::Version::HTTP_11 | http::Version::HTTP_10 = request.version() {
                     request
                         .headers_mut()
-                        .insert(::http::header::HOST, host_header.clone());
+                        .insert(http::header::HOST, host_header.clone());
                 }
 
                 tracing::debug!(

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -95,10 +95,10 @@ where
                 // was stripped on the peer's outbound proxy. But the request
                 // should have an updated `Host` header now that it's being
                 // routed in the cluster.
-                if let http::Version::HTTP_11 | http::Version::HTTP_10 = request.version() {
+                if let ::http::Version::HTTP_11 | ::http::Version::HTTP_10 = request.version() {
                     request
                         .headers_mut()
-                        .insert(http::header::HOST, host_header.clone());
+                        .insert(::http::header::HOST, host_header.clone());
                 }
 
                 tracing::debug!(

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -144,7 +144,6 @@ mod test {
                 Config { allow_discovery }.build(
                     move |_: _| outbound.clone(),
                     profiles,
-                    ([127, 0, 0, 1], 4140).into(),
                     tls::PeerIdentity::Some(identity::Name::from(
                         dns::Name::try_from("gateway.id.test".as_bytes()).unwrap(),
                     )),

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -170,7 +170,6 @@ impl Config {
             let http_gateway = gateway.build(
                 outbound_http,
                 dst.profiles.clone(),
-                outbound_addr,
                 local_identity.as_ref().map(|l| l.name().clone()),
             );
 


### PR DESCRIPTION
The gateway has two deficiencies:

* Using the outbound proxy port for the outbound original dst leads to
  the incorrect port being used in the `l5d-dst-canonical` header. Now,
  we instead use the proper port with an unroutable IP address.
* Because the source cluster's outbound proxy strips `Host` headers,
  there's no `Host` present on gatewayed HTTP/1 requests. Now, the
  `Host` header is updated on all gatewayed HTTP/1 requests.