### PR TITLE
admin: stackify admin server

### DIFF
--- a/linkerd/app/core/src/admin/mod.rs
+++ b/linkerd/app/core/src/admin/mod.rs
@@ -1,7 +1,14 @@
-//! Serves an HTTP/1.1. admin server.
+//! Serves an HTTP admin server.
 //!
-//! * `/metrics` -- reports prometheus-formatted metrics.
-//! * `/ready` -- returns 200 when the proxy is ready to participate in meshed traffic.
+//! * `GET /metrics` -- reports prometheus-formatted metrics.
+//! * `GET /ready` -- returns 200 when the proxy is ready to participate in meshed
+//!   traffic.
+//! * `GET /live` -- returns 200 when the proxy is live.
+//! * `GET /proxy-log-level` -- returns the current proxy tracing filter.
+//! * `PUT /proxy-log-level` -- sets a new tracing filter.
+//! * `GET /tasks` -- returns a dump of spawned Tokio tasks (when enabled by the
+//!   tracing configuration).
+//! * `POST /shutdown` -- shuts down the proxy.
 
 use crate::{proxy::http::ClientHandle, svc, trace};
 use futures::future;

--- a/linkerd/app/core/src/admin/mod.rs
+++ b/linkerd/app/core/src/admin/mod.rs
@@ -3,15 +3,13 @@
 //! * `/metrics` -- reports prometheus-formatted metrics.
 //! * `/ready` -- returns 200 when the proxy is ready to participate in meshed traffic.
 
-use crate::{
-    io,
-    proxy::http::{ClientHandle, SetClientHandle},
-    svc, tls, trace,
-    transport::listen::Addrs,
-};
+use crate::{proxy::http::ClientHandle, svc, trace};
 use futures::future;
 use http::StatusCode;
