### PR TITLE
tests: replace string matching on metrics with parsing

### DIFF
--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -136,19 +136,23 @@ macro_rules! assert_contains {
 
 #[macro_export]
 macro_rules! assert_eventually_contains {
-    ($scrape:expr, $contains:expr) => {
+    ($scrape:expr, $contains:expr) => {{
+        let mut res: Result<(), crate::metrics::MatchErr> = Ok(());
         assert_eventually!(
-            $scrape.contains($contains),
-            "metrics scrape:\n{}\ndid not contain:\n{}",
-            $scrape,
-            $contains
+            {
+                res = $contains.is_in($scrape);
+                res.is_ok()
+            },
+            "{}",
+            res.unwrap_err(),
         )
-    };
+    }};
 }
 
 pub mod client;
 pub mod controller;
 pub mod identity;
+pub mod metrics;
 pub mod proxy;
 pub mod server;
 pub mod tap;

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -138,13 +138,14 @@ macro_rules! assert_contains {
 macro_rules! assert_eventually_contains {
     ($scrape:expr, $contains:expr) => {{
         let mut res: Result<(), crate::metrics::MatchErr> = Ok(());
+        let res_ref = &mut res;
         assert_eventually!(
             {
-                res = $contains.is_in($scrape);
-                res.is_ok()
+                *res_ref = $contains.is_in($scrape);
+                res_ref.is_ok()
             },
             "{}",
-            res.unwrap_err(),
+            std::mem::replace(res_ref, Ok(())).unwrap_err(),
         )
     }};
 }

--- a/linkerd/app/integration/src/metrics.rs
+++ b/linkerd/app/integration/src/metrics.rs
@@ -1,15 +1,22 @@
 use std::fmt;
 use std::string::ToString;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MetricMatch {
     name: String,
     labels: Vec<String>,
     value: Option<String>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct Labels(Vec<String>);
+
 pub fn metric(name: impl Into<String>) -> MetricMatch {
     MetricMatch::new(name)
+}
+
+pub fn labels() -> Labels {
+    Labels::default()
 }
 
 #[derive(Eq, PartialEq)]
@@ -24,16 +31,21 @@ impl MetricMatch {
         }
     }
 
-    pub fn with_label(mut self, key: impl AsRef<str>, val: impl fmt::Display) -> Self {
+    pub fn label(mut self, key: impl AsRef<str>, val: impl fmt::Display) -> Self {
         self.labels.push(format!("{}=\"{}\"", key.as_ref(), val));
         self
     }
 
-    pub fn with_value(self, value: impl ToString) -> Self {
+    pub fn value(self, value: impl ToString) -> Self {
         Self {
             value: Some(value.to_string()),
             ..self
         }
+    }
+
+    pub fn set_value(&mut self, value: impl ToString) -> &mut Self {
+        self.value = Some(value.to_string());
+        self
     }
 
     pub fn is_not_in(&self, scrape: impl AsRef<str>) -> bool {
@@ -87,7 +99,72 @@ impl MetricMatch {
 
         Ok(())
     }
+
+    #[track_caller]
+    pub async fn assert_in(&self, client: &crate::client::Client) {
+        use std::str::FromStr;
+        use std::time::{Duration, Instant};
+        use std::{env, u64};
+        use tracing::Instrument as _;
+        const MAX_RETRIES: usize = 5;
+        // TODO: don't do this *every* time eventually is called (lazy_static?)
+        let patience = env::var(crate::ENV_TEST_PATIENCE_MS)
+            .ok()
+            .map(|s| {
+                let millis = u64::from_str(&s).expect(
+                    "Could not parse RUST_TEST_PATIENCE_MS environment \
+                         variable.",
+                );
+                Duration::from_millis(millis)
+            })
+            .unwrap_or(crate::DEFAULT_TEST_PATIENCE);
+        async {
+            let start_t = Instant::now();
+            for i in 1..=MAX_RETRIES {
+                tracing::info!(retries_remaining = MAX_RETRIES - i);
+                let scrape = client.get("/metrics").await;
+                match self.is_in(scrape) {
+                    Ok(()) => break,
+                    Err(e) if i == MAX_RETRIES => panic!(
+                        "{}\n  retried {} times ({:?})",
+                        e,
+                        MAX_RETRIES,
+                        start_t.elapsed()
+                    ),
+                    Err(_) => {
+                        tracing::trace!("waiting...");
+                        tokio::time::sleep(patience).await;
+                        std::thread::yield_now();
+                        tracing::trace!("done")
+                    }
+                }
+            }
+        }
+        .instrument(tracing::trace_span!(
+            "assert_eventually",
+            patience  = ?patience,
+            max_retries = MAX_RETRIES,
+        ))
+        .await
+    }
 }
+
+impl Labels {
+    pub fn label(mut self, key: impl AsRef<str>, val: impl fmt::Display) -> Self {
+        self.0.push(format!("{}=\"{}\"", key.as_ref(), val));
+        self
+    }
+
+    pub fn metric(&self, name: impl Into<String>) -> MetricMatch {
+        MetricMatch {
+            labels: self.0.clone(),
+            name: name.into(),
+            value: None,
+        }
+    }
+}
+
+// === impl MatchErr ===
 
 impl fmt::Debug for MatchErr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/linkerd/app/integration/src/metrics.rs
+++ b/linkerd/app/integration/src/metrics.rs
@@ -61,10 +61,9 @@ impl MetricMatch {
         let mut candidates = Vec::new();
         'lines: for &line in &lines {
             if let Some(labels) = line
-                .split("{")
-                .skip(1)
-                .next()
-                .and_then(|line| line.split("}").next())
+                .split('{')
+                .nth(1)
+                .and_then(|line| line.split('}').next())
             {
                 for label in &self.labels {
                     if !labels.contains(&label[..]) {
@@ -84,7 +83,7 @@ impl MetricMatch {
 
         if let Some(ref expected_value) = self.value {
             for &line in &candidates {
-                if let Some(value) = line.split("}").skip(1).next() {
+                if let Some(value) = line.split('}').nth(1) {
                     let value = value.trim();
                     if value == expected_value {
                         return Ok(());

--- a/linkerd/app/integration/src/metrics.rs
+++ b/linkerd/app/integration/src/metrics.rs
@@ -1,0 +1,102 @@
+use std::fmt;
+use std::string::ToString;
+
+#[derive(Debug)]
+pub struct MetricMatch {
+    name: String,
+    labels: Vec<String>,
+    value: Option<String>,
+}
+
+pub fn metric(name: impl Into<String>) -> MetricMatch {
+    MetricMatch::new(name)
+}
+
+#[derive(Eq, PartialEq)]
+pub struct MatchErr(String);
+
+impl MetricMatch {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            labels: Vec::new(),
+            value: None,
+        }
+    }
+
+    pub fn with_label(mut self, key: impl AsRef<str>, val: impl fmt::Display) -> Self {
+        self.labels.push(format!("{}=\"{}\"", key.as_ref(), val));
+        self
+    }
+
+    pub fn with_value(self, value: impl ToString) -> Self {
+        Self {
+            value: Some(value.to_string()),
+            ..self
+        }
+    }
+
+    pub fn is_not_in(&self, scrape: impl AsRef<str>) -> bool {
+        self.is_in(scrape).is_err()
+    }
+
+    pub fn is_in(&self, scrape: impl AsRef<str>) -> Result<(), MatchErr> {
+        let scrape = scrape.as_ref();
+        let lines = scrape
+            .lines()
+            .filter(|&line| line.starts_with(&self.name))
+            .collect::<Vec<&str>>();
+        let mut candidates = Vec::new();
+        'lines: for &line in &lines {
+            if let Some(labels) = line
+                .split("{")
+                .skip(1)
+                .next()
+                .and_then(|line| line.split("}").next())
+            {
+                for label in &self.labels {
+                    if !labels.contains(&label[..]) {
+                        continue 'lines;
+                    }
+                }
+                candidates.push(line);
+            }
+        }
+
+        if candidates.is_empty() {
+            return Err(MatchErr(format!(
+                "did not find a `{}` metric\n  with labels: {:?}\nfound metrics: {:#?}",
+                self.name, self.labels, lines
+            )));
+        }
+
+        if let Some(ref expected_value) = self.value {
+            for &line in &candidates {
+                if let Some(value) = line.split("}").skip(1).next() {
+                    let value = value.trim();
+                    if value == expected_value {
+                        return Ok(());
+                    }
+                }
+            }
+            return Err(MatchErr(format!(
+                "did not find a `{}` metric\n  with labels: {:?}\n    and value: {}\nfound metrics: {:#?}",
+                self.name, self.labels, expected_value, candidates
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Debug for MatchErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for MatchErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}

--- a/linkerd/app/integration/src/tests/discovery.rs
+++ b/linkerd/app/integration/src/tests/discovery.rs
@@ -383,13 +383,17 @@ mod http2 {
         tokio::task::yield_now().await;
 
         // Wait until the proxy has seen the `srv1` disconnect...
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            &format!(
-                "tcp_close_total{{peer=\"dst\",authority=\"disco.test.svc.cluster.local:{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"}} 1",
-                port
+        let metric = metrics::metric("tcp_close_total")
+            .with_label("peer", "dst")
+            .with_label("direction", "outbound")
+            .with_label("tls", "no_identity")
+            .with_label("no_tls_reason", "not_provided_by_service_discovery")
+            .with_label(
+                "authority",
+                format_args!("disco.test.svc.cluster.local:{}", port),
             )
-        );
+            .with_value(1);
+        assert_eventually_contains!(metrics.get("/metrics").await, metric);
 
         // Start a new request to the destination, now that the server is dead.
         // This request should be waiting at the balancer for a ready endpoint.

--- a/linkerd/app/integration/src/tests/discovery.rs
+++ b/linkerd/app/integration/src/tests/discovery.rs
@@ -383,17 +383,18 @@ mod http2 {
         tokio::task::yield_now().await;
 
         // Wait until the proxy has seen the `srv1` disconnect...
-        let metric = metrics::metric("tcp_close_total")
-            .with_label("peer", "dst")
-            .with_label("direction", "outbound")
-            .with_label("tls", "no_identity")
-            .with_label("no_tls_reason", "not_provided_by_service_discovery")
-            .with_label(
+        metrics::metric("tcp_close_total")
+            .label("peer", "dst")
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "not_provided_by_service_discovery")
+            .label(
                 "authority",
                 format_args!("disco.test.svc.cluster.local:{}", port),
             )
-            .with_value(1);
-        assert_eventually_contains!(metrics.get("/metrics").await, metric);
+            .value(1u64)
+            .assert_in(&metrics)
+            .await;
 
         // Start a new request to the destination, now that the server is dead.
         // This request should be waiting at the balancer for a ready endpoint.

--- a/linkerd/app/integration/src/tests/profiles.rs
+++ b/linkerd/app/integration/src/tests/profiles.rs
@@ -163,12 +163,13 @@ async fn retry_uses_budget() {
             assert_eq!(res.status(), 533);
         },
         with_metrics: |metrics: client::Client, port| async move {
-            let metric = metrics::metric("route_retryable_total")
-                .with_label("direction", "outbound")
-                .with_label("dst", format_args!("profiles.test.svc.cluster.local:{}", port))
-                .with_label("skipped", "no_budget")
-                .with_value(1);
-            assert_eventually_contains!(metrics.get("/metrics").await, metric);
+            metrics::metric("route_retryable_total")
+                .label("direction", "outbound")
+                .label("dst", format_args!("profiles.test.svc.cluster.local:{}", port))
+                .label("skipped", "no_budget")
+                .value(1u64)
+                .assert_in(&metrics)
+                .await;
         }
     }
 }
@@ -333,13 +334,14 @@ async fn timeout() {
             assert_eq!(res.status(), 504);
         },
         with_metrics: |metrics: client::Client, port| async move {
-            let metric = metrics::metric("route_response_total")
-            .with_label("direction", "outbound")
-            .with_label("dst", format_args!("profiles.test.svc.cluster.local:{}", port))
-            .with_label("classification", "failure")
-            .with_label("error", "timeout")
-            .with_value(1);
-            assert_eventually_contains!(metrics.get("/metrics").await, metric);
+            metrics::metric("route_response_total")
+                .label("direction", "outbound")
+                .label("dst", format_args!("profiles.test.svc.cluster.local:{}", port))
+                .label("classification", "failure")
+                .label("error", "timeout")
+                .value(1u64)
+                .assert_in(&metrics)
+                .await;
         }
     }
 }

--- a/linkerd/app/integration/src/tests/profiles.rs
+++ b/linkerd/app/integration/src/tests/profiles.rs
@@ -163,11 +163,12 @@ async fn retry_uses_budget() {
             assert_eq!(res.status(), 533);
         },
         with_metrics: |metrics: client::Client, port| async move {
-            let expected = format!(
-                "route_retryable_total{{direction=\"outbound\",dst=\"profiles.test.svc.cluster.local:{}\",skipped=\"no_budget\"}} 1",
-                port
-            );
-            assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
+            let metric = metrics::metric("route_retryable_total")
+                .with_label("direction", "outbound")
+                .with_label("dst", format_args!("profiles.test.svc.cluster.local:{}", port))
+                .with_label("skipped", "no_budget")
+                .with_value(1);
+            assert_eventually_contains!(metrics.get("/metrics").await, metric);
         }
     }
 }
@@ -332,11 +333,13 @@ async fn timeout() {
             assert_eq!(res.status(), 504);
         },
         with_metrics: |metrics: client::Client, port| async move {
-            let expected = format!(
-                "route_response_total{{direction=\"outbound\",dst=\"profiles.test.svc.cluster.local:{}\",classification=\"failure\",error=\"timeout\"}} 1",
-                port
-            );
-            assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
+            let metric = metrics::metric("route_response_total")
+            .with_label("direction", "outbound")
+            .with_label("dst", format_args!("profiles.test.svc.cluster.local:{}", port))
+            .with_label("classification", "failure")
+            .with_label("error", "timeout")
+            .with_value(1);
+            assert_eventually_contains!(metrics.get("/metrics").await, metric);
         }
     }
 }

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -153,10 +153,9 @@ async fn metrics_endpoint_inbound_request_count() {
 
     // prior to seeing any requests, request count should be empty.
     let metric = metrics::metric("request_total")
-        .with_label("authority", "tele.test.svc.cluster.local")
-        .with_label("direction", "inbound")
-        .with_label("tls", "disabled")
-        .with_value(10);
+        .label("authority", "tele.test.svc.cluster.local")
+        .label("direction", "inbound")
+        .label("tls", "disabled");
 
     assert!(metric.is_not_in(metrics.get("/metrics").await));
 
@@ -164,8 +163,7 @@ async fn metrics_endpoint_inbound_request_count() {
     assert_eq!(client.get("/").await, "hello");
 
     // after seeing a request, the request count should be 1.
-    let metric = metric.with_value(1);
-    assert_eventually_contains!(metrics.get("/metrics").await, metric);
+    metric.value(1u64).assert_in(&metrics).await;
 }
 
 #[tokio::test]
@@ -181,10 +179,10 @@ async fn metrics_endpoint_outbound_request_count() {
 
     let srv_port = proxy.outbound_server.as_ref().unwrap().addr.port();
     let metric = metrics::metric("request_total")
-        .with_label("direction", "outbound")
-        .with_label("tls", "no_identity")
-        .with_label("no_tls_reason", "not_provided_by_service_discovery")
-        .with_label(
+        .label("direction", "outbound")
+        .label("tls", "no_identity")
+        .label("no_tls_reason", "not_provided_by_service_discovery")
+        .label(
             "authority",
             format_args!("tele.test.svc.cluster.local:{}", srv_port),
         );
@@ -194,1349 +192,1462 @@ async fn metrics_endpoint_outbound_request_count() {
     assert_eq!(client.get("/").await, "hello");
 
     // after seeing a request, the request count should be 1.
-    let metric = metric.with_value(1);
-    assert_eventually_contains!(metrics.get("/metrics").await, metric);
+    metric.value(1u64).assert_in(&metrics).await;
 }
 
-// mod response_classification {
-//     use super::Fixture;
-//     use crate::*;
-//     use tracing::info;
-
-//     const REQ_STATUS_HEADER: &str = "x-test-status-requested";
-//     const REQ_GRPC_STATUS_HEADER: &str = "x-test-grpc-status-requested";
-
-//     const STATUSES: [http::StatusCode; 6] = [
-//         http::StatusCode::OK,
-//         http::StatusCode::NOT_MODIFIED,
-//         http::StatusCode::BAD_REQUEST,
-//         http::StatusCode::IM_A_TEAPOT,
-//         http::StatusCode::GATEWAY_TIMEOUT,
-//         http::StatusCode::INTERNAL_SERVER_ERROR,
-//     ];
-
-//     fn expected_metric(
-//         status: &http::StatusCode,
-//         direction: &str,
-//         tls: &str,
-//         no_tls_reason: Option<&str>,
-//         port: Option<u16>,
-//     ) -> String {
-//         let port = if let Some(port) = port {
-//             format!(":{}", port)
-//         } else {
-//             String::new()
-//         };
-//         format!(
-//             "response_total{{authority=\"tele.test.svc.cluster.local{}\",direction=\"{}\",tls=\"{}\",{}status_code=\"{}\",classification=\"{}\"}} 1",
-//             port,
-//             direction,
-//             tls,
-//             if let Some(reason) = no_tls_reason {
-//                 format!("no_tls_reason=\"{}\",", reason)
-//             } else {
-//                 String::new()
-//             },
-//             status.as_u16(),
-//             if status.is_server_error() { "failure" } else { "success" },
-//         )
-//     }
-
-//     async fn make_test_server() -> server::Listening {
-//         fn parse_header(headers: &http::HeaderMap, which: &str) -> Option<http::StatusCode> {
-//             headers.get(which).map(|val| {
-//                 val.to_str()
-//                     .expect("requested status should be ascii")
-//                     .parse::<http::StatusCode>()
-//                     .expect("requested status should be numbers")
-//             })
-//         }
-//         info!("running test server");
-//         server::new()
-//             .route_fn("/", move |req| {
-//                 let headers = req.headers();
-//                 let status =
-//                     parse_header(headers, REQ_STATUS_HEADER).unwrap_or(http::StatusCode::OK);
-//                 let grpc_status = parse_header(headers, REQ_GRPC_STATUS_HEADER);
-//                 let mut rsp = if let Some(_grpc_status) = grpc_status {
-//                     // TODO: tests for grpc statuses
-//                     unreachable!("not called in test")
-//                 } else {
-//                     Response::new("".into())
-//                 };
-//                 *rsp.status_mut() = status;
-//                 rsp
-//             })
-//             .run()
-//             .await
-//     }
-
-//     #[tokio::test]
-//     async fn inbound_http() {
-//         let _trace = trace_init();
-//         let Fixture {
-//             client,
-//             metrics,
-//             proxy: _proxy,
-//             _profile,
-//             dst_tx: _dst_tx,
-//         } = Fixture::inbound_with_server(make_test_server().await).await;
-
-//         for (i, status) in STATUSES.iter().enumerate() {
-//             let request = client
-//                 .request(
-//                     client
-//                         .request_builder("/")
-//                         .header(REQ_STATUS_HEADER, status.as_str())
-//                         .method("GET"),
-//                 )
-//                 .await
-//                 .unwrap();
-//             assert_eq!(&request.status(), status);
-
-//             for status in &STATUSES[0..i] {
-//                 // assert that the current status code is incremented, *and* that
-//                 // all previous requests are *not* incremented.
-//                 assert_eventually_contains!(
-//                     metrics.get("/metrics").await,
-//                     &expected_metric(status, "inbound", "disabled", None, None)
-//                 )
-//             }
-//         }
-//     }
-
-//     #[tokio::test]
-//     async fn outbound_http() {
-//         let _trace = trace_init();
-//         let Fixture {
-//             client,
-//             metrics,
-//             proxy,
-//             _profile,
-//             dst_tx: _dst_tx,
-//         } = Fixture::outbound_with_server(make_test_server().await).await;
-//         let port = proxy.outbound_server.as_ref().unwrap().addr.port();
-//         for (i, status) in STATUSES.iter().enumerate() {
-//             let request = client
-//                 .request(
-//                     client
-//                         .request_builder("/")
-//                         .header(REQ_STATUS_HEADER, status.as_str())
-//                         .method("GET"),
-//                 )
-//                 .await
-//                 .unwrap();
-//             assert_eq!(&request.status(), status);
-
-//             for status in &STATUSES[0..i] {
-//                 // assert that the current status code is incremented, *and* that
-//                 // all previous requests are *not* incremented.
-//                 assert_eventually_contains!(
-//                     metrics.get("/metrics").await,
-//                     &expected_metric(
-//                         status,
-//                         "outbound",
-//                         "no_identity",
-//                         Some("not_provided_by_service_discovery"),
-//                         Some(port)
-//                     )
-//                 )
-//             }
-//         }
-//     }
-// }
-
-// // Ignore this test on CI, because our method of adding latency to requests
-// // (calling `thread::sleep`) is likely to be flakey on Travis.
-// // Eventually, we can add some kind of mock timer system for simulating latency
-// // more reliably, and re-enable this test.
-// #[tokio::test]
-// #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-// async fn metrics_endpoint_inbound_response_latency() {
-//     let _trace = trace_init();
-
-//     info!("running test server");
-//     let srv = server::new()
-//         .route_with_latency("/hey", "hello", Duration::from_millis(500))
-//         .route_with_latency("/hi", "good morning", Duration::from_millis(40))
-//         .run()
-//         .await;
-
-//     let Fixture {
-//         client,
-//         metrics,
-//         proxy: _proxy,
-//         _profile,
-//         dst_tx: _dst_tx,
-//     } = Fixture::inbound_with_server(srv).await;
-
-//     info!("client.get(/hey)");
-//     assert_eq!(client.get("/hey").await, "hello");
-
-//     // assert the >=1000ms bucket is incremented by our request with 500ms
-//     // extra latency.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 1");
-//     // the histogram's count should be 1.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 1");
-//     // TODO: we're not going to make any assertions about the
-//     // response_latency_ms_sum stat, since its granularity depends on the actual
-//     // observed latencies, which may vary a bit. we could make more reliable
-//     // assertions about that stat if we were using a mock timer, though, as the
-//     // observed latency values would be predictable.
-
-//     info!("client.get(/hi)");
-//     assert_eq!(client.get("/hi").await, "good morning");
-
-//     // request with 40ms extra latency should fall into the 50ms bucket.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"50\"} 1");
-//     // 1000ms bucket should be incremented as well, since it counts *all*
-//     // observations less than or equal to 1000ms, even if they also increment
-//     // other buckets.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 2");
-//     // the histogram's total count should be 2.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 2");
-
-//     info!("client.get(/hi)");
-//     assert_eq!(client.get("/hi").await, "good morning");
-
-//     // request with 40ms extra latency should fall into the 50ms bucket.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"50\"} 2");
-//     // 1000ms bucket should be incremented as well.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 3");
-//     // the histogram's total count should be 3.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 3");
-
-//     info!("client.get(/hey)");
-//     assert_eq!(client.get("/hey").await, "hello");
-
-//     // 50ms bucket should be un-changed by the request with 500ms latency.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"50\"} 2");
-//     // 1000ms bucket should be incremented.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 4");
-//     // the histogram's total count should be 4.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 4");
-// }
-
-// // Ignore this test on CI, because our method of adding latency to requests
-// // (calling `thread::sleep`) is likely to be flakey on Travis.
-// // Eventually, we can add some kind of mock timer system for simulating latency
-// // more reliably, and re-enable this test.
-// #[tokio::test]
-// #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-// async fn metrics_endpoint_outbound_response_latency() {
-//     let _trace = trace_init();
-
-//     info!("running test server");
-//     let srv = server::new()
-//         .route_with_latency("/hey", "hello", Duration::from_millis(500))
-//         .route_with_latency("/hi", "good morning", Duration::from_millis(40))
-//         .run()
-//         .await;
-
-//     let Fixture {
-//         client,
-//         metrics,
-//         proxy: _proxy,
-//         _profile,
-//         dst_tx: _dst_tx,
-//     } = Fixture::outbound_with_server(srv).await;
-
-//     info!("client.get(/hey)");
-//     assert_eq!(client.get("/hey").await, "hello");
-
-//     // assert the >=1000ms bucket is incremented by our request with 500ms
-//     // extra latency.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 1");
-//     // the histogram's count should be 1.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-//     // TODO: we're not going to make any assertions about the
-//     // response_latency_ms_sum stat, since its granularity depends on the actual
-//     // observed latencies, which may vary a bit. we could make more reliable
-//     // assertions about that stat if we were using a mock timer, though, as the
-//     // observed latency values would be predictable.
-
-//     info!("client.get(/hi)");
-//     assert_eq!(client.get("/hi").await, "good morning");
-
-//     // request with 40ms extra latency should fall into the 50ms bucket.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"50\"} 1");
-//     // 1000ms bucket should be incremented as well, since it counts *all*
-//     // bservations less than or equal to 1000ms, even if they also increment
-//     // other buckets.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 2");
-//     // the histogram's total count should be 2.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 2");
-
-//     info!("client.get(/hi)");
-//     assert_eq!(client.get("/hi").await, "good morning");
-
-//     // request with 40ms extra latency should fall into the 50ms bucket.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"50\"} 2");
-//     // 1000ms bucket should be incremented as well.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 3");
-//     // the histogram's total count should be 3.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 3");
-
-//     info!("client.get(/hey)");
-//     assert_eq!(client.get("/hey").await, "hello");
-
-//     // 50ms bucket should be un-changed by the request with 500ms latency.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"50\"} 2");
-//     // 1000ms bucket should be incremented.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 4");
-//     // the histogram's total count should be 4.
-//     assert_eventually_contains!(metrics.get("/metrics").await,
-//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 4");
-// }
-
-// // Tests for destination labels provided by control plane service discovery.
-// mod outbound_dst_labels {
-//     use super::Fixture;
-//     use crate::*;
-//     use controller::DstSender;
-
-//     async fn fixture(dest: &str) -> (Fixture, SocketAddr) {
-//         info!("running test server");
-//         let srv = server::new().route("/", "hello").run().await;
-
-//         let addr = srv.addr;
-
-//         let ctrl = controller::new();
-//         let _profile = ctrl.profile_tx_default(addr, dest);
-//         let dst_tx = ctrl.destination_tx(format!("{}:{}", dest, addr.port()));
-
-//         let proxy = proxy::new()
-//             .controller(ctrl.run().await)
-//             .outbound(srv)
-//             .run()
-//             .await;
-//         let metrics = client::http1(proxy.metrics, "localhost");
-
-//         let client = client::new(proxy.outbound, dest);
-
-//         let f = Fixture {
-//             client,
-//             metrics,
-//             proxy,
-//             _profile,
-//             dst_tx: Some(dst_tx),
-//         };
-
-//         (f, addr)
-//     }
-
-//     #[tokio::test]
-//     async fn multiple_addr_labels() {
-//         let _trace = trace_init();
-//         let (
-//             Fixture {
-//                 client,
-//                 metrics,
-//                 proxy: _proxy,
-//                 _profile,
-//                 dst_tx,
-//             },
-//             addr,
-//         ) = fixture("labeled.test.svc.cluster.local").await;
-//         let dst_tx = dst_tx.unwrap();
-//         {
-//             let mut labels = HashMap::new();
-//             labels.insert("addr_label1".to_owned(), "foo".to_owned());
-//             labels.insert("addr_label2".to_owned(), "bar".to_owned());
-//             dst_tx.send_labeled(addr, labels, HashMap::new());
-//         }
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         // We can't make more specific assertions about the metrics
-//         // besides asserting that both labels are present somewhere in the
-//         // scrape, because testing for whole metric lines would depend on
-//         // the order in which the labels occur, and we can't depend on hash
-//         // map ordering.
-//         assert_eventually_contains!(metrics.get("/metrics").await, "dst_addr_label1=\"foo\"");
-//         assert_eventually_contains!(metrics.get("/metrics").await, "dst_addr_label2=\"bar\"");
-//     }
-
-//     #[tokio::test]
-//     async fn multiple_addrset_labels() {
-//         let _trace = trace_init();
-//         let (
-//             Fixture {
-//                 client,
-//                 metrics,
-//                 proxy: _proxy,
-//                 _profile,
-//                 dst_tx,
-//             },
-//             addr,
-//         ) = fixture("labeled.test.svc.cluster.local").await;
-//         let dst_tx = dst_tx.unwrap();
-
-//         {
-//             let mut labels = HashMap::new();
-//             labels.insert("set_label1".to_owned(), "foo".to_owned());
-//             labels.insert("set_label2".to_owned(), "bar".to_owned());
-//             dst_tx.send_labeled(addr, HashMap::new(), labels);
-//         }
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         // We can't make more specific assertions about the metrics
-//         // besides asserting that both labels are present somewhere in the
-//         // scrape, because testing for whole metric lines would depend on
-//         // the order in which the labels occur, and we can't depend on hash
-//         // map ordering.
-//         assert_eventually_contains!(metrics.get("/metrics").await, "dst_set_label1=\"foo\"");
-//         assert_eventually_contains!(metrics.get("/metrics").await, "dst_set_label2=\"bar\"");
-//     }
-
-//     #[tokio::test]
-//     async fn labeled_addr_and_addrset() {
-//         let _trace = trace_init();
-//         let (
-//             Fixture {
-//                 client,
-//                 metrics,
-//                 proxy,
-//                 _profile,
-//                 dst_tx,
-//             },
-//             addr,
-//         ) = fixture("labeled.test.svc.cluster.local").await;
-//         let dst_tx = dst_tx.unwrap();
-//         let auth = format!(
-//             "labeled.test.svc.cluster.local:{}",
-//             proxy.outbound_server.as_ref().unwrap().addr.port()
-//         );
-
-//         {
-//             let mut alabels = HashMap::new();
-//             alabels.insert("addr_label".to_owned(), "foo".to_owned());
-//             let mut slabels = HashMap::new();
-//             slabels.insert("set_label".to_owned(), "bar".to_owned());
-//             dst_tx.send_labeled(addr, alabels, slabels);
-//         }
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         let expected = format!(
-//             "response_latency_ms_count{{authority=\"{}\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"}} 1",
-//             auth
-//         );
-//         assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
-
-//         let expected =             format!(
-//             "request_total{{authority=\"{}\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} 1",
-//             auth
-//         );
-//         assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
-
-//         let expected = format!(
-//             "response_total{{authority=\"{}\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"}} 1",
-//             auth
-//         );
-//         assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
-//     }
-
-//     // Ignore this test on CI, as it may fail due to the reduced concurrency
-//     // on CI containers causing the proxy to see both label updates from
-//     // the mock controller before the first request has finished.
-//     // See linkerd/linkerd2#751
-//     #[tokio::test]
-//     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-//     async fn controller_updates_addr_labels() {
-//         let _trace = trace_init();
-//         info!("running test server");
-
-//         let (
-//             Fixture {
-//                 client,
-//                 metrics,
-//                 proxy: _proxy,
-//                 _profile,
-//                 dst_tx,
-//             },
-//             addr,
-//         ) = fixture("labeled.test.svc.cluster.local").await;
-//         let dst_tx = dst_tx.unwrap();
-//         {
-//             let mut alabels = HashMap::new();
-//             alabels.insert("addr_label".to_owned(), "foo".to_owned());
-//             let mut slabels = HashMap::new();
-//             slabels.insert("set_label".to_owned(), "unchanged".to_owned());
-//             dst_tx.send_labeled(addr, alabels, slabels);
-//         }
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         // the first request should be labeled with `dst_addr_label="foo"`
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-
-//         {
-//             let mut alabels = HashMap::new();
-//             alabels.insert("addr_label".to_owned(), "bar".to_owned());
-//             let mut slabels = HashMap::new();
-//             slabels.insert("set_label".to_owned(), "unchanged".to_owned());
-//             dst_tx.send_labeled(addr, alabels, slabels);
-//         }
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         // the second request should increment stats labeled with `dst_addr_label="bar"`
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"bar\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"bar\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"bar\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-//         // stats recorded from the first request should still be present.
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-//     }
-
-//     // Ignore this test on CI, as it may fail due to the reduced concurrency
-//     // on CI containers causing the proxy to see both label updates from
-//     // the mock controller before the first request has finished.
-//     // See linkerd/linkerd2#751
-//     #[tokio::test]
-//     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-//     async fn controller_updates_set_labels() {
-//         let _trace = trace_init();
-//         info!("running test server");
-//         let (
-//             Fixture {
-//                 client,
-//                 metrics,
-//                 proxy: _proxy,
-//                 _profile,
-//                 dst_tx,
-//             },
-//             addr,
-//         ) = fixture("labeled.test.svc.cluster.local").await;
-//         let dst_tx = dst_tx.unwrap();
-//         {
-//             let alabels = HashMap::new();
-//             let mut slabels = HashMap::new();
-//             slabels.insert("set_label".to_owned(), "foo".to_owned());
-//             dst_tx.send_labeled(addr, alabels, slabels);
-//         }
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         // the first request should be labeled with `dst_addr_label="foo"`
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-
-//         {
-//             let alabels = HashMap::new();
-//             let mut slabels = HashMap::new();
-//             slabels.insert("set_label".to_owned(), "bar".to_owned());
-//             dst_tx.send_labeled(addr, alabels, slabels);
-//         }
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         // the second request should increment stats labeled with `dst_addr_label="bar"`
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-//         // stats recorded from the first request should still be present.
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-//     }
-// }
-
-// #[tokio::test]
-// async fn metrics_have_no_double_commas() {
-//     // Test for regressions to linkerd/linkerd2#600.
-//     let _trace = trace_init();
-
-//     info!("running test server");
-//     let inbound_srv = server::new().route("/hey", "hello").run().await;
-//     let outbound_srv = server::new().route("/hey", "hello").run().await;
-
-//     let ctrl = controller::new();
-//     let _profile_in =
-//         ctrl.profile_tx_default("tele.test.svc.cluster.local", "tele.test.svc.cluster.local");
-//     let _profile_out = ctrl.profile_tx_default(outbound_srv.addr, "tele.test.svc.cluster.local");
-//     let out_dest = ctrl.destination_tx(format!(
-//         "tele.test.svc.cluster.local:{}",
-//         outbound_srv.addr.port()
-//     ));
-//     out_dest.send_addr(outbound_srv.addr);
-//     let in_dest = ctrl.destination_tx(format!(
-//         "tele.test.svc.cluster.local:{}",
-//         inbound_srv.addr.port()
-//     ));
-//     in_dest.send_addr(inbound_srv.addr);
-//     let proxy = proxy::new()
-//         .controller(ctrl.run().await)
-//         .inbound(inbound_srv)
-//         .outbound(outbound_srv)
-//         .run()
-//         .await;
-//     let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
-//     let metrics = client::http1(proxy.metrics, "localhost");
-
-//     let scrape = metrics.get("/metrics").await;
-//     assert!(!scrape.contains(",,"));
-
-//     info!("inbound.get(/hey)");
-//     assert_eq!(client.get("/hey").await, "hello");
-
-//     let scrape = metrics.get("/metrics").await;
-//     assert!(!scrape.contains(",,"), "inbound metrics had double comma");
-
-//     let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
-
-//     info!("outbound.get(/hey)");
-//     assert_eq!(client.get("/hey").await, "hello");
-
-//     let scrape = metrics.get("/metrics").await;
-//     assert!(!scrape.contains(",,"), "outbound metrics had double comma");
-// }
-
-// #[tokio::test]
-// async fn metrics_has_start_time() {
-//     let Fixture {
-//         metrics,
-//         proxy: _proxy,
-//         _profile,
-//         dst_tx: _dst_tx,
-//         ..
-//     } = Fixture::inbound().await;
-//     let uptime_regex = regex::Regex::new(r"process_start_time_seconds \d+")
-//         .expect("compiling regex shouldn't fail");
-//     assert_eventually!(uptime_regex.find(&metrics.get("/metrics").await).is_some())
-// }
-
-// mod transport {
-//     use super::*;
-//     use crate::*;
-
-//     #[tokio::test]
-//     async fn inbound_http_accept() {
-//         let _trace = trace_init();
-//         let Fixture {
-//             client,
-//             metrics,
-//             proxy,
-//             _profile,
-//             dst_tx: _dst_tx,
-//         } = Fixture::inbound().await;
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 1"
-//         );
-//         // Shut down the client to force the connection to close.
-//         client.shutdown().await;
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1"
-//         );
-
-//         // create a new client to force a new connection
-//         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 2"
-//         );
-//         // Shut down the client to force the connection to close.
-//         client.shutdown().await;
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 2"
-//         );
-//     }
-
-//     #[tokio::test]
-//     async fn inbound_http_connect() {
-//         let _trace = trace_init();
-//         let Fixture {
-//             client,
-//             metrics,
-//             proxy,
-//             _profile,
-//             dst_tx: _dst_tx,
-//         } = Fixture::inbound().await;
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-//         );
-
-//         // create a new client to force a new connection
-//         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         // server connection should be pooled
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-//         );
-//     }
-
-//     #[tokio::test]
-//     async fn outbound_http_accept() {
-//         let _trace = trace_init();
-//         let Fixture {
-//             client,
-//             metrics,
-//             proxy,
-//             _profile,
-//             dst_tx: _dst_tx,
-//         } = Fixture::outbound().await;
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-//         );
-//         // Shut down the client to force the connection to close.
-//         client.shutdown().await;
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1"
-//         );
-
-//         // create a new client to force a new connection
-//         let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 2"
-//         );
-//         // Shut down the client to force the connection to close.
-//         client.shutdown().await;
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2"
-//         );
-//     }
-
-//     #[tokio::test]
-//     async fn outbound_http_connect() {
-//         let _trace = trace_init();
-//         let Fixture {
-//             client,
-//             metrics,
-//             proxy,
-//             _profile,
-//             dst_tx: _dst_tx,
-//         } = Fixture::outbound().await;
-//         let expected = format!(
-//             "tcp_open_total{{peer=\"dst\",authority=\"tele.test.svc.cluster.local:{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} 1",
-//             proxy.outbound_server.as_ref().unwrap().addr.port(),
-//         );
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
-
-//         // create a new client to force a new connection
-//         let client2 = client::new(proxy.outbound, "tele.test.svc.cluster.local");
-
-//         info!("client.get(/)");
-//         assert_eq!(client2.get("/").await, "hello");
-//         // server connection should be pooled
-//         assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
-//     }
-
-//     #[tokio::test]
-//     async fn inbound_tcp_connect() {
-//         let _trace = trace_init();
-//         let TcpFixture {
-//             client,
-//             metrics,
-//             proxy: _proxy,
-//             dst: _dst,
-//             profile: _profile,
-//         } = TcpFixture::inbound().await;
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1");
-//     }
-
-//     #[tokio::test]
-//     #[cfg(target_os = "macos")]
-//     async fn inbound_tcp_connect_err() {
-//         let _trace = trace_init();
-//         let srv = tcp::server()
-//             .accept_fut(move |sock| {
-//                 drop(sock);
-//                 future::ok(())
-//             })
-//             .run()
-//             .await;
-//         let proxy = proxy::new().inbound(srv).run().await;
-
-//         let client = client::tcp(proxy.inbound);
-//         let metrics = client::http1(proxy.metrics, "localhost");
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, &[]);
-//         // Connection to the server should be a failure with the EXFULL error
-//         // code.
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"EXFULL\"} 1");
-//         // Connection from the client should have closed cleanly.
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1"
-//         );
-//     }
-
-//     #[test]
-//     #[cfg(target_os = "macos")]
-//     fn outbound_tcp_connect_err() {
-//         let _trace = trace_init();
-//         let srv = tcp::server()
-//             .accept_fut(move |sock| {
-//                 drop(sock);
-//                 future::ok(())
-//             })
-//             .run()
-//             .await;
-//         let proxy = proxy::new().outbound(srv).run().await;
-
-//         let client = client::tcp(proxy.outbound);
-//         let metrics = client::http1(proxy.metrics, "localhost");
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, &[]);
-//         // Connection to the server should be a failure with the EXFULL error
-//         // code.
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"EXFULL\"} 1");
-//         // Connection from the client should have closed cleanly.
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-//     }
-
-//     #[tokio::test]
-//     async fn inbound_tcp_accept() {
-//         let _trace = trace_init();
-//         let TcpFixture {
-//             client,
-//             metrics,
-//             proxy: _proxy,
-//             dst: _dst,
-//             profile: _profile,
-//         } = TcpFixture::inbound().await;
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 1"
-//         );
-
-//         tcp_client.shutdown().await;
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1"
-//         );
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 2"
-//         );
-//         tcp_client.shutdown().await;
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 2"
-//         );
-//     }
-
-//     // linkerd/linkerd2#831
-//     #[tokio::test]
-//     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-//     async fn inbound_tcp_duration() {
-//         let _trace = trace_init();
-//         let TcpFixture {
-//             client,
-//             metrics,
-//             proxy: _proxy,
-//             dst: _dst,
-//             profile: _profile,
-//         } = TcpFixture::inbound().await;
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         tcp_client.shutdown().await;
-//         // TODO: make assertions about buckets
-//         let out = metrics.get("/metrics").await;
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1");
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         let out = metrics.get("/metrics").await;
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1");
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-
-//         tcp_client.shutdown().await;
-//         let out = metrics.get("/metrics").await;
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 2");
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2");
-//     }
-
-//     #[tokio::test]
-//     async fn inbound_tcp_write_bytes_total() {
-//         let _trace = trace_init();
-//         let TcpFixture {
-//             client,
-//             metrics,
-//             proxy: _proxy,
-//             dst: _dst,
-//             profile: _profile,
-//         } = TcpFixture::inbound().await;
-//         let src_expected = format!(
-//             "tcp_write_bytes_total{{peer=\"src\",direction=\"inbound\",tls=\"disabled\"}} {}",
-//             TcpFixture::BYE_MSG.len()
-//         );
-//         let dst_expected = format!(
-//             "tcp_write_bytes_total{{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
-//             TcpFixture::HELLO_MSG.len()
-//         );
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         tcp_client.shutdown().await;
-
-//         let out = metrics.get("/metrics").await;
-//         assert_eventually_contains!(out, &src_expected);
-//         assert_eventually_contains!(out, &dst_expected);
-//     }
-
-//     #[tokio::test]
-//     async fn inbound_tcp_read_bytes_total() {
-//         let _trace = trace_init();
-//         let TcpFixture {
-//             client,
-//             metrics,
-//             proxy: _proxy,
-//             dst: _dst,
-//             profile: _profile,
-//         } = TcpFixture::inbound().await;
-//         let src_expected = format!(
-//             "tcp_read_bytes_total{{peer=\"src\",direction=\"inbound\",tls=\"disabled\"}} {}",
-//             TcpFixture::HELLO_MSG.len()
-//         );
-//         let dst_expected = format!(
-//             "tcp_read_bytes_total{{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
-//             TcpFixture::BYE_MSG.len()
-//         );
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         tcp_client.shutdown().await;
-
-//         let out = metrics.get("/metrics").await;
-//         assert_eventually_contains!(out, &src_expected);
-//         assert_eventually_contains!(out, &dst_expected);
-//     }
-
-//     #[tokio::test]
-//     async fn outbound_tcp_connect() {
-//         let _trace = trace_init();
-//         let TcpFixture {
-//             client,
-//             metrics,
-//             proxy,
-//             dst: _dst,
-//             profile: _profile,
-//         } = TcpFixture::outbound().await;
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         let expected = format!(
-//             "tcp_open_total{{peer=\"dst\",authority=\"{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} 1",
-//             proxy.outbound_server.as_ref().unwrap().addr,
-//         );
-//         assert_eventually_contains!(metrics.get("/metrics").await, &expected);
-//     }
-
-//     #[tokio::test]
-//     async fn outbound_tcp_accept() {
-//         let _trace = trace_init();
-//         let TcpFixture {
-//             client,
-//             metrics,
-//             proxy: _proxy,
-//             dst: _dst,
-//             profile: _profile,
-//         } = TcpFixture::outbound().await;
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-//         );
-
-//         tcp_client.shutdown().await;
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 2"
-//         );
-//         tcp_client.shutdown().await;
-//         assert_eventually_contains!(metrics.get("/metrics").await,
-//             "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2");
-//     }
-
-//     #[tokio::test]
-//     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-//     async fn outbound_tcp_duration() {
-//         let _trace = trace_init();
-//         let TcpFixture {
-//             client,
-//             metrics,
-//             proxy: _proxy,
-//             dst: _dst,
-//             profile: _profile,
-//         } = TcpFixture::outbound().await;
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         tcp_client.shutdown().await;
-//         // TODO: make assertions about buckets
-//         let out = metrics.get("/metrics").await;
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"} 1");
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         let out = metrics.get("/metrics").await;
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"} 1");
-
-//         tcp_client.shutdown().await;
-//         let out = metrics.get("/metrics").await;
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2");
-//         assert_eventually_contains!(out,
-//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"} 2");
-//     }
-
-//     #[tokio::test]
-//     async fn outbound_tcp_write_bytes_total() {
-//         let _trace = trace_init();
-//         let TcpFixture {
-//             client,
-//             metrics,
-//             proxy,
-//             dst: _dst,
-//             profile: _profile,
-//         } = TcpFixture::outbound().await;
-//         let src_expected = format!(
-//             "tcp_write_bytes_total{{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
-//             TcpFixture::BYE_MSG.len()
-//         );
-//         let dst_expected = format!(
-//             "tcp_write_bytes_total{{peer=\"dst\",authority=\"{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} {}",
-//             proxy.outbound_server.as_ref().unwrap().addr,
-//             TcpFixture::HELLO_MSG.len()
-//         );
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         tcp_client.shutdown().await;
-
-//         let out = metrics.get("/metrics").await;
-//         assert_eventually_contains!(out, &src_expected);
-//         assert_eventually_contains!(out, &dst_expected);
-//     }
-
-//     #[tokio::test]
-//     async fn outbound_tcp_read_bytes_total() {
-//         let _trace = trace_init();
-//         let TcpFixture {
-//             client,
-//             metrics,
-//             proxy,
-//             dst: _dst,
-//             profile: _profile,
-//         } = TcpFixture::outbound().await;
-
-//         let src_expected = format!(
-//             "tcp_read_bytes_total{{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
-//             TcpFixture::HELLO_MSG.len()
-//         );
-//         let dst_expected = format!(
-//             "tcp_read_bytes_total{{peer=\"dst\",authority=\"{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} {}",
-//             proxy.outbound_server.as_ref().unwrap().addr,
-//             TcpFixture::BYE_MSG.len()
-//         );
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         tcp_client.shutdown().await;
-
-//         let out = metrics.get("/metrics").await;
-//         assert_eventually_contains!(out, &src_expected);
-//         assert_eventually_contains!(out, &dst_expected);
-//     }
-
-//     #[tokio::test]
-//     async fn outbound_tcp_open_connections() {
-//         let _trace = trace_init();
-//         let fixture = TcpFixture::outbound().await;
-//         let client = fixture.client;
-//         let metrics = fixture.metrics;
-
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-//         );
-//         tcp_client.shutdown().await;
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
-//         );
-//         let tcp_client = client.connect().await;
-
-//         tcp_client.write(TcpFixture::HELLO_MSG).await;
-//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-//         );
-
-//         tcp_client.shutdown().await;
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
-//         );
-//     }
-
-//     #[tokio::test]
-//     async fn outbound_http_tcp_open_connections() {
-//         let _trace = trace_init();
-//         let Fixture {
-//             client,
-//             metrics,
-//             proxy,
-//             _profile,
-//             dst_tx: _dst_tx,
-//         } = Fixture::outbound().await;
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-//         );
-//         // Shut down the client to force the connection to close.
-//         client.shutdown().await;
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
-//         );
-
-//         // create a new client to force a new connection
-//         let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
-
-//         info!("client.get(/)");
-//         assert_eq!(client.get("/").await, "hello");
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-//         );
-//         // Shut down the client to force the connection to close.
-//         client.shutdown().await;
-//         assert_eventually_contains!(
-//             metrics.get("/metrics").await,
-//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
-//         );
-//     }
-// }
-
-// // linkerd/linkerd2#613
-// #[tokio::test]
-// async fn metrics_compression() {
-//     let _trace = trace_init();
-
-//     let Fixture {
-//         client,
-//         metrics,
-//         proxy: _proxy,
-//         _profile,
-//         dst_tx: _dst_tx,
-//     } = Fixture::inbound().await;
-
-//     let do_scrape = |encoding: &str| {
-//         let req = metrics.request(
-//             metrics
-//                 .request_builder("/metrics")
-//                 .method("GET")
-//                 .header("Accept-Encoding", encoding),
-//         );
-
-//         let encoding = encoding.to_owned();
-//         async move {
-//             let resp = req.await.expect("scrape");
-
-//             {
-//                 // create a new scope so we can release our borrow on `resp` before
-//                 // getting the body
-//                 let content_encoding = resp.headers().get("content-encoding").as_ref().map(|val| {
-//                     val.to_str()
-//                         .expect("content-encoding value should be ascii")
-//                 });
-//                 assert_eq!(
-//                     content_encoding,
-//                     Some("gzip"),
-//                     "unexpected Content-Encoding {:?} (requested Accept-Encoding: {})",
-//                     content_encoding,
-//                     encoding.as_str()
-//                 );
-//             }
-
-//             let mut body = hyper::body::aggregate(resp.into_body())
-//                 .await
-//                 .expect("response body concat");
-//             let mut decoder = flate2::read::GzDecoder::new(std::io::Cursor::new(
-//                 body.copy_to_bytes(body.remaining()),
-//             ));
-//             let mut scrape = String::new();
-//             decoder.read_to_string(&mut scrape).unwrap_or_else(|_| {
-//                 panic!("decode gzip (requested Accept-Encoding: {})", encoding)
-//             });
-//             scrape
-//         }
-//     };
-
-//     let encodings = &[
-//         "gzip",
-//         "deflate, gzip",
-//         "gzip,deflate",
-//         "brotli,gzip,deflate",
-//     ];
-
-//     info!("client.get(/)");
-//     assert_eq!(client.get("/").await, "hello");
-
-//     for &encoding in encodings {
-//         assert_eventually_contains!(do_scrape(encoding).await,
-//             "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 1");
-//     }
-
-//     info!("client.get(/)");
-//     assert_eq!(client.get("/").await, "hello");
-
-//     for &encoding in encodings {
-//         assert_eventually_contains!(do_scrape(encoding).await,
-//             "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 2");
-//     }
-// }
+mod response_classification {
+    use super::Fixture;
+    use crate::*;
+    use tracing::info;
+
+    const REQ_STATUS_HEADER: &str = "x-test-status-requested";
+    const REQ_GRPC_STATUS_HEADER: &str = "x-test-grpc-status-requested";
+
+    const STATUSES: [http::StatusCode; 6] = [
+        http::StatusCode::OK,
+        http::StatusCode::NOT_MODIFIED,
+        http::StatusCode::BAD_REQUEST,
+        http::StatusCode::IM_A_TEAPOT,
+        http::StatusCode::GATEWAY_TIMEOUT,
+        http::StatusCode::INTERNAL_SERVER_ERROR,
+    ];
+
+    fn expected_metric(
+        status: &http::StatusCode,
+        direction: &str,
+        tls: &str,
+        no_tls_reason: Option<&str>,
+        port: Option<u16>,
+    ) -> metrics::MetricMatch {
+        let addr = if let Some(port) = port {
+            format!("tele.test.svc.cluster.local:{}", port)
+        } else {
+            String::from("tele.test.svc.cluster.local")
+        };
+        let mut metric = metrics::metric("response_total")
+            .label("authority", addr)
+            .label("direction", direction)
+            .label("tls", tls)
+            .label("status_code", status.as_u16())
+            .label(
+                "classification",
+                if status.is_server_error() {
+                    "failure"
+                } else {
+                    "success"
+                },
+            )
+            .value(1u64);
+        if let Some(reason) = no_tls_reason {
+            metric = metric.label("no_tls_reason", reason);
+        }
+        metric
+    }
+
+    async fn make_test_server() -> server::Listening {
+        fn parse_header(headers: &http::HeaderMap, which: &str) -> Option<http::StatusCode> {
+            headers.get(which).map(|val| {
+                val.to_str()
+                    .expect("requested status should be ascii")
+                    .parse::<http::StatusCode>()
+                    .expect("requested status should be numbers")
+            })
+        }
+        info!("running test server");
+        server::new()
+            .route_fn("/", move |req| {
+                let headers = req.headers();
+                let status =
+                    parse_header(headers, REQ_STATUS_HEADER).unwrap_or(http::StatusCode::OK);
+                let grpc_status = parse_header(headers, REQ_GRPC_STATUS_HEADER);
+                let mut rsp = if let Some(_grpc_status) = grpc_status {
+                    // TODO: tests for grpc statuses
+                    unreachable!("not called in test")
+                } else {
+                    Response::new("".into())
+                };
+                *rsp.status_mut() = status;
+                rsp
+            })
+            .run()
+            .await
+    }
+
+    #[tokio::test]
+    async fn inbound_http() {
+        let _trace = trace_init();
+        let Fixture {
+            client,
+            metrics,
+            proxy: _proxy,
+            _profile,
+            dst_tx: _dst_tx,
+        } = Fixture::inbound_with_server(make_test_server().await).await;
+
+        for (i, status) in STATUSES.iter().enumerate() {
+            let request = client
+                .request(
+                    client
+                        .request_builder("/")
+                        .header(REQ_STATUS_HEADER, status.as_str())
+                        .method("GET"),
+                )
+                .await
+                .unwrap();
+            assert_eq!(&request.status(), status);
+
+            for status in &STATUSES[0..i] {
+                // assert that the current status code is incremented, *and* that
+                // all previous requests are *not* incremented.
+                expected_metric(status, "inbound", "disabled", None, None)
+                    .assert_in(&metrics)
+                    .await;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn outbound_http() {
+        let _trace = trace_init();
+        let Fixture {
+            client,
+            metrics,
+            proxy,
+            _profile,
+            dst_tx: _dst_tx,
+        } = Fixture::outbound_with_server(make_test_server().await).await;
+        let port = proxy.outbound_server.as_ref().unwrap().addr.port();
+        for (i, status) in STATUSES.iter().enumerate() {
+            let request = client
+                .request(
+                    client
+                        .request_builder("/")
+                        .header(REQ_STATUS_HEADER, status.as_str())
+                        .method("GET"),
+                )
+                .await
+                .unwrap();
+            assert_eq!(&request.status(), status);
+
+            for status in &STATUSES[0..i] {
+                // assert that the current status code is incremented, *and* that
+                expected_metric(
+                    status,
+                    "outbound",
+                    "no_identity",
+                    Some("not_provided_by_service_discovery"),
+                    Some(port),
+                )
+                .assert_in(&metrics)
+                .await;
+            }
+        }
+    }
+}
+
+// Ignore this test on CI, because our method of adding latency to requests
+// (calling `thread::sleep`) is likely to be flakey on Travis.
+// Eventually, we can add some kind of mock timer system for simulating latency
+// more reliably, and re-enable this test.
+#[tokio::test]
+#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+async fn metrics_endpoint_inbound_response_latency() {
+    let _trace = trace_init();
+
+    info!("running test server");
+    let srv = server::new()
+        .route_with_latency("/hey", "hello", Duration::from_millis(500))
+        .route_with_latency("/hi", "good morning", Duration::from_millis(40))
+        .run()
+        .await;
+
+    let Fixture {
+        client,
+        metrics,
+        proxy: _proxy,
+        _profile,
+        dst_tx: _dst_tx,
+    } = Fixture::inbound_with_server(srv).await;
+
+    info!("client.get(/hey)");
+    assert_eq!(client.get("/hey").await, "hello");
+
+    // assert the >=1000ms bucket is incremented by our request with 500ms
+    // extra latency.
+    let labels = metrics::labels()
+        .label("authority", "tele.test.svc.cluster.local")
+        .label("direction", "inbound")
+        .label("tls", "disabled")
+        .label("status_code", 200);
+    let mut bucket_1000 = labels
+        .clone()
+        .metric("response_latency_ms_bucket")
+        .label("le", 1000)
+        .value(1u64);
+    let mut bucket_50 = labels.metric("response_latency_ms_bucket").label("le", 40);
+    let mut count = labels.metric("response_latency_ms_count").value(1u64);
+
+    bucket_1000.assert_in(&metrics).await;
+    // the histogram's count should be 1.
+    count.assert_in(&metrics).await;
+    // TODO: we're not going to make any assertions about the
+    // response_latency_ms_sum stat, since its granularity depends on the actual
+    // observed latencies, which may vary a bit. we could make more reliable
+    // assertions about that stat if we were using a mock timer, though, as the
+    // observed latency values would be predictable.
+
+    info!("client.get(/hi)");
+    assert_eq!(client.get("/hi").await, "good morning");
+
+    // request with 40ms extra latency should fall into the 50ms bucket.
+    bucket_50.set_value(1u64).assert_in(&metrics).await;
+    // 1000ms bucket should be incremented as well, since it counts *all*
+    // observations less than or equal to 1000ms, even if they also increment
+    // other buckets.
+    bucket_1000.set_value(2u64).assert_in(&metrics).await;
+    // the histogram's total count should be 2.
+    count.set_value(2u64).assert_in(&metrics).await;
+
+    info!("client.get(/hi)");
+    assert_eq!(client.get("/hi").await, "good morning");
+
+    // request with 40ms extra latency should fall into the 50ms bucket.
+    bucket_50.set_value(2u64).assert_in(&metrics).await;
+    // 1000ms bucket should be incremented as well.
+    bucket_1000.set_value(3).assert_in(&metrics).await;
+    // the histogram's total count should be 3.
+    count.set_value(3).assert_in(&metrics).await;
+
+    info!("client.get(/hey)");
+    assert_eq!(client.get("/hey").await, "hello");
+
+    // 50ms bucket should be un-changed by the request with 500ms latency.
+    bucket_50.assert_in(&metrics).await;
+    // 1000ms bucket should be incremented.
+    bucket_1000.set_value(4).assert_in(&metrics).await;
+    // the histogram's total count should be 4.
+    count.set_value(4).assert_in(&metrics).await;
+}
+
+// Ignore this test on CI, because our method of adding latency to requests
+// (calling `thread::sleep`) is likely to be flakey on Travis.
+// Eventually, we can add some kind of mock timer system for simulating latency
+// more reliably, and re-enable this test.
+#[tokio::test]
+#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+async fn metrics_endpoint_outbound_response_latency() {
+    let _trace = trace_init();
+
+    info!("running test server");
+    let srv = server::new()
+        .route_with_latency("/hey", "hello", Duration::from_millis(500))
+        .route_with_latency("/hi", "good morning", Duration::from_millis(40))
+        .run()
+        .await;
+
+    let Fixture {
+        client,
+        metrics,
+        proxy: _proxy,
+        _profile,
+        dst_tx: _dst_tx,
+    } = Fixture::outbound_with_server(srv).await;
+
+    info!("client.get(/hey)");
+    assert_eq!(client.get("/hey").await, "hello");
+
+    // assert the >=1000ms bucket is incremented by our request with 500ms
+    // extra latency.
+    let labels = metrics::labels()
+        .label("authority", "tele.test.svc.cluster.local")
+        .label("direction", "outbound")
+        .label("tls", "no_identity")
+        .label("no_tls_reason", "not_provided_by_service_discovery")
+        .label("status_code", 200);
+    let mut bucket_1000 = labels
+        .clone()
+        .metric("response_latency_ms_bucket")
+        .label("le", 1000)
+        .value(1u64);
+    let mut bucket_50 = labels.metric("response_latency_ms_bucket").label("le", 40);
+    let mut count = labels.metric("response_latency_ms_count").value(1u64);
+
+    bucket_1000.assert_in(&metrics).await;
+    // the histogram's count should be 1.
+    count.assert_in(&metrics).await;
+    // TODO: we're not going to make any assertions about the
+    // response_latency_ms_sum stat, since its granularity depends on the actual
+    // observed latencies, which may vary a bit. we could make more reliable
+    // assertions about that stat if we were using a mock timer, though, as the
+    // observed latency values would be predictable.
+
+    info!("client.get(/hi)");
+    assert_eq!(client.get("/hi").await, "good morning");
+
+    // request with 40ms extra latency should fall into the 50ms bucket.
+    bucket_50.set_value(1u64).assert_in(&metrics).await;
+    // 1000ms bucket should be incremented as well, since it counts *all*
+    // observations less than or equal to 1000ms, even if they also increment
+    // other buckets.
+    bucket_1000.set_value(2u64).assert_in(&metrics).await;
+    // the histogram's total count should be 2.
+    count.set_value(2u64).assert_in(&metrics).await;
+
+    info!("client.get(/hi)");
+    assert_eq!(client.get("/hi").await, "good morning");
+
+    // request with 40ms extra latency should fall into the 50ms bucket.
+    bucket_50.set_value(2u64).assert_in(&metrics).await;
+    // 1000ms bucket should be incremented as well.
+    bucket_1000.set_value(3).assert_in(&metrics).await;
+    // the histogram's total count should be 3.
+    count.set_value(3).assert_in(&metrics).await;
+
+    info!("client.get(/hey)");
+    assert_eq!(client.get("/hey").await, "hello");
+
+    // 50ms bucket should be un-changed by the request with 500ms latency.
+    bucket_50.assert_in(&metrics).await;
+    // 1000ms bucket should be incremented.
+    bucket_1000.set_value(4).assert_in(&metrics).await;
+    // the histogram's total count should be 4.
+    count.set_value(4).assert_in(&metrics).await;
+}
+
+// Tests for destination labels provided by control plane service discovery.
+mod outbound_dst_labels {
+    use super::Fixture;
+    use crate::*;
+    use controller::DstSender;
+
+    async fn fixture(dest: &str) -> (Fixture, SocketAddr) {
+        info!("running test server");
+        let srv = server::new().route("/", "hello").run().await;
+
+        let addr = srv.addr;
+
+        let ctrl = controller::new();
+        let _profile = ctrl.profile_tx_default(addr, dest);
+        let dst_tx = ctrl.destination_tx(format!("{}:{}", dest, addr.port()));
+
+        let proxy = proxy::new()
+            .controller(ctrl.run().await)
+            .outbound(srv)
+            .run()
+            .await;
+        let metrics = client::http1(proxy.metrics, "localhost");
+
+        let client = client::new(proxy.outbound, dest);
+
+        let f = Fixture {
+            client,
+            metrics,
+            proxy,
+            _profile,
+            dst_tx: Some(dst_tx),
+        };
+
+        (f, addr)
+    }
+
+    #[tokio::test]
+    async fn multiple_addr_labels() {
+        let _trace = trace_init();
+        let (
+            Fixture {
+                client,
+                metrics,
+                proxy: _proxy,
+                _profile,
+                dst_tx,
+            },
+            addr,
+        ) = fixture("labeled.test.svc.cluster.local").await;
+        let dst_tx = dst_tx.unwrap();
+        {
+            let mut labels = HashMap::new();
+            labels.insert("addr_label1".to_owned(), "foo".to_owned());
+            labels.insert("addr_label2".to_owned(), "bar".to_owned());
+            dst_tx.send_labeled(addr, labels, HashMap::new());
+        }
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+
+        let labels = metrics::labels()
+            .label("dst_addr_label1", "foo")
+            .label("dst_addr_label2", "bar");
+
+        for &metric in &[
+            "request_total",
+            "response_total",
+            "response_latency_ms_count",
+        ] {
+            labels.metric(metric).assert_in(&metrics).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn multiple_addrset_labels() {
+        let _trace = trace_init();
+        let (
+            Fixture {
+                client,
+                metrics,
+                proxy: _proxy,
+                _profile,
+                dst_tx,
+            },
+            addr,
+        ) = fixture("labeled.test.svc.cluster.local").await;
+        let dst_tx = dst_tx.unwrap();
+
+        {
+            let mut labels = HashMap::new();
+            labels.insert("set_label1".to_owned(), "foo".to_owned());
+            labels.insert("set_label2".to_owned(), "bar".to_owned());
+            dst_tx.send_labeled(addr, HashMap::new(), labels);
+        }
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+
+        let labels = metrics::labels()
+            .label("dst_set_label1", "foo")
+            .label("dst_set_label2", "bar");
+
+        for &metric in &[
+            "request_total",
+            "response_total",
+            "response_latency_ms_count",
+        ] {
+            labels.metric(metric).assert_in(&metrics).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn labeled_addr_and_addrset() {
+        let _trace = trace_init();
+        let (
+            Fixture {
+                client,
+                metrics,
+                proxy: _proxy,
+                _profile,
+                dst_tx,
+            },
+            addr,
+        ) = fixture("labeled.test.svc.cluster.local").await;
+        let dst_tx = dst_tx.unwrap();
+
+        {
+            let mut alabels = HashMap::new();
+            alabels.insert("addr_label".to_owned(), "foo".to_owned());
+            let mut slabels = HashMap::new();
+            slabels.insert("set_label".to_owned(), "bar".to_owned());
+            dst_tx.send_labeled(addr, alabels, slabels);
+        }
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+
+        let labels = metrics::labels()
+            .label("dst_addr_label", "foo")
+            .label("dst_set_label", "bar");
+
+        for &metric in &[
+            "request_total",
+            "response_total",
+            "response_latency_ms_count",
+        ] {
+            labels.metric(metric).assert_in(&metrics).await;
+        }
+    }
+
+    // Ignore this test on CI, as it may fail due to the reduced concurrency
+    // on CI containers causing the proxy to see both label updates from
+    // the mock controller before the first request has finished.
+    // See linkerd/linkerd2#751
+    #[tokio::test]
+    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    async fn controller_updates_addr_labels() {
+        let _trace = trace_init();
+        info!("running test server");
+
+        let (
+            Fixture {
+                client,
+                metrics,
+                proxy: _proxy,
+                _profile,
+                dst_tx,
+            },
+            addr,
+        ) = fixture("labeled.test.svc.cluster.local").await;
+        let dst_tx = dst_tx.unwrap();
+        {
+            let mut alabels = HashMap::new();
+            alabels.insert("addr_label".to_owned(), "foo".to_owned());
+            let mut slabels = HashMap::new();
+            slabels.insert("set_label".to_owned(), "unchanged".to_owned());
+            dst_tx.send_labeled(addr, alabels, slabels);
+        }
+
+        let labels = metrics::labels()
+            .label("dst_addr_label", "foo")
+            .label("dst_set_label", "unchanged");
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+
+        // the first request should be labeled with `dst_addr_label="foo"`
+        for &metric in &[
+            "request_total",
+            "response_total",
+            "response_latency_ms_count",
+        ] {
+            labels
+                .clone()
+                .metric(metric)
+                .value(1u64)
+                .assert_in(&metrics)
+                .await;
+        }
+
+        {
+            let mut alabels = HashMap::new();
+            alabels.insert("addr_label".to_owned(), "bar".to_owned());
+            let mut slabels = HashMap::new();
+            slabels.insert("set_label".to_owned(), "unchanged".to_owned());
+            dst_tx.send_labeled(addr, alabels, slabels);
+        }
+
+        let labels2 = metrics::labels()
+            .label("dst_addr_label", "bar")
+            .label("dst_set_label", "unchanged");
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+
+        // the second request should increment stats labeled with `dst_addr_label="bar"`
+        // the first request should be labeled with `dst_addr_label="foo"`
+        for &metric in &[
+            "request_total",
+            "response_total",
+            "response_latency_ms_count",
+        ] {
+            labels2
+                .clone()
+                .metric(metric)
+                .value(1u64)
+                .assert_in(&metrics)
+                .await;
+        }
+
+        // stats recorded from the first request should still be present.
+        // the first request should be labeled with `dst_addr_label="foo"`
+        for &metric in &[
+            "request_total",
+            "response_total",
+            "response_latency_ms_count",
+        ] {
+            labels
+                .clone()
+                .metric(metric)
+                .value(1u64)
+                .assert_in(&metrics)
+                .await;
+        }
+    }
+
+    // Ignore this test on CI, as it may fail due to the reduced concurrency
+    // on CI containers causing the proxy to see both label updates from
+    // the mock controller before the first request has finished.
+    // See linkerd/linkerd2#751
+    #[tokio::test]
+    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    async fn controller_updates_set_labels() {
+        let _trace = trace_init();
+        info!("running test server");
+        let (
+            Fixture {
+                client,
+                metrics,
+                proxy: _proxy,
+                _profile,
+                dst_tx,
+            },
+            addr,
+        ) = fixture("labeled.test.svc.cluster.local").await;
+        let dst_tx = dst_tx.unwrap();
+        {
+            let alabels = HashMap::new();
+            let mut slabels = HashMap::new();
+            slabels.insert("set_label".to_owned(), "foo".to_owned());
+            dst_tx.send_labeled(addr, alabels, slabels);
+        }
+        let labels1 = metrics::labels().label("dst_set_label", "foo");
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+        // the first request should be labeled with `dst_addr_label="foo"
+        for &metric in &[
+            "request_total",
+            "response_total",
+            "response_latency_ms_count",
+        ] {
+            labels1
+                .clone()
+                .metric(metric)
+                .value(1u64)
+                .assert_in(&client)
+                .await;
+        }
+
+        {
+            let alabels = HashMap::new();
+            let mut slabels = HashMap::new();
+            slabels.insert("set_label".to_owned(), "bar".to_owned());
+            dst_tx.send_labeled(addr, alabels, slabels);
+        }
+        let labels2 = metrics::labels().label("dst_set_label", "bar");
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+        // the second request should increment stats labeled with `dst_addr_label="bar"`
+        for &metric in &[
+            "request_total",
+            "response_total",
+            "response_latency_ms_count",
+        ] {
+            labels2.metric(metric).value(1u64).assert_in(&metrics).await;
+        }
+        // stats recorded from the first request should still be present.
+        for &metric in &[
+            "request_total",
+            "response_total",
+            "response_latency_ms_count",
+        ] {
+            labels1.metric(metric).value(1u64).assert_in(&metrics).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn metrics_have_no_double_commas() {
+    // Test for regressions to linkerd/linkerd2#600.
+    let _trace = trace_init();
+
+    info!("running test server");
+    let inbound_srv = server::new().route("/hey", "hello").run().await;
+    let outbound_srv = server::new().route("/hey", "hello").run().await;
+
+    let ctrl = controller::new();
+    let _profile_in =
+        ctrl.profile_tx_default("tele.test.svc.cluster.local", "tele.test.svc.cluster.local");
+    let _profile_out = ctrl.profile_tx_default(outbound_srv.addr, "tele.test.svc.cluster.local");
+    let out_dest = ctrl.destination_tx(format!(
+        "tele.test.svc.cluster.local:{}",
+        outbound_srv.addr.port()
+    ));
+    out_dest.send_addr(outbound_srv.addr);
+    let in_dest = ctrl.destination_tx(format!(
+        "tele.test.svc.cluster.local:{}",
+        inbound_srv.addr.port()
+    ));
+    in_dest.send_addr(inbound_srv.addr);
+    let proxy = proxy::new()
+        .controller(ctrl.run().await)
+        .inbound(inbound_srv)
+        .outbound(outbound_srv)
+        .run()
+        .await;
+    let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
+    let metrics = client::http1(proxy.metrics, "localhost");
+
+    let scrape = metrics.get("/metrics").await;
+    assert!(!scrape.contains(",,"));
+
+    info!("inbound.get(/hey)");
+    assert_eq!(client.get("/hey").await, "hello");
+
+    let scrape = metrics.get("/metrics").await;
+    assert!(!scrape.contains(",,"), "inbound metrics had double comma");
+
+    let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
+
+    info!("outbound.get(/hey)");
+    assert_eq!(client.get("/hey").await, "hello");
+
+    let scrape = metrics.get("/metrics").await;
+    assert!(!scrape.contains(",,"), "outbound metrics had double comma");
+}
+
+#[tokio::test]
+async fn metrics_has_start_time() {
+    let Fixture {
+        metrics,
+        proxy: _proxy,
+        _profile,
+        dst_tx: _dst_tx,
+        ..
+    } = Fixture::inbound().await;
+    let uptime_regex = regex::Regex::new(r"process_start_time_seconds \d+")
+        .expect("compiling regex shouldn't fail");
+    assert_eventually!(uptime_regex.find(&metrics.get("/metrics").await).is_some())
+}
+
+mod transport {
+    use super::*;
+    use crate::*;
+
+    #[tokio::test]
+    async fn inbound_http_accept() {
+        let _trace = trace_init();
+        let Fixture {
+            client,
+            metrics,
+            proxy,
+            _profile,
+            dst_tx: _dst_tx,
+        } = Fixture::inbound().await;
+
+        let labels = metrics::labels()
+            .label("peer", "src")
+            .label("direction", "inbound")
+            .label("tls", "disabled");
+
+        let mut opens = labels.metric("tcp_open_total").value(1u64);
+        let mut closes = labels
+            .clone()
+            .metric("tcp_close_total")
+            .label("errno", "")
+            .value(1u64);
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+        opens.assert_in(&metrics).await;
+        // Shut down the client to force the connection to close.
+        client.shutdown().await;
+        closes.assert_in(&metrics).await;
+
+        // create a new client to force a new connection
+        let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+        opens.set_value(2u64).assert_in(&metrics).await;
+        // Shut down the client to force the connection to close.
+        client.shutdown().await;
+        closes.set_value(2u64).assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn inbound_http_connect() {
+        let _trace = trace_init();
+        let Fixture {
+            client,
+            metrics,
+            proxy,
+            _profile,
+            dst_tx: _dst_tx,
+        } = Fixture::inbound().await;
+
+        let metric = metrics::metric("tcp_open_total")
+            .label("peer", "dst")
+            .label("direction", "inbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback")
+            .value(1u64);
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+        metric.assert_in(&metrics).await;
+
+        // create a new client to force a new connection
+        let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+        // server connection should be pooled
+        metric.assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn outbound_http_accept() {
+        let _trace = trace_init();
+        let Fixture {
+            client,
+            metrics,
+            proxy,
+            _profile,
+            dst_tx: _dst_tx,
+        } = Fixture::outbound().await;
+
+        let labels = metrics::labels()
+            .label("peer", "src")
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback");
+        let mut opens = labels.metric("tcp_open_total").value(1u64);
+        let mut closes = labels
+            .metric("tcp_close_total")
+            .label("errno", "")
+            .value(1u64);
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+        opens.assert_in(&metrics).await;
+        // Shut down the client to force the connection to close.
+        client.shutdown().await;
+        closes.assert_in(&metrics).await;
+
+        // create a new client to force a new connection
+        let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+        opens.set_value(2u64).assert_in(&metrics).await;
+        // Shut down the client to force the connection to close.
+        client.shutdown().await;
+        closes.set_value(2u64).assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn outbound_http_connect() {
+        let _trace = trace_init();
+        let Fixture {
+            client,
+            metrics,
+            proxy,
+            _profile,
+            dst_tx: _dst_tx,
+        } = Fixture::outbound().await;
+        let metric = metrics::metric("tcp_open_total")
+            .label("peer", "dst")
+            .label(
+                "authority",
+                format_args!(
+                    "tele.test.svc.cluster.local:{}",
+                    proxy.outbound_server.as_ref().unwrap().addr.port()
+                ),
+            )
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "not_provided_by_service_discovery")
+            .value(1u64);
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+        metric.assert_in(&metrics).await;
+
+        // create a new client to force a new connection
+        let client2 = client::new(proxy.outbound, "tele.test.svc.cluster.local");
+
+        info!("client.get(/)");
+        assert_eq!(client2.get("/").await, "hello");
+        // server connection should be pooled
+        metric.assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn inbound_tcp_connect() {
+        let _trace = trace_init();
+        let TcpFixture {
+            client,
+            metrics,
+            proxy: _proxy,
+            dst: _dst,
+            profile: _profile,
+        } = TcpFixture::inbound().await;
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        metrics::metric("tcp_open_total")
+            .label("peer", "dst")
+            .label("direction", "inbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback")
+            .value(1u64)
+            .assert_in(&metrics)
+            .await;
+    }
+
+    #[tokio::test]
+    #[cfg(target_os = "macos")]
+    async fn inbound_tcp_connect_err() {
+        let _trace = trace_init();
+        let srv = tcp::server()
+            .accept_fut(move |sock| {
+                drop(sock);
+                future::ok(())
+            })
+            .run()
+            .await;
+        let proxy = proxy::new().inbound(srv).run().await;
+
+        let client = client::tcp(proxy.inbound);
+        let metrics = client::http1(proxy.metrics, "localhost");
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, &[]);
+        // Connection to the server should be a failure with the EXFULL error
+        metrics::metric("tcp_close_total")
+            .label("peer", "dst")
+            .label("direction", "inbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "not_provided_by_service_discovery")
+            .label("errno", "EXFULL")
+            .value(1u64)
+            .assert_in(&metrics)
+            .await;
+
+        // Connection from the client should have closed cleanly.
+        metrics::metric("tcp_close_total")
+            .label("peer", "src")
+            .label("direction", "inbound")
+            .label("tls", "disabled")
+            .label("errno", "")
+            .value(1u64)
+            .assert_in(&metrics)
+            .await;
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn outbound_tcp_connect_err() {
+        let _trace = trace_init();
+        let srv = tcp::server()
+            .accept_fut(move |sock| {
+                drop(sock);
+                future::ok(())
+            })
+            .run()
+            .await;
+        let proxy = proxy::new().outbound(srv).run().await;
+
+        let client = client::tcp(proxy.outbound);
+        let metrics = client::http1(proxy.metrics, "localhost");
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, &[]);
+        // Connection to the server should be a failure with the EXFULL error
+        metrics::metric("tcp_close_total")
+            .label("peer", "dst")
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "not_provided_by_service_discovery")
+            .label("errno", "EXFULL")
+            .value(1u64)
+            .assert_in(&metrics)
+            .await;
+
+        // Connection from the client should have closed cleanly.
+        metrics::metric("tcp_close_total")
+            .label("peer", "src")
+            .label("direction", "outbound")
+            .label("tls", "disabled")
+            .label("errno", "")
+            .value(1u64)
+            .assert_in(&metrics)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn inbound_tcp_accept() {
+        let _trace = trace_init();
+        let TcpFixture {
+            client,
+            metrics,
+            proxy: _proxy,
+            dst: _dst,
+            profile: _profile,
+        } = TcpFixture::inbound().await;
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+
+        let labels = metrics::labels()
+            .label("peer", "src")
+            .label("direction", "inbound")
+            .label("tls", "disabled");
+        let mut opens = labels.metric("tcp_open_total").value(1u64);
+        let mut closes = labels
+            .metric("tcp_close_total")
+            .label("errno", "")
+            .value(1u64);
+        opens.assert_in(&metrics).await;
+
+        tcp_client.shutdown().await;
+        closes.assert_in(&metrics).await;
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        opens.set_value(2u64).assert_in(&metrics).await;
+
+        tcp_client.shutdown().await;
+        closes.set_value(2u64).assert_in(&metrics).await;
+    }
+
+    // linkerd/linkerd2#831
+    #[tokio::test]
+    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    async fn inbound_tcp_duration() {
+        let _trace = trace_init();
+        let TcpFixture {
+            client,
+            metrics,
+            proxy: _proxy,
+            dst: _dst,
+            profile: _profile,
+        } = TcpFixture::inbound().await;
+
+        let tcp_client = client.connect().await;
+
+        let mut src_count = metrics::metric("tcp_connection_duration_count")
+            .label("peer", "src")
+            .label("direction", "inbound")
+            .label("tls", "disabled")
+            .label("errno", "")
+            .value(1u64);
+
+        let mut dst_count = metrics::metric("tcp_connection_duration_count")
+            .label("peer", "dst")
+            .label("direction", "inbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback")
+            .label("errno", "")
+            .value(1u64);
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        tcp_client.shutdown().await;
+        // TODO: make assertions about buckets
+        src_count.assert_in(&metrics).await;
+        dst_count.assert_in(&metrics).await;
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        src_count.assert_in(&metrics).await;
+        dst_count.assert_in(&metrics).await;
+
+        tcp_client.shutdown().await;
+        src_count.set_value(2u64).assert_in(&metrics).await;
+        dst_count.set_value(2u64).assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn inbound_tcp_write_bytes_total() {
+        let _trace = trace_init();
+        let TcpFixture {
+            client,
+            metrics,
+            proxy: _proxy,
+            dst: _dst,
+            profile: _profile,
+        } = TcpFixture::inbound().await;
+        let src = metrics::metric("tcp_write_bytes_total")
+            .label("peer", "src")
+            .label("direction", "inbound")
+            .label("tls", "disabled")
+            .value(TcpFixture::BYE_MSG.len());
+
+        let dst = metrics::metric("tcp_write_bytes_total")
+            .label("peer", "dst")
+            .label("direction", "inbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback")
+            .value(TcpFixture::HELLO_MSG.len());
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        tcp_client.shutdown().await;
+
+        src.assert_in(&metrics).await;
+        dst.assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn inbound_tcp_read_bytes_total() {
+        let _trace = trace_init();
+        let TcpFixture {
+            client,
+            metrics,
+            proxy: _proxy,
+            dst: _dst,
+            profile: _profile,
+        } = TcpFixture::inbound().await;
+        let src = metrics::metric("tcp_read_bytes_total")
+            .label("peer", "src")
+            .label("direction", "inbound")
+            .label("tls", "disabled")
+            .value(TcpFixture::HELLO_MSG.len());
+
+        let dst = metrics::metric("tcp_read_bytes_total")
+            .label("peer", "dst")
+            .label("direction", "inbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback")
+            .value(TcpFixture::BYE_MSG.len());
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        tcp_client.shutdown().await;
+
+        src.assert_in(&metrics).await;
+        dst.assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn outbound_tcp_connect() {
+        let _trace = trace_init();
+        let TcpFixture {
+            client,
+            metrics,
+            proxy,
+            dst: _dst,
+            profile: _profile,
+        } = TcpFixture::outbound().await;
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        metrics::metric("tcp_open_total")
+            .label("peer", "dst")
+            .label("authority", proxy.outbound_server.as_ref().unwrap().addr)
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "not_provided_by_service_discovery")
+            .value(1u64)
+            .assert_in(&metrics)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn outbound_tcp_accept() {
+        let _trace = trace_init();
+        let TcpFixture {
+            client,
+            metrics,
+            proxy: _proxy,
+            dst: _dst,
+            profile: _profile,
+        } = TcpFixture::outbound().await;
+
+        let labels = metrics::labels()
+            .label("peer", "src")
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback");
+        let mut opens = labels.metric("tcp_open_total").value(1u64);
+        let mut closes = labels
+            .metric("tcp_close_total")
+            .label("errno", "")
+            .value(1u64);
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        opens.assert_in(&metrics).await;
+
+        tcp_client.shutdown().await;
+        closes.assert_in(&metrics).await;
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        opens.set_value(2u64).assert_in(&metrics).await;
+
+        tcp_client.shutdown().await;
+        closes.set_value(2u64).assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    async fn outbound_tcp_duration() {
+        let _trace = trace_init();
+        let TcpFixture {
+            client,
+            metrics,
+            proxy: _proxy,
+            dst: _dst,
+            profile: _profile,
+        } = TcpFixture::outbound().await;
+
+        let mut src_count = metrics::metric("tcp_connection_duration_count")
+            .label("peer", "src")
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback")
+            .label("errno", "")
+            .value(1u64);
+
+        let mut dst_count = metrics::metric("tcp_connection_duration_count")
+            .label("peer", "dst")
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "not_provided_by_service_discovery")
+            .label("errno", "")
+            .value(1u64);
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        tcp_client.shutdown().await;
+        // TODO: make assertions about buckets
+        src_count.assert_in(&metrics).await;
+        dst_count.assert_in(&metrics).await;
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        src_count.assert_in(&metrics).await;
+        dst_count.assert_in(&metrics).await;
+
+        tcp_client.shutdown().await;
+        src_count.set_value(2u64).assert_in(&metrics).await;
+        dst_count.set_value(2u64).assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn outbound_tcp_write_bytes_total() {
+        let _trace = trace_init();
+        let TcpFixture {
+            client,
+            metrics,
+            proxy,
+            dst: _dst,
+            profile: _profile,
+        } = TcpFixture::outbound().await;
+        let src = metrics::metric("tcp_write_bytes_total")
+            .label("peer", "src")
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback")
+            .value(TcpFixture::BYE_MSG.len());
+
+        let dst = metrics::metric("tcp_write_bytes_total")
+            .label("peer", "dst")
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "not_provided_by_service_discovery")
+            .label("authority", proxy.outbound_server.as_ref().unwrap().addr)
+            .value(TcpFixture::HELLO_MSG.len());
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        tcp_client.shutdown().await;
+
+        src.assert_in(&metrics).await;
+        dst.assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn outbound_tcp_read_bytes_total() {
+        let _trace = trace_init();
+        let TcpFixture {
+            client,
+            metrics,
+            proxy,
+            dst: _dst,
+            profile: _profile,
+        } = TcpFixture::outbound().await;
+
+        let src = metrics::metric("tcp_read_bytes_total")
+            .label("peer", "src")
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback")
+            .value(TcpFixture::HELLO_MSG.len());
+
+        let dst = metrics::metric("tcp_read_bytes_total")
+            .label("peer", "dst")
+            .label("direction", "outbound")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "not_provided_by_service_discovery")
+            .label("authority", proxy.outbound_server.as_ref().unwrap().addr)
+            .value(TcpFixture::BYE_MSG.len());
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        tcp_client.shutdown().await;
+
+        src.assert_in(&metrics).await;
+        dst.assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn outbound_tcp_open_connections() {
+        let _trace = trace_init();
+        let fixture = TcpFixture::outbound().await;
+        let client = fixture.client;
+        let metrics = fixture.metrics;
+        let mut open_conns = metrics::metric("tcp_open_connections")
+            .label("direction", "outbound")
+            .label("peer", "src")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback");
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        open_conns.set_value(1).assert_in(&metrics).await;
+
+        tcp_client.shutdown().await;
+        open_conns.set_value(0).assert_in(&metrics).await;
+
+        let tcp_client = client.connect().await;
+
+        tcp_client.write(TcpFixture::HELLO_MSG).await;
+        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+        open_conns.set_value(1).assert_in(&metrics).await;
+
+        tcp_client.shutdown().await;
+        open_conns.set_value(0).assert_in(&metrics).await;
+    }
+
+    #[tokio::test]
+    async fn outbound_http_tcp_open_connections() {
+        let _trace = trace_init();
+        let Fixture {
+            client,
+            metrics,
+            proxy,
+            _profile,
+            dst_tx: _dst_tx,
+        } = Fixture::outbound().await;
+
+        let mut open_conns = metrics::metric("tcp_open_connections")
+            .label("direction", "outbound")
+            .label("peer", "src")
+            .label("tls", "no_identity")
+            .label("no_tls_reason", "loopback");
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+
+        open_conns.set_value(1).assert_in(&metrics).await;
+        // Shut down the client to force the connection to close.
+        client.shutdown().await;
+        open_conns.set_value(0).assert_in(&metrics).await;
+
+        // create a new client to force a new connection
+        let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
+
+        info!("client.get(/)");
+        assert_eq!(client.get("/").await, "hello");
+        open_conns.set_value(1).assert_in(&metrics).await;
+
+        // Shut down the client to force the connection to close.
+        client.shutdown().await;
+        open_conns.set_value(0).assert_in(&metrics).await;
+    }
+}
+
+// linkerd/linkerd2#613
+#[tokio::test]
+async fn metrics_compression() {
+    let _trace = trace_init();
+
+    let Fixture {
+        client,
+        metrics,
+        proxy: _proxy,
+        _profile,
+        dst_tx: _dst_tx,
+    } = Fixture::inbound().await;
+
+    let do_scrape = |encoding: &str| {
+        let req = metrics.request(
+            metrics
+                .request_builder("/metrics")
+                .method("GET")
+                .header("Accept-Encoding", encoding),
+        );
+
+        let encoding = encoding.to_owned();
+        async move {
+            let resp = req.await.expect("scrape");
+
+            {
+                // create a new scope so we can release our borrow on `resp` before
+                // getting the body
+                let content_encoding = resp.headers().get("content-encoding").as_ref().map(|val| {
+                    val.to_str()
+                        .expect("content-encoding value should be ascii")
+                });
+                assert_eq!(
+                    content_encoding,
+                    Some("gzip"),
+                    "unexpected Content-Encoding {:?} (requested Accept-Encoding: {})",
+                    content_encoding,
+                    encoding.as_str()
+                );
+            }
+
+            let mut body = hyper::body::aggregate(resp.into_body())
+                .await
+                .expect("response body concat");
+            let mut decoder = flate2::read::GzDecoder::new(std::io::Cursor::new(
+                body.copy_to_bytes(body.remaining()),
+            ));
+            let mut scrape = String::new();
+            decoder.read_to_string(&mut scrape).unwrap_or_else(|_| {
+                panic!("decode gzip (requested Accept-Encoding: {})", encoding)
+            });
+            scrape
+        }
+    };
+
+    let encodings = &[
+        "gzip",
+        "deflate, gzip",
+        "gzip,deflate",
+        "brotli,gzip,deflate",
+    ];
+
+    info!("client.get(/)");
+    assert_eq!(client.get("/").await, "hello");
+
+    let mut metric = metrics::metric("response_latency_ms_count")
+        .label("authority", "tele.test.svc.cluster.local")
+        .label("direction", "inbound")
+        .label("tls", "disabled")
+        .label("status_code", 200)
+        .value(1u64);
+
+    for &encoding in encodings {
+        assert_eventually_contains!(do_scrape(encoding).await, &metric);
+    }
+
+    info!("client.get(/)");
+    assert_eq!(client.get("/").await, "hello");
+
+    for &encoding in encodings {
+        assert_eventually_contains!(do_scrape(encoding).await, &metric.set_value(2u64));
+    }
+}

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -152,14 +152,20 @@ async fn metrics_endpoint_inbound_request_count() {
     } = Fixture::inbound().await;
 
     // prior to seeing any requests, request count should be empty.
-    assert!(!metrics.get("/metrics").await
-        .contains("request_total{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\"}"));
+    let metric = metrics::metric("request_total")
+        .with_label("authority", "tele.test.svc.cluster.local")
+        .with_label("direction", "inbound")
+        .with_label("tls", "disabled")
+        .with_value(10);
+
+    assert!(metric.is_not_in(metrics.get("/metrics").await));
 
     info!("client.get(/)");
     assert_eq!(client.get("/").await, "hello");
 
     // after seeing a request, the request count should be 1.
-    assert_eventually_contains!(metrics.get("/metrics").await, "request_total{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\"} 1");
+    let metric = metric.with_value(1);
+    assert_eventually_contains!(metrics.get("/metrics").await, metric);
 }
 
 #[tokio::test]
@@ -174,1357 +180,1363 @@ async fn metrics_endpoint_outbound_request_count() {
     } = Fixture::outbound().await;
 
     let srv_port = proxy.outbound_server.as_ref().unwrap().addr.port();
-    let expected = format!("request_total{{authority=\"tele.test.svc.cluster.local:{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}}", srv_port);
-    // prior to seeing any requests, request count should be empty.
-    assert!(!metrics.get("/metrics").await.contains(&expected[..]));
+    let metric = metrics::metric("request_total")
+        .with_label("direction", "outbound")
+        .with_label("tls", "no_identity")
+        .with_label("no_tls_reason", "not_provided_by_service_discovery")
+        .with_label(
+            "authority",
+            format_args!("tele.test.svc.cluster.local:{}", srv_port),
+        );
+    assert!(metric.is_not_in(metrics.get("/metrics").await));
 
     info!("client.get(/)");
     assert_eq!(client.get("/").await, "hello");
 
     // after seeing a request, the request count should be 1.
-    let expected = format!("request_total{{authority=\"tele.test.svc.cluster.local:{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} 1", srv_port);
-    assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
+    let metric = metric.with_value(1);
+    assert_eventually_contains!(metrics.get("/metrics").await, metric);
 }
 
-mod response_classification {
-    use super::Fixture;
-    use crate::*;
-    use tracing::info;
-
-    const REQ_STATUS_HEADER: &str = "x-test-status-requested";
-    const REQ_GRPC_STATUS_HEADER: &str = "x-test-grpc-status-requested";
-
-    const STATUSES: [http::StatusCode; 6] = [
-        http::StatusCode::OK,
-        http::StatusCode::NOT_MODIFIED,
-        http::StatusCode::BAD_REQUEST,
-        http::StatusCode::IM_A_TEAPOT,
-        http::StatusCode::GATEWAY_TIMEOUT,
-        http::StatusCode::INTERNAL_SERVER_ERROR,
-    ];
-
-    fn expected_metric(
-        status: &http::StatusCode,
-        direction: &str,
-        tls: &str,
-        no_tls_reason: Option<&str>,
-        port: Option<u16>,
-    ) -> String {
-        let port = if let Some(port) = port {
-            format!(":{}", port)
-        } else {
-            String::new()
-        };
-        format!(
-            "response_total{{authority=\"tele.test.svc.cluster.local{}\",direction=\"{}\",tls=\"{}\",{}status_code=\"{}\",classification=\"{}\"}} 1",
-            port,
-            direction,
-            tls,
-            if let Some(reason) = no_tls_reason {
-                format!("no_tls_reason=\"{}\",", reason)
-            } else {
-                String::new()
-            },
-            status.as_u16(),
-            if status.is_server_error() { "failure" } else { "success" },
-        )
-    }
-
-    async fn make_test_server() -> server::Listening {
-        fn parse_header(headers: &http::HeaderMap, which: &str) -> Option<http::StatusCode> {
-            headers.get(which).map(|val| {
-                val.to_str()
-                    .expect("requested status should be ascii")
-                    .parse::<http::StatusCode>()
-                    .expect("requested status should be numbers")
-            })
-        }
-        info!("running test server");
-        server::new()
-            .route_fn("/", move |req| {
-                let headers = req.headers();
-                let status =
-                    parse_header(headers, REQ_STATUS_HEADER).unwrap_or(http::StatusCode::OK);
-                let grpc_status = parse_header(headers, REQ_GRPC_STATUS_HEADER);
-                let mut rsp = if let Some(_grpc_status) = grpc_status {
-                    // TODO: tests for grpc statuses
-                    unreachable!("not called in test")
-                } else {
-                    Response::new("".into())
-                };
-                *rsp.status_mut() = status;
-                rsp
-            })
-            .run()
-            .await
-    }
-
-    #[tokio::test]
-    async fn inbound_http() {
-        let _trace = trace_init();
-        let Fixture {
-            client,
-            metrics,
-            proxy: _proxy,
-            _profile,
-            dst_tx: _dst_tx,
-        } = Fixture::inbound_with_server(make_test_server().await).await;
-
-        for (i, status) in STATUSES.iter().enumerate() {
-            let request = client
-                .request(
-                    client
-                        .request_builder("/")
-                        .header(REQ_STATUS_HEADER, status.as_str())
-                        .method("GET"),
-                )
-                .await
-                .unwrap();
-            assert_eq!(&request.status(), status);
-
-            for status in &STATUSES[0..i] {
-                // assert that the current status code is incremented, *and* that
-                // all previous requests are *not* incremented.
-                assert_eventually_contains!(
-                    metrics.get("/metrics").await,
-                    &expected_metric(status, "inbound", "disabled", None, None)
-                )
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn outbound_http() {
-        let _trace = trace_init();
-        let Fixture {
-            client,
-            metrics,
-            proxy,
-            _profile,
-            dst_tx: _dst_tx,
-        } = Fixture::outbound_with_server(make_test_server().await).await;
-        let port = proxy.outbound_server.as_ref().unwrap().addr.port();
-        for (i, status) in STATUSES.iter().enumerate() {
-            let request = client
-                .request(
-                    client
-                        .request_builder("/")
-                        .header(REQ_STATUS_HEADER, status.as_str())
-                        .method("GET"),
-                )
-                .await
-                .unwrap();
-            assert_eq!(&request.status(), status);
-
-            for status in &STATUSES[0..i] {
-                // assert that the current status code is incremented, *and* that
-                // all previous requests are *not* incremented.
-                assert_eventually_contains!(
-                    metrics.get("/metrics").await,
-                    &expected_metric(
-                        status,
-                        "outbound",
-                        "no_identity",
-                        Some("not_provided_by_service_discovery"),
-                        Some(port)
-                    )
-                )
-            }
-        }
-    }
-}
-
-// Ignore this test on CI, because our method of adding latency to requests
-// (calling `thread::sleep`) is likely to be flakey on Travis.
-// Eventually, we can add some kind of mock timer system for simulating latency
-// more reliably, and re-enable this test.
-#[tokio::test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
-async fn metrics_endpoint_inbound_response_latency() {
-    let _trace = trace_init();
-
-    info!("running test server");
-    let srv = server::new()
-        .route_with_latency("/hey", "hello", Duration::from_millis(500))
-        .route_with_latency("/hi", "good morning", Duration::from_millis(40))
-        .run()
-        .await;
-
-    let Fixture {
-        client,
-        metrics,
-        proxy: _proxy,
-        _profile,
-        dst_tx: _dst_tx,
-    } = Fixture::inbound_with_server(srv).await;
-
-    info!("client.get(/hey)");
-    assert_eq!(client.get("/hey").await, "hello");
-
-    // assert the >=1000ms bucket is incremented by our request with 500ms
-    // extra latency.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 1");
-    // the histogram's count should be 1.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 1");
-    // TODO: we're not going to make any assertions about the
-    // response_latency_ms_sum stat, since its granularity depends on the actual
-    // observed latencies, which may vary a bit. we could make more reliable
-    // assertions about that stat if we were using a mock timer, though, as the
-    // observed latency values would be predictable.
-
-    info!("client.get(/hi)");
-    assert_eq!(client.get("/hi").await, "good morning");
-
-    // request with 40ms extra latency should fall into the 50ms bucket.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"50\"} 1");
-    // 1000ms bucket should be incremented as well, since it counts *all*
-    // observations less than or equal to 1000ms, even if they also increment
-    // other buckets.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 2");
-    // the histogram's total count should be 2.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 2");
-
-    info!("client.get(/hi)");
-    assert_eq!(client.get("/hi").await, "good morning");
-
-    // request with 40ms extra latency should fall into the 50ms bucket.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"50\"} 2");
-    // 1000ms bucket should be incremented as well.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 3");
-    // the histogram's total count should be 3.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 3");
-
-    info!("client.get(/hey)");
-    assert_eq!(client.get("/hey").await, "hello");
-
-    // 50ms bucket should be un-changed by the request with 500ms latency.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"50\"} 2");
-    // 1000ms bucket should be incremented.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 4");
-    // the histogram's total count should be 4.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 4");
-}
-
-// Ignore this test on CI, because our method of adding latency to requests
-// (calling `thread::sleep`) is likely to be flakey on Travis.
-// Eventually, we can add some kind of mock timer system for simulating latency
-// more reliably, and re-enable this test.
-#[tokio::test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
-async fn metrics_endpoint_outbound_response_latency() {
-    let _trace = trace_init();
-
-    info!("running test server");
-    let srv = server::new()
-        .route_with_latency("/hey", "hello", Duration::from_millis(500))
-        .route_with_latency("/hi", "good morning", Duration::from_millis(40))
-        .run()
-        .await;
-
-    let Fixture {
-        client,
-        metrics,
-        proxy: _proxy,
-        _profile,
-        dst_tx: _dst_tx,
-    } = Fixture::outbound_with_server(srv).await;
-
-    info!("client.get(/hey)");
-    assert_eq!(client.get("/hey").await, "hello");
-
-    // assert the >=1000ms bucket is incremented by our request with 500ms
-    // extra latency.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 1");
-    // the histogram's count should be 1.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-    // TODO: we're not going to make any assertions about the
-    // response_latency_ms_sum stat, since its granularity depends on the actual
-    // observed latencies, which may vary a bit. we could make more reliable
-    // assertions about that stat if we were using a mock timer, though, as the
-    // observed latency values would be predictable.
-
-    info!("client.get(/hi)");
-    assert_eq!(client.get("/hi").await, "good morning");
-
-    // request with 40ms extra latency should fall into the 50ms bucket.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"50\"} 1");
-    // 1000ms bucket should be incremented as well, since it counts *all*
-    // bservations less than or equal to 1000ms, even if they also increment
-    // other buckets.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 2");
-    // the histogram's total count should be 2.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 2");
-
-    info!("client.get(/hi)");
-    assert_eq!(client.get("/hi").await, "good morning");
-
-    // request with 40ms extra latency should fall into the 50ms bucket.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"50\"} 2");
-    // 1000ms bucket should be incremented as well.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 3");
-    // the histogram's total count should be 3.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 3");
-
-    info!("client.get(/hey)");
-    assert_eq!(client.get("/hey").await, "hello");
-
-    // 50ms bucket should be un-changed by the request with 500ms latency.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"50\"} 2");
-    // 1000ms bucket should be incremented.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 4");
-    // the histogram's total count should be 4.
-    assert_eventually_contains!(metrics.get("/metrics").await,
-        "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 4");
-}
-
-// Tests for destination labels provided by control plane service discovery.
-mod outbound_dst_labels {
-    use super::Fixture;
-    use crate::*;
-    use controller::DstSender;
-
-    async fn fixture(dest: &str) -> (Fixture, SocketAddr) {
-        info!("running test server");
-        let srv = server::new().route("/", "hello").run().await;
-
-        let addr = srv.addr;
-
-        let ctrl = controller::new();
-        let _profile = ctrl.profile_tx_default(addr, dest);
-        let dst_tx = ctrl.destination_tx(format!("{}:{}", dest, addr.port()));
-
-        let proxy = proxy::new()
-            .controller(ctrl.run().await)
-            .outbound(srv)
-            .run()
-            .await;
-        let metrics = client::http1(proxy.metrics, "localhost");
-
-        let client = client::new(proxy.outbound, dest);
-
-        let f = Fixture {
-            client,
-            metrics,
-            proxy,
-            _profile,
-            dst_tx: Some(dst_tx),
-        };
-
-        (f, addr)
-    }
-
-    #[tokio::test]
-    async fn multiple_addr_labels() {
-        let _trace = trace_init();
-        let (
-            Fixture {
-                client,
-                metrics,
-                proxy: _proxy,
-                _profile,
-                dst_tx,
-            },
-            addr,
-        ) = fixture("labeled.test.svc.cluster.local").await;
-        let dst_tx = dst_tx.unwrap();
-        {
-            let mut labels = HashMap::new();
-            labels.insert("addr_label1".to_owned(), "foo".to_owned());
-            labels.insert("addr_label2".to_owned(), "bar".to_owned());
-            dst_tx.send_labeled(addr, labels, HashMap::new());
-        }
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // We can't make more specific assertions about the metrics
-        // besides asserting that both labels are present somewhere in the
-        // scrape, because testing for whole metric lines would depend on
-        // the order in which the labels occur, and we can't depend on hash
-        // map ordering.
-        assert_eventually_contains!(metrics.get("/metrics").await, "dst_addr_label1=\"foo\"");
-        assert_eventually_contains!(metrics.get("/metrics").await, "dst_addr_label2=\"bar\"");
-    }
-
-    #[tokio::test]
-    async fn multiple_addrset_labels() {
-        let _trace = trace_init();
-        let (
-            Fixture {
-                client,
-                metrics,
-                proxy: _proxy,
-                _profile,
-                dst_tx,
-            },
-            addr,
-        ) = fixture("labeled.test.svc.cluster.local").await;
-        let dst_tx = dst_tx.unwrap();
-
-        {
-            let mut labels = HashMap::new();
-            labels.insert("set_label1".to_owned(), "foo".to_owned());
-            labels.insert("set_label2".to_owned(), "bar".to_owned());
-            dst_tx.send_labeled(addr, HashMap::new(), labels);
-        }
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // We can't make more specific assertions about the metrics
-        // besides asserting that both labels are present somewhere in the
-        // scrape, because testing for whole metric lines would depend on
-        // the order in which the labels occur, and we can't depend on hash
-        // map ordering.
-        assert_eventually_contains!(metrics.get("/metrics").await, "dst_set_label1=\"foo\"");
-        assert_eventually_contains!(metrics.get("/metrics").await, "dst_set_label2=\"bar\"");
-    }
-
-    #[tokio::test]
-    async fn labeled_addr_and_addrset() {
-        let _trace = trace_init();
-        let (
-            Fixture {
-                client,
-                metrics,
-                proxy,
-                _profile,
-                dst_tx,
-            },
-            addr,
-        ) = fixture("labeled.test.svc.cluster.local").await;
-        let dst_tx = dst_tx.unwrap();
-        let auth = format!(
-            "labeled.test.svc.cluster.local:{}",
-            proxy.outbound_server.as_ref().unwrap().addr.port()
-        );
-
-        {
-            let mut alabels = HashMap::new();
-            alabels.insert("addr_label".to_owned(), "foo".to_owned());
-            let mut slabels = HashMap::new();
-            slabels.insert("set_label".to_owned(), "bar".to_owned());
-            dst_tx.send_labeled(addr, alabels, slabels);
-        }
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        let expected = format!(
-            "response_latency_ms_count{{authority=\"{}\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"}} 1",
-            auth
-        );
-        assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
-
-        let expected =             format!(
-            "request_total{{authority=\"{}\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} 1",
-            auth
-        );
-        assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
-
-        let expected = format!(
-            "response_total{{authority=\"{}\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"}} 1",
-            auth
-        );
-        assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
-    }
-
-    // Ignore this test on CI, as it may fail due to the reduced concurrency
-    // on CI containers causing the proxy to see both label updates from
-    // the mock controller before the first request has finished.
-    // See linkerd/linkerd2#751
-    #[tokio::test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-    async fn controller_updates_addr_labels() {
-        let _trace = trace_init();
-        info!("running test server");
-
-        let (
-            Fixture {
-                client,
-                metrics,
-                proxy: _proxy,
-                _profile,
-                dst_tx,
-            },
-            addr,
-        ) = fixture("labeled.test.svc.cluster.local").await;
-        let dst_tx = dst_tx.unwrap();
-        {
-            let mut alabels = HashMap::new();
-            alabels.insert("addr_label".to_owned(), "foo".to_owned());
-            let mut slabels = HashMap::new();
-            slabels.insert("set_label".to_owned(), "unchanged".to_owned());
-            dst_tx.send_labeled(addr, alabels, slabels);
-        }
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // the first request should be labeled with `dst_addr_label="foo"`
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-
-        {
-            let mut alabels = HashMap::new();
-            alabels.insert("addr_label".to_owned(), "bar".to_owned());
-            let mut slabels = HashMap::new();
-            slabels.insert("set_label".to_owned(), "unchanged".to_owned());
-            dst_tx.send_labeled(addr, alabels, slabels);
-        }
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // the second request should increment stats labeled with `dst_addr_label="bar"`
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"bar\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"bar\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"bar\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-        // stats recorded from the first request should still be present.
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-    }
-
-    // Ignore this test on CI, as it may fail due to the reduced concurrency
-    // on CI containers causing the proxy to see both label updates from
-    // the mock controller before the first request has finished.
-    // See linkerd/linkerd2#751
-    #[tokio::test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-    async fn controller_updates_set_labels() {
-        let _trace = trace_init();
-        info!("running test server");
-        let (
-            Fixture {
-                client,
-                metrics,
-                proxy: _proxy,
-                _profile,
-                dst_tx,
-            },
-            addr,
-        ) = fixture("labeled.test.svc.cluster.local").await;
-        let dst_tx = dst_tx.unwrap();
-        {
-            let alabels = HashMap::new();
-            let mut slabels = HashMap::new();
-            slabels.insert("set_label".to_owned(), "foo".to_owned());
-            dst_tx.send_labeled(addr, alabels, slabels);
-        }
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // the first request should be labeled with `dst_addr_label="foo"`
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-
-        {
-            let alabels = HashMap::new();
-            let mut slabels = HashMap::new();
-            slabels.insert("set_label".to_owned(), "bar".to_owned());
-            dst_tx.send_labeled(addr, alabels, slabels);
-        }
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // the second request should increment stats labeled with `dst_addr_label="bar"`
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-        // stats recorded from the first request should still be present.
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
-    }
-}
-
-#[tokio::test]
-async fn metrics_have_no_double_commas() {
-    // Test for regressions to linkerd/linkerd2#600.
-    let _trace = trace_init();
-
-    info!("running test server");
-    let inbound_srv = server::new().route("/hey", "hello").run().await;
-    let outbound_srv = server::new().route("/hey", "hello").run().await;
-
-    let ctrl = controller::new();
-    let _profile_in =
-        ctrl.profile_tx_default("tele.test.svc.cluster.local", "tele.test.svc.cluster.local");
-    let _profile_out = ctrl.profile_tx_default(outbound_srv.addr, "tele.test.svc.cluster.local");
-    let out_dest = ctrl.destination_tx(format!(
-        "tele.test.svc.cluster.local:{}",
-        outbound_srv.addr.port()
-    ));
-    out_dest.send_addr(outbound_srv.addr);
-    let in_dest = ctrl.destination_tx(format!(
-        "tele.test.svc.cluster.local:{}",
-        inbound_srv.addr.port()
-    ));
-    in_dest.send_addr(inbound_srv.addr);
-    let proxy = proxy::new()
-        .controller(ctrl.run().await)
-        .inbound(inbound_srv)
-        .outbound(outbound_srv)
-        .run()
-        .await;
-    let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
-    let metrics = client::http1(proxy.metrics, "localhost");
-
-    let scrape = metrics.get("/metrics").await;
-    assert!(!scrape.contains(",,"));
-
-    info!("inbound.get(/hey)");
-    assert_eq!(client.get("/hey").await, "hello");
-
-    let scrape = metrics.get("/metrics").await;
-    assert!(!scrape.contains(",,"), "inbound metrics had double comma");
-
-    let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
-
-    info!("outbound.get(/hey)");
-    assert_eq!(client.get("/hey").await, "hello");
-
-    let scrape = metrics.get("/metrics").await;
-    assert!(!scrape.contains(",,"), "outbound metrics had double comma");
-}
-
-#[tokio::test]
-async fn metrics_has_start_time() {
-    let Fixture {
-        metrics,
-        proxy: _proxy,
-        _profile,
-        dst_tx: _dst_tx,
-        ..
-    } = Fixture::inbound().await;
-    let uptime_regex = regex::Regex::new(r"process_start_time_seconds \d+")
-        .expect("compiling regex shouldn't fail");
-    assert_eventually!(uptime_regex.find(&metrics.get("/metrics").await).is_some())
-}
-
-mod transport {
-    use super::*;
-    use crate::*;
-
-    #[tokio::test]
-    async fn inbound_http_accept() {
-        let _trace = trace_init();
-        let Fixture {
-            client,
-            metrics,
-            proxy,
-            _profile,
-            dst_tx: _dst_tx,
-        } = Fixture::inbound().await;
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 1"
-        );
-        // Shut down the client to force the connection to close.
-        client.shutdown().await;
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1"
-        );
-
-        // create a new client to force a new connection
-        let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 2"
-        );
-        // Shut down the client to force the connection to close.
-        client.shutdown().await;
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 2"
-        );
-    }
-
-    #[tokio::test]
-    async fn inbound_http_connect() {
-        let _trace = trace_init();
-        let Fixture {
-            client,
-            metrics,
-            proxy,
-            _profile,
-            dst_tx: _dst_tx,
-        } = Fixture::inbound().await;
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-        );
-
-        // create a new client to force a new connection
-        let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // server connection should be pooled
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-        );
-    }
-
-    #[tokio::test]
-    async fn outbound_http_accept() {
-        let _trace = trace_init();
-        let Fixture {
-            client,
-            metrics,
-            proxy,
-            _profile,
-            dst_tx: _dst_tx,
-        } = Fixture::outbound().await;
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-        );
-        // Shut down the client to force the connection to close.
-        client.shutdown().await;
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1"
-        );
-
-        // create a new client to force a new connection
-        let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 2"
-        );
-        // Shut down the client to force the connection to close.
-        client.shutdown().await;
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2"
-        );
-    }
-
-    #[tokio::test]
-    async fn outbound_http_connect() {
-        let _trace = trace_init();
-        let Fixture {
-            client,
-            metrics,
-            proxy,
-            _profile,
-            dst_tx: _dst_tx,
-        } = Fixture::outbound().await;
-        let expected = format!(
-            "tcp_open_total{{peer=\"dst\",authority=\"tele.test.svc.cluster.local:{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} 1",
-            proxy.outbound_server.as_ref().unwrap().addr.port(),
-        );
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
-
-        // create a new client to force a new connection
-        let client2 = client::new(proxy.outbound, "tele.test.svc.cluster.local");
-
-        info!("client.get(/)");
-        assert_eq!(client2.get("/").await, "hello");
-        // server connection should be pooled
-        assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
-    }
-
-    #[tokio::test]
-    async fn inbound_tcp_connect() {
-        let _trace = trace_init();
-        let TcpFixture {
-            client,
-            metrics,
-            proxy: _proxy,
-            dst: _dst,
-            profile: _profile,
-        } = TcpFixture::inbound().await;
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1");
-    }
-
-    #[tokio::test]
-    #[cfg(target_os = "macos")]
-    async fn inbound_tcp_connect_err() {
-        let _trace = trace_init();
-        let srv = tcp::server()
-            .accept_fut(move |sock| {
-                drop(sock);
-                future::ok(())
-            })
-            .run()
-            .await;
-        let proxy = proxy::new().inbound(srv).run().await;
-
-        let client = client::tcp(proxy.inbound);
-        let metrics = client::http1(proxy.metrics, "localhost");
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, &[]);
-        // Connection to the server should be a failure with the EXFULL error
-        // code.
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"EXFULL\"} 1");
-        // Connection from the client should have closed cleanly.
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1"
-        );
-    }
-
-    #[test]
-    #[cfg(target_os = "macos")]
-    fn outbound_tcp_connect_err() {
-        let _trace = trace_init();
-        let srv = tcp::server()
-            .accept_fut(move |sock| {
-                drop(sock);
-                future::ok(())
-            })
-            .run()
-            .await;
-        let proxy = proxy::new().outbound(srv).run().await;
-
-        let client = client::tcp(proxy.outbound);
-        let metrics = client::http1(proxy.metrics, "localhost");
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, &[]);
-        // Connection to the server should be a failure with the EXFULL error
-        // code.
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"EXFULL\"} 1");
-        // Connection from the client should have closed cleanly.
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-    }
-
-    #[tokio::test]
-    async fn inbound_tcp_accept() {
-        let _trace = trace_init();
-        let TcpFixture {
-            client,
-            metrics,
-            proxy: _proxy,
-            dst: _dst,
-            profile: _profile,
-        } = TcpFixture::inbound().await;
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 1"
-        );
-
-        tcp_client.shutdown().await;
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1"
-        );
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 2"
-        );
-        tcp_client.shutdown().await;
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 2"
-        );
-    }
-
-    // linkerd/linkerd2#831
-    #[tokio::test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-    async fn inbound_tcp_duration() {
-        let _trace = trace_init();
-        let TcpFixture {
-            client,
-            metrics,
-            proxy: _proxy,
-            dst: _dst,
-            profile: _profile,
-        } = TcpFixture::inbound().await;
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        tcp_client.shutdown().await;
-        // TODO: make assertions about buckets
-        let out = metrics.get("/metrics").await;
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1");
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        let out = metrics.get("/metrics").await;
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1");
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-
-        tcp_client.shutdown().await;
-        let out = metrics.get("/metrics").await;
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 2");
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2");
-    }
-
-    #[tokio::test]
-    async fn inbound_tcp_write_bytes_total() {
-        let _trace = trace_init();
-        let TcpFixture {
-            client,
-            metrics,
-            proxy: _proxy,
-            dst: _dst,
-            profile: _profile,
-        } = TcpFixture::inbound().await;
-        let src_expected = format!(
-            "tcp_write_bytes_total{{peer=\"src\",direction=\"inbound\",tls=\"disabled\"}} {}",
-            TcpFixture::BYE_MSG.len()
-        );
-        let dst_expected = format!(
-            "tcp_write_bytes_total{{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
-            TcpFixture::HELLO_MSG.len()
-        );
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        tcp_client.shutdown().await;
-
-        let out = metrics.get("/metrics").await;
-        assert_eventually_contains!(out, &src_expected);
-        assert_eventually_contains!(out, &dst_expected);
-    }
-
-    #[tokio::test]
-    async fn inbound_tcp_read_bytes_total() {
-        let _trace = trace_init();
-        let TcpFixture {
-            client,
-            metrics,
-            proxy: _proxy,
-            dst: _dst,
-            profile: _profile,
-        } = TcpFixture::inbound().await;
-        let src_expected = format!(
-            "tcp_read_bytes_total{{peer=\"src\",direction=\"inbound\",tls=\"disabled\"}} {}",
-            TcpFixture::HELLO_MSG.len()
-        );
-        let dst_expected = format!(
-            "tcp_read_bytes_total{{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
-            TcpFixture::BYE_MSG.len()
-        );
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        tcp_client.shutdown().await;
-
-        let out = metrics.get("/metrics").await;
-        assert_eventually_contains!(out, &src_expected);
-        assert_eventually_contains!(out, &dst_expected);
-    }
-
-    #[tokio::test]
-    async fn outbound_tcp_connect() {
-        let _trace = trace_init();
-        let TcpFixture {
-            client,
-            metrics,
-            proxy,
-            dst: _dst,
-            profile: _profile,
-        } = TcpFixture::outbound().await;
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        let expected = format!(
-            "tcp_open_total{{peer=\"dst\",authority=\"{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} 1",
-            proxy.outbound_server.as_ref().unwrap().addr,
-        );
-        assert_eventually_contains!(metrics.get("/metrics").await, &expected);
-    }
-
-    #[tokio::test]
-    async fn outbound_tcp_accept() {
-        let _trace = trace_init();
-        let TcpFixture {
-            client,
-            metrics,
-            proxy: _proxy,
-            dst: _dst,
-            profile: _profile,
-        } = TcpFixture::outbound().await;
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-        );
-
-        tcp_client.shutdown().await;
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 2"
-        );
-        tcp_client.shutdown().await;
-        assert_eventually_contains!(metrics.get("/metrics").await,
-            "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2");
-    }
-
-    #[tokio::test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
-    async fn outbound_tcp_duration() {
-        let _trace = trace_init();
-        let TcpFixture {
-            client,
-            metrics,
-            proxy: _proxy,
-            dst: _dst,
-            profile: _profile,
-        } = TcpFixture::outbound().await;
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        tcp_client.shutdown().await;
-        // TODO: make assertions about buckets
-        let out = metrics.get("/metrics").await;
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"} 1");
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        let out = metrics.get("/metrics").await;
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"} 1");
-
-        tcp_client.shutdown().await;
-        let out = metrics.get("/metrics").await;
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2");
-        assert_eventually_contains!(out,
-            "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"} 2");
-    }
-
-    #[tokio::test]
-    async fn outbound_tcp_write_bytes_total() {
-        let _trace = trace_init();
-        let TcpFixture {
-            client,
-            metrics,
-            proxy,
-            dst: _dst,
-            profile: _profile,
-        } = TcpFixture::outbound().await;
-        let src_expected = format!(
-            "tcp_write_bytes_total{{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
-            TcpFixture::BYE_MSG.len()
-        );
-        let dst_expected = format!(
-            "tcp_write_bytes_total{{peer=\"dst\",authority=\"{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} {}",
-            proxy.outbound_server.as_ref().unwrap().addr,
-            TcpFixture::HELLO_MSG.len()
-        );
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        tcp_client.shutdown().await;
-
-        let out = metrics.get("/metrics").await;
-        assert_eventually_contains!(out, &src_expected);
-        assert_eventually_contains!(out, &dst_expected);
-    }
-
-    #[tokio::test]
-    async fn outbound_tcp_read_bytes_total() {
-        let _trace = trace_init();
-        let TcpFixture {
-            client,
-            metrics,
-            proxy,
-            dst: _dst,
-            profile: _profile,
-        } = TcpFixture::outbound().await;
-
-        let src_expected = format!(
-            "tcp_read_bytes_total{{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
-            TcpFixture::HELLO_MSG.len()
-        );
-        let dst_expected = format!(
-            "tcp_read_bytes_total{{peer=\"dst\",authority=\"{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} {}",
-            proxy.outbound_server.as_ref().unwrap().addr,
-            TcpFixture::BYE_MSG.len()
-        );
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        tcp_client.shutdown().await;
-
-        let out = metrics.get("/metrics").await;
-        assert_eventually_contains!(out, &src_expected);
-        assert_eventually_contains!(out, &dst_expected);
-    }
-
-    #[tokio::test]
-    async fn outbound_tcp_open_connections() {
-        let _trace = trace_init();
-        let fixture = TcpFixture::outbound().await;
-        let client = fixture.client;
-        let metrics = fixture.metrics;
-
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-        );
-        tcp_client.shutdown().await;
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
-        );
-        let tcp_client = client.connect().await;
-
-        tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-        );
-
-        tcp_client.shutdown().await;
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
-        );
-    }
-
-    #[tokio::test]
-    async fn outbound_http_tcp_open_connections() {
-        let _trace = trace_init();
-        let Fixture {
-            client,
-            metrics,
-            proxy,
-            _profile,
-            dst_tx: _dst_tx,
-        } = Fixture::outbound().await;
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-        );
-        // Shut down the client to force the connection to close.
-        client.shutdown().await;
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
-        );
-
-        // create a new client to force a new connection
-        let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
-        );
-        // Shut down the client to force the connection to close.
-        client.shutdown().await;
-        assert_eventually_contains!(
-            metrics.get("/metrics").await,
-            "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
-        );
-    }
-}
-
-// linkerd/linkerd2#613
-#[tokio::test]
-async fn metrics_compression() {
-    let _trace = trace_init();
-
-    let Fixture {
-        client,
-        metrics,
-        proxy: _proxy,
-        _profile,
-        dst_tx: _dst_tx,
-    } = Fixture::inbound().await;
-
-    let do_scrape = |encoding: &str| {
-        let req = metrics.request(
-            metrics
-                .request_builder("/metrics")
-                .method("GET")
-                .header("Accept-Encoding", encoding),
-        );
-
-        let encoding = encoding.to_owned();
-        async move {
-            let resp = req.await.expect("scrape");
-
-            {
-                // create a new scope so we can release our borrow on `resp` before
-                // getting the body
-                let content_encoding = resp.headers().get("content-encoding").as_ref().map(|val| {
-                    val.to_str()
-                        .expect("content-encoding value should be ascii")
-                });
-                assert_eq!(
-                    content_encoding,
-                    Some("gzip"),
-                    "unexpected Content-Encoding {:?} (requested Accept-Encoding: {})",
-                    content_encoding,
-                    encoding.as_str()
-                );
-            }
-
-            let mut body = hyper::body::aggregate(resp.into_body())
-                .await
-                .expect("response body concat");
-            let mut decoder = flate2::read::GzDecoder::new(std::io::Cursor::new(
-                body.copy_to_bytes(body.remaining()),
-            ));
-            let mut scrape = String::new();
-            decoder.read_to_string(&mut scrape).unwrap_or_else(|_| {
-                panic!("decode gzip (requested Accept-Encoding: {})", encoding)
-            });
-            scrape
-        }
-    };
-
-    let encodings = &[
-        "gzip",
-        "deflate, gzip",
-        "gzip,deflate",
-        "brotli,gzip,deflate",
-    ];
-
-    info!("client.get(/)");
-    assert_eq!(client.get("/").await, "hello");
-
-    for &encoding in encodings {
-        assert_eventually_contains!(do_scrape(encoding).await,
-            "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 1");
-    }
-
-    info!("client.get(/)");
-    assert_eq!(client.get("/").await, "hello");
-
-    for &encoding in encodings {
-        assert_eventually_contains!(do_scrape(encoding).await,
-            "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 2");
-    }
-}
+// mod response_classification {
+//     use super::Fixture;
+//     use crate::*;
+//     use tracing::info;
+
+//     const REQ_STATUS_HEADER: &str = "x-test-status-requested";
+//     const REQ_GRPC_STATUS_HEADER: &str = "x-test-grpc-status-requested";
+
+//     const STATUSES: [http::StatusCode; 6] = [
+//         http::StatusCode::OK,
+//         http::StatusCode::NOT_MODIFIED,
+//         http::StatusCode::BAD_REQUEST,
+//         http::StatusCode::IM_A_TEAPOT,
+//         http::StatusCode::GATEWAY_TIMEOUT,
+//         http::StatusCode::INTERNAL_SERVER_ERROR,
+//     ];
+
+//     fn expected_metric(
+//         status: &http::StatusCode,
+//         direction: &str,
+//         tls: &str,
+//         no_tls_reason: Option<&str>,
+//         port: Option<u16>,
+//     ) -> String {
+//         let port = if let Some(port) = port {
+//             format!(":{}", port)
+//         } else {
+//             String::new()
+//         };
+//         format!(
+//             "response_total{{authority=\"tele.test.svc.cluster.local{}\",direction=\"{}\",tls=\"{}\",{}status_code=\"{}\",classification=\"{}\"}} 1",
+//             port,
+//             direction,
+//             tls,
+//             if let Some(reason) = no_tls_reason {
+//                 format!("no_tls_reason=\"{}\",", reason)
+//             } else {
+//                 String::new()
+//             },
+//             status.as_u16(),
+//             if status.is_server_error() { "failure" } else { "success" },
+//         )
+//     }
+
+//     async fn make_test_server() -> server::Listening {
+//         fn parse_header(headers: &http::HeaderMap, which: &str) -> Option<http::StatusCode> {
+//             headers.get(which).map(|val| {
+//                 val.to_str()
+//                     .expect("requested status should be ascii")
+//                     .parse::<http::StatusCode>()
+//                     .expect("requested status should be numbers")
+//             })
+//         }
+//         info!("running test server");
+//         server::new()
+//             .route_fn("/", move |req| {
+//                 let headers = req.headers();
+//                 let status =
+//                     parse_header(headers, REQ_STATUS_HEADER).unwrap_or(http::StatusCode::OK);
+//                 let grpc_status = parse_header(headers, REQ_GRPC_STATUS_HEADER);
+//                 let mut rsp = if let Some(_grpc_status) = grpc_status {
+//                     // TODO: tests for grpc statuses
+//                     unreachable!("not called in test")
+//                 } else {
+//                     Response::new("".into())
+//                 };
+//                 *rsp.status_mut() = status;
+//                 rsp
+//             })
+//             .run()
+//             .await
+//     }
+
+//     #[tokio::test]
+//     async fn inbound_http() {
+//         let _trace = trace_init();
+//         let Fixture {
+//             client,
+//             metrics,
+//             proxy: _proxy,
+//             _profile,
+//             dst_tx: _dst_tx,
+//         } = Fixture::inbound_with_server(make_test_server().await).await;
+
+//         for (i, status) in STATUSES.iter().enumerate() {
+//             let request = client
+//                 .request(
+//                     client
+//                         .request_builder("/")
+//                         .header(REQ_STATUS_HEADER, status.as_str())
+//                         .method("GET"),
+//                 )
+//                 .await
+//                 .unwrap();
+//             assert_eq!(&request.status(), status);
+
+//             for status in &STATUSES[0..i] {
+//                 // assert that the current status code is incremented, *and* that
+//                 // all previous requests are *not* incremented.
+//                 assert_eventually_contains!(
+//                     metrics.get("/metrics").await,
+//                     &expected_metric(status, "inbound", "disabled", None, None)
+//                 )
+//             }
+//         }
+//     }
+
+//     #[tokio::test]
+//     async fn outbound_http() {
+//         let _trace = trace_init();
+//         let Fixture {
+//             client,
+//             metrics,
+//             proxy,
+//             _profile,
+//             dst_tx: _dst_tx,
+//         } = Fixture::outbound_with_server(make_test_server().await).await;
+//         let port = proxy.outbound_server.as_ref().unwrap().addr.port();
+//         for (i, status) in STATUSES.iter().enumerate() {
+//             let request = client
+//                 .request(
+//                     client
+//                         .request_builder("/")
+//                         .header(REQ_STATUS_HEADER, status.as_str())
+//                         .method("GET"),
+//                 )
+//                 .await
+//                 .unwrap();
+//             assert_eq!(&request.status(), status);
+
+//             for status in &STATUSES[0..i] {
+//                 // assert that the current status code is incremented, *and* that
+//                 // all previous requests are *not* incremented.
+//                 assert_eventually_contains!(
+//                     metrics.get("/metrics").await,
+//                     &expected_metric(
+//                         status,
+//                         "outbound",
+//                         "no_identity",
+//                         Some("not_provided_by_service_discovery"),
+//                         Some(port)
+//                     )
+//                 )
+//             }
+//         }
+//     }
+// }
+
+// // Ignore this test on CI, because our method of adding latency to requests
+// // (calling `thread::sleep`) is likely to be flakey on Travis.
+// // Eventually, we can add some kind of mock timer system for simulating latency
+// // more reliably, and re-enable this test.
+// #[tokio::test]
+// #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+// async fn metrics_endpoint_inbound_response_latency() {
+//     let _trace = trace_init();
+
+//     info!("running test server");
+//     let srv = server::new()
+//         .route_with_latency("/hey", "hello", Duration::from_millis(500))
+//         .route_with_latency("/hi", "good morning", Duration::from_millis(40))
+//         .run()
+//         .await;
+
+//     let Fixture {
+//         client,
+//         metrics,
+//         proxy: _proxy,
+//         _profile,
+//         dst_tx: _dst_tx,
+//     } = Fixture::inbound_with_server(srv).await;
+
+//     info!("client.get(/hey)");
+//     assert_eq!(client.get("/hey").await, "hello");
+
+//     // assert the >=1000ms bucket is incremented by our request with 500ms
+//     // extra latency.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 1");
+//     // the histogram's count should be 1.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 1");
+//     // TODO: we're not going to make any assertions about the
+//     // response_latency_ms_sum stat, since its granularity depends on the actual
+//     // observed latencies, which may vary a bit. we could make more reliable
+//     // assertions about that stat if we were using a mock timer, though, as the
+//     // observed latency values would be predictable.
+
+//     info!("client.get(/hi)");
+//     assert_eq!(client.get("/hi").await, "good morning");
+
+//     // request with 40ms extra latency should fall into the 50ms bucket.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"50\"} 1");
+//     // 1000ms bucket should be incremented as well, since it counts *all*
+//     // observations less than or equal to 1000ms, even if they also increment
+//     // other buckets.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 2");
+//     // the histogram's total count should be 2.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 2");
+
+//     info!("client.get(/hi)");
+//     assert_eq!(client.get("/hi").await, "good morning");
+
+//     // request with 40ms extra latency should fall into the 50ms bucket.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"50\"} 2");
+//     // 1000ms bucket should be incremented as well.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 3");
+//     // the histogram's total count should be 3.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 3");
+
+//     info!("client.get(/hey)");
+//     assert_eq!(client.get("/hey").await, "hello");
+
+//     // 50ms bucket should be un-changed by the request with 500ms latency.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"50\"} 2");
+//     // 1000ms bucket should be incremented.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",le=\"1000\"} 4");
+//     // the histogram's total count should be 4.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 4");
+// }
+
+// // Ignore this test on CI, because our method of adding latency to requests
+// // (calling `thread::sleep`) is likely to be flakey on Travis.
+// // Eventually, we can add some kind of mock timer system for simulating latency
+// // more reliably, and re-enable this test.
+// #[tokio::test]
+// #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+// async fn metrics_endpoint_outbound_response_latency() {
+//     let _trace = trace_init();
+
+//     info!("running test server");
+//     let srv = server::new()
+//         .route_with_latency("/hey", "hello", Duration::from_millis(500))
+//         .route_with_latency("/hi", "good morning", Duration::from_millis(40))
+//         .run()
+//         .await;
+
+//     let Fixture {
+//         client,
+//         metrics,
+//         proxy: _proxy,
+//         _profile,
+//         dst_tx: _dst_tx,
+//     } = Fixture::outbound_with_server(srv).await;
+
+//     info!("client.get(/hey)");
+//     assert_eq!(client.get("/hey").await, "hello");
+
+//     // assert the >=1000ms bucket is incremented by our request with 500ms
+//     // extra latency.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 1");
+//     // the histogram's count should be 1.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
+//     // TODO: we're not going to make any assertions about the
+//     // response_latency_ms_sum stat, since its granularity depends on the actual
+//     // observed latencies, which may vary a bit. we could make more reliable
+//     // assertions about that stat if we were using a mock timer, though, as the
+//     // observed latency values would be predictable.
+
+//     info!("client.get(/hi)");
+//     assert_eq!(client.get("/hi").await, "good morning");
+
+//     // request with 40ms extra latency should fall into the 50ms bucket.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"50\"} 1");
+//     // 1000ms bucket should be incremented as well, since it counts *all*
+//     // bservations less than or equal to 1000ms, even if they also increment
+//     // other buckets.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 2");
+//     // the histogram's total count should be 2.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 2");
+
+//     info!("client.get(/hi)");
+//     assert_eq!(client.get("/hi").await, "good morning");
+
+//     // request with 40ms extra latency should fall into the 50ms bucket.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"50\"} 2");
+//     // 1000ms bucket should be incremented as well.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 3");
+//     // the histogram's total count should be 3.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 3");
+
+//     info!("client.get(/hey)");
+//     assert_eq!(client.get("/hey").await, "hello");
+
+//     // 50ms bucket should be un-changed by the request with 500ms latency.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"50\"} 2");
+//     // 1000ms bucket should be incremented.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_bucket{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",le=\"1000\"} 4");
+//     // the histogram's total count should be 4.
+//     assert_eventually_contains!(metrics.get("/metrics").await,
+//         "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 4");
+// }
+
+// // Tests for destination labels provided by control plane service discovery.
+// mod outbound_dst_labels {
+//     use super::Fixture;
+//     use crate::*;
+//     use controller::DstSender;
+
+//     async fn fixture(dest: &str) -> (Fixture, SocketAddr) {
+//         info!("running test server");
+//         let srv = server::new().route("/", "hello").run().await;
+
+//         let addr = srv.addr;
+
+//         let ctrl = controller::new();
+//         let _profile = ctrl.profile_tx_default(addr, dest);
+//         let dst_tx = ctrl.destination_tx(format!("{}:{}", dest, addr.port()));
+
+//         let proxy = proxy::new()
+//             .controller(ctrl.run().await)
+//             .outbound(srv)
+//             .run()
+//             .await;
+//         let metrics = client::http1(proxy.metrics, "localhost");
+
+//         let client = client::new(proxy.outbound, dest);
+
+//         let f = Fixture {
+//             client,
+//             metrics,
+//             proxy,
+//             _profile,
+//             dst_tx: Some(dst_tx),
+//         };
+
+//         (f, addr)
+//     }
+
+//     #[tokio::test]
+//     async fn multiple_addr_labels() {
+//         let _trace = trace_init();
+//         let (
+//             Fixture {
+//                 client,
+//                 metrics,
+//                 proxy: _proxy,
+//                 _profile,
+//                 dst_tx,
+//             },
+//             addr,
+//         ) = fixture("labeled.test.svc.cluster.local").await;
+//         let dst_tx = dst_tx.unwrap();
+//         {
+//             let mut labels = HashMap::new();
+//             labels.insert("addr_label1".to_owned(), "foo".to_owned());
+//             labels.insert("addr_label2".to_owned(), "bar".to_owned());
+//             dst_tx.send_labeled(addr, labels, HashMap::new());
+//         }
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         // We can't make more specific assertions about the metrics
+//         // besides asserting that both labels are present somewhere in the
+//         // scrape, because testing for whole metric lines would depend on
+//         // the order in which the labels occur, and we can't depend on hash
+//         // map ordering.
+//         assert_eventually_contains!(metrics.get("/metrics").await, "dst_addr_label1=\"foo\"");
+//         assert_eventually_contains!(metrics.get("/metrics").await, "dst_addr_label2=\"bar\"");
+//     }
+
+//     #[tokio::test]
+//     async fn multiple_addrset_labels() {
+//         let _trace = trace_init();
+//         let (
+//             Fixture {
+//                 client,
+//                 metrics,
+//                 proxy: _proxy,
+//                 _profile,
+//                 dst_tx,
+//             },
+//             addr,
+//         ) = fixture("labeled.test.svc.cluster.local").await;
+//         let dst_tx = dst_tx.unwrap();
+
+//         {
+//             let mut labels = HashMap::new();
+//             labels.insert("set_label1".to_owned(), "foo".to_owned());
+//             labels.insert("set_label2".to_owned(), "bar".to_owned());
+//             dst_tx.send_labeled(addr, HashMap::new(), labels);
+//         }
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         // We can't make more specific assertions about the metrics
+//         // besides asserting that both labels are present somewhere in the
+//         // scrape, because testing for whole metric lines would depend on
+//         // the order in which the labels occur, and we can't depend on hash
+//         // map ordering.
+//         assert_eventually_contains!(metrics.get("/metrics").await, "dst_set_label1=\"foo\"");
+//         assert_eventually_contains!(metrics.get("/metrics").await, "dst_set_label2=\"bar\"");
+//     }
+
+//     #[tokio::test]
+//     async fn labeled_addr_and_addrset() {
+//         let _trace = trace_init();
+//         let (
+//             Fixture {
+//                 client,
+//                 metrics,
+//                 proxy,
+//                 _profile,
+//                 dst_tx,
+//             },
+//             addr,
+//         ) = fixture("labeled.test.svc.cluster.local").await;
+//         let dst_tx = dst_tx.unwrap();
+//         let auth = format!(
+//             "labeled.test.svc.cluster.local:{}",
+//             proxy.outbound_server.as_ref().unwrap().addr.port()
+//         );
+
+//         {
+//             let mut alabels = HashMap::new();
+//             alabels.insert("addr_label".to_owned(), "foo".to_owned());
+//             let mut slabels = HashMap::new();
+//             slabels.insert("set_label".to_owned(), "bar".to_owned());
+//             dst_tx.send_labeled(addr, alabels, slabels);
+//         }
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         let expected = format!(
+//             "response_latency_ms_count{{authority=\"{}\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"}} 1",
+//             auth
+//         );
+//         assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
+
+//         let expected =             format!(
+//             "request_total{{authority=\"{}\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} 1",
+//             auth
+//         );
+//         assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
+
+//         let expected = format!(
+//             "response_total{{authority=\"{}\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"}} 1",
+//             auth
+//         );
+//         assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
+//     }
+
+//     // Ignore this test on CI, as it may fail due to the reduced concurrency
+//     // on CI containers causing the proxy to see both label updates from
+//     // the mock controller before the first request has finished.
+//     // See linkerd/linkerd2#751
+//     #[tokio::test]
+//     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+//     async fn controller_updates_addr_labels() {
+//         let _trace = trace_init();
+//         info!("running test server");
+
+//         let (
+//             Fixture {
+//                 client,
+//                 metrics,
+//                 proxy: _proxy,
+//                 _profile,
+//                 dst_tx,
+//             },
+//             addr,
+//         ) = fixture("labeled.test.svc.cluster.local").await;
+//         let dst_tx = dst_tx.unwrap();
+//         {
+//             let mut alabels = HashMap::new();
+//             alabels.insert("addr_label".to_owned(), "foo".to_owned());
+//             let mut slabels = HashMap::new();
+//             slabels.insert("set_label".to_owned(), "unchanged".to_owned());
+//             dst_tx.send_labeled(addr, alabels, slabels);
+//         }
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         // the first request should be labeled with `dst_addr_label="foo"`
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
+
+//         {
+//             let mut alabels = HashMap::new();
+//             alabels.insert("addr_label".to_owned(), "bar".to_owned());
+//             let mut slabels = HashMap::new();
+//             slabels.insert("set_label".to_owned(), "unchanged".to_owned());
+//             dst_tx.send_labeled(addr, alabels, slabels);
+//         }
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         // the second request should increment stats labeled with `dst_addr_label="bar"`
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"bar\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"bar\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"bar\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
+//         // stats recorded from the first request should still be present.
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_addr_label=\"foo\",dst_set_label=\"unchanged\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
+//     }
+
+//     // Ignore this test on CI, as it may fail due to the reduced concurrency
+//     // on CI containers causing the proxy to see both label updates from
+//     // the mock controller before the first request has finished.
+//     // See linkerd/linkerd2#751
+//     #[tokio::test]
+//     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+//     async fn controller_updates_set_labels() {
+//         let _trace = trace_init();
+//         info!("running test server");
+//         let (
+//             Fixture {
+//                 client,
+//                 metrics,
+//                 proxy: _proxy,
+//                 _profile,
+//                 dst_tx,
+//             },
+//             addr,
+//         ) = fixture("labeled.test.svc.cluster.local").await;
+//         let dst_tx = dst_tx.unwrap();
+//         {
+//             let alabels = HashMap::new();
+//             let mut slabels = HashMap::new();
+//             slabels.insert("set_label".to_owned(), "foo".to_owned());
+//             dst_tx.send_labeled(addr, alabels, slabels);
+//         }
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         // the first request should be labeled with `dst_addr_label="foo"`
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
+
+//         {
+//             let alabels = HashMap::new();
+//             let mut slabels = HashMap::new();
+//             slabels.insert("set_label".to_owned(), "bar".to_owned());
+//             dst_tx.send_labeled(addr, alabels, slabels);
+//         }
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         // the second request should increment stats labeled with `dst_addr_label="bar"`
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"bar\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
+//         // stats recorded from the first request should still be present.
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_latency_ms_count{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "request_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"} 1");
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "response_total{authority=\"labeled.test.svc.cluster.local\",direction=\"outbound\",dst_set_label=\"foo\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",status_code=\"200\",classification=\"success\"} 1");
+//     }
+// }
+
+// #[tokio::test]
+// async fn metrics_have_no_double_commas() {
+//     // Test for regressions to linkerd/linkerd2#600.
+//     let _trace = trace_init();
+
+//     info!("running test server");
+//     let inbound_srv = server::new().route("/hey", "hello").run().await;
+//     let outbound_srv = server::new().route("/hey", "hello").run().await;
+
+//     let ctrl = controller::new();
+//     let _profile_in =
+//         ctrl.profile_tx_default("tele.test.svc.cluster.local", "tele.test.svc.cluster.local");
+//     let _profile_out = ctrl.profile_tx_default(outbound_srv.addr, "tele.test.svc.cluster.local");
+//     let out_dest = ctrl.destination_tx(format!(
+//         "tele.test.svc.cluster.local:{}",
+//         outbound_srv.addr.port()
+//     ));
+//     out_dest.send_addr(outbound_srv.addr);
+//     let in_dest = ctrl.destination_tx(format!(
+//         "tele.test.svc.cluster.local:{}",
+//         inbound_srv.addr.port()
+//     ));
+//     in_dest.send_addr(inbound_srv.addr);
+//     let proxy = proxy::new()
+//         .controller(ctrl.run().await)
+//         .inbound(inbound_srv)
+//         .outbound(outbound_srv)
+//         .run()
+//         .await;
+//     let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
+//     let metrics = client::http1(proxy.metrics, "localhost");
+
+//     let scrape = metrics.get("/metrics").await;
+//     assert!(!scrape.contains(",,"));
+
+//     info!("inbound.get(/hey)");
+//     assert_eq!(client.get("/hey").await, "hello");
+
+//     let scrape = metrics.get("/metrics").await;
+//     assert!(!scrape.contains(",,"), "inbound metrics had double comma");
+
+//     let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
+
+//     info!("outbound.get(/hey)");
+//     assert_eq!(client.get("/hey").await, "hello");
+
+//     let scrape = metrics.get("/metrics").await;
+//     assert!(!scrape.contains(",,"), "outbound metrics had double comma");
+// }
+
+// #[tokio::test]
+// async fn metrics_has_start_time() {
+//     let Fixture {
+//         metrics,
+//         proxy: _proxy,
+//         _profile,
+//         dst_tx: _dst_tx,
+//         ..
+//     } = Fixture::inbound().await;
+//     let uptime_regex = regex::Regex::new(r"process_start_time_seconds \d+")
+//         .expect("compiling regex shouldn't fail");
+//     assert_eventually!(uptime_regex.find(&metrics.get("/metrics").await).is_some())
+// }
+
+// mod transport {
+//     use super::*;
+//     use crate::*;
+
+//     #[tokio::test]
+//     async fn inbound_http_accept() {
+//         let _trace = trace_init();
+//         let Fixture {
+//             client,
+//             metrics,
+//             proxy,
+//             _profile,
+//             dst_tx: _dst_tx,
+//         } = Fixture::inbound().await;
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 1"
+//         );
+//         // Shut down the client to force the connection to close.
+//         client.shutdown().await;
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1"
+//         );
+
+//         // create a new client to force a new connection
+//         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 2"
+//         );
+//         // Shut down the client to force the connection to close.
+//         client.shutdown().await;
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 2"
+//         );
+//     }
+
+//     #[tokio::test]
+//     async fn inbound_http_connect() {
+//         let _trace = trace_init();
+//         let Fixture {
+//             client,
+//             metrics,
+//             proxy,
+//             _profile,
+//             dst_tx: _dst_tx,
+//         } = Fixture::inbound().await;
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
+//         );
+
+//         // create a new client to force a new connection
+//         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         // server connection should be pooled
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
+//         );
+//     }
+
+//     #[tokio::test]
+//     async fn outbound_http_accept() {
+//         let _trace = trace_init();
+//         let Fixture {
+//             client,
+//             metrics,
+//             proxy,
+//             _profile,
+//             dst_tx: _dst_tx,
+//         } = Fixture::outbound().await;
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
+//         );
+//         // Shut down the client to force the connection to close.
+//         client.shutdown().await;
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1"
+//         );
+
+//         // create a new client to force a new connection
+//         let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 2"
+//         );
+//         // Shut down the client to force the connection to close.
+//         client.shutdown().await;
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2"
+//         );
+//     }
+
+//     #[tokio::test]
+//     async fn outbound_http_connect() {
+//         let _trace = trace_init();
+//         let Fixture {
+//             client,
+//             metrics,
+//             proxy,
+//             _profile,
+//             dst_tx: _dst_tx,
+//         } = Fixture::outbound().await;
+//         let expected = format!(
+//             "tcp_open_total{{peer=\"dst\",authority=\"tele.test.svc.cluster.local:{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} 1",
+//             proxy.outbound_server.as_ref().unwrap().addr.port(),
+//         );
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
+
+//         // create a new client to force a new connection
+//         let client2 = client::new(proxy.outbound, "tele.test.svc.cluster.local");
+
+//         info!("client.get(/)");
+//         assert_eq!(client2.get("/").await, "hello");
+//         // server connection should be pooled
+//         assert_eventually_contains!(metrics.get("/metrics").await, &expected[..]);
+//     }
+
+//     #[tokio::test]
+//     async fn inbound_tcp_connect() {
+//         let _trace = trace_init();
+//         let TcpFixture {
+//             client,
+//             metrics,
+//             proxy: _proxy,
+//             dst: _dst,
+//             profile: _profile,
+//         } = TcpFixture::inbound().await;
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1");
+//     }
+
+//     #[tokio::test]
+//     #[cfg(target_os = "macos")]
+//     async fn inbound_tcp_connect_err() {
+//         let _trace = trace_init();
+//         let srv = tcp::server()
+//             .accept_fut(move |sock| {
+//                 drop(sock);
+//                 future::ok(())
+//             })
+//             .run()
+//             .await;
+//         let proxy = proxy::new().inbound(srv).run().await;
+
+//         let client = client::tcp(proxy.inbound);
+//         let metrics = client::http1(proxy.metrics, "localhost");
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, &[]);
+//         // Connection to the server should be a failure with the EXFULL error
+//         // code.
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"EXFULL\"} 1");
+//         // Connection from the client should have closed cleanly.
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1"
+//         );
+//     }
+
+//     #[test]
+//     #[cfg(target_os = "macos")]
+//     fn outbound_tcp_connect_err() {
+//         let _trace = trace_init();
+//         let srv = tcp::server()
+//             .accept_fut(move |sock| {
+//                 drop(sock);
+//                 future::ok(())
+//             })
+//             .run()
+//             .await;
+//         let proxy = proxy::new().outbound(srv).run().await;
+
+//         let client = client::tcp(proxy.outbound);
+//         let metrics = client::http1(proxy.metrics, "localhost");
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, &[]);
+//         // Connection to the server should be a failure with the EXFULL error
+//         // code.
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"EXFULL\"} 1");
+//         // Connection from the client should have closed cleanly.
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
+//     }
+
+//     #[tokio::test]
+//     async fn inbound_tcp_accept() {
+//         let _trace = trace_init();
+//         let TcpFixture {
+//             client,
+//             metrics,
+//             proxy: _proxy,
+//             dst: _dst,
+//             profile: _profile,
+//         } = TcpFixture::inbound().await;
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 1"
+//         );
+
+//         tcp_client.shutdown().await;
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1"
+//         );
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 2"
+//         );
+//         tcp_client.shutdown().await;
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 2"
+//         );
+//     }
+
+//     // linkerd/linkerd2#831
+//     #[tokio::test]
+//     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+//     async fn inbound_tcp_duration() {
+//         let _trace = trace_init();
+//         let TcpFixture {
+//             client,
+//             metrics,
+//             proxy: _proxy,
+//             dst: _dst,
+//             profile: _profile,
+//         } = TcpFixture::inbound().await;
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         tcp_client.shutdown().await;
+//         // TODO: make assertions about buckets
+//         let out = metrics.get("/metrics").await;
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1");
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         let out = metrics.get("/metrics").await;
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 1");
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
+
+//         tcp_client.shutdown().await;
+//         let out = metrics.get("/metrics").await;
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"inbound\",tls=\"disabled\",errno=\"\"} 2");
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2");
+//     }
+
+//     #[tokio::test]
+//     async fn inbound_tcp_write_bytes_total() {
+//         let _trace = trace_init();
+//         let TcpFixture {
+//             client,
+//             metrics,
+//             proxy: _proxy,
+//             dst: _dst,
+//             profile: _profile,
+//         } = TcpFixture::inbound().await;
+//         let src_expected = format!(
+//             "tcp_write_bytes_total{{peer=\"src\",direction=\"inbound\",tls=\"disabled\"}} {}",
+//             TcpFixture::BYE_MSG.len()
+//         );
+//         let dst_expected = format!(
+//             "tcp_write_bytes_total{{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
+//             TcpFixture::HELLO_MSG.len()
+//         );
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         tcp_client.shutdown().await;
+
+//         let out = metrics.get("/metrics").await;
+//         assert_eventually_contains!(out, &src_expected);
+//         assert_eventually_contains!(out, &dst_expected);
+//     }
+
+//     #[tokio::test]
+//     async fn inbound_tcp_read_bytes_total() {
+//         let _trace = trace_init();
+//         let TcpFixture {
+//             client,
+//             metrics,
+//             proxy: _proxy,
+//             dst: _dst,
+//             profile: _profile,
+//         } = TcpFixture::inbound().await;
+//         let src_expected = format!(
+//             "tcp_read_bytes_total{{peer=\"src\",direction=\"inbound\",tls=\"disabled\"}} {}",
+//             TcpFixture::HELLO_MSG.len()
+//         );
+//         let dst_expected = format!(
+//             "tcp_read_bytes_total{{peer=\"dst\",direction=\"inbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
+//             TcpFixture::BYE_MSG.len()
+//         );
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         tcp_client.shutdown().await;
+
+//         let out = metrics.get("/metrics").await;
+//         assert_eventually_contains!(out, &src_expected);
+//         assert_eventually_contains!(out, &dst_expected);
+//     }
+
+//     #[tokio::test]
+//     async fn outbound_tcp_connect() {
+//         let _trace = trace_init();
+//         let TcpFixture {
+//             client,
+//             metrics,
+//             proxy,
+//             dst: _dst,
+//             profile: _profile,
+//         } = TcpFixture::outbound().await;
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         let expected = format!(
+//             "tcp_open_total{{peer=\"dst\",authority=\"{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} 1",
+//             proxy.outbound_server.as_ref().unwrap().addr,
+//         );
+//         assert_eventually_contains!(metrics.get("/metrics").await, &expected);
+//     }
+
+//     #[tokio::test]
+//     async fn outbound_tcp_accept() {
+//         let _trace = trace_init();
+//         let TcpFixture {
+//             client,
+//             metrics,
+//             proxy: _proxy,
+//             dst: _dst,
+//             profile: _profile,
+//         } = TcpFixture::outbound().await;
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
+//         );
+
+//         tcp_client.shutdown().await;
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 2"
+//         );
+//         tcp_client.shutdown().await;
+//         assert_eventually_contains!(metrics.get("/metrics").await,
+//             "tcp_close_total{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2");
+//     }
+
+//     #[tokio::test]
+//     #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+//     async fn outbound_tcp_duration() {
+//         let _trace = trace_init();
+//         let TcpFixture {
+//             client,
+//             metrics,
+//             proxy: _proxy,
+//             dst: _dst,
+//             profile: _profile,
+//         } = TcpFixture::outbound().await;
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         tcp_client.shutdown().await;
+//         // TODO: make assertions about buckets
+//         let out = metrics.get("/metrics").await;
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"} 1");
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         let out = metrics.get("/metrics").await;
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 1");
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"} 1");
+
+//         tcp_client.shutdown().await;
+//         let out = metrics.get("/metrics").await;
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\",errno=\"\"} 2");
+//         assert_eventually_contains!(out,
+//             "tcp_connection_duration_ms_count{peer=\"dst\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\",errno=\"\"} 2");
+//     }
+
+//     #[tokio::test]
+//     async fn outbound_tcp_write_bytes_total() {
+//         let _trace = trace_init();
+//         let TcpFixture {
+//             client,
+//             metrics,
+//             proxy,
+//             dst: _dst,
+//             profile: _profile,
+//         } = TcpFixture::outbound().await;
+//         let src_expected = format!(
+//             "tcp_write_bytes_total{{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
+//             TcpFixture::BYE_MSG.len()
+//         );
+//         let dst_expected = format!(
+//             "tcp_write_bytes_total{{peer=\"dst\",authority=\"{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} {}",
+//             proxy.outbound_server.as_ref().unwrap().addr,
+//             TcpFixture::HELLO_MSG.len()
+//         );
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         tcp_client.shutdown().await;
+
+//         let out = metrics.get("/metrics").await;
+//         assert_eventually_contains!(out, &src_expected);
+//         assert_eventually_contains!(out, &dst_expected);
+//     }
+
+//     #[tokio::test]
+//     async fn outbound_tcp_read_bytes_total() {
+//         let _trace = trace_init();
+//         let TcpFixture {
+//             client,
+//             metrics,
+//             proxy,
+//             dst: _dst,
+//             profile: _profile,
+//         } = TcpFixture::outbound().await;
+
+//         let src_expected = format!(
+//             "tcp_read_bytes_total{{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"}} {}",
+//             TcpFixture::HELLO_MSG.len()
+//         );
+//         let dst_expected = format!(
+//             "tcp_read_bytes_total{{peer=\"dst\",authority=\"{}\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"not_provided_by_service_discovery\"}} {}",
+//             proxy.outbound_server.as_ref().unwrap().addr,
+//             TcpFixture::BYE_MSG.len()
+//         );
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         tcp_client.shutdown().await;
+
+//         let out = metrics.get("/metrics").await;
+//         assert_eventually_contains!(out, &src_expected);
+//         assert_eventually_contains!(out, &dst_expected);
+//     }
+
+//     #[tokio::test]
+//     async fn outbound_tcp_open_connections() {
+//         let _trace = trace_init();
+//         let fixture = TcpFixture::outbound().await;
+//         let client = fixture.client;
+//         let metrics = fixture.metrics;
+
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
+//         );
+//         tcp_client.shutdown().await;
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
+//         );
+//         let tcp_client = client.connect().await;
+
+//         tcp_client.write(TcpFixture::HELLO_MSG).await;
+//         assert_eq!(tcp_client.read().await, TcpFixture::BYE_MSG.as_bytes());
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
+//         );
+
+//         tcp_client.shutdown().await;
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
+//         );
+//     }
+
+//     #[tokio::test]
+//     async fn outbound_http_tcp_open_connections() {
+//         let _trace = trace_init();
+//         let Fixture {
+//             client,
+//             metrics,
+//             proxy,
+//             _profile,
+//             dst_tx: _dst_tx,
+//         } = Fixture::outbound().await;
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
+//         );
+//         // Shut down the client to force the connection to close.
+//         client.shutdown().await;
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
+//         );
+
+//         // create a new client to force a new connection
+//         let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
+
+//         info!("client.get(/)");
+//         assert_eq!(client.get("/").await, "hello");
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 1"
+//         );
+//         // Shut down the client to force the connection to close.
+//         client.shutdown().await;
+//         assert_eventually_contains!(
+//             metrics.get("/metrics").await,
+//             "tcp_open_connections{peer=\"src\",direction=\"outbound\",tls=\"no_identity\",no_tls_reason=\"loopback\"} 0"
+//         );
+//     }
+// }
+
+// // linkerd/linkerd2#613
+// #[tokio::test]
+// async fn metrics_compression() {
+//     let _trace = trace_init();
+
+//     let Fixture {
+//         client,
+//         metrics,
+//         proxy: _proxy,
+//         _profile,
+//         dst_tx: _dst_tx,
+//     } = Fixture::inbound().await;
+
+//     let do_scrape = |encoding: &str| {
+//         let req = metrics.request(
+//             metrics
+//                 .request_builder("/metrics")
+//                 .method("GET")
+//                 .header("Accept-Encoding", encoding),
+//         );
+
+//         let encoding = encoding.to_owned();
+//         async move {
+//             let resp = req.await.expect("scrape");
+
+//             {
+//                 // create a new scope so we can release our borrow on `resp` before
+//                 // getting the body
+//                 let content_encoding = resp.headers().get("content-encoding").as_ref().map(|val| {
+//                     val.to_str()
+//                         .expect("content-encoding value should be ascii")
+//                 });
+//                 assert_eq!(
+//                     content_encoding,
+//                     Some("gzip"),
+//                     "unexpected Content-Encoding {:?} (requested Accept-Encoding: {})",
+//                     content_encoding,
+//                     encoding.as_str()
+//                 );
+//             }
+
+//             let mut body = hyper::body::aggregate(resp.into_body())
+//                 .await
+//                 .expect("response body concat");
+//             let mut decoder = flate2::read::GzDecoder::new(std::io::Cursor::new(
+//                 body.copy_to_bytes(body.remaining()),
+//             ));
+//             let mut scrape = String::new();
+//             decoder.read_to_string(&mut scrape).unwrap_or_else(|_| {
+//                 panic!("decode gzip (requested Accept-Encoding: {})", encoding)
+//             });
+//             scrape
+//         }
+//     };
+
+//     let encodings = &[
+//         "gzip",
+//         "deflate, gzip",
+//         "gzip,deflate",
+//         "brotli,gzip,deflate",
+//     ];
+
+//     info!("client.get(/)");
+//     assert_eq!(client.get("/").await, "hello");
+
+//     for &encoding in encodings {
+//         assert_eventually_contains!(do_scrape(encoding).await,
+//             "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 1");
+//     }
+
+//     info!("client.get(/)");
+//     assert_eq!(client.get("/").await, "hello");
+
+//     for &encoding in encodings {
+//         assert_eventually_contains!(do_scrape(encoding).await,
+//             "response_latency_ms_count{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\"} 2");
+//     }
+// }

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1338,10 +1338,12 @@ async fn retry_reconnect_errors() {
 
     // wait until metrics has seen our connection, this can be flaky depending on
     // all the other threads currently running...
-    assert_eventually_contains!(
-        metrics.get("/metrics").await,
-        "tcp_open_total{peer=\"src\",direction=\"inbound\",tls=\"disabled\"} 1"
-    );
+    let metric = metrics::metric("tcp_open_total")
+        .with_label("peer", "src")
+        .with_label("direction", "inbound")
+        .with_label("tls", "disabled")
+        .with_value(1);
+    assert_eventually_contains!(metrics.get("/metrics").await, metric);
 
     drop(tx); // start `listen` now
               // This may be flaky on CI.

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1338,12 +1338,13 @@ async fn retry_reconnect_errors() {
 
     // wait until metrics has seen our connection, this can be flaky depending on
     // all the other threads currently running...
-    let metric = metrics::metric("tcp_open_total")
-        .with_label("peer", "src")
-        .with_label("direction", "inbound")
-        .with_label("tls", "disabled")
-        .with_value(1);
-    assert_eventually_contains!(metrics.get("/metrics").await, metric);
+    metrics::metric("tcp_open_total")
+        .label("peer", "src")
+        .label("direction", "inbound")
+        .label("tls", "disabled")
+        .value(1u64)
+        .assert_in(&metrics)
+        .await;
 
     drop(tx); // start `listen` now
               // This may be flaky on CI.


### PR DESCRIPTION
This branch changes the metrics integration tests so that we no longer
make assertions about metrics by searching the entire metrics scrape for
a specific string. Instead, we now have a simple builder API for
constructing a type that tries to parse the metrics scrape to find
individual metrics with certain label combinations and/or values.

Advantages of the new approach include:
- it's not ordering dependent --- changing the label ordering doesn't
  change whether or not the match succeeds. for example, changes
  like #856 won't break the tests.
- the presence of *additional* labels doesn't break the assertions
  (although we may want to add an "exact" matching mode in case we
  *do* want to assert that other labels are not present).
- metrics can easily be matched with and without values
- the failure reporting is *much* better. when the scrape doesn't
  contain the required metric, we can now report the metric we wanted
  in a nicely formatted way, and show only a list of the "similar"
  metrics that were found. with the previous code, panics included the
  entire metrics scrape, which was very hard to read and debug.

This should make it much easier to modify the tests to add new metric
labels or add existing ones, since we no longer depend on specific
hard-coded strings, but are instead making assertions about the
properties we actually want to find.

Example of the new errors:

```
thread 'tests::telemetry::response_classification::inbound_http' panicked at 'did not find a `response_total` metric
  with labels: ["authority=\"tele.test.svc.cluster.local\"", "direction=\"inbound\"", "tls=\"disabled\"", "status_code=\"200 OK\"", "classification=\"success\""]
found metrics: [
    "response_total{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"200\",classification=\"success\"} 1",
    "response_total{authority=\"tele.test.svc.cluster.local\",direction=\"inbound\",tls=\"disabled\",status_code=\"304\",classification=\"success\"} 1",
]
  retried 5 times (73.314652ms)', linkerd/app/integration/src/metrics.rs:128:51
stack backtrace:
    ... snip ...
```

These *could* probably be improved even more, for example, by
highlighting the specific label that was missing. However, this felt
like a pretty significant improvement for a first pass.

In a follow-up, I'll also reduce some of the code duplication between
the tests that are repeated for inbound and outbound. While working
on this change, I found that modifying the tests was much harder since
almost all of them were duplicated on the inbound and outbound halves
of the proxy. I'll merge that in a separate PR to reduce the size of
this diff, though.