### PR TITLE
Rename transport types to ConnectTcp and BindTcp

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -1,11 +1,11 @@
 pub use crate::exp_backoff::ExponentialBackoff;
 pub use crate::proxy::http::{h1, h2};
-pub use crate::transport::{Bind, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr};
+pub use crate::transport::{BindTcp, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr};
 use std::time::Duration;
 
 #[derive(Clone, Debug)]
 pub struct ServerConfig<A: OrigDstAddr = NoOrigDstAddr> {
-    pub bind: Bind<A>,
+    pub bind: BindTcp<A>,
     pub h2_settings: h2::Settings,
 }
 

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -3,7 +3,7 @@ use crate::{
     proxy::http,
     reconnect,
     svc::{self, NewService},
-    transport::tls,
+    transport::{tls, ConnectTcp},
     Addr, Error,
 };
 use std::fmt;
@@ -57,7 +57,7 @@ impl Config {
             let backoff = self.connect.backoff;
             move |_| Ok(backoff.stream())
         };
-        svc::connect(self.connect.keepalive)
+        svc::stack(ConnectTcp::new(self.connect.keepalive))
             .push(tls::Client::layer(identity))
             .push_timeout(self.connect.timeout)
             .push(self::client::layer())

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -1,7 +1,6 @@
 // Possibly unused, but useful during development.
 
 pub use crate::proxy::http;
-use crate::transport::Connect;
 use crate::{cache, Error};
 pub use linkerd2_buffer as buffer;
 pub use linkerd2_concurrency_limit::ConcurrencyLimit;
