### PR TITLE
Simplify tcp::Forward stack initialization

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -109,7 +109,7 @@ impl Config {
             .push_make_thunk()
             .push_on_response(
                 svc::layers()
-                    .push(svc::layer::mk(tcp::Forward::new))
+                    .push(tcp::Forward::layer())
                     .push(drain::Retain::layer(drain.clone())),
             )
             .instrument(|_: &_| debug_span!("tcp"))

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -202,7 +202,7 @@ where
 
     let tcp_forward = svc::stack(tcp_connect)
         .push_make_thunk()
-        .push_on_response(svc::layer::mk(tcp::Forward::new))
+        .push_on_response(tcp::Forward::layer())
         .into_new_service()
         .push_on_response(metrics.stack.layer(stack_labels("tcp", "forward")))
         .push_map_target(tcp::Endpoint::from_logical(

--- a/linkerd/app/outbound/src/tcp/balance.rs
+++ b/linkerd/app/outbound/src/tcp/balance.rs
@@ -56,7 +56,7 @@ where
                     crate::EWMA_DEFAULT_RTT,
                     crate::EWMA_DECAY,
                 ))
-                .push(svc::layer::mk(tcp::Forward::new))
+                .push(tcp::Forward::layer())
                 .push(drain::Retain::layer(drain)),
         )
         .into_new_service()

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -59,7 +59,7 @@ where
 {
     svc::stack(connect)
         .push_make_thunk()
-        .push_on_response(svc::layer::mk(super::Forward::new))
+        .push_on_response(super::Forward::layer())
         .instrument(|_: &Endpoint<P>| debug_span!("tcp.forward"))
         .check_new_service::<Endpoint<P>, I>()
         .into_inner()

--- a/linkerd/proxy/tcp/src/forward.rs
+++ b/linkerd/proxy/tcp/src/forward.rs
@@ -1,6 +1,7 @@
 use futures::prelude::*;
 use linkerd2_duplex::Duplex;
 use linkerd2_error::Error;
+use linkerd2_stack::layer;
 use std::{
     future::Future,
     pin::Pin,
@@ -14,9 +15,13 @@ pub struct Forward<C> {
     connect: C,
 }
 
-impl<M> Forward<M> {
-    pub fn new(connect: M) -> Self {
+impl<C> Forward<C> {
+    fn new(connect: C) -> Self {
         Self { connect }
+    }
+
+    pub fn layer() -> impl layer::Layer<C, Service = Self> + Clone + Copy {
+        layer::mk(Self::new)
     }
 }
 


### PR DESCRIPTION
Add a `tcp::Forward::layer` helper to simplify stack initialization.