### PR TITLE
outbound: Skip endpoint resolution on profile hint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.14"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.14#76470482fb53c359e6f823d0279d1c7b26030a6a"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=ver/profile-endpoint#c2ad9823c5f5a98d339b41d4bc6ff172667f3bee"
 dependencies = [
  "h2 0.2.6",
  "http 0.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,6 +1407,7 @@ dependencies = [
  "linkerd2-dns-name",
  "linkerd2-error",
  "linkerd2-proxy-api",
+ "linkerd2-proxy-api-resolve",
  "linkerd2-stack",
  "pin-project",
  "prost-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,8 +1168,8 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.1.14"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=ver/profile-endpoint#c2ad9823c5f5a98d339b41d4bc6ff172667f3bee"
+version = "0.1.15"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.15#d260ea21a0e490d863a9ed02bcc051035be9d238"
 dependencies = [
  "h2 0.2.6",
  "http 0.2.1",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -40,7 +40,7 @@ linkerd2-http-metrics = { path = "../../http-metrics" }
 linkerd2-metrics = { path = "../../metrics" }
 linkerd2-opencensus = { path = "../../opencensus" }
 linkerd2-proxy-core = { path = "../../proxy/core" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.15" }
 linkerd2-proxy-api-resolve = { path = "../../proxy/api-resolve" }
 linkerd2-proxy-discover = { path = "../../proxy/discover" }
 linkerd2-proxy-identity = { path = "../../proxy/identity" }
@@ -86,5 +86,5 @@ libc = "0.2"
 procinfo = "0.4.2"
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.15", features = ["arbitrary"] }
 prost-types = "0.6.0"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -40,7 +40,7 @@ linkerd2-http-metrics = { path = "../../http-metrics" }
 linkerd2-metrics = { path = "../../metrics" }
 linkerd2-opencensus = { path = "../../opencensus" }
 linkerd2-proxy-core = { path = "../../proxy/core" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.14" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
 linkerd2-proxy-api-resolve = { path = "../../proxy/api-resolve" }
 linkerd2-proxy-discover = { path = "../../proxy/discover" }
 linkerd2-proxy-identity = { path = "../../proxy/identity" }
@@ -86,5 +86,5 @@ libc = "0.2"
 procinfo = "0.4.2"
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.14", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint", features = ["arbitrary"] }
 prost-types = "0.6.0"

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -262,6 +262,16 @@ impl<S> Stack<S> {
         }))
     }
 
+    pub fn push_switch<T: Clone, U: Clone>(
+        self,
+        switch: T,
+        other: U,
+    ) -> Stack<stack::MakeSwitch<T, S, U>> {
+        self.push(layer::mk(|inner: S| {
+            stack::MakeSwitch::new(switch.clone(), inner, other.clone())
+        }))
+    }
+
     // pub fn box_http_request<B>(self) -> Stack<http::boxed::BoxRequest<S, B>>
     // where
     //     B: hyper::body::HttpBody<Data = http::boxed::Data, Error = Error> + 'static,

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -27,7 +27,7 @@ hyper = "0.13.7"
 linkerd2-app = { path = "..", features = ["mock-orig-dst"] }
 linkerd2-app-core = { path = "../core", features = ["mock-orig-dst"] }
 linkerd2-metrics = { path = "../../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.15", features = ["arbitrary"] }
 linkerd2-app-test = { path = "../test" }
 regex = "0.1"
 socket2 = "0.3.12"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -27,7 +27,7 @@ hyper = "0.13.7"
 linkerd2-app = { path = "..", features = ["mock-orig-dst"] }
 linkerd2-app-core = { path = "../core", features = ["mock-orig-dst"] }
 linkerd2-metrics = { path = "../../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.14", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint", features = ["arbitrary"] }
 linkerd2-app-test = { path = "../test" }
 regex = "0.1"
 socket2 = "0.3.12"

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -5,7 +5,9 @@ use linkerd2_app_core::{
     config::ProxyConfig,
     metrics, profiles,
     proxy::{api_resolve::Metadata, core::Resolve, http},
-    retry, svc, Addr, Error, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER,
+    retry, svc,
+    transport::tls::ReasonForNoPeerName,
+    Addr, Error, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER,
 };
 use tracing::debug_span;
 
@@ -128,7 +130,9 @@ where
                         ))
                         .box_http_request(),
                 )