@@ -31,10 +30,6 @@ pub fn layers() -> Layers<Identity> {
 
 pub fn stack<S>(inner: S) -> Stack<S> {
     Stack(inner)
-}
-
-pub fn connect(keepalive: Option<Duration>) -> Stack<Connect> {
-    Stack(Connect::new(keepalive))
 }
 
 pub fn proxies() -> Stack<IdentityProxy> {

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -137,7 +137,7 @@ impl Config {
     > + Clone {
         // Establishes connections to remote peers (for both TCP
         // forwarding and HTTP proxying).
-        svc::connect(self.proxy.connect.keepalive)
+        svc::stack(transport::ConnectTcp::new(self.proxy.connect.keepalive))
             .push_map_response(io::BoxedIo::new) // Ensures the transport propagates shutdown properly.
             // Limits the time we wait for a connection to be established.
             .push_timeout(self.proxy.connect.timeout)

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -5,7 +5,7 @@ use linkerd2_app_core::{
     metrics,
     proxy::identity,
     svc,
-    transport::{io, tls},
+    transport::{io, tls, ConnectTcp},
     Error,
 };
 use tracing::debug_span;
@@ -23,7 +23,7 @@ pub fn stack<P>(
     Error = Error,
     Future = impl Send,
 > + Clone {
-    svc::connect(config.keepalive)
+    svc::stack(ConnectTcp::new(config.keepalive))
         // Initiates mTLS if the target is configured with identity.
         .push(tls::Client::layer(local_identity))
         // If the endpoint has an opaque transport hint, this layer ensures the

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -4,7 +4,7 @@ pub use ipnet::IpNet;
 use linkerd2_app_core::{
     config, exp_backoff,
     proxy::http::{h1, h2},
-    transport::listen,
+    transport::BindTcp,
     IpMatch,
 };
 pub use linkerd2_app_test as support;
@@ -17,7 +17,7 @@ pub fn default_config(orig_dst: SocketAddr) -> Config {
         allow_discovery: IpMatch::new(Some(IpNet::from_str("0.0.0.0/0").unwrap())).into(),
         proxy: config::ProxyConfig {
             server: config::ServerConfig {
-                bind: listen::Bind::new(SocketAddr::new(LOCALHOST.into(), 0), None)
+                bind: BindTcp::new(SocketAddr::new(LOCALHOST.into(), 0), None)
                     .with_orig_dst_addr(orig_dst.into()),
                 h2_settings: h2::Settings::default(),
             },

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -3,7 +3,7 @@ use crate::core::{
     config::*,
     control::{Config as ControlConfig, ControlAddr},
     proxy::http::{h1, h2},
-    transport::{listen, tls},
+    transport::{tls, BindTcp},
     Addr, AddrMatch, NameMatch,
 };
 use crate::{dns, gateway, identity, inbound, oc_collector, outbound};
@@ -388,7 +388,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
     let outbound = {
         let keepalive = outbound_accept_keepalive?;
-        let bind = listen::Bind::new(
+        let bind = BindTcp::new(
             outbound_listener_addr?
                 .unwrap_or_else(|| parse_socket_addr(DEFAULT_OUTBOUND_LISTEN_ADDR).unwrap()),
             keepalive,
@@ -449,7 +449,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
     let inbound = {
         let keepalive = inbound_accept_keepalive?;
-        let bind = listen::Bind::new(
+        let bind = BindTcp::new(
             inbound_listener_addr?
                 .unwrap_or_else(|| parse_socket_addr(DEFAULT_INBOUND_LISTEN_ADDR).unwrap()),
             keepalive,
@@ -561,7 +561,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let admin = super::admin::Config {
         metrics_retain_idle: metrics_retain_idle?.unwrap_or(DEFAULT_METRICS_RETAIN_IDLE),
         server: ServerConfig {
-            bind: listen::Bind::new(
+            bind: BindTcp::new(
                 admin_listener_addr?
                     .unwrap_or_else(|| parse_socket_addr(DEFAULT_ADMIN_LISTEN_ADDR).unwrap()),
                 inbound.proxy.server.bind.keepalive(),
@@ -610,7 +610,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         .map(|(addr, ids)| super::tap::Config::Enabled {
             permitted_peer_identities: ids,
             config: ServerConfig {
-                bind: listen::Bind::new(addr, inbound.proxy.server.bind.keepalive()),
+                bind: BindTcp::new(addr, inbound.proxy.server.bind.keepalive()),
                 h2_settings,
             },
         })

--- a/linkerd/proxy/transport/src/connect.rs
+++ b/linkerd/proxy/transport/src/connect.rs
@@ -4,17 +4,17 @@ use tokio::net::TcpStream;
 use tracing::debug;
 
 #[derive(Copy, Clone, Debug)]
-pub struct Connect {
+pub struct ConnectTcp {
     keepalive: Option<Duration>,
 }
 
-impl Connect {
+impl ConnectTcp {
     pub fn new(keepalive: Option<Duration>) -> Self {
-        Connect { keepalive }
+        Self { keepalive }
     }
 }
 
-impl<T: Into<SocketAddr>> tower::Service<T> for Connect {
+impl<T: Into<SocketAddr>> tower::Service<T> for ConnectTcp {
     type Response = TcpStream;
     type Error = io::Error;
     type Future =

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -12,10 +12,10 @@ pub mod metrics;
 pub mod tls;
 
 pub use self::{
-    connect::Connect,
+    connect::ConnectTcp,
     detect::{Detect, DetectService, NewDetectService},
     io::BoxedIo,
-    listen::{Bind, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr},
+    listen::{BindTcp, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr},
 };
 
 // Misc.

--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -10,7 +10,7 @@ pub trait OrigDstAddr: Clone {
 }
 
 #[derive(Clone, Debug)]
-pub struct Bind<O: OrigDstAddr = NoOrigDstAddr> {
+pub struct BindTcp<O: OrigDstAddr = NoOrigDstAddr> {
     bind_addr: SocketAddr,
     keepalive: Option<Duration>,
     orig_dst_addr: O,
@@ -37,7 +37,7 @@ pub use self::sys::SysOrigDstAddr as DefaultOrigDstAddr;
 #[cfg(feature = "mock-orig-dst")]
 pub use self::mock::MockOrigDstAddr as DefaultOrigDstAddr;
 
-impl Bind {
+impl BindTcp {
     pub fn new(bind_addr: SocketAddr, keepalive: Option<Duration>) -> Self {
         Self {
             bind_addr,
@@ -47,9 +47,9 @@ impl Bind {
     }
 }
 
-impl<A: OrigDstAddr> Bind<A> {
-    pub fn with_orig_dst_addr<B: OrigDstAddr>(self, orig_dst_addr: B) -> Bind<B> {
-        Bind {
+impl<A: OrigDstAddr> BindTcp<A> {
+    pub fn with_orig_dst_addr<B: OrigDstAddr>(self, orig_dst_addr: B) -> BindTcp<B> {
+        BindTcp {
             orig_dst_addr,
             bind_addr: self.bind_addr,
             keepalive: self.keepalive,

--- a/linkerd/proxy/transport/tests/tls_accept.rs
+++ b/linkerd/proxy/transport/tests/tls_accept.rs
@@ -14,9 +14,8 @@ use linkerd2_proxy_transport::tls::{
     Conditional,
 };
 use linkerd2_proxy_transport::{
-    connect,
     io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BoxedIo},
-    Bind,
+    BindTcp, ConnectTcp,
 };
 use linkerd2_stack::NewService;
 use std::future::Future;
@@ -146,7 +145,7 @@ where
         // a fixed port.
         let addr = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
 
-        let (listen_addr, listen) = Bind::new(addr, None).bind().expect("must bind");
+        let (listen_addr, listen) = BindTcp::new(addr, None).bind().expect("must bind");
 
         let mut detect = DetectTls::new(
             server_tls,
@@ -205,7 +204,7 @@ where
         let peer_identity = Some(client_target_name.clone());
         let client = async move {
             let conn = tls::Client::layer(client_tls)
-                .layer(connect::Connect::new(None))
+                .layer(ConnectTcp::new(None))
                 .oneshot(Target(server_addr, client_target_name))
                 .await;
             match conn {


### PR DESCRIPTION
This change makes it clearer that these are concrete types and not
abstract traits. It also removes the `svc::connect` helper, as its
overly specialized.

This is intended to setup decoupling TCP connections from the
inbound/outbound stacks so that we can setup the entire stack without
interacting with OS sockets.