### PR TITLE
Remove weights from endpoint metadata

### DIFF
--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -158,7 +158,6 @@ async fn profile_endpoint_propagates_conn_errors() {
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         Some(id_name.clone()),
-        10_000,
         None,
     );
 
@@ -268,7 +267,6 @@ async fn meshed_hello_world() {
         Default::default(),
         support::resolver::ProtocolHint::Http2,
         Some(id_name.clone()),
-        10_000,
         None,
     );
 
@@ -330,7 +328,6 @@ async fn stacks_idle_out() {
         Default::default(),
         support::resolver::ProtocolHint::Http2,
         Some(id_name.clone()),
-        10_000,
         None,
     );
 
@@ -402,7 +399,6 @@ async fn active_stacks_dont_idle_out() {
         Default::default(),
         support::resolver::ProtocolHint::Http2,
         Some(id_name.clone()),
-        10_000,
         None,
     );
 

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -132,7 +132,6 @@ async fn tls_when_hinted() {
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         Some(id_name),
-        10_000,
         None,
     );
 
@@ -190,7 +189,6 @@ async fn resolutions_are_reused() {
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         Some(id_name),
-        10_000,
         None,
     );
 
@@ -290,7 +288,6 @@ async fn load_balances() {
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         Some(id_name),
-        10_000,
         None,
     );
 
@@ -385,7 +382,6 @@ async fn load_balancer_add_endpoints() {
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         Some(id_name),
-        10_000,
         None,
     );
 
@@ -500,7 +496,6 @@ async fn load_balancer_remove_endpoints() {
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         Some(id_name),
-        10_000,
         None,
     );
 
@@ -601,7 +596,6 @@ async fn no_profiles_when_outside_search_nets() {
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         Some(id_name),
-        10_000,
         None,
     );
 
@@ -656,7 +650,6 @@ async fn no_discovery_when_profile_has_an_endpoint() {
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         Some(id_name.clone()),
-        10_000,
         None,
     );
 
@@ -710,7 +703,6 @@ async fn profile_endpoint_propagates_conn_errors() {
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         Some(id_name.clone()),
-        10_000,
         None,
     );
 

--- a/linkerd/proxy/api-resolve/src/metadata.rs
+++ b/linkerd/proxy/api-resolve/src/metadata.rs
@@ -5,17 +5,6 @@ use indexmap::IndexMap;
 /// Metadata describing an endpoint.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Metadata {
-    /// An endpoint's relative weight.
-    ///
-    /// A weight of 0 means that the endpoint should never be preferred over a
-    /// non 0-weighted endpoint.
-    ///
-    /// The default weight, corresponding to 1.0, is 10,000. This enables us to
-    /// specify weights as small as 0.0001 and as large as 400,000+.
-    ///
-    /// A float is not used so that this type can implement `Eq`.
-    weight: u32,
-
     /// Arbitrary endpoint labels. Primarily used for telemetry.
     labels: IndexMap<String, String>,
 
@@ -47,7 +36,6 @@ impl Default for Metadata {
             labels: IndexMap::default(),
             protocol_hint: ProtocolHint::Unknown,
             identity: None,
-            weight: 10_000,
             authority_override: None,
         }
     }
@@ -58,14 +46,12 @@ impl Metadata {
         labels: IndexMap<String, String>,
         protocol_hint: ProtocolHint,
         identity: Option<identity::Name>,
-        weight: u32,
         authority_override: Option<Authority>,
     ) -> Self {
         Self {
             labels,
             protocol_hint,
             identity,
-            weight,
             authority_override,
         }
     }

--- a/linkerd/proxy/api-resolve/src/pb.rs
+++ b/linkerd/proxy/api-resolve/src/pb.rs
@@ -43,7 +43,7 @@ pub fn to_addr_meta(
     }
 
     let tls_id = pb.tls_identity.and_then(to_id);
-    let meta = Metadata::new(meta, proto_hint, tls_id, pb.weight, authority_override);
+    let meta = Metadata::new(meta, proto_hint, tls_id, authority_override);
     Some((addr, meta))
 }
 


### PR DESCRIPTION
Endpoint weights are unused. This change removes weights from the
metadata struct.