### PR TITLE
update Tower to v0.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd7b451959622e21de79261673d658a0944b835012c58c51878ea55957fb51a"
+checksum = "713c629c07a3a97f741c140e474e7304294fabec66a43a33f0832e98315ab07f"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3.9"
 http = "0.2"
 hyper = "0.14.2"
 pin-project = "1"
-tower = { version = "0.4.1", default-features = false, features = ["load"] }
+tower = { version = "0.4.5", default-features = false, features = ["load"] }
 tokio = { version = "1", features = ["macros"] }
 
 [dev-dependencies]

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -14,12 +14,12 @@ linkerd-app-core = { path = "../core" }
 linkerd-app-inbound = { path = "../inbound" }
 linkerd-app-outbound = { path = "../outbound" }
 tokio = { version = "1", features = ["sync"] }
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }
 tracing = "0.1.23"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
 tokio-test = "0.4"
-tower = { version = "0.4.1", default-features = false, features = ["util"] }
+tower = { version = "0.4.5", default-features = false, features = ["util"] }
 tower-test = "0.4"
 linkerd-app-test = { path = "../test" }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -34,7 +34,7 @@ socket2 = "0.3.12"
 rustls = "0.19"
 tokio = { version = "1", features = ["io-util", "net", "rt", "macros"]}
 tokio-rustls = "0.22"
-tower = { version = "0.4.1", default-features = false}
+tower = { version = "0.4.5", default-features = false}
 tonic = { version = "0.4", default-features = false }
 tracing = "0.1.23"
 webpki = "0.21"

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -29,7 +29,7 @@ linkerd-io = { path = "../../io", features = ["tokio-test"] }
 regex = "1"
 tokio = { version = "1", features = ["io-util", "net", "rt", "sync"]}
 tokio-test = "0.4"
-tower = { version = "0.4.1", default-features = false}
+tower = { version = "0.4.5", default-features = false}
 tracing = "0.1.23"
 tracing-subscriber = "0.2.11"
 

--- a/linkerd/buffer/Cargo.toml
+++ b/linkerd/buffer/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3.9"
 linkerd-channel = { path = "../channel" }
 linkerd-error = { path = "../error" }
 tokio = { version = "1", features = ["sync", "time", "macros"] }
-tower = { version = "0.4.1", default_features = false, features = ["util"] }
+tower = { version = "0.4.5", default_features = false, features = ["util"] }
 tracing = "0.1.23"
 pin-project = "1"
 

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -12,7 +12,7 @@ linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 parking_lot = "0.11"
 tokio = { version = "1", default-features = false, features = ["rt", "sync", "time"] }
-tower = { version = "0.4.1", default-features = false, features = ["util"] }
+tower = { version = "0.4.5", default-features = false, features = ["util"] }
 tracing = "0.1.23"
 
 [dev-dependencies]

--- a/linkerd/concurrency-limit/Cargo.toml
+++ b/linkerd/concurrency-limit/Cargo.toml
@@ -11,6 +11,6 @@ publish = false
 futures = "0.3.9"
 linkerd-stack = { path = "../stack" }
 tokio = { version = "1", features = ["sync"] }
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }
 tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/drain/Cargo.toml
+++ b/linkerd/drain/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.9"
 tokio = { version = "1", features = ["macros", "sync"] }
 
 linkerd-stack = { path = "../stack", optional = true }
-tower = { version = "0.4.1", default-features = false, optional = true }
+tower = { version = "0.4.5", default-features = false, optional = true }
 
 [dev-dependencies]
 pin-project = "1"

--- a/linkerd/error-metrics/Cargo.toml
+++ b/linkerd/error-metrics/Cargo.toml
@@ -11,5 +11,5 @@ publish = false
 futures = "0.3.9"
 indexmap = "1.0"
 linkerd-metrics = { path = "../metrics" }
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }
 pin-project = "1"

--- a/linkerd/error-respond/Cargo.toml
+++ b/linkerd/error-respond/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 [dependencies]
 futures = "0.3.9"
 linkerd-error = { path = "../error" }
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }
 pin-project = "1"

