### PR TITLE
WIP: cache: Decouple idle tracking & eviction from the cache layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,9 +1044,10 @@ dependencies = [
  "linkerd2-error",
  "linkerd2-stack",
  "parking_lot",
- "tokio 0.2.23",
+ "tokio 0.3.5",
  "tower",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -229,8 +229,9 @@ impl<S> Stack<S> {
 
     pub fn push_cache<T>(self) -> Stack<cache::Cache<T, S, S::Service>>
     where
-        T: Eq + std::hash::Hash,
-        S: NewService<(cache::Handle, T)>,
+        T: Eq + std::hash::Hash + Send + Sync + 'static,
+        S: NewService<(cache::Handle, T)> + 'static,
+        S::Service: Send + Sync + 'static,
     {
         self.push(cache::Cache::layer())
     }

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -78,18 +78,6 @@ impl<L> Layers<L> {
         self.push(buffer::SpawnBufferLayer::new(capacity))
     }
 
-    pub fn push_spawn_buffer_with_idle_timeout<Req, Rsp>(
-        self,
-        capacity: usize,
-        idle_timeout: Duration,
-    ) -> Layers<Pair<L, buffer::SpawnBufferLayer<Req, Rsp>>>
-    where
-        Req: Send + 'static,
-        Rsp: Send + 'static,
-    {
-        self.push(buffer::SpawnBufferLayer::new(capacity).with_idle_timeout(idle_timeout))
-    }
-
     // Makes the service eagerly process and fail requests after the given timeout.
     pub fn push_failfast(self, timeout: Duration) -> Layers<Pair<L, timeout::FailFastLayer>> {
         self.push(timeout::FailFastLayer::new(timeout))
@@ -247,11 +235,11 @@ impl<S> Stack<S> {
         self.push(cache::Cache::layer())
     }
 
-    pub fn push_cache_tracker<T>(self) -> Stack<cache::NewTrack<S>>
+    pub fn push_cache_tracker<T>(self, idle: Duration) -> Stack<cache::NewTrack<S>>
     where
         S: NewService<T>,
     {
-        self.push(cache::NewTrack::layer())
+        self.push(cache::NewTrack::layer(idle))
     }
 
     /// Push a service that either calls the inner service if it is ready, or

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -274,11 +274,11 @@ impl Config {
         // fails, skips that stack to forward to the local endpoint.
         svc::stack(switch_loopback)
             .check_new_service::<Target, http::Request<http::boxed::BoxBody>>()
-            .push_cache_tracker()
+            .push_cache_tracker(cache_max_idle_age)
             .push_on_response(
                 svc::layers()
                     .push_failfast(dispatch_timeout)
-                    .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
+                    .push_spawn_buffer(buffer_capacity)
                     .push(metrics.stack.layer(stack_labels("logical")))
                     .box_http_response(),
             )

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -82,11 +82,11 @@ where
             AllowHttpProfile(allow_discovery),
         ))
         .check_new_service::<Target, http::Request<_>>()
-        .push_cache_tracker()
+        .push_cache_tracker(cache_max_idle_age)
         .push_on_response(
             svc::layers()
                 .push_failfast(dispatch_timeout)
-                .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age),
+                .push_spawn_buffer(buffer_capacity),
         )
         .push_cache()
         .check_new_service::<Target, http::Request<_>>()

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -118,7 +118,7 @@ where
     .push_on_response(
         svc::layers()
             .push_failfast(dispatch_timeout)
-            .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age),
+            .push_spawn_buffer(buffer_capacity),
     )
     .instrument(|_: &_| debug_span!("tcp"))
     .check_new_service::<tcp::Logical, transport::io::PrefixedIo<transport::metrics::SensorIo<I>>>()
@@ -156,11 +156,11 @@ where
             AllowProfile(config.allow_discovery.clone().into()),
         ))
         .check_new_service::<tcp::Accept, transport::metrics::SensorIo<I>>()
-        .push_cache_tracker()
+        .push_cache_tracker(cache_max_idle_age)
         .push_on_response(
             svc::layers()
                 .push_failfast(dispatch_timeout)
-                .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age),
+                .push_spawn_buffer(buffer_capacity),
         )
         .push_cache()
         .check_new_service::<tcp::Accept, transport::metrics::SensorIo<I>>()

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -10,6 +10,7 @@ futures = "0.3"
 linkerd2-error = { path = "../error" }
 linkerd2-stack = { path = "../stack" }
 parking_lot = "0.11"
-tokio = "0.2"
+tokio = { version = "0.3", default-features = false, features = ["macros", "sync"] }
 tower = { version = "0.4", default-features = false, features = ["util"] }
 tracing = "0.1.22"
+tracing-futures = "0.2"

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -10,7 +10,9 @@ use std::{
     hash::Hash,
     sync::{Arc, Weak},
 };
-use tracing::{debug, trace};
+use tokio::sync::Notify;
+use tracing::{debug, debug_span, trace};
+use tracing_futures::Instrument;
 
 #[derive(Clone)]
 pub struct Cache<T, N, S>
