### PR TITLE
Update http::Insert to use `Param`

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -154,8 +154,8 @@ impl<S> Stack<S> {
         self.push(tower::timeout::TimeoutLayer::new(timeout))
     }
 
-    pub fn push_http_insert_target(self) -> Stack<http::insert::target::NewService<S>> {
-        self.push(http::insert::target::layer())
+    pub fn push_http_insert_target<P>(self) -> Stack<http::insert::NewInsert<P, S>> {
+        self.push(http::insert::NewInsert::layer())
     }
 
     pub fn push_cache<T>(self, idle: Duration) -> Stack<cache::Cache<T, S>>

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -153,7 +153,7 @@ where
             svc::proxies()
                 // Sets the route as a request extension so that it can be used
                 // by tap.
-                .push_http_insert_target()
+                .push_http_insert_target::<dst::Route>()
                 // Records per-route metrics.
                 .push(metrics.http_route.to_layer::<classify::Response, _>())
                 // Sets the per-route response classifier as a request
@@ -207,7 +207,7 @@ where
         .instrument_from_target()
         .push(svc::NewRouter::layer(RequestTarget::from))
         // Used by tap.
-        .push_http_insert_target()
+        .push_http_insert_target::<HttpAccept>()
         .into_inner()
 }
 

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -240,13 +240,15 @@ impl classify::CanClassify for Target {
 
 impl tap::Inspect for Target {
     fn src_addr<B>(&self, req: &http::Request<B>) -> Option<SocketAddr> {
-        req.extensions().get::<TcpAccept>().map(|s| s.client_addr)
+        req.extensions()
+            .get::<HttpAccept>()
+            .map(|s| s.tcp.client_addr)
     }
 
     fn src_tls<B>(&self, req: &http::Request<B>) -> tls::ConditionalServerTls {
         req.extensions()
-            .get::<TcpAccept>()
-            .map(|s| s.tls.clone())
+            .get::<HttpAccept>()
+            .map(|s| s.tcp.tls.clone())
             .unwrap_or_else(|| Conditional::None(tls::NoServerTls::Disabled))
     }
 


### PR DESCRIPTION
The `http::insert` module provides a utility to insert the target value
into each request's HTTP extensions. But it's not always desirable to
insert the entire target. We may want only insert a single parameter
from the target.

This change replaces the `insert::target` module with an
`insert::NewInsert` type that uses `Param` to extract a value from the
target.

In doing this, I also noticed that 58c78596 changed the extension type
needed by tap::Inspect. This change fixes this and sets up further
improvements to use narrower-scoped param types so that this can't break
as easily moving forward.