### PR TITLE
h2: enable HTTP/2 keepalive PING frames

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -371,28 +371,36 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let ingress_mode = parse(strings, ENV_INGRESS_MODE, parse_bool)?.unwrap_or(false);
 
     let outbound = {
+        let keepalive = outbound_accept_keepalive?;
         let bind = listen::Bind::new(
             outbound_listener_addr?
                 .unwrap_or_else(|| parse_socket_addr(DEFAULT_OUTBOUND_LISTEN_ADDR).unwrap()),
-            outbound_accept_keepalive?,
+            keepalive,
         );
         let server = ServerConfig {
             bind: bind.with_orig_dst_addr(outbound_orig_dst),
-            h2_settings,
+            h2_settings: h2::Settings {
+                keepalive_timeout: keepalive,
+                ..h2_settings
+            },
         };
         let cache_max_idle_age =
             outbound_cache_max_idle_age?.unwrap_or(DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE);
         let max_idle =
             outbound_max_idle_per_endoint?.unwrap_or(DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT);
+        let keepalive = outbound_connect_keepalive?;
         let connect = ConnectConfig {
-            keepalive: outbound_connect_keepalive?,
+            keepalive,
             timeout: outbound_connect_timeout?.unwrap_or(DEFAULT_OUTBOUND_CONNECT_TIMEOUT),
             backoff: parse_backoff(
                 strings,
                 OUTBOUND_CONNECT_BASE,
                 DEFAULT_OUTBOUND_CONNECT_BACKOFF,
             )?,
-            h2_settings,
+            h2_settings: h2::Settings {
+                keepalive_timeout: Keepalive,
+                ..h2_settings,
+            },
             h1_settings: h1::PoolSettings {
                 max_idle,
                 idle_timeout: cache_max_idle_age,
@@ -425,28 +433,36 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     };
 
     let inbound = {
+        let keepalive = inbound_accept_keepalive?;
         let bind = listen::Bind::new(
             inbound_listener_addr?
                 .unwrap_or_else(|| parse_socket_addr(DEFAULT_INBOUND_LISTEN_ADDR).unwrap()),
-            inbound_accept_keepalive?,
+            keepalive,
         );
         let server = ServerConfig {
             bind: bind.with_orig_dst_addr(inbound_orig_dst),
-            h2_settings,
+            h2_settings: h2::Settings {
+                keepalive_timeout: keepalive,
+                ..h2_settings
+            },
         };
         let cache_max_idle_age =
             inbound_cache_max_idle_age?.unwrap_or(DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE);
         let max_idle =
             inbound_max_idle_per_endpoint?.unwrap_or(DEFAULT_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT);
+        let keepalive = inbound_connect_keepalive?;
         let connect = ConnectConfig {
-            keepalive: inbound_connect_keepalive?,
+            keepalive,
             timeout: inbound_connect_timeout?.unwrap_or(DEFAULT_INBOUND_CONNECT_TIMEOUT),
             backoff: parse_backoff(
                 strings,
                 INBOUND_CONNECT_BASE,
                 DEFAULT_INBOUND_CONNECT_BACKOFF,
             )?,
-            h2_settings,
+            h2_settings: h2::Settings {
+                keepalive_timeout: keepalive,
+                ..h2_settings
+            },
             h1_settings: h1::PoolSettings {
                 max_idle,
                 idle_timeout: cache_max_idle_age,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -340,6 +340,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         initial_connection_window_size: Some(
             initial_connection_window_size?.unwrap_or(DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE),
         ),
+        ..Default::default()
     };
 
     let buffer_capacity = buffer_capacity?.unwrap_or(DEFAULT_BUFFER_CAPACITY);
@@ -399,7 +400,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             )?,
             h2_settings: h2::Settings {
                 keepalive_timeout: Keepalive,
-                ..h2_settings,
+                ..h2_settings
             },
             h1_settings: h1::PoolSettings {
                 max_idle,

--- a/linkerd/proxy/http/src/detect.rs
+++ b/linkerd/proxy/http/src/detect.rs
@@ -58,6 +58,16 @@ impl<F, H> DetectHttp<F, H> {
             .http2_initial_stream_window_size(h2.initial_stream_window_size)
             .http2_initial_connection_window_size(h2.initial_connection_window_size);
 
+        // Configure HTTP/2 PING frames
+        if let Some(timeout) = h2.keepalive_timeout {
+            // XXX(eliza): is this a reasonable interval between
+            // PING frames?
+            let interval = timeout / 4;
+            server
+                .http2_keep_alive_timeout(timeout)
+                .http2_keep_alive_interval(interval);
+        }
+
         Self {
             server,
             tcp,

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -110,7 +110,7 @@ where
                         .http2_keep_alive_while_idle(true);
                 }
 
-                let (tx, conn) = conn::Builder::new()
+                let (tx, conn) = builder
                     .handshake(io)
                     .instrument(trace_span!("handshake"))
                     .await?;


### PR DESCRIPTION
This branch enables HTTP/2 PING frames in the proxy's HTTP/2 clients and
servers. The timeout for responding to a PING frame is configured based
on the `{INBOUND, OUTBOUND}_{CONNECT, ACCEPT}_KEEPALIVE` env variables,
and the interval between PING frames is currently 1/4th of the timeout.
I'm happy to change that if anyone has better ideas.

Collecting metrics related to H2 PINGs probably requires support in 
Hyper that doesn't currently exist, so this PR doesn't add that. We 
can implement metrics in a follow-up, as it's lower priority.

Closes linkerd/linkerd2#1580