### PR TITLE
metrics: Report build_info metric last

### DIFF
--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -108,7 +108,7 @@ impl Config {
 
         let identity = info_span!("identity")
             .in_scope(|| identity.build(dns.resolver.clone(), metrics.control.clone()))?;
-        let report = report.and_then(identity.metrics());
+        let report = identity.metrics().and_then(report);
 
         let (drain_tx, drain_rx) = drain::channel();
 


### PR DESCRIPTION
When spot-checking proxy metrics, it's extraordinarily helpful to be
able to spot-check the proxy's build info by having it be the last line
in the metrics output. #787 introduced identity metrics, appending them
to the end of the report.

This change moves identity metrics to the start of the metrics dump so
that build_info remains the final metric emitted.