### PR TITLE
stack: Implement Clone for ResultService

### DIFF
--- a/linkerd/stack/src/request_filter.rs
+++ b/linkerd/stack/src/request_filter.rs
@@ -1,7 +1,6 @@
 //! A `Service` middleware that applies arbitrary-user provided logic to each
 //! target before it is issued to an inner service.
 
-use linkerd_error::Error;
 pub use tower::filter::{Filter, FilterLayer, Predicate};
 
 impl<T, F, S> super::NewService<T> for Filter<S, F>
@@ -9,7 +8,7 @@ where
     F: Predicate<T>,
     S: super::NewService<F::Request>,
 {
-    type Service = super::ResultService<S::Service, Error>;
+    type Service = super::ResultService<S::Service>;
 
     fn new_service(&mut self, request: T) -> Self::Service {
         self.check(request)


### PR DESCRIPTION
`stack::ResultService` cannot implement `Clone` because it holds an
error type. This error is always coerced to `Error`, so its type is
unimportant.

This change wraps the service's error type in an `Arc` (instead of an
`Option`) so that `ResultService` can safely be cloned.