### PR TITLE
metrics: add `target_addr` labels to HTTP metrics

### DIFF
--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -12,6 +12,7 @@ use linkerd_addr::Addr;
 use linkerd_metrics::FmtLabels;
 pub use linkerd_metrics::*;
 use std::fmt::{self, Write};
+use std::net::SocketAddr;
 use std::time::{Duration, SystemTime};
 
 pub type ControlHttp = http_metrics::Requests<ControlLabels, Class>;
@@ -58,6 +59,7 @@ pub enum EndpointLabels {
 pub struct InboundEndpointLabels {
     pub client_id: tls::server::ConditionalTls,
     pub authority: Option<http::uri::Authority>,
+    pub target_addr: SocketAddr,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -65,6 +67,7 @@ pub struct OutboundEndpointLabels {
     pub server_id: tls::ConditionalServerId,
     pub authority: Option<http::uri::Authority>,
     pub labels: Option<String>,
+    pub target_addr: SocketAddr,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -266,6 +269,8 @@ impl FmtLabels for InboundEndpointLabels {
             write!(f, ",")?;
         }
 
+        write!(f, "target_addr=\"{}\"", self.target_addr)?;
+
         TlsAccept::from(&self.client_id).fmt_labels(f)?;
 
         Ok(())
@@ -278,6 +283,8 @@ impl FmtLabels for OutboundEndpointLabels {
             Authority(a).fmt_labels(f)?;
             write!(f, ",")?;
         }
+
+        write!(f, "target_addr=\"{}\"", self.target_addr)?;
 
         TlsConnect::from(&self.server_id).fmt_labels(f)?;
 

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -269,7 +269,7 @@ impl FmtLabels for InboundEndpointLabels {
             write!(f, ",")?;
         }
 
-        write!(f, "target_addr=\"{}\"", self.target_addr)?;
+        write!(f, "target_addr=\"{}\",", self.target_addr)?;
 
         TlsAccept::from(&self.client_id).fmt_labels(f)?;
 
@@ -284,7 +284,7 @@ impl FmtLabels for OutboundEndpointLabels {
             write!(f, ",")?;
         }
 
-        write!(f, "target_addr=\"{}\"", self.target_addr)?;
+        write!(f, "target_addr=\"{}\",", self.target_addr)?;
 
         TlsConnect::from(&self.server_id).fmt_labels(f)?;
 

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -185,6 +185,7 @@ impl Into<metrics::EndpointLabels> for &'_ Target {
         metrics::InboundEndpointLabels {
             client_id: self.client_id.clone(),
             authority: self.dst.name_addr().map(|d| d.as_http_authority()),
+            target_addr: self.target_addr,
         }
         .into()
     }

--- a/linkerd/app/integration/src/metrics.rs
+++ b/linkerd/app/integration/src/metrics.rs
@@ -227,6 +227,17 @@ impl Labels {
         self
     }
 
+    /// Return a new `Labels` consisting of all the labels in `self` plus all
+    /// the labels in `other`.
+    ///
+    /// If `other` defines values for labels that are also defined in `self`,
+    /// the values from `other` overwrite the values in `self`.
+    pub fn and(&self, other: Labels) -> Labels {
+        let mut new_labels = self.0.clone();
+        new_labels.extend(other.0.into_iter());
+        Labels(new_labels)
+    }
+
     pub fn metric(&self, name: impl Into<String>) -> MetricMatch {
         MetricMatch {
             labels: self.0.clone(),

--- a/linkerd/app/integration/src/metrics.rs
+++ b/linkerd/app/integration/src/metrics.rs
@@ -121,6 +121,12 @@ impl MetricMatch {
                         );
                     }
 
+                    // Ignore the quotation marks on either side of the value
+                    // when comparing it against the expected value. We just
+                    // checked that there are quotation marks, on both sides, so
+                    // we know the first and last chars are quotes.
+                    let value = &value[1..value.len() - 1];
+
                     if let Some(expected_value) = self.labels.get(key) {
                         if expected_value != value {
                             tracing::trace!(key, value, ?expected_value, "label is not a match!");

--- a/linkerd/app/outbound/src/tcp/opaque_transport.rs
+++ b/linkerd/app/outbound/src/tcp/opaque_transport.rs
@@ -114,6 +114,7 @@ mod test {
     fn ep(metadata: Metadata) -> Endpoint<()> {
         Endpoint {
             addr: ([127, 0, 0, 2], 4321).into(),
+            target_addr: ([127, 0, 0, 2], 4321).into(),
             identity: Conditional::None(tls::NoServerId::NotProvidedByServiceDiscovery),
             metadata,
             concrete: Concrete {


### PR DESCRIPTION
This branch builds on #861 and adds `target_addr` labels to HTTP metrics
as well as transport metrics. These labels contain a string
representation of the original destination address of the connection on
which that request was sent.

Additionally, I've made some more improvements to the metrics tests:
after the test code failed to catch a missing commma in labels, I
changed the metrics matching code to check that the metric is correctly
formatted, as well as containing the expected labels and values.
Furthermore, after rebasing onto `main` made some labels in tests added
in this PR incorrect, I modified the tests so that a majority of the
expected labels are defined in a single place by the text fuxtures,
since they don't actually differ between tests.