### PR TITLE
tap: Simplify tap initialization

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -61,7 +61,7 @@ impl Config {
         local_identity: tls::Conditional<identity::Local>,
         http_loopback: L,
         profiles_client: P,
-        tap_layer: tap::Layer,
+        tap: tap::Registry,
         metrics: metrics::Proxy,
         span_sink: Option<mpsc::Sender<oc::Span>>,
         drain: drain::Watch,
@@ -87,7 +87,7 @@ impl Config {
             prevent_loop,
             http_loopback,
             profiles_client,
-            tap_layer,
+            tap,
             metrics.clone(),
             span_sink.clone(),
         );
@@ -146,7 +146,7 @@ impl Config {
         prevent_loop: impl Into<PreventLoop>,
         loopback: L,
         profiles_client: P,
-        tap_layer: tap::Layer,
+        tap: tap::Registry,
         metrics: metrics::Proxy,
         span_sink: Option<mpsc::Sender<oc::Span>>,
     ) -> impl svc::NewService<
@@ -203,7 +203,7 @@ impl Config {
 
         let observe = svc::layers()
             // Registers the stack to be tapped.
-            .push(tap_layer)
+            .push(tap::NewTapHttp::layer(tap))
             // Records metrics for each `Target`.
             .push(metrics.http_endpoint.to_layer::<classify::Response, _>())
             .push_on_response(TraceContext::layer(

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -17,7 +17,7 @@ use tracing::debug_span;
 pub fn stack<B, C>(
     config: &ConnectConfig,
     tcp_connect: C,
-    tap_layer: tap::Layer,
+    tap: tap::Registry,
     metrics: metrics::Proxy,
     span_sink: Option<mpsc::Sender<oc::Span>>,
 ) -> impl svc::NewService<
@@ -53,7 +53,7 @@ where
             }
         }))
         .check_new::<Endpoint>()
