### PR TITLE
io: simplify the `Io` trait

### DIFF
--- a/linkerd/io/src/lib.rs
+++ b/linkerd/io/src/lib.rs
@@ -9,9 +9,8 @@ pub use self::{
     prefixed::PrefixedIo,
     sensor::{Sensor, SensorIo},
 };
-use bytes::{Buf, BufMut};
 pub use std::io::*;
-use std::{net::SocketAddr, pin::Pin, task::Context};
+use std::net::SocketAddr;
 pub use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 pub use tokio_util::io::{poll_read_buf, poll_write_buf};
 
@@ -51,48 +50,4 @@ impl PeerAddr for tokio::io::DuplexStream {
     fn peer_addr(&self) -> Result<SocketAddr> {
         Ok(([0, 0, 0, 0], 0).into())
     }
-}
-
-/// This trait is private, since its purpose is for creating a dynamic trait
-/// object, but doing so without care can to lead not getting vectored
-/// writes.
-///
-/// Instead, use the concrete `BoxedIo` type.
-pub trait Io: AsyncRead + AsyncWrite + PeerAddr + Send + internal::Sealed {
-    /// This method is to allow using `Async::polL_read_buf` even through a
-    /// trait object.
-    #[inline]
-    fn poll_read_buf_erased(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        mut buf: &mut dyn BufMut,
-    ) -> Poll<usize>
-    where
-        Self: Sized,
-    {
-        crate::poll_read_buf(self, cx, &mut buf)
-    }
-
-    /// This method is to allow using `Async::poll_write_buf` even through a
-    /// trait object.
-    #[inline]
-    fn poll_write_buf_erased(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        mut buf: &mut dyn Buf,
-    ) -> Poll<usize>
-    where
-        Self: Sized,
-    {
-        crate::poll_write_buf(self, cx, &mut buf)
-    }
-}
-
-impl<I> Io for I where I: AsyncRead + AsyncWrite + PeerAddr + Send + internal::Sealed {}
-mod internal {
-    use super::Io;
-    pub trait Sealed {}
-    impl Sealed for tokio::net::TcpStream {}
-    impl<S: Io + Unpin> Sealed for tokio_rustls::server::TlsStream<S> {}
-    impl<S: Io + Unpin> Sealed for tokio_rustls::client::TlsStream<S> {}
 }

--- a/linkerd/io/src/prefixed.rs
+++ b/linkerd/io/src/prefixed.rs
@@ -1,4 +1,4 @@
-use crate::{Io, IoSlice, PeerAddr, Poll};
+use crate::{IoSlice, PeerAddr, Poll};
 use bytes::{Buf, Bytes};
 use pin_project::pin_project;
 use std::{cmp, io};
@@ -91,5 +91,3 @@ impl<S: AsyncWrite> AsyncWrite for PrefixedIo<S> {
         self.io.is_write_vectored()
     }
 }
-
-impl<S: Io> crate::internal::Sealed for PrefixedIo<S> {}

--- a/linkerd/io/src/sensor.rs
+++ b/linkerd/io/src/sensor.rs
@@ -1,4 +1,4 @@
-use crate::{Io, IoSlice, PeerAddr, Poll};
+use crate::{IoSlice, PeerAddr, Poll};
 use futures::ready;
 use linkerd2_errno::Errno;
 use pin_project::pin_project;
@@ -76,8 +76,6 @@ impl<T: AsyncRead + AsyncWrite, S: Sensor> AsyncWrite for SensorIo<T, S> {
         self.io.is_write_vectored()
     }
 }
-
-impl<T: Io, S: Sensor + Send> crate::internal::Sealed for SensorIo<T, S> {}
 
 impl<T: PeerAddr, S> PeerAddr for SensorIo<T, S> {
     fn peer_addr(&self) -> Result<std::net::SocketAddr> {


### PR DESCRIPTION
Since `poll_read_buf` and `poll_write_buf` are now free functions in
`tokio-util::io`, rather than trait methods on `AsyncRead` and
`AsyncWrite`, it's no longer necessary for us to provide type-erased
implementations of them. Therefore, the `Io` trait in
`linkerd2-proxy-io` can be made much simpler --- now, its job is *just*
to give a single trait for the trait object inside a `BoxedIo`, as trait
objects may not have multiple non-marker traits.

This branch simplifies  `Io` to just be `AsyncRead + AsyncWrite +
PeerAddr`, and removes the `poll_read_buf_erased` and
`poll_write_buf_erased` methods. It also unseals `Io`, since it's no
longer responsible for ensuring correct propagation of vectored writes.

There should be no functional changes in this PR.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>