### PR TITLE
http: Simplify http::boxed type references

### DIFF
--- a/linkerd/app/gateway/src/config.rs
+++ b/linkerd/app/gateway/src/config.rs
@@ -23,8 +23,8 @@ impl Config {
     ) -> impl svc::NewService<
         inbound::Target,
         Service = impl tower::Service<
-            http::Request<http::boxed::BoxBody>,
-            Response = http::Response<http::boxed::BoxBody>,
+            http::Request<http::BoxBody>,
+            Response = http::Response<http::BoxBody>,
             Error = impl Into<Error>,
             Future = impl Send,
         > + Send
@@ -36,21 +36,19 @@ impl Config {
         P::Future: Send + 'static,
         P::Error: Send,
         O: svc::NewService<outbound::http::Logical, Service = S> + Clone + Send + 'static,
-        S: tower::Service<
-                http::Request<http::boxed::BoxBody>,
-                Response = http::Response<http::boxed::BoxBody>,
-            > + Send
+        S: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+            + Send
             + 'static,
         S::Error: Into<Error>,
         S::Future: Send + 'static,
     {
         svc::stack(MakeGateway::new(outbound, local_id))
-            .check_new_service::<super::make::Target, http::Request<http::boxed::BoxBody>>()
+            .check_new_service::<super::make::Target, http::Request<http::BoxBody>>()
             .push(profiles::discover::layer(
                 profiles,
                 Allow(self.allow_discovery),
             ))
-            .check_new_service::<inbound::Target, http::Request<http::boxed::BoxBody>>()
+            .check_new_service::<inbound::Target, http::Request<http::BoxBody>>()
             .instrument(|_: &inbound::Target| debug_span!("gateway"))
             .into_inner()
     }

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -46,7 +46,7 @@ type ResponseFuture<T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 
 impl<B, O> tower::Service<http::Request<B>> for Gateway<O>
 where
     B: http::HttpBody + 'static,
-    O: tower::Service<http::Request<B>, Response = http::Response<http::boxed::BoxBody>>,
+    O: tower::Service<http::Request<B>, Response = http::Response<http::BoxBody>>,
     O::Error: Into<Error> + 'static,
     O::Future: Send + 'static,
 {

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -120,7 +120,7 @@ mod test {
     }
 
     impl Test {
-        async fn run(self) -> Result<http::Response<http::boxed::BoxBody>, Error> {
+        async fn run(self) -> Result<http::Response<http::BoxBody>, Error> {
             let Self {
                 suffix,
                 dst_name,
@@ -128,10 +128,8 @@ mod test {
                 orig_fwd,
             } = self;
 
-            let (outbound, mut handle) = mock::pair::<
-                http::Request<http::boxed::BoxBody>,
-                http::Response<http::boxed::BoxBody>,
-            >();
+            let (outbound, mut handle) =
+                mock::pair::<http::Request<http::BoxBody>, http::Response<http::BoxBody>>();
             let mut make_gateway = {
                 let profiles = service_fn(move |na: NameAddr| async move {
                     let rx = support::profile::only(profiles::Profile {

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -24,7 +24,7 @@ pub fn stack<B, C>(
     Endpoint,
     Service = impl tower::Service<
         http::Request<B>,
-        Response = http::Response<http::boxed::BoxBody>,
+        Response = http::Response<http::BoxBody>,
         Error = Error,
         Future = impl Send,
     > + Send,
@@ -65,7 +65,7 @@ where
             "host",
             CANONICAL_DST_HEADER,
         ]))
-        .push_on_response(http::boxed::BoxResponse::layer())
+        .push_on_response(http::BoxResponse::layer())
         .check_new::<Endpoint>()
         .instrument(|e: &Endpoint| debug_span!("endpoint", peer.addr = %e.addr))
         .into_inner()

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -51,8 +51,8 @@ where
     TSvc::Future: Send,
     H: svc::NewService<http::Logical, Service = HSvc> + Unpin + Clone + Send + Sync + 'static,
     HSvc: tower::Service<
-            http::Request<http::boxed::BoxBody>,
-            Response = http::Response<http::boxed::BoxBody>,
+            http::Request<http::BoxBody>,
+            Response = http::Response<http::BoxBody>,
             Error = Error,
         > + Send
         + 'static,
@@ -103,7 +103,7 @@ where
         .check_new_service::<http::Accept, http::Request<_>>()
         .push_on_response(
             svc::layers()
-                .push(http::boxed::BoxRequest::layer())
+                .push(http::BoxRequest::layer())
                 // Limits the number of in-flight requests.
                 .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
                 // Eagerly fail requests when the proxy is out of capacity for a
@@ -118,7 +118,7 @@ where
                 })))
                 .push(metrics.stack.layer(stack_labels("http", "server")))
                 .push_spawn_buffer(buffer_capacity)
-                .push(http::boxed::BoxResponse::layer()),
+                .push(http::BoxResponse::layer()),
         )
         .check_new_service::<http::Accept, http::Request<_>>()
         .push(http::NewNormalizeUri::layer())

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -46,8 +46,8 @@ where
     C::Future: Unpin + Send,
     H: svc::NewService<http::Logical, Service = S> + Unpin + Clone + Send + Sync + 'static,
     S: tower::Service<
-            http::Request<http::boxed::BoxBody>,
-            Response = http::Response<http::boxed::BoxBody>,
+            http::Request<http::BoxBody>,
+            Response = http::Response<http::BoxBody>,
             Error = Error,
         > + Send
         + 'static,
@@ -154,8 +154,8 @@ where
     <TSvc as tower::Service<transport::metrics::SensorIo<I>>>::Future: Unpin + Send + 'static,
     H: svc::NewService<http::Logical, Service = HSvc> + Unpin + Clone + Send + Sync + 'static,
     HSvc: tower::Service<
-            http::Request<http::boxed::BoxBody>,
-            Response = http::Response<http::boxed::BoxBody>,
+            http::Request<http::BoxBody>,
+            Response = http::Response<http::BoxBody>,
             Error = Error,
         > + Send
         + 'static,
@@ -187,7 +187,7 @@ where
     svc::stack(http_router)
         .push_on_response(
             svc::layers()
-                .push(http::boxed::BoxRequest::layer())
+                .push(http::BoxRequest::layer())
                 // Limits the number of in-flight requests.
                 .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
                 // Eagerly fail requests when the proxy is out of capacity for a
@@ -202,7 +202,7 @@ where
                 })))
                 .push(metrics.stack.layer(stack_labels("http", "server")))
                 .push_spawn_buffer(buffer_capacity)
-                .push(http::boxed::BoxResponse::layer()),
+                .push(http::BoxResponse::layer()),
         )
         .push(http::NewNormalizeUri::layer())
         .instrument(|l: &http::Logical| debug_span!("http", v = %l.protocol))

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -223,7 +223,7 @@ impl Config {
                         inbound_addr,
                         local_identity,
                         svc::stack(http_gateway)
-                            .push_on_response(http::boxed::BoxRequest::layer())
+                            .push_on_response(http::BoxRequest::layer())
                             .into_inner(),
                         dst.profiles,
                         tap_layer,

--- a/linkerd/app/test/src/service.rs
+++ b/linkerd/app/test/src/service.rs
@@ -18,8 +18,8 @@ impl<T: std::fmt::Debug> svc::NewService<T> for NoHttp {
     }
 }
 
-impl svc::Service<http::Request<http::boxed::BoxBody>> for NoHttp {
-    type Response = http::Response<http::boxed::BoxBody>;
+impl svc::Service<http::Request<http::BoxBody>> for NoHttp {
+    type Response = http::Response<http::BoxBody>;
     type Error = Error;
     type Future = futures::future::Ready<Result<Self::Response, Self::Error>>;
     fn poll_ready(
@@ -29,7 +29,7 @@ impl svc::Service<http::Request<http::boxed::BoxBody>> for NoHttp {
         panic!("http services should not be used in this test!")
     }
 
-    fn call(&mut self, _: http::Request<http::boxed::BoxBody>) -> Self::Future {
+    fn call(&mut self, _: http::Request<http::BoxBody>) -> Self::Future {
         panic!("http services should not be used in this test!")
     }
 }

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -38,7 +38,7 @@ pub use self::{
 };
 pub use http::{header, uri, Request, Response, StatusCode};
 pub use hyper::body::HttpBody;
-pub use linkerd2_http_box as boxed;
+pub use linkerd2_http_box::{BoxBody, BoxRequest, BoxResponse};
 use std::str::FromStr;
 
 pub trait HasH2Reason {

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -92,11 +92,8 @@ where
 impl<I, S> Service<PrefixedIo<I>> for ServeHttp<S>
 where
     I: io::AsyncRead + io::AsyncWrite + PeerAddr + Send + Unpin + 'static,
-    S: Service<
-            http::Request<UpgradeBody>,
-            Response = http::Response<http::boxed::BoxBody>,
-            Error = Error,
-        > + Clone
+    S: Service<http::Request<UpgradeBody>, Response = http::Response<http::BoxBody>, Error = Error>
+        + Clone
         + Unpin
         + Send
         + 'static,


### PR DESCRIPTION
The `proxy::http` module re-exports the boxed _module_ so that all uses
are referenced like `http::boxed::BoxBody`. This is needlessly verbose.

This change re-exports the `BoxBody`, `BoxRequest`, and `BoxResponse`
types directly from the `http` module to simplify references as, e.g.
`http::BoxBody`.