### PR TITLE
Update the base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG RUST_IMAGE=rust:1.49.0-buster
 
 # Use an arbitrary ~recent edge release image to get the proxy
 # identity-initializing wrapper.
-ARG RUNTIME_IMAGE=gcr.io/linkerd-io/proxy:edge-20.8.2
+ARG RUNTIME_IMAGE=ghcr.io/linkerd/proxy:edge-21.1.2
 
 # Build the proxy, leveraging (new, experimental) cache mounting.
 #


### PR DESCRIPTION
This change updates the base docker image to use
ghcr.io/linkerd/proxy:edge-21.1.2. This removes a dependency on the old
gcr.io repository.