### PR TITLE
http: Configure client connection pools

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -1,5 +1,5 @@
 pub use crate::exp_backoff::ExponentialBackoff;
-pub use crate::proxy::http::h2;
+pub use crate::proxy::http::{h1, h2};
 pub use crate::transport::{Bind, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr};
 use std::time::Duration;
 
@@ -14,6 +14,7 @@ pub struct ConnectConfig {
     pub backoff: ExponentialBackoff,
     pub timeout: Duration,
     pub keepalive: Option<Duration>,
+    pub h1_settings: h1::PoolSettings,
     pub h2_settings: h2::Settings,
 }
 

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -204,7 +204,10 @@ impl Config {
 
         // Creates HTTP clients for each inbound port & HTTP settings.
         let endpoint = svc::stack(tcp_connect)
-            .push(http::client::layer(connect.h2_settings))
+            .push(http::client::layer(
+                connect.h1_settings,
+                connect.h2_settings,
+            ))
             .push(reconnect::layer({
                 let backoff = connect.backoff.clone();
                 move |_| Ok(backoff.stream())

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -41,7 +41,7 @@ where
         // Initiates an HTTP client on the underlying transport. Prior-knowledge HTTP/2
         // is typically used (i.e. when communicating with other proxies); though
         // HTTP/1.x fallback is supported as needed.
-        .push(http::client::layer(config.h2_settings))
+        .push(http::client::layer(config.h1_settings, config.h2_settings))
         // Re-establishes a connection when the client fails.
         .push(reconnect::layer({
             let backoff = config.backoff.clone();

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -2,7 +2,10 @@ use crate::Config;
 pub use futures::prelude::*;
 pub use ipnet::IpNet;
 use linkerd2_app_core::{
-    config, exp_backoff, profiles, proxy::http::h2, transport::listen, IpMatch,
+    config, exp_backoff, profiles,
+    proxy::http::{h1, h2},
+    transport::listen,
+    IpMatch,
 };
 pub use linkerd2_app_test as support;
 use std::{net::SocketAddr, str::FromStr, time::Duration};
@@ -33,6 +36,10 @@ pub fn default_config(orig_dst: SocketAddr) -> Config {
                     0.1,
                 )
                 .unwrap(),
+                h1_settings: h1::PoolSettings {
+                    max_idle: 1,
+                    idle_timeout: Duration::from_secs(1),
+                },
                 h2_settings: h2::Settings::default(),
             },
             buffer_capacity: 10_000,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -192,8 +192,8 @@ const DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE: u32 = 1048576; // 1MB ~ 16 streams
 // 10_000 is arbitrarily chosen for now...
 const DEFAULT_BUFFER_CAPACITY: usize = 10_000;
 
-const DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(60);
-const DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(60);
+const DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(10);
+const DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(3);
 
 const DEFAULT_INBOUND_MAX_IDLE_PER_ENDPOINT: usize = std::usize::MAX;
 const DEFAULT_OUTBOUND_MAX_IDLE_PER_ENDPOINT: usize = std::usize::MAX;

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -82,8 +82,9 @@ pub const ENV_BUFFER_CAPACITY: &str = "LINKERD2_PROXY_BUFFER_CAPACITY";
 pub const ENV_INBOUND_ROUTER_MAX_IDLE_AGE: &str = "LINKERD2_PROXY_INBOUND_ROUTER_MAX_IDLE_AGE";
 pub const ENV_OUTBOUND_ROUTER_MAX_IDLE_AGE: &str = "LINKERD2_PROXY_OUTBOUND_ROUTER_MAX_IDLE_AGE";
 
-const ENV_INBOUND_MAX_IDLE_PER_ENDPOINT: &str = "LINKERD2_PROXY_MAX_IDLE_PER_ENDPOINT";
-const ENV_OUTBOUND_MAX_IDLE_PER_ENDPOINT: &str = "LINKERD2_PROXY_OUTBOUND_MAX_IDLE_PER_ENDPOINT";
+const ENV_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: &str = "LINKERD2_PROXY_MAX_IDLE_CONNS_PER_ENDPOINT";
+const ENV_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: &str =
+    "LINKERD2_PROXY_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT";
 
 pub const ENV_INBOUND_MAX_IN_FLIGHT: &str = "LINKERD2_PROXY_INBOUND_MAX_IN_FLIGHT";
 pub const ENV_OUTBOUND_MAX_IN_FLIGHT: &str = "LINKERD2_PROXY_OUTBOUND_MAX_IN_FLIGHT";
@@ -192,11 +193,26 @@ const DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE: u32 = 1048576; // 1MB ~ 16 streams
 // 10_000 is arbitrarily chosen for now...
 const DEFAULT_BUFFER_CAPACITY: usize = 10_000;
 
-const DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(10);
-const DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(3);
+// This configuration limits the amount of time Linkerd retains cached clients &
+// connections.
+//
+// After this timeout expires, the proxy will need to re-resolve destination
+// metadata. The outbound default of 5s matches Kubernetes' default DNS TTL. On
+// the outbound side, especially, we want to use a limited idle timeout since
+// stale clients/connections can have a severe memory impact, especially when
+// the application communicates with many endpoints or at high concurrency.
+//
+// On the inbound side, we want to be a bit more permissive so that periodic, as
+// the number of endpoints should generally be pretty constrained.
+const DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(20);
+const DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(5);
 
-const DEFAULT_INBOUND_MAX_IDLE_PER_ENDPOINT: usize = std::usize::MAX;
-const DEFAULT_OUTBOUND_MAX_IDLE_PER_ENDPOINT: usize = std::usize::MAX;
+// By default, we don't limit the number of connections a connection pol may
+// use, as doing so can severely impact CPU utilization for applications with
+// many concurrent requests. It's generally preferable to use the MAX_IDLE_AGE
+// limitations to quickly drop idle connections.
+const DEFAULT_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = std::usize::MAX;
+const DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = std::usize::MAX;
 
 // By default, don't accept more requests than we can buffer.
 const DEFAULT_INBOUND_MAX_IN_FLIGHT: usize = DEFAULT_BUFFER_CAPACITY;
@@ -250,10 +266,16 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let outbound_cache_max_idle_age =
         parse(strings, ENV_OUTBOUND_ROUTER_MAX_IDLE_AGE, parse_duration);
 
-    let inbound_max_idle_per_endpoint =
-        parse(strings, ENV_INBOUND_MAX_IDLE_PER_ENDPOINT, parse_number);
-    let outbound_max_idle_per_endoint =
-        parse(strings, ENV_OUTBOUND_MAX_IDLE_PER_ENDPOINT, parse_number);
+    let inbound_max_idle_per_endpoint = parse(
+        strings,
+        ENV_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT,
+        parse_number,
+    );
+    let outbound_max_idle_per_endoint = parse(
+        strings,
+        ENV_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT,
+        parse_number,
+    );
 
     let inbound_max_in_flight = parse(strings, ENV_INBOUND_MAX_IN_FLIGHT, parse_number);
     let outbound_max_in_flight = parse(strings, ENV_OUTBOUND_MAX_IN_FLIGHT, parse_number);
@@ -361,7 +383,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         let cache_max_idle_age =
             outbound_cache_max_idle_age?.unwrap_or(DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE);
         let max_idle =
-            outbound_max_idle_per_endoint?.unwrap_or(DEFAULT_OUTBOUND_MAX_IDLE_PER_ENDPOINT);
+            outbound_max_idle_per_endoint?.unwrap_or(DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT);
         let connect = ConnectConfig {
             keepalive: outbound_connect_keepalive?,
             timeout: outbound_connect_timeout?.unwrap_or(DEFAULT_OUTBOUND_CONNECT_TIMEOUT),
@@ -415,7 +437,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         let cache_max_idle_age =
             inbound_cache_max_idle_age?.unwrap_or(DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE);
         let max_idle =
-            inbound_max_idle_per_endpoint?.unwrap_or(DEFAULT_INBOUND_MAX_IDLE_PER_ENDPOINT);
+            inbound_max_idle_per_endpoint?.unwrap_or(DEFAULT_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT);
         let connect = ConnectConfig {
             keepalive: inbound_connect_keepalive?,
             timeout: inbound_connect_timeout?.unwrap_or(DEFAULT_INBOUND_CONNECT_TIMEOUT),


### PR DESCRIPTION
When an HTTP/1.1 client has many concurent requests, it may create an
arbitrary number of TCP connections. These connections are retained for
90s before they are dropped. In HTTP/1.1. applications communicate at
high concurrency, this can lead to elevated memory requirements.

Similar behavior is observed with HTTP/2 clients (i.e. when using mesh
protocol upgrades) if the application communicates with many unique
services, as is the case for Prometheus.

To address this issue, we want to be more aggressive about tearing down
idle/unused clients. This is primarily achieved by reducing the outbound
"max idle age" setting to 5s, which matches the default Kubernetes DNS
TTL. On the inbound side, the max idle age is set to 20s, as the number
of clients is typically on the order of <5.

Additionally, `MAX_IDLE_CONNS_PER_ENDPOINT` configurations are
introduced to bound the number of idle connections that may be retained
in an HTTP/1.1 client's connection pool. These pools remain unbounded by
default, as this setting causes elevated CPU usage in load tests. It is
generally preferable to bound the length of time an idle
client/connection is cached.