### PR TITLE
Ensure that services are held as long they are being used

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -323,7 +323,6 @@ impl Config {
                 Error = Error,
             > + Clone
             + Send
-            + Sync
             + 'static,
         S::Future: Send,
     {

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -351,11 +351,7 @@ impl Config {
         let http_server = svc::stack(http_router)
             // Removes the override header after it has been used to
             // determine a reuquest target.
-            .push_on_response(
-                svc::layers()
-                    .push(strip_header::request::layer(DST_OVERRIDE_HEADER))
-                    .push(http::Retain::layer()),
-            )
+            .push_on_response(strip_header::request::layer(DST_OVERRIDE_HEADER))
             // Routes each request to a target, obtains a service for that
             // target, and dispatches the request.
             .instrument_from_target()

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -86,7 +86,8 @@ where
             svc::layers().push_on_response(
                 svc::layers()
                     .push_failfast(dispatch_timeout)
-                    .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age),
+                    .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
+                    .push(http::Retain::layer()),
             ),
         )
         .check_new_service::<Target, http::Request<_>>()

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -86,8 +86,7 @@ where
             svc::layers().push_on_response(
                 svc::layers()
                     .push_failfast(dispatch_timeout)
-                    .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age)
-                    .push(http::Retain::layer()),
+                    .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age),
             ),
         )
         .check_new_service::<Target, http::Request<_>>()

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -16,6 +16,7 @@ pub mod insert;
 pub mod normalize_uri;
 pub mod orig_proto;
 pub mod override_authority;
+mod retain;
 mod server;
 pub mod strip_header;
 pub mod timeout;
@@ -25,8 +26,9 @@ mod version;
 
 pub use self::{
     client_handle::{ClientHandle, SetClientHandle},
-    glue::HyperServerSvc,
+    glue::{HyperServerSvc, UpgradeBody},
     override_authority::CanOverrideAuthority,
+    retain::Retain,
     server::NewServeHttp,
     timeout::MakeTimeoutLayer,
     version::Version,

--- a/linkerd/proxy/http/src/retain.rs
+++ b/linkerd/proxy/http/src/retain.rs
@@ -1,5 +1,5 @@
 //! Provides a middleware that holds an inner service as long as responses are
-//! being processed..
+//! being processed.
 
 use linkerd2_stack::layer;
 use pin_project::pin_project;

--- a/linkerd/proxy/http/src/retain.rs
+++ b/linkerd/proxy/http/src/retain.rs
@@ -55,7 +55,7 @@ impl<S: Clone, B> Clone for Retain<S, B> {
 
 impl<S, Req, RspB> tower::Service<Req> for Retain<S, RspB>
 where
-    S: tower::Service<Req, Response = http::Response<RspB>> + Clone + Send + Sync + 'static,
+    S: tower::Service<Req, Response = http::Response<RspB>> + Clone + Send + 'static,
     S::Future: Send + 'static,
 {
     type Response = http::Response<RetainBody<S, RspB>>;

--- a/linkerd/proxy/http/src/retain.rs
+++ b/linkerd/proxy/http/src/retain.rs
@@ -1,0 +1,127 @@
+//! Provides a middleware that holds an inner service as long as responses are
+//! being processed..
+
+use linkerd2_stack::layer;
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// Retains an inner service as long as its HTTP responses are being processsed
+/// so that RAII-guarded resources are held. This is mostly intended to support
+/// cache eviction.
+#[derive(Debug)]
+pub struct Retain<S, B> {
+    inner: S,
+    _marker: std::marker::PhantomData<fn() -> B>,
+}
+
+/// Wraps a `B` typed HTTP body to ensure that a `T` typed instance is held until
+/// the body is fully processed.
+#[pin_project]
+#[derive(Debug)]
+pub struct RetainBody<T, B> {
+    #[pin]
+    inner: B,
+
+    _retain: Option<T>,
+}
+
+// === impl Retain ===
+
+impl<S, B> Retain<S, B> {
+    pub fn new(inner: S) -> Self {
+        Self {
+            inner,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn layer() -> impl layer::Layer<S, Service = Self> + Copy + Clone {
+        layer::mk(Self::new)
+    }
+}
+
+impl<S: Clone, B> Clone for Retain<S, B> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<S, Req, RspB> tower::Service<Req> for Retain<S, RspB>
+where
+    S: tower::Service<Req, Response = http::Response<RspB>> + Clone + Send + Sync + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = http::Response<RetainBody<S, RspB>>;
+    type Error = S::Error;
+    type Future = Pin<
+        Box<
+            dyn Future<Output = Result<http::Response<RetainBody<S, RspB>>, S::Error>>
+                + Send
+                + 'static,
+        >,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        let fut = self.inner.call(req);
+
+        // Retain a handle to the inner service until the response is completely
+        // processed.
+        let service = self.inner.clone();
+        Box::pin(async move {
+            let rsp = fut.await?;
+            Ok(rsp.map(move |inner| RetainBody {
+                inner,
+                _retain: Some(service),
+            }))
+        })
+    }
+}
+
+// === impl RetainBody ===
+
+impl<T, B: Default> Default for RetainBody<T, B> {
+    fn default() -> Self {
+        Self {
+            inner: B::default(),
+            _retain: None,
+        }
+    }
+}
+
+impl<T, B: http_body::Body> http_body::Body for RetainBody<T, B> {
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<B::Data, B::Error>>> {
+        self.project().inner.poll_data(cx)
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap<http::HeaderValue>>, B::Error>> {
+        self.project().inner.poll_trailers(cx)
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}


### PR DESCRIPTION
Middlewares, especially the cache, may want to use RAII to detect when a
service is idle, but the TCP server and HTTP routers drop services as
soon as the request is dispatched.

This change modifies the TCP server to hold its per-connection service until
all work on that connection is complete. It also introduces a new
`http::Retain` middleware that clones its inner service into repsonse
bodies.

This is necesarry for upcoming cache eviction changes to address
linkerd/linkerd2#5334.