### PR TITLE
outbound: stack tests for idling out services

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,6 +1011,7 @@ dependencies = [
  "http-body",
  "hyper",
  "linkerd2-app-core",
+ "linkerd2-identity",
  "regex 0.1.80",
  "tokio 0.3.5",
  "tokio-test 0.3.0",

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -56,7 +56,7 @@ where
 {
     let (metrics, _) = metrics::Metrics::new(Duration::from_secs(10));
     let (accept, drain_tx) = build_accept(&cfg, profiles, resolver, connect, &metrics);
-    let svc = crate::server::cache_accept(&cfg.proxy, metrics.outbound, accept);
+    let svc = crate::server::cache(&cfg.proxy, metrics.outbound, accept);
     (svc, drain_tx)
 }
 
@@ -357,7 +357,7 @@ async fn stacks_idle_out() {
     let (metrics, _) = metrics::Metrics::new(Duration::from_secs(10));
     let (accept, _drain_tx) = build_accept(&cfg, profiles, resolver, connect, &metrics);
     let (handle, accept) = track::new_service(accept);
-    let mut svc = crate::server::cache_accept(&cfg.proxy, metrics.outbound, accept);
+    let mut svc = crate::server::cache(&cfg.proxy, metrics.outbound, accept);
     assert_eq!(handle.tracked_services(), 0);
 
     let server = svc.new_service(addrs);
@@ -435,7 +435,7 @@ async fn active_stacks_dont_idle_out() {
     let (metrics, _) = metrics::Metrics::new(Duration::from_secs(10));
     let (accept, _drain_tx) = build_accept(&cfg, profiles, resolver, connect, &metrics);
     let (handle, accept) = track::new_service(accept);
-    let mut svc = crate::server::cache_accept(&cfg.proxy, metrics.outbound, accept);
+    let mut svc = crate::server::cache(&cfg.proxy, metrics.outbound, accept);
     assert_eq!(handle.tracked_services(), 0);
 
     let server = svc.new_service(addrs);

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -15,6 +15,7 @@ use linkerd2_app_core::{
     proxy::{identity::Name, tap},
     svc::{self, NewService},
     transport::{
+        self,
         io::{self, BoxedIo},
         listen,
     },
@@ -54,6 +55,35 @@ where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
 {
     let (metrics, _) = metrics::Metrics::new(Duration::from_secs(10));
+    let (accept, drain_tx) = build_accept(&cfg, profiles, resolver, connect, &metrics);
+    let svc = crate::server::cache_accept(&cfg.proxy, metrics.outbound, accept);
+    (svc, drain_tx)
+}
+
+fn build_accept<I>(
+    cfg: &Config,
+    profiles: resolver::Profiles<SocketAddr>,
+    resolver: resolver::Dst<Addr, resolver::Metadata>,
+    connect: Connect<Endpoint>,
+    metrics: &metrics::Metrics,
+) -> (
+    impl svc::NewService<
+            crate::tcp::Accept,
+            Service = impl tower::Service<
+                transport::metrics::SensorIo<I>,
+                Response = (),
+                Error = impl Into<Error>,
+                Future = impl Send + 'static,
+            > + Send
+                          + 'static,
+        > + Clone
+        + Send
+        + 'static,
+    drain::Signal,
+)
+where
+    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
+{
     let (drain_tx, drain) = drain::channel();
 
     let (_, tap, _) = tap::new();
@@ -79,8 +109,7 @@ where
         None,
         drain,
     );
-    let svc = crate::server::cache_accept(&cfg.proxy, metrics.outbound, accept);
-    (svc, drain_tx)
+    (accept, drain_tx)
 }
 
 #[derive(Clone, Debug)]
@@ -326,31 +355,7 @@ async fn stacks_idle_out() {
 
     // Build the outbound server
     let (metrics, _) = metrics::Metrics::new(Duration::from_secs(10));
-    let (_, drain) = drain::channel();
-
-    let (_, tap, _) = tap::new();
-    let router = super::logical::stack(
-        &cfg.proxy,
-        super::endpoint::stack(
-            &cfg.proxy.connect,
-            connect,
-            tap,
-            metrics.outbound.clone(),
-            None,
-        ),
-        resolver.clone(),
-        metrics.outbound.clone(),
-    );
-    let accept = crate::server::accept_stack(
-        &cfg,
-        profiles,
-        support::connect::NoRawTcp,
-        NoTcpBalancer,
-        router,
-        metrics.outbound.clone(),
-        None,
-        drain,
-    );
+    let (accept, _drain_tx) = build_accept(&cfg, profiles, resolver, connect, &metrics);
     let (handle, accept) = track::new_service(accept);
     let mut svc = crate::server::cache_accept(&cfg.proxy, metrics.outbound, accept);
     assert_eq!(handle.tracked_services(), 0);
@@ -439,32 +444,8 @@ async fn active_stacks_dont_idle_out() {
         .expect("still listening to resolution");
 
     // Build the outbound server
-    let (metrics, _) = metrics::Metrics::new(Duration::from_millis(10));
-    let (_, drain) = drain::channel();
-
-    let (_, tap, _) = tap::new();
-    let router = super::logical::stack(
-        &cfg.proxy,
-        super::endpoint::stack(
-            &cfg.proxy.connect,
-            connect,
-            tap,
-            metrics.outbound.clone(),
-            None,
-        ),
-        resolver.clone(),
-        metrics.outbound.clone(),
-    );
-    let accept = crate::server::accept_stack(
-        &cfg,
-        profiles,
-        support::connect::NoRawTcp,
-        NoTcpBalancer,
-        router,
-        metrics.outbound.clone(),
-        None,
-        drain,
-    );
+    let (metrics, _) = metrics::Metrics::new(Duration::from_secs(10));
+    let (accept, _drain_tx) = build_accept(&cfg, profiles, resolver, connect, &metrics);
     let (handle, accept) = track::new_service(accept);
     let mut svc = crate::server::cache_accept(&cfg.proxy, metrics.outbound, accept);
     assert_eq!(handle.tracked_services(), 0);

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -494,11 +494,11 @@ where
         .map_err(Into::into)
         .expect("proxy server failed to become ready")
         .call(server_io);
-    drop(server);
 
-    tracing::debug!("dropped server");
     let proxy = async move {
         let res = f.await.map_err(Into::into);
+        drop(server);
+        tracing::debug!("dropped server");
         tracing::info!(?res, "proxy serve task complete");
         res.expect("proxy failed");
     }

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -69,7 +69,7 @@ where
         resolver.clone(),
         metrics.outbound.clone(),
     );
-    let accept = crate::server::accept_with_tcp_balancer(
+    let accept = crate::server::accept_stack(
         &cfg,
         profiles,
         support::connect::NoRawTcp,
@@ -341,7 +341,7 @@ async fn stacks_idle_out() {
         resolver.clone(),
         metrics.outbound.clone(),
     );
-    let accept = crate::server::accept_with_tcp_balancer(
+    let accept = crate::server::accept_stack(
         &cfg,
         profiles,
         support::connect::NoRawTcp,
@@ -455,7 +455,7 @@ async fn active_stacks_dont_idle_out() {
         resolver.clone(),
         metrics.outbound.clone(),
     );
-    let accept = crate::server::accept_with_tcp_balancer(
+    let accept = crate::server::accept_stack(
         &cfg,
         profiles,
         support::connect::NoRawTcp,

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -55,7 +55,7 @@ where
     P::Error: Send,
 {
     let tcp_balance = tcp::balance::stack(&config.proxy, tcp_connect.clone(), resolve);
-    let accept = accept_with_tcp_balancer(
+    let accept = accept_stack(
         config,
         profiles,
         tcp_connect,
@@ -110,7 +110,7 @@ where
         .into_inner()
 }
 
-pub fn accept_with_tcp_balancer<P, C, T, H, S, I>(
+pub fn accept_stack<P, C, T, H, S, I>(
     config: &Config,
     profiles: P,
     tcp_connect: C,

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -65,10 +65,10 @@ where
         span_sink,
         drain,
     );
-    cache_accept(&config.proxy, metrics, accept)
+    cache(&config.proxy, metrics, accept)
 }
 
-pub fn cache_accept<N, S, I>(
+pub fn cache<N, S, I>(
     config: &ProxyConfig,
     metrics: metrics::Proxy,
     stack: N,

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -55,27 +55,23 @@ where
     P::Error: Send,
 {
     let tcp_balance = tcp::balance::stack(&config.proxy, tcp_connect.clone(), resolve);
-    stack_with_tcp_balancer(
+    let accept = accept_with_tcp_balancer(
         config,
         profiles,
         tcp_connect,
         tcp_balance,
         http_router,
-        metrics,
+        metrics.clone(),
         span_sink,
         drain,
-    )
+    );
+    cache_accept(&config.proxy, metrics, accept)
 }
 
-pub fn stack_with_tcp_balancer<P, C, T, H, S, I>(
-    config: &Config,
-    profiles: P,
-    tcp_connect: C,
-    tcp_balance: T,
-    http_router: H,
+pub fn cache_accept<N, S, I>(
+    config: &ProxyConfig,
     metrics: metrics::Proxy,
-    span_sink: Option<mpsc::Sender<oc::Span>>,
-    drain: drain::Watch,
+    stack: N,
 ) -> impl svc::NewService<
     listen::Addrs,
     Service = impl tower::Service<
@@ -86,6 +82,53 @@ pub fn stack_with_tcp_balancer<P, C, T, H, S, I>(
     > + Send
                   + 'static,
 > + Send
+       + 'static
+where
+    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
+    transport::metrics::SensorIo<I>: Send + 'static,
+    N: svc::NewService<tcp::Accept, Service = S> + Clone + Send + 'static,
+    S: svc::Service<transport::metrics::SensorIo<I>, Response = ()> + Send + 'static,
+    S::Error: Into<Error> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    svc::stack(stack)
+        .check_new_service::<tcp::Accept, transport::metrics::SensorIo<I>>()
+        .cache(
+            svc::layers().push_on_response(
+                svc::layers()
+                    .push_failfast(config.dispatch_timeout)
+                    .push_spawn_buffer_with_idle_timeout(
+                        config.buffer_capacity,
+                        config.cache_max_idle_age,
+                    ),
+            ),
+        )
+        .check_new_service::<tcp::Accept, transport::metrics::SensorIo<I>>()
+        .push(metrics.transport.layer_accept())
+        .push_map_target(tcp::Accept::from)
+        .check_new_service::<listen::Addrs, I>()
+        .into_inner()
+}
+
+pub fn accept_with_tcp_balancer<P, C, T, H, S, I>(
+    config: &Config,
+    profiles: P,
+    tcp_connect: C,
+    tcp_balance: T,
+    http_router: H,
+    metrics: metrics::Proxy,
+    span_sink: Option<mpsc::Sender<oc::Span>>,
+    drain: drain::Watch,
+) -> impl svc::NewService<
+    tcp::Accept,
+    Service = impl tower::Service<
+        transport::metrics::SensorIo<I>,
+        Response = (),
+        Error = impl Into<Error>,
+        Future = impl Send + 'static,
+    > + Send
+                  + 'static,
+> + Clone + Send
        + 'static
 where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
@@ -205,17 +248,6 @@ where
             AllowProfile(config.allow_discovery.clone().into()),
         ))
         .check_new_service::<tcp::Accept, transport::metrics::SensorIo<I>>()
-        .cache(
-            svc::layers().push_on_response(
-                svc::layers()
-                    .push_failfast(dispatch_timeout)
-                    .push_spawn_buffer_with_idle_timeout(buffer_capacity, cache_max_idle_age),
-            ),
-        )
-        .check_new_service::<tcp::Accept, transport::metrics::SensorIo<I>>()
-        .push(metrics.transport.layer_accept())
-        .push_map_target(tcp::Accept::from)
-        .check_new_service::<listen::Addrs, I>()
         .into_inner()
 }
 

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -24,6 +24,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = "0.14.0-dev"
 linkerd2-app-core = { path = "../core", features = ["mock-orig-dst"] }
+linkerd2-identity = { path = "../../identity" }
 regex = "0.1"
 tokio = { version = "0.3", features = ["io-util", "net", "rt", "sync"]}
 tokio-test = "0.3"

--- a/linkerd/app/test/src/http_util.rs
+++ b/linkerd/app/test/src/http_util.rs
@@ -1,0 +1,92 @@
+use crate::app_core::{
+    transport::{
+        io::BoxedIo,
+        tls::{HasPeerIdentity, PeerIdentity, ReasonForNoPeerName},
+    },
+    Conditional, Error,
+};
+use hyper::{Body, Request, Response};
+use linkerd2_identity::Name;
+use std::sync::{Arc, Mutex};
+use tracing::Instrument;
+
+pub struct Server {
+    settings: hyper::server::conn::Http,
+    identity: Option<PeerIdentity>,
+    f: Box<dyn (FnMut(Request<Body>) -> Result<Response<Body>, Error>) + Send>,
+}
+
+pub struct Client {}
+
+impl Default for Server {
+    fn default() -> Self {
+        Self {
+            settings: hyper::server::conn::Http::new(),
+            identity: None,
+            f: Box::new(|_| {
+                Ok(Response::builder()
+                    .status(http::status::StatusCode::NOT_FOUND)
+                    .body(Body::empty())
+                    .expect("known status code is fine"))
+            }),
+        }
+    }
+}
+
+impl Server {
+    pub fn http1(mut self) -> Self {
+        self.settings.http1_only(true);
+        self
+    }
+
+    pub fn http2(mut self) -> Self {
+        self.settings.http2_only(true);
+        self
+    }
+
+    pub fn expect_identity(mut self, id: impl Into<Name>) -> Self {
+        self.identity = Some(Conditional::Some(id.into()));
+        self
+    }
+
+    pub fn no_identity(mut self, reason: ReasonForNoPeerName) -> Self {
+        self.identity = Some(Conditional::None(reason));
+        self
+    }
+
+    pub fn new(mut f: impl (FnMut(Request<Body>) -> Response<Body>) + Send + 'static) -> Self {
+        Self {
+            f: Box::new(move |req| Ok::<_, Error>(f(req))),
+            ..Default::default()
+        }
+    }
+
+    pub fn run<E: HasPeerIdentity + std::fmt::Debug>(
+        self,
+    ) -> impl (FnMut(E) -> Result<BoxedIo, Error>) + Send + 'static {
+        let Self {
+            f,
+            settings,
+            identity,
+        } = self;
+        let f = Arc::new(Mutex::new(f));
+        move |endpoint| {
+            let span = tracing::debug_span!("server::run", ?endpoint);
+            let _e = span.enter();
+            if let Some(ref id) = identity {
+                assert_eq!(&endpoint.peer_identity(), id)
+            }
+            let f = f.clone();
+            let (client_io, server_io) = crate::io::duplex(4096);
+            let svc = hyper::service::service_fn(move |request: Request<Body>| {
+                let f = f.clone();
+                async move {
+                    tracing::info!(?request);
+                    f.lock().unwrap()(request)
+                }
+            });
+            tokio::spawn(settings.serve_connection(server_io, svc).in_current_span());
+            Ok(BoxedIo::new(client_io))
+        }
+    }
+}

--- a/linkerd/app/test/src/http_util.rs
+++ b/linkerd/app/test/src/http_util.rs
@@ -16,8 +16,6 @@ pub struct Server {
     f: Box<dyn (FnMut(Request<Body>) -> Result<Response<Body>, Error>) + Send>,
 }
 
-pub struct Client {}
-
 impl Default for Server {
     fn default() -> Self {
         Self {

--- a/linkerd/app/test/src/lib.rs
+++ b/linkerd/app/test/src/lib.rs
@@ -23,6 +23,7 @@ pub mod connect;
 pub mod profile;
 pub mod resolver;
 pub mod service;
+pub mod track;
 
 pub fn resolver<T, E>() -> resolver::Dst<T, E>
 where

--- a/linkerd/app/test/src/lib.rs
+++ b/linkerd/app/test/src/lib.rs
@@ -20,6 +20,7 @@ pub mod io {
 }
 
 pub mod connect;
+pub mod http_util;
 pub mod profile;
 pub mod resolver;
 pub mod service;

--- a/linkerd/app/test/src/track.rs
+++ b/linkerd/app/test/src/track.rs
@@ -63,3 +63,10 @@ impl<S: Service<R>, R> Service<R> for Track<S> {
         self.inner.call(request)
     }
 }
+
+impl<S> Drop for Track<S> {
+    fn drop(&mut self) {
+        let tracked = self.track.take();
+        tracing::trace!(is_tracked = tracked.is_some(), "drop tracked service");
+    }
+}

--- a/linkerd/app/test/src/track.rs
+++ b/linkerd/app/test/src/track.rs
@@ -1,0 +1,65 @@
+use crate::app_core::svc::{NewService, Service};
+use std::{
+    sync::{Arc, Weak},
+    task::{Context, Poll},
+};
+
+pub struct Handle(Arc<()>);
+
+/// Tracks the number of `Service`s created by a `NewService`.
+#[derive(Debug, Clone)]
+pub struct NewTrack<N> {
+    inner: N,
+    /// Cloning the `NewService` shouldn't increment the number of tracked `Service`s.
+    track: Weak<()>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Track<S> {
+    inner: S,
+    track: Option<Arc<()>>,
+}
+
+/// Track the number of `Service`s created by the provided `NewService`.
+pub fn new_service<N>(inner: N) -> (Handle, NewTrack<N>) {
+    let handle = Arc::new(());
+    let track = Arc::downgrade(&handle);
+    (Handle(handle), NewTrack { inner, track })
+}
+
+// === impl Handle ===
+
+impl Handle {
+    pub fn tracked_services(&self) -> usize {
+        // minus 1 for the `Handle`'s clone of the `Arc`.
+        Arc::strong_count(&self.0) - 1
+    }
+}
+
+// === impl NewTrack ===
+
+impl<N: NewService<T>, T> NewService<T> for NewTrack<N> {
+    type Service = Track<N::Service>;
+    fn new_service(&mut self, target: T) -> Self::Service {
+        let track = self.track.upgrade();
+        let inner = self.inner.new_service(target);
+        tracing::trace!(is_tracked = track.is_some(), "new tracked service");
+        Track { inner, track }
+    }
+}
+
+// === impl Track ===
+
+impl<S: Service<R>, R> Service<R> for Track<S> {
+    type Response = S::Response;
+    type Future = S::Future;
+    type Error = S::Error;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: R) -> Self::Future {
+        self.inner.call(request)
+    }
+}


### PR DESCRIPTION
This branch adds new stack tests in the outbound crate testing behavior
around dropping idle services. I've added a new test utility for
wrapping a `NewService` to track the number of currently alive `Service`
instances created by that `NewService`, using an `Arc`. The tests can
then wrap the HTTP router stack with this wrapper, and make assertions
about how many services are alive.

I had to do a bit of stack surgery to fit the tracking layer in the right place.
Sorry in advance for any merge conflicts.

This branch adds two tests. One asserts that services are dropped after
the idle timeout when they are inactive, and another asserts that
services which are currently streaming response bodies are *not* idled
out.

The second of these tests fails on `main`, which is expected. We expect
PR #768 to fix this.

Depends on #765.