### PR TITLE
Represent local identity as an Option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,6 +682,7 @@ dependencies = [
  "linkerd-exp-backoff",
  "linkerd-http-classify",
  "linkerd-http-metrics",
+ "linkerd-identity",
  "linkerd-metrics",
  "linkerd-opencensus",
  "linkerd-proxy-api-resolve",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -38,6 +38,7 @@ linkerd-error-respond = { path = "../../error-respond" }
 linkerd-exp-backoff = { path = "../../exp-backoff" }
 linkerd-http-classify = { path = "../../http-classify" }
 linkerd-http-metrics = { path = "../../http-metrics" }
+linkerd-identity = { path = "../../identity" }
 linkerd-metrics = { path = "../../metrics" }
 linkerd-transport-header = { path = "../../transport-header" }
 linkerd-opencensus = { path = "../../opencensus" }

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -45,7 +45,7 @@ impl Config {
         self,
         dns: dns::Resolver,
         metrics: metrics::ControlHttp,
-        identity: tls::Conditional<I>,
+        identity: Option<I>,
     ) -> Client<B>
     where
         B: http::HttpBody + Send + 'static,

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -17,6 +17,7 @@ pub use linkerd_drain as drain;
 pub use linkerd_error::{Error, Never, Recover};
 pub use linkerd_exp_backoff as exp_backoff;
 pub use linkerd_http_metrics as http_metrics;
+pub use linkerd_identity as identity;
 pub use linkerd_opencensus as opencensus;
 pub use linkerd_reconnect as reconnect;
 pub use linkerd_service_profiles as profiles;

--- a/linkerd/app/gateway/src/config.rs
+++ b/linkerd/app/gateway/src/config.rs
@@ -1,6 +1,6 @@
 use super::make::MakeGateway;
 use linkerd_app_core::{
-    discovery_rejected, profiles, proxy::http, svc, transport::tls, Error, NameAddr, NameMatch,
+    discovery_rejected, identity, profiles, proxy::http, svc, Error, NameAddr, NameMatch,
 };
 use linkerd_app_inbound::endpoint as inbound;
 use linkerd_app_outbound as outbound;
@@ -19,7 +19,7 @@ impl Config {
         self,
         outbound: O,
         profiles: P,
-        local_id: tls::PeerIdentity,
+        local_id: Option<identity::Name>,
     ) -> impl svc::NewService<
         inbound::Target,
         Service = impl tower::Service<

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -142,7 +142,7 @@ mod test {
                 Config { allow_discovery }.build(
                     move |_: _| outbound.clone(),
                     profiles,
-                    tls::PeerIdentity::Some(identity::Name::from(
+                    Some(identity::Name::from(
                         dns::Name::from_str("gateway.id.test").unwrap(),
                     )),
                 )

--- a/linkerd/app/gateway/src/make.rs
+++ b/linkerd/app/gateway/src/make.rs
@@ -1,5 +1,5 @@
 use super::gateway::Gateway;
-use linkerd_app_core::{profiles, svc, transport::tls, NameAddr};
+use linkerd_app_core::{identity, profiles, svc, transport::tls, NameAddr};
 use linkerd_app_inbound::endpoint as inbound;
 use linkerd_app_outbound as outbound;
 use tracing::debug;
@@ -7,11 +7,11 @@ use tracing::debug;
 #[derive(Clone, Debug)]
 pub(crate) struct MakeGateway<O> {
     outbound: O,
-    local_id: tls::PeerIdentity,
+    local_id: Option<identity::Name>,
 }
 
 impl<O> MakeGateway<O> {
-    pub fn new(outbound: O, local_id: tls::PeerIdentity) -> Self {
+    pub fn new(outbound: O, local_id: Option<identity::Name>) -> Self {
         Self { outbound, local_id }
     }
 }
@@ -33,7 +33,7 @@ where
         } = target;
 
         let (source_id, local_id) = match (tls_client_id, self.local_id.clone()) {
-            (tls::Conditional::Some(src), tls::Conditional::Some(local)) => (src, local),
+            (tls::Conditional::Some(src), Some(local)) => (src, local),
             _ => return Gateway::NoIdentity,
         };
 

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -78,7 +78,7 @@ impl Config {
     pub fn build<I, C, L, LSvc, P>(
         self,
         listen_addr: SocketAddr,
-        local_identity: tls::Conditional<identity::Local>,
+        local_identity: Option<identity::Local>,
         connect: C,
         http_loopback: L,
         profiles_client: P,
@@ -386,7 +386,7 @@ impl Config {
         self,
         detect: D,
         tcp_forward: F,
-        identity: tls::Conditional<identity::Local>,
+        identity: Option<identity::Local>,
         metrics: metrics::Proxy,
     ) -> impl svc::NewService<
         listen::Addrs,

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -15,7 +15,7 @@ use tracing::debug_span;
 pub fn stack<P>(
     config: &ConnectConfig,
     server_port: u16,
-    local_identity: tls::Conditional<identity::Local>,
+    local_identity: Option<identity::Local>,
     metrics: &metrics::Proxy,
 ) -> impl svc::Service<
     Endpoint<P>,

--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -1,4 +1,4 @@
-use crate::identity::LocalIdentity;
+use crate::identity;
 use linkerd_app_core::{
     admin, config::ServerConfig, drain, metrics::FmtMetrics, serve, trace, transport::tls, Error,
 };
@@ -20,7 +20,7 @@ pub struct Admin {
 impl Config {
     pub fn build<R>(
         self,
-        identity: LocalIdentity,
+        identity: Option<identity::Local>,
         report: R,
         trace: trace::Handle,
         drain: drain::Watch,

--- a/linkerd/app/src/dst.rs
+++ b/linkerd/app/src/dst.rs
@@ -3,7 +3,6 @@ use linkerd_app_core::{
     exp_backoff::{ExponentialBackoff, ExponentialBackoffStream},
     is_discovery_rejected, metrics, profiles,
     proxy::{api_resolve as api, identity, resolve::recover},
-    transport::tls,
     Error, Recover,
 };
 use tonic::body::BoxBody;
@@ -37,7 +36,7 @@ impl Config {
         self,
         dns: dns::Resolver,
         metrics: metrics::ControlHttp,
-        identity: tls::Conditional<identity::Local>,
+        identity: Option<identity::Local>,
     ) -> Result<Dst, Error> {
         let addr = self.control.addr.clone();
         let backoff = BackoffUnlessInvalidArgument(self.control.connect.backoff);

--- a/linkerd/app/src/oc_collector.rs
+++ b/linkerd/app/src/oc_collector.rs
@@ -1,4 +1,4 @@
-use crate::{dns, identity::LocalIdentity};
+use crate::{dns, identity};
 use linkerd_app_core::{control, metrics::ControlHttp as HttpMetrics, Error};
 use linkerd_channel::into_stream::IntoStream;
 use linkerd_opencensus::{metrics, proto, SpanExporter};
@@ -42,7 +42,7 @@ impl Config {
 
     pub fn build(
         self,
-        identity: LocalIdentity,
+        identity: Option<identity::Local>,
         dns: dns::Resolver,
         metrics: metrics::Registry,
         client_metrics: HttpMetrics,

--- a/linkerd/app/src/tap.rs
+++ b/linkerd/app/src/tap.rs
@@ -34,7 +34,7 @@ pub enum Tap {
 impl Config {
     pub fn build(
         self,
-        identity: tls::Conditional<identity::Local>,
+        identity: Option<identity::Local>,
         drain: drain::Watch,
     ) -> Result<Tap, Error> {
         let (registry, server) = tap::new();

--- a/linkerd/proxy/transport/src/tls/client.rs
+++ b/linkerd/proxy/transport/src/tls/client.rs
@@ -22,7 +22,7 @@ pub trait HasConfig {
 
 #[derive(Clone, Debug)]
 pub struct Client<L, C> {
-    local: Conditional<L>,
+    local: Option<L>,
     inner: C,
 }
 
@@ -35,7 +35,7 @@ pub type Io<T> = io::EitherIo<T, TlsStream<T>>;
 // === impl Client ===
 
 impl<L: Clone, C> Client<L, C> {
-    pub fn layer(local: Conditional<L>) -> impl layer::Layer<C, Service = Self> + Clone {
+    pub fn layer(local: Option<L>) -> impl layer::Layer<C, Service = Self> + Clone {
         layer::mk(move |inner| Self {
             inner,
             local: local.clone(),
@@ -61,10 +61,10 @@ where
     }
 
     fn call(&mut self, target: T) -> Self::Future {
-        let tls = match self.local.clone() {
-            Conditional::Some(l) => tokio_rustls::TlsConnector::from(l.tls_client_config()),
-            Conditional::None(reason) => {
-                trace!(%reason, "Local identity disabled");
+        let tls = match self.local.as_ref() {
+            Some(l) => tokio_rustls::TlsConnector::from(l.tls_client_config()),
+            None => {
+                trace!("Local identity disabled");
                 return Either::Left(self.inner.call(target).map_ok(io::EitherIo::Left));
             }
         };


### PR DESCRIPTION
There's only one reason we may lack a local identity: when it's
explicitly disabled.

This change decouples the local identity types from the
`ReasonForNoPeerName` conditional, as local identity has nothing to do
with peer names. We instead represent local identity as a simple
`Option` type.