### PR TITLE
test: make integration tests shut up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1012,6 +1012,7 @@ dependencies = [
  "hyper",
  "linkerd2-app-core",
  "linkerd2-identity",
+ "linkerd2-io",
  "regex 0.1.80",
  "tokio 0.3.5",
  "tokio-test 0.3.0",

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -198,6 +198,14 @@ impl Listening {
 }
 
 async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
+    // Logs from spawned threads will not be captured, so use a filter that
+    // disables most of the proxy's logs by default.
+    // TODO(eliza): when we're on Rust 1.49.0+, libtest *will* capture these
+    // logs, so we can use the same default filter as other test code.
+    const DEFAULT_LOG: &'static str = "error,\
+                                       linkerd2_proxy_http=off,\
+                                       linkerd2_proxy_transport=off";
+
     use app::env::Strings;
 
     let controller = if let Some(controller) = proxy.controller {
@@ -291,7 +299,7 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
     }
 
     let config = app::env::parse_config(&env).unwrap();
-    let (trace, trace_handle) = super::trace_subscriber();
+    let (trace, trace_handle) = super::trace_subscriber(DEFAULT_LOG);
 
     let (running_tx, running_rx) = oneshot::channel();
     let (term_tx, term_rx) = oneshot::channel();

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -25,6 +25,7 @@ http-body = "0.4"
 hyper = "0.14.0-dev"
 linkerd2-app-core = { path = "../core", features = ["mock-orig-dst"] }
 linkerd2-identity = { path = "../../identity" }
+linkerd2-io = { path = "../../io", features = ["tokio-test"] }
 regex = "0.1"
 tokio = { version = "0.3", features = ["io-util", "net", "rt", "sync"]}
 tokio-test = "0.3"

--- a/linkerd/app/test/src/lib.rs
+++ b/linkerd/app/test/src/lib.rs
@@ -54,13 +54,11 @@ const DEFAULT_LOG: &'static str = "warn,\
                                    linkerd2_proxy_http=error,\
                                    linkerd2_proxy_transport=error";
 
-pub fn trace_subscriber() -> (Dispatch, app_core::trace::Handle) {
+pub fn trace_subscriber(default_filter: &str) -> (Dispatch, app_core::trace::Handle) {
     use std::env;
     let log_level = env::var("LINKERD2_PROXY_LOG")
         .or_else(|_| env::var("RUST_LOG"))
-        .unwrap_or_else(|_| DEFAULT_LOG.to_owned());
-    env::set_var("RUST_LOG", &log_level);
-    env::set_var("LINKERD2_PROXY_LOG", &log_level);
+        .unwrap_or_else(|_| default_filter.to_owned());
     let log_format = env::var("LINKERD2_PROXY_LOG_FORMAT").unwrap_or_else(|_| "PLAIN".to_string());
     env::set_var("LINKERD2_PROXY_LOG_FORMAT", &log_format);
     // This may fail, since the global log compat layer may have been
@@ -74,6 +72,6 @@ pub fn trace_subscriber() -> (Dispatch, app_core::trace::Handle) {
 }
 
 pub fn trace_init() -> tracing::dispatcher::DefaultGuard {
-    let (d, _) = trace_subscriber();
+    let (d, _) = trace_subscriber(DEFAULT_LOG);
     tracing::dispatcher::set_default(&d)
 }


### PR DESCRIPTION
PR #766 changed the proxy tests to set a much more verbose default log
filter, relying on libtest's output capturing to prevent the tests from
spamming stdout when they don't fail. However, the integration tests run
the proxy in a separate thread, and libtest can't currently capture
output from spawned threads. This results in a bunch of unnecessary
noise when running the integration tests.

When Rust 1.49.0 is released, we should revisit this, as output capturing
will work for spawned threads.

This branch changes the integration tests so that the spawned proxy
thread uses the old filter settings instead. We still get more detailed
output from stack tests, and from the main test threads in the
integration tests. I removed some code that would set the value of the
log level env vars, since that made this impossible — I'm not really
sure why that code was ever necessary in the first place.

Also, I fixed a compiler error in `linkerd2-app-test` due to a missing
Cargo feature.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>