### PR TITLE
identity: add `identity_cert_refresh_count` metric

### DIFF
--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -46,7 +46,7 @@ impl Config {
         match self {
             Config::Disabled => Ok(Identity::Disabled),
             Config::Enabled { control, certify } => {
-                let (local, crt_store) = Local::new(&certify);
+                let (local, daemon) = Local::new(&certify);
 
                 let addr = control.addr.clone();
                 let svc = control.build(
@@ -60,7 +60,7 @@ impl Config {
                     let addr = addr.clone();
                     Box::pin(async move {
                         debug!(peer.addr = ?addr, "running");
-                        certify::daemon(certify, crt_store, svc).await
+                        daemon.run(svc).await
                     })
                 };
 

--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -49,11 +49,8 @@ impl Config {
                 let (local, daemon) = Local::new(&certify);
 
                 let addr = control.addr.clone();
-                let svc = control.build(
-                    dns,
-                    metrics,
-                    tls::Conditional::Some(certify.trust_anchors.clone()),
-                );
+                let svc =
+                    control.build(dns, metrics, tls::Conditional::Some(certify.trust_anchors));
 
                 // Save to be spawned on an auxiliary runtime.
                 let task = {


### PR DESCRIPTION
Depends on #787.

This commit adds a new `identity_cert_refresh_count` counter metric,
which tracks the number of times the proxy's identity certificate has
been successfully refreshed by the Identity service.

This change was fairly straightforward, but I did make a few internal
changes so that the counter could be passed into the daemon task. This
resulted in a couple things moving around, but the moved code is largely
unchanged.

In the future we may want to count cert refresh errors as well, possibly
adding labels for successes/failures, or a new metric tracking errors.