### PR TITLE
Simplify tls::client module

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -58,7 +58,7 @@ impl Config {
             move |_| Ok(backoff.stream())
         };
         svc::connect(self.connect.keepalive)
-            .push(tls::ConnectLayer::new(identity))
+            .push(tls::Client::layer(identity))
             .push_timeout(self.connect.timeout)
             .push(self::client::layer())
             .push(reconnect::layer(backoff))

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -27,7 +27,7 @@ pub fn stack<P>(
        + Send {
     svc::connect(config.keepalive)
         // Initiates mTLS if the target is configured with identity.
-        .push(tls::client::ConnectLayer::new(local_identity))
+        .push(tls::Client::layer(local_identity))
         // If the endpoint has an opaque transport hint, this layer ensures the
         // transport header is written on the connection as soon as the
         // connection is established.

--- a/linkerd/proxy/transport/src/tls/mod.rs
+++ b/linkerd/proxy/transport/src/tls/mod.rs
@@ -4,10 +4,10 @@ use std::fmt;
 
 pub mod accept;
 pub mod client;
-pub mod conditional_accept;
+mod conditional_accept;
 
 pub use self::accept::DetectTls;
-pub use self::client::ConnectLayer;
+pub use self::client::Client;
 
 /// Describes whether or not a connection was secured with TLS and, if it was
 /// not, the reason why.


### PR DESCRIPTION
The tls::client module uses an old-style manual future implementation,
which makes it difficult to read.

This change replaces the `client::ConnectLayer` type with an anonymous
helper function and replaces the manual future state machine with an
async block.