### PR TITLE
tracing: update to 0.1.23, remove `tracing-futures`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,6 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -678,7 +677,6 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -715,7 +713,6 @@ dependencies = [
  "tokio-test",
  "tower",
  "tracing",
- "tracing-futures",
  "tracing-subscriber",
 ]
 
@@ -744,7 +741,6 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "tracing-futures",
  "tracing-subscriber",
  "webpki",
 ]
@@ -769,7 +765,6 @@ dependencies = [
  "tokio-test",
  "tower",
  "tracing",
- "tracing-futures",
  "tracing-subscriber",
 ]
 
@@ -791,7 +786,6 @@ dependencies = [
  "tokio-test",
  "tower",
  "tracing",
- "tracing-futures",
  "tracing-subscriber",
 ]
 
@@ -808,7 +802,6 @@ dependencies = [
  "tower",
  "tower-test",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -822,7 +815,6 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "tracing-futures",
  "tracing-subscriber",
 ]
 
@@ -1098,7 +1090,6 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -1115,7 +1106,6 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -1148,7 +1138,6 @@ dependencies = [
  "tokio-test",
  "tower",
  "tracing",
- "tracing-futures",
  "tracing-subscriber",
  "try-lock",
 ]
@@ -1208,7 +1197,6 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -1293,7 +1281,6 @@ dependencies = [
  "tonic",
  "tower",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -1340,7 +1327,6 @@ dependencies = [
  "pin-project 1.0.4",
  "tower",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -1377,7 +1363,6 @@ dependencies = [
  "tokio-rustls",
  "tower",
  "tracing",
- "tracing-futures",
  "tracing-subscriber",
  "untrusted",
  "webpki",
@@ -2328,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
 dependencies = [
  "cfg-if",
  "log",
@@ -2341,9 +2326,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -29,5 +29,4 @@ regex = "1.0.0"
 tokio = { version = "1", features = ["rt"] }
 tonic = { version = "0.4", default-features = false, features = ["prost"] }
 tower = "0.4"
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -68,8 +68,8 @@ linkerd-trace-context = { path = "../../trace-context" }
 regex = "1.0.0"
 tokio = { version = "1", features = ["macros", "sync", "parking_lot"]}
 tonic = { version = "0.4", default-features = false, features = ["prost"] }
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"
+
 pin-project = "1"
 
 [dependencies.tower]

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -69,7 +69,6 @@ regex = "1.0.0"
 tokio = { version = "1", features = ["macros", "sync", "parking_lot"]}
 tonic = { version = "0.4", default-features = false, features = ["prost"] }
 tracing = "0.1.23"
-
 pin-project = "1"
 
 [dependencies.tower]

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -5,7 +5,7 @@ use linkerd_error::Error;
 use linkerd_proxy_transport::listen::Addrs;
 use tower::util::ServiceExt;
 use tracing::{debug, info, info_span, warn};
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 /// Spawns a task that binds an `L`-typed listener with an `A`-typed
 /// connection-accepting service.

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -4,8 +4,8 @@ use futures::prelude::*;
 use linkerd_error::Error;
 use linkerd_proxy_transport::listen::Addrs;
 use tower::util::ServiceExt;
-use tracing::{debug, info, info_span, warn};
 use tracing::instrument::Instrument;
+use tracing::{debug, info, info_span, warn};
 
 /// Spawns a task that binds an `L`-typed listener with an `A`-typed
 /// connection-accepting service.

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -15,7 +15,7 @@ linkerd-app-inbound = { path = "../inbound" }
 linkerd-app-outbound = { path = "../outbound" }
 tokio = { version = "1", features = ["sync"] }
 tower = { version = "0.4.1", default-features = false }
-tracing = "0.1.22"
+tracing = "0.1.23"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3.9"
 indexmap = "1.0"
 linkerd-app-core = { path = "../core" }
 tokio = { version = "1", features = ["sync"] }
-tracing = "0.1.22"
+tracing = "0.1.23"
 
 [dependencies.tower]
 version = "0.4"
@@ -33,5 +33,5 @@ linkerd-app-test = { path = "../test" }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 tokio = { version = "1", features = ["full", "macros"]}
 tokio-test = "0.4"
-tracing-futures = "0.2"
+
 tracing-subscriber = "0.2"

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -33,5 +33,4 @@ linkerd-app-test = { path = "../test" }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 tokio = { version = "1", features = ["full", "macros"]}
 tokio-test = "0.4"
-
 tracing-subscriber = "0.2"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -36,8 +36,8 @@ tokio = { version = "1", features = ["io-util", "net", "rt", "macros"]}
 tokio-rustls = "0.22"
 tower = { version = "0.4.1", default-features = false}
 tonic = { version = "0.4", default-features = false }
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"
+
 webpki = "0.21"
 
 [dependencies.tracing-subscriber]

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -37,7 +37,6 @@ tokio-rustls = "0.22"
 tower = { version = "0.4.1", default-features = false}
 tonic = { version = "0.4", default-features = false }
 tracing = "0.1.23"
-
 webpki = "0.21"
 
 [dependencies.tracing-subscriber]

--- a/linkerd/app/integration/src/client.rs
+++ b/linkerd/app/integration/src/client.rs
@@ -7,7 +7,7 @@ use tokio::net::TcpStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::info_span;
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 use webpki::{DNSName, DNSNameRef};
 
 type ClientError = hyper::Error;

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -10,7 +10,7 @@ use std::ops::{Bound, RangeBounds};
 use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 use tonic as grpc;
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 pub fn new() -> Controller {
     Controller::new()

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -1,6 +1,6 @@
 use super::*;
 use std::{future::Future, pin::Pin, task::Poll, thread};
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 pub fn new() -> Proxy {
     Proxy::default()

--- a/linkerd/app/integration/src/server.rs
+++ b/linkerd/app/integration/src/server.rs
@@ -14,7 +14,7 @@ use tokio::net::TcpStream;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tokio_rustls::TlsAcceptor;
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 pub fn new() -> Server {
     http2()

--- a/linkerd/app/integration/src/tcp.rs
+++ b/linkerd/app/integration/src/tcp.rs
@@ -9,7 +9,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 type TcpConnSender = mpsc::UnboundedSender<(
     Option<Vec<u8>>,

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -41,5 +41,4 @@ linkerd-app-test = { path = "../test" }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 tokio = { version = "1", features = ["full", "macros"]}
 tokio-test = "0.4"
-
 tracing-subscriber = "0.2"

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -22,7 +22,7 @@ linkerd-app-core = { path = "../core" }
 linkerd-identity = { path = "../../identity" }
 linkerd-retry = { path = "../../retry" }
 tokio = { version = "1", features = ["sync"]}
-tracing = "0.1.22"
+tracing = "0.1.23"
 pin-project = "1"
 
 [dependencies.tower]
@@ -41,5 +41,5 @@ linkerd-app-test = { path = "../test" }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 tokio = { version = "1", features = ["full", "macros"]}
 tokio-test = "0.4"
-tracing-futures = "0.2"
+
 tracing-subscriber = "0.2"

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -22,7 +22,7 @@ use std::{
     },
 };
 use tower::ServiceExt;
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 #[tokio::test]
 async fn plaintext_tcp() {

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -22,8 +22,8 @@ use linkerd_channel::into_stream::IntoStream;
 use std::{net::SocketAddr, pin::Pin};
 use tokio::{sync::mpsc, time::Duration};
 
-use tracing::{debug, error, info, info_span};
 use tracing::instrument::Instrument;
+use tracing::{debug, error, info, info_span};
 
 /// Spawns a sidecar proxy.
 ///

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -23,7 +23,7 @@ use std::{net::SocketAddr, pin::Pin};
 use tokio::{sync::mpsc, time::Duration};
 
 use tracing::{debug, error, info, info_span};
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 /// Spawns a sidecar proxy.
 ///

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -31,7 +31,6 @@ tokio = { version = "1", features = ["io-util", "net", "rt", "sync"]}
 tokio-test = "0.4"
 tower = { version = "0.4.1", default-features = false}
 tracing = "0.1.23"
-
 tracing-subscriber = "0.2.11"
 
 [dev-dependencies.tracing-subscriber]

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -30,8 +30,8 @@ regex = "1"
 tokio = { version = "1", features = ["io-util", "net", "rt", "sync"]}
 tokio-test = "0.4"
 tower = { version = "0.4.1", default-features = false}
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"
+
 tracing-subscriber = "0.2.11"
 
 [dev-dependencies.tracing-subscriber]

--- a/linkerd/app/test/src/connect.rs
+++ b/linkerd/app/test/src/connect.rs
@@ -7,7 +7,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use tokio_test::io;
-use tracing_futures::{Instrument, Instrumented};
+use tracing::instrument::{Instrument, Instrumented};
 
 type ConnectFn<E> = Box<dyn FnMut(E) -> ConnectFuture + Send>;
 

--- a/linkerd/buffer/Cargo.toml
+++ b/linkerd/buffer/Cargo.toml
@@ -12,8 +12,8 @@ linkerd-channel = { path = "../channel" }
 linkerd-error = { path = "../error" }
 tokio = { version = "1", features = ["sync", "time", "macros"] }
 tower = { version = "0.4.1", default_features = false, features = ["util"] }
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"
+
 pin-project = "1"
 
 [dev-dependencies]

--- a/linkerd/buffer/Cargo.toml
+++ b/linkerd/buffer/Cargo.toml
@@ -13,7 +13,6 @@ linkerd-error = { path = "../error" }
 tokio = { version = "1", features = ["sync", "time", "macros"] }
 tower = { version = "0.4.1", default_features = false, features = ["util"] }
 tracing = "0.1.23"
-
 pin-project = "1"
 
 [dev-dependencies]

--- a/linkerd/buffer/src/layer.rs
+++ b/linkerd/buffer/src/layer.rs
@@ -1,7 +1,7 @@
 use crate::Buffer;
 use linkerd_error::Error;
 use std::time::Duration;
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 pub struct SpawnBufferLayer<Req, Rsp> {
     capacity: usize,

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -13,8 +13,8 @@ linkerd-stack = { path = "../stack" }
 parking_lot = "0.11"
 tokio = { version = "1", default-features = false, features = ["rt", "sync", "time"] }
 tower = { version = "0.4.1", default-features = false, features = ["util"] }
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"
+
 
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = ["macros", "test-util", "time"] }

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -15,7 +15,6 @@ tokio = { version = "1", default-features = false, features = ["rt", "sync", "ti
 tower = { version = "0.4.1", default-features = false, features = ["util"] }
 tracing = "0.1.23"
 
-
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = ["macros", "test-util", "time"] }
 tracing-subscriber = "0.2"

--- a/linkerd/concurrency-limit/Cargo.toml
+++ b/linkerd/concurrency-limit/Cargo.toml
@@ -12,5 +12,5 @@ futures = "0.3.9"
 linkerd-stack = { path = "../stack" }
 tokio = { version = "1", features = ["sync"] }
 tower = { version = "0.4.1", default-features = false }
-tracing = "0.1.22"
+tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/detect/Cargo.toml
+++ b/linkerd/detect/Cargo.toml
@@ -14,4 +14,4 @@ linkerd-io = { path = "../io" }
 linkerd-stack = { path = "../stack" }
 tokio = { version = "1", features = ["time"] }
 tower = "0.4"
-tracing = "0.1.22"
+tracing = "0.1.23"

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 futures = "0.3.9"
 linkerd-dns-name = { path = "./name" }
 linkerd-error = { path = "../error" }
-tracing = "0.1.22"
+tracing = "0.1.23"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 pin-project = "1"
 

--- a/linkerd/duplex/Cargo.toml
+++ b/linkerd/duplex/Cargo.toml
@@ -11,5 +11,5 @@ bytes = "1"
 futures = "0.3.9"
 tokio = { version = "1", features = ["io-util"] }
 pin-project = "1"
-tracing = "0.1.22"
+tracing = "0.1.23"
 linkerd-io = { path = "../io" }

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -17,7 +17,7 @@ linkerd-error = { path = "../error" }
 linkerd-http-classify = { path = "../http-classify" }
 linkerd-metrics = { path = "../metrics" }
 linkerd-stack = { path = "../stack" } 
-tracing = "0.1.22"
+tracing = "0.1.23"
 pin-project = "1"
 
 [dependencies.tower]

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -17,4 +17,4 @@ opencensus-proto = { path = "../../opencensus-proto" }
 tonic = { version = "0.4", default-features = false, features = ["prost", "codegen"] }
 tower = { version = "0.4.1", default-features = false }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
-tracing = "0.1.22"
+tracing = "0.1.23"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -22,4 +22,4 @@ pin-project = "1"
 prost = "0.7"
 tonic = { version = "0.4", default-features = false }
 tower = { version = "0.4.1", default-features = false }
-tracing = "0.1.22"
+tracing = "0.1.23"

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -17,8 +17,8 @@ linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["sync", "time"] }
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"
+
 pin-project = "1"
 
 [dependencies.tower]

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -18,7 +18,6 @@ linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["sync", "time"] }
 tracing = "0.1.23"
-
 pin-project = "1"
 
 [dependencies.tower]

--- a/linkerd/proxy/discover/src/buffer.rs
+++ b/linkerd/proxy/discover/src/buffer.rs
@@ -10,7 +10,7 @@ use tokio::sync::oneshot;
 use tokio::time::{self, Sleep};
 use tower::discover;
 use tracing::warn;
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 #[derive(Clone, Debug)]
 pub struct Buffer<M> {

--- a/linkerd/proxy/discover/src/buffer.rs
+++ b/linkerd/proxy/discover/src/buffer.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio::time::{self, Sleep};
 use tower::discover;
-use tracing::warn;
 use tracing::instrument::Instrument;
+use tracing::warn;
 
 #[derive(Clone, Debug)]
 pub struct Buffer<M> {

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -20,7 +20,6 @@ linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["sync"] }
 tracing = "0.1.9"
 
-
 [dependencies.tower]
 version = "0.4"
 # disable tower's tracing `log` integration for performance reasons, since we

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -19,7 +19,7 @@ linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["sync"] }
 tracing = "0.1.9"
-tracing-futures = "0.2"
+
 
 [dependencies.tower]
 version = "0.4"

--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -12,8 +12,8 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::sync::mpsc;
-use tracing::{debug, trace};
 use tracing::instrument::Instrument;
+use tracing::{debug, trace};
 
 /// A Resolver that attempts to lookup targets via DNS.
 ///

--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use tokio::sync::mpsc;
 use tracing::{debug, trace};
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 /// A Resolver that attempts to lookup targets via DNS.
 ///

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -36,7 +36,6 @@ rand = "0.8"
 tokio = { version = "1", features = ["time", "rt"] }
 tower = { version = "0.4.1", default-features = false, features = ["balance", "load", "discover"] }
 tracing = "0.1.23"
-
 try-lock = "0.2"
 pin-project = "1"
 

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -35,8 +35,8 @@ linkerd-timeout = { path = "../../timeout" }
 rand = "0.8"
 tokio = { version = "1", features = ["time", "rt"] }
 tower = { version = "0.4.1", default-features = false, features = ["balance", "load", "discover"] }
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"
+
 try-lock = "0.2"
 pin-project = "1"
 

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -16,7 +16,7 @@ use std::{
 };
 use tower::ServiceExt;
 use tracing::{debug, debug_span};
-use tracing_futures::{Instrument, Instrumented};
+use tracing::instrument::{Instrument, Instrumented};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Settings {

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -15,8 +15,8 @@ use std::{
     task::{Context, Poll},
 };
 use tower::ServiceExt;
-use tracing::{debug, debug_span};
 use tracing::instrument::{Instrument, Instrumented};
+use tracing::{debug, debug_span};
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub enum Settings {

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -13,8 +13,8 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::io::{AsyncRead, AsyncWrite};
-use tracing::{debug, debug_span, trace_span};
 use tracing::instrument::Instrument;
+use tracing::{debug, debug_span, trace_span};
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Settings {

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::{debug, debug_span, trace_span};
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Settings {

--- a/linkerd/proxy/http/src/trace.rs
+++ b/linkerd/proxy/http/src/trace.rs
@@ -1,5 +1,5 @@
 use std::future::Future;
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 #[derive(Clone, Debug, Default)]
 pub struct Executor(());

--- a/linkerd/proxy/http/src/upgrade.rs
+++ b/linkerd/proxy/http/src/upgrade.rs
@@ -12,8 +12,8 @@ use std::fmt;
 use std::mem;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use tracing::{debug, info, trace};
 use tracing::instrument::Instrument;
+use tracing::{debug, info, trace};
 use try_lock::TryLock;
 
 /// A type inserted into `http::Extensions` to bridge together HTTP Upgrades.

--- a/linkerd/proxy/http/src/upgrade.rs
+++ b/linkerd/proxy/http/src/upgrade.rs
@@ -13,7 +13,7 @@ use std::mem;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tracing::{debug, info, trace};
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 use try_lock::TryLock;
 
 /// A type inserted into `http::Extensions` to bridge together HTTP Upgrades.

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -16,6 +16,6 @@ linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }
 tokio = { version = "1", features = ["time", "sync"] }
 tonic = { version = "0.4", default-features = false }
-tracing = "0.1.22"
+tracing = "0.1.23"
 http-body = "0.4"
 pin-project = "1"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -26,7 +26,6 @@ tokio = { version = "1", features = ["time"]}
 tower = { version = "0.4.1", default-features = false }
 tonic = { version = "0.4", default-features = false }
 tracing = "0.1.23"
-
 pin-project = "1"
 
 [dev-dependencies]

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -25,8 +25,8 @@ rand = { version = "0.8" }
 tokio = { version = "1", features = ["time"]}
 tower = { version = "0.4.1", default-features = false }
 tonic = { version = "0.4", default-features = false }
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"
+
 pin-project = "1"
 
 [dev-dependencies]

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -27,7 +27,7 @@ pin-project = "1"
 socket2 = "0.3"
 tokio = { version = "1", features = ["macros", "net"] }
 tower = { version = "0.4", features = ["make"] }
-tracing = "0.1.22"
+tracing = "0.1.23"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -11,5 +11,5 @@ linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 futures = "0.3.9"
 tower = { version = "0.4.1", default-features = false }
-tracing = "0.1.22"
+tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/retry/Cargo.toml
+++ b/linkerd/retry/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 tower = { version = "0.4.1", default-features = false, features = ["retry", "util"] }
-tracing = "0.1.22"
+tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -26,8 +26,8 @@ regex = "1.0.0"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 async-stream = "0.3"
 tonic = { version = "0.4", default-features = false }
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"
+
 pin-project = "1"
 
 [dependencies.tower]

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -27,7 +27,6 @@ tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 async-stream = "0.3"
 tonic = { version = "0.4", default-features = false }
 tracing = "0.1.23"
-
 pin-project = "1"
 
 [dependencies.tower]

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -26,7 +26,7 @@ use tonic::{
 };
 use tower::retry::budget::Budget;
 use tracing::{debug, debug_span, error, trace, warn};
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 #[derive(Clone, Debug)]
 pub struct Client<S, R> {

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -25,8 +25,8 @@ use tonic::{
     client::GrpcService,
 };
 use tower::retry::budget::Budget;
-use tracing::{debug, debug_span, error, trace, warn};
 use tracing::instrument::Instrument;
+use tracing::{debug, debug_span, error, trace, warn};
 
 #[derive(Clone, Debug)]
 pub struct Client<S, R> {

--- a/linkerd/signal/Cargo.toml
+++ b/linkerd/signal/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 
 [dependencies]
 tokio = { version = "1", features = ["macros", "signal"] }
-tracing = "0.1.22"
+tracing = "0.1.23"

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 futures = "0.3.9"
 linkerd-error = { path = "../../error" }
 linkerd-stack = { path = ".." }
-tracing = "0.1.22"
-tracing-futures = "0.2"
+tracing = "0.1.23"
+
 pin-project = "1"
 
 [dependencies.tower]

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -11,7 +11,6 @@ futures = "0.3.9"
 linkerd-error = { path = "../../error" }
 linkerd-stack = { path = ".." }
 tracing = "0.1.23"
-
 pin-project = "1"
 
 [dependencies.tower]

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tracing::{trace, Span};
-use tracing_futures::{Instrument as _, Instrumented};
+use tracing::instrument::{Instrument as _, Instrumented};
 
 /// A strategy for creating spans based on a service's target.
 pub trait GetSpan<T> {

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -4,8 +4,8 @@ use pin_project::pin_project;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tracing::{trace, Span};
 use tracing::instrument::{Instrument as _, Instrumented};
+use tracing::{trace, Span};
 
 /// A strategy for creating spans based on a service's target.
 pub trait GetSpan<T> {

--- a/linkerd/timeout/Cargo.toml
+++ b/linkerd/timeout/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 futures = "0.3.9"
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
-tracing = "0.1.22"
+tracing = "0.1.23"
 pin-project = "1"
 tokio = { version = "1", features = ["time"] }
 

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -20,7 +20,7 @@ rustls = "0.19"
 tokio = { version = "1", features = ["macros", "time"]}
 tokio-rustls = "0.22"
 tower = "0.4"
-tracing = "0.1.22"
+tracing = "0.1.23"
 webpki = "0.21"
 untrusted = "0.7"
 
@@ -29,5 +29,5 @@ linkerd-identity = { path = "../identity", features = ["test-util"] }
 linkerd-proxy-transport = { path = "../proxy/transport" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tower = { version = "0.4.1", default-features = false, features = ["util"] }
-tracing-futures = "0.2"
+
 tracing-subscriber = "0.2.14"

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -29,5 +29,4 @@ linkerd-identity = { path = "../identity", features = ["test-util"] }
 linkerd-proxy-transport = { path = "../proxy/transport" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tower = { version = "0.4.1", default-features = false, features = ["util"] }
-
 tracing-subscriber = "0.2.14"

--- a/linkerd/tls/tests/tls_accept.rs
+++ b/linkerd/tls/tests/tls_accept.rs
@@ -20,7 +20,7 @@ use tower::{
     layer::Layer,
     util::{service_fn, ServiceExt},
 };
-use tracing_futures::Instrument;
+use tracing::instrument::Instrument;
 
 #[test]
 fn plaintext() {

--- a/linkerd/tracing/Cargo.toml
+++ b/linkerd/tracing/Cargo.toml
@@ -15,7 +15,7 @@ linkerd-error = { path = "../error" }
 serde_json = "1"
 tokio = { version = "1", features = ["time"] }
 tokio-trace = { git = "https://github.com/hawkw/tokio-trace", rev = "7d5998e7cb3beb06ada5983675319dc4853576c5", features = ["serde"] }
-tracing = "0.1.22"
+tracing = "0.1.23"
 tracing-log = "0.1"
 
 [dependencies.tracing-subscriber]

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -16,7 +16,7 @@ linkerd-io = { path = "../io" }
 linkerd-stack = { path = "../stack" }
 prost = "0.7"
 tokio = { version = "1", features = ["time"] }
-tracing = "0.1"
+tracing = "0.1.23"
 
 [build-dependencies]
 prost-build = { version = "0.7", default-features = false }

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -19,4 +19,4 @@ num_cpus = { version = "1", optional = true }
 linkerd-app = { path = "../linkerd/app" }
 linkerd-signal = { path = "../linkerd/signal" }
 tokio = { version = "1", features = ["rt", "time", "net"] }
-tracing = "0.1.22"
+tracing = "0.1.23"


### PR DESCRIPTION
This branch updates the proxy's dependency on the `tracing` crate to
v0.1.23. It also removes the dependency on the `tracing-futures` crate
entirely, as the `Instrument` trait and `Instrumented` macro for
`std::future`s are now provided by `tracing` itself, and we don't use
any of the other functionality provided by `tracing-futures`. This
simplifies our dependency tree a bit.

Unfortunately, the outdated `pin_project` is still in our dependency
tree via `h2`'s `tracing-futures` dependency, but I'll go ahead and
put a `tracing-futures` release together as well.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>