### PR TITLE
http: Parameterize the HTTP server

### DIFF
--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -18,7 +18,7 @@ use linkerd_app_core::{
     transport::{self, ConnectAddr},
     Conditional, Error, NameAddr,
 };
-use std::{net::SocketAddr, time::Duration};
+use std::time::Duration;
 use tracing::Instrument;
 
 fn build_server<I>(
@@ -65,7 +65,6 @@ async fn unmeshed_http1_hello_world() {
     let mut client = ClientBuilder::new();
     let _trace = support::trace_init();
 
-    let ep1 = SocketAddr::from(([127, 0, 0, 1], 5550));
     let accept = HttpAccept {
         version: proxy::http::Version::Http1,
         tcp: TcpAccept {
@@ -75,9 +74,10 @@ async fn unmeshed_http1_hello_world() {
         },
     };
 
-    let cfg = default_config(ep1);
+    let cfg = default_config(accept.tcp.target_addr);
     // Build a mock "connector" that returns the upstream "server" IO.
-    let connect = support::connect().endpoint_fn_boxed(ep1, hello_server(server));
+    let connect =
+        support::connect().endpoint_fn_boxed(accept.tcp.target_addr, hello_server(server));
 
     let profiles = profile::resolver();
     let profile_tx =
@@ -112,7 +112,6 @@ async fn downgrade_origin_form() {
     client.http2_only(true);
     let _trace = support::trace_init();
 
-    let ep1 = SocketAddr::from(([127, 0, 0, 1], 5550));
     let accept = HttpAccept {
         version: proxy::http::Version::H2,
         tcp: TcpAccept {
@@ -122,9 +121,10 @@ async fn downgrade_origin_form() {
         },
     };
 
-    let cfg = default_config(ep1);
+    let cfg = default_config(accept.tcp.target_addr);
     // Build a mock "connector" that returns the upstream "server" IO.
-    let connect = support::connect().endpoint_fn_boxed(ep1, hello_server(server));
+    let connect =
+        support::connect().endpoint_fn_boxed(accept.tcp.target_addr, hello_server(server));
 
     let profiles = profile::resolver();
     let profile_tx =
@@ -160,7 +160,6 @@ async fn downgrade_absolute_form() {
     client.http2_only(true);
     let _trace = support::trace_init();
 
-    let ep1 = SocketAddr::from(([127, 0, 0, 1], 5550));
     let accept = HttpAccept {
         version: proxy::http::Version::H2,
         tcp: TcpAccept {
@@ -170,9 +169,10 @@ async fn downgrade_absolute_form() {
         },
     };
 
-    let cfg = default_config(ep1);
+    let cfg = default_config(accept.tcp.target_addr);
     // Build a mock "connector" that returns the upstream "server" IO.
-    let connect = support::connect().endpoint_fn_boxed(ep1, hello_server(server));
+    let connect =
+        support::connect().endpoint_fn_boxed(accept.tcp.target_addr, hello_server(server));
 
     let profiles = profile::resolver();
     let profile_tx =

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -14,8 +14,12 @@ pub mod target;
 #[cfg(test)]
 pub(crate) mod test_util;
 
-pub use self::target::{HttpEndpoint, Logical, RequestTarget, Target, TcpAccept, TcpEndpoint};
-use self::{prevent_loop::PreventLoop, require_identity::RequireIdentityForPorts};
+pub use self::target::{HttpEndpoint, Logical, RequestTarget, Target, TcpEndpoint};
+use self::{
+    prevent_loop::PreventLoop,
+    require_identity::RequireIdentityForPorts,
+    target::{HttpAccept, TcpAccept},
+};
 use linkerd_app_core::{
     config::{ConnectConfig, ProxyConfig},
     detect, drain, io, metrics,
@@ -133,6 +137,7 @@ impl Config {
             span_sink.clone(),
         );
         svc::stack(http::server(&self.proxy, http, &metrics, span_sink, drain))
+            .push_map_target(HttpAccept::from)
             .push(svc::UnwrapOr::layer(
                 // When HTTP detection fails, forward the connection to the
                 // application as an opaque TCP stream.

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -10,7 +10,7 @@ use linkerd_app_core::{
     transport_header::TransportHeader,
     Addr, Conditional, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER,
 };
-use std::{convert::TryInto, net::SocketAddr, str::FromStr, sync::Arc};
+use std::{net::SocketAddr, str::FromStr, sync::Arc};
 use tracing::debug;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -18,6 +18,12 @@ pub struct TcpAccept {
     pub target_addr: SocketAddr,
     pub client_addr: SocketAddr,
     pub tls: tls::ConditionalServerTls,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct HttpAccept {
+    pub tcp: TcpAccept,
+    pub version: http::Version,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -48,7 +54,7 @@ pub struct TcpEndpoint {
 
 #[derive(Clone, Debug)]
 pub struct RequestTarget {
-    accept: TcpAccept,
+    accept: HttpAccept,
 }
 
 // === impl TcpAccept ===
@@ -79,15 +85,6 @@ impl Param<SocketAddr> for TcpAccept {
     }
 }
 
-impl Param<http::normalize_uri::DefaultAuthority> for TcpAccept {
-    fn param(&self) -> http::normalize_uri::DefaultAuthority {
-        http::normalize_uri::DefaultAuthority(Some(
-            http::uri::Authority::from_str(&self.target_addr.to_string())
-                .expect("Address must be a valid authority"),
-        ))
-    }
-}
-
 impl Param<transport::labels::Key> for TcpAccept {
     fn param(&self) -> transport::labels::Key {
         transport::labels::Key::accept(
@@ -95,6 +92,29 @@ impl Param<transport::labels::Key> for TcpAccept {
             self.tls.clone(),
             self.target_addr,
         )
+    }
+}
+
+// === impl HttpAccept ===
+
+impl From<(http::Version, TcpAccept)> for HttpAccept {
+    fn from((version, tcp): (http::Version, TcpAccept)) -> Self {
+        Self { version, tcp }
+    }
+}
+
+impl Param<http::Version> for HttpAccept {
+    fn param(&self) -> http::Version {
+        self.version
+    }
+}
+
+impl Param<http::normalize_uri::DefaultAuthority> for HttpAccept {
+    fn param(&self) -> http::normalize_uri::DefaultAuthority {
+        http::normalize_uri::DefaultAuthority(Some(
+            http::uri::Authority::from_str(&self.tcp.target_addr.to_string())
+                .expect("Address must be a valid authority"),
+        ))
     }
 }
 
@@ -169,6 +189,23 @@ pub(super) fn route((route, logical): (profiles::http::Route, Logical)) -> dst::
 }
 
 // === impl Target ===
+
+impl From<HttpAccept> for Target {
+    fn from(HttpAccept { version, tcp }: HttpAccept) -> Self {
+        Self {
+            dst: tcp.target_addr.into(),
+            target_addr: tcp.target_addr,
+            http_version: version,
+            tls: tcp.tls,
+        }
+    }
+}
+
+impl From<Logical> for Target {
+    fn from(Logical { target, .. }: Logical) -> Self {
+        target
+    }
+}
 
 impl Param<profiles::LogicalAddr> for Target {
     fn param(&self) -> profiles::LogicalAddr {
@@ -255,8 +292,8 @@ impl stack_tracing::GetSpan<()> for Target {
 
 // === impl RequestTarget ===
 
-impl From<TcpAccept> for RequestTarget {
-    fn from(accept: TcpAccept) -> Self {
+impl From<HttpAccept> for RequestTarget {
+    fn from(accept: HttpAccept) -> Self {
         Self { accept }
     }
 }
@@ -286,23 +323,14 @@ impl<A> svc::stack::RecognizeRoute<http::Request<A>> for RequestTarget {
             })
             .or_else(|| http_request_authority_addr(req).ok())
             .or_else(|| http_request_host_addr(req).ok())
-            .unwrap_or_else(|| self.accept.target_addr.into());
+            .unwrap_or_else(|| self.accept.tcp.target_addr.into());
 
         Target {
             dst,
-            target_addr: self.accept.target_addr,
-            tls: self.accept.tls.clone(),
-            http_version: req
-                .version()
-                .try_into()
-                .expect("HTTP version must be valid"),
+            target_addr: self.accept.tcp.target_addr,
+            tls: self.accept.tcp.tls.clone(),
+            http_version: self.accept.version,
         }
-    }
-}
-
-impl From<Logical> for Target {
-    fn from(Logical { target, .. }: Logical) -> Self {
-        target
     }
 }
 

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -23,6 +23,12 @@ pub type Logical = crate::target::Logical<Version>;
 pub type Concrete = crate::target::Concrete<Version>;
 pub type Endpoint = crate::target::Endpoint<Version>;
 
+impl Param<Version> for Accept {
+    fn param(&self) -> Version {
+        self.protocol
+    }
+}
+
 impl Param<normalize_uri::DefaultAuthority> for Accept {
     fn param(&self) -> normalize_uri::DefaultAuthority {
         normalize_uri::DefaultAuthority(Some(
@@ -39,6 +45,12 @@ impl From<(Version, tcp::Logical)> for Logical {
             orig_dst: logical.orig_dst,
             profile: logical.profile,
         }
+    }
+}
+
+impl Param<Version> for Logical {
+    fn param(&self) -> Version {
+        self.protocol
     }
 }
 

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -119,9 +119,9 @@ where
         .push(http::NewNormalizeUri::layer())
         .check_new_service::<http::Accept, http::Request<_>>()
         .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
-        .push_map_target(http::Accept::from)
-        .check_new_service::<(http::Version, tcp::Accept), http::Request<_>>()
+        .check_new_service::<http::Accept, http::Request<_>>()
         .push(http::NewServeHttp::layer(h2_settings, drain))
+        .push_map_target(http::Accept::from)
         .push(svc::UnwrapOr::layer(tcp))
         .push_cache(cache_max_idle_age)
         .push(detect::NewDetectService::timeout(

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -189,8 +189,8 @@ where
         // Record when a HTTP/1 URI originated in absolute form
         .push_on_response(http::normalize_uri::MarkAbsoluteForm::layer())
         .instrument(|l: &http::Logical| debug_span!("http", v = %l.protocol))
-        .push_map_target(http::Logical::from)
         .push(http::NewServeHttp::layer(h2_settings, drain))
+        .push_map_target(http::Logical::from)
         .push(svc::UnwrapOr::layer(
             // When an HTTP version cannot be detected, we fallback to a logical
             // TCP stack. This service needs to be buffered so that it can be


### PR DESCRIPTION
The HTTP server requires that targets are in the form `(Version, T)`.
This is inflexible, though.

This change updates the HTTP server to instead require that targets
satisfy `Param<Version>` so that tuple types are not required. This
requires the introduction of a new HttpAccept type in the inbound proxy.