-use hyper::{Body, Request, Response};
+use hyper::{
+    body::{Body, HttpBody},
+    Request, Response,
+};
 use linkerd_error::{Error, Never};
 use linkerd_metrics::{self as metrics, FmtMetrics};
 use std::{
@@ -35,15 +33,15 @@ pub struct Admin<M> {
 }
 
 #[derive(Clone)]
-pub struct Accept<M> {
-    service: Admin<M>,
+pub struct Accept<S> {
+    service: S,
     server: hyper::server::conn::Http,
 }
 
 #[derive(Clone)]
-pub struct Serve<M> {
+pub struct Serve<S> {
     client_addr: SocketAddr,
-    inner: Accept<M>,
+    inner: S,
 }
 
 pub type ResponseFuture =
@@ -61,13 +59,6 @@ impl<M> Admin<M> {
             ready,
             shutdown_tx,
             tracing,
-        }
-    }
-
-    pub fn into_accept(self) -> Accept<M> {
-        Accept {
-            service: self,
-            server: hyper::server::conn::Http::new(),
         }
     }
 
@@ -148,7 +139,20 @@ impl<M> Admin<M> {
     }
 }
 
-impl<M: FmtMetrics> tower::Service<http::Request<Body>> for Admin<M> {
+impl<M: FmtMetrics + Clone, T> svc::NewService<T> for Admin<M> {
+    type Service = Self;
+    fn new_service(&mut self, _: T) -> Self::Service {
+        self.clone()
+    }
+}
+
+impl<M, B> tower::Service<http::Request<B>> for Admin<M>
+where
+    M: FmtMetrics,
+    B: HttpBody + Send + Sync + 'static,
+    B::Error: Into<Error>,
+    B::Data: Send,
+{
     type Response = http::Response<Body>;
     type Error = Never;
     type Future = ResponseFuture;
@@ -157,7 +161,7 @@ impl<M: FmtMetrics> tower::Service<http::Request<Body>> for Admin<M> {
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
+    fn call(&mut self, req: Request<B>) -> Self::Future {
         match req.uri().path() {
             "/live" => Box::pin(future::ok(Self::live_rsp())),
             "/ready" => Box::pin(future::ok(self.ready_rsp())),
@@ -207,51 +211,6 @@ impl<M: FmtMetrics> tower::Service<http::Request<Body>> for Admin<M> {
             }
             _ => Box::pin(future::ok(Self::not_found())),
         }
-    }
-}
-
-impl<M: Clone> svc::NewService<tls::server::Meta<Addrs>> for Accept<M> {
-    type Service = Serve<M>;
-
-    fn new_service(&mut self, (_, addrs): tls::server::Meta<Addrs>) -> Self::Service {
-        Serve {
-            client_addr: addrs.peer(),
-            inner: self.clone(),
-        }
-    }
-}
-
-impl<I, M> svc::Service<I> for Serve<M>
-where
-    I: io::AsyncRead + io::AsyncWrite + Send + Unpin + 'static,
-    M: FmtMetrics + Clone + Send + 'static,
-{
-    type Response = ();
-    type Error = Error;
-    type Future = Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'static>>;
-
-    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, io: I) -> Self::Future {
-        // Since the `/proxy-log-level` controls access based on the
-        // client's IP address, we wrap the service with a new service
-        // that adds the remote IP as a request extension.
-        let (svc, closed) = SetClientHandle::new(self.client_addr, self.inner.service.clone());
-        let mut conn = self.inner.server.serve_connection(io, svc);
-
-        Box::pin(async move {
-            tokio::select! {
-                res = &mut conn => res?,
-                () = closed => {
-                    Pin::new(&mut conn).graceful_shutdown();
-                    conn.await?;
-                }
-            }
-
-            Ok(())
-        })
     }
 }
 

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -14,7 +14,7 @@ use futures::{future, FutureExt, TryFutureExt};
 pub use linkerd_app_core::{self as core, metrics, trace};
 use linkerd_app_core::{control::ControlAddr, dns, drain, proxy::http, serve, svc, Error};
 use linkerd_app_gateway as gateway;
-use linkerd_app_inbound as inbound;
+pub(crate) use linkerd_app_inbound as inbound;
 use linkerd_app_outbound as outbound;
 use linkerd_channel::into_stream::IntoStream;
 use std::{net::SocketAddr, pin::Pin};

--- a/linkerd/metrics/src/serve.rs
+++ b/linkerd/metrics/src/serve.rs
@@ -33,7 +33,7 @@ impl<M> Serve<M> {
 }
 
 impl<M: FmtMetrics> Serve<M> {
-    pub fn serve(&self, req: http::Request<Body>) -> std::io::Result<http::Response<Body>> {
+    pub fn serve<B>(&self, req: http::Request<B>) -> std::io::Result<http::Response<Body>> {
         if Self::is_gzip(&req) {
             trace!("gzipping metrics");
             let mut writer = GzEncoder::new(Vec::<u8>::new(), CompressionOptions::fast());

--- a/linkerd/tracing/src/level.rs
+++ b/linkerd/tracing/src/level.rs
@@ -1,4 +1,4 @@
-use hyper::{body::Buf, Body};
+use hyper::body::{Body, Buf, HttpBody};
 use linkerd_error::Error;
 use std::{io, str};
 use tracing::{trace, warn};
@@ -12,10 +12,14 @@ impl Handle {
         Self(handle)
     }
 
-    pub(crate) async fn serve(
+    pub(crate) async fn serve<B>(
         &self,
-        req: http::Request<Body>,
-    ) -> Result<http::Response<Body>, Error> {
+        req: http::Request<B>,
+    ) -> Result<http::Response<Body>, Error>
+    where
+        B: HttpBody,
+        B::Error: Into<Error>,
+    {
         match *req.method() {
             http::Method::GET => {
                 let level = self.current()?;

--- a/linkerd/tracing/src/tasks.rs
+++ b/linkerd/tracing/src/tasks.rs
@@ -9,7 +9,7 @@ pub(crate) struct Handle {
 }
 
 impl Handle {
-    pub(crate) fn serve(&self, req: http::Request<Body>) -> Result<http::Response<Body>, Error> {
+    pub(crate) fn serve<B>(&self, req: http::Request<B>) -> Result<http::Response<Body>, Error> {
         tracing::debug!("dumping tasks...");
         if accept_json(&req) {
             let body = self.render_json()?;


### PR DESCRIPTION
This branch refactors the proxy admin endpoint to build a server stack
using the same primitives used for the proxy servers. This is intended
primarily to allow us to easily add metrics to the admin server by just
slotting in the existing proxy metrics layers.

This change also has some side benefits:

* We now reuse more existing code for building the admin server, rather
  than writing separate versions of our accept & serve HTTP code
  specifically for admin,
* We now support HTTP/2 for the admin server :)