-                .push_map_target(Endpoint::from)
+                .push_map_target(Endpoint::from_logical(
+                    ReasonForNoPeerName::NotProvidedByServiceDiscovery,
+                ))
                 .into_inner(),
         )
         .into_inner()

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -120,10 +120,10 @@ where
         .check_new_service::<Logical, http::Request<_>>();
 
     svc::stack(service).push_switch(
-        |_: &Logical| true,
+        Logical::should_resolve,
         svc::stack(endpoint)
             .push_on_response(svc::layers().box_http_request())
-            .push_map_target(|l: Logical| Endpoint::from(l))
+            .push_map_target(Endpoint::from)
             .into_inner(),
     )
 }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -48,7 +48,7 @@ where
     } = config.clone();
     let watchdog = cache_max_idle_age * 2;
 
-    svc::stack(endpoint)
+    let service = svc::stack(endpoint.clone())
         .check_new_service::<Endpoint, http::Request<http::boxed::Payload>>()
         .push_on_response(
             svc::layers()
@@ -117,6 +117,7 @@ where
                 .push(svc::layers().box_http_response()),
         )
         .instrument(|l: &Logical| debug_span!("logical", dst = %l.addr()))
-        .check_new_service::<Logical, http::Request<_>>()
-        .into_inner()
+        .check_new_service::<Logical, http::Request<_>>();
+
+    service.into_inner()
 }

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -133,7 +133,8 @@ where
         .check_new_service::<tcp::Logical, transport::metrics::SensorIo<I>>()
         .into_inner();
 
