### PR TITLE
outbound: test load balancer adding/removing TCP endpoints

### DIFF
--- a/linkerd/app/outbound/src/tests/tcp.rs
+++ b/linkerd/app/outbound/src/tests/tcp.rs
@@ -411,7 +411,6 @@ async fn load_balancer_add_endpoints() {
         .expect("still listening");
 
     conns().await;
-    assert!(endpoints[0].1.load(Ordering::Acquire) >= 10);
     assert_ne!(
         endpoints[1].1.load(Ordering::Acquire),
         0,

--- a/linkerd/app/outbound/src/tests/tcp.rs
+++ b/linkerd/app/outbound/src/tests/tcp.rs
@@ -318,6 +318,7 @@ async fn load_balances() {
     );
 }
 
+#[tokio::test(core_threads = 1)]
 async fn load_balancer_add_endpoints() {
     let _trace = test_support::trace_init();
 

--- a/linkerd/app/outbound/src/tests/tcp.rs
+++ b/linkerd/app/outbound/src/tests/tcp.rs
@@ -168,9 +168,9 @@ async fn resolutions_are_reused() {
     // Build a mock "connector" that returns the upstream "server" IO.
     let connect = test_support::connect().endpoint(
         addr,
-        Endpoint {
+        Connection {
             identity: tls::Conditional::Some(id_name.clone()),
-            ..Endpoint::default()
+            ..Connection::default()
         },
     );
 
@@ -251,10 +251,10 @@ async fn load_balances() {
     for &(addr, ref conns) in endpoints {
         connect = connect.endpoint(
             addr,
-            Endpoint {
+            Connection {
                 identity: tls::Conditional::Some(id_name.clone()),
                 count: conns.clone(),
-                ..Endpoint::default()
+                ..Connection::default()
             },
         );
     }
@@ -341,10 +341,10 @@ async fn load_balancer_add_endpoints() {
     for &(addr, ref conns) in endpoints {
         connect = connect.endpoint(
             addr,
-            Endpoint {
+            Connection {
                 identity: tls::Conditional::Some(id_name.clone()),
                 count: conns.clone(),
-                ..Endpoint::default()
+                ..Connection::default()
             },
         );
     }
@@ -451,10 +451,10 @@ async fn load_balancer_remove_endpoints() {
     for &(addr, ref enabled) in endpoints {
         connect = connect.endpoint(
             addr,
-            Endpoint {
+            Connection {
                 identity: tls::Conditional::Some(id_name.clone()),
                 enabled: enabled.clone(),
-                ..Endpoint::default()
+                ..Default::default()
             },
         );
     }
@@ -599,13 +599,13 @@ async fn no_profiles_when_outside_search_nets() {
     );
 }
 
-struct Endpoint {
+struct Connection {
     identity: tls::Conditional<linkerd2_identity::Name>,
     count: Arc<AtomicUsize>,
     enabled: Arc<AtomicBool>,
 }
 
-impl Default for Endpoint {
+impl Default for Connection {
     fn default() -> Self {
         Self {
             identity: tls::Conditional::None(
@@ -618,7 +618,7 @@ impl Default for Endpoint {
 }
 
 impl Into<Box<dyn FnMut(TcpEndpoint) -> test_support::connect::ConnectFuture + Send + 'static>>
-    for Endpoint
+    for Connection
 {
     fn into(
         self,

--- a/linkerd/app/outbound/src/tests/tcp.rs
+++ b/linkerd/app/outbound/src/tests/tcp.rs
@@ -3,7 +3,7 @@ use crate::TcpEndpoint;
 use linkerd2_app_core::{drain, metrics, svc, transport::listen, Addr};
 use std::{
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
@@ -164,21 +164,15 @@ async fn resolutions_are_reused() {
         b"foo.ns1.serviceaccount.identity.linkerd.cluster.local",
     )
     .expect("hostname is valid");
-    let id_name2 = id_name.clone();
 
     // Build a mock "connector" that returns the upstream "server" IO.
-    let connect = test_support::connect().endpoint_fn(addr, move |endpoint: TcpEndpoint| {
-        assert_eq!(
-            endpoint.peer_identity(),
-            tls::Conditional::Some(id_name2.clone())
-        );
-        let io = test_support::io()
-            .write(b"hello")
-            .read(b"world")
-            .read_error(std::io::ErrorKind::ConnectionReset.into())
-            .build();
-        Ok(io)
-    });
+    let connect = test_support::connect().endpoint(
+        addr,
+        Endpoint {
+            identity: tls::Conditional::Some(id_name.clone()),
+            ..Endpoint::default()
+        },
+    );
 
     let meta = test_support::resolver::Metadata::new(
         Default::default(),
@@ -255,22 +249,14 @@ async fn load_balances() {
     // Build a mock "connector" that returns the upstream "server" IO
     let mut connect = test_support::connect();
     for &(addr, ref conns) in endpoints {
-        let id_name = id_name.clone();
-        let conns = conns.clone();
-        connect = connect.endpoint_fn(addr, move |endpoint: TcpEndpoint| {
-            let num = conns.fetch_add(1, Ordering::Release) + 1;
-            tracing::info!(?addr, ?endpoint, num, "connecting");
-            assert_eq!(
-                endpoint.peer_identity(),
-                tls::Conditional::Some(id_name.clone())
-            );
-            let io = test_support::io()
-                .write(b"hello")
-                .read(b"world")
-                .read_error(std::io::ErrorKind::ConnectionReset.into())
-                .build();
-            Ok(io)
-        });
+        connect = connect.endpoint(
+            addr,
+            Endpoint {
+                identity: tls::Conditional::Some(id_name.clone()),
+                count: conns.clone(),
+                ..Endpoint::default()
+            },
+        );
     }
 
     let profiles = test_support::profile::resolver().profile(svc_addr, Default::default());
@@ -353,22 +339,14 @@ async fn load_balancer_add_endpoints() {
 
     let mut connect = test_support::connect();
     for &(addr, ref conns) in endpoints {
-        let id_name = id_name.clone();
-        let conns = conns.clone();
-        connect = connect.endpoint_fn(addr, move |endpoint: TcpEndpoint| {
-            let num = conns.fetch_add(1, Ordering::Release) + 1;
-            tracing::info!(?addr, ?endpoint, num, "connecting");
-            assert_eq!(
-                endpoint.peer_identity(),
-                tls::Conditional::Some(id_name.clone())
-            );
-            let io = test_support::io()
-                .write(b"hello")
-                .read(b"world")
-                .read_error(std::io::ErrorKind::ConnectionReset.into())
-                .build();
-            Ok(io)
-        });
+        connect = connect.endpoint(
+            addr,
+            Endpoint {
+                identity: tls::Conditional::Some(id_name.clone()),
+                count: conns.clone(),
+                ..Endpoint::default()
+            },
+        );
     }
 
     let profiles = test_support::profile::resolver().profile(svc_addr, Default::default());
@@ -441,6 +419,107 @@ async fn load_balancer_add_endpoints() {
         0,
         "no connections to endpoint 2 after it was added"
     );
+}
+
+#[tokio::test]
+async fn load_balancer_remove_endpoints() {
+    let _trace = test_support::trace_init();
+
+    let svc_addr = SocketAddr::new([10, 0, 142, 80].into(), 5550);
+    let endpoints = &[
+        (
+            SocketAddr::new([10, 0, 170, 42].into(), 5550),
+            Arc::new(AtomicBool::new(true)),
+        ),
+        (
+            SocketAddr::new([10, 0, 170, 68].into(), 5550),
+            Arc::new(AtomicBool::new(true)),
+        ),
+        (
+            SocketAddr::new([10, 0, 106, 66].into(), 5550),
+            Arc::new(AtomicBool::new(true)),
+        ),
+    ];
+
+    let cfg = default_config(svc_addr);
+    let id_name = linkerd2_identity::Name::from_hostname(
+        b"foo.ns1.serviceaccount.identity.linkerd.cluster.local",
+    )
+    .expect("hostname is valid");
+
+    let mut connect = test_support::connect();
+    for &(addr, ref enabled) in endpoints {
+        connect = connect.endpoint(
+            addr,
+            Endpoint {
+                identity: tls::Conditional::Some(id_name.clone()),
+                enabled: enabled.clone(),
+                ..Endpoint::default()
+            },
+        );
+    }
+
+    let profiles = test_support::profile::resolver().profile(svc_addr, Default::default());
+
+    let meta = test_support::resolver::Metadata::new(
+        Default::default(),
+        test_support::resolver::ProtocolHint::Unknown,
+        Some(id_name),
+        10_000,
+        None,
+    );
+
+    let resolver = test_support::resolver();
+    let mut dst = resolver.endpoint_tx(Addr::Socket(svc_addr));
+    dst.add(Some((endpoints[0].0, meta.clone())))
+        .expect("still listening");
+
+    // Build the outbound server
+    let mut server = build_server(cfg, profiles, resolver, connect);
+
+    let mut conns = || {
+        let conns = (0..10)
+            .map(|i| {
+                tokio::spawn(
+                    hello_world_client(svc_addr, &mut server)
+                        .instrument(tracing::info_span!("conn", i)),
+                )
+                .err_into::<Error>()
+            })
+            .collect::<Vec<_>>();
+
+        async move {
+            if let Err(e) = futures::future::try_join_all(conns).await {
+                panic!("connection panicked: {:?}", e);
+            }
+        }
+    };
+
+    // All endpoints are enabled
+    conns().await;
+
+    let mut remove = |i: usize| {
+        dst.remove(Some(endpoints[i].0)).expect("still listening");
+        endpoints[i].1.store(false, Ordering::Release);
+        tracing::info!(removed = i, addr = %endpoints[i].0);
+    };
+
+    // Remove endpoint 2.
+    remove(2);
+    conns().await;
+
+    // Remove endpoint 1.
+    remove(1);
+    conns().await;
+
+    // Remove endpoint 0, and add endpoint 2.
+    remove(0);
+    drop(remove);
+    dst.add(Some((endpoints[2].0, meta.clone())))
+        .expect("still listening");
+    endpoints[2].1.store(true, Ordering::Release);
+    tracing::info!(added = 2);
+    conns().await;
 }
 
 #[tokio::test]
@@ -518,6 +597,48 @@ async fn no_profiles_when_outside_search_nets() {
         profile_state.only_configured(),
         "profiles outside the search networks were resolved"
     );
+}
+
+struct Endpoint {
+    identity: tls::Conditional<linkerd2_identity::Name>,
+    count: Arc<AtomicUsize>,
+    enabled: Arc<AtomicBool>,
+}
+
+impl Default for Endpoint {
+    fn default() -> Self {
+        Self {
+            identity: tls::Conditional::None(
+                tls::ReasonForNoPeerName::NotProvidedByServiceDiscovery,
+            ),
+            count: Arc::new(AtomicUsize::new(0)),
+            enabled: Arc::new(AtomicBool::new(true)),
+        }
+    }
+}
+
+impl Into<Box<dyn FnMut(TcpEndpoint) -> test_support::connect::ConnectFuture + Send + 'static>>
+    for Endpoint
+{
+    fn into(
+        self,
+    ) -> Box<dyn FnMut(TcpEndpoint) -> test_support::connect::ConnectFuture + Send + 'static> {
+        Box::new(move |endpoint| {
+            assert!(
+                self.enabled.load(Ordering::Acquire),
+                "tried to connect to an endpoint that should not be connected to!"
+            );
+            let num = self.count.fetch_add(1, Ordering::Release) + 1;
+            tracing::info!(?endpoint, num, "connecting");
+            assert_eq!(endpoint.peer_identity(), self.identity);
+            let io = test_support::io()
+                .write(b"hello")
+                .read(b"world")
+                .read_error(std::io::ErrorKind::ConnectionReset.into())
+                .build();
+            Box::pin(async move { Ok(io) })
+        })
+    }
 }
 
 fn build_server<I>(

--- a/linkerd/app/outbound/src/tests/tcp.rs
+++ b/linkerd/app/outbound/src/tests/tcp.rs
@@ -8,7 +8,10 @@ use std::{
     },
     time::Duration,
 };
-use test_support::{connect::Connect, resolver};
+use test_support::{
+    connect::{Connect, ConnectFuture},
+    resolver,
+};
 use tls::HasPeerIdentity;
 use tracing_futures::Instrument;
 
@@ -617,12 +620,8 @@ impl Default for Connection {
     }
 }
 
-impl Into<Box<dyn FnMut(TcpEndpoint) -> test_support::connect::ConnectFuture + Send + 'static>>
-    for Connection
-{
-    fn into(
-        self,
-    ) -> Box<dyn FnMut(TcpEndpoint) -> test_support::connect::ConnectFuture + Send + 'static> {
+impl Into<Box<dyn FnMut(TcpEndpoint) -> ConnectFuture + Send + 'static>> for Connection {
+    fn into(self) -> Box<dyn FnMut(TcpEndpoint) -> ConnectFuture + Send + 'static> {
         Box::new(move |endpoint| {
             assert!(
                 self.enabled.load(Ordering::Acquire),

--- a/linkerd/app/test/src/connect.rs
+++ b/linkerd/app/test/src/connect.rs
@@ -7,6 +7,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use tokio_test::io;
+use tracing_futures::{Instrument, Instrumented};
 
 type ConnectFn<E> = Box<dyn FnMut(E) -> ConnectFuture + Send>;
 
@@ -22,7 +23,7 @@ where
     E: Clone + fmt::Debug + Into<SocketAddr>,
 {
     type Response = io::Mock;
-    type Future = ConnectFuture;
+    type Future = Instrumented<ConnectFuture>;
     type Error = Error;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -31,11 +32,15 @@ where
 
     fn call(&mut self, endpoint: E) -> Self::Future {
         let addr = endpoint.clone().into();
-        tracing::trace!(%addr, "connect");
-        match self.endpoints.lock().unwrap().get_mut(&addr) {
-            Some(f) => (f)(endpoint),
-            None => panic!("did not expect to connect to the endpoint {:?}", endpoint),
-        }
+        let span = tracing::info_span!("connect", %addr);
+        let f = span.in_scope(|| {
+            tracing::trace!("connecting...");
+            match self.endpoints.lock().unwrap().get_mut(&addr) {
+                Some(f) => (f)(endpoint),
+                None => panic!("did not expect to connect to the endpoint {:?}", endpoint),
+            }
+        });
+        f.instrument(span)
     }
 }
 
@@ -46,15 +51,15 @@ impl<E: fmt::Debug> Connect<E> {
         }
     }
 
-    pub fn endpoint_future(
+    pub fn endpoint(
         self,
         endpoint: impl Into<SocketAddr>,
-        f: impl (FnMut(E) -> ConnectFuture) + Send + 'static,
+        f: impl Into<Box<dyn FnMut(E) -> ConnectFuture + Send + 'static>>,
     ) -> Self {
         self.endpoints
             .lock()
             .unwrap()
-            .insert(endpoint.into(), Box::new(f));
+            .insert(endpoint.into(), f.into());
         self
     }
 
@@ -63,10 +68,14 @@ impl<E: fmt::Debug> Connect<E> {
         endpoint: impl Into<SocketAddr>,
         mut f: impl (FnMut(E) -> Result<io::Mock, Error>) + Send + 'static,
     ) -> Self {
-        self.endpoint_future(endpoint, move |endpoint| {
-            let conn = f(endpoint);
-            Box::pin(async move { conn })
-        })
+        self.endpoints.lock().unwrap().insert(
+            endpoint.into(),
+            Box::new(move |endpoint| {
+                let conn = f(endpoint);
+                Box::pin(async move { conn })
+            }),
+        );
+        self
     }
 
     pub fn endpoint_builder(

--- a/linkerd/app/test/src/connect.rs
+++ b/linkerd/app/test/src/connect.rs
@@ -54,24 +54,24 @@ impl<E: fmt::Debug> Connect<E> {
     pub fn endpoint(
         self,
         endpoint: impl Into<SocketAddr>,
-        f: impl Into<Box<dyn FnMut(E) -> ConnectFuture + Send + 'static>>,
+        on_connect: impl Into<Box<dyn FnMut(E) -> ConnectFuture + Send + 'static>>,
     ) -> Self {
         self.endpoints
             .lock()
             .unwrap()
-            .insert(endpoint.into(), f.into());
+            .insert(endpoint.into(), on_connect.into());
         self
     }
 
     pub fn endpoint_fn(
         self,
         endpoint: impl Into<SocketAddr>,
-        mut f: impl (FnMut(E) -> Result<io::Mock, Error>) + Send + 'static,
+        mut on_connect: impl (FnMut(E) -> Result<io::Mock, Error>) + Send + 'static,
     ) -> Self {
         self.endpoints.lock().unwrap().insert(
             endpoint.into(),
             Box::new(move |endpoint| {
-                let conn = f(endpoint);
+                let conn = on_connect(endpoint);
                 Box::pin(async move { conn })
             }),
         );


### PR DESCRIPTION
Depends on #714

This branch adds new tests for updating TCP destinations by adding and
removing endpoints. The first test asserts that when new endpoints are
added to a load balancer, some connections after they are added are
routed to the new endpoint. The other test asserts that when endpoints
are removed, they no longer receive connections.

I've also done some more test cleanup & boilerplate removal.