### PR TITLE
Rename DetectHttp to NewServeHttp

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -375,7 +375,7 @@ impl Config {
             .check_new_service::<(http::Version, TcpAccept), http::Request<_>>()
             .into_inner();
 
-        svc::stack(http::DetectHttp::new(
+        svc::stack(http::NewServeHttp::new(
             h2_settings,
             http_server,
             svc::stack(tcp_forward)

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -129,7 +129,7 @@ where
         ))
         .into_inner();
 
-    svc::stack(http::DetectHttp::new(h2_settings, http, tcp, drain))
+    svc::stack(http::NewServeHttp::new(h2_settings, http, tcp, drain))
         .check_new_service::<tcp::Accept, io::PrefixedIo<transport::metrics::SensorIo<I>>>()
         .push_on_response(svc::layers().push_spawn_buffer(buffer_capacity).push(
             transport::Prefix::layer(

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -124,7 +124,7 @@ where
     .check_new_service::<tcp::Logical, transport::io::PrefixedIo<transport::metrics::SensorIo<I>>>()
     .into_inner();
 
-    let http = svc::stack(http::DetectHttp::new(
+    let http = svc::stack(http::NewServeHttp::new(
         h2_settings,
         http_server,
         tcp_balance,

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -8,7 +8,6 @@ pub mod add_header;
 pub mod balance;
 pub mod client;
 pub mod client_handle;
-pub mod detect;
 mod glue;
 pub mod h1;
 pub mod h2;
@@ -17,6 +16,7 @@ pub mod insert;
 pub mod normalize_uri;
 pub mod orig_proto;
 pub mod override_authority;
+mod server;
 pub mod strip_header;
 pub mod timeout;
 pub mod trace;
@@ -25,9 +25,9 @@ mod version;
 
 pub use self::{
     client_handle::{ClientHandle, SetClientHandle},
-    detect::DetectHttp,
     glue::{Body as Payload, HyperServerSvc},
     override_authority::CanOverrideAuthority,
+    server::NewServeHttp,
     timeout::MakeTimeoutLayer,
     version::Version,
 };


### PR DESCRIPTION
In preparation for an upcoming change that decouples HTTP detection
logic from server initialization, this chagne renames `DetectHttp` to
`NewServeHttp` and `AcceptHttp` to `ServeHttp`.