### PR TITLE
inbound: use MakeSwitch for loopback

### DIFF
--- a/linkerd/app/inbound/src/prevent_loop.rs
+++ b/linkerd/app/inbound/src/prevent_loop.rs
@@ -1,5 +1,5 @@
 //use futures::future;
-use linkerd2_app_core::{svc::stack::FilterRequest, Error};
+use linkerd2_app_core::{svc::stack::FilterRequest, svc::stack::Switch, Error};
 
 /// A connection policy that drops
 #[derive(Copy, Clone, Debug)]
@@ -32,6 +32,17 @@ where
         }
 
         Ok(t)
+    }
+}
+
+impl<T> Switch<T> for PreventLoop
+where
+    for<'t> &'t T: Into<std::net::SocketAddr>,
+{
+    fn use_primary(&self, target: &T) -> bool {
+        let addr = target.into();
+        tracing::debug!(%addr, self.port);
+        addr.port() == self.port
     }
 }
 


### PR DESCRIPTION
Currently, loopback connections are detected using the `PreventLoop`
layer, which returns an error when the target address' port matches the
proxy listener's port. The inbound router currently uses a `Fallback`
layer to detect this error and send loopback traffic to a loopback
service (the mutlicluster gateway).

This branch changes the inbound proxy to dispatch loopback connections
to the multicluster gateway using a `MakeSwitch` layer instead. The
`MakeSwitch` layer inspects the target type and applies a predicate to
it that determines which of two services to make. This is essentially
the same behavior as using the fallback on error layer, but with fewer
steps.