### PR TITLE
Ensure each crate can be built indpendently

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       - run: make lint
 
   check:
-    timeout-minutes: 5
+    timeout-minutes: 15
     runs-on: ubuntu-18.04
     container:
       image: docker://rust:1.47.0-buster

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,8 @@ jobs:
       image: docker://rust:1.47.0-buster
     steps:
       - uses: actions/checkout@v1
-      - run: make check
+      # Iterate through all subcrates to ensure each compiles indpendently.
+      - run: for d in $(for toml in $(find . -name Cargo.toml) ; do echo ${toml%/*} ; done | sort -r ) ; do echo "# $d" ; (cd $d ; cargo check --all-targets) ; done
 
   test:
     timeout-minutes: 15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2787,13 +2787,13 @@ dependencies = [
 [[package]]
 name = "tower-layer"
 version = "0.3.0"
-source = "git+https://github.com/tower-rs/tower?rev=450fa3d2be2b43850ceb125009d636d1d8629ad7#450fa3d2be2b43850ceb125009d636d1d8629ad7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
 
 [[package]]
 name = "tower-layer"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
+source = "git+https://github.com/tower-rs/tower?rev=450fa3d2be2b43850ceb125009d636d1d8629ad7#450fa3d2be2b43850ceb125009d636d1d8629ad7"
 
 [[package]]
 name = "tower-request-modifier"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
  "hyper",
  "pin-project 0.4.22",
  "tokio 0.3.5",
- "tokio-test 0.2.1",
+ "tokio-test 0.3.0",
  "tower",
 ]
 
@@ -922,7 +922,7 @@ dependencies = [
  "linkerd2-app-outbound",
  "linkerd2-app-test",
  "tokio 0.3.5",
- "tokio-test 0.2.1",
+ "tokio-test 0.3.0",
  "tower",
  "tower-test",
  "tracing",
@@ -1031,7 +1031,7 @@ dependencies = [
  "linkerd2-error",
  "pin-project 0.4.22",
  "tokio 0.3.5",
- "tokio-test 0.2.1",
+ "tokio-test 0.3.0",
  "tower",
  "tower-test",
  "tracing",
@@ -1193,7 +1193,6 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.6.0",
  "futures 0.3.5",
- "h2 0.3.0",
  "http",
  "http-body",
  "hyper",
@@ -1238,7 +1237,6 @@ name = "linkerd2-metrics"
 version = "0.1.0"
 dependencies = [
  "deflate",
- "futures 0.3.5",
  "hdrhistogram",
  "http",
  "hyper",
@@ -1329,7 +1327,6 @@ version = "0.1.0"
 dependencies = [
  "async-stream 0.2.1",
  "futures 0.3.5",
- "indexmap",
  "linkerd2-channel",
  "linkerd2-error",
  "linkerd2-proxy-core",
@@ -1558,7 +1555,7 @@ dependencies = [
  "linkerd2-error",
  "pin-project 0.4.22",
  "tokio 0.3.5",
- "tokio-test 0.2.1",
+ "tokio-test 0.3.0",
  "tower",
  "tower-test",
  "tracing",
@@ -1597,7 +1594,7 @@ dependencies = [
  "pin-project 0.4.22",
  "tokio 0.3.5",
  "tokio-connect",
- "tokio-test 0.2.1",
+ "tokio-test 0.3.0",
  "tower",
  "tower-test",
  "tracing",

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -14,4 +14,4 @@ tower = { version = "0.4", default-features = false, features = ["load"]}
 tokio = { version = "0.3", features = ["macros"]}
 
 [dev-dependencies]
-tokio-test = "0.2"
+tokio-test = "0.3"

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -17,7 +17,7 @@ tracing = "0.1.22"
 
 [dev-dependencies]
 tokio = { version = "0.3", features = ["rt", "macros"] }
-tokio-test = "0.2"
+tokio-test = "0.3"
 tower = { version = "0.4", default-features = false, features = ["util"] }
 tower-test = "0.3"
 linkerd2-app-test = { path = "../test" }

--- a/linkerd/buffer/Cargo.toml
+++ b/linkerd/buffer/Cargo.toml
@@ -16,5 +16,6 @@ tracing-futures = { version = "0.2", features = ["std-future"] }
 pin-project = "0.4"
 
 [dev-dependencies]
+tokio = { version = "0.3", features = ["rt-multi-thread"] }
 tower-test = "0.3"
-tokio-test = "0.2"
+tokio-test = "0.3"

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 bytes = "0.6"
 futures = "0.3"
-h2 = { git = "https://github.com/hyperium/h2" }
 http = "0.2"
 http-body = "0.4"
 hyper = "0.14.0-dev"

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -12,7 +12,6 @@ test_util = []
 
 [dependencies]
 deflate = { version = "0.7.18", features = ["gzip"] }
-futures = "0.3"
 hdrhistogram = { version = "7.1", optional = true }
 http = "0.2"
 hyper = "0.14.0-dev"

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -7,13 +7,13 @@ publish = false
 
 [dependencies]
 futures = "0.3"
+http = "0.2"
+http-body = "0.4"
 linkerd2-error = { path = "../error" }
 linkerd2-metrics = { path = "../metrics" }
 opencensus-proto = { path = "../../opencensus-proto" }
-tokio = "0.2"
-tonic = { version = "0.3", default-features = false, features = ["prost", "codegen"] }
-tracing = "0.1.22"
 pin-project = "0.4"
-http = "0.2"
-http-body = "0.4"
+tokio = { version = "0.2", features = ["sync"] }
+tonic = { version = "0.3", default-features = false, features = ["prost", "codegen"] }
 tower = { version = "0.4", default-features = false }
+tracing = "0.1.22"

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -15,7 +15,6 @@ linkerd2-channel = { path = "../../channel" }
 linkerd2-error = { path = "../../error" }
 linkerd2-proxy-core = { path = "../core" }
 linkerd2-stack = { path = "../../stack" }
-indexmap = "1.0"
 tokio = { version = "0.3", features = ["sync", "time", "stream"] }
 tracing = "0.1.22"
 tracing-futures = { version = "0.2", features = ["std-future"] }

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -28,7 +28,7 @@ linkerd2-io = { path = "../../io" }
 linkerd2-metrics = { path = "../../metrics" }
 linkerd2-stack = { path = "../../stack" }
 rustls = "0.18"
-tokio = { version = "0.3", features = ["io-util", "net", "time"]}
+tokio = { version = "0.3", features = ["io-util", "macros", "net", "time"]}
 tokio-rustls = "0.20"
 tokio-util = { version = "0.5", features = ["compat"]}
 tracing = "0.1.22"
@@ -51,5 +51,6 @@ libc = "0.2"
 [dev-dependencies]
 linkerd2-identity = { path = "../../identity", features = ["test-util"] }
 tracing-subscriber = "0.2.14"
+tokio = { version = "0.3", features = ["rt-multi-thread"] }
 tower = { version = "0.4", default-features = false, features = ["util"] }
 tracing-futures = { version = "0.2", features = ["std-future"] }

--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -186,7 +186,6 @@ mod sys {
 
     #[cfg(target_os = "linux")]
     mod linux {
-        use libc;
         use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
         use std::os::unix::io::RawFd;
         use std::{io, mem};

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -27,6 +27,6 @@ features = [
 
 [dev-dependencies]
 tower-test = "0.3"
-tokio-test = "0.2"
+tokio-test = "0.3"
 tracing-subscriber = "0.2.14"
-tokio = { version = "0.3", features = ["time", "macros"] }
+tokio = { version = "0.3", features = ["rt-multi-thread", "time", "macros"] }

--- a/linkerd/timeout/Cargo.toml
+++ b/linkerd/timeout/Cargo.toml
@@ -26,5 +26,5 @@ features = [
 
 [dev-dependencies]
 tower-test = "0.3"
-tokio-test = "0.2"
-tokio = { version = "0.3", features = ["macros"] }
+tokio-test = "0.3"
+tokio = { version = "0.3", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Some subcrates have unneeded or outdated dependencies. This change
updates most of them. The opencensus and trace-context traits should be
updated in a followup.