### PR TITLE
inbound: Cache HTTP gateways per destination

### DIFF
--- a/linkerd/addr/src/lib.rs
+++ b/linkerd/addr/src/lib.rs
@@ -224,6 +224,19 @@ impl fmt::Display for NameAddr {
     }
 }
 
+// === impl Error ===
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidHost => write!(f, "address contains an invalid host"),
+            Self::MissingPort => write!(f, "address is missing a port"),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/linkerd/app/gateway/src/config.rs
+++ b/linkerd/app/gateway/src/config.rs
@@ -49,7 +49,7 @@ impl Config {
                 Allow(self.allow_discovery),
             ))
             .instrument(
-                |g: &inbound::HttpGatewayTarget| debug_span!("gateway", target=%g.target, v=%g.version),
+                |g: &inbound::HttpGatewayTarget| debug_span!("gateway", target = %g.target, v = %g.version),
             )
             .into_inner()
     }

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -1,41 +1,28 @@
-use futures::{future, ready, TryFutureExt};
+use futures::{future, TryFutureExt};
 use linkerd_app_core::{dns, errors::HttpError, proxy::http, tls, Error, NameAddr};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use tracing::warn;
 
 #[derive(Clone, Debug)]
 pub(crate) enum Gateway<O> {
-    NoAuthority,
     NoIdentity,
     BadDomain(dns::Name),
     Outbound {
         outbound: O,
         local_identity: tls::LocalId,
-        host_header: http::header::HeaderValue,
-        forwarded_header: http::header::HeaderValue,
+        host: String,
     },
 }
 
 impl<O> Gateway<O> {
-    pub fn new(
-        outbound: O,
-        dst: NameAddr,
-        source_identity: tls::server::ClientId,
-        local_identity: tls::LocalId,
-    ) -> Self {
+    pub fn new(outbound: O, dst: NameAddr, local_identity: tls::LocalId) -> Self {
         let host = dst.as_http_authority().to_string();
-        let fwd = format!(
-            "by={};for={};host={};proto=https",
-            local_identity, source_identity, host
-        );
         Gateway::Outbound {
             outbound,
             local_identity,
-            host_header: http::header::HeaderValue::from_str(&host)
-                .expect("Host header value must be valid"),
-            forwarded_header: http::header::HeaderValue::from_str(&fwd)
-                .expect("Forwarded header value must be valid"),
+            host,
         }
     }
 }
@@ -55,9 +42,7 @@ where
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         match self {
-            Self::Outbound { outbound, .. } => {
-                Poll::Ready(ready!(outbound.poll_ready(cx)).map_err(Into::into))
-            }
+            Self::Outbound { outbound, .. } => outbound.poll_ready(cx).map_err(Into::into),
             _ => Poll::Ready(Ok(())),
         }
     }
@@ -66,8 +51,7 @@ where
         match self {
             Self::Outbound {
                 ref mut outbound,
-                ref host_header,
-                ref forwarded_header,
+                ref host,
                 local_identity: tls::LocalId(local_id),
             } => {
                 // Check forwarded headers to see if this request has already
@@ -86,28 +70,41 @@ where
                     }
                 }
 
-                // Add a forwarded header.
-                request
-                    .headers_mut()
-                    .append(http::header::FORWARDED, forwarded_header.clone());
+                // Determine the value of the forwarded header using the Client
+                // ID from the requests's extensions.
+                let fwd = match request.extensions_mut().remove::<tls::ClientId>() {
+                    Some(client_id) => {
+                        let fwd = format!(
+                            "by={};for={};host={};proto=https",
+                            local_id, client_id, host
+                        );
+                        http::header::HeaderValue::from_str(&fwd)
+                            .expect("Forwarded header value must be valid")
+                    }
+                    None => {
+                        warn!("Request missing ClientId extension");
+                        return Box::pin(future::err(
+                            HttpError::identity_required("no identity").into(),
+                        ));
+                    }
+                };
+                request.headers_mut().append(http::header::FORWARDED, fwd);
 
                 // If we're forwarding HTTP/1 requests, the old `Host` header
                 // was stripped on the peer's outbound proxy. But the request
                 // should have an updated `Host` header now that it's being
                 // routed in the cluster.
                 if let ::http::Version::HTTP_11 | ::http::Version::HTTP_10 = request.version() {
-                    request
-                        .headers_mut()
-                        .insert(http::header::HOST, host_header.clone());
+                    request.headers_mut().insert(
+                        http::header::HOST,
+                        http::header::HeaderValue::from_str(host)
+                            .expect("Host header value must be valid"),
+                    );
                 }
 
