### PR TITLE
http: more consistent names for body types

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -275,7 +275,7 @@ impl<S> Stack<S> {
     // pub fn box_http_request<B>(self) -> Stack<http::boxed::BoxRequest<S, B>>
     // where
     //     B: hyper::body::HttpBody<Data = http::boxed::Data, Error = Error> + 'static,
-    //     S: tower::Service<http::Request<http::boxed::Payload>>,
+    //     S: tower::Service<http::Request<http::boxed::BoxBody>>,
     // {
     //     self.push(http::boxed::request::Layer::new())
     // }

--- a/linkerd/app/gateway/src/config.rs
+++ b/linkerd/app/gateway/src/config.rs
@@ -23,8 +23,8 @@ impl Config {
     ) -> impl svc::NewService<
         inbound::Target,
         Service = impl tower::Service<
-            http::Request<http::boxed::Payload>,
-            Response = http::Response<http::boxed::Payload>,
+            http::Request<http::boxed::BoxBody>,
+            Response = http::Response<http::boxed::BoxBody>,
             Error = impl Into<Error>,
             Future = impl Send,
         > + Send
@@ -37,20 +37,20 @@ impl Config {
         P::Error: Send,
         O: svc::NewService<outbound::http::Logical, Service = S> + Clone + Send + 'static,
         S: tower::Service<
-                http::Request<http::boxed::Payload>,
-                Response = http::Response<http::boxed::Payload>,
+                http::Request<http::boxed::BoxBody>,
+                Response = http::Response<http::boxed::BoxBody>,
             > + Send
             + 'static,
         S::Error: Into<Error>,
         S::Future: Send + 'static,
     {
         svc::stack(MakeGateway::new(outbound, local_id))
-            .check_new_service::<super::make::Target, http::Request<http::boxed::Payload>>()
+            .check_new_service::<super::make::Target, http::Request<http::boxed::BoxBody>>()
             .push(profiles::discover::layer(
                 profiles,
                 Allow(self.allow_discovery),
             ))
-            .check_new_service::<inbound::Target, http::Request<http::boxed::Payload>>()
+            .check_new_service::<inbound::Target, http::Request<http::boxed::BoxBody>>()
             .instrument(|_: &inbound::Target| debug_span!("gateway"))
             .into_inner()
     }

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -44,7 +44,7 @@ impl<O> Gateway<O> {
 impl<B, O> tower::Service<http::Request<B>> for Gateway<O>
 where
     B: http::HttpBody + 'static,
-    O: tower::Service<http::Request<B>, Response = http::Response<http::boxed::Payload>>,
+    O: tower::Service<http::Request<B>, Response = http::Response<http::boxed::BoxBody>>,
     O::Error: Into<Error> + 'static,
     O::Future: Send + 'static,
 {

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -120,7 +120,7 @@ mod test {
     }
 
     impl Test {
-        async fn run(self) -> Result<http::Response<http::boxed::Payload>, Error> {
+        async fn run(self) -> Result<http::Response<http::boxed::BoxBody>, Error> {
             let Self {
                 suffix,
                 dst_name,
@@ -129,8 +129,8 @@ mod test {
             } = self;
 
             let (outbound, mut handle) = mock::pair::<
-                http::Request<http::boxed::Payload>,
-                http::Response<http::boxed::Payload>,
+                http::Request<http::boxed::BoxBody>,
+                http::Response<http::boxed::BoxBody>,
             >();
             let mut make_gateway = {
                 let profiles = service_fn(move |na: NameAddr| async move {

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -24,7 +24,7 @@ pub fn stack<B, C>(
     Endpoint,
     Service = impl tower::Service<
         http::Request<B>,
-        Response = http::Response<http::boxed::Payload>,
+        Response = http::Response<http::boxed::BoxBody>,
         Error = Error,
         Future = impl Send,
     > + Send,

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -20,7 +20,7 @@ pub fn stack<B, E, S, R>(
     Logical,
     Service = impl tower::Service<
         http::Request<B>,
-        Response = http::Response<http::boxed::Payload>,
+        Response = http::Response<http::boxed::BoxBody>,
         Error = Error,
         Future = impl Send,
     > + Send,
@@ -32,8 +32,8 @@ where
     B::Data: Send + 'static,
     E: svc::NewService<Endpoint, Service = S> + Clone + Send + Sync + Unpin + 'static,
     S: tower::Service<
-            http::Request<http::boxed::Payload>,
-            Response = http::Response<http::boxed::Payload>,
+            http::Request<http::boxed::BoxBody>,
+            Response = http::Response<http::boxed::BoxBody>,
             Error = Error,
         > + Send
         + 'static,
@@ -51,7 +51,7 @@ where
     let watchdog = cache_max_idle_age * 2;
 
     svc::stack(endpoint.clone())
-        .check_new_service::<Endpoint, http::Request<http::boxed::Payload>>()
+        .check_new_service::<Endpoint, http::Request<http::boxed::BoxBody>>()
         .push_on_response(
             svc::layers()
                 .push(svc::layer::mk(svc::SpawnReady::new))

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -50,8 +50,8 @@ where
     TSvc::Future: Send,
     H: svc::NewService<http::Logical, Service = HSvc> + Unpin + Clone + Send + Sync + 'static,
     HSvc: tower::Service<
-            http::Request<http::boxed::Payload>,
-            Response = http::Response<http::boxed::Payload>,
+            http::Request<http::boxed::BoxBody>,
+            Response = http::Response<http::boxed::BoxBody>,
             Error = Error,
         > + Send
         + 'static,

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -44,8 +44,8 @@ where
     C::Future: Unpin + Send,
     H: svc::NewService<http::Logical, Service = S> + Unpin + Clone + Send + Sync + 'static,
     S: tower::Service<
-            http::Request<http::boxed::Payload>,
-            Response = http::Response<http::boxed::Payload>,
+            http::Request<http::boxed::BoxBody>,
+            Response = http::Response<http::boxed::BoxBody>,
             Error = Error,
         > + Send
         + 'static,

--- a/linkerd/app/test/src/service.rs
+++ b/linkerd/app/test/src/service.rs
@@ -18,8 +18,8 @@ impl<T: std::fmt::Debug> svc::NewService<T> for NoHttp {
     }
 }
 
-impl svc::Service<http::Request<http::boxed::Payload>> for NoHttp {
-    type Response = http::Response<http::boxed::Payload>;
+impl svc::Service<http::Request<http::boxed::BoxBody>> for NoHttp {
+    type Response = http::Response<http::boxed::BoxBody>;
     type Error = Error;
     type Future = futures::future::Ready<Result<Self::Response, Self::Error>>;
     fn poll_ready(
@@ -29,7 +29,7 @@ impl svc::Service<http::Request<http::boxed::Payload>> for NoHttp {
         panic!("http services should not be used in this test!")
     }
 
-    fn call(&mut self, _: http::Request<http::boxed::Payload>) -> Self::Future {
+    fn call(&mut self, _: http::Request<http::boxed::BoxBody>) -> Self::Future {
         panic!("http services should not be used in this test!")
     }
 }

--- a/linkerd/http-box/src/body.rs
+++ b/linkerd/http-box/src/body.rs
@@ -5,7 +5,7 @@ use pin_project::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-pub struct Payload {
+pub struct BoxBody {
     inner: Pin<Box<dyn Body<Data = Data, Error = Error> + Send + 'static>>,
 }
 
@@ -18,17 +18,17 @@ pub struct Data {
 #[pin_project]
 struct Inner<B: Body>(#[pin] B);
 
-struct NoPayload;
+struct NoBody;
 
-impl Default for Payload {
+impl Default for BoxBody {
     fn default() -> Self {
         Self {
-            inner: Box::pin(NoPayload),
+            inner: Box::pin(NoBody),
         }
     }
 }
 
-impl Payload {
+impl BoxBody {
     pub fn new<B>(inner: B) -> Self
     where
         B: Body + Send + 'static,
@@ -41,7 +41,7 @@ impl Payload {
     }
 }
 
-impl Body for Payload {
+impl Body for BoxBody {
     type Data = Data;
     type Error = Error;
 
@@ -123,13 +123,13 @@ where
     }
 }
 
-impl std::fmt::Debug for Payload {
+impl std::fmt::Debug for BoxBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Payload").finish()
+        f.debug_struct("BoxBody").finish()
     }
 }
 
-impl Body for NoPayload {
+impl Body for NoBody {
     type Data = Data;
     type Error = Error;
 

--- a/linkerd/http-box/src/lib.rs
+++ b/linkerd/http-box/src/lib.rs
@@ -1,11 +1,11 @@
 #![deny(warnings, rust_2018_idioms)]
 
-mod payload;
+mod body;
 pub mod request;
 pub mod response;
 
 pub use self::{
-    payload::{Data, Payload},
+    body::{BoxBody, Data},
     request::BoxRequest,
     response::BoxResponse,
 };

--- a/linkerd/http-box/src/request.rs
+++ b/linkerd/http-box/src/request.rs
@@ -1,6 +1,6 @@
 //! A middleware that boxes HTTP request bodies.
 
-use crate::Payload;
+use crate::BoxBody;
 use linkerd2_error::Error;
 use std::task::{Context, Poll};
 
@@ -30,7 +30,7 @@ where
     B: http_body::Body + 'static,
     B::Data: Send + 'static,
     B::Error: Into<Error>,
-    S: tower::Service<http::Request<Payload>>,
+    S: tower::Service<http::Request<BoxBody>>,
     BoxRequest<S, B>: tower::Service<http::Request<B>>,
 {
     type Service = BoxRequest<S, B>;
@@ -51,7 +51,7 @@ where
     B: http_body::Body + Send + 'static,
     B::Data: Send + 'static,
     B::Error: Into<Error>,
-    S: tower::Service<http::Request<Payload>>,
+    S: tower::Service<http::Request<BoxBody>>,
 {
     type Response = S::Response;
     type Error = S::Error;
@@ -62,6 +62,6 @@ where
     }
 
     fn call(&mut self, req: http::Request<B>) -> Self::Future {
-        self.0.call(req.map(Payload::new))
+        self.0.call(req.map(BoxBody::new))
     }
 }

--- a/linkerd/http-box/src/response.rs
+++ b/linkerd/http-box/src/response.rs
@@ -1,6 +1,6 @@
 //! A middleware that boxes HTTP response bodies.
 
-use crate::Payload;
+use crate::BoxBody;
 use futures::{future, TryFutureExt};
 use linkerd2_error::Error;
 use std::task::{Context, Poll};
@@ -32,7 +32,7 @@ where
     B::Data: Send + 'static,
     B::Error: Into<Error> + 'static,
 {
-    type Response = http::Response<Payload>;
+    type Response = http::Response<BoxBody>;
     type Error = S::Error;
     type Future = future::MapOk<S::Future, fn(S::Response) -> Self::Response>;
 
@@ -41,6 +41,6 @@ where
     }
 
     fn call(&mut self, req: Req) -> Self::Future {
-        self.0.call(req).map_ok(|rsp| rsp.map(Payload::new))
+        self.0.call(req).map_ok(|rsp| rsp.map(BoxBody::new))
     }
 }

--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -1,5 +1,5 @@
 use crate::{
-    glue::{Body, HyperConnect},
+    glue::{HyperConnect, UpgradeBody},
     upgrade::{Http11Upgrade, HttpConnect},
 };
 use futures::prelude::*;
@@ -59,8 +59,9 @@ impl<C: Clone, T: Clone, B> Clone for Client<C, T, B> {
     }
 }
 
-type RspFuture =
-    Pin<Box<dyn Future<Output = Result<http::Response<Body>, hyper::Error>> + Send + 'static>>;
+type RspFuture = Pin<
+    Box<dyn Future<Output = Result<http::Response<UpgradeBody>, hyper::Error>> + Send + 'static>,
+>;
 
 impl<C, T, B> Client<C, T, B>
 where
@@ -151,7 +152,7 @@ where
                 strip_connection_headers(rsp.headers_mut());
             }
 
-            rsp.map(Body::from)
+            rsp.map(UpgradeBody::from)
         }))
     }
 }

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -25,7 +25,7 @@ mod version;
 
 pub use self::{
     client_handle::{ClientHandle, SetClientHandle},
-    glue::{Body as Payload, HyperServerSvc},
+    glue::{HyperServerSvc, UpgradeBody as Payload},
     override_authority::CanOverrideAuthority,
     server::NewServeHttp,
     timeout::MakeTimeoutLayer,

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -25,7 +25,7 @@ mod version;
 
 pub use self::{
     client_handle::{ClientHandle, SetClientHandle},
-    glue::{HyperServerSvc, UpgradeBody as Payload},
+    glue::HyperServerSvc,
     override_authority::CanOverrideAuthority,
     server::NewServeHttp,
     timeout::MakeTimeoutLayer,

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -1,4 +1,4 @@
-use super::{glue::Body, h1, h2, upgrade};
+use super::{glue::UpgradeBody, h1, h2, upgrade};
 use futures::{future, prelude::*};
 use http::header::{HeaderValue, TRANSFER_ENCODING};
 use linkerd2_error::Error;
@@ -44,10 +44,13 @@ where
     B::Data: Send,
     B::Error: Into<Error> + Send + Sync,
 {
-    type Response = http::Response<Body>;
+    type Response = http::Response<UpgradeBody>;
     type Error = hyper::Error;
-    type Future =
-        Pin<Box<dyn Future<Output = Result<http::Response<Body>, hyper::Error>> + Send + 'static>>;
+    type Future = Pin<
+        Box<
+            dyn Future<Output = Result<http::Response<UpgradeBody>, hyper::Error>> + Send + 'static,
+        >,
+    >;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.h2.poll_ready(cx)
@@ -101,7 +104,7 @@ where
                 .unwrap_or(orig_version);
             trace!(?version, "Downgrading response");
             *rsp.version_mut() = version;
-            rsp.map(Body::from)
+            rsp.map(UpgradeBody::from)
         }))
     }
 }

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -1,7 +1,7 @@
 use crate::{
     self as http,
     client_handle::SetClientHandle,
-    glue::{Body, HyperServerSvc},
+    glue::{HyperServerSvc, UpgradeBody},
     h2::Settings as H2Settings,
     trace, upgrade, Version as HttpVersion,
 };
@@ -125,8 +125,11 @@ where
     FSvc::Error: Into<Error>,
     FSvc::Future: Send + 'static,
     H: NewService<(HttpVersion, T), Service = HSvc> + Clone,
-    HSvc: Service<http::Request<Body>, Response = http::Response<http::boxed::Payload>, Error = Error>
-        + Clone
+    HSvc: Service<
+            http::Request<UpgradeBody>,
+            Response = http::Response<http::boxed::Payload>,
+            Error = Error,
+        > + Clone
         + Unpin
         + Send
         + 'static,

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -127,7 +127,7 @@ where
     H: NewService<(HttpVersion, T), Service = HSvc> + Clone,
     HSvc: Service<
             http::Request<UpgradeBody>,
-            Response = http::Response<http::boxed::Payload>,
+            Response = http::Response<http::boxed::BoxBody>,
             Error = Error,
         > + Clone
         + Unpin

--- a/linkerd/proxy/http/src/upgrade.rs
+++ b/linkerd/proxy/http/src/upgrade.rs
@@ -1,6 +1,6 @@
 //! HTTP/1.1 Upgrades
 
-use crate::{glue::Body, h1};
+use crate::{glue::UpgradeBody, h1};
 use futures::{
     future::{self, Either},
     TryFutureExt,
@@ -175,7 +175,7 @@ impl<S> Service<S> {
 
 impl<S, B> tower::Service<http::Request<hyper::Body>> for Service<S>
 where
-    S: tower::Service<http::Request<Body>, Response = http::Response<B>>,
+    S: tower::Service<http::Request<UpgradeBody>, Response = http::Response<B>>,
     B: Default,
 {
     type Response = S::Response;
@@ -215,7 +215,7 @@ where
             None
         };
 
-        let req = req.map(|body| Body::new(body, upgrade));
+        let req = req.map(|body| UpgradeBody::new(body, upgrade));
 
         Either::Left(self.service.call(req))
     }


### PR DESCRIPTION
HTTP bodies are represented by the `Body` trait in the `HttpBody` crate.
Hyper re-exports this trait as `HttpBody`, and provides its own concrete
type named `Body`, implementing this trait. Previously, Hyper provided
its own trait, named `Payload`.

In the proxy, there are several types implementing `Body`. The naming
scheme for these types is inconsistent: some of them are named `Body`,
and others are named `Payload`. This makes it somewhat unclear what
these names refer to, especially when they show up in compiler errors
like "expected type 'Body', but found type 'Body'." 

This branch renames these types to use a more consistent naming scheme:

* The `Body` type in `linkerd2_proxy_http::glue` is now named
  `UpgradeBody`, since it deals with handling HTTP/1.1 upgrades,
* The `Payload` type in `linkerd2_http_box` is now named `BoxBody`,
  since the "payload" terminology isn't really used elsewhere in
  the proxy codebase, and the new name makes it clearer that this
  is the boxed, type-erased body type,
* The re-export of `glue::Body as Payload` from `linkerd2_proxy_http`
  is removed --- it turns out this wasn't being used anywhere, and the
  renaming just makes things more confusing (IMO).

There should be no functional changes in this PR, just renaming.