### PR TITLE
trace: nicer traces in tests, clean up trace configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2810660b9d5b18895d140caba6401765749a6a162e5d0736cfc44ea50db9d79d"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/linkerd/app/core/src/admin/mod.rs
+++ b/linkerd/app/core/src/admin/mod.rs
@@ -210,7 +210,7 @@ mod tests {
         let (r, l0) = Readiness::new();
         let l1 = l0.clone();
 
-        let (_, t) = trace::with_filter_and_format("", "");
+        let (_, t) = trace::Settings::default().build();
         let admin = Admin::new((), r, t);
         macro_rules! call {
             () => {{

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -762,7 +762,7 @@ async fn profile_endpoint_propagates_conn_errors() {
         )
         .await
         .map_err(Into::into);
-    tracing::info!(?res);
+    tracing::debug!(?res);
     assert_eq!(
         res.unwrap_err()
             .downcast_ref::<io::Error>()
@@ -861,13 +861,13 @@ where
             Some(orig_dst),
         );
         let svc = new_svc.new_service(addrs);
-        tracing::debug!("new service");
+        tracing::trace!("new service");
         svc
     };
     async move {
         let io = support::io().read(b"hello\r\n").write(b"world").build();
         let res = svc.oneshot(io).err_into::<Error>().await;
-        tracing::debug!(?res);
+        tracing::trace!(?res);
         if let Err(err) = res {
             if let Some(err) = err.downcast_ref::<std::io::Error>() {
                 // did the pretend server hang up, or did something

--- a/linkerd/app/test/src/lib.rs
+++ b/linkerd/app/test/src/lib.rs
@@ -47,9 +47,10 @@ pub fn io() -> io::Builder {
 }
 
 /// By default, disable logging in modules that are expected to error in tests.
-const DEFAULT_LOG: &'static str = "error,\
-                                   linkerd2_proxy_http=off,\
-                                   linkerd2_proxy_transport=off";
+const DEFAULT_LOG: &'static str = "warn,\
+                                   linkerd=debug,\
+                                   linkerd2_proxy_http=error,\
+                                   linkerd2_proxy_transport=error";
 
 pub fn trace_subscriber() -> (Dispatch, app_core::trace::Handle) {
     use std::env;
@@ -63,7 +64,11 @@ pub fn trace_subscriber() -> (Dispatch, app_core::trace::Handle) {
     // This may fail, since the global log compat layer may have been
     // initialized by another test.
     let _ = app_core::trace::init_log_compat();
-    app_core::trace::with_filter_and_format(&log_level, &log_format)
+    app_core::trace::Settings::default()
+        .filter(log_level)
+        .format(log_format)
+        .test(true)
+        .build()
 }
 
 pub fn trace_init() -> tracing::dispatcher::DefaultGuard {

--- a/linkerd/tracing/Cargo.toml
+++ b/linkerd/tracing/Cargo.toml
@@ -18,7 +18,7 @@ tracing = "0.1.22"
 tracing-log = "0.1"
 
 [dependencies.tracing-subscriber]
-version = "0.2.14"
+version = "0.2.15"
 # we don't need `chrono` time formatting or ANSI colored output
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot"]


### PR DESCRIPTION
This branch improves how traces are displayed in tests. In particular,
I've made the following changes:

* When running tests, use a "test writer" that participates in libtest's
  output capturing. Now, traces from tests will be displayed grouped
  together when the test fails, rather than printed to the console as
  soon as they occur. Logs can now be printed for successful tests using
  `cargo test -- --show-output`, and will still be grouped by test.
* Because test traces are now captured, enable a more verbose default
  filter for tests. The logs will no longer be spammed to the console,
  so it's okay to have more verbose logging on by default when tests
  fail.
* Disabled thread IDs in test mode. The tests run single-threaded
  proxies, and the new-style stack tests are completely single threaded.
  Some of the integration tests spawn test clients or servers in
  background threads, but those have their own spans which should make
  it much clearer to figure out where logs came from than just a numeric
  thread ID. Removing IDs makes the log lines a little shorter.

I considered also enabling thread names in the test logs (since the name
of a test thread is the name of the test it's running). I decided not
to, as they end up being quite long since the module path of the test
function is also incldued, and `--show-output` and panic output already
groups the logs by which test output them. However, we could turn thread
names on if we want to.

I also refactored the code for setting up tracing a bit. Hopefully it's
clearer now --- I was able to remove some complexity from how we pass
around the handle for reloading the trace level.

I also bumped some of the more verbose logs from the test support code
down to `trace`, since they get kinda annoying to have them on by
default (particularly the "new service" one).