-        .push(tap_layer)
+        .push(tap::NewTapHttp::layer(tap))
         .push(metrics.http_endpoint.to_layer::<classify::Response, _>())
         .push_on_response(TraceContext::layer(
             span_sink.map(|sink| SpanConverter::client(sink, crate::trace_labels())),

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -86,7 +86,7 @@ where
 {
     let (drain_tx, drain) = drain::channel();
 
-    let (_, tap, _) = tap::new();
+    let (tap, _) = tap::new();
     let router = super::logical::stack(
         &cfg.proxy,
         super::endpoint::stack(

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -136,7 +136,7 @@ impl Config {
         let outbound_metrics = metrics.outbound;
 
         let local_identity = identity.local();
-        let tap_layer = tap.layer();
+        let tap_registry = tap.registry();
         let oc_span_sink = oc_collector.span_sink();
 
         let start_proxy = Box::pin(async move {
@@ -150,7 +150,7 @@ impl Config {
                         local_identity.clone(),
                         &outbound_metrics,
                     ),
-                    tap_layer.clone(),
+                    tap_registry.clone(),
                     outbound_metrics.clone(),
                     oc_span_sink.clone(),
                 ),
@@ -226,7 +226,7 @@ impl Config {
                             .push_on_response(http::BoxRequest::layer())
                             .into_inner(),
                         dst.profiles,
-                        tap_layer,
+                        tap_registry,
                         inbound_metrics,
                         oc_span_sink,
                         drain_rx.clone(),

--- a/linkerd/app/src/tap.rs
+++ b/linkerd/app/src/tap.rs
@@ -8,8 +8,7 @@ use linkerd2_app_core::{
     transport::{io, tls},
     Error,
 };
-use std::net::SocketAddr;
-use std::pin::Pin;
+use std::{net::SocketAddr, pin::Pin};
 use tower::util::{service_fn, ServiceExt};
 
 #[derive(Clone, Debug)]
@@ -23,11 +22,10 @@ pub enum Config {
 
 pub enum Tap {
     Disabled {
-        layer: tap::Layer,
+        registry: tap::Registry,
     },
     Enabled {
         listen_addr: SocketAddr,
-        layer: tap::Layer,
         registry: tap::Registry,
         serve: Pin<Box<dyn std::future::Future<Output = Result<(), Error>> + Send + 'static>>,
     },
@@ -39,11 +37,11 @@ impl Config {
         identity: tls::Conditional<identity::Local>,
         drain: drain::Watch,
     ) -> Result<Tap, Error> {
-        let (registry, layer, server) = tap::new();
+        let (registry, server) = tap::new();
         match self {
             Config::Disabled => {
-                drop((registry, server));
-                Ok(Tap::Disabled { layer })
+                drop(server);
+                Ok(Tap::Disabled { registry })
             }
             Config::Enabled {
                 config,
@@ -71,7 +69,6 @@ impl Config {
 
                 Ok(Tap::Enabled {
                     listen_addr,
-                    layer,
                     registry,
                     serve,
                 })
@@ -81,10 +78,10 @@ impl Config {
 }
 
 impl Tap {
-    pub fn layer(&self) -> tap::Layer {
+    pub fn registry(&self) -> tap::Registry {
         match self {
-            Tap::Disabled { ref layer } => layer.clone(),
-            Tap::Enabled { ref layer, .. } => layer.clone(),
+            Tap::Disabled { ref registry } => registry.clone(),
+            Tap::Enabled { ref registry, .. } => registry.clone(),
         }
     }
 }

--- a/linkerd/proxy/tap/src/lib.rs
+++ b/linkerd/proxy/tap/src/lib.rs
@@ -12,10 +12,7 @@ mod grpc;
 mod registry;
 mod service;
 
-pub use self::accept::AcceptPermittedClients;
-
-/// Instruments service stacks so that requests may be tapped.
-pub type Layer = service::Layer<grpc::Tap>;
+pub use self::{accept::AcceptPermittedClients, service::NewTapHttp};
 
 /// A registry containing all the active taps that have registered with the
 /// gRPC server.
@@ -24,11 +21,10 @@ pub type Registry = registry::Registry<grpc::Tap>;
 // The number of events that may be buffered for a given response.
 const PER_RESPONSE_EVENT_BUFFER_CAPACITY: usize = 400;
 
-pub fn new() -> (Registry, Layer, grpc::Server) {
+pub fn new() -> (Registry, grpc::Server) {
     let registry = Registry::new();
-    let layer = Layer::new(registry.clone());
     let server = grpc::Server::new(registry.clone());
-    (registry, layer, server)
+    (registry, server)
 }
 
 /// Inspects a request for a `Stack`.

--- a/linkerd/proxy/tap/src/registry.rs
+++ b/linkerd/proxy/tap/src/registry.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use tokio::sync::watch;
 use tracing::trace;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Registry<T> {
     inner: Arc<Mutex<Inner<T>>>,
     taps_recv: watch::Receiver<Vec<T>>,
@@ -57,6 +57,15 @@ where
                 inner.taps.retain(|tap| tap.can_tap_more());
                 trace!("retained {} of {} taps", inner.taps.len(), count);
             }
+        }
+    }
+}
+
+impl<T> Clone for Registry<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            taps_recv: self.taps_recv.clone(),
         }
     }
 }

--- a/linkerd/proxy/tap/src/service.rs
+++ b/linkerd/proxy/tap/src/service.rs
@@ -12,8 +12,8 @@ use std::task::{Context, Poll};
 
 /// Makes wrapped Services to record taps.
 #[derive(Clone, Debug)]
-pub struct NewTapHttp<M, T> {
-    inner: M,
+pub struct NewTapHttp<N, T> {
+    inner: N,
     registry: Registry<T>,
 }
 

--- a/linkerd/proxy/tap/src/service.rs
+++ b/linkerd/proxy/tap/src/service.rs
@@ -1,50 +1,28 @@
 use super::iface::{Tap, TapPayload, TapResponse};
 use super::registry::Registry;
 use super::Inspect;
-use futures::{ready, TryFuture};
+use futures::ready;
 use hyper::body::HttpBody;
 use linkerd2_proxy_http::HasH2Reason;
-use linkerd2_stack::NewService;
+use linkerd2_stack::{layer, NewService};
 use pin_project::{pin_project, pinned_drop};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-/// A layer that wraps MakeServices to record taps.
-#[derive(Clone, Debug)]
-pub struct Layer<T> {
-    registry: Registry<T>,
-}
-
 /// Makes wrapped Services to record taps.
 #[derive(Clone, Debug)]
-pub struct MakeService<M, T> {
+pub struct NewTapHttp<M, T> {
     inner: M,
-    registry: Registry<T>,
-}
-
-/// Future returned by `MakeService`.
-#[pin_project]
-pub struct MakeFuture<F, I, T> {
-    #[pin]
-    inner: F,
-    inspect: I,
     registry: Registry<T>,
 }
 
 /// A middleware that records HTTP taps.
 #[derive(Clone, Debug)]
-pub struct Service<S, I, T> {
+pub struct TapHttp<S, I, T> {
     inner: S,
     inspect: I,
     registry: Registry<T>,
-}
-
-#[pin_project]
-pub struct ResponseFuture<F, T> {
-    #[pin]
-    inner: F,
-    taps: Vec<T>,
 }
 
 // A `Body` instrumented with taps.
@@ -61,101 +39,44 @@ where
     taps: Vec<T>,
 }
 
-// === Layer ===
+// === NewTapHttp ===
 
-impl<T> Layer<T> {
-    pub(super) fn new(registry: Registry<T>) -> Self {
-        Self { registry }
-    }
-}
-
-impl<M, T> tower::layer::Layer<M> for Layer<T>
-where
-    T: Clone,
-{
-    type Service = MakeService<M, T>;
-
-    fn layer(&self, inner: M) -> Self::Service {
-        MakeService {
+impl<N, T> NewTapHttp<N, T> {
+    pub fn layer(registry: Registry<T>) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self {
             inner,
-            registry: self.registry.clone(),
-        }
+            registry: registry.clone(),
+        })
     }
 }
 
-// === MakeService ===
-
-impl<M, I, T> NewService<I> for MakeService<M, T>
+impl<N, I, T> NewService<I> for NewTapHttp<N, T>
 where
-    M: NewService<I>,
+    N: NewService<I>,
     I: Inspect + Clone,
     T: Clone,
 {
-    type Service = Service<M::Service, I, T>;
+    type Service = TapHttp<N::Service, I, T>;
 
     fn new_service(&mut self, target: I) -> Self::Service {
-        let inspect = target.clone();
-        Service {
+        TapHttp {
+            inspect: target.clone(),
             inner: self.inner.new_service(target),
-            inspect,
             registry: self.registry.clone(),
         }
-    }
-}
-
-impl<M, I, T> tower::Service<I> for MakeService<M, T>
-where
-    M: tower::Service<I>,
-    I: Inspect + Clone,
-    T: Clone,
-{
-    type Response = Service<M::Response, I, T>;
-    type Error = M::Error;
-    type Future = MakeFuture<M::Future, I, T>;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, target: I) -> Self::Future {
-        let inspect = target.clone();
-        MakeFuture {
-            inner: self.inner.call(target),
-            inspect,
-            registry: self.registry.clone(),
-        }
-    }
-}
-
-// === MakeFuture ===
-
-impl<F, I, T> Future for MakeFuture<F, I, T>
-where
-    F: TryFuture,
-    I: Clone,
-    T: Clone,
-{
-    type Output = Result<Service<F::Ok, I, T>, F::Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        let inner = ready!(this.inner.try_poll(cx))?;
-        Poll::Ready(Ok(Service {
-            inner,
-            inspect: this.inspect.clone(),
-            registry: this.registry.clone(),
-        }))
     }
 }
 
 // === Service ===
 
-impl<S, I, T, A, B> tower::Service<http::Request<A>> for Service<S, I, T>
+impl<S, I, T, A, B> tower::Service<http::Request<A>> for TapHttp<S, I, T>
 where
     S: tower::Service<http::Request<Body<A, T::TapRequestPayload>>, Response = http::Response<B>>,
     S::Error: HasH2Reason,
+    S::Future: Send + 'static,
     I: Inspect,
     T: Tap,
+    T::TapResponse: Send + 'static,
     T::TapRequestPayload: Send + 'static,
     T::TapResponsePayload: Send + 'static,
     A: HttpBody,
@@ -165,8 +86,9 @@ where
 {
     type Response = http::Response<Body<B, T::TapResponsePayload>>;
     type Error = S::Error;
-    type Future = ResponseFuture<S::Future, T::TapResponse>;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, S::Error>> + Send + 'static>>;
 
+    #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
@@ -189,49 +111,30 @@ where
             taps: req_taps,
         });
 
-        let inner = self.inner.call(req);
-
-        ResponseFuture {
-            inner,
-            taps: rsp_taps,
-        }
-    }
-}
-
-impl<F, T, B> Future for ResponseFuture<F, T>
-where
-    F: TryFuture<Ok = http::Response<B>>,
-    F::Error: HasH2Reason,
-    T: TapResponse,
-    T::TapPayload: Send + 'static,
-    B: HttpBody,
-    B::Error: HasH2Reason,
-{
-    type Output = Result<http::Response<Body<B, T::TapPayload>>, F::Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        match ready!(this.inner.try_poll(cx)) {
-            Ok(rsp) => {
-                // Tap the response headers and use the response
-                // body taps to decorate the response body.
-                let taps = this.taps.drain(..).map(|t| t.tap(&rsp)).collect();
-                let rsp = rsp.map(move |inner| {
-                    let mut body = Body { inner, taps };
-                    if body.is_end_stream() {
-                        eos(&mut body.taps, None);
-                    }
-                    body
-                });
-                Poll::Ready(Ok(rsp))
-            }
-            Err(e) => {
-                for tap in this.taps.drain(..) {
-                    tap.fail(&e);
+        let call = self.inner.call(req);
+        Box::pin(async move {
+            match call.await {
+                Ok(rsp) => {
+                    // Tap the response headers and use the response
+                    // body taps to decorate the response body.
+                    let taps = rsp_taps.drain(..).map(|t| t.tap(&rsp)).collect();
+                    let rsp = rsp.map(move |inner| {
+                        let mut body = Body { inner, taps };
+                        if body.is_end_stream() {
+                            eos(&mut body.taps, None);
+                        }
+                        body
+                    });
+                    Ok(rsp)
                 }
-                Poll::Ready(Err(e))
+                Err(e) => {
+                    for tap in rsp_taps.drain(..) {
+                        tap.fail(&e);
+                    }
+                    Err(e)
+                }
             }
-        }
+        })
     }
 }
 


### PR DESCRIPTION
This change updates the tap module to look more like our other modules.
Instead of building a layer that is passed into stack builders, the tap
module now only produces its registry and stacks are instrumented with
the (renamed) `NewTapHttp::layer` helper.

This change removes the unused MakeService implementation and replaces
the manual future implementation with a boxed async closure.