### PR TITLE
Introduce a connection-header module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,6 +1078,22 @@ name = "linkerd2-conditional"
 version = "0.1.0"
 
 [[package]]
+name = "linkerd2-connection-header"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes 0.6.0",
+ "linkerd2-dns-name",
+ "linkerd2-error",
+ "linkerd2-io",
+ "linkerd2-proxy-transport",
+ "prost",
+ "prost-build",
+ "tokio 0.3.5",
+ "tokio-test 0.3.0",
+]
+
+[[package]]
 name = "linkerd2-dns"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "linkerd/channel",
     "linkerd/concurrency-limit",
     "linkerd/conditional",
+    "linkerd/connection-header",
     "linkerd/dns/name",
     "linkerd/dns",
     "linkerd/drain",

--- a/linkerd/connection-header/Cargo.toml
+++ b/linkerd/connection-header/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "linkerd2-connection-header"
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+edition = "2018"
+publish = false
+
+[dependencies]
+async-trait = "0.1"
+bytes = "0.6"
+linkerd2-dns-name = { path = "../dns/name" }
+linkerd2-error = { path = "../error" }
+linkerd2-io = { path = "../io" }
+linkerd2-proxy-transport = { path = "../proxy/transport" }
+prost = "0.6"
+
+[build-dependencies]
+prost-build = { version = "0.6", default-features = false }
+
+[dev-dependencies]
+tokio = { version = "0.3", features = ["macros"] }
+tokio-test = "0.3"

--- a/linkerd/connection-header/build.rs
+++ b/linkerd/connection-header/build.rs
@@ -1,0 +1,13 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let files = &["proto/header.proto"];
+    let dirs = &["proto"];
+
+    prost_build::compile_protos(files, dirs)?;
+
+    // recompile protobufs only if any of the proto files changes.
+    for file in files {
+        println!("cargo:rerun-if-changed={}", file);
+    }
+
+    Ok(())
+}

--- a/linkerd/connection-header/proto/header.proto
+++ b/linkerd/connection-header/proto/header.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package header.proxy.l5d.io;
+
+message Header {
+  // The target port.
+  int32 port = 1;
+
+  // An optional hostname. Intended for gateway forwarding.
+  string name = 2;
+}

