### PR TITLE
Simplify http::normalize_uri initialization

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -385,7 +385,7 @@ impl Config {
                     .box_http_request()
                     .box_http_response(),
             )
-            .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
+            .push(http::NewNormalizeUri::layer())
             .push_map_target(|(_, accept): (_, TcpAccept)| accept)
             .instrument(|(v, _): &(http::Version, _)| debug_span!("http", %v))
             .check_new_service::<(http::Version, TcpAccept), http::Request<_>>()

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -117,7 +117,7 @@ where
                 .box_http_response(),
         )
         .check_new_service::<http::Accept, http::Request<_>>()
-        .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
+        .push(http::NewNormalizeUri::layer())
         .check_new_service::<http::Accept, http::Request<_>>()
         .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
         .push_map_target(http::Accept::from)

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -195,7 +195,7 @@ where
                 .push_spawn_buffer(buffer_capacity)
                 .box_http_response(),
         )
-        .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
+        .push(http::NewNormalizeUri::layer())
         .instrument(|l: &http::Logical| debug_span!("http", v = %l.protocol))
         .push_map_target(http::Logical::from)
         .into_inner();

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -14,7 +14,7 @@ pub mod h1;
 pub mod h2;
 pub mod header_from_target;
 pub mod insert;
-pub mod normalize_uri;
+mod normalize_uri;
 pub mod orig_proto;
 pub mod override_authority;
 mod retain;
@@ -29,6 +29,7 @@ pub use self::{
     client_handle::{ClientHandle, SetClientHandle},
     detect::DetectHttp,
     glue::{HyperServerSvc, UpgradeBody},
+    normalize_uri::NewNormalizeUri,
     override_authority::CanOverrideAuthority,
     retain::Retain,
     server::NewServeHttp,


### PR DESCRIPTION
In order to simplify stack initialization, this change renames the
`MakeNormalizeUri` type to `NewNormalizeUri` and adds a `layer` helper.