### PR TITLE
Remove tap status being explicitly set in config

### DIFF
--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -244,17 +244,16 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
         Some(identity.addr)
     } else {
         env.put(app::env::ENV_IDENTITY_DISABLED, "test".to_owned());
-        env.put(app::env::ENV_TAP_DISABLED, "test".to_owned());
         None
     };
 
     // If identity is enabled but the test is not concerned with tap, ensure
     // there is a tap service name set
-    if !env.contains_key(app::env::ENV_TAP_DISABLED)
-        && !env.contains_key(app::env::ENV_TAP_SVC_NAME)
-    {
-        env.put(app::env::ENV_TAP_SVC_NAME, "test-identity".to_owned())
-    }
+    // if !env.contains_key(app::env::ENV_TAP_DISABLED)
+    //     && !env.contains_key(app::env::ENV_TAP_SVC_NAME)
+    // {
+    //     env.put(app::env::ENV_TAP_SVC_NAME, "test-identity".to_owned())
+    // }
 
     if let Some(ports) = proxy.inbound_disable_ports_protocol_detection {
         let ports = ports

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -247,14 +247,6 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
         None
     };
 
-    // If identity is enabled but the test is not concerned with tap, ensure
-    // there is a tap service name set
-    // if !env.contains_key(app::env::ENV_TAP_DISABLED)
-    //     && !env.contains_key(app::env::ENV_TAP_SVC_NAME)
-    // {
-    //     env.put(app::env::ENV_TAP_SVC_NAME, "test-identity".to_owned())
-    // }
-
     if let Some(ports) = proxy.inbound_disable_ports_protocol_detection {
         let ports = ports
             .into_iter()

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -714,7 +714,7 @@ fn parse_tap_config(
 ) -> Result<Option<(SocketAddr, IndexSet<identity::Name>)>, EnvError> {
     let tap_identity = parse(strings, ENV_TAP_SVC_NAME, parse_identity)?;
     if id_disabled {
-        if let Some(_) = tap_identity {
+        if tap_identity.is_some() {
             warn!(
                 "{} should not be set if identity is disabled; continuing with tap disabled",
                 ENV_TAP_SVC_NAME
@@ -727,7 +727,7 @@ fn parse_tap_config(
             return Ok(Some((addr, vec![id].into_iter().collect())));
         }
     };
-    return Ok(None);
+    Ok(None)
 }
 
 fn parse_bool(s: &str) -> Result<bool, ParseError> {


### PR DESCRIPTION
This is required as part of linkerd/linkerd2#5326 because the tap env variables
will no longer always be set.

There is a dependency on identity being enabled for tap to work. The
status of tap is determined by the `ENV_TAP_SVC_NAME` env variable being set
or not set.

- If identity is disabled, tap is disabled, but a warning is issued if
  `ENV_TAP_SVC_NAME` is set.
- If identity is enabled, the status of tap is determined by
  `ENV_TAP_SVC_NAME`.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>