### PR TITLE
profiles: Use a LogicalAddr param type

### DIFF
--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -153,9 +153,9 @@ pub(super) fn route((route, logical): (profiles::http::Route, Logical)) -> dst::
 
 // === impl Target ===
 
-impl Param<profiles::Logical> for Target {
-    fn param(&self) -> profiles::Logical {
-        profiles::Logical(self.dst.clone())
+impl Param<profiles::LogicalAddr> for Target {
+    fn param(&self) -> profiles::LogicalAddr {
+        profiles::LogicalAddr(self.dst.clone())
     }
 }
 

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -153,23 +153,9 @@ pub(super) fn route((route, logical): (profiles::http::Route, Logical)) -> dst::
 
 // === impl Target ===
 
-/// Used for profile discovery.
-impl Param<Addr> for Target {
-    fn param(&self) -> Addr {
-        self.dst.clone()
-    }
-}
-
-/// Used for profile discovery.
-impl Param<SocketAddr> for Target {
-    fn param(&self) -> SocketAddr {
-        self.target_addr
-    }
-}
-
-impl Param<tls::ConditionalClientTls> for Target {
-    fn param(&self) -> tls::ConditionalClientTls {
-        Conditional::None(tls::NoClientTls::Loopback)
+impl Param<profiles::Logical> for Target {
+    fn param(&self) -> profiles::Logical {
+        profiles::Logical(self.dst.clone())
     }
 }
 

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -92,9 +92,9 @@ impl<P> Param<SocketAddr> for Logical<P> {
 }
 
 /// Used for default traffic split
-impl<P> Param<profiles::Logical> for Logical<P> {
-    fn param(&self) -> profiles::Logical {
-        profiles::Logical(self.addr())
+impl<P> Param<profiles::LogicalAddr> for Logical<P> {
+    fn param(&self) -> profiles::LogicalAddr {
+        profiles::LogicalAddr(self.addr())
     }
 }
 

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -92,9 +92,9 @@ impl<P> Param<SocketAddr> for Logical<P> {
 }
 
 /// Used for default traffic split
-impl<P> Param<Addr> for Logical<P> {
-    fn param(&self) -> Addr {
-        self.addr()
+impl<P> Param<profiles::Logical> for Logical<P> {
+    fn param(&self) -> profiles::Logical {
+        profiles::Logical(self.addr())
     }
 }
 

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -32,6 +32,10 @@ pub struct Profile {
     pub endpoint: Option<(SocketAddr, Metadata)>,
 }
 
+/// A profile lookup target.
+#[derive(Clone, Debug)]
+pub struct Logical(pub Addr);
+
 #[derive(Clone, Debug)]
 pub struct Target {
     pub addr: Addr,

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -34,7 +34,7 @@ pub struct Profile {
 
 /// A profile lookup target.
 #[derive(Clone, Debug)]
-pub struct Logical(pub Addr);
+pub struct LogicalAddr(pub Addr);
 
 #[derive(Clone, Debug)]
 pub struct Target {

--- a/linkerd/service-profiles/src/split.rs
+++ b/linkerd/service-profiles/src/split.rs
@@ -1,4 +1,4 @@
-use crate::{Logical, Profile, Receiver, Target};
+use crate::{LogicalAddr, Profile, Receiver, Target};
 use futures::{prelude::*, ready};
 use indexmap::IndexSet;
 use linkerd_addr::Addr;
@@ -57,7 +57,7 @@ impl<N: Clone, S, Req> Clone for NewSplit<N, S, Req> {
 
 impl<T, N, S, Req> NewService<T> for NewSplit<N, S, Req>
 where
-    T: Clone + Param<Logical> + Param<Option<Receiver>>,
+    T: Clone + Param<LogicalAddr> + Param<Option<Receiver>>,
     N: NewService<(Option<Addr>, T), Service = S> + Clone,
     S: tower::Service<Req>,
     S::Error: Into<Error>,
@@ -79,7 +79,7 @@ where
             Some(rx) => {
                 let mut targets = rx.borrow().targets.clone();
                 if targets.is_empty() {
-                    let Logical(addr) = target.param();
+                    let LogicalAddr(addr) = target.param();
                     targets.push(Target { addr, weight: 1 })
                 }
                 trace!(?targets, "Building split service");
@@ -116,7 +116,7 @@ where
 impl<T, N, S, Req> tower::Service<Req> for Split<T, N, S, Req>
 where
     Req: Send + 'static,
-    T: Clone + Param<Logical>,
+    T: Clone + Param<LogicalAddr>,
     N: NewService<(Option<Addr>, T), Service = S> + Clone,
     S: tower::Service<Req> + Send + 'static,
     S::Response: Send + 'static,
@@ -140,7 +140,7 @@ where
                 // services that existed in the prior state.
                 if let Some(Profile { mut targets, .. }) = update {
                     if targets.is_empty() {
-                        let Logical(addr) = inner.target.param();
+                        let LogicalAddr(addr) = inner.target.param();
                         targets.push(Target { addr, weight: 1 })
                     }
                     debug!(?targets, "Updating");


### PR DESCRIPTION
The profiles stack expects targets to satisfy `Param<Addr>`, which is
ambiguous. This change introduces a `profiles::LogicalAddr` type and updates
the target types to provide `Param<profiles::LogicalAddr>`.