### PR TITLE
actions: Update actions to use full SHAs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       # Create a build image on a Linkerd build host.
       - name: Setup (Origin)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 40
     steps:
       - name: git co
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: meta
         id: release-tag-meta
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: git co
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: meta
         id: release-tag-meta
@@ -82,7 +82,7 @@ jobs:
         run: ls -R artifacts
 
       - name: release
-        uses: softprops/action-gh-release@b21b43d
+        uses: softprops/action-gh-release@affa18ef97bc9db20076945705aba8c516139abd
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
     - uses: actions/checkout@v2
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: EmbarkStudios/cargo-deny-action@202e2b23300c1ef90c9d7389a0bc5b34c05c0fe4
       with:
         command: check ${{ matrix.checks }}
 


### PR DESCRIPTION
GitHub is deprecating short shas in GitHub actions.

This change updates our actions to use full SHAs. It also updates
actions/checkout to v2.