### PR TITLE
Allow specifying the number of available cores via the env

### DIFF
--- a/linkerd2-proxy/src/rt.rs
+++ b/linkerd2-proxy/src/rt.rs
@@ -1,5 +1,5 @@
 use tokio::runtime::{Builder, Runtime};
-use tracing::{debug, warn};
+use tracing::{info, warn};
 
 #[cfg(feature = "multicore")]
 pub(crate) fn build() -> Runtime {
@@ -32,23 +32,28 @@ pub(crate) fn build() -> Runtime {
         cores = cpus;
     }
 
-    debug!(cores, "Initializing runtime");
     match cores {
         // `0` is unexpected, but it's a wild world out there.
-        0 | 1 => Builder::new()
-            .enable_all()
-            .thread_name("proxy")
-            .basic_scheduler()
-            .build()
-            .expect("failed to build basic runtime!"),
-        num_cpus => Builder::new()
-            .enable_all()
-            .thread_name("proxy")
-            .threaded_scheduler()
-            .core_threads(num_cpus)
-            .max_threads(num_cpus)
-            .build()
-            .expect("failed to build threaded runtime!"),
+        0 | 1 => {
+            info!("Using single-threaded proxy runtime");
+            Builder::new()
+                .enable_all()
+                .thread_name("proxy")
+                .basic_scheduler()
+                .build()
+                .expect("failed to build basic runtime!")
+        }
+        num_cpus => {
+            info!(%cores, "Using multi-threaded proxy runtime");
+            Builder::new()
+                .enable_all()
+                .thread_name("proxy")
+                .threaded_scheduler()
+                .core_threads(num_cpus)
+                .max_threads(num_cpus)
+                .build()
+                .expect("failed to build threaded runtime!")
+        }
     }
 }
 


### PR DESCRIPTION
When testing the proxy (i.e. outside of Kubernetes), it can be desirable
to limit the number of cores the proxy uses. This change introduces a
`LINKERD2_PROXY_CORE` environment that overrides the `num-cpus`-based
detection.