### PR TITLE
Track stack metrics within failfast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1333,6 +1333,7 @@ version = "0.1.0"
 dependencies = [
  "indexmap",
  "linkerd-metrics",
+ "tokio",
  "tower",
 ]
 

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -70,6 +70,8 @@ where
     let http = svc::stack(http_loopback)
         .push_on_response(
             svc::layers()
+                .push(svc::layer::mk(svc::SpawnReady::new))
+                .push(metrics.stack.layer(crate::stack_labels("http", "gateway")))
                 .push(svc::FailFast::layer("Gateway", dispatch_timeout))
                 .push_spawn_buffer(config.buffer_capacity),
         )

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -77,7 +77,6 @@ where
                 .push(TraceContext::layer(
                     span_sink.map(|k| SpanConverter::server(k, trace_labels())),
                 ))
-                .push(metrics.stack.layer(stack_labels("http", "server")))
                 // Record when an HTTP/1 URI was in absolute form
                 .push(http::normalize_uri::MarkAbsoluteForm::layer())
                 .push(http::BoxRequest::layer())
@@ -168,10 +167,13 @@ where
             profiles_client,
             AllowProfile(config.allow_discovery.clone()),
         ))
-        .push_on_response(http::BoxResponse::layer())
         .instrument(|_: &Target| debug_span!("profile"))
+        .push_on_response(
+            svc::layers()
+                .push(http::BoxResponse::layer())
+                .push(svc::layer::mk(svc::SpawnReady::new)),
+        )
         // Skip the profile stack if it takes too long to become ready.
-        .push_on_response(svc::layer::mk(svc::SpawnReady::new))
         .push_when_unready(
             config.profile_idle_timeout,
             target
@@ -182,12 +184,12 @@ where
         .check_new_service::<Target, http::Request<http::BoxBody>>()
         .push_on_response(
             svc::layers()
+                .push(metrics.stack.layer(crate::stack_labels("http", "logical")))
                 .push(svc::FailFast::layer(
                     "HTTP Logical",
                     config.proxy.dispatch_timeout,
                 ))
-                .push_spawn_buffer(config.proxy.buffer_capacity)
-                .push(metrics.stack.layer(stack_labels("http", "logical"))),
+                .push_spawn_buffer(config.proxy.buffer_capacity),
         )
         .push_cache(config.proxy.cache_max_idle_age)
         .push_on_response(
@@ -215,8 +217,4 @@ fn trace_labels() -> std::collections::HashMap<String, String> {
     let mut l = std::collections::HashMap::new();
     l.insert("direction".to_string(), "inbound".to_string());
     l
-}
-
-fn stack_labels(proto: &'static str, name: &'static str) -> metrics::StackLabels {
-    metrics::StackLabels::inbound(proto, name)
 }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -190,3 +190,7 @@ impl svc::Predicate<listen::Addrs> for SkipByPort {
         }
     }
 }
+
+fn stack_labels(proto: &'static str, name: &'static str) -> metrics::StackLabels {
+    metrics::StackLabels::inbound(proto, name)
+}

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -69,9 +69,9 @@ where
                     crate::EWMA_DEFAULT_RTT,
                     crate::EWMA_DECAY,
                 ))
+                .push(metrics.stack.layer(stack_labels("http", "balancer")))
                 .push(svc::layer::mk(svc::SpawnReady::new))
-                .push(svc::FailFast::layer("HTTP Balancer", dispatch_timeout))
-                .push(metrics.stack.layer(stack_labels("http", "concrete"))),
+                .push(svc::FailFast::layer("HTTP Balancer", dispatch_timeout)),
         )
         .push(svc::MapErrLayer::new(Into::into))
         // Drives the initial resolution via the service's readiness.
@@ -95,6 +95,7 @@ where
         .push_on_response(
             svc::layers()
                 .push(svc::layer::mk(svc::SpawnReady::new))
+                .push(metrics.stack.layer(stack_labels("http", "logical")))
                 .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
                 .push_spawn_buffer(buffer_capacity),
         )

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -91,6 +91,7 @@ where
         ))
         .push_on_response(
             svc::layers()
+                .push(metrics.stack.layer(stack_labels("http", "logical")))
                 .push(svc::layer::mk(svc::SpawnReady::new))
                 .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
                 .push_spawn_buffer(buffer_capacity),
@@ -112,7 +113,6 @@ where
                 .push(TraceContext::layer(span_sink.map(|span_sink| {
                     SpanConverter::server(span_sink, trace_labels())
                 })))
-                .push(metrics.stack.layer(stack_labels("http", "server")))
                 .push(http::BoxResponse::layer()),
         )
         .check_new_service::<http::Accept, http::Request<_>>()

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -67,7 +67,9 @@ async fn plaintext_tcp() {
 
     // Build the outbound TCP balancer stack.
     let (_, drain) = drain::channel();
-    let forward = super::balance::stack(&cfg.proxy, connect, resolver, drain).new_service(concrete);
+    let (metrics, _) = metrics::Metrics::new(Duration::from_secs(10));
+    let forward = super::balance::stack(&cfg.proxy, connect, resolver, &metrics.outbound, drain)
+        .new_service(concrete);
 
     forward
         .oneshot(client_io)
@@ -146,7 +148,9 @@ async fn tls_when_hinted() {
 
     // Build the outbound TCP balancer stack.
     let (_, drain) = drain::channel();
-    let mut balance = super::balance::stack(&cfg.proxy, connect, resolver, drain);
+    let (metrics, _) = metrics::Metrics::new(Duration::from_secs(10));
+    let mut balance =
+        super::balance::stack(&cfg.proxy, connect, resolver, &metrics.outbound, drain);
 
     let plain = balance
         .new_service(plain_concrete)

--- a/linkerd/stack/metrics/Cargo.toml
+++ b/linkerd/stack/metrics/Cargo.toml
@@ -10,3 +10,4 @@ publish = false
 indexmap = "1.0"
 linkerd-metrics = { path = "../../metrics" }
 tower = { version = "0.4.1", default-features = false }
+tokio = { version = "1", features = ["time"] }


### PR DESCRIPTION
Our stack metrics are generally applied outside of failfast modules
so we have no insight into how long services are actually stuck in
pending.

This PR addresses this as follows:

1. The stack metrics `Service` impl no longer implements `Clone`. It
   doesn't really make sense to track idleness across clones. Stacks
   that require clone are no longer tracked by metrics.
2. `poll_total_ms` is now updated on each pending poll so that we need
   not wait until a state change to update the value; and
3. All applicable uses of failfast have been updated to include stack
   metrics. This gives us a better sense of the behavior of buffered
   services.