### PR TITLE
Backport 2a645b72 to v2.124.0

### DIFF
--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -116,7 +116,8 @@ where
                 .box_http_response(),
         )
         .check_new_service::<http::Accept, http::Request<_>>()
-        .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
+        .push(http::normalize_uri::NewNormalizeUri::layer())
+        .push_on_response(http::normalize_uri::MarkAbsoluteForm::layer())
         .check_new_service::<http::Accept, http::Request<_>>()
         .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
         .push_map_target(http::Accept::from)

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -87,7 +87,8 @@ where
                 .box_http_response(),
         )
         .check_new_service::<http::Logical, http::Request<_>>()
-        .push(svc::layer::mk(http::normalize_uri::MakeNormalizeUri::new))
+        .push(http::normalize_uri::NewNormalizeUri::layer())
+        .push_on_response(http::normalize_uri::MarkAbsoluteForm::layer())
         .instrument(|l: &http::Logical| debug_span!("http", v = %l.protocol))
         .push_map_target(http::Logical::from)
         .check_new_service::<(http::Version, tcp::Logical), http::Request<_>>()


### PR DESCRIPTION
Between stable-2.8.1 and v2.124.0, the inbound proxy changed so
that orig-proto requests would not be properly normalized,
breaking compatibility between 2.8.1 clients and recent servers.

This was fixed in 2a645b72 on main, but main includes many other
changes since v2.124.0. This change backports the important parts
of the change to v2.124.0 to ensure that inbound proxies normalize
downgraded requests.

Once merged, we'll tag `release/v2.124.1` off of the `release/v2.124`
branch and then wire that through for a stable-2.9.3 release.