### PR TITLE
test: Disable tracing-subscriber by default

### DIFF
--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -9,6 +9,10 @@ description = """
 Configures and runs the outbound proxy
 """
 
+[features]
+default = []
+test-subscriber = []
+
 [dependencies]
 bytes = "1"
 http = "0.2"

--- a/linkerd/app/outbound/src/tcp/opaque_transport.rs
+++ b/linkerd/app/outbound/src/tcp/opaque_transport.rs
@@ -130,6 +130,7 @@ mod test {
 
     #[tokio::test(flavor = "current_thread")]
     async fn plain() {
+        #[cfg(feature = "test-subscriber")]
         let _ = tracing_subscriber::fmt().with_test_writer().try_init();
 
         let svc = OpaqueTransport {
@@ -149,6 +150,7 @@ mod test {
 
     #[tokio::test(flavor = "current_thread")]
     async fn opaque_no_name() {
+        #[cfg(feature = "test-subscriber")]
         let _ = tracing_subscriber::fmt().with_test_writer().try_init();
 
         let svc = OpaqueTransport {
@@ -181,6 +183,7 @@ mod test {
 
     #[tokio::test(flavor = "current_thread")]
     async fn opaque_named_with_port() {
+        #[cfg(feature = "test-subscriber")]
         let _ = tracing_subscriber::fmt().with_test_writer().try_init();
 
         let svc = OpaqueTransport {
@@ -213,6 +216,7 @@ mod test {
 
     #[tokio::test(flavor = "current_thread")]
     async fn opaque_named_no_port() {
+        #[cfg(feature = "test-subscriber")]
         let _ = tracing_subscriber::fmt().with_test_writer().try_init();
 
         let svc = OpaqueTransport {


### PR DESCRIPTION
When running tests, we encounter panics like:

```
tcache_thread_shutdown(): unaligned tcache chunk detected
```

Disabling tracing-subscriber eliminates these panics. This change
disables the tracing subscriber for these tests until the underlying
issue is resolved.