### PR TITLE
admin: add metrics

### DIFF
--- a/linkerd/app/core/src/admin/mod.rs
+++ b/linkerd/app/core/src/admin/mod.rs
@@ -17,7 +17,7 @@ use hyper::{
     body::{Body, HttpBody},
     Request, Response,
 };
-use linkerd_error::{Error, Never};
+use linkerd_error::Error;
 use linkerd_metrics::{self as metrics, FmtMetrics};
 use std::{
     future::Future,
@@ -52,7 +52,7 @@ pub struct Serve<S> {
 }
 
 pub type ResponseFuture =
-    Pin<Box<dyn Future<Output = Result<Response<Body>, Never>> + Send + 'static>>;
+    Pin<Box<dyn Future<Output = Result<Response<Body>, Error>> + Send + 'static>>;
 
 impl<M> Admin<M> {
     pub fn new(
@@ -161,7 +161,7 @@ where
     B::Data: Send,
 {
     type Response = http::Response<Body>;
-    type Error = Never;
+    type Error = Error;
     type Future = ResponseFuture;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/linkerd/app/integration/src/client.rs
+++ b/linkerd/app/integration/src/client.rs
@@ -207,6 +207,10 @@ impl Client {
             tls,
         }
     }
+
+    pub fn target_addr(&self) -> SocketAddr {
+        self.addr
+    }
 }
 
 impl Reconnect {

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -194,24 +194,15 @@ impl TcpFixture {
 async fn metrics_endpoint_admin_request_count() {
     let fixture = Fixture::inbound().await;
     let metrics = fixture.metrics;
-    let mut metric = metrics::metric("request_total")
+    let metric = metrics::metric("request_total")
         .label("direction", "inbound")
         .label("tls", "disabled")
         .label("target_addr", metrics.target_addr())
-        .label("path", "/ready")
         .value(1usize);
 
-    assert!(metric.is_not_in(metrics.get("/metrics").await));
-
-    info!("GET /ready");
-    metrics.get("/ready").await;
-
+    // We can't assert that the metric is not present, since `GET /metrics`
+    // will bump the request count, lol
     metric.assert_in(&metrics).await;
-
-    info!("GET /ready");
-    metrics.get("/ready").await;
-
-    metric.set_value(2usize).assert_in(&metrics).await;
 }
 
 #[tokio::test]

--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -51,11 +51,6 @@ impl Config {
                 svc::layers()
                     .push(metrics.http_errors.clone())
                     .push(errors::layer())
-                    .push(
-                        metrics
-                            .stack
-                            .layer(metrics::StackLabels::inbound("http", "admin")),
-                    )
                     .push(http::BoxResponse::layer()),
             )
             .push(svc::stack::MapTargetLayer::new(|(http_version, tcp)| {

--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -51,6 +51,11 @@ impl Config {
                 svc::layers()
                     .push(metrics.http_errors.clone())
                     .push(errors::layer())
+                    .push(
+                        metrics
+                            .stack
+                            .layer(metrics::StackLabels::inbound("http", "admin")),
+                    )
                     .push(http::BoxResponse::layer()),
             )
             .push(svc::stack::MapTargetLayer::new(|(http_version, tcp)| {

--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -60,15 +60,13 @@ impl Config {
             )
             .push(svc::stack::MapTargetLayer::new(|(http_version, tcp)| {
                 let inbound::TcpAccept {
-                    target_addr,
-                    client_id,
-                    ..
+                    target_addr, tls, ..
                 } = tcp;
                 inbound::Target {
                     dst: Addr::Socket(target_addr),
                     target_addr,
                     http_version,
-                    client_id,
+                    tls,
                 }
             }))
             .push(http::NewServeHttp::layer(Default::default(), drain.clone()))

--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -74,6 +74,7 @@ impl Config {
                 DETECT_TIMEOUT,
                 http::DetectHttp::default(),
             ))
+            .push(metrics.transport.layer_accept())
             .push_map_target(inbound::TcpAccept::from)
             .check_new_clone::<tls::server::Meta<listen::Addrs>>()
             .push(tls::NewDetectTls::layer(identity, DETECT_TIMEOUT))

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -124,8 +124,10 @@ impl Config {
         let admin = {
             let identity = identity.local();
             let drain = drain_rx.clone();
-            info_span!("admin")
-                .in_scope(move || admin.build(identity, report, log_level, drain, shutdown_tx))?
+            let metrics = metrics.inbound.clone();
+            info_span!("admin").in_scope(move || {
+                admin.build(identity, report, metrics, log_level, drain, shutdown_tx)
+            })?
         };
 
         let dst_addr = dst.addr.clone();


### PR DESCRIPTION
This PR adds HTTP request/response, transport, and stack metrics for the
admin server to the proxy's inbound metrics. The `target_addr` labels
added in #861 and #866 disambiguate these metrics from other inbound
metrics.

I've also added new tests for admin server metrics.

Since the admin server serves a known set of HTTP paths, I'd like to add
per-path metrics to the admin metrics as well. We could do this by using
the existing service profiles code to add profile metrics to the admin
server with a hard-coded service profile. As this is probably a bigger
change, I'll work on this in a follow-up branch.