### PR TITLE
outbound: Set source address in Tap metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "linkerd2-app-core",
  "linkerd2-app-test",
  "linkerd2-identity",
+ "linkerd2-io",
  "linkerd2-retry",
  "pin-project",
  "tokio",
@@ -1157,6 +1158,7 @@ dependencies = [
  "pin-project",
  "tokio",
  "tokio-rustls",
+ "tokio-test",
 ]
 
 [[package]]

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -308,7 +308,7 @@ impl Config {
            + Send
            + 'static
     where
-        I: io::AsyncRead + io::AsyncWrite + Unpin + Send + 'static,
+        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Unpin + Send + 'static,
         F: svc::NewService<TcpEndpoint, Service = A> + Unpin + Clone + Send + 'static,
         A: tower::Service<io::PrefixedIo<I>, Response = ()> + Clone + Send + 'static,
         A::Error: Into<Error>,

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -31,6 +31,7 @@ features = [
 
 [dev-dependencies]
 ipnet = "1.0"
+linkerd2-io = { path = "../../io", features = ["tokio-test"] }
 linkerd2-app-test = { path = "../test" }
 tokio = { version = "0.2", features = ["full", "macros"]}
 tracing-futures = "0.2"

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -6,8 +6,7 @@ use linkerd2_app_core::{
     profiles,
     proxy::{
         api_resolve::{Metadata, ProtocolHint},
-        http::override_authority::CanOverrideAuthority,
-        http::{self},
+        http::{self, override_authority::CanOverrideAuthority, ClientAddr},
         identity,
         resolve::map_endpoint::MapEndpoint,
         tap,
@@ -258,8 +257,10 @@ impl<P> CanOverrideAuthority for Endpoint<P> {
 }
 
 impl tap::Inspect for HttpEndpoint {
-    fn src_addr<B>(&self, _: &http::Request<B>) -> Option<SocketAddr> {
-        None
+    fn src_addr<B>(&self, req: &http::Request<B>) -> Option<SocketAddr> {
+        req.extensions()
+            .get::<ClientAddr>()
+            .map(|c| c.as_ref().clone())
     }
 
     fn src_tls<'a, B>(

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -18,7 +18,7 @@ use linkerd2_app_core::{
     reconnect, retry,
     spans::SpanConverter,
     svc::{self},
-    transport::{self, listen, tls},
+    transport::{self, io, listen, tls},
     Addr, Error, IpMatch, ProxyMetrics, TraceContext, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER,
     L5D_REQUIRE_ID,
 };
@@ -66,7 +66,7 @@ impl Config {
         HttpEndpoint,
         Error = Error,
         Future = impl future::Future + Send,
-        Response = impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+        Response = impl io::AsyncRead + io::AsyncWrite + Unpin + Send + 'static,
     > + Unpin
            + Clone
            + Send {
@@ -103,12 +103,12 @@ impl Config {
            + 'static
     where
         C: tower::Service<TcpEndpoint, Error = Error> + Unpin + Clone + Send + Sync + 'static,
-        C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+        C::Response: io::AsyncRead + io::AsyncWrite + Unpin + Send + 'static,
         C::Future: Unpin + Send,
         R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Unpin + Clone + Send + 'static,
         R::Future: Unpin + Send,
         R::Resolution: Unpin + Send,
-        I: tokio::io::AsyncRead + tokio::io::AsyncWrite + std::fmt::Debug + Unpin + Send + 'static,
+        I: io::AsyncRead + io::AsyncWrite + std::fmt::Debug + Unpin + Send + 'static,
     {
         svc::stack(connect)
             .push_make_thunk()
@@ -320,7 +320,7 @@ impl Config {
     > + Send
            + 'static
     where
-        I: tokio::io::AsyncRead + tokio::io::AsyncWrite + std::fmt::Debug + Unpin + Send + 'static,
+        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
         R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Unpin + Clone + Send + 'static,
         R::Future: Unpin + Send,
         R::Resolution: Unpin + Send,

--- a/linkerd/app/outbound/src/tests/tcp.rs
+++ b/linkerd/app/outbound/src/tests/tcp.rs
@@ -1,6 +1,10 @@
 use super::*;
 use crate::TcpEndpoint;
-use linkerd2_app_core::{drain, metrics, svc, transport::listen, Addr};
+use linkerd2_app_core::{
+    drain, metrics, svc,
+    transport::{io, listen},
+    Addr,
+};
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},
@@ -334,7 +338,7 @@ fn build_server<I>(
 > + Send
        + 'static
 where
-    I: tokio::io::AsyncRead + tokio::io::AsyncWrite + std::fmt::Debug + Unpin + Send + 'static,
+    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
 {
     let (metrics, _) = metrics::Metrics::new(Duration::from_secs(10));
     let (_, drain) = drain::channel();

--- a/linkerd/io/Cargo.toml
+++ b/linkerd/io/Cargo.toml
@@ -8,10 +8,14 @@ description = """
 General I/O primitives.
 """
 
+[features]
+default = []
+
 [dependencies]
 futures = "0.3"
 bytes = "0.5"
 linkerd2-errno = { path = "../errno" }
 tokio = { version = "0.2", features = ["io-util", "net", "macros"] }
 tokio-rustls = "0.13"
+tokio-test = { version = "0.2", optional = true }
 pin-project = "0.4"

--- a/linkerd/io/src/boxed.rs
+++ b/linkerd/io/src/boxed.rs
@@ -1,4 +1,4 @@
-use super::{internal::Io, AsyncRead, AsyncWrite, Poll};
+use super::{internal::Io, AsyncRead, AsyncWrite, PeerAddr, Poll};
 use bytes::{Buf, BufMut};
 use std::{mem::MaybeUninit, pin::Pin, task::Context};
 
@@ -11,6 +11,12 @@ pub struct BoxedIo(Pin<Box<dyn Io + Unpin>>);
 impl BoxedIo {
     pub fn new<T: Io + Unpin + 'static>(io: T) -> Self {
         BoxedIo(Box::pin(io))
+    }
+}
+
+impl PeerAddr for BoxedIo {
+    fn peer_addr(&self) -> std::net::SocketAddr {
+        self.0.peer_addr()
     }
 }
 

--- a/linkerd/io/src/boxed.rs
+++ b/linkerd/io/src/boxed.rs
@@ -105,6 +105,12 @@ mod tests {
     #[derive(Debug)]
     struct WriteBufDetector;
 
+    impl PeerAddr for WriteBufDetector {
+        fn peer_addr(&self) -> std::net::SocketAddr {
+            ([0, 0, 0, 0], 0).into()
+        }
+    }
+
     impl AsyncRead for WriteBufDetector {
         fn poll_read(self: Pin<&mut Self>, _: &mut Context<'_>, _: &mut [u8]) -> Poll<usize> {
             unreachable!("not called in test")

--- a/linkerd/io/src/lib.rs
+++ b/linkerd/io/src/lib.rs
@@ -37,6 +37,13 @@ impl<T: PeerAddr> PeerAddr for tokio_rustls::server::TlsStream<T> {
     }
 }
 
+#[cfg(feature = "tokio-test")]
+impl PeerAddr for tokio_test::io::Mock {
+    fn peer_addr(&self) -> SocketAddr {
+        ([0, 0, 0, 0], 0).into()
+    }
+}
+
 mod internal {
     use super::{AsyncRead, AsyncWrite, PeerAddr, Poll};
     use bytes::{Buf, BufMut};

--- a/linkerd/io/src/prefixed.rs
+++ b/linkerd/io/src/prefixed.rs
@@ -1,4 +1,4 @@
-use crate::{internal::Io, Poll};
+use crate::{internal::Io, PeerAddr, Poll};
 use bytes::{Buf, BufMut, Bytes};
 use std::{cmp, io};
 use std::{mem::MaybeUninit, pin::Pin, task::Context};
@@ -24,6 +24,12 @@ impl<S: AsyncRead + AsyncWrite> PrefixedIo<S> {
 
     pub fn prefix(&self) -> &Bytes {
         &self.prefix
+    }
+}
+
+impl<S: PeerAddr> PeerAddr for PrefixedIo<S> {
+    fn peer_addr(&self) -> std::net::SocketAddr {
+        self.io.peer_addr()
     }
 }
 

--- a/linkerd/io/src/sensor.rs
+++ b/linkerd/io/src/sensor.rs
@@ -1,4 +1,4 @@
-use crate::{internal::Io, Poll};
+use crate::{internal::Io, PeerAddr, Poll};
 use bytes::{Buf, BufMut};
 use futures::ready;
 use linkerd2_errno::Errno;
@@ -102,5 +102,11 @@ impl<T: Io, S: Sensor + Send> Io for SensorIo<T, S> {
         mut buf: &mut dyn BufMut,
     ) -> Poll<usize> {
         self.poll_read_buf(cx, &mut buf)
+    }
+}
+
+impl<T: PeerAddr, S> PeerAddr for SensorIo<T, S> {
+    fn peer_addr(&self) -> std::net::SocketAddr {
+        self.io.peer_addr()
     }
 }

--- a/linkerd/proxy/http/src/client_addr.rs
+++ b/linkerd/proxy/http/src/client_addr.rs
@@ -1,0 +1,50 @@
+use std::{
+    net::SocketAddr,
+    task::{Context, Poll},
+};
+
+/// A server-set extension that holds the connection's peer address.
+#[derive(Copy, Clone, Debug)]
+pub struct ClientAddr(SocketAddr);
+
+#[derive(Clone, Debug)]
+pub struct SetClientAddr<S> {
+    inner: S,
+    addr: SocketAddr,
+}
+
+impl AsRef<SocketAddr> for ClientAddr {
+    fn as_ref(&self) -> &SocketAddr {
+        &self.0
+    }
+}
+
+impl Into<SocketAddr> for ClientAddr {
+    fn into(self) -> SocketAddr {
+        self.0
+    }
+}
+
+impl<S> SetClientAddr<S> {
+    pub fn new(addr: SocketAddr, inner: S) -> Self {
+        Self { inner, addr }
+    }
+}
+
+impl<B, S> tower::Service<http::Request<B>> for SetClientAddr<S>
+where
+    S: tower::Service<http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+        req.extensions_mut().insert(ClientAddr(self.addr));
+        self.inner.call(req)
+    }
+}

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -7,6 +7,7 @@ use linkerd2_identity as identity;
 pub mod add_header;
 pub mod balance;
 pub mod client;
+mod client_addr;
 pub mod detect;
 mod glue;
 pub mod h1;
@@ -23,6 +24,7 @@ pub mod upgrade;
 mod version;
 
 pub use self::{
+    client_addr::{ClientAddr, SetClientAddr},
     detect::DetectHttp,
     glue::{Body as Payload, HyperServerSvc},
     timeout::MakeTimeoutLayer,


### PR DESCRIPTION
We recently stopped exposing source addresses on outbound Tap metadata,
but this causes some confusion in the Tap UIs.

This change introduces an `io::PeerAddr` trait that is implemented by
all `Io` types and a `proxy::http:SetClientAddr` middleware that inserts
a `ClientAddr` type onto requests. This middleware is now applied by the
`DetectHttp` server to ensure the HTTP stack can access the source
address.