### PR TITLE
Simplify HTTP metrics initialization

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -65,7 +65,7 @@ impl Config {
             .push(self::resolve::layer(dns, backoff))
             .push_on_response(self::control::balance::layer())
             .into_new_service()
-            .push(metrics.into_layer::<classify::Response>())
+            .push(metrics.to_layer::<classify::Response, _>())
             .push(self::add_origin::layer())
             .push_on_response(svc::layers().push_spawn_buffer(self.buffer_capacity))
             .new_service(self.addr)

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -228,7 +228,7 @@ impl Config {
             // Registers the stack to be tapped.
             .push(tap_layer)
             // Records metrics for each `Target`.
-            .push(metrics.http_endpoint.into_layer::<classify::Response>())
+            .push(metrics.http_endpoint.to_layer::<classify::Response, _>())
             .push_on_response(TraceContext::layer(
                 span_sink.map(|span_sink| SpanConverter::client(span_sink, trace_labels())),
             ));
@@ -254,7 +254,7 @@ impl Config {
                     // by tap.
                     .push_http_insert_target()
                     // Records per-route metrics.
-                    .push(metrics.http_route.into_layer::<classify::Response>())
+                    .push(metrics.http_route.to_layer::<classify::Response, _>())
                     // Sets the per-route response classifier as a request
                     // extension.
                     .push(classify::Layer::new())

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -55,7 +55,7 @@ where
         }))
         .check_new::<Endpoint>()
         .push(tap_layer)
-        .push(metrics.http_endpoint.into_layer::<classify::Response>())
+        .push(metrics.http_endpoint.to_layer::<classify::Response, _>())
         .push_on_response(TraceContext::layer(
             span_sink.map(|sink| SpanConverter::client(sink, crate::trace_labels())),
         ))

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -101,13 +101,17 @@ where
         .check_new_service::<Logical, http::Request<_>>()
         .push(profiles::http::route_request::layer(
             svc::proxies()
-                .push(metrics.http_route_actual.into_layer::<classify::Response>())
+                .push(
+                    metrics
+                        .http_route_actual
+                        .to_layer::<classify::Response, _>(),
+                )
                 // Sets an optional retry policy.
                 .push(retry::layer(metrics.http_route_retry))
                 // Sets an optional request timeout.
                 .push(http::MakeTimeoutLayer::default())
                 // Records per-route metrics.
-                .push(metrics.http_route.into_layer::<classify::Response>())
+                .push(metrics.http_route.to_layer::<classify::Response, _>())
                 // Sets the per-route response classifier as a request
                 // extension.
                 .push(classify::Layer::new())


### PR DESCRIPTION
This change replaces the http_metrics::requests::Layer type with an
anonymous helper and removes the unneeded `MakeService` and future
implementations.