--- a/linkerd/http-classify/Cargo.toml
+++ b/linkerd/http-classify/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 http = "0.2"
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -15,6 +15,6 @@ linkerd-error = { path = "../error" }
 linkerd-metrics = { path = "../metrics" }
 opencensus-proto = { path = "../../opencensus-proto" }
 tonic = { version = "0.4", default-features = false, features = ["prost", "codegen"] }
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tracing = "0.1.23"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -21,5 +21,5 @@ indexmap = "1.0"
 pin-project = "1"
 prost = "0.7"
 tonic = { version = "0.4", default-features = false }
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }
 tracing = "0.1.23"

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -12,5 +12,5 @@ Core interfaces needed to implement proxy components
 [dependencies]
 futures = "0.3.9"
 linkerd-error = { path = "../../error" }
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }
 pin-project = "0.4"

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -30,4 +30,4 @@ features = ["discover"]
 [dev-dependencies]
 async-stream = "0.3"
 tokio = { version = "1", features = ["macros", "rt"] }
-tower = { version = "0.4.1", default-features = false, features = ["discover", "util"]}
+tower = { version = "0.4.5", default-features = false, features = ["discover", "util"]}

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -34,7 +34,7 @@ linkerd-stack = { path = "../../stack" }
 linkerd-timeout = { path = "../../timeout" }
 rand = "0.8"
 tokio = { version = "1", features = ["time", "rt"] }
-tower = { version = "0.4.1", default-features = false, features = ["balance", "load", "discover"] }
+tower = { version = "0.4.5", default-features = false, features = ["balance", "load", "discover"] }
 tracing = "0.1.23"
 try-lock = "0.2"
 pin-project = "1"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -23,7 +23,7 @@ linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }
 rand = { version = "0.8" }
 tokio = { version = "1", features = ["time"]}
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }
 tonic = { version = "0.4", default-features = false }
 tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/proxy/tcp/Cargo.toml
+++ b/linkerd/proxy/tcp/Cargo.toml
@@ -14,5 +14,5 @@ linkerd-error = { path = "../../error" }
 linkerd-stack = { path = "../../stack" }
 rand = "0.8"
 tokio = { version = "1" }
-tower = { version = "0.4.1", default-features = false, features = ["balance", "load", "discover"] }
+tower = { version = "0.4.5", default-features = false, features = ["balance", "load", "discover"] }
 pin-project = "1"

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 futures = "0.3.9"
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }
 tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/retry/Cargo.toml
+++ b/linkerd/retry/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 [dependencies]
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
-tower = { version = "0.4.1", default-features = false, features = ["retry", "util"] }
+tower = { version = "0.4.5", default-features = false, features = ["retry", "util"] }
 tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/stack/metrics/Cargo.toml
+++ b/linkerd/stack/metrics/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 [dependencies]
 indexmap = "1.0"
 linkerd-metrics = { path = "../../metrics" }
-tower = { version = "0.4.1", default-features = false }
+tower = { version = "0.4.5", default-features = false }
 tokio = { version = "1", features = ["time"] }

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -19,7 +19,7 @@ linkerd-stack = { path = "../stack" }
 rustls = "0.19"
 tokio = { version = "1", features = ["macros", "time"]}
 tokio-rustls = "0.22"
-tower = "0.4"
+tower = "0.4.5"
 tracing = "0.1.23"
 webpki = "0.21"
 untrusted = "0.7"
@@ -28,5 +28,5 @@ untrusted = "0.7"
 linkerd-identity = { path = "../identity", features = ["test-util"] }
 linkerd-proxy-transport = { path = "../proxy/transport" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
-tower = { version = "0.4.1", default-features = false, features = ["util"] }
+tower = { version = "0.4.5", default-features = false, features = ["util"] }
 tracing-subscriber = "0.2.14"

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -16,5 +16,5 @@ linkerd-channel = { path = "../channel" }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 rand = "0.8"
-tower = { version = "0.4.1", default-features = false, features = ["util"] }
+tower = { version = "0.4.5", default-features = false, features = ["util"] }
 tracing = "0.1.2"


### PR DESCRIPTION
The recently released v0.4.5 of Tower includes a change to
`tower::buffer` to use `tokio-util`'s `PollSemaphore`, which should
reduce allocations when polling `Buffer` services. Additionally, it
includes a fix for `tracing` spans not being propagated to the tasks
spawned by the `SpawnReady` middleware.

No functional changes.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>