### PR TITLE
Default the protocol detection timeout to 10s

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -174,7 +174,7 @@ pub const DEFAULT_CONTROL_LISTEN_ADDR: &str = "0.0.0.0:4190";
 const DEFAULT_ADMIN_LISTEN_ADDR: &str = "127.0.0.1:4191";
 const DEFAULT_METRICS_RETAIN_IDLE: Duration = Duration::from_secs(10 * 60);
 const DEFAULT_INBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(1);
-const DEFAULT_INBOUND_DETECT_TIMEOUT: Duration = Duration::from_secs(90);
+const DEFAULT_INBOUND_DETECT_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_INBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(100);
 const DEFAULT_INBOUND_CONNECT_BACKOFF: ExponentialBackoff = ExponentialBackoff {
     min: Duration::from_millis(100),
@@ -182,7 +182,7 @@ const DEFAULT_INBOUND_CONNECT_BACKOFF: ExponentialBackoff = ExponentialBackoff {
     jitter: 0.1,
 };
 const DEFAULT_OUTBOUND_DISPATCH_TIMEOUT: Duration = Duration::from_secs(3);
-const DEFAULT_OUTBOUND_DETECT_TIMEOUT: Duration = Duration::from_secs(90);
+const DEFAULT_OUTBOUND_DETECT_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_OUTBOUND_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_OUTBOUND_CONNECT_BACKOFF: ExponentialBackoff = ExponentialBackoff {
     min: Duration::from_millis(100),


### PR DESCRIPTION
The proxy fails connections that do not complete protocol detection
within a given timeout. This timeout has been derived from the
request-level dispatch timeout; but in practice, many applications may
create idle connections, i.e. in a connection pool, and distribute
requests over them as requests or events come into the application.

In order to better-support these applications, we want to extend the
detection timeout to permit idle connections to be established without
failing them eagerly; though we do not want to increase the
request-level dispatch timeout, as that can lead to undesirable memory
pressure and request-level latency.

This change creates a dedicated pair of configurations for the detection
timeout, decoupled from the dispatch timeout, and sets its default to
10s.