### PR TITLE
failfast: Improve diagnostic logging

### DIFF
--- a/linkerd/timeout/src/failfast.rs
+++ b/linkerd/timeout/src/failfast.rs
@@ -11,7 +11,7 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::time::{self, Duration, Instant, Sleep};
-use tracing::{debug, trace};
+use tracing::{debug, trace, warn};
 
 #[derive(Debug)]
 pub struct FailFast<S> {
@@ -102,6 +102,7 @@ where
                         self.wait
                             .as_mut()
                             .reset(Instant::now() + self.max_unavailable);
+                        debug!("{} service has become unavailable", self.scope);
                         State::Waiting
                     }
 
@@ -112,12 +113,16 @@ where
                             trace!("Pending");
                             return Poll::Pending;
                         }
+                        warn!(
+                            "{} entering failfast after {:?}",
+                            self.scope, self.max_unavailable
+                        );
                         State::FailFast
                     }
 
                     // Admit requests and fail them immediately.
                     State::FailFast => {
-                        debug!("Failing");
+                        trace!("{} in failfast", self.scope);
                         return Poll::Ready(Ok(()));
                     }
                 };
@@ -128,8 +133,8 @@ where
             ret => {
                 match self.state {
                     State::Open => {}
-                    State::Waiting => trace!("Ready"),
-                    State::FailFast => debug!("Recovered"),
+                    State::Waiting => trace!("{} has become ready", self.scope),
+                    State::FailFast => debug!("{} service has recovered", self.scope),
                 }
                 self.state = State::Open;
                 ret.map_err(Into::into)

--- a/linkerd/timeout/src/failfast.rs
+++ b/linkerd/timeout/src/failfast.rs
@@ -11,7 +11,7 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::time::{self, Duration, Instant, Sleep};
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 #[derive(Debug)]
 pub struct FailFast<S> {
@@ -134,7 +134,7 @@ where
                 match self.state {
                     State::Open => {}
                     State::Waiting => trace!("{} has become ready", self.scope),
-                    State::FailFast => debug!("{} service has recovered", self.scope),
+                    State::FailFast => info!("{} service has recovered", self.scope),
                 }
                 self.state = State::Open;
                 ret.map_err(Into::into)

--- a/linkerd/timeout/src/failfast.rs
+++ b/linkerd/timeout/src/failfast.rs
@@ -122,7 +122,7 @@ where
 
                     // Admit requests and fail them immediately.
                     State::FailFast => {
-                        trace!("{} in failfast", self.scope);
+                        debug!("{} in failfast", self.scope);
                         return Poll::Ready(Ok(()));
                     }
                 };


### PR DESCRIPTION
Failfast errors can be difficult to track down. This change updates the
failfast module to emit more descriptive log messages. A `WARN`-level
message is emitted when a service enters failfast.