### PR TITLE
trace: update `tracing-subscriber` to 0.2.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "js-sys"
@@ -1566,6 +1579,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,9 +2310,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "0.2.8"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "scopeguard"
@@ -2324,12 +2356,26 @@ name = "serde"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.2",
+ "syn 1.0.21",
+]
 
 [[package]]
 name = "serde_json"
-version = "1.0.27"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59790990c5115d16027f00913e2e66de23a51f70422e549d2ad68c8c5f268f1c"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -2338,11 +2384,12 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
 dependencies = [
  "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -2764,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.14"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db63662723c316b43ca36d833707cc93dff82a02ba3d7e354f342682cc8b3545"
+checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
 ]
@@ -2794,9 +2841,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
  "serde",
  "tracing-core",
@@ -2804,9 +2851,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd165311cc4d7a555ad11cc77a37756df836182db0d81aac908c8184c584f40"
+checksum = "2810660b9d5b18895d140caba6401765749a6a162e5d0736cfc44ea50db9d79d"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -2819,6 +2866,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local 1.0.1",
+ "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -42,7 +42,7 @@ tracing-futures = { version = "0.2", features = ["std-future"] }
 webpki = "0.21.0"
 
 [dependencies.tracing-subscriber]
-version = "0.2.11"
+version = "0.2.14"
 # we don't need `chrono` time formatting or ANSI colored output
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot"]
@@ -51,7 +51,7 @@ features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot
 flate2 = { version = "1.0.1", default-features = false, features = ["rust_backend"] }
 
 [dev-dependencies.tracing-subscriber]
-version = "0.2.8"
+version = "0.2.14"
 # turn on ANSI colors for tests :)
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "ansi", "tracing-log", "json", "parking_lot"]

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -33,7 +33,7 @@ tracing-futures = { version = "0.2", features = ["std-future"] }
 tracing-subscriber = "0.2.11"
 
 [dev-dependencies.tracing-subscriber]
-version = "0.2.8"
+version = "0.2.14"
 # turn on ANSI colors for tests :)
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "ansi", "tracing-log", "json", "parking_lot"]

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -49,6 +49,6 @@ libc = "0.2"
 
 [dev-dependencies]
 linkerd2-identity = { path = "../../identity", features = ["test-util"] }
-tracing-subscriber = "0.2.11"
+tracing-subscriber = "0.2.14"
 tower = { version = "0.3", default-features = false, features = ["util"] }
 tracing-futures = { version = "0.2", features = ["std-future"] }

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -27,5 +27,5 @@ features = [
 [dev-dependencies]
 tower-test = "0.3"
 tokio-test = "0.2"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.2.14"
 tokio = { version = "0.2", features = ["time", "macros"] }

--- a/linkerd/tracing/Cargo.toml
+++ b/linkerd/tracing/Cargo.toml
@@ -19,7 +19,7 @@ tracing-futures = { version = "0.2" }
 tracing-log = "0.1"
 
 [dependencies.tracing-subscriber]
-version = "0.2.11"
+version = "0.2.14"
 # we don't need `chrono` time formatting or ANSI colored output
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot"]


### PR DESCRIPTION
This picks up the following upstream changes:

* tokio-rs/tracing#1064, which fixes a bug where creating a subscriber
  would allocate a large amount of memory that was not actually used

* tokio-rs/tracing#1058, which significantly reduces the overhead of
  entering and exiting spans

Together, these changes should improve proxy performance when tracing is
enabled.