@@ -19,32 +21,115 @@ where
 {
     inner: N,
     services: Services<T, S>,
+
+    // As long as this is held, the eviction tasks will activate every time it is
+    // notified.
+    evict: Arc<Notify>,
 }
 
 /// A tracker inserted into each inner service that, when dropped, indicates the
 /// service may be removed from the cache.
-pub type Handle = Arc<()>;
+#[derive(Clone, Debug)]
+pub struct Handle {
+    inner: Arc<()>,
+    evict: Weak<Notify>,
+}
 
 type Services<T, S> = Arc<RwLock<HashMap<T, (S, Weak<()>)>>>;
 
+// === impl Handle ===
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+        if let Some(evict) = self.evict.upgrade() {
+            evict.notify_one();
+        }
+    }
+}
+
 // === impl Cache ===
+
+impl<T, N> Cache<T, N, N::Service>
+where
+    T: Eq + Hash + Send + Sync + 'static,
+    N: NewService<(Handle, T)> + 'static,
+    N::Service: Send + Sync + 'static,
+{
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Copy + Clone {
+        layer::mk(|inner| {
+            let (cache, _) = Self::new(inner);
+            cache
+        })
+    }
+
+    fn new(inner: N) -> (Self, tokio::task::JoinHandle<()>) {
+        let services = Services::default();
+        let evict = Arc::new(Notify::new());
+
+        // Spawn a background task to remove defunct services.
+        let task = tokio::spawn(
+            Self::evict(Arc::downgrade(&evict), services.clone()).instrument(debug_span!("evict")),
+        );
+
+        let cache = Self {
+            inner,
+            services,
+            evict,
+        };
+        (cache, task)
+    }
+
+    // Evicts services every time the evict handle is notified, as long as the
+    // evict handle remains active.
+    async fn evict(evict: Weak<Notify>, services: Services<T, N::Service>) {
+        loop {
+            // If the cache still holds the eviction handle
+            match evict.upgrade() {
+                Some(e) => {
+                    trace!("Awaiting eviction signal");
+                    e.notified().await;
+                    trace!("Evicting services");
+                }
+                None => {
+                    debug!("Cache dropped");
+                    return;
+                }
+            }
+
+            // Drop defunct services before inserting the new service into the
+            // cache.
+            let mut svcs = services.write();
+            let orig_len = svcs.len();
+            svcs.retain(|_, (_, weak)| {
+                if weak.strong_count() > 0 {
+                    true
+                } else {
+                    trace!("Dropping defunct service");
+                    false
+                }
+            });
+            debug!(services = svcs.len(), dropped = orig_len - svcs.len());
+        }
+    }
+}
+
+impl<T: Eq + Hash, N, S> Drop for Cache<T, N, S> {
+    fn drop(&mut self) {
+        // When the cache is dropped, notify the eviction task so it terminates.
+        self.evict.notify_one()
+    }
+}
 
 impl<T, N> Cache<T, N, N::Service>
 where
     T: Eq + Hash,
     N: NewService<(Handle, T)>,
 {
-    pub fn layer() -> impl layer::Layer<N, Service = Self> + Copy + Clone {
-        layer::mk(|inner| Self {
-            inner,
-            services: Services::default(),
-        })
-    }
-
-    fn new_entry(new: &mut N, target: T) -> (N::Service, Weak<()>) {
-        let handle = Arc::new(());
-        let weak = Arc::downgrade(&handle);
-        let svc = new.new_service((handle, target));
+    fn new_entry(new: &mut N, target: T, evict: &Arc<Notify>) -> (N::Service, Weak<()>) {
+        let inner = Arc::new(());
+        let weak = Arc::downgrade(&inner);
+        let evict = Arc::downgrade(evict);
+        let svc = new.new_service((Handle { inner, evict }, target));
         (svc, weak)
     }
 }
@@ -58,7 +143,8 @@ where
     type Service = N::Service;
 
     fn new_service(&mut self, target: T) -> N::Service {
-        // We expect the item to be available in most cases, so initially obtain only a read lock.
+        // We expect the item to be available in most cases, so initially obtain
+        // only a read lock.
         if let Some((service, weak)) = self.services.read().get(&target) {
             if weak.upgrade().is_some() {
                 trace!("Using cached service");
@@ -67,47 +153,27 @@ where
         }
 
         // Otherwise, obtain a write lock to insert a new service.
-        let mut services = self.services.write();
-
-        let service = match services.entry(target.clone()) {
+        match self.services.write().entry(target.clone()) {
             Entry::Occupied(mut entry) => {
-                // Another thread raced us to create a service for this target. Use it.
+                // Another thread raced us to create a service for this target.
+                // Try to use it.
                 let (svc, weak) = entry.get();
                 if weak.upgrade().is_some() {
                     trace!("Using cached service");
                     svc.clone()
                 } else {
                     debug!("Replacing defunct service");
-                    let (svc, weak) = Self::new_entry(&mut self.inner, target);
+                    let (svc, weak) = Self::new_entry(&mut self.inner, target, &self.evict);
                     entry.insert((svc.clone(), weak));
                     svc
                 }
             }
             Entry::Vacant(entry) => {
-                // Make a new service for the target.
                 debug!("Caching new service");
-                let (svc, weak) = Self::new_entry(&mut self.inner, target);
+                let (svc, weak) = Self::new_entry(&mut self.inner, target, &self.evict);
                 entry.insert((svc.clone(), weak));
                 svc
             }
-        };
-
-        // Drop defunct services before inserting the new service into the
-        // cache.
-        let orig_len = services.len();
-        services.retain(|_, (_, weak)| {
-            if weak.strong_count() > 0 {
-                true
-            } else {
-                trace!("Dropping defunct service");
-                false
-            }
-        });
-        debug!(
-            services = services.len(),
-            dropped = orig_len - services.len()
-        );
-
-        service
+        }
     }
 }

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -57,12 +57,12 @@ where
 {
     pub fn layer() -> impl layer::Layer<N, Service = Self> + Copy + Clone {
         layer::mk(|inner| {
-            let (cache, _) = Self::new(inner);
+            let (cache, _) = Self::spawn(inner);
             cache
         })
     }
 
-    fn new(inner: N) -> (Self, tokio::task::JoinHandle<()>) {
+    fn spawn(inner: N) -> (Self, tokio::task::JoinHandle<()>) {
         let services = Services::default();
         let evict = Arc::new(Notify::new());
 

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -29,7 +29,7 @@ where
 
 /// A tracker inserted into each inner service that, when dropped, indicates the
 /// service may be removed from the cache.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Handle {
     inner: Arc<()>,
     evict: Weak<Notify>,
@@ -83,7 +83,9 @@ where
     // evict handle remains active.
     async fn evict(evict: Weak<Notify>, services: Services<T, N::Service>) {
         loop {
-            // If the cache still holds the eviction handle
+            // If the cache still holds the eviction handle, wait for it to be
+            // notified before evicting services. It is notified whenever a
+            // handle is dropped and when the cache is dropped.
             match evict.upgrade() {
                 Some(e) => {
                     trace!("Awaiting eviction signal");

--- a/linkerd/cache/src/track.rs
+++ b/linkerd/cache/src/track.rs
@@ -1,33 +1,63 @@
 use crate::Handle;
 use linkerd2_stack::{layer, NewService};
-use std::task::{Context, Poll};
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::{sync::Notify, time};
+use tracing::{debug, debug_span, trace};
+use tracing_futures::Instrument;
 
 #[derive(Clone)]
 pub struct NewTrack<N> {
     inner: N,
+    idle: time::Duration,
 }
 
 #[derive(Clone)]
 pub struct Track<T> {
     inner: T,
-    _handle: Handle,
+    notify: Arc<Notify>,
 }
 
-/// === impl NewTrack ===
-
 impl<N> NewTrack<N> {
-    pub fn layer() -> impl layer::Layer<N, Service = NewTrack<N>> + Copy + Clone {
-        layer::mk(|inner| NewTrack { inner })
+    pub fn layer(
+        idle: time::Duration,
+    ) -> impl layer::Layer<N, Service = NewTrack<N>> + Copy + Clone {
+        layer::mk(move |inner| Self { inner, idle })
     }
 }
 
 impl<T, N: NewService<T>> NewService<(Handle, T)> for NewTrack<N> {
     type Service = Track<N::Service>;
 
-    #[inline]
-    fn new_service(&mut self, (_handle, target): (Handle, T)) -> Self::Service {
+    fn new_service(&mut self, (handle, target): (Handle, T)) -> Self::Service {
+        let idle = self.idle;
+        let notify = Arc::new(Notify::new());
+
+        // Create a background task that drops the cache entry's handle when the
+        // service hasn't been notified for an `idle` interval.
+        tokio::spawn({
+            let notify = notify.clone();
+            async move {
+                loop {
+                    tokio::select! {
+                        _ = notify.notified() => {
+                            trace!(idle = idle.as_secs(), "Resetting");
+                        }
+                        _ = time::sleep(idle) => {
+                            debug!(idle = idle.as_secs(), "Idled out");
+                            drop(handle);
+                            return;
+                        }
+                    }
+                }
+            }
+            .instrument(debug_span!("tracker"))
+        });
+
         let inner = self.inner.new_service(target);
-        Track { inner, _handle }
+        Track { inner, notify }
     }
 }
 
@@ -45,6 +75,9 @@ impl<T, S: tower::Service<T>> tower::Service<T> for Track<S> {
 
     #[inline]
     fn call(&mut self, req: T) -> Self::Future {
+        // Notify the background task on each request.
+        self.notify.notify_one();
+
         self.inner.call(req)
     }
 }


### PR DESCRIPTION
The cache relies on the buffer's idle timeout to evict cache entries.
This approach (1) causes us to rely on a specialized Buffer
implementation (rather than using tower's Buffer) and (2) is inflexible,
preventing the outbound connection-oriented cache from `taking into
account connection-level activity.

This change modifies the `cache::NewTrack` middleware to spawn a task
that tracks its service's idleness. When the service hasn't been used
for an idle timeout, the cache handle is dropped so that the cache knows
to clear the appropriate entry.