### PR TITLE
Update Hyper for  RUSTSEC-2021-0020

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,9 +452,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
  "bytes",
  "futures-channel",


### PR DESCRIPTION
Advisory: https://rustsec.org/advisories/RUSTSEC-2021-0020

    hyper's HTTP server code had a flaw that incorrectly understands some requests
    with multiple transfer-encoding headers to have a chunked payload, when it
    should have been rejected as illegal. This combined with an upstream HTTP proxy
    that understands the request payload boundary differently can result in
    "request smuggling" or "desync attacks".