### PR TITLE
http: Parameterize normalize_uri::DefaultAuthority

### DIFF
--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -17,7 +17,6 @@ use linkerd_app_core::{
     spans::SpanConverter,
     svc, Error, NameAddr, TraceContext, DST_OVERRIDE_HEADER,
 };
-use std::net::SocketAddr;
 use tokio::sync::mpsc;
 use tracing::debug_span;
 
@@ -35,7 +34,7 @@ pub fn server<T, I, H, HSvc>(
     Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send> + Clone,
 > + Clone
 where
-    T: svc::stack::Param<SocketAddr>,
+    T: svc::stack::Param<http::normalize_uri::DefaultAuthority>,
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
     H: svc::NewService<T, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
     HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -79,6 +79,15 @@ impl Param<SocketAddr> for TcpAccept {
     }
 }
 
+impl Param<http::normalize_uri::DefaultAuthority> for TcpAccept {
+    fn param(&self) -> http::normalize_uri::DefaultAuthority {
+        http::normalize_uri::DefaultAuthority(Some(
+            http::uri::Authority::from_str(&self.target_addr.to_string())
+                .expect("Address must be a valid authority"),
+        ))
+    }
+}
+
 impl Param<transport::labels::Key> for TcpAccept {
     fn param(&self) -> transport::labels::Key {
         transport::labels::Key::accept(


### PR DESCRIPTION
The NormalizeUri module needs is configured with a fallback authority in
case we're dealing with poorly-formed HTTP requests (i.e., HTTP/1.0).
Currently, the module is parameterized on a `SocketAddr`, because on the
outbound side this makes sense as a default value. But on the inbound
side, especially in a gateway configuration, it doesn't make sense to
support a default value. It's better to just fail the request early.

This change updates the NormalizeUri type to require its targets to be
parameterized on a DefaultAuthority type. This type provides an
_optional_ `http::uri::Authority` so the target may provide a named
value (i.e., from a service profile response) when appropriate. It will
also enable us to omit a default when appropriate.