### PR TITLE
Add checks to ensure support for opaque transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 [[package]]
 name = "http-body"
 version = "0.4.0"
-source = "git+https://github.com/hyperium/http-body?branch=master#5e434739e747c0b6611ec41020740b17f735d25a"
+source = "git+https://github.com/hyperium/http-body#5e434739e747c0b6611ec41020740b17f735d25a"
 dependencies = [
  "bytes 0.6.0",
  "http",


### PR DESCRIPTION
This change adds startup configuration checks to ensure that:

1. Identity is required on the inbound port; and
2. The inbound port is not included in the opaque ports list.

This helps to ensure that the inbound proxy port is only used to
securely proxy opaque transport messages (as well as HTTP requests for
multicluster gateways).