### PR TITLE
Prevent outbound connections on the loopback interface

### DIFF
--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -1,6 +1,5 @@
-use super::require_identity_on_endpoint::NewRequireIdentity;
-use super::Endpoint;
-use crate::{tcp, Outbound};
+use super::{require_identity_on_endpoint::NewRequireIdentity, Endpoint};
+use crate::Outbound;
 use linkerd_app_core::{
     classify, config, http_tracing,
     proxy::{http, tap},
@@ -54,13 +53,7 @@ where
             // Re-establishes a connection when the client fails.
             .push(reconnect::layer({
                 let backoff = backoff;
-                move |e: Error| {
-                    if tcp::connect::is_loop(&*e) {
-                        Err(e)
-                    } else {
-                        Ok(backoff.stream())
-                    }
-                }
+                move |_| Ok(backoff.stream())
             }))
             .check_new::<Endpoint>()
             .push(tap::NewTapHttp::layer(rt.tap.clone()))

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -57,7 +57,6 @@ impl<C> Outbound<C> {
 
     pub fn into_server<R, P, I>(
         self,
-        server_port: u16,
         resolve: R,
         profiles: P,
     ) -> impl svc::NewService<
@@ -86,12 +85,12 @@ impl<C> Outbound<C> {
     {
         let tcp = self
             .clone()
-            .push_tcp_endpoint(server_port)
+            .push_tcp_endpoint()
             .push_tcp_balance(resolve.clone())
             .into_inner();
         let http = self
             .clone()
-            .push_tcp_endpoint(server_port)
+            .push_tcp_endpoint()
             .push_http_endpoint()
             .push_http_logical(resolve)
             .push_http_server()

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -160,7 +160,7 @@ impl Config {
 
             if ingress_mode {
                 let tcp = Outbound::new_tcp_connect(outbound.clone(), outbound_rt.clone())
-                    .push_tcp_endpoint(outbound_addr.port())
+                    .push_tcp_endpoint()
                     .push_tcp_forward()
                     .into_inner();
                 let http = Outbound::new_tcp_connect(outbound.clone(), outbound_rt.clone())
@@ -181,11 +181,7 @@ impl Config {
                 );
             } else {
                 let server = Outbound::new_tcp_connect(outbound.clone(), outbound_rt.clone())
-                    .into_server(
-                        outbound_addr.port(),
-                        dst.resolve.clone(),
-                        dst.profiles.clone(),
-                    );
+                    .into_server(dst.resolve.clone(), dst.profiles.clone());
                 tokio::spawn(
                     serve::serve(outbound_listen, server, drain_rx.clone().signaled())
                         .map_err(|e| panic!("outbound failed: {}", e))
@@ -213,7 +209,7 @@ impl Config {
                 gateway,
                 inbound.clone(),
                 Outbound::new_tcp_connect(outbound, outbound_rt)
-                    .push_tcp_endpoint(outbound_addr.port())
+                    .push_tcp_endpoint()
                     .push_http_endpoint()
                     .push_http_logical(dst.resolve.clone())
                     .into_inner(),


### PR DESCRIPTION
The outbound proxy attempts to prevent loops by preventing connections
to the proxy's outbound server port; but the outbound proxy **only**
listens on the loopback interface, so port-based matching is
ineffective.

We *should* prevent all outbound connections on the loopback
interface--it indicates an iptables misconfiguration; but this would
unfortunately break many of our integration tests

This change removes outbound loop prevention.