### PR TITLE
Rename opaque-transport to transport-header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,7 +876,6 @@ dependencies = [
  "linkerd2-http-classify",
  "linkerd2-http-metrics",
  "linkerd2-metrics",
- "linkerd2-opaque-transport",
  "linkerd2-opencensus",
  "linkerd2-proxy-api",
  "linkerd2-proxy-api-resolve",
@@ -898,6 +897,7 @@ dependencies = [
  "linkerd2-timeout",
  "linkerd2-trace-context",
  "linkerd2-tracing",
+ "linkerd2-transport-header",
  "pin-project 0.4.22",
  "procinfo",
  "prost-types",
@@ -1250,23 +1250,6 @@ dependencies = [
  "parking_lot",
  "quickcheck",
  "tokio 0.3.5",
- "tracing",
-]
-
-[[package]]
-name = "linkerd2-opaque-transport"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "bytes 0.6.0",
- "linkerd2-dns-name",
- "linkerd2-error",
- "linkerd2-io",
- "linkerd2-proxy-transport",
- "prost",
- "prost-build",
- "tokio 0.3.5",
- "tokio-test 0.3.0",
  "tracing",
 ]
 
@@ -1656,6 +1639,23 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "linkerd2-transport-header"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes 0.6.0",
+ "linkerd2-dns-name",
+ "linkerd2-error",
+ "linkerd2-io",
+ "linkerd2-proxy-transport",
+ "prost",
+ "prost-build",
+ "tokio 0.3.5",
+ "tokio-test 0.3.0",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
     "linkerd/channel",
     "linkerd/concurrency-limit",
     "linkerd/conditional",
-    "linkerd/opaque-transport",
+    "linkerd/transport-header",
     "linkerd/dns/name",
     "linkerd/dns",
     "linkerd/drain",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -38,7 +38,7 @@ linkerd2-exp-backoff = { path = "../../exp-backoff" }
 linkerd2-http-classify = { path = "../../http-classify" }
 linkerd2-http-metrics = { path = "../../http-metrics" }
 linkerd2-metrics = { path = "../../metrics" }
-linkerd2-opaque-transport = { path = "../../opaque-transport" }
+linkerd2-transport-header = { path = "../../transport-header" }
 linkerd2-opencensus = { path = "../../opencensus" }
 linkerd2-proxy-core = { path = "../../proxy/core" }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.16" }

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -17,7 +17,6 @@ pub use linkerd2_drain as drain;
 pub use linkerd2_error::{Error, Never, Recover};
 pub use linkerd2_exp_backoff as exp_backoff;
 pub use linkerd2_http_metrics as http_metrics;
-pub use linkerd2_opaque_transport as opaque_transport;
 pub use linkerd2_opencensus as opencensus;
 pub use linkerd2_reconnect as reconnect;
 pub use linkerd2_service_profiles as profiles;
@@ -25,6 +24,7 @@ pub use linkerd2_stack_metrics as stack_metrics;
 pub use linkerd2_stack_tracing as stack_tracing;
 pub use linkerd2_trace_context::TraceContext;
 pub use linkerd2_tracing as trace;
+pub use linkerd2_transport_header as transport_header;
 
 mod addr_match;
 pub mod admin;

--- a/linkerd/app/inbound/src/endpoint.rs
+++ b/linkerd/app/inbound/src/endpoint.rs
@@ -1,12 +1,11 @@
 use indexmap::IndexMap;
 use linkerd2_app_core::{
     classify, dst, http_request_authority_addr, http_request_host_addr,
-    http_request_l5d_override_dst_addr, metrics,
-    opaque_transport::Header,
-    profiles,
+    http_request_l5d_override_dst_addr, metrics, profiles,
     proxy::{http, identity, tap},
     stack_tracing, svc,
     transport::{self, listen, tls},
+    transport_header::TransportHeader,
     Addr, Conditional, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER,
 };
 use std::{convert::TryInto, net::SocketAddr, str::FromStr, sync::Arc};
@@ -113,8 +112,8 @@ impl From<TcpAccept> for TcpEndpoint {
     }
 }
 
