### PR TITLE
outbound: Avoid building balancers when no concrete name

### DIFF
--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -85,17 +85,14 @@ where
         // If there's no resolveable address, bypass the load balancer.
         .push(svc::UnwrapOr::layer(
             svc::stack(endpoint.clone())
-                .check_new_service::<Endpoint, http::Request<http::BoxBody>>()
                 .push_on_response(
                     svc::layers()
                         .push(http::BoxRequest::layer())
                         .push(http::BoxResponse::layer()),
                 )
-                .check_new_service::<Endpoint, http::Request<_>>()
                 .push_map_target(Endpoint::from_logical(
                     tls::NoClientTls::NotProvidedByServiceDiscovery,
                 ))
-                .check_new_service::<Logical, http::Request<_>>()
                 .into_inner(),
         ))
         // Distribute requests over a distribution of balancers via a traffic

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -85,7 +85,7 @@ impl Param<normalize_uri::DefaultAuthority> for Logical {
 
 impl Param<client::Settings> for Endpoint {
     fn param(&self) -> client::Settings {
-        match self.concrete.logical.protocol {
+        match self.logical.protocol {
             Version::H2 => client::Settings::H2,
             Version::Http1 => match self.metadata.protocol_hint() {
                 ProtocolHint::Unknown => client::Settings::Http1,
@@ -97,7 +97,7 @@ impl Param<client::Settings> for Endpoint {
 
 impl Param<Option<SessionProtocol>> for Endpoint {
     fn param(&self) -> Option<SessionProtocol> {
-        match self.concrete.logical.protocol {
+        match self.logical.protocol {
             Version::H2 => Some(SessionProtocol::Http2),
             Version::Http1 => match self.metadata.protocol_hint() {
                 ProtocolHint::Http2 => Some(SessionProtocol::Http2),

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -98,7 +98,6 @@ where
     let accept = crate::server::accept_stack(
         &cfg,
         profiles,
-        support::connect::NoRawTcp,
         NoTcpBalancer,
         router,
         metrics.outbound.clone(),
@@ -111,9 +110,9 @@ where
 #[derive(Clone, Debug)]
 struct NoTcpBalancer;
 
-impl svc::NewService<crate::tcp::Concrete> for NoTcpBalancer {
+impl<T: std::fmt::Debug> svc::NewService<T> for NoTcpBalancer {
     type Service = Self;
-    fn new_service(&mut self, target: crate::tcp::Concrete) -> Self::Service {
+    fn new_service(&mut self, target: T) -> Self::Service {
         panic!(
             "no TCP load balancer should be created in this test!\n\ttarget = {:?}",
             target

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -48,13 +48,7 @@ where
     P::Future: Send,
     P::Error: Send,
 {
-    let tcp = tcp::balance::stack(
-        &config.proxy,
-        tcp_connect.clone(),
-        resolve,
-        &metrics,
-        drain.clone(),
-    );
+    let tcp = tcp::balance::stack(&config.proxy, tcp_connect, resolve, &metrics, drain.clone());
     let accept = accept_stack(
         config,
         profiles,

--- a/linkerd/app/outbound/src/server.rs
+++ b/linkerd/app/outbound/src/server.rs
@@ -8,7 +8,7 @@ use linkerd_app_core::{
     profiles,
     proxy::{api_resolve::Metadata, core::resolve::Resolve},
     spans::SpanConverter,
-    svc, tls,
+    svc,
     transport::{listen, metrics::SensorIo},
     Addr, Error, IpMatch, TraceContext,
 };
@@ -33,7 +33,7 @@ where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
     R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Clone + Send + 'static,
     R::Resolution: Send,
-    R::Future: Send,
+    R::Future: Send + Unpin,
     C: svc::Service<tcp::Endpoint> + Clone + Send + 'static,
     C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
     C::Error: Into<Error>,
@@ -48,13 +48,11 @@ where
     P::Future: Send,
     P::Error: Send,
 {
-    let tcp_balance =
-        tcp::balance::stack(&config.proxy, tcp_connect.clone(), resolve, drain.clone());
+    let tcp = tcp::balance::stack(&config.proxy, tcp_connect, resolve, drain.clone());
     let accept = accept_stack(
         config,
         profiles,
-        tcp_connect,
-        tcp_balance,
+        tcp,
         http_router,
         metrics.clone(),
         span_sink,
@@ -100,11 +98,10 @@ where
         .into_inner()
 }
 
-pub fn accept_stack<P, C, T, TSvc, H, HSvc, I>(
+pub fn accept_stack<P, T, TSvc, H, HSvc, I>(
     config: &Config,
     profiles: P,
-    tcp_connect: C,
-    tcp_balance: T,
+    tcp: T,
     http_router: H,
     metrics: metrics::Proxy,
     span_sink: Option<mpsc::Sender<oc::Span>>,
@@ -115,19 +112,10 @@ pub fn accept_stack<P, C, T, TSvc, H, HSvc, I>(
 > + Clone
 where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
-    C: svc::Service<tcp::Endpoint> + Clone + Send + 'static,
-    C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
-    C::Error: Into<Error>,
-    C::Future: Send,
-    T: svc::NewService<tcp::Concrete, Service = TSvc> + Clone + Send + 'static,
-    TSvc: svc::Service<io::PrefixedIo<I>, Response = ()>
-        + svc::Service<I, Response = ()>
-        + Send
-        + 'static,
-    <TSvc as svc::Service<I>>::Error: Into<Error>,
-    <TSvc as svc::Service<I>>::Future: Send,
-    <TSvc as svc::Service<io::PrefixedIo<I>>>::Error: Into<Error>,
-    <TSvc as svc::Service<io::PrefixedIo<I>>>::Future: Send,
+    T: svc::NewService<(Option<Addr>, tcp::Logical), Service = TSvc> + Clone + Send + 'static,
+    TSvc: svc::Service<io::EitherIo<I, io::PrefixedIo<I>>, Response = ()> + Send + 'static,
+    TSvc::Error: Into<Error>,
+    TSvc::Future: Send,
     H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + 'static,
     HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
         + Send
@@ -148,15 +136,8 @@ where
         ..
     } = config.proxy.clone();
 
-    let tcp_forward = svc::stack(tcp_connect)
-        .push_make_thunk()
-        .push_on_response(tcp::Forward::layer())
-        .push(svc::MapErrLayer::new(Into::into))
-        .into_new_service()
-        .push_on_response(metrics.stack.layer(stack_labels("tcp", "forward")))
-        .push_map_target(tcp::Endpoint::from_logical(
-            tls::NoClientTls::NotProvidedByServiceDiscovery,
-        ))
+    let tcp_forward = svc::stack(tcp.clone())
+        .push_map_target(|l| (None, l))
         .into_inner();
 
     svc::stack(http_router)
@@ -195,12 +176,12 @@ where
             // When an HTTP version cannot be detected, we fallback to a logical
             // TCP stack. This service needs to be buffered so that it can be
             // cached and cloned per connection.
-            svc::stack(tcp_balance.clone())
-                .push_map_target(tcp::Concrete::from)
+            svc::stack(tcp.clone())
                 .push(profiles::split::layer())
                 .push_switch(ShouldResolve, tcp_forward.clone())
                 .push_on_response(
                     svc::layers()
+                        .push_map_target(io::EitherIo::Right)
                         .push(svc::layer::mk(svc::SpawnReady::new))
                         .push(svc::FailFast::layer("TCP Logical", dispatch_timeout))
                         .push_spawn_buffer(buffer_capacity)
@@ -222,11 +203,14 @@ where
             // detection and just use the TCP logical stack directly. Unlike the
             // above case, this stack need not be buffered, since `fn cache`
             // applies its own buffer on the returned service.
-            svc::stack(tcp_balance)
-                .push_map_target(tcp::Concrete::from)
+            svc::stack(tcp)
                 .push(profiles::split::layer())
                 .push_switch(ShouldResolve, tcp_forward)
-                .push_on_response(metrics.stack.layer(stack_labels("tcp", "passthru")))
+                .push_on_response(
+                    svc::layers()
+                        .push_map_target(io::EitherIo::Left)
+                        .push(metrics.stack.layer(stack_labels("tcp", "passthru"))),
+                )
                 .instrument(|_: &_| debug_span!("tcp.opaque"))
                 .into_inner(),
         )

--- a/linkerd/app/outbound/src/tcp/balance.rs
+++ b/linkerd/app/outbound/src/tcp/balance.rs
@@ -1,10 +1,10 @@
-use super::{Concrete, Endpoint};
+use super::{Concrete, Endpoint, Logical};
 use crate::resolve;
 use linkerd_app_core::{
     config::ProxyConfig,
     drain, io,
     proxy::{api_resolve::Metadata, core::Resolve, tcp},
-    svc, Addr, Conditional, Error,
+    svc, tls, Addr, Conditional, Error,
 };
 use tracing::debug_span;
 
@@ -15,9 +15,8 @@ pub fn stack<I, C, R>(
     resolve: R,
     drain: drain::Watch,
 ) -> impl svc::NewService<
-    Concrete,
-    Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>
-                  + svc::Service<io::PrefixedIo<I>, Response = (), Error = Error, Future = impl Send>,
+    (Option<Addr>, Logical),
+    Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
 > + Clone
 where
     I: io::AsyncRead + io::AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
@@ -25,11 +24,11 @@ where
     C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
     C::Error: Into<Error>,
     C::Future: Send,
-    R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Clone + 'static,
+    R: Resolve<Addr, Endpoint = Metadata, Error = Error> + Clone + Send + 'static,
     R::Resolution: Send,
-    R::Future: Send,
+    R::Future: Send + Unpin,
 {
-    svc::stack(connect)
+    svc::stack(connect.clone())
         .push_make_thunk()
         .instrument(|t: &Endpoint| match t.tls.as_ref() {
             Conditional::Some(tls) => {
@@ -47,7 +46,27 @@ where
                     crate::EWMA_DECAY,
                 ))
                 .push(tcp::Forward::layer())
-                .push(drain::Retain::layer(drain)),
+                .push(drain::Retain::layer(drain.clone())),
         )
         .into_new_service()
+        .push_map_target(Concrete::from)
+        // If there's no resolveable address, bypass the load balancer.
+        .push(svc::UnwrapOr::layer(
+            svc::stack(connect)
+                .push_make_thunk()
+                .push(svc::MapErrLayer::new(Into::into))
+                .instrument(|t: &Endpoint| debug_span!("tcp.forward", server.addr = %t.addr))
+                .push_on_response(
+                    svc::layers()
+                        .push(tcp::Forward::layer())
+                        .push(drain::Retain::layer(drain)),
+                )
+                .into_new_service()
+                .push_map_target(Endpoint::from_logical(
+                    tls::NoClientTls::NotProvidedByServiceDiscovery,
+                ))
+                .into_inner(),
+        ))
+        .check_new_service::<(Option<Addr>, Logical), I>()
+        .into_inner()
 }

--- a/linkerd/app/outbound/src/tcp/opaque_transport.rs
+++ b/linkerd/app/outbound/src/tcp/opaque_transport.rs
@@ -112,7 +112,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::target::{Concrete, Endpoint, Logical};
+    use crate::target::{Endpoint, Logical};
     use futures::future;
     use linkerd_app_core::{
         io::{self, AsyncWriteExt},
@@ -131,13 +131,10 @@ mod test {
             target_addr: ([127, 0, 0, 2], 4321).into(),
             tls: Conditional::None(tls::NoClientTls::NotProvidedByServiceDiscovery),
             metadata,
-            concrete: Concrete {
-                resolve: None,
-                logical: Logical {
-                    orig_dst: ([127, 0, 0, 2], 4321).into(),
-                    profile: None,
-                    protocol: (),
-                },
+            logical: Logical {
+                orig_dst: ([127, 0, 0, 2], 4321).into(),
+                profile: None,
+                protocol: (),
             },
         }
     }
@@ -172,7 +169,7 @@ mod test {
             inner: service_fn(|ep: Endpoint<()>| {
                 assert_eq!(ep.addr.port(), 4143);
                 let hdr = TransportHeader {
-                    port: ep.concrete.logical.orig_dst.port(),
+                    port: ep.logical.orig_dst.port(),
                     name: None,
                     protocol: None,
                 };
@@ -242,7 +239,7 @@ mod test {
             inner: service_fn(|ep: Endpoint<()>| {
                 assert_eq!(ep.addr.port(), 4143);
                 let hdr = TransportHeader {
-                    port: ep.concrete.logical.orig_dst.port(),
+                    port: ep.logical.orig_dst.port(),
                     name: None,
                     protocol: None,
                 };

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -1,4 +1,4 @@
-use super::{Concrete, Endpoint, Logical};
+use super::{Endpoint, Logical};
 use crate::test_util::{
     support::{
         connect::{Connect, ConnectFuture},
@@ -33,13 +33,10 @@ async fn plaintext_tcp() {
     // ports or anything. These will just be used so that the proxy has a socket
     // address to resolve, etc.
     let target_addr = SocketAddr::new([0, 0, 0, 0].into(), 666);
-    let concrete = Concrete {
-        logical: Logical {
-            orig_dst: target_addr,
-            profile: Some(profile::only_default()),
-            protocol: (),
-        },
-        resolve: Some(target_addr.into()),
+    let logical = Logical {
+        orig_dst: target_addr,
+        profile: Some(profile::only_default()),
+        protocol: (),
     };
 
     let cfg = default_config(target_addr);
@@ -59,15 +56,13 @@ async fn plaintext_tcp() {
 
     // Configure the mock destination resolver to just give us a single endpoint
     // for the target, which always exists and has no metadata.
-    let resolver = support::resolver().endpoint_exists(
-        concrete.resolve.clone().unwrap(),
-        target_addr,
-        support::resolver::Metadata::default(),
-    );
+    let resolver =
+        support::resolver().endpoint_exists(target_addr, target_addr, Default::default());
 
     // Build the outbound TCP balancer stack.
     let (_, drain) = drain::channel();
-    let forward = super::balance::stack(&cfg.proxy, connect, resolver, drain).new_service(concrete);
+    let forward = super::balance::stack(&cfg.proxy, connect, resolver, drain)
+        .new_service((Some(target_addr.into()), logical));
 
     forward
         .oneshot(client_io)
@@ -81,23 +76,17 @@ async fn tls_when_hinted() {
     let _trace = support::trace_init();
 
     let tls_addr = SocketAddr::new([0, 0, 0, 0].into(), 5550);
-    let tls_concrete = Concrete {
-        logical: Logical {
-            orig_dst: tls_addr,
-            profile: Some(profile::only_default()),
-            protocol: (),
-        },
-        resolve: Some(tls_addr.into()),
+    let tls_logical = Logical {
+        orig_dst: tls_addr,
+        profile: Some(profile::only_default()),
+        protocol: (),
     };
 
     let plain_addr = SocketAddr::new([0, 0, 0, 0].into(), 5551);
-    let plain_concrete = Concrete {
-        logical: Logical {
-            orig_dst: tls_addr,
-            profile: Some(profile::only_default()),
-            protocol: (),
-        },
-        resolve: Some(plain_addr.into()),
+    let plain_logical = Logical {
+        orig_dst: tls_addr,
+        profile: Some(profile::only_default()),
+        protocol: (),
     };
 
     let cfg = default_config(plain_addr);
@@ -133,12 +122,8 @@ async fn tls_when_hinted() {
     // Configure the mock destination resolver to just give us a single endpoint
     // for the target, which always exists and has no metadata.
     let resolver = support::resolver()
-        .endpoint_exists(
-            plain_concrete.resolve.clone().unwrap(),
-            plain_addr,
-            support::resolver::Metadata::default(),
-        )
-        .endpoint_exists(tls_concrete.resolve.clone().unwrap(), tls_addr, tls_meta);
+        .endpoint_exists(plain_addr, plain_addr, Default::default())
+        .endpoint_exists(tls_addr, tls_addr, tls_meta);
 
     // Configure mock IO for the "client".
     let mut client_io = support::io();
@@ -149,11 +134,11 @@ async fn tls_when_hinted() {
     let mut balance = super::balance::stack(&cfg.proxy, connect, resolver, drain);
 
     let plain = balance
-        .new_service(plain_concrete)
+        .new_service((Some(plain_addr.into()), plain_logical))
         .oneshot(client_io.build())
         .err_into::<Error>();
     let tls = balance
-        .new_service(tls_concrete)
+        .new_service((Some(tls_addr.into()), tls_logical))
         .oneshot(client_io.build())
         .err_into::<Error>();
 


### PR DESCRIPTION
The outbound balancers are always built, even when there is no
resolveable concrete address.

This change modifies the outbound `Concrete` target to require a
resolveable address. When no address is present, the balancer stack is
skipped in favor of an endpoint stack.