### PR TITLE
add tests; fix profile endpoint TLS ID being ignored

### DIFF
--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -7,7 +7,7 @@ use linkerd2_app_core::{
     proxy::{api_resolve::Metadata, core::resolve::Resolve},
     spans::SpanConverter,
     svc,
-    transport::{self, io, listen},
+    transport::{self, io, listen, tls},
     Addr, Error, IpMatch, TraceContext,
 };
 use std::net::SocketAddr;
@@ -127,7 +127,9 @@ where
     .into_inner();
 
     let tcp = svc::stack(tcp::connect::forward(tcp_connect))
-        .push_map_target(tcp::Endpoint::from)
+        .push_map_target(tcp::Endpoint::from_logical(
+            tls::ReasonForNoPeerName::PortSkipped,
+        ))
         .check_new_service::<tcp::Logical, transport::metrics::SensorIo<I>>()
         .into_inner();
 

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -7,7 +7,7 @@ use linkerd2_app_core::{
     proxy::{api_resolve::Metadata, core::resolve::Resolve},
     spans::SpanConverter,
     svc,
-    transport::{self, io, listen, tls},
+    transport::{self, io, listen},
     Addr, Error, IpMatch, TraceContext,
 };
 use std::net::SocketAddr;
@@ -127,9 +127,7 @@ where
     .into_inner();
 
     let tcp = svc::stack(tcp::connect::forward(tcp_connect))
-        .push_map_target(tcp::Endpoint::from_logical(
-            tls::ReasonForNoPeerName::PortSkipped,
-        ))
+        .push_map_target(tcp::Endpoint::from)
         .check_new_service::<tcp::Logical, transport::metrics::SensorIo<I>>()
         .into_inner();
 

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -661,52 +661,52 @@ async fn no_discovery_when_profile_has_an_endpoint() {
     );
 }
 
-#[tokio::test(core_threads = 1)]
-async fn re_resolves_failed_endpoint() {
-    // This test asserts that when profile resolution returns an endpoint, and
-    // connecting to that endpoint fails, the proxy will resolve a new endpoint
-    // for subsequent connections to the same original destination.
-    let _trace = support::trace_init();
+// #[tokio::test(core_threads = 1)]
+// async fn re_resolves_failed_endpoint() {
+//     // This test asserts that when profile resolution returns an endpoint, and
+//     // connecting to that endpoint fails, the proxy will resolve a new endpoint
+//     // for subsequent connections to the same original destination.
+//     let _trace = support::trace_init();
 
-    let ep1 = SocketAddr::new([10, 0, 0, 41].into(), 5550);
-    let ep2 = SocketAddr::new([10, 0, 0, 42].into(), 5550);
-    let id_name = linkerd2_identity::Name::from_hostname(
-        b"foo.ns1.serviceaccount.identity.linkerd.cluster.local",
-    )
-    .expect("hostname is invalid");
-    let meta = support::resolver::Metadata::new(
-        Default::default(),
-        support::resolver::ProtocolHint::Unknown,
-        Some(id_name.clone()),
-        10_000,
-        None,
-    );
+//     let ep1 = SocketAddr::new([10, 0, 0, 41].into(), 5550);
+//     let ep2 = SocketAddr::new([10, 0, 0, 42].into(), 5550);
+//     let id_name = linkerd2_identity::Name::from_hostname(
+//         b"foo.ns1.serviceaccount.identity.linkerd.cluster.local",
+//     )
+//     .expect("hostname is invalid");
+//     let meta = support::resolver::Metadata::new(
+//         Default::default(),
+//         support::resolver::ProtocolHint::Unknown,
+//         Some(id_name.clone()),
+//         10_000,
+//         None,
+//     );
 
-    // Build a mock "connector" that returns the upstream "server" IO.
-    let connect = support::connect()
-        .endpoint_fn(ep1, |_| {
-            Err(Box::new(io::Error::new(
-                io::ErrorKind::NotConnected,
-                "transport endpoint was weird and i didnt like it lol",
-            )))
-        })
-        .endpoint(
-            ep2,
-            Connection {
-                identity: tls::Conditional::Some(id_name.clone()),
-                ..Connection::default()
-            },
-        );
+//     // Build a mock "connector" that returns the upstream "server" IO.
+//     let connect = support::connect()
+//         .endpoint_fn(ep1, |_| {
+//             Err(Box::new(io::Error::new(
+//                 io::ErrorKind::NotConnected,
+//                 "transport endpoint was weird and i didnt like it lol",
+//             )))
+//         })
+//         .endpoint(
+//             ep2,
+//             Connection {
+//                 identity: tls::Conditional::Some(id_name.clone()),
+//                 ..Connection::default()
+//             },
+//         );
 
-    let profiles = profile::resolver();
-    let profile_tx = profiles.profile_tx(ep1);
-    profile_tx.broadcast(profile::Profile {
-        opaque_protocol: true,
-        endpoint: Some((ep1, meta.clone())),
-        ..Default::default()
-    });
-    todo!("eliza finish this one");
-}
+//     let profiles = profile::resolver();
+//     let profile_tx = profiles.profile_tx(ep1);
+//     profile_tx.broadcast(profile::Profile {
+//         opaque_protocol: true,
+//         endpoint: Some((ep1, meta.clone())),
+//         ..Default::default()
+//     });
+//     todo!("eliza finish this one");
+// }
 
 struct Connection {
     identity: tls::Conditional<linkerd2_identity::Name>,

--- a/linkerd/app/test/src/resolver.rs
+++ b/linkerd/app/test/src/resolver.rs
@@ -28,7 +28,7 @@ pub type Profiles<T> = Resolver<T, Option<profiles::Receiver>>;
 #[derive(Debug, Clone)]
 pub struct DstSender<T>(mpsc::UnboundedSender<Result<Update<T>, Error>>);
 
-pub struct ProfileSender(watch::Sender<Profile>);
+pub type ProfileSender = watch::Sender<Profile>;
 
 #[derive(Debug, Clone)]
 pub struct Handle<T, E>(Arc<State<T, E>>);
@@ -144,7 +144,7 @@ where
     pub fn profile_tx(&self, addr: T) -> ProfileSender {
         let (tx, rx) = watch::channel(Profile::default());
         self.state.endpoints.lock().unwrap().insert(addr, Some(rx));
-        ProfileSender(tx)
+        tx
     }
 
     pub fn profile(self, addr: T, profile: Profile) -> Self {

--- a/linkerd/io/src/lib.rs
+++ b/linkerd/io/src/lib.rs
@@ -9,7 +9,7 @@ pub use self::{
     prefixed::PrefixedIo,
     sensor::{Sensor, SensorIo},
 };
-pub use std::io::{Error, Read, Result, Write};
+pub use std::io::{Error, ErrorKind, Read, Result, Write};
 use std::net::SocketAddr;
 pub use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 


### PR DESCRIPTION
This branch fixes a bug where TLS would never be used for endpoint hints
provided by service profile discovery, even when the profile endpoint
metadata has an identity. This is because the wrong conversion was used
when mapping a `Logical` target into a `tcp::Endpoint`, which always
ignored the profile endpoint metadata.

Additionally, I've added tests for the new behavior added in this
branch, including one which reproduced the above issue, and one for
connection error propagation.