### PR TITLE
Remove dependency on tower-http

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -906,7 +906,6 @@ dependencies = [
  "tokio-timer",
  "tonic",
  "tower",
- "tower-request-modifier",
  "tracing",
  "tracing-futures",
 ]
@@ -2818,15 +2817,6 @@ checksum = "a35d656f2638b288b33495d1053ea74c40dc05ec0b92084dd71ca5566c4ed1dc"
 name = "tower-layer"
 version = "0.3.0"
 source = "git+https://github.com/tower-rs/tower?rev=450fa3d2be2b43850ceb125009d636d1d8629ad7#450fa3d2be2b43850ceb125009d636d1d8629ad7"
-
-[[package]]
-name = "tower-request-modifier"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http?rev=bd7a4654bdc4e2b5363572e9f66b4dbbc7c0e1ea#bd7a4654bdc4e2b5363572e9f66b4dbbc7c0e1ea"
-dependencies = [
- "http",
- "tower-service",
-]
 
 [[package]]
 name = "tower-service"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -63,7 +63,6 @@ linkerd2-trace-context = { path = "../../trace-context" }
 regex = "1.0.0"
 tokio = { version = "0.3", features = ["macros", "sync", "parking_lot"]}
 tokio-timer = "0.2"
-tower-request-modifier = { git = "https://github.com/tower-rs/tower-http", rev = "bd7a4654bdc4e2b5363572e9f66b4dbbc7c0e1ea" }
 tonic = { version = "0.3", default-features = false, features = ["prost"] }
 tracing = "0.1.22"
 tracing-futures = { version = "0.2" }
@@ -75,10 +74,10 @@ version = "0.4"
 # will consume tower's traces as traces.
 default-features = false
 features = [
-    "util",
     "make",
+    "spawn-ready",
     "timeout",
-    "spawn-ready"
+    "util",
 ]
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
tower-http is not actually production ready, and our git depenency now
introduces outdated crate dependencies. This change replaces the use of
`tower-request-modifier` with a simple one-off service.

This ends up being a net reduction in code.