### PR TITLE
Use transport header protocol hint for HTTP gateway

### DIFF
--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -26,6 +26,9 @@ type FwdIo<I> = io::PrefixedIo<SensorIo<tls::server::Io<I>>>;
 #[derive(Debug, Default)]
 struct RefusedNoHeader(());
 
+#[derive(Clone, Debug)]
+struct HttpFromTransportHeader;
+
 /// Builds a stack that handles connections that target the proxy's inbound port
 /// (i.e. without an SO_ORIGINAL_DST setting). This port behaves differently from
 /// the main proxy stack:
@@ -78,10 +81,16 @@ where
         // target, and dispatches the request.
         .instrument_from_target()
         .push(svc::NewRouter::layer(RequestTarget::from))
+        .check_new_service::<TcpAccept, _>()
         .into_inner();
 
-    let http_detect = svc::stack(http::server(&config, http, metrics, span_sink, drain))
-        .push_cache(config.cache_max_idle_age)
+    let http_server = svc::stack(http::server(&config, http, metrics, span_sink, drain))
+        .check_new_service::<(http::Version, TcpAccept), _>()
+        .push_cache(config.cache_max_idle_age);
+
+    let http_detect = http_server
+        .clone()
+        .push_on_response(svc::layers().push_map_target(io::EitherIo::Left))
         .push(svc::UnwrapOr::layer(
             svc::Fail::<_, RefusedNoHeader>::default(),
         ))
@@ -89,22 +98,13 @@ where
             detect_timeout,
             http::DetectHttp::default(),
         ))
+        .check_new_service::<TcpAccept, FwdIo<I>>()
         .into_inner();
 
     // If a transport header can be detected, use it to configure TCP
     // forwarding. If a transport header cannot be detected, try to
     // handle the connection as HTTP gateway traffic.
     svc::stack(tcp_forward)
-        .push_map_target(TcpEndpoint::from)
-        // Update the TcpAccept target using a parsed transport-header.
-        //
-        // TODO: Use the transport header's `name` to inform gateway routing.
-        //
-        // TODO: Use the header's session protocol, i.e. for gateway processing.
-        .push_map_target(|(h, mut t): (TransportHeader, TcpAccept)| {
-            t.target_addr = (t.target_addr.ip(), h.port).into();
-            t
-        })
         // We always try to detect a protocol header. We _can_ know whether it's
         // expected based on the serverside ALPN (passed via the target), but
         // it's easier to just do detection and handle the case when it's not
@@ -115,16 +115,27 @@ where
         // opaque.
         //
         // TODO: Stop supporting headerless connections after stable-2.10.
+        .check_new_service::<TcpEndpoint, FwdIo<I>>()
+        .push_switch(
+            HttpFromTransportHeader,
+            http_server
+                .push_on_response(svc::layers().push_map_target(io::EitherIo::Right))
+                .check_new_service::<(http::Version, TcpAccept), FwdIo<I>>()
+                .into_inner(),
+        )
+        .check_new_service::<(TransportHeader, TcpAccept), FwdIo<I>>()
         .push(svc::UnwrapOr::layer(http_detect))
         .push(detect::NewDetectService::timeout(
             detect_timeout,
             DetectHeader::default(),
         ))
+        .check_new_service::<TcpAccept, _>()
         // TODO: this filter should actually extract the TLS status so it's no
         // longer wrapped in a conditional... i.e. proving to the inner stack
         // that the connection is secure.
         .push_request_filter(RequireIdentityForDirect)
         .push(metrics.transport.layer_accept())
+        .check_new_service::<TcpAccept, _>()
         .push_map_target(TcpAccept::from)
         .push(tls::NewDetectTls::layer(
             local_identity.map(WithTransportHeaderAlpn),
@@ -132,6 +143,32 @@ where
         ))
         .check_new_service::<listen::Addrs, I>()
         .into_inner()
+}
+
+// === impl HttpFromTransportHeader ===
+
+impl svc::Predicate<(TransportHeader, TcpAccept)> for HttpFromTransportHeader {
+    type Request = svc::Either<TcpEndpoint, (http::Version, TcpAccept)>;
+
+    // TODO: Use the transport header's `name` to inform gateway routing.
+    //
+    // TODO: Use the header's session protocol, i.e. for gateway processing.
+    fn check(&mut self, (h, mut t): (TransportHeader, TcpAccept)) -> Result<Self::Request, Error> {
+        match h.protocol {
+            None => {
+                // Update the TcpAccept target using a parsed transport-header.
+                t.target_addr = (t.target_addr.ip(), h.port).into();
+                Ok(svc::Either::A(t.into()))
+            }
+            Some(p) => {
+                let v = match p {
+                    transport_header::SessionProtocol::Http1 => http::Version::Http1,
+                    transport_header::SessionProtocol::Http2 => http::Version::H2,
+                };
+                Ok(svc::Either::B((v, t)))
+            }
+        }
+    }
 }
 
 // === impl WithTransportHeaderAlpn ===

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -3,7 +3,9 @@ use crate::{
     target::{self, HttpEndpoint, Logical, RequestTarget, Target, TcpAccept, TcpEndpoint},
     Config,
 };
-pub use linkerd_app_core::proxy::http::{strip_header, BoxBody, DetectHttp, Request, Response};
+pub use linkerd_app_core::proxy::http::{
+    strip_header, BoxBody, DetectHttp, Request, Response, Version,
+};
 use linkerd_app_core::{
     classify,
     config::{ProxyConfig, ServerConfig},

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -64,7 +64,10 @@ impl Param<Option<SessionProtocol>> for Endpoint {
     fn param(&self) -> Option<SessionProtocol> {
         match self.concrete.logical.protocol {
             http::Version::H2 => Some(SessionProtocol::Http2),
-            http::Version::Http1 => Some(SessionProtocol::Http1),
+            http::Version::Http1 => match self.metadata.protocol_hint() {
+                ProtocolHint::Http2 => Some(SessionProtocol::Http2),
+                ProtocolHint::Unknown => Some(SessionProtocol::Http1),
+            },
         }
     }
 }


### PR DESCRIPTION
122d263d introduced session protocol hints to the transport header, but
the inbound direct stack was not updated to use this hint when deciding
whether to pass connections to the TCP gateway.

This change:

1. Updates the inbound direct stack to use the header-provided hint so
   that, when set, HTTP detection can simply be skipped -- the value is
   used to inform the HTTP server directly.
2. The outbound proxy could incorrectly set the protocol hint to the
   original protocol, ignoring HTTP/2 upgrade hinting. This has been
   fixed.

These changes have been tested against Linkerd2's multicluster
integration tests.