-    svc::stack(svc::stack::MakeSwitch::new(SkipByProfile, http, tcp))
+    svc::stack(http)
+        .push_switch(SkipByProfile, tcp)
         .check_new_service::<tcp::Logical, transport::metrics::SensorIo<I>>()
         .push_map_target(tcp::Logical::from)
         .push(profiles::discover::layer(

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -176,6 +176,13 @@ impl<P> Endpoint<P> {
     }
 }
 
+impl<P> From<Logical<P>> for Endpoint<P> {
+    fn from(logical: Logical<P>) -> Self {
+        //logical.profile.map(|p| p.borrow().endpoint.clone())
+        Self::from_logical(tls::ReasonForNoPeerName::NotProvidedByServiceDiscovery)(logical)
+    }
+}
+
 impl<P> Into<SocketAddr> for Endpoint<P> {
     fn into(self) -> SocketAddr {
         self.addr

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -206,12 +206,6 @@ impl<P> Endpoint<P> {
     }
 }
 
-impl<P> From<Logical<P>> for Endpoint<P> {
-    fn from(logical: Logical<P>) -> Self {
-        Self::from_logical(tls::ReasonForNoPeerName::NotProvidedByServiceDiscovery)(logical)
-    }
-}
-
 impl<P> Into<SocketAddr> for Endpoint<P> {
     fn into(self) -> SocketAddr {
         self.addr

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -2,7 +2,7 @@ use super::{Concrete, Endpoint, Logical};
 use crate::test_util::{
     support::{
         connect::{Connect, ConnectFuture},
-        resolver,
+        profile, resolver,
     },
     *,
 };
@@ -608,6 +608,129 @@ async fn no_profiles_when_outside_search_nets() {
     assert!(
         profile_state.only_configured(),
         "profiles outside the search networks were resolved"
+    );
+}
+
+#[tokio::test(core_threads = 1)]
+async fn no_discovery_when_profile_has_an_endpoint() {
+    let _trace = support::trace_init();
+
+    let ep = SocketAddr::new([10, 0, 0, 41].into(), 5550);
+    let cfg = default_config(ep);
+    let id_name = linkerd2_identity::Name::from_hostname(
+        b"foo.ns1.serviceaccount.identity.linkerd.cluster.local",
+    )
+    .expect("hostname is invalid");
+    let meta = support::resolver::Metadata::new(
+        Default::default(),
+        support::resolver::ProtocolHint::Unknown,
+        Some(id_name.clone()),
+        10_000,
+        None,
+    );
+
+    // Build a mock "connector" that returns the upstream "server" IO.
+    let connect = support::connect().endpoint(
+        ep,
+        Connection {
+            identity: tls::Conditional::Some(id_name.clone()),
+            ..Connection::default()
+        },
+    );
+
+    let resolver = support::resolver::<Addr, support::resolver::Metadata>();
+    let resolve_state = resolver.handle();
+
+    let profiles = profile::resolver().profile(
+        ep,
+        profile::Profile {
+            opaque_protocol: true,
+            endpoint: Some((ep, meta.clone())),
+            ..Default::default()
+        },
+    );
+
+    // Build the outbound server
+    let mut server = build_server(cfg, profiles, resolver, connect);
+
+    hello_world_client(ep, &mut server).await;
+
+    assert!(
+        resolve_state.is_empty(),
+        "proxy tried to resolve endpoints provided by profile discovery!"
+    );
+}
+
+#[tokio::test(core_threads = 1)]
+async fn profile_endpoint_propagates_conn_errors() {
+    // This test asserts that when profile resolution returns an endpoint, and
+    // connecting to that endpoint fails, the proxy will resolve a new endpoint
+    // for subsequent connections to the same original destination.
+    let _trace = support::trace_init();
+
+    let ep1 = SocketAddr::new([10, 0, 0, 41].into(), 5550);
+    let ep2 = SocketAddr::new([10, 0, 0, 42].into(), 5550);
+
+    let cfg = default_config(ep1);
+    let id_name = linkerd2_identity::Name::from_hostname(
+        b"foo.ns1.serviceaccount.identity.linkerd.cluster.local",
+    )
+    .expect("hostname is invalid");
+    let meta = support::resolver::Metadata::new(
+        Default::default(),
+        support::resolver::ProtocolHint::Unknown,
+        Some(id_name.clone()),
+        10_000,
+        None,
+    );
+
+    // Build a mock "connector" that returns the upstream "server" IO.
+    let connect = support::connect()
+        .endpoint_fn(ep1, |_| {
+            Err(Box::new(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "i dont like you, go away",
+            )))
+        })
+        .endpoint(
+            ep2,
+            Connection {
+                identity: tls::Conditional::Some(id_name.clone()),
+                ..Connection::default()
+            },
+        );
+
+    let profiles = profile::resolver();
+    let profile_tx = profiles.profile_tx(ep1);
+    profile_tx
+        .broadcast(profile::Profile {
+            opaque_protocol: true,
+            endpoint: Some((ep1, meta.clone())),
+            ..Default::default()
+        })
+        .expect("still listening to profiles");
+
+    let resolver = support::resolver::<Addr, support::resolver::Metadata>();
+
+    // Build the outbound server
+    let mut server = build_server(cfg, profiles, resolver, connect);
+
+    let svc = server.new_service(listen::Addrs::new(
+        ([127, 0, 0, 1], 4140).into(),
+        ([127, 0, 0, 1], 666).into(),
+        Some(ep1),
+    ));
+
+    let res = svc
+        .oneshot(support::io().read(b"hello\r\n").write(b"world").build())
+        .await
+        .map_err(Into::into);
+    tracing::info!(?res);
+    assert_eq!(
+        res.unwrap_err()
+            .downcast_ref::<io::Error>()
+            .map(io::Error::kind),
+        Some(io::ErrorKind::ConnectionReset)
     );
 }
 

--- a/linkerd/app/test/src/resolver.rs
+++ b/linkerd/app/test/src/resolver.rs
@@ -28,7 +28,7 @@ pub type Profiles<T> = Resolver<T, Option<profiles::Receiver>>;
 #[derive(Debug, Clone)]
 pub struct DstSender<T>(mpsc::UnboundedSender<Result<Update<T>, Error>>);
 
-pub struct ProfileSender(watch::Sender<Profile>);
+pub type ProfileSender = watch::Sender<Profile>;
 
 #[derive(Debug, Clone)]
 pub struct Handle<T, E>(Arc<State<T, E>>);
@@ -144,7 +144,7 @@ where
     pub fn profile_tx(&self, addr: T) -> ProfileSender {
         let (tx, rx) = watch::channel(Profile::default());
         self.state.endpoints.lock().unwrap().insert(addr, Some(rx));
-        ProfileSender(tx)
+        tx
     }
 
     pub fn profile(self, addr: T, profile: Profile) -> Self {

--- a/linkerd/io/src/lib.rs
+++ b/linkerd/io/src/lib.rs
@@ -9,7 +9,7 @@ pub use self::{
     prefixed::PrefixedIo,
     sensor::{Sensor, SensorIo},
 };
-pub use std::io::{Error, Read, Result, Write};
+pub use std::io::{Error, ErrorKind, Read, Result, Write};
 use std::net::SocketAddr;
 pub use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -12,7 +12,7 @@ Implements the Resolve trait using the proxy's gRPC API
 async-stream = "0.2.1"
 futures = "0.3"
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.15" }
 linkerd2-proxy-core = { path = "../core" }
 prost = "0.6"
 http = "0.2"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -12,7 +12,7 @@ Implements the Resolve trait using the proxy's gRPC API
 async-stream = "0.2.1"
 futures = "0.3"
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.14" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
 linkerd2-proxy-core = { path = "../core" }
 prost = "0.6"
 http = "0.2"

--- a/linkerd/proxy/api-resolve/src/lib.rs
+++ b/linkerd/proxy/api-resolve/src/lib.rs
@@ -6,7 +6,7 @@ use linkerd2_proxy_api as api;
 use linkerd2_proxy_core as core;
 
 mod metadata;
-mod pb;
+pub mod pb;
 mod resolve;
 
 pub use self::metadata::{Metadata, ProtocolHint};

--- a/linkerd/proxy/api-resolve/src/pb.rs
+++ b/linkerd/proxy/api-resolve/src/pb.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use std::{collections::HashMap, net::SocketAddr};
 
 /// Construct a new labeled `SocketAddr `from a protobuf `WeightedAddr`.
-pub(in crate) fn to_addr_meta(
+pub fn to_addr_meta(
     pb: WeightedAddr,
     set_labels: &HashMap<String, String>,
 ) -> Option<(SocketAddr, Metadata)> {

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 futures = "0.3"
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.15" }
 linkerd2-proxy-transport = { path = "../transport" }
 tokio = { version = "0.2", features = ["time", "sync"] }
 tonic = { version = "0.3", default-features = false }

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 futures = "0.3"
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.14" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
 linkerd2-proxy-transport = { path = "../transport" }
 tokio = { version = "0.2", features = ["time", "sync"] }
 tonic = { version = "0.3", default-features = false }

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -15,7 +15,7 @@ ipnet = "2.0"
 linkerd2-conditional = { path = "../../conditional" }
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.15" }
 linkerd2-proxy-http = { path = "../http" }
 linkerd2-proxy-transport = { path = "../transport" }
 linkerd2-stack = { path = "../../stack" }
@@ -28,5 +28,5 @@ tracing-futures = "0.2"
 pin-project = "0.4"
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.15", features = ["arbitrary"] }
 prost-types = "0.6.0"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -15,7 +15,7 @@ ipnet = "2.0"
 linkerd2-conditional = { path = "../../conditional" }
 linkerd2-error = { path = "../../error" }
 linkerd2-identity = { path = "../../identity" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.14" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
 linkerd2-proxy-http = { path = "../http" }
 linkerd2-proxy-transport = { path = "../transport" }
 linkerd2-stack = { path = "../../stack" }
@@ -28,5 +28,5 @@ tracing-futures = "0.2"
 pin-project = "0.4"
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.14", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint", features = ["arbitrary"] }
 prost-types = "0.6.0"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = "1.0"
 linkerd2-addr = { path  = "../addr" }
 linkerd2-dns-name = { path  = "../dns/name" }
 linkerd2-error = { path  = "../error" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.15" }
 linkerd2-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd2-stack = { path  = "../stack" }
 rand = { version = "0.7", features = ["small_rng"] }
@@ -40,6 +40,6 @@ features = [
 ]
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.15", features = ["arbitrary"] }
 prost-types = "0.6.0"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -17,7 +17,7 @@ indexmap = "1.0"
 linkerd2-addr = { path  = "../addr" }
 linkerd2-dns-name = { path  = "../dns/name" }
 linkerd2-error = { path  = "../error" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.14" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
 linkerd2-stack = { path  = "../stack" }
 rand = { version = "0.7", features = ["small_rng"] }
 regex = "1.0.0"
@@ -39,6 +39,6 @@ features = [
 ]
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.14", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint", features = ["arbitrary"] }
 prost-types = "0.6.0"
 quickcheck = { version = "0.9", default-features = false }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -18,6 +18,7 @@ linkerd2-addr = { path  = "../addr" }
 linkerd2-dns-name = { path  = "../dns/name" }
 linkerd2-error = { path  = "../error" }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "ver/profile-endpoint" }
+linkerd2-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd2-stack = { path  = "../stack" }
 rand = { version = "0.7", features = ["small_rng"] }
 regex = "1.0.0"

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -6,6 +6,7 @@ use linkerd2_addr::Addr;
 use linkerd2_dns_name::Name;
 use linkerd2_error::{Error, Recover};
 use linkerd2_proxy_api::destination as api;
+use linkerd2_proxy_api_resolve::pb as resolve;
 use pin_project::pin_project;
 use regex::Regex;
 use std::{
@@ -241,11 +242,16 @@ where
                     .into_iter()
                     .filter_map(convert_dst_override)
                     .collect();
+                let endpoint = proto.endpoint.and_then(|e| {
+                    let labels = std::collections::HashMap::new();
+                    resolve::to_addr_meta(e, &labels)
+                });
                 Profile {
                     name,
                     http_routes,
                     targets,
                     opaque_protocol: proto.opaque_protocol,
+                    endpoint,
                 }
             })
         });

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -3,8 +3,10 @@
 use linkerd2_addr::Addr;
 use linkerd2_dns_name::Name;
 use linkerd2_error::Error;
+use linkerd2_proxy_api_resolve::Metadata;
 use std::{
     future::Future,
+    net::SocketAddr,
     task::{Context, Poll},
 };
 use tower::util::{Oneshot, ServiceExt};
@@ -25,6 +27,7 @@ pub struct Profile {
     pub http_routes: Vec<(self::http::RequestMatch, self::http::Route)>,
     pub targets: Vec<Target>,
     pub opaque_protocol: bool,
+    pub endpoint: Option<(SocketAddr, Metadata)>,
 }
 
 #[derive(Clone, Debug)]

--- a/linkerd/stack/src/fail_on_error.rs
+++ b/linkerd/stack/src/fail_on_error.rs
@@ -1,0 +1,88 @@
+use linkerd2_error::Error;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug)]
+pub struct FailOnError<E, S> {
+    inner: S,
+    error: Arc<Mutex<Option<SharedError>>>,
+    _marker: std::marker::PhantomData<E>,
+}
+
+#[derive(Clone, Debug)]
+struct SharedError(Arc<Error>);
+
+impl<E, S> FailOnError<E, S> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            error: Arc::new(Mutex::new(None)),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<E, S, Req> tower::Service<Req> for FailOnError<E, S>
+where
+    S: tower::Service<Req>,
+    S::Response: Send,
+    S::Error: Into<Error> + Send,
+    S::Future: Send + 'static,
+    E: std::error::Error + 'static,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<S::Response, Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+        futures::ready!(self.inner.poll_ready(cx).map_err(Into::into))?;
+        if let Ok(e) = self.error.try_lock() {
+            if let Some(e) = &*e {
+                return Poll::Ready(Err(e.clone().into()));
+            }
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        let fut = self.inner.call(req);
+        let error = self.error.clone();
+        Box::pin(async move {
+            match fut.await {
+                Ok(rsp) => Ok(rsp),
+                Err(e) => {
+                    let e = e.into();
+                    if is_error::<E>(&*e) {
+                        let e = SharedError(Arc::new(e));
+                        let mut error = error.lock().await;
+                        *error = Some(e.clone());
+                        Err(e.into())
+                    } else {
+                        Err(e)
+                    }
+                }
+            }
+        })
+    }
+}
+
+fn is_error<E: std::error::Error + 'static>(e: &(dyn std::error::Error + 'static)) -> bool {
+    e.is::<E>() || e.source().map(is_error::<E>).unwrap_or(false)
+}
+
+impl std::fmt::Display for SharedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::error::Error for SharedError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&**self.0.as_ref())
+    }
+}

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![deny(warnings, rust_2018_idioms)]
 
+mod fail_on_error;
 mod future_service;
 pub mod layer;
 pub mod make_ready;
@@ -18,6 +19,7 @@ pub mod router;
 mod switch;
 mod switch_ready;
 
+pub use self::fail_on_error::FailOnError;
 pub use self::future_service::FutureService;
 pub use self::make_ready::{MakeReady, MakeReadyLayer};
 pub use self::make_thunk::MakeThunk;

--- a/linkerd/stack/src/switch.rs
+++ b/linkerd/stack/src/switch.rs
@@ -20,6 +20,12 @@ pub struct MakeSwitch<S, P, F> {
     fallback: F,
 }
 
+impl<T, F: Fn(&T) -> bool> Switch<T> for F {
+    fn use_primary(&self, target: &T) -> bool {
+        (self)(target)
+    }
+}
+
 impl<S, P, F> MakeSwitch<S, P, F> {
     pub fn new(switch: S, primary: P, fallback: F) -> Self {
         MakeSwitch {


### PR DESCRIPTION
Profile resolutions may provide an endpoint response when the
target is a pod or otherwise known endpoint. When these endpoints fail
requests with an I/O error, we assume that the endpoint is defunct and
fail the service so that subsequent connections require a new
resolution.