-impl From<Header> for TcpEndpoint {
-    fn from(Header { port, .. }: Header) -> Self {
+impl From<TransportHeader> for TcpEndpoint {
+    fn from(TransportHeader { port, .. }: TransportHeader) -> Self {
         Self { port }
     }
 }

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -355,7 +355,7 @@ macro_rules! http1_tests {
         }
 
         #[tokio::test]
-        async fn http1_removes_transport_headers() {
+        async fn http1_removes_connection_headers() {
             let _trace = trace_init();
 
             let srv = server::http1()

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -355,7 +355,7 @@ macro_rules! http1_tests {
         }
 
         #[tokio::test]
-        async fn http1_removes_opaque_transports() {
+        async fn http1_removes_transport_headers() {
             let _trace = trace_init();
 
             let srv = server::http1()

--- a/linkerd/app/outbound/src/tcp/opaque_transport.rs
+++ b/linkerd/app/outbound/src/tcp/opaque_transport.rs
@@ -1,9 +1,9 @@
 use crate::target::Endpoint;
 use linkerd2_app_core::{
     dns::Name,
-    opaque_transport::Header,
     svc::{self, layer},
     transport::io,
+    transport_header::TransportHeader,
     Error,
 };
 use std::{
@@ -66,12 +66,12 @@ where
                         Name::from_str(auth.host())
                             .map_err(|error| warn!(%error, "Invalid name"))
                             .ok()
-                            .map(|n| Header {
+                            .map(|n| TransportHeader {
                                 port,
                                 name: Some(n),
                             })
                     })
-                    .unwrap_or(Header {
+                    .unwrap_or(TransportHeader {
                         port: orig_port,
                         name: None,
                     });
@@ -103,12 +103,12 @@ mod test {
     use crate::target::{Concrete, Endpoint, Logical};
     use futures::future;
     use linkerd2_app_core::{
-        opaque_transport::Header,
         proxy::api_resolve::{Metadata, ProtocolHint},
         transport::{
             io::{self, AsyncWriteExt},
             tls,
         },
+        transport_header::TransportHeader,
     };
     use tower::util::{service_fn, ServiceExt};
 
@@ -156,7 +156,7 @@ mod test {
         let svc = OpaqueTransport {
             inner: service_fn(|ep: Endpoint<()>| {
                 assert_eq!(ep.addr.port(), 4143);
-                let hdr = Header {
+                let hdr = TransportHeader {
                     port: ep.concrete.logical.orig_dst.port(),
                     name: None,
                 };
@@ -188,7 +188,7 @@ mod test {
         let svc = OpaqueTransport {
             inner: service_fn(|ep: Endpoint<()>| {
                 assert_eq!(ep.addr.port(), 4143);
-                let hdr = Header {
+                let hdr = TransportHeader {
                     port: 5555,
                     name: Some(Name::from_str("foo.bar.example.com").unwrap()),
                 };
@@ -220,7 +220,7 @@ mod test {
         let svc = OpaqueTransport {
             inner: service_fn(|ep: Endpoint<()>| {
                 assert_eq!(ep.addr.port(), 4143);
-                let hdr = Header {
+                let hdr = TransportHeader {
                     port: ep.concrete.logical.orig_dst.port(),
                     name: None,
                 };

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "linkerd2-opaque-transport"
+name = "linkerd2-transport-header"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 edition = "2018"

--- a/linkerd/transport-header/build.rs
+++ b/linkerd/transport-header/build.rs
@@ -1,5 +1,5 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let files = &["proto/opaque.proto"];
+    let files = &["proto/header.proto"];
     let dirs = &["proto"];
 
     prost_build::compile_protos(files, dirs)?;

--- a/linkerd/transport-header/proto/header.proto
+++ b/linkerd/transport-header/proto/header.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package opaque.proxy.l5d.io;
+package transport.l5d.io;
 
 message Header {
   // The target port.


### PR DESCRIPTION
Transport headers may be used for non-opaque traffic, i.e., for
multicluster.

This change renames the module and changes the transport preface to
reflect this.