### PR TITLE
Simplify NewRouter initialization

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -5,7 +5,7 @@ use crate::transport::Connect;
 use crate::{cache, Error};
 pub use linkerd2_buffer as buffer;
 use linkerd2_concurrency_limit as concurrency_limit;
-pub use linkerd2_stack::{self as stack, layer, NewService};
+pub use linkerd2_stack::{self as stack, layer, NewRouter, NewService};
 pub use linkerd2_stack_tracing::{InstrumentMake, InstrumentMakeLayer};
 pub use linkerd2_timeout as timeout;
 use std::{

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -369,9 +369,7 @@ impl Config {
             // Routes each request to a target, obtains a service for that
             // target, and dispatches the request.
             .instrument_from_target()
-            .push(svc::layer::mk(|inner| {
-                svc::stack::NewRouter::new(RequestTarget::from, inner)
-            }))
+            .push(svc::NewRouter::layer(RequestTarget::from))
             .check_new_service::<TcpAccept, http::Request<_>>()
             // Used by tap.
             .push_http_insert_target()

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -92,9 +92,7 @@ where
         .push_on_response(http::Retain::layer())
         .check_new_service::<Target, http::Request<_>>()
         .instrument(|t: &Target| info_span!("target", dst = %t.dst))
-        .push(svc::layer::mk(|inner| {
-            svc::stack::NewRouter::new(TargetPerRequest::accept, inner)
-        }))
+        .push(svc::NewRouter::layer(TargetPerRequest::accept))
         .check_new_service::<http::Accept, http::Request<_>>()
         .push_on_response(
             svc::layers()

--- a/linkerd/stack/src/router.rs
+++ b/linkerd/stack/src/router.rs
@@ -1,4 +1,4 @@
-use crate::NewService;
+use crate::{layer, NewService};
 use std::task::{Context, Poll};
 use tower::util::{Oneshot, ServiceExt};
 
@@ -21,11 +21,18 @@ pub struct Router<T, N> {
 }
 
 impl<K, N> NewRouter<K, N> {
-    pub fn new(new_recgonize: K, inner: N) -> Self {
+    fn new(new_recgonize: K, inner: N) -> Self {
         Self {
             new_recgonize,
             inner,
         }
+    }
+
+    pub fn layer(new_recgonize: K) -> impl layer::Layer<N, Service = Self> + Clone
+    where
+        K: Clone,
+    {
+        layer::mk(move |inner| Self::new(new_recgonize.clone(), inner))
     }
 }
 


### PR DESCRIPTION
NewRouter initialization is needlessly verbose.

This change reduces boilerplate by adding a `NewRouter::layer` helper.