--- a/linkerd/connection-header/src/lib.rs
+++ b/linkerd/connection-header/src/lib.rs
@@ -1,0 +1,271 @@
+use bytes::{
+    buf::{Buf, BufMut},
+    BytesMut,
+};
+use linkerd2_dns_name::Name;
+use linkerd2_error::Error;
+use linkerd2_io::{self as io, AsyncReadExt};
+use linkerd2_proxy_transport::Detect;
+use prost::Message;
+use std::str::FromStr;
+
+mod proto {
+    include!(concat!(env!("OUT_DIR"), "/header.proxy.l5d.io.rs"));
+}
+
+#[derive(Clone, Debug)]
+pub struct Header {
+    /// The target port.
+    port: u16,
+
+    /// The logical name of the target (service), if one is known.
+    pub name: Option<Name>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DetectHeader(());
+
+const PREFACE: &[u8] = b"proxy.l5d.io/connect\r\n\r\n";
+const PREFACE_AND_SIZE_LEN: usize = PREFACE.len() + 4;
+
+#[async_trait::async_trait]
+impl Detect for DetectHeader {
+    type Protocol = Header;
+
+    #[inline]
+    async fn detect<I: io::AsyncRead + Send + Unpin + 'static>(
+        &self,
+        io: &mut I,
+        buf: &mut BytesMut,
+    ) -> Result<Option<Header>, Error> {
+        let header = Header::read_prefaced(io, buf).await?;
+        Ok(header)
+    }
+}
+
+impl Header {
+    /// Encodes the connection header to a byte buffer.
+    #[inline]
+    pub fn encode_prefaced(&self, buf: &mut BytesMut) -> Result<(), Error> {
+        buf.reserve(PREFACE_AND_SIZE_LEN);
+        buf.put(PREFACE);
+
+        debug_assert!(buf.capacity() >= 4);
+        // Safety: These bytes must be initialized below once the message has
+        // been encoded.
+        unsafe {
+            buf.advance_mut(4);
+        }
+
+        self.encode(buf)?;
+
+        // Once the message length is known, we back-fill the length at the
+        // start of the buffer.
+        let len = buf.len() - PREFACE_AND_SIZE_LEN;
+        assert!(len <= std::u32::MAX as usize);
+        {
+            let mut buf = &mut buf[PREFACE.len()..PREFACE_AND_SIZE_LEN];
+            buf.put_u32(len as u32);
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn encode(&self, buf: &mut BytesMut) -> Result<(), Error> {
+        let header = proto::Header {
+            port: self.port as i32,
+            name: self
+                .name
+                .as_ref()
+                .map(|n| n.to_string())
+                .unwrap_or_default(),
+        };
+        header.encode(buf)?;
+        Ok(())
+    }
+
+    /// Attempts to decode a connection header from an I/O stream.
+    ///
+    /// If the header is not present, the non-header bytes that were read are
+    /// returned.
+    ///
+    /// An I/O error is returned if the connection header is invalid.
+    #[inline]
+    async fn read_prefaced<I: io::AsyncRead + Unpin + 'static>(
+        io: &mut I,
+        buf: &mut BytesMut,
+    ) -> io::Result<Option<Self>> {
+        // Read at least enough data to determine whether a connection header is
+        // present and, if so, how long it is.
+        while buf.len() < PREFACE_AND_SIZE_LEN {
+            if io.read_buf(buf).await? == 0 {
+                return Ok(None);
+            }
+        }
+
+        // Advance the buffer past the preface if it matches.
+        if &buf.bytes()[..PREFACE.len()] != PREFACE {
+            return Ok(None);
+        }
+        buf.advance(PREFACE.len());
+
+        // Read the message length. If it is larger than our allowed buffer
+        // capacity, fail the connection.
+        let msg_len = buf.get_u32() as usize;
+        if msg_len > buf.capacity() + PREFACE_AND_SIZE_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Message length exceeds capacity",
+            ));
+        }
+
+        // Free up parsed preface data and ensure there's enough capacity for
+        // the message.
+        buf.reserve(msg_len);
+        while buf.len() < msg_len {
+            if io.read_buf(buf).await? == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "Full header message not provided",
+                ));
+            }
+        }
+
+        // Take the bytes needed to parse the message and leave the remaining
+        // bytes in the caller-provided buffer.
+        let msg = buf.split_to(msg_len);
+        Self::decode(msg.freeze())
+    }
+
+    // Decodes a protobuf message from the buffer.
+    #[inline]
+    fn decode<B: Buf>(buf: B) -> io::Result<Option<Self>> {
+        let h = proto::Header::decode(buf)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        let name = if h.name.is_empty() {
+            None
+        } else {
+            let n = Name::from_str(&h.name)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            Some(n)
+        };
+
+        if h.port <= 0 || h.port > std::u16::MAX as i32 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Invalid port value",
+            ));
+        }
+
+        Ok(Some(Self {
+            name,
+            port: h.port as u16,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn roundtrip_prefaced() {
+        let header = Header {
+            port: 4040,
+            name: Some(Name::from_str("foo.bar.example.com").unwrap()),
+        };
+        let mut rx = {
+            let mut buf = BytesMut::new();
+            header.encode_prefaced(&mut buf).expect("must encode");
+            buf.put_slice(b"12345");
+            std::io::Cursor::new(buf.freeze())
+        };
+        let mut buf = BytesMut::new();
+        let h = Header::read_prefaced(&mut rx, &mut buf)
+            .await
+            .expect("decodes")
+            .expect("decodes");
+        assert_eq!(header.port, h.port);
+        assert_eq!(header.name, h.name);
+        assert_eq!(buf.as_ref(), b"12345");
+    }
+
+    #[tokio::test]
+    async fn detect_prefaced() {
+        let header = Header {
+            port: 4040,
+            name: Some(Name::from_str("foo.bar.example.com").unwrap()),
+        };
+        let mut rx = {
+            let mut buf = BytesMut::new();
+            header.encode_prefaced(&mut buf).expect("must encode");
+            buf.put_slice(b"12345");
+            std::io::Cursor::new(buf.freeze())
+        };
+        let mut buf = BytesMut::new();
+        let h = DetectHeader::default()
+            .detect(&mut rx, &mut buf)
+            .await
+            .expect("must decode")
+            .expect("must decode");
+        assert_eq!(header.port, h.port);
+        assert_eq!(header.name, h.name);
+        assert_eq!(&buf[..], b"12345");
+    }
+
+    #[tokio::test]
+    async fn detect_no_header() {
+        const MSG: &[u8] = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        let (mut rx, _tx) = tokio_test::io::Builder::new().read(MSG).build_with_handle();
+        let mut buf = BytesMut::new();
+        let h = DetectHeader::default()
+            .detect(&mut rx, &mut buf)
+            .await
+            .expect("must not fail");
+        assert!(h.is_none(), "must not decode");
+        assert_eq!(&buf[..], MSG);
+    }
+
+    #[tokio::test]
+    async fn many_reads() {
+        let header = Header {
+            port: 4040,
+            name: Some(Name::from_str("foo.bar.example.com").unwrap()),
+        };
+        let mut rx = {
+            let msg = {
+                let mut buf = BytesMut::new();
+                header.encode(&mut buf).expect("must encode");
+                buf.freeze()
+            };
+            let len = {
+                let mut buf = BytesMut::with_capacity(4);
+                buf.put_u32(msg.len() as u32);
+                buf.freeze()
+            };
+            tokio_test::io::Builder::new()
+                .read(b"proxy.l5d")
+                .read(b".io/connect")
+                .read(b"\r\n\r\n")
+                .read(len.as_ref())
+                .read(msg.as_ref())
+                .read(b"12345")
+                .build()
+        };
+        let mut buf = BytesMut::new();
+        let h = Header::read_prefaced(&mut rx, &mut buf)
+            .await
+            .expect("I/O must not error")
+            .expect("header must be present");
+        assert_eq!(header.port, h.port);
+        assert_eq!(header.name, h.name);
+
+        let mut buf = [0u8; 5];
+        rx.read_exact(&mut buf)
+            .await
+            .expect("I/O must still have data");
+        assert_eq!(&buf, b"12345");
+    }
+}

--- a/linkerd/dns/name/src/name.rs
+++ b/linkerd/dns/name/src/name.rs
@@ -73,6 +73,14 @@ impl AsRef<str> for Name {
     }
 }
 
+impl std::fmt::Display for InvalidName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Invalid DNS name")
+    }
+}
+
+impl std::error::Error for InvalidName {}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Proxies are not able to securely transport server-first protocols,
since the server-side proxy cannot now whether to perform TLS detection
or direct forwarding. Similarly, multicluster gateways are unable to
proxy arbitrary TCP connections, since the gateway has no means to
discover the intended target for a connection in the destination
cluster.

In order to address both of these situations, this change introduces a
"connection header" module that can be used to transport routing
information for arbitrary TCP streams. When instrumented in the stack,
this module will allow inbound proxies to receive mTLS connections on a
dedicated port and route the connection to proper destination port.
Similar logic applies for multicluster gateways.

This protocol includes a prefix, `"proxy.l5d.io/connect\r\n\r\n"` so
that proxies can differentiate these streams from HTTP streams.
Following this, a network-endian 4-byte length prefix is encoded,
indicating the number of bytes comprising the protocol header. Finally,
the protocol header is encoded as a protobuf structure. The protobuf
message currently includes a target port, which must be set to indicate
how the connection should be routed, as well as an optional `name`,
which may be used for discovery in the multicluster gateway use case.

This change does not actually instrument the module into the proxy
stacks.