### PR TITLE
Apply clippy to all targets, including tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ fmt:
 
 .PHONY: lint
 lint:
-	$(CARGO_CLIPPY)
+	$(CARGO_CLIPPY) --all-targets
 
 
 .PHONY: shellcheck

--- a/hyper-balance/src/lib.rs
+++ b/hyper-balance/src/lib.rs
@@ -438,7 +438,7 @@ mod tests {
         ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
             let mut this = self.as_mut();
             assert!(this.0.is_empty());
-            Poll::Ready(Ok(this.1.take().into()))
+            Poll::Ready(Ok(this.1.take()))
         }
     }
 

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -3,6 +3,8 @@
 #![deny(warnings, rust_2018_idioms)]
 #![recursion_limit = "256"]
 #![type_length_limit = "16289823"]
+// It's not clear where this originates.
+#![allow(clippy::eval_order_dependence)]
 
 mod test_env;
 

--- a/linkerd/app/integration/src/tests/discovery.rs
+++ b/linkerd/app/integration/src/tests/discovery.rs
@@ -182,7 +182,7 @@ macro_rules! generate_tests {
 
             let srv = $make_server().route("/", "hello").run().await;
 
-            const NAME: &'static str = "unresolvable.svc.cluster.local";
+            const NAME: &str = "unresolvable.svc.cluster.local";
             let ctrl = controller::new();
             let profile = ctrl.profile_tx(&srv.addr.to_string());
             profile.send_err(grpc::Status::new(

--- a/linkerd/app/integration/src/tests/identity.rs
+++ b/linkerd/app/integration/src/tests/identity.rs
@@ -234,7 +234,7 @@ async fn refresh() {
 
     tokio::time::sleep(how_long).await;
 
-    assert_eventually!(refreshed.load(Ordering::SeqCst) == true);
+    assert_eventually!(refreshed.load(Ordering::SeqCst));
 }
 
 mod require_id_header {

--- a/linkerd/app/integration/src/tests/shutdown.rs
+++ b/linkerd/app/integration/src/tests/shutdown.rs
@@ -113,10 +113,7 @@ async fn tcp_waits_for_proxies_to_close() {
                 assert_eq!(&vec[..n], msg1.as_bytes());
                 sock.write_all(msg2.as_bytes()).await
             }
-            .map(|res| match res {
-                Err(e) => panic!("tcp server error: {}", e),
-                Ok(_) => {}
-            })
+            .map(|res| res.expect("TCP server must not error"))
         })
         .run()
         .await;

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -191,8 +191,8 @@ mod response_classification {
     use crate::*;
     use tracing::info;
 
-    const REQ_STATUS_HEADER: &'static str = "x-test-status-requested";
-    const REQ_GRPC_STATUS_HEADER: &'static str = "x-test-grpc-status-requested";
+    const REQ_STATUS_HEADER: &str = "x-test-status-requested";
+    const REQ_GRPC_STATUS_HEADER: &str = "x-test-grpc-status-requested";
 
     const STATUSES: [http::StatusCode; 6] = [
         http::StatusCode::OK,
@@ -1000,7 +1000,7 @@ mod transport {
     }
 
     #[tokio::test]
-    #[cfg(macos)]
+    #[cfg(target_os = "macos")]
     async fn inbound_tcp_connect_err() {
         let _trace = trace_init();
         let srv = tcp::server()
@@ -1031,7 +1031,7 @@ mod transport {
     }
 
     #[test]
-    #[cfg(macos)]
+    #[cfg(target_os = "macos")]
     fn outbound_tcp_connect_err() {
         let _trace = trace_init();
         let srv = tcp::server()
@@ -1498,10 +1498,9 @@ async fn metrics_compression() {
                 body.copy_to_bytes(body.remaining()),
             ));
             let mut scrape = String::new();
-            decoder.read_to_string(&mut scrape).expect(&format!(
-                "decode gzip (requested Accept-Encoding: {})",
-                encoding
-            ));
+            decoder.read_to_string(&mut scrape).unwrap_or_else(|_| {
+                panic!("decode gzip (requested Accept-Encoding: {})", encoding)
+            });
             scrape
         }
     };

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1,3 +1,6 @@
+// It's not clear where this originates.
+#![allow(clippy::redundant_closure_call)]
+
 use crate::*;
 use std::error::Error as _;
 use tokio::sync::mpsc;
@@ -212,12 +215,9 @@ async fn test_server_speaks_first(env: TestEnv) {
                 let n = sock.read(&mut vec).await?;
                 assert_eq!(s(&vec[..n]), msg2);
                 tx.send(()).await.unwrap();
-                Ok(())
+                Ok::<(), io::Error>(())
             }
-            .map(|res: std::io::Result<()>| match res {
-                Err(e) => panic!("tcp server error: {}", e),
-                Ok(()) => {}
-            })
+            .map(|res| res.expect("TCP server must not fail"))
         })
         .run()
         .await;
@@ -313,12 +313,9 @@ async fn tcp_connections_close_if_client_closes() {
                 assert_eq!(n, 0);
                 panic!("lol");
                 tx.send(()).await.unwrap();
-                Ok(())
+                Ok::<(), io::Error>(())
             }
-            .map(|res: std::io::Result<()>| match res {
-                Err(e) => panic!("tcp server error: {}", e),
-                Ok(()) => {}
-            })
+            .map(|res| res.expect("TCP server must not fail"))
         })
         .run()
         .await;
