### PR TITLE
inbound: Decouple inbound stack from TCP connections

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -4,19 +4,20 @@ pub use crate::proxy::http;
 use crate::{cache, Error};
 pub use linkerd2_buffer as buffer;
 pub use linkerd2_concurrency_limit::ConcurrencyLimit;
-pub use linkerd2_stack::{self as stack, layer, BoxNewService, NewRouter, NewService};
+pub use linkerd2_stack::{self as stack, layer, BoxNewService, Fail, NewRouter, NewService};
 pub use linkerd2_stack_tracing::{InstrumentMake, InstrumentMakeLayer};
 pub use linkerd2_timeout::{self as timeout, FailFast};
 use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use tower::layer::util::{Identity, Stack as Pair};
-pub use tower::layer::Layer;
-pub use tower::make::MakeService;
-pub use tower::spawn_ready::SpawnReady;
-pub use tower::util::Either;
-pub use tower::{service_fn as mk, Service, ServiceExt};
+use tower::{
+    layer::util::{Identity, Stack as Pair},
+    make::MakeService,
+};
+pub use tower::{
+    layer::Layer, service_fn as mk, spawn_ready::SpawnReady, util::Either, Service, ServiceExt,
+};
 
 #[derive(Clone, Debug)]
 pub struct Layers<L>(L);

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -88,18 +88,6 @@ impl Into<transport::labels::Key> for &'_ TcpAccept {
 
 // === impl HttpEndpoint ===
 
-impl Into<SocketAddr> for HttpEndpoint {
-    fn into(self) -> SocketAddr {
-        (&self).into()
-    }
-}
-
-impl Into<SocketAddr> for &'_ HttpEndpoint {
-    fn into(self) -> SocketAddr {
-        ([127, 0, 0, 1], self.port).into()
-    }
-}
-
 impl Into<http::client::Settings> for &'_ HttpEndpoint {
     fn into(self) -> http::client::Settings {
         self.settings
@@ -115,23 +103,6 @@ impl From<Target> for HttpEndpoint {
     }
 }
 
-impl tls::HasPeerIdentity for HttpEndpoint {
-    fn peer_identity(&self) -> tls::PeerIdentity {
-        Conditional::None(tls::ReasonForNoPeerName::Loopback)
-    }
-}
-
-impl Into<transport::labels::Key> for &'_ HttpEndpoint {
-    fn into(self) -> transport::labels::Key {
-        transport::labels::Key::Connect(transport::labels::EndpointLabels {
-            direction: transport::labels::Direction::In,
-            authority: None,
-            labels: None,
-            tls_id: tls::Conditional::None(tls::ReasonForNoPeerName::Loopback).into(),
-        })
-    }
-}
-
 // === TcpEndpoint ===
 
 impl From<TcpAccept> for TcpEndpoint {
@@ -142,30 +113,21 @@ impl From<TcpAccept> for TcpEndpoint {
     }
 }
 
-impl From<(Option<Header>, TcpAccept)> for TcpEndpoint {
-    fn from((hdr, tcp): (Option<Header>, TcpAccept)) -> Self {
-        match hdr {
-            Some(Header { port, .. }) => Self { port },
-            None => tcp.into(),
-        }
+impl From<Header> for TcpEndpoint {
+    fn from(Header { port, .. }: Header) -> Self {
+        Self { port }
     }
 }
 
-impl Into<SocketAddr> for TcpEndpoint {
-    fn into(self) -> SocketAddr {
-        (&self).into()
+impl From<HttpEndpoint> for TcpEndpoint {
+    fn from(HttpEndpoint { port, .. }: HttpEndpoint) -> Self {
+        Self { port }
     }
 }
 
-impl Into<SocketAddr> for &'_ TcpEndpoint {
-    fn into(self) -> SocketAddr {
-        ([127, 0, 0, 1], self.port).into()
-    }
-}
-
-impl tls::HasPeerIdentity for TcpEndpoint {
-    fn peer_identity(&self) -> tls::PeerIdentity {
-        Conditional::None(tls::ReasonForNoPeerName::Loopback)
+impl Into<u16> for TcpEndpoint {
+    fn into(self) -> u16 {
+        self.port
     }
 }
 

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -321,11 +321,9 @@ impl Config {
                 // the connection with a ConnectionRefused error.
                 svc::stack(tcp_forward)
                     .push_map_target(|(h, _): (opaque_transport::Header, _)| TcpEndpoint::from(h))
-                    .push(svc::stack::NewOptional::layer(svc::Fail::<
-                        _,
-                        NonOpaqueRefused,
-                    >::default(
-                    )))
+                    .push(svc::NewUnwrapOr::layer(
+                        svc::Fail::<_, NonOpaqueRefused>::default(),
+                    ))
                     .push(transport::NewDetectService::layer(
                         transport::detect::DetectTimeout::new(
                             self.proxy.detect_protocol_timeout,

--- a/linkerd/stack/src/fail.rs
+++ b/linkerd/stack/src/fail.rs
@@ -1,0 +1,58 @@
+use crate::NewService;
+use futures::future;
+use linkerd2_error::Error;
+use std::{
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+#[derive(Debug)]
+pub struct Fail<U, E> {
+    _marker: PhantomData<fn() -> Result<U, E>>,
+}
+
+impl<T, U, E> NewService<T> for Fail<U, E> {
+    type Service = Self;
+
+    #[inline]
+    fn new_service(&mut self, _: T) -> Self::Service {
+        *self
+    }
+}
+
+impl<T, U, E> tower::Service<T> for Fail<U, E>
+where
+    E: Default + Into<Error>,
+{
+    type Response = U;
+    type Error = Error;
+    type Future = future::Ready<Result<U, Error>>;
+
+    #[inline]
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    #[inline]
+    fn call(&mut self, _: T) -> Self::Future {
+        future::err(E::default().into())
+    }
+}
+
+impl<U, E> Default for Fail<U, E> {
+    fn default() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<U, E> Clone for Fail<U, E> {
+    fn clone(&self) -> Self {
+        Self {
+            _marker: self._marker,
+        }
+    }
+}
+
+impl<U, E> Copy for Fail<U, E> {}

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(warnings, rust_2018_idioms)]
 
 mod box_new_service;
+mod fail;
 mod fail_on_error;
 mod future_service;
 pub mod layer;
@@ -20,6 +21,7 @@ mod switch;
 mod switch_ready;
 
 pub use self::box_new_service::BoxNewService;
+pub use self::fail::Fail;
 pub use self::fail_on_error::FailOnError;
 pub use self::future_service::FutureService;
 pub use self::make_thunk::MakeThunk;


### PR DESCRIPTION
In order to make the inbound stack testable without initializing OS
sockets, this change decouples the inbound stack from its TCP client,
passing in an abstract implementation to `inbound::Config::build`.

This change introduces a new `stack::Fail` module that always fails.
This is used to ensure that connections targeting the inbound server
without an opaque port are not forwarded, removing the need for
endpoint-level loop prevention.