### PR TITLE
outbound: add stack tests for http

### DIFF
--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -249,7 +249,6 @@ async fn meshed_hello_world() {
     let profiles = profile::resolver().profile(
         ep1,
         profile::Profile {
-            opaque_protocol: false,
             name: Some(svc_name.clone()),
             ..Default::default()
         },

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -804,7 +804,7 @@ impl Into<Box<dyn FnMut(Endpoint) -> ConnectFuture + Send + 'static>> for Connec
                 .read(b"world")
                 .read_error(std::io::ErrorKind::ConnectionReset.into())
                 .build();
-            Box::pin(async move { Ok(io) })
+            Box::pin(async move { Ok(io::BoxedIo::new(io)) })
         })
     }
 }

--- a/linkerd/io/src/boxed.rs
+++ b/linkerd/io/src/boxed.rs
@@ -66,6 +66,7 @@ impl std::fmt::Debug for BoxedIo {
         f.debug_struct("BoxedIo").finish()
     }
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/linkerd/io/src/boxed.rs
+++ b/linkerd/io/src/boxed.rs
@@ -66,7 +66,6 @@ impl std::fmt::Debug for BoxedIo {
         f.debug_struct("BoxedIo").finish()
     }
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This branch adds some new stack tests for simple HTTP/1 and HTTP/2
meshed and unmeshed outbound requests. These tests also assert that TCP
load balancers are not constructed when HTTP traffic is detected.

The hope was that the panic on constructing TCP balancers would catch a
bug that exists in #744, but that issue appears to be related to the
cache instead. Still, it's probably worth having these tests.