### PR TITLE
io: Set a minimum detect buffer size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-test",
+ "tracing",
 ]
 
 [[package]]

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -384,7 +384,7 @@ impl Config {
         ))
         .push_on_response(svc::layers().push_spawn_buffer(buffer_capacity).push(
             transport::Prefix::layer(
-                http::Version::DETECT_BUFFER_MINIMUM,
+                0,
                 http::Version::DETECT_BUFFER_CAPACITY,
                 detect_protocol_timeout,
             ),

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -384,6 +384,7 @@ impl Config {
         ))
         .push_on_response(svc::layers().push_spawn_buffer(buffer_capacity).push(
             transport::Prefix::layer(
+                http::Version::DETECT_BUFFER_MINIMUM,
                 http::Version::DETECT_BUFFER_CAPACITY,
                 detect_protocol_timeout,
             ),

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -136,7 +136,7 @@ where
         .check_new_service::<tcp::Accept, io::PrefixedIo<transport::metrics::SensorIo<I>>>()
         .push_on_response(svc::layers().push_spawn_buffer(buffer_capacity).push(
             transport::Prefix::layer(
-                http::Version::DETECT_BUFFER_MINIMUM,
+                0,
                 http::Version::DETECT_BUFFER_CAPACITY,
                 detect_protocol_timeout,
             ),

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -136,6 +136,7 @@ where
         .check_new_service::<tcp::Accept, io::PrefixedIo<transport::metrics::SensorIo<I>>>()
         .push_on_response(svc::layers().push_spawn_buffer(buffer_capacity).push(
             transport::Prefix::layer(
+                http::Version::DETECT_BUFFER_MINIMUM,
                 http::Version::DETECT_BUFFER_CAPACITY,
                 detect_protocol_timeout,
             ),

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -119,7 +119,7 @@ where
     .check_new_service::<tcp::Logical, transport::io::PrefixedIo<transport::metrics::SensorIo<I>>>()
     .push_on_response(svc::layers().push_spawn_buffer(buffer_capacity).push(
         transport::Prefix::layer(
-            http::Version::DETECT_BUFFER_MINIMUM,
+            0,
             http::Version::DETECT_BUFFER_CAPACITY,
             detect_protocol_timeout,
         ),

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -119,6 +119,7 @@ where
     .check_new_service::<tcp::Logical, transport::io::PrefixedIo<transport::metrics::SensorIo<I>>>()
     .push_on_response(svc::layers().push_spawn_buffer(buffer_capacity).push(
         transport::Prefix::layer(
+            http::Version::DETECT_BUFFER_MINIMUM,
             http::Version::DETECT_BUFFER_CAPACITY,
             detect_protocol_timeout,
         ),

--- a/linkerd/io/Cargo.toml
+++ b/linkerd/io/Cargo.toml
@@ -15,10 +15,11 @@ default = []
 futures = "0.3"
 bytes = "0.5"
 linkerd2-errno = { path = "../errno" }
+pin-project = "0.4"
 tokio = { version = "0.2", features = ["io-util", "net", "macros"] }
 tokio-rustls = "0.14.1"
 tokio-test = { version = "0.2", optional = true }
-pin-project = "0.4"
+tracing = "0.1"
 
 [dev-dependencies]
 tokio-test = "0.2"

--- a/linkerd/io/Cargo.toml
+++ b/linkerd/io/Cargo.toml
@@ -19,3 +19,6 @@ tokio = { version = "0.2", features = ["io-util", "net", "macros"] }
 tokio-rustls = "0.14.1"
 tokio-test = { version = "0.2", optional = true }
 pin-project = "0.4"
+
+[dev-dependencies]
+tokio-test = "0.2"

--- a/linkerd/io/src/peek.rs
+++ b/linkerd/io/src/peek.rs
@@ -14,17 +14,18 @@ pub struct Peek<T>(Option<Inner<T>>);
 #[derive(Debug)]
 struct Inner<T> {
     buf: BytesMut,
+    minimum: usize,
 
     #[pin]
     io: T,
 }
 
 pub trait Peekable: AsyncRead + AsyncWrite + Unpin {
-    fn peek(self, capacity: usize) -> Peek<Self>
+    fn peek(self, minimum: usize, capacity: usize) -> Peek<Self>
     where
         Self: Sized,
     {
-        Peek::with_capacity(capacity, self)
+        Peek::with_capacity(minimum, capacity, self)
     }
 }
 
@@ -33,12 +34,12 @@ impl<I: AsyncRead + AsyncWrite + Unpin> Peekable for I {}
 // === impl Peek ===
 
 impl<T: AsyncRead + AsyncWrite> Peek<T> {
-    pub fn with_capacity(capacity: usize, io: T) -> Self
+    pub fn with_capacity(minimum: usize, capacity: usize, io: T) -> Self
     where
         Self: Sized + Future,
     {
         let buf = BytesMut::with_capacity(capacity);
-        Peek(Some(Inner { buf, io }))
+        Peek(Some(Inner { buf, io, minimum }))
     }
 }
 
@@ -52,7 +53,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Future for Peek<T> {
             .as_mut()
             .expect("polled after complete")
             .poll_peek(cx))?;
-        let Inner { buf, io } = this.0.take().expect("polled after complete");
+        let Inner { buf, io, .. } = this.0.take().expect("polled after complete");
         Poll::Ready(Ok(PrefixedIo::new(buf.freeze(), io)))
     }
 }
@@ -61,9 +62,47 @@ impl<T: AsyncRead + AsyncWrite + Unpin> Future for Peek<T> {
 
 impl<T: AsyncRead + Unpin> Inner<T> {
     fn poll_peek(&mut self, cx: &mut Context<'_>) -> Poll<Result<usize, io::Error>> {
-        if self.buf.capacity() == 0 {
-            return Poll::Ready(Ok(self.buf.len()));
+        loop {
+            match futures::ready!(Pin::new(&mut self.io).poll_read_buf(cx, &mut self.buf)) {
+                Ok(sz) => {
+                    // Return the number of buffered bytes if the inner stream
+                    // has completed, the buffer is full, or the minimum buffer
+                    // size has been met.
+                    if sz == 0 || self.buf.len() >= self.minimum {
+                        return Poll::Ready(Ok(self.buf.len()));
+                    }
+                    // Otherwise, continue reading.
+                }
+                Err(e) => return Poll::Ready(Err(e)),
+            }
         }
-        Pin::new(&mut self.io).poll_read_buf(cx, &mut self.buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Peekable;
+
+    #[tokio::test]
+    async fn peek_minimum() {
+        let io = tokio_test::io::Builder::new()
+            .read(b"foo")
+            .read(b"barbazbah")
+            .build()
+            .peek(6, 9)
+            .await
+            .unwrap();
+        assert_eq!(io.prefix().as_ref(), b"foobarbaz");
+    }
+
+    #[tokio::test]
+    async fn peek_eof() {
+        let io = tokio_test::io::Builder::new()
+            .read(b"foo")
+            .build()
+            .peek(6, 6)
+            .await
+            .unwrap();
+        assert_eq!(io.prefix().as_ref(), b"foo");
     }
 }

--- a/linkerd/io/src/peek.rs
+++ b/linkerd/io/src/peek.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use tracing::trace;
 
 /// A future of when some `Peek` fulfills with some bytes.
 #[derive(Debug)]
@@ -69,9 +70,11 @@ impl<T: AsyncRead + Unpin> Inner<T> {
                     // has completed, the buffer is full, or the minimum buffer
                     // size has been met.
                     if sz == 0 || self.buf.len() >= self.minimum {
+                        trace!(buf=%self.buf.len(), "Complete");
                         return Poll::Ready(Ok(self.buf.len()));
                     }
                     // Otherwise, continue reading.
+                    trace!(sz, "Read");
                 }
                 Err(e) => return Poll::Ready(Err(e)),
             }

--- a/linkerd/proxy/http/src/version.rs
+++ b/linkerd/proxy/http/src/version.rs
@@ -21,8 +21,9 @@ impl std::convert::TryFrom<http::Version> for Version {
 }
 
 impl Version {
-    pub const DETECT_BUFFER_CAPACITY: usize = 8192;
     const H2_PREFACE: &'static [u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+    pub const DETECT_BUFFER_MINIMUM: usize = Self::H2_PREFACE.len();
+    pub const DETECT_BUFFER_CAPACITY: usize = 8192;
 
     /// Tries to detect a known protocol in the peeked bytes.
     ///

--- a/linkerd/proxy/http/src/version.rs
+++ b/linkerd/proxy/http/src/version.rs
@@ -22,7 +22,6 @@ impl std::convert::TryFrom<http::Version> for Version {
 
 impl Version {
     const H2_PREFACE: &'static [u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
-    pub const DETECT_BUFFER_MINIMUM: usize = Self::H2_PREFACE.len();
     pub const DETECT_BUFFER_CAPACITY: usize = 8192;
 
     /// Tries to detect a known protocol in the peeked bytes.


### PR DESCRIPTION
If a client writes a partial message, `io::Peek` may return incomplete
data. This change modifies the `io::Peek` future to have a minimum
buffer size.

This is primarily necessary for upcoming server-first TCP mTLS wrapping.