### PR TITLE
actions: Add timeouts to GitHub workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   docker:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
             strip: arm-linux-gnueabihf-strip
     name: Package (${{ matrix.architecture }})
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - name: git co
         uses: actions/checkout@v1
@@ -61,6 +62,7 @@ jobs:
     needs: [package]
     name: GitHub Release
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: git co
         uses: actions/checkout@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   fmt:
+    timeout-minutes: 5
     runs-on: ubuntu-18.04
     container:
       image: docker://rust:1.47.0-buster
@@ -17,6 +18,7 @@ jobs:
       - run: make check-fmt
 
   check:
+    timeout-minutes: 5
     runs-on: ubuntu-18.04
     container:
       image: docker://rust:1.47.0-buster
@@ -25,6 +27,7 @@ jobs:
       - run: make check
 
   test:
+    timeout-minutes: 15
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
In order to prevent runaway tests from consuming actions resources, we
set reasonable default timeouts for each job. This replaces the default
6 hour(!) timeout.