-                tracing::debug!(
-                    headers = ?request.headers(),
-                    "Passing request to outbound"
-                );
+                tracing::debug!("Passing request to outbound");
                 Box::pin(outbound.call(request).map_err(Into::into))
             }
-            Self::NoAuthority => Box::pin(future::err(HttpError::not_found("no authority").into())),
             Self::NoIdentity => Box::pin(future::err(
                 HttpError::identity_required("no identity").into(),
             )),

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -1,19 +1,16 @@
-use crate::{
-    http,
-    require_identity::RequireIdentityForDirect,
-    target::{HttpAccept, RequestTarget, Target, TcpAccept, TcpEndpoint},
-};
+use crate::{http, target::TcpEndpoint};
 use linkerd_app_core::{
     config::ProxyConfig,
     detect, drain, io, metrics,
     opencensus::proto::trace::v1 as oc,
     proxy::identity::LocalCrtKey,
-    svc, tls,
-    transport::{listen, metrics::SensorIo},
-    transport_header::{self, DetectHeader, TransportHeader},
-    Error, DST_OVERRIDE_HEADER,
+    svc::{self, stack::Param},
+    tls,
+    transport::{self, listen, metrics::SensorIo},
+    transport_header::{self, DetectHeader, SessionProtocol, TransportHeader},
+    Conditional, Error, NameAddr,
 };
-use std::fmt::Debug;
+use std::{convert::TryInto, fmt::Debug, net::SocketAddr, str::FromStr};
 use tokio::sync::mpsc;
 
 #[derive(Clone, Debug)]
@@ -24,10 +21,43 @@ type FwdIo<I> = io::PrefixedIo<SensorIo<tls::server::Io<I>>>;
 /// Creates I/O errors when a connection cannot be forwarded because no transport
 /// header was present.
 #[derive(Debug, Default)]
-struct RefusedNoHeader(());
+struct RefusedNoHeader;
+
+#[derive(Debug)]
+struct RefusedNoIdentity;
+
+#[derive(Debug)]
+struct RefusedNoTarget;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HttpGatewayTarget {
+    /// HTTP gateway targets *must* have a logical name.
+    pub target: NameAddr,
+    /// The outbound protocol, i.e. before upgrading.
+    pub version: http::Version,
+}
+
+/// Routes HTTP requests to an `HttpGatewayTarget`.
+#[derive(Clone, Debug)]
+struct RouteHttpGatewayTarget(HttpClientInfo);
 
 #[derive(Clone, Debug)]
-struct HttpFromTransportHeader;
+struct HttpClientInfo {
+    /// HTTP connections should have a target addr from the transport header.
+    /// Legacy clients may not provide one, though.
+    target: Option<NameAddr>,
+    /// The serverside protocol, i.e. before downgrading.
+    version: http::Version,
+    client: ClientInfo,
+}
+
+/// Client connections *must* have an identity.
+#[derive(Clone, Debug)]
+struct ClientInfo {
+    client_id: tls::ClientId,
+    client_addr: SocketAddr,
+    local_addr: SocketAddr,
+}
 
 /// Builds a stack that handles connections that target the proxy's inbound port
 /// (i.e. without an SO_ORIGINAL_DST setting). This port behaves differently from
@@ -37,11 +67,11 @@ struct HttpFromTransportHeader;
 /// 2. TLS is required;
 /// 3. A transport header is expected. It's not strictly required, as
 ///    gateways may need to accept HTTP requests from older proxy versions
