### PR TITLE
stack: Make the router fallible

### DIFF
--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -8,7 +8,7 @@ use linkerd_app_core::{
     tls,
     transport::{self, listen},
     transport_header::TransportHeader,
-    Addr, Conditional, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER,
+    Addr, Conditional, Error, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER,
 };
 use std::{convert::TryInto, net::SocketAddr, str::FromStr, sync::Arc};
 use tracing::debug;
@@ -301,7 +301,7 @@ impl From<HttpAccept> for RequestTarget {
 impl<A> svc::stack::RecognizeRoute<http::Request<A>> for RequestTarget {
     type Key = Target;
 
-    fn recognize(&self, req: &http::Request<A>) -> Self::Key {
+    fn recognize(&self, req: &http::Request<A>) -> Result<Self::Key, Error> {
         let dst = req
             .headers()
             .get(CANONICAL_DST_HEADER)
@@ -325,7 +325,7 @@ impl<A> svc::stack::RecognizeRoute<http::Request<A>> for RequestTarget {
             .or_else(|| http_request_host_addr(req).ok())
             .unwrap_or_else(|| self.accept.tcp.target_addr.into());
 
-        Target {
+        Ok(Target {
             dst,
             target_addr: self.accept.tcp.target_addr,
             tls: self.accept.tcp.tls.clone(),
@@ -335,7 +335,7 @@ impl<A> svc::stack::RecognizeRoute<http::Request<A>> for RequestTarget {
                 .version()
                 .try_into()
                 .expect("HTTP version must be valid"),
-        }
+        })
     }
 }
 

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -187,10 +187,10 @@ impl TargetPerRequest {
 impl<B> svc::stack::RecognizeRoute<http::Request<B>> for TargetPerRequest {
     type Key = Target;
 
-    fn recognize(&self, req: &http::Request<B>) -> Self::Key {
-        Target {
+    fn recognize(&self, req: &http::Request<B>) -> Result<Self::Key, Error> {
+        Ok(Target {
             accept: self.0,
             dst: http_request_l5d_override_dst_addr(req).unwrap_or_else(|_| self.0.orig_dst.into()),
-        }
+        })
     }
 }


### PR DESCRIPTION
The `Router` service looks at each request to produce a routing key; but
it may not always be possible to satisfy a key for al requests. In these
cases, we currently need to encode the error case into the key type and
fail request on its inner stack. This is needlessly cumbersome.

This change modifies the `router::RecognizeRoute` trait to return a
`Result` so that requests can be failed eagerly by the router.