### PR TITLE
Simplify orig_proto::Downgrade intializaiton

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -352,7 +352,7 @@ impl Config {
         // Handles requests as they are initially received by the proxy.
         let http_admit_request = svc::layers()
             // Downgrades the protocol if upgraded by an outbound proxy.
-            .push(svc::layer::mk(orig_proto::Downgrade::new))
+            .push(orig_proto::Downgrade::layer())
             // Limits the number of in-flight requests.
             .push_concurrency_limit(max_in_flight_requests)
             // Eagerly fail requests when the proxy is out of capacity for a

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -2,6 +2,7 @@ use super::{glue::UpgradeBody, h1, h2, upgrade};
 use futures::{future, prelude::*};
 use http::header::{HeaderValue, TRANSFER_ENCODING};
 use linkerd2_error::Error;
+use linkerd2_stack::layer;
 use std::{
     future::Future,
     pin::Pin,
@@ -112,11 +113,8 @@ where
 // ===== impl Downgrade =====
 
 impl<S> Downgrade<S> {
-    pub fn new<A, B>(inner: S) -> Self
-    where
-        S: tower::Service<http::Request<A>, Response = http::Response<B>>,
-    {
-        Self { inner }
+    pub fn layer() -> impl layer::Layer<S, Service = Self> + Copy + Clone {
+        layer::mk(|inner| Self { inner })
     }
 }
 


### PR DESCRIPTION
This change adds a helper, `orig_proto::Downgrade::layer`, to simplify
stack initialization.