-pub fn stack<I, F, FSvc, L, LSvc>(
+pub fn stack<I, F, FSvc, H, HSvc>(
     config: &ProxyConfig,
     local_identity: Option<LocalCrtKey>,
-    tcp_forward: F,
-    http_loopback: L,
+    tcp: F,
+    http: H,
     metrics: &metrics::Proxy,
     span_sink: Option<mpsc::Sender<oc::Span>>,
     drain: drain::Watch,
@@ -56,90 +86,136 @@ where
     FSvc: svc::Service<FwdIo<I>, Response = ()> + Clone + Send + Sync + Unpin + 'static,
     FSvc::Error: Into<Error>,
     FSvc::Future: Send + Unpin,
-    L: svc::NewService<Target, Service = LSvc> + Clone + Send + Sync + Unpin + 'static,
-    LSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+    H: svc::NewService<HttpGatewayTarget, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
+    HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
         + Send
         + 'static,
-    LSvc::Error: Into<Error>,
-    LSvc::Future: Send,
+    HSvc::Error: Into<Error>,
+    HSvc::Future: Send,
 {
     let detect_timeout = config.detect_protocol_timeout;
     let dispatch_timeout = config.dispatch_timeout;
 
-    // Direct traffic may target an HTTP gateway.
-    let http = svc::stack(http_loopback)
-        .push_on_response(
-            svc::layers()
-                .push(svc::layer::mk(svc::SpawnReady::new))
-                .push(metrics.stack.layer(crate::stack_labels("http", "gateway")))
-                .push(svc::FailFast::layer("Gateway", dispatch_timeout))
-                .push_spawn_buffer(config.buffer_capacity),
-        )
-        .check_new_service::<Target, http::Request<http::BoxBody>>()
-        // Removes the override header after it has been used to
-        // determine a request target.
-        .push_on_response(http::strip_header::request::layer(DST_OVERRIDE_HEADER))
-        // Routes each request to a target, obtains a service for that
-        // target, and dispatches the request.
-        .instrument_from_target()
-        .push(svc::NewRouter::layer(RequestTarget::from))
-        .check_new_service::<HttpAccept, _>()
-        .into_inner();
-
-    let http_server = svc::stack(http::server(&config, http, metrics, span_sink, drain))
-        .check_new_service::<HttpAccept, _>()
-        .push_cache(config.cache_max_idle_age)
-        .push_map_target(HttpAccept::from);
-
-    let http_detect = http_server
-        .clone()
-        .push_on_response(svc::layers().push_map_target(io::EitherIo::Left))
-        .push(svc::UnwrapOr::layer(
-            svc::Fail::<_, RefusedNoHeader>::default(),
-        ))
-        .push(detect::NewDetectService::timeout(
-            detect_timeout,
-            http::DetectHttp::default(),
-        ))
-        .check_new_service::<TcpAccept, FwdIo<I>>()
-        .into_inner();
-
-    // If a transport header can be detected, use it to configure TCP
-    // forwarding. If a transport header cannot be detected, try to
-    // handle the connection as HTTP gateway traffic.
-    svc::stack(tcp_forward)
-        // We always try to detect a protocol header. We _can_ know whether it's
-        // expected based on the serverside ALPN (passed via the target), but
-        // it's easier to just do detection and handle the case when it's not
-        // present as an exception.
+    let http_server = {
+        // Cache an HTTP gateway service for each destination and HTTP version.
         //
-        // HTTP detection must *only* be performed when a transport header is
-        // absent. When the header is present, we must assume the protocol is
-        // opaque.
+        // The destination is determined from the transport header or, if none was
+        // present, the request URI.
         //
-        // TODO: Stop supporting headerless connections after stable-2.10.
+        // The client's ID is set as a request extension, as required by the
+        // gateway. This permits gateway services (and profile resolutions) to be
+        // cached per target, shared across clients.
+        let gateway = svc::stack(http)
+            .push_on_response(
+                svc::layers()
+                    .push(svc::layer::mk(svc::SpawnReady::new))
+                    .push(metrics.stack.layer(crate::stack_labels("http", "gateway")))
+                    .push(svc::FailFast::layer("Gateway", dispatch_timeout))
+                    .push_spawn_buffer(config.buffer_capacity),
+            )
+            .push_cache(config.cache_max_idle_age)
+            .push_on_response(
+                svc::layers()
+                    .push(http::Retain::layer())
+                    .push(http::BoxResponse::layer()),
+            )
+            .check_new_service::<HttpGatewayTarget, http::Request<_>>()
+            .push(svc::NewRouter::layer(RouteHttpGatewayTarget))
+            .check_new_service::<HttpClientInfo, http::Request<_>>()
+            .push_http_insert_target::<tls::ClientId>()
+            .into_inner();
+
+        http::server(&config, gateway, metrics, span_sink, drain)
+    };
+
+    svc::stack(tcp)
         .check_new_service::<TcpEndpoint, FwdIo<I>>()
+        // When the transport header is present, it may be used for either local
+        // TCP forwarding, or we may be processing an HTTP gateway connection.
+        // HTTP gateway connections that have a transport header must provide a
+        // target name as a part of the header.
         .push_switch(
-            HttpFromTransportHeader,
-            http_server
-                .push_on_response(svc::layers().push_map_target(io::EitherIo::Right))
-                .check_new_service::<(http::Version, TcpAccept), FwdIo<I>>()
+            |(h, client): (TransportHeader, ClientInfo)| match h {
+                TransportHeader {
+                    port,
+                    protocol: None,
+                    ..
+                } => Ok(svc::Either::A(TcpEndpoint { port })),
+                TransportHeader {
+                    port,
+                    name: Some(name),
+                    protocol: Some(proto),
+                } => Ok(svc::Either::B(HttpClientInfo {
+                    client,
+                    target: Some(NameAddr::from((name, port))),
+                    version: match proto {
+                        SessionProtocol::Http1 => http::Version::Http1,
+                        SessionProtocol::Http2 => http::Version::H2,
+                    },
+                })),
+                TransportHeader {
+                    name: None,
+                    protocol: Some(_),
+                    ..
+                } => Err(RefusedNoTarget),
+            },
+            // HTTP detection is not necessary in this case, since the transport
+            // header indicates the connection's HTTP version.
+            svc::stack(http_server.clone())
+                .push_on_response(svc::layers().push_map_target(io::EitherIo::Left))
+                .check_new_service::<HttpClientInfo, FwdIo<I>>()
                 .into_inner(),
         )
-        .check_new_service::<(TransportHeader, TcpAccept), FwdIo<I>>()
-        .push(svc::UnwrapOr::layer(http_detect))
+        // When the transport header is not present, perform HTTP detection to
+        // support legacy gateway clients.
+        //
+        // TODO: Stop supporting headerless connections after we have at least
+        // one stable release out with transport header support.
+        .push(svc::UnwrapOr::layer(
+            svc::stack(http_server)
+                .check_new_service::<HttpClientInfo, _>()
+                .push_on_response(svc::layers().push_map_target(io::EitherIo::Right))
+                .push_map_target(
+                    |(version, client): (http::Version, ClientInfo)| HttpClientInfo {
+                        version,
+                        client,
+                        target: None,
+                    },
+                )
+                .push(svc::UnwrapOr::layer(
+                    svc::Fail::<_, RefusedNoHeader>::default(),
+                ))
+                .push(detect::NewDetectService::timeout(
+                    detect_timeout,
+                    http::DetectHttp::default(),
+                ))
+                .check_new_service::<ClientInfo, FwdIo<I>>()
+                .into_inner(),
+        ))
+        // We always try to detect a protocol header. While we can know whether
+        // it's expected based on the serverside ALPN (passed via the target),
+        // it's easier to just do detection and handle the case when it's not
+        // present as an exception.
         .push(detect::NewDetectService::timeout(
             detect_timeout,
             DetectHeader::default(),
         ))
-        .check_new_service::<TcpAccept, _>()
-        // TODO: this filter should actually extract the TLS status so it's no
-        // longer wrapped in a conditional... i.e. proving to the inner stack
-        // that the connection is secure.
-        .push_request_filter(RequireIdentityForDirect)
         .push(metrics.transport.layer_accept())
-        .check_new_service::<TcpAccept, _>()
-        .push_map_target(TcpAccept::from)
+        // Build a ClientInfo target for each accepted connection. Refuse the
+        // connection if it doesn't include an mTLS identity.
+        .push_request_filter(
+            |(tls, addrs): (tls::ConditionalServerTls, listen::Addrs)| match tls {
+                Conditional::Some(tls::ServerTls::Established {
+                    client_id: Some(client_id),
+                    ..
+                }) => Ok(ClientInfo {
+                    client_id,
+                    client_addr: addrs.peer(),
+                    local_addr: addrs.target_addr(),
+                }),
+                _ => Err(RefusedNoIdentity),
+            },
+        )
         .push(tls::NewDetectTls::layer(
             local_identity.map(WithTransportHeaderAlpn),
             config.detect_protocol_timeout,
@@ -148,29 +224,61 @@ where
         .into_inner()
 }
 
-// === impl HttpFromTransportHeader ===
+// === impl ClientInfo ===
 
-impl svc::Predicate<(TransportHeader, TcpAccept)> for HttpFromTransportHeader {
-    type Request = svc::Either<TcpEndpoint, (http::Version, TcpAccept)>;
+impl Param<transport::labels::Key> for ClientInfo {
+    fn param(&self) -> transport::labels::Key {
+        transport::labels::Key::accept(
+            transport::labels::Direction::In,
+            Conditional::Some(tls::ServerTls::Established {
+                client_id: Some(self.client_id.clone()),
+                negotiated_protocol: None, // unused
+            }),
+            self.local_addr,
+        )
+    }
+}
 
-    // TODO: Use the transport header's `name` to inform gateway routing.
-    //
-    // TODO: Use the header's session protocol, i.e. for gateway processing.
-    fn check(&mut self, (h, mut t): (TransportHeader, TcpAccept)) -> Result<Self::Request, Error> {
-        match h.protocol {
-            None => {
-                // Update the TcpAccept target using a parsed transport-header.
-                t.target_addr = (t.target_addr.ip(), h.port).into();
-                Ok(svc::Either::A(t.into()))
-            }
-            Some(p) => {
-                let v = match p {
-                    transport_header::SessionProtocol::Http1 => http::Version::Http1,
-                    transport_header::SessionProtocol::Http2 => http::Version::H2,
-                };
-                Ok(svc::Either::B((v, t)))
-            }
+// === impl HttpClientInfo ===
+
+impl Param<http::normalize_uri::DefaultAuthority> for HttpClientInfo {
+    fn param(&self) -> http::normalize_uri::DefaultAuthority {
+        http::normalize_uri::DefaultAuthority(self.target.clone().map(|t| {
+            http::uri::Authority::from_str(&t.to_string()).expect("Address must be a valid URI")
+        }))
+    }
+}
+
+impl Param<http::Version> for HttpClientInfo {
+    fn param(&self) -> http::Version {
+        self.version
+    }
+}
+
+impl Param<tls::ClientId> for HttpClientInfo {
+    fn param(&self) -> tls::ClientId {
+        self.client.client_id.clone()
+    }
+}
+
+// === impl RouteHttpGatewayTarget ===
+
+impl<B> svc::stack::RecognizeRoute<http::Request<B>> for RouteHttpGatewayTarget {
+    type Key = HttpGatewayTarget;
+
+    fn recognize(&self, req: &http::Request<B>) -> Result<Self::Key, Error> {
+        let version = req.version().try_into()?;
+
+        if let Some(target) = self.0.target.clone() {
+            return Ok(HttpGatewayTarget { target, version });
         }
+
+        if let Some(a) = req.uri().authority() {
+            let target = NameAddr::from_str(&a.to_string())?;
+            return Ok(HttpGatewayTarget { target, version });
+        }
+
+        Err(RefusedNoTarget.into())
     }
 }
 
@@ -207,3 +315,23 @@ impl Into<Error> for RefusedNoHeader {
         ))
     }
 }
+
+// === impl RefusedNoIdentity ===
+
+impl std::fmt::Display for RefusedNoIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Direct connections must be mutually authenticated")
+    }
+}
+
+impl std::error::Error for RefusedNoIdentity {}
+
+// === impl RefusedNoTarget ===
+
+impl std::fmt::Display for RefusedNoTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "A named target must be provided on gateway connections")
+    }
+}
+
+impl std::error::Error for RefusedNoTarget {}

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -4,7 +4,8 @@ use crate::{
     Config,
 };
 pub use linkerd_app_core::proxy::http::{
-    strip_header, BoxBody, DetectHttp, Request, Response, Version,
+    normalize_uri, strip_header, uri, BoxBody, BoxResponse, DetectHttp, Request, Response, Retain,
+    Version,
 };
 use linkerd_app_core::{
     classify,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -14,7 +14,10 @@ pub mod target;
 #[cfg(test)]
 pub(crate) mod test_util;
 
-pub use self::target::{HttpEndpoint, Logical, RequestTarget, Target, TcpEndpoint};
+pub use self::{
+    direct::HttpGatewayTarget,
+    target::{HttpEndpoint, Logical, RequestTarget, Target, TcpEndpoint},
+};
 use self::{
     prevent_loop::PreventLoop,
     require_identity::RequireIdentityForPorts,
@@ -91,7 +94,8 @@ impl Config {
         C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin + 'static,
         C::Error: Into<Error>,
         C::Future: Send + Unpin,
-        L: svc::NewService<Target, Service = LSvc> + Clone + Send + Sync + Unpin + 'static,
+        L: svc::NewService<HttpGatewayTarget, Service = LSvc>,
+        L: Clone + Send + Sync + Unpin + 'static,
         LSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
             + Send
             + 'static,

--- a/linkerd/app/inbound/src/require_identity.rs
+++ b/linkerd/app/inbound/src/require_identity.rs
@@ -3,11 +3,6 @@ use indexmap::IndexSet;
 use linkerd_app_core::{svc::stack::Predicate, tls, Conditional, Error};
 use std::sync::Arc;
 
-/// A connection policy that fails direct connections that don't have a client
-/// identity.
-#[derive(Clone, Debug)]
-pub struct RequireIdentityForDirect;
-
 /// A connection policy that fails connections that don't have a client identity
 /// if they target one of the configured local ports.
 #[derive(Clone, Debug)]
@@ -17,22 +12,6 @@ pub struct RequireIdentityForPorts {
 
 #[derive(Debug)]
 pub struct IdentityRequired(());
-
-// === impl RequireIdentityForDirect ===
-
-impl Predicate<TcpAccept> for RequireIdentityForDirect {
-    type Request = TcpAccept;
-
-    fn check(&mut self, meta: TcpAccept) -> Result<TcpAccept, Error> {
-        tracing::debug!(tls = ?meta.tls);
-        match meta.tls {
-            Conditional::Some(tls::ServerTls::Established {
-                client_id: Some(_), ..
-            }) => Ok(meta),
-            _ => Err(IdentityRequired(()).into()),
-        }
-    }
-}
 
 // === impl RequireIdentityForPorts ===
 


### PR DESCRIPTION
When handling the HTTP gateway connections, the inbound proxy includes
the client's ID in the gateway's cache key so that a gateway service is
created for each (client, target) pair. Furthermore, the HTTP server
cache includes client _addresses_ in its key, so that a service is
cached for each _connection_ (which makes no sense).

In preparation for TCP gateway support, this change simplifies
inbound gateway handling by creating distinct target types used only by
the direct stack. Connections that lack identity or a target are failed
as early as possible, simplifying the gateway implementation. Client
identity is provided to gateway by setting the identity as a request
extension before the service is cached.