### PR TITLE
Update ipnet to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,12 +735,6 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51268c3a27ad46afd1cca0bbf423a5be2e9fd3e6a7534736c195f0f834b763ef"
-
-[[package]]
-name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
@@ -833,7 +827,7 @@ version = "0.1.0"
 dependencies = [
  "futures 0.3.5",
  "indexmap",
- "ipnet 1.0.0",
+ "ipnet",
  "linkerd2-app-core",
  "linkerd2-app-gateway",
  "linkerd2-app-inbound",
@@ -858,7 +852,7 @@ dependencies = [
  "http-body",
  "hyper",
  "indexmap",
- "ipnet 1.0.0",
+ "ipnet",
  "libc",
  "linkerd2-addr",
  "linkerd2-buffer",
@@ -981,7 +975,7 @@ dependencies = [
  "http",
  "hyper",
  "indexmap",
- "ipnet 1.0.0",
+ "ipnet",
  "linkerd2-app-core",
  "linkerd2-app-test",
  "linkerd2-identity",
@@ -1430,7 +1424,7 @@ dependencies = [
  "http",
  "hyper",
  "indexmap",
- "ipnet 2.3.0",
+ "ipnet",
  "linkerd2-conditional",
  "linkerd2-error",
  "linkerd2-identity",
@@ -2948,7 +2942,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "idna",
- "ipnet 2.3.0",
+ "ipnet",
  "lazy_static",
  "log",
  "rand 0.7.2",

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -16,7 +16,7 @@ mock-orig-dst  = ["linkerd2-app-core/mock-orig-dst"]
 [dependencies]
 futures = "0.3"
 indexmap = "1.0"
-ipnet = "1.0"
+ipnet = "2.0"
 linkerd2-app-core = { path = "./core" }
 linkerd2-app-gateway = { path = "./gateway" }
 linkerd2-app-inbound = { path = "./inbound" }

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -21,7 +21,7 @@ http-body = "0.4"
 hyper = "0.14.0-dev"
 futures = "0.3"
 indexmap = "1.0"
-ipnet = "1.0"
+ipnet = "2.0"
 linkerd2-addr = { path = "../../addr" }
 linkerd2-cache = { path = "../../cache" }
 linkerd2-buffer = { path = "../../buffer" }

--- a/linkerd/app/core/src/addr_match.rs
+++ b/linkerd/app/core/src/addr_match.rs
@@ -1,4 +1,4 @@
-use ipnet::{Contains, IpNet};
+use ipnet::IpNet;
 use linkerd2_addr::Addr;
 use linkerd2_dns::{Name, Suffix};
 use std::{net::IpAddr, sync::Arc};

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -31,7 +31,7 @@ features = [
 
 [dev-dependencies]
 hyper = "0.14.0-dev"
-ipnet = "1.0"
+ipnet = "2.0"
 linkerd2-app-test = { path = "../test" }
 linkerd2-io = { path = "../../io", features = ["tokio-test"] }
 tokio = { version = "0.3", features = ["full", "macros"]}


### PR DESCRIPTION
We depend on both ipnet v1 and ipnet v2. This change updates all
dependencies to v2.