@@ -519,10 +516,7 @@ macro_rules! http1_tests {
                         // Some processing... and then write back in chatproto...
                         sock.write_all(chatproto_res.as_bytes()).await
                     }
-                    .map(|res: std::io::Result<()>| match res {
-                        Ok(()) => {}
-                        Err(e) => panic!("tcp server error: {}", e),
-                    })
+                    .map(|res| res.expect("TCP server must not fail"))
                 })
                 .run()
                 .await;

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -1081,12 +1081,12 @@ mod tests {
 
     #[test]
     fn parse_duration_unit_ms() {
-        test_unit("ms", |v| Duration::from_millis(v));
+        test_unit("ms", Duration::from_millis);
     }
 
     #[test]
     fn parse_duration_unit_s() {
-        test_unit("s", |v| Duration::from_secs(v));
+        test_unit("s", Duration::from_secs);
     }
 
     #[test]

--- a/linkerd/dns/name/src/name.rs
+++ b/linkerd/dns/name/src/name.rs
@@ -76,6 +76,7 @@ impl AsRef<str> for Name {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn test_is_localhost() {
@@ -102,8 +103,8 @@ mod tests {
             ("web.svc.local.", "web.svc.local"),
         ];
         for (host, expected_result) in cases {
-            let dns_name =
-                Name::try_from(host.as_bytes()).expect(&format!("'{}' was invalid", host));
+            let dns_name = Name::try_from(host.as_bytes())
+                .unwrap_or_else(|_| panic!("'{}' was invalid", host));
             assert_eq!(
                 dns_name.without_trailing_dot(),
                 *expected_result,
@@ -111,7 +112,7 @@ mod tests {
                 dns_name
             )
         }
-        assert!(Name::try_from(".".as_bytes()).is_err());
-        assert!(Name::try_from("".as_bytes()).is_err());
+        assert!(Name::from_str(".").is_err());
+        assert!(Name::from_str("").is_err());
     }
 }

--- a/linkerd/drain/src/lib.rs
+++ b/linkerd/drain/src/lib.rs
@@ -216,13 +216,13 @@ mod tests {
             poll_cnt: AtomicUsize::new(0),
         });
 
-        let watch1 = task::spawn(rx.clone().watch(TestMeFut(fut1.clone()), |fut| {
-            fut.0.draining.store(true, Relaxed)
-        }));
+        let watch1 = task::spawn(
+            rx.clone()
+                .watch(TestMeFut(fut1), |fut| fut.0.draining.store(true, Relaxed)),
+        );
 
-        let watch2 = task::spawn(rx.watch(TestMeFut(fut2.clone()), |fut| {
-            fut.0.draining.store(true, Relaxed)
-        }));
+        let watch2 =
+            task::spawn(rx.watch(TestMeFut(fut2), |fut| fut.0.draining.store(true, Relaxed)));
 
         let mut draining = task::spawn(tx.drain());
 

--- a/linkerd/http-metrics/src/requests/mod.rs
+++ b/linkerd/http-metrics/src/requests/mod.rs
@@ -145,7 +145,7 @@ mod tests {
         let metrics = registry
             .by_target
             .entry(Target(123))
-            .or_insert_with(|| Default::default())
+            .or_insert_with(Default::default)
             .clone();
         assert_eq!(registry.by_target.len(), 1, "target should be registered");
         let after_update = Instant::now();

--- a/linkerd/metrics/src/counter.rs
+++ b/linkerd/metrics/src/counter.rs
@@ -92,6 +92,7 @@ impl<F: Factor> FmtMetric for Counter<F> {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
     use crate::{MicrosAsSeconds, MillisAsSeconds, MAX_PRECISE_UINT64};

--- a/linkerd/metrics/src/histogram.rs
+++ b/linkerd/metrics/src/histogram.rs
@@ -275,6 +275,7 @@ impl cmp::PartialOrd<f64> for Bucket {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
 
@@ -282,7 +283,7 @@ mod tests {
     use std::collections::HashMap;
     use std::u64;
 
-    static BOUNDS: &'static Bounds = &Bounds(&[
+    static BOUNDS: &Bounds = &Bounds(&[
         Bucket::Le(0.010),
         Bucket::Le(0.020),
         Bucket::Le(0.030),

--- a/linkerd/proxy/http/src/detect.rs
+++ b/linkerd/proxy/http/src/detect.rs
@@ -146,8 +146,7 @@ mod tests {
             assert_eq!(kind, Some(Version::Http1));
         }
 
-        const REQ: &'static [u8] =
-            b"GET /foo/bar/bar/blah HTTP/1.1\r\nHost: foob.example.com\r\n\r\n";
+        const REQ: &[u8] = b"GET /foo/bar/bar/blah HTTP/1.1\r\nHost: foob.example.com\r\n\r\n";
         let mut buf = BytesMut::with_capacity(1024);
         let mut io = io::Builder::new().read(&REQ).build();
         let kind = DetectHttp(()).detect(&mut io, &mut buf).await.unwrap();
@@ -155,7 +154,7 @@ mod tests {
         assert_eq!(&buf[..], REQ);
 
         // Starts with a P, like the h2 preface.
-        const POST: &'static [u8] = b"POST /foo HTTP/1.1\r\n";
+        const POST: &[u8] = b"POST /foo HTTP/1.1\r\n";
         for i in 1..POST.len() {
             let mut buf = BytesMut::with_capacity(1024);
             let mut io = io::Builder::new().read(&POST[..i]).read(&POST[i..]).build();

--- a/linkerd/proxy/transport/tests/tls_accept.rs
+++ b/linkerd/proxy/transport/tests/tls_accept.rs
@@ -133,7 +133,7 @@ where
             Conditional::Some(ClientTls(crtkey)),
             Conditional::Some(name),
         ),
-        Conditional::None(reason) => (Conditional::None(reason.clone()), Conditional::None(reason)),
+        Conditional::None(reason) => (Conditional::None(reason), Conditional::None(reason)),
     };
 
     // A future that will receive a single connection.


### PR DESCRIPTION
There are some lints that are obfuscated by macros, so the integration
tests have some blanket allows.