### PR TITLE
Simplify stack type constraints

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -11,7 +11,6 @@ pub use self::endpoint::{
 };
 use self::prevent_loop::PreventLoop;
 use self::require_identity_for_ports::RequireIdentityForPorts;
-use futures::future;
 use linkerd2_app_core::{
     classify,
     config::{ProxyConfig, ServerConfig},
@@ -56,7 +55,7 @@ type SensorIo<T> = io::SensorIo<T, transport::metrics::Sensor>;
 
 #[allow(clippy::too_many_arguments)]
 impl Config {
-    pub fn build<L, S, P>(
+    pub fn build<L, LSvc, P>(
         self,
         listen_addr: std::net::SocketAddr,
         local_identity: tls::Conditional<identity::Local>,
@@ -71,24 +70,20 @@ impl Config {
         Service = impl tower::Service<
             tokio::net::TcpStream,
             Response = (),
-            Error = impl Into<Error>,
-            Future = impl Send + 'static,
-        > + Send
-                      + 'static,
+            Error = Error,
+            Future = impl Send,
+        >,
     > + Clone
-           + Send
-           + 'static
     where
-        L: svc::NewService<Target, Service = S> + Unpin + Clone + Send + Sync + 'static,
-        S: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
-            + Unpin
+        L: svc::NewService<Target, Service = LSvc> + Clone + Send + Sync + 'static,
+        LSvc: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
             + Send
             + 'static,
-        S::Error: Into<Error>,
-        S::Future: Unpin + Send,
-        P: profiles::GetProfile<NameAddr> + Unpin + Clone + Send + Sync + 'static,
-        P::Future: Unpin + Send,
+        LSvc::Error: Into<Error>,
+        LSvc::Future: Send,
+        P: profiles::GetProfile<NameAddr> + Clone + Send + Sync + 'static,
         P::Error: Send,
+        P::Future: Send,
     {
         let prevent_loop = PreventLoop::from(listen_addr.port());
         let tcp_connect = self.build_tcp_connect(prevent_loop, &metrics);
@@ -131,17 +126,15 @@ impl Config {
         metrics: &metrics::Proxy,
     ) -> impl tower::Service<
         TcpEndpoint,
-        Error = impl Into<Error>,
-        Future = impl future::Future + Unpin + Send,
-        Response = impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
+        Error = Error,
+        Future = impl Send,
+        Response = impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,
     > + tower::Service<
         HttpEndpoint,
-        Error = impl Into<Error>,
-        Future = impl future::Future + Unpin + Send,
-        Response = impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
-    > + Unpin
-           + Clone
-           + Send {
+        Error = Error,
+        Future = impl Send,
+        Response = impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,
+    > + Clone {
         // Establishes connections to remote peers (for both TCP
         // forwarding and HTTP proxying).
         svc::connect(self.proxy.connect.keepalive)
@@ -153,7 +146,7 @@ impl Config {
             .into_inner()
     }
 
-    pub fn build_http_router<C, P, L, S>(
+    pub fn build_http_router<C, P, L, LSvc>(
         &self,
         tcp_connect: C,
         prevent_loop: impl Into<PreventLoop>,
@@ -169,29 +162,23 @@ impl Config {
             Response = http::Response<http::BoxBody>,
             Error = Error,
             Future = impl Send,
-        > + Clone
-                      + Send
-                      + Sync
-                      + Unpin,
-    > + Unpin
-           + Clone
-           + Send
+        > + Clone,
+    > + Clone
     where
-        C: tower::Service<HttpEndpoint> + Unpin + Clone + Send + Sync + 'static,
+        C: tower::Service<HttpEndpoint> + Clone + Send + Sync + Unpin + 'static,
+        C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,
         C::Error: Into<Error>,
-        C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
-        C::Future: Unpin + Send,
-        P: profiles::GetProfile<NameAddr> + Unpin + Clone + Send + Sync + 'static,
-        P::Future: Unpin + Send,
+        C::Future: Send + Unpin,
+        P: profiles::GetProfile<NameAddr> + Clone + Send + Sync + 'static,
+        P::Future: Send,
         P::Error: Send,
         // The loopback router processes requests sent to the inbound port.
-        L: svc::NewService<Target, Service = S> + Unpin + Send + Clone + Sync + 'static,
-        S: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
-            + Unpin
+        L: svc::NewService<Target, Service = LSvc> + Clone + Send + Sync + 'static,
+        LSvc: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
             + Send
             + 'static,
-        S::Error: Into<Error>,
-        S::Future: Unpin + Send,
+        LSvc::Error: Into<Error>,
+        LSvc::Future: Send,
     {
         let Config {
             allow_discovery,
@@ -293,7 +280,7 @@ impl Config {
             .into_inner()
     }
 
-    pub fn build_accept<I, F, A, H, S>(
+    pub fn build_accept<I, F, FSvc, H, HSvc>(
         &self,
         prevent_loop: impl Into<PreventLoop>,
         tcp_forward: F,
@@ -303,38 +290,28 @@ impl Config {
         drain: drain::Watch,
     ) -> impl svc::NewService<
         TcpAccept,
-        Service = impl tower::Service<
-            I,
-            Response = (),
-            Error = impl Into<Error>,
-            Future = impl Send + 'static,
-        > + Send
-                      + 'static,
+        Service = impl tower::Service<I, Response = (), Error = Error, Future = impl Send>,
     > + Clone
-           + Send
-           + 'static
     where
-        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Unpin + Send + 'static,
-        F: svc::NewService<TcpEndpoint, Service = A> + Unpin + Clone + Send + Sync + 'static,
-        A: tower::Service<io::PrefixedIo<I>, Response = ()> + Clone + Send + Sync + 'static,
-        <A as tower::Service<io::PrefixedIo<I>>>::Error: Into<Error>,
-        <A as tower::Service<io::PrefixedIo<I>>>::Future: Send,
-        A: tower::Service<io::PrefixedIo<io::PrefixedIo<I>>, Response = ()>
+        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
+        F: svc::NewService<TcpEndpoint, Service = FSvc> + Clone + Send + Sync + 'static,
+        FSvc: tower::Service<io::PrefixedIo<I>, Response = ()>
+            + tower::Service<io::PrefixedIo<io::PrefixedIo<I>>, Response = ()>
             + Clone
             + Send
             + Sync
             + 'static,
-        <A as tower::Service<io::PrefixedIo<io::PrefixedIo<I>>>>::Error: Into<Error>,
-        <A as tower::Service<io::PrefixedIo<io::PrefixedIo<I>>>>::Future: Send,
-        H: svc::NewService<Target, Service = S> + Unpin + Clone + Send + Sync + 'static,
-        S: tower::Service<
-                http::Request<http::BoxBody>,
-                Response = http::Response<http::BoxBody>,
-                Error = Error,
-            > + Clone
+        <FSvc as tower::Service<io::PrefixedIo<I>>>::Error: Into<Error>,
+        <FSvc as tower::Service<io::PrefixedIo<I>>>::Future: Send,
+        <FSvc as tower::Service<io::PrefixedIo<io::PrefixedIo<I>>>>::Error: Into<Error>,
+        <FSvc as tower::Service<io::PrefixedIo<io::PrefixedIo<I>>>>::Future: Send,
+        H: svc::NewService<Target, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
+        HSvc: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+            + Clone
             + Send
             + 'static,
-        S::Future: Send,
+        HSvc::Error: Into<Error>,
+        HSvc::Future: Send,
     {
         let ProxyConfig {
             server: ServerConfig { h2_settings, .. },
@@ -413,7 +390,7 @@ impl Config {
             .into_inner()
     }
 
-    pub fn build_tls_accept<D, A, F, B>(
+    pub fn build_tls_accept<D, DSvc, F, FSvc>(
         self,
         detect: D,
         tcp_forward: F,
@@ -421,25 +398,17 @@ impl Config {
         metrics: metrics::Proxy,
     ) -> impl svc::NewService<
         listen::Addrs,
-        Service = impl tower::Service<
-            TcpStream,
-            Response = (),
-            Error = impl Into<Error>,
-            Future = impl Send + 'static,
-        > + Send
-                      + 'static,
+        Service = impl tower::Service<TcpStream, Response = (), Error = Error, Future = impl Send>,
     > + Clone
-           + Send
-           + 'static
     where
-        D: svc::NewService<TcpAccept, Service = A> + Unpin + Clone + Send + Sync + 'static,
-        A: tower::Service<SensorIo<io::BoxedIo>, Response = ()> + Unpin + Send + 'static,
-        A::Error: Into<Error>,
-        A::Future: Send,
-        F: svc::NewService<TcpEndpoint, Service = B> + Unpin + Clone + Send + Sync + 'static,
-        B: tower::Service<SensorIo<TcpStream>, Response = ()> + Unpin + Send + 'static,
-        B::Error: Into<Error>,
-        B::Future: Send,
+        D: svc::NewService<TcpAccept, Service = DSvc> + Clone + Send + 'static,
+        DSvc: tower::Service<SensorIo<io::BoxedIo>, Response = ()> + Send + 'static,
+        DSvc::Error: Into<Error>,
+        DSvc::Future: Send,
+        F: svc::NewService<TcpEndpoint, Service = FSvc> + Clone + 'static,
+        FSvc: tower::Service<SensorIo<TcpStream>, Response = ()> + 'static,
+        FSvc::Error: Into<Error>,
+        FSvc::Future: Send,
     {
         let ProxyConfig {
             detect_protocol_timeout,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -67,7 +67,7 @@ impl Config {
         drain: drain::Watch,
     ) -> impl svc::NewService<
         listen::Addrs,
-        Service = impl tower::Service<
+        Service = impl svc::Service<
             tokio::net::TcpStream,
             Response = (),
             Error = Error,
@@ -76,7 +76,7 @@ impl Config {
     > + Clone
     where
         L: svc::NewService<Target, Service = LSvc> + Clone + Send + Sync + 'static,
-        LSvc: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+        LSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
             + Send
             + 'static,
         LSvc::Error: Into<Error>,
@@ -124,12 +124,12 @@ impl Config {
         &self,
         prevent_loop: PreventLoop,
         metrics: &metrics::Proxy,
-    ) -> impl tower::Service<
+    ) -> impl svc::Service<
         TcpEndpoint,
         Error = Error,
         Future = impl Send,
         Response = impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,
-    > + tower::Service<
+    > + svc::Service<
         HttpEndpoint,
         Error = Error,
         Future = impl Send,
@@ -157,7 +157,7 @@ impl Config {
         span_sink: Option<mpsc::Sender<oc::Span>>,
     ) -> impl svc::NewService<
         Target,
-        Service = impl tower::Service<
+        Service = impl svc::Service<
             http::Request<http::BoxBody>,
             Response = http::Response<http::BoxBody>,
             Error = Error,
@@ -165,7 +165,7 @@ impl Config {
         > + Clone,
     > + Clone
     where
-        C: tower::Service<HttpEndpoint> + Clone + Send + Sync + Unpin + 'static,
+        C: svc::Service<HttpEndpoint> + Clone + Send + Sync + Unpin + 'static,
         C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,
         C::Error: Into<Error>,
         C::Future: Send + Unpin,
@@ -174,7 +174,7 @@ impl Config {
         P::Error: Send,
         // The loopback router processes requests sent to the inbound port.
         L: svc::NewService<Target, Service = LSvc> + Clone + Send + Sync + 'static,
-        LSvc: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+        LSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
             + Send
             + 'static,
         LSvc::Error: Into<Error>,
@@ -290,23 +290,23 @@ impl Config {
         drain: drain::Watch,
     ) -> impl svc::NewService<
         TcpAccept,
-        Service = impl tower::Service<I, Response = (), Error = Error, Future = impl Send>,
+        Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
     > + Clone
     where
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
         F: svc::NewService<TcpEndpoint, Service = FSvc> + Clone + Send + Sync + 'static,
-        FSvc: tower::Service<io::PrefixedIo<I>, Response = ()>
-            + tower::Service<io::PrefixedIo<io::PrefixedIo<I>>, Response = ()>
+        FSvc: svc::Service<io::PrefixedIo<I>, Response = ()>
+            + svc::Service<io::PrefixedIo<io::PrefixedIo<I>>, Response = ()>
             + Clone
             + Send
             + Sync
             + 'static,
-        <FSvc as tower::Service<io::PrefixedIo<I>>>::Error: Into<Error>,
-        <FSvc as tower::Service<io::PrefixedIo<I>>>::Future: Send,
-        <FSvc as tower::Service<io::PrefixedIo<io::PrefixedIo<I>>>>::Error: Into<Error>,
-        <FSvc as tower::Service<io::PrefixedIo<io::PrefixedIo<I>>>>::Future: Send,
+        <FSvc as svc::Service<io::PrefixedIo<I>>>::Error: Into<Error>,
+        <FSvc as svc::Service<io::PrefixedIo<I>>>::Future: Send,
+        <FSvc as svc::Service<io::PrefixedIo<io::PrefixedIo<I>>>>::Error: Into<Error>,
+        <FSvc as svc::Service<io::PrefixedIo<io::PrefixedIo<I>>>>::Future: Send,
         H: svc::NewService<Target, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
-        HSvc: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+        HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
             + Clone
             + Send
             + 'static,
@@ -398,15 +398,15 @@ impl Config {
         metrics: metrics::Proxy,
     ) -> impl svc::NewService<
         listen::Addrs,
-        Service = impl tower::Service<TcpStream, Response = (), Error = Error, Future = impl Send>,
+        Service = impl svc::Service<TcpStream, Response = (), Error = Error, Future = impl Send>,
     > + Clone
     where
         D: svc::NewService<TcpAccept, Service = DSvc> + Clone + Send + 'static,
-        DSvc: tower::Service<SensorIo<io::BoxedIo>, Response = ()> + Send + 'static,
+        DSvc: svc::Service<SensorIo<io::BoxedIo>, Response = ()> + Send + 'static,
         DSvc::Error: Into<Error>,
         DSvc::Future: Send,
         F: svc::NewService<TcpEndpoint, Service = FSvc> + Clone + 'static,
-        FSvc: tower::Service<SensorIo<TcpStream>, Response = ()> + 'static,
+        FSvc: svc::Service<SensorIo<TcpStream>, Response = ()> + 'static,
         FSvc::Error: Into<Error>,
         FSvc::Future: Send,
     {

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -22,7 +22,7 @@ pub fn stack<B, C>(
     span_sink: Option<mpsc::Sender<oc::Span>>,
 ) -> impl svc::NewService<
     Endpoint,
-    Service = impl tower::Service<
+    Service = impl svc::Service<
         http::Request<B>,
         Response = http::Response<http::BoxBody>,
         Error = Error,
@@ -32,7 +32,7 @@ pub fn stack<B, C>(
 where
     B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
     B::Data: Send + 'static,
-    C: tower::Service<Endpoint, Error = Error> + Clone + Send + Sync + Unpin + 'static,
+    C: svc::Service<Endpoint, Error = Error> + Clone + Send + Sync + Unpin + 'static,
     C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
     C::Future: Send + Unpin,
 {

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -27,15 +27,14 @@ pub fn stack<B, C>(
         Response = http::Response<http::BoxBody>,
         Error = Error,
         Future = impl Send,
-    > + Send,
+    >,
 > + Clone
-       + Send
 where
     B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
     B::Data: Send + 'static,
-    C: tower::Service<Endpoint, Error = Error> + Unpin + Clone + Send + Sync + 'static,
-    C::Response: io::AsyncRead + io::AsyncWrite + Unpin + Send + 'static,
-    C::Future: Unpin + Send,
+    C: tower::Service<Endpoint, Error = Error> + Clone + Send + Sync + Unpin + 'static,
+    C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
+    C::Future: Send + Unpin,
 {
     svc::stack(tcp_connect)
         // Initiates an HTTP client on the underlying transport. Prior-knowledge HTTP/2

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -18,7 +18,7 @@ pub fn stack<B, E, ESvc, R>(
     metrics: metrics::Proxy,
 ) -> impl svc::NewService<
     Logical,
-    Service = impl tower::Service<
+    Service = impl svc::Service<
         http::Request<B>,
         Response = http::Response<http::BoxBody>,
         Error = Error,
@@ -29,7 +29,7 @@ where
     B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
     B::Data: Send + 'static,
     E: svc::NewService<Endpoint, Service = ESvc> + Clone + Send + 'static,
-    ESvc: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+    ESvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
         + Send
         + 'static,
     ESvc::Error: Into<Error>,

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -11,7 +11,7 @@ use linkerd2_app_core::{
 };
 use tracing::debug_span;
 
-pub fn stack<B, E, S, R>(
+pub fn stack<B, E, ESvc, R>(
     config: &ProxyConfig,
     endpoint: E,
     resolve: R,
@@ -23,24 +23,20 @@ pub fn stack<B, E, S, R>(
         Response = http::Response<http::BoxBody>,
         Error = Error,
         Future = impl Send,
-    > + Send,
-> + Unpin
-       + Clone
-       + Send
+    >,
+> + Clone
 where
     B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
     B::Data: Send + 'static,
-    E: svc::NewService<Endpoint, Service = S> + Clone + Send + Sync + Unpin + 'static,
-    S: tower::Service<
-            http::Request<http::BoxBody>,
-            Response = http::Response<http::BoxBody>,
-            Error = Error,
-        > + Send
+    E: svc::NewService<Endpoint, Service = ESvc> + Clone + Send + 'static,
+    ESvc: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+        + Send
         + 'static,
-    S::Future: Send,
-    R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Unpin + Clone + Send + 'static,
-    R::Future: Unpin + Send,
-    R::Resolution: Unpin + Send,
+    ESvc::Error: Into<Error>,
+    ESvc::Future: Send,
+    R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Clone + Send + 'static,
+    R::Resolution: Send,
+    R::Future: Send,
 {
     let ProxyConfig {
         buffer_capacity,

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -28,38 +28,27 @@ pub fn stack<P, T, TSvc, H, HSvc, I>(
     drain: drain::Watch,
 ) -> impl svc::NewService<
     listen::Addrs,
-    Service = impl tower::Service<
-        I,
-        Response = (),
-        Error = impl Into<Error>,
-        Future = impl Send + 'static,
-    > + Send
-                  + 'static,
-> + Send
-       + 'static
+    Service = impl tower::Service<I, Response = (), Error = Error, Future = impl Send>,
+>
 where
-    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
-    T: svc::NewService<tcp::Endpoint, Service = TSvc> + Unpin + Clone + Send + Sync + 'static,
-    TSvc: tower::Service<
-            io::PrefixedIo<transport::metrics::SensorIo<I>>,
-            Response = (),
-            Error = Error,
-        > + Clone
+    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+    T: svc::NewService<tcp::Endpoint, Service = TSvc> + Clone + Send + Sync + 'static,
+    TSvc: tower::Service<io::PrefixedIo<transport::metrics::SensorIo<I>>, Response = ()>
+        + Clone
         + Send
         + Sync
         + 'static,
+    TSvc::Error: Into<Error>,
     TSvc::Future: Send,
-    H: svc::NewService<http::Logical, Service = HSvc> + Unpin + Clone + Send + Sync + 'static,
-    HSvc: tower::Service<
-            http::Request<http::BoxBody>,
-            Response = http::Response<http::BoxBody>,
-            Error = Error,
-        > + Send
+    H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + Sync + 'static,
+    HSvc: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+        + Send
         + 'static,
+    HSvc::Error: Into<Error>,
     HSvc::Future: Send,
-    P: profiles::GetProfile<Addr> + Unpin + Clone + Send + Sync + 'static,
-    P::Future: Unpin + Send,
+    P: profiles::GetProfile<Addr> + Clone + Send + Sync + 'static,
     P::Error: Send,
+    P::Future: Send,
 {
     let Config {
         allow_discovery,

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -28,12 +28,12 @@ pub fn stack<P, T, TSvc, H, HSvc, I>(
     drain: drain::Watch,
 ) -> impl svc::NewService<
     listen::Addrs,
-    Service = impl tower::Service<I, Response = (), Error = Error, Future = impl Send>,
+    Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
 >
 where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
     T: svc::NewService<tcp::Endpoint, Service = TSvc> + Clone + Send + Sync + 'static,
-    TSvc: tower::Service<io::PrefixedIo<transport::metrics::SensorIo<I>>, Response = ()>
+    TSvc: svc::Service<io::PrefixedIo<transport::metrics::SensorIo<I>>, Response = ()>
         + Clone
         + Send
         + Sync
@@ -41,7 +41,7 @@ where
     TSvc::Error: Into<Error>,
     TSvc::Future: Send,
     H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + Sync + 'static,
-    HSvc: tower::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+    HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
         + Send
         + 'static,
     HSvc::Error: Into<Error>,

--- a/linkerd/app/outbound/src/resolve.rs
+++ b/linkerd/app/outbound/src/resolve.rs
@@ -35,8 +35,8 @@ where
     for<'t> &'t T: Into<std::net::SocketAddr>,
     EndpointFromMetadata: map_endpoint::MapEndpoint<T, Metadata>,
     R: Resolve<Addr, Endpoint = Metadata>,
-    R::Future: Send + 'static,
-    R::Resolution: Send + 'static,
+    R::Future: Send,
+    R::Resolution: Send,
 {
     map_endpoint::Resolve::new(
         EndpointFromMetadata,
@@ -53,9 +53,9 @@ pub fn layer<T, E, R, N>(
 where
     T: Clone,
     for<'t> &'t T: Into<std::net::SocketAddr>,
-    R: Resolve<Addr, Error = Error, Endpoint = Metadata> + Clone,
-    R::Future: Send + 'static,
-    R::Resolution: Send + 'static,
+    R: Resolve<Addr, Endpoint = Metadata> + Clone,
+    R::Resolution: Send,
+    R::Future: Send,
     EndpointFromMetadata: map_endpoint::MapEndpoint<T, Metadata, Out = E>,
     ResolveStack<R>: Resolve<T, Endpoint = E> + Clone,
     N: NewService<E>,

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -9,14 +9,14 @@ use linkerd2_app_core::{
     proxy::{api_resolve::Metadata, core::resolve::Resolve},
     spans::SpanConverter,
     svc,
-    transport::{self, io, listen, tls},
+    transport::{self, io, listen, metrics::SensorIo, tls},
     Addr, Error, IpMatch, TraceContext,
 };
 use std::net::SocketAddr;
 use tokio::sync::mpsc;
 use tracing::debug_span;
 
-pub fn stack<R, P, C, H, S, I>(
+pub fn stack<R, P, C, H, HSvc, I>(
     config: &Config,
     profiles: P,
     resolve: R,
@@ -27,33 +27,25 @@ pub fn stack<R, P, C, H, S, I>(
     drain: drain::Watch,
 ) -> impl svc::NewService<
     listen::Addrs,
-    Service = impl tower::Service<
-        I,
-        Response = (),
-        Error = impl Into<Error>,
-        Future = impl Send + 'static,
-    > + Send
-                  + 'static,
-> + Send
-       + 'static
+    Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
+>
 where
-    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
-    R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Unpin + Clone + Send + Sync + 'static,
-    R::Future: Unpin + Send,
-    R::Resolution: Unpin + Send,
-    C: tower::Service<tcp::Endpoint, Error = Error> + Unpin + Clone + Send + Sync + 'static,
-    C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
-    C::Future: Unpin + Send,
-    H: svc::NewService<http::Logical, Service = S> + Unpin + Clone + Send + Sync + 'static,
-    S: tower::Service<
-            http::Request<http::BoxBody>,
-            Response = http::Response<http::BoxBody>,
-            Error = Error,
-        > + Send
+    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+    R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Clone + Send + 'static,
+    R::Resolution: Send,
+    R::Future: Send,
+    C: svc::Service<tcp::Endpoint> + Clone + Send + 'static,
+    C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
+    C::Error: Into<Error>,
+    C::Future: Send,
+    H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + 'static,
+    HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+        + Send
         + 'static,
-    S::Future: Send,
-    P: profiles::GetProfile<SocketAddr> + Unpin + Clone + Send + Sync + 'static,
-    P::Future: Unpin + Send,
+    HSvc::Error: Into<Error>,
+    HSvc::Future: Send,
+    P: profiles::GetProfile<SocketAddr> + Clone + Send + 'static,
+    P::Future: Send,
     P::Error: Send,
 {
     let tcp_balance =
@@ -76,28 +68,20 @@ where
 /// Services are cached as long as they are retained by the caller (usually
 /// core::serve) and are evicted from the cache when they have been dropped for
 /// `config.cache_max_idle_age` with no new acquisitions.
-pub fn cache<N, S, I>(
+pub fn cache<N, NSvc, I>(
     config: &ProxyConfig,
     metrics: metrics::Proxy,
     stack: N,
 ) -> impl svc::NewService<
     listen::Addrs,
-    Service = impl tower::Service<
-        I,
-        Response = (),
-        Error = impl Into<Error>,
-        Future = impl Send + 'static,
-    > + Send
-                  + 'static,
-> + Send
-       + 'static
+    Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
+>
 where
-    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
-    transport::metrics::SensorIo<I>: Send + 'static,
-    N: svc::NewService<tcp::Accept, Service = S> + Clone + Send + 'static,
-    S: svc::Service<transport::metrics::SensorIo<I>, Response = ()> + Send + 'static,
-    S::Error: Into<Error> + Send + 'static,
-    S::Future: Send + 'static,
+    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+    N: svc::NewService<tcp::Accept, Service = NSvc> + 'static,
+    NSvc: svc::Service<SensorIo<I>, Response = ()> + Send + 'static,
+    NSvc::Error: Into<Error>,
+    NSvc::Future: Send,
 {
     svc::stack(stack)
         .push_on_response(
@@ -122,46 +106,31 @@ pub fn accept_stack<P, C, T, TSvc, H, HSvc, I>(
     drain: drain::Watch,
 ) -> impl svc::NewService<
     tcp::Accept,
-    Service = impl tower::Service<
-        transport::metrics::SensorIo<I>,
-        Response = (),
-        Error = impl Into<Error>,
-        Future = impl Send + 'static,
-    > + Send
-                  + 'static,
+    Service = impl svc::Service<SensorIo<I>, Response = (), Error = Error, Future = impl Send>,
 > + Clone
-       + Send
-       + 'static
 where
-    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
-    C: tower::Service<tcp::Endpoint, Error = Error> + Unpin + Clone + Send + Sync + 'static,
-    C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
-    C::Future: Unpin + Send,
-    T: svc::NewService<tcp::Concrete, Service = TSvc> + Clone + Unpin + Send + 'static,
-    TSvc: tower::Service<
-            transport::io::PrefixedIo<transport::metrics::SensorIo<I>>,
-            Response = (),
-            Error = Error,
-        > + Unpin
+    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+    C: svc::Service<tcp::Endpoint> + Clone + Send + 'static,
+    C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
+    C::Error: Into<Error>,
+    C::Future: Send,
+    T: svc::NewService<tcp::Concrete, Service = TSvc> + Clone + Send + 'static,
+    TSvc: svc::Service<io::PrefixedIo<SensorIo<I>>, Response = ()>
+        + svc::Service<SensorIo<I>, Response = ()>
         + Send
         + 'static,
-    <TSvc as tower::Service<transport::io::PrefixedIo<transport::metrics::SensorIo<I>>>>::Future:
-        Unpin + Send + 'static,
-    TSvc: tower::Service<transport::metrics::SensorIo<I>, Response = (), Error = Error>
-        + Unpin
+    <TSvc as svc::Service<SensorIo<I>>>::Error: Into<Error>,
+    <TSvc as svc::Service<SensorIo<I>>>::Future: Send,
+    <TSvc as svc::Service<io::PrefixedIo<SensorIo<I>>>>::Error: Into<Error>,
+    <TSvc as svc::Service<io::PrefixedIo<SensorIo<I>>>>::Future: Send,
+    H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + 'static,
+    HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
         + Send
         + 'static,
-    <TSvc as tower::Service<transport::metrics::SensorIo<I>>>::Future: Unpin + Send + 'static,
-    H: svc::NewService<http::Logical, Service = HSvc> + Unpin + Clone + Send + Sync + 'static,
-    HSvc: tower::Service<
-            http::Request<http::BoxBody>,
-            Response = http::Response<http::BoxBody>,
-            Error = Error,
-        > + Send
-        + 'static,
+    HSvc::Error: Into<Error>,
     HSvc::Future: Send,
-    P: profiles::GetProfile<SocketAddr> + Unpin + Clone + Send + Sync + 'static,
-    P::Future: Unpin + Send,
+    P: profiles::GetProfile<SocketAddr> + Clone + Send + 'static,
+    P::Future: Send,
     P::Error: Send,
 {
     let ProxyConfig {

--- a/linkerd/app/outbound/src/tcp/balance.rs
+++ b/linkerd/app/outbound/src/tcp/balance.rs
@@ -18,17 +18,12 @@ pub fn stack<I, C, R>(
     drain: drain::Watch,
 ) -> impl svc::NewService<
     Concrete,
-    Service = impl tower::Service<I, Response = (), Error = Error, Future = impl Send>
-                  + tower::Service<
-        io::PrefixedIo<I>,
-        Response = (),
-        Error = Error,
-        Future = impl Send,
-    >,
+    Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>
+                  + svc::Service<io::PrefixedIo<I>, Response = (), Error = Error, Future = impl Send>,
 > + Clone
 where
     I: io::AsyncRead + io::AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
-    C: tower::Service<Endpoint> + Clone + Send + 'static,
+    C: svc::Service<Endpoint> + Clone + Send + 'static,
     C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
     C::Error: Into<Error>,
     C::Future: Send,

--- a/linkerd/app/outbound/src/tcp/balance.rs
+++ b/linkerd/app/outbound/src/tcp/balance.rs
@@ -18,31 +18,23 @@ pub fn stack<I, C, R>(
     drain: drain::Watch,
 ) -> impl svc::NewService<
     Concrete,
-    Service = impl tower::Service<
-        I,
-        Response = (),
-        Future = impl Unpin + Send + 'static,
-        Error = Error,
-    > + tower::Service<
+    Service = impl tower::Service<I, Response = (), Error = Error, Future = impl Send>
+                  + tower::Service<
         io::PrefixedIo<I>,
         Response = (),
-        Future = impl Unpin + Send + 'static,
         Error = Error,
-    > + Unpin
-                  + Send
-                  + 'static,
+        Future = impl Send,
+    >,
 > + Clone
-       + Unpin
-       + Send
-       + 'static
 where
-    C: tower::Service<Endpoint, Error = Error> + Unpin + Clone + Send + Sync + 'static,
-    C::Response: io::AsyncRead + io::AsyncWrite + Unpin + Send + 'static,
-    C::Future: Unpin + Send,
-    R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Unpin + Clone + Send + 'static,
-    R::Future: Unpin + Send,
-    R::Resolution: Unpin + Send,
-    I: io::AsyncRead + io::AsyncWrite + std::fmt::Debug + Unpin + Send + 'static,
+    I: io::AsyncRead + io::AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
+    C: tower::Service<Endpoint> + Clone + Send + 'static,
+    C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
+    C::Error: Into<Error>,
+    C::Future: Send,
+    R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Clone + 'static,
+    R::Resolution: Send,
+    R::Future: Send,
 {
     svc::stack(connect)
         .push_make_thunk()

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -19,12 +19,10 @@ pub fn stack<P>(
     metrics: &metrics::Proxy,
 ) -> impl tower::Service<
     Endpoint<P>,
+    Response = impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
     Error = Error,
     Future = impl Send,
-    Response = impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
-> + Unpin
-       + Clone
-       + Send {
+> + Clone {
     svc::connect(config.keepalive)
         // Initiates mTLS if the target is configured with identity.
         .push(tls::Client::layer(local_identity))
@@ -43,19 +41,15 @@ pub fn forward<P, I, C>(
     connect: C,
 ) -> impl svc::NewService<
     Endpoint<P>,
-    Service = impl tower::Service<I, Response = (), Error = Error, Future = impl Send + 'static>
-                  + Clone
-                  + Send
-                  + 'static,
+    Service = impl tower::Service<I, Response = (), Error = Error, Future = impl Send> + Clone,
 > + Clone
-       + Send
-       + 'static
 where
     P: Clone + Send + 'static,
-    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Unpin + Send + 'static,
-    C: tower::Service<Endpoint<P>, Error = Error> + Unpin + Clone + Send + Sync + 'static,
-    C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + 'static,
-    C::Future: Unpin + Send,
+    I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+    C: tower::Service<Endpoint<P>> + Clone + Send + 'static,
+    C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
+    C::Error: Into<Error>,
+    C::Future: Send,
 {
     svc::stack(connect)
         .push_make_thunk()

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -17,7 +17,7 @@ pub fn stack<P>(
     server_port: u16,
     local_identity: tls::Conditional<identity::Local>,
     metrics: &metrics::Proxy,
-) -> impl tower::Service<
+) -> impl svc::Service<
     Endpoint<P>,
     Response = impl tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
     Error = Error,
@@ -41,12 +41,12 @@ pub fn forward<P, I, C>(
     connect: C,
 ) -> impl svc::NewService<
     Endpoint<P>,
-    Service = impl tower::Service<I, Response = (), Error = Error, Future = impl Send> + Clone,
+    Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send> + Clone,
 > + Clone
 where
     P: Clone + Send + 'static,
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
-    C: tower::Service<Endpoint<P>> + Clone + Send + 'static,
+    C: svc::Service<Endpoint<P>> + Clone + Send + 'static,
     C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
     C::Error: Into<Error>,
     C::Future: Send,

--- a/linkerd/app/outbound/src/tcp/opaque_transport.rs
+++ b/linkerd/app/outbound/src/tcp/opaque_transport.rs
@@ -20,7 +20,7 @@ pub struct OpaqueTransport<S> {
 }
 
 impl<S> OpaqueTransport<S> {
-    pub fn layer() -> impl layer::Layer<S, Service = Self> {
+    pub fn layer() -> impl layer::Layer<S, Service = Self> + Copy {
         layer::mk(|inner| OpaqueTransport { inner })
     }
 }
@@ -29,7 +29,7 @@ impl<S, P> svc::Service<Endpoint<P>> for OpaqueTransport<S>
 where
     S: svc::Service<Endpoint<P>> + Send + 'static,
     S::Error: Into<Error>,
-    S::Response: io::AsyncWrite + Unpin + Send + 'static,
+    S::Response: io::AsyncWrite + Send + Unpin,
     S::Future: Send + 'static,
 {
     type Response = S::Response;


### PR DESCRIPTION
We've grown a bunch of type constraints that don't actually influence
compilation. This change removes unnecessary constraints.