### PR TITLE
channel: use `tokio-util`'s `PollSemaphore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,7 @@ dependencies = [
  "futures",
  "tokio",
  "tokio-test",
+ "tokio-util",
 ]
 
 [[package]]

--- a/linkerd/channel/Cargo.toml
+++ b/linkerd/channel/Cargo.toml
@@ -11,6 +11,7 @@ A bounded MPSC channel where senders expose a `poll_ready` method.
 
 [dependencies]
 tokio = { version = "1", features = ["sync", "time"] }
+tokio-util = { version = "0.6.3" }
 futures = "0.3.9"
 
 [dev-dependencies]


### PR DESCRIPTION
The `linkerd-channel` crate currently uses a custom wrapper around
`tokio::sync::Semaphore` to permit polling the semaphore manually, by
boxing the futures returned by `Semaphore::acquire_owned`. This means
that every time a message is sent to the channel, reserving capacity
requires allocating and deallocating a `Box`.

The `tokio-util` crate now has a `PollSemaphore` type which allows
polling the semaphore to acquire permits without requiring an allocation
per message. This is implemented using the `ReusableBoxFuture` type, which
allows using a single allocation per sender for every `acquire_owned`
future that sender creates.

This should be somewhat more efficient and also reduces the complexity
of our code a bit.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>