### PR TITLE
Improve diagnostics around the SwitchReady module

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -182,8 +182,8 @@ impl<S> Stack<S> {
     /// for the `skip_after` duration.
     pub fn push_when_unready<B: Clone>(
         self,
-        secondary: B,
         skip_after: Duration,
+        secondary: B,
     ) -> Stack<stack::NewSwitchReady<S, B>> {
         self.push(layer::mk(|inner: S| {
             stack::NewSwitchReady::new(inner, secondary.clone(), skip_after)

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -312,11 +312,17 @@ impl Config {
             .push_on_response(http::BoxResponse::layer())
             .instrument(|_: &Target| debug_span!("profile"))
             // Skip the profile stack if it takes too long to become ready.
-            .push_when_unready(target.clone(), self.profile_idle_timeout)
+            .push_on_response(svc::layer::mk(svc::SpawnReady::new))
+            .push_when_unready(
+                self.profile_idle_timeout,
+                target
+                    .clone()
+                    .push_on_response(svc::layer::mk(svc::SpawnReady::new))
+                    .into_inner(),
+            )
             .check_new_service::<Target, http::Request<http::BoxBody>>()
             .push_on_response(
                 svc::layers()
-                    .push(svc::layer::mk(svc::SpawnReady::new))
                     .push(svc::FailFast::layer(
                         "HTTP Logical",
                         self.proxy.dispatch_timeout,


### PR DESCRIPTION
The `SpawnReady` module is used by the inbound stack to short-circuit
the profile stack when resolutions are not forthcoming (i.e. because the
destination service is unavailable).

This changes the module as follows:

- Logs about important state transitions are now emitted at DEBUG
  instead of TRACE;
- The poll_ready function has been restructured for clarity,
  including additional comments;
- When an error is encountered while waiting, the state transitions back
  to primary. Errors are always terminal for `poll_ready`;
- The module's tests have been updated to use `time:pause`;
- The error-propagation test has been split into two tests because it's
  not appropriate to continue polling the service after an error; and
- Finally, the inbound HTTP logical stack has been modified so that the
  both the primary and secondary services are instrumented with
  `SpawnReady`, so that each service may be driven to readiness
  independently.