### PR TITLE
stack: Rename NewOptional to NewUnwrapOr

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -4,7 +4,7 @@ pub use crate::proxy::http;
 use crate::{cache, Error};
 pub use linkerd2_buffer as buffer;
 pub use linkerd2_concurrency_limit::ConcurrencyLimit;
-pub use linkerd2_stack::{self as stack, layer, BoxNewService, NewRouter, NewService};
+pub use linkerd2_stack::{self as stack, layer, BoxNewService, NewRouter, NewService, NewUnwrapOr};
 pub use linkerd2_stack_tracing::{InstrumentMake, InstrumentMakeLayer};
 pub use linkerd2_timeout::{self as timeout, FailFast};
 use std::{

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -373,7 +373,7 @@ impl Config {
             .instrument(|(v, _): &(http::Version, _)| debug_span!("http", %v))
             .check_new_service::<(http::Version, TcpAccept), http::Request<_>>()
             .push(http::NewServeHttp::layer(h2_settings, drain))
-            .push(svc::stack::NewOptional::layer(tcp))
+            .push(svc::NewUnwrapOr::layer(tcp))
             .push_cache(cache_max_idle_age)
             .push(transport::NewDetectService::layer(
                 transport::detect::DetectTimeout::new(

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -116,7 +116,7 @@ where
         .push_map_target(http::Accept::from)
         .check_new_service::<(http::Version, tcp::Accept), http::Request<_>>()
         .push(http::NewServeHttp::layer(h2_settings, drain))
-        .push(svc::stack::NewOptional::layer(tcp))
+        .push(svc::NewUnwrapOr::layer(tcp))
         .push_cache(cache_max_idle_age)
         .push(transport::NewDetectService::layer(
             transport::detect::DetectTimeout::new(

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -177,7 +177,7 @@ where
         .instrument(|l: &http::Logical| debug_span!("http", v = %l.protocol))
         .push_map_target(http::Logical::from)
         .push(http::NewServeHttp::layer(h2_settings, drain))
-        .push(svc::stack::NewOptional::layer(
+        .push(svc::NewUnwrapOr::layer(
             // When an HTTP version cannot be detected, we fallback to a logical
             // TCP stack. This service needs to be buffered so that it can be
             // cached and cloned per connection.

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -11,27 +11,29 @@ pub mod map_response;
 pub mod map_target;
 pub mod new_service;
 pub mod on_response;
-mod optional;
 mod proxy;
 mod request_filter;
 mod result;
 pub mod router;
 mod switch;
 mod switch_ready;
+mod unwrap_or;
 
-pub use self::box_new_service::BoxNewService;
-pub use self::fail_on_error::FailOnError;
-pub use self::future_service::FutureService;
-pub use self::make_thunk::MakeThunk;
-pub use self::map_response::{MapResponse, MapResponseLayer};
-pub use self::map_target::{MapTarget, MapTargetLayer, MapTargetService};
-pub use self::new_service::NewService;
-pub use self::on_response::{OnResponse, OnResponseLayer};
-pub use self::optional::NewOptional;
-pub use self::proxy::{Proxy, ProxyService};
-pub use self::request_filter::{FilterRequest, RequestFilter};
-pub use self::result::ResultService;
-pub use self::router::{NewRouter, RecognizeRoute};
-pub use self::switch::{MakeSwitch, Switch};
-pub use self::switch_ready::{NewSwitchReady, SwitchReady};
+pub use self::{
+    box_new_service::BoxNewService,
+    fail_on_error::FailOnError,
+    future_service::FutureService,
+    make_thunk::MakeThunk,
+    map_response::{MapResponse, MapResponseLayer},
+    map_target::{MapTarget, MapTargetLayer, MapTargetService},
+    new_service::NewService,
+    on_response::{OnResponse, OnResponseLayer},
+    proxy::{Proxy, ProxyService},
+    request_filter::{FilterRequest, RequestFilter},
+    result::ResultService,
+    router::{NewRouter, RecognizeRoute},
+    switch::{MakeSwitch, Switch},
+    switch_ready::{NewSwitchReady, SwitchReady},
+    unwrap_or::NewUnwrapOr,
+};
 pub use tower::util::Either;

--- a/linkerd/stack/src/unwrap_or.rs
+++ b/linkerd/stack/src/unwrap_or.rs
@@ -3,14 +3,14 @@ use crate::{layer, Either, NewService};
 /// A stack middleware that takes an optional target type and builds an `A`-typed
 /// stack if the target is set and a `B`-typed stack if it is not.
 #[derive(Clone, Debug, Default)]
-pub struct NewOptional<A, B> {
+pub struct NewUnwrapOr<A, B> {
     new_some: A,
     new_none: B,
 }
 
-// === impl NewOptional ===
+// === impl NewUnwrapOr ===
 
-impl<A, B> NewOptional<A, B> {
+impl<A, B> NewUnwrapOr<A, B> {
     pub fn new(new_some: A, new_none: B) -> Self {
         Self { new_some, new_none }
     }
@@ -23,7 +23,7 @@ impl<A, B> NewOptional<A, B> {
     }
 }
 
-impl<T, U, A, B> NewService<(Option<T>, U)> for NewOptional<A, B>
+impl<T, U, A, B> NewService<(Option<T>, U)> for NewUnwrapOr<A, B>
 where
     A: NewService<(T, U)> + Clone,
     B: NewService<U> + Clone,


### PR DESCRIPTION
The `NewOptional` module's name is a bit misleading. This change renames
it to `NewUnwrapOr` which is a slightly better analog of what it
actually does.