### PR TITLE
Update *ring* to 0.6.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1785,9 +1785,9 @@ checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opencensus-proto"
@@ -2230,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.15"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",

--- a/linkerd/identity/Cargo.toml
+++ b/linkerd/identity/Cargo.toml
@@ -10,7 +10,7 @@ test-util = []
 
 [dependencies]
 linkerd2-dns-name = { path = "../dns/name" }
-ring = "0.16"
+ring = "0.16.19"
 rustls = "0.18"
 tracing = "0.1.2"
 untrusted = "0.7"


### PR DESCRIPTION
Includes latest BoringSSL changes.