### PR TITLE
inbound: Handle direct connections with a dedicated stack

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -132,6 +132,7 @@ impl Config {
         // 1. Protocol detection is always performed;
         // 2. TLS is required;
         // 3. A transport header is expected. It's not strictly required, as
+        //    gateways may need to accept HTTP requests from older proxy versions.
         let direct = {
             let http = svc::stack(http_loopback)
                 .push_on_response(

--- a/linkerd/app/inbound/src/prevent_loop.rs
+++ b/linkerd/app/inbound/src/prevent_loop.rs
@@ -1,5 +1,4 @@
 use crate::TcpEndpoint;
-//use futures::future;
 use linkerd_app_core::{
     svc::stack::{Predicate, Switch},
     transport::listen::Addrs,

--- a/linkerd/app/inbound/src/prevent_loop.rs
+++ b/linkerd/app/inbound/src/prevent_loop.rs
@@ -1,5 +1,10 @@
+use crate::TcpEndpoint;
 //use futures::future;
-use linkerd_app_core::{svc::stack::Predicate, svc::stack::Switch, Error};
+use linkerd_app_core::{
+    svc::stack::{Predicate, Switch},
+    transport::listen::Addrs,
+    Error,
+};
 
 /// A connection policy that drops
 #[derive(Copy, Clone, Debug)]
@@ -18,29 +23,21 @@ impl From<u16> for PreventLoop {
     }
 }
 
-impl<T> Predicate<T> for PreventLoop
-where
-    for<'t> &'t T: Into<std::net::SocketAddr>,
-{
-    type Request = T;
+impl Predicate<TcpEndpoint> for PreventLoop {
+    type Request = TcpEndpoint;
 
-    fn check(&mut self, t: T) -> Result<T, Error> {
-        let addr = (&t).into();
-        tracing::debug!(%addr, self.port);
-        if addr.port() == self.port {
-            return Err(LoopPrevented { port: self.port }.into());
+    fn check(&mut self, t: TcpEndpoint) -> Result<TcpEndpoint, Error> {
+        if t.port == self.port {
+            Err(LoopPrevented { port: t.port }.into())
+        } else {
+            Ok(t)
         }
-
-        Ok(t)
     }
 }
 
-impl<T> Switch<T> for PreventLoop
-where
-    for<'t> &'t T: Into<std::net::SocketAddr>,
-{
-    fn use_primary(&self, target: &T) -> bool {
-        let addr = target.into();
+impl Switch<Addrs> for PreventLoop {
+    fn use_primary(&self, addrs: &Addrs) -> bool {
+        let addr = addrs.target_addr();
         tracing::debug!(%addr, self.port);
         addr.port() != self.port
     }

--- a/linkerd/app/inbound/src/require_identity.rs
+++ b/linkerd/app/inbound/src/require_identity.rs
@@ -3,11 +3,13 @@ use indexmap::IndexSet;
 use linkerd_app_core::{svc::stack::Predicate, Conditional, Error};
 use std::sync::Arc;
 
-/// A connection policy that drops
+/// A connection policy that fails direct connections that don't have a client
+/// identity.
 #[derive(Clone, Debug)]
 pub struct RequireIdentityForDirect;
 
-/// A connection policy that drops
+/// A connection policy that fails connections that don't have a client identity
+/// if they target one of the configured local ports.
 #[derive(Clone, Debug)]
 pub struct RequireIdentityForPorts {
     ports: Arc<IndexSet<u16>>,

--- a/linkerd/app/inbound/src/require_identity.rs
+++ b/linkerd/app/inbound/src/require_identity.rs
@@ -26,10 +26,9 @@ impl Predicate<TcpAccept> for RequireIdentityForDirect {
     fn check(&mut self, meta: TcpAccept) -> Result<TcpAccept, Error> {
         tracing::debug!(client.id = ?meta.client_id);
         match meta.client_id {
-            Conditional::Some(Some(_)) => {}
-            _ => return Err(IdentityRequired(()).into()),
+            Conditional::Some(Some(_)) => Ok(meta),
+            _ => Err(IdentityRequired(()).into()),
         }
-        Ok(meta)
     }
 }
 
@@ -51,14 +50,10 @@ impl Predicate<TcpAccept> for RequireIdentityForPorts {
         let id_required = self.ports.contains(&port);
 
         tracing::debug!(%port, client.id = ?meta.client_id, %id_required);
-        if id_required {
-            match meta.client_id {
-                Conditional::Some(Some(_)) => {}
-                _ => return Err(IdentityRequired(()).into()),
-            }
+        match meta.client_id {
+            Conditional::Some(Some(_)) if id_required => Ok(meta),
+            _ => Err(IdentityRequired(()).into()),
         }
-
-        Ok(meta)
     }
 }
 

--- a/linkerd/app/inbound/src/require_identity.rs
+++ b/linkerd/app/inbound/src/require_identity.rs
@@ -50,9 +50,13 @@ impl Predicate<TcpAccept> for RequireIdentityForPorts {
         let id_required = self.ports.contains(&port);
 
         tracing::debug!(%port, client.id = ?meta.client_id, %id_required);
-        match meta.client_id {
-            Conditional::Some(Some(_)) if id_required => Ok(meta),
-            _ => Err(IdentityRequired(()).into()),
+        if id_required {
+            match meta.client_id {
+                Conditional::Some(Some(_)) => Ok(meta),
+                _ => Err(IdentityRequired(()).into()),
+            }
+        } else {
+            Ok(meta)
         }
     }
 }

--- a/linkerd/app/inbound/src/require_identity.rs
+++ b/linkerd/app/inbound/src/require_identity.rs
@@ -1,7 +1,11 @@
 use crate::target::TcpAccept;
 use indexmap::IndexSet;
-use linkerd_app_core::{svc::stack::Predicate, Error};
+use linkerd_app_core::{svc::stack::Predicate, Conditional, Error};
 use std::sync::Arc;
+
+/// A connection policy that drops
+#[derive(Clone, Debug)]
+pub struct RequireIdentityForDirect;
 
 /// A connection policy that drops
 #[derive(Clone, Debug)]
@@ -11,6 +15,23 @@ pub struct RequireIdentityForPorts {
 
 #[derive(Debug)]
 pub struct IdentityRequired(());
+
+// === impl RequireIdentityForDirect ===
+
+impl Predicate<TcpAccept> for RequireIdentityForDirect {
+    type Request = TcpAccept;
+
+    fn check(&mut self, meta: TcpAccept) -> Result<TcpAccept, Error> {
+        tracing::debug!(client.id = ?meta.client_id);
+        match meta.client_id {
+            Conditional::Some(Some(_)) => {}
+            _ => return Err(IdentityRequired(()).into()),
+        }
+        Ok(meta)
+    }
+}
+
+// === impl RequireIdentityForPorts ===
 
 impl<T: IntoIterator<Item = u16>> From<T> for RequireIdentityForPorts {
     fn from(ports: T) -> Self {
@@ -27,14 +48,19 @@ impl Predicate<TcpAccept> for RequireIdentityForPorts {
         let port = meta.target_addr.port();
         let id_required = self.ports.contains(&port);
 
-        tracing::debug!(%port, peer.id = ?meta.client_id, %id_required);
-        if id_required && meta.client_id.is_none() {
-            return Err(IdentityRequired(()).into());
+        tracing::debug!(%port, client.id = ?meta.client_id, %id_required);
+        if id_required {
+            match meta.client_id {
+                Conditional::Some(Some(_)) => {}
+                _ => return Err(IdentityRequired(()).into()),
+            }
         }
 
         Ok(meta)
     }
 }
+
+// === impl IdentityRequired ===
 
 impl std::fmt::Display for IdentityRequired {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Currently, the inbound proxy handles direct connections--connections
where the original destination is the inbound proxy port--in two places.
TCP forwarding is handled distinctly from HTTP forwarding (for
gateways).

This change modifies the inbound proxy to dispatch these connections to
a dedicated `direct` stack that does its own protocol detection and
routing.

This sets up to (1) modify the server to configure ALPN on only these
connections and (2) support transport-header-based gateway routing.