### PR TITLE
Log warnings when controller components do not resolve

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
       - run: make lint
 
   check:
-    timeout-minutes: 15
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     container:
       image: docker://rust:1.49.0-buster

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,6 @@ dependencies = [
 name = "linkerd-app-core"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "bytes",
  "futures",
  "http",
@@ -631,6 +630,7 @@ dependencies = [
  "linkerd-addr",
  "linkerd-buffer",
  "linkerd-cache",
+ "linkerd-channel",
  "linkerd-concurrency-limit",
  "linkerd-conditional",
  "linkerd-detect",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ dependencies = [
 name = "linkerd-app-core"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "bytes",
  "futures",
  "http",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -16,7 +16,6 @@ independently of the inbound and outbound proxy logic.
 mock-orig-dst  = ["linkerd-proxy-transport/mock-orig-dst"]
 
 [dependencies]
-async-stream = "0.3"
 bytes = "1"
 http = "0.2"
 http-body = "0.4"
@@ -25,8 +24,9 @@ futures = "0.3.9"
 indexmap = "1.0"
 ipnet = "2.0"
 linkerd-addr = { path = "../../addr" }
-linkerd-cache = { path = "../../cache" }
 linkerd-buffer = { path = "../../buffer" }
+linkerd-cache = { path = "../../cache" }
+linkerd-channel = { path = "../../channel" }
 linkerd-concurrency-limit = { path = "../../concurrency-limit" }
 linkerd-conditional = { path = "../../conditional" }
 linkerd-dns = { path = "../../dns" }

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -16,6 +16,7 @@ independently of the inbound and outbound proxy logic.
 mock-orig-dst  = ["linkerd-proxy-transport/mock-orig-dst"]
 
 [dependencies]
+async-stream = "0.3"
 bytes = "1"
 http = "0.2"
 http-body = "0.4"

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -7,8 +7,8 @@ use crate::{
     transport::ConnectTcp,
     Addr, Error,
 };
-use async_stream::stream;
-use futures::future::Either;
+use futures::{future::Either, StreamExt};
+use linkerd_channel::into_stream::IntoStream;
 use std::fmt;
 use tokio::time;
 use tracing::warn;
@@ -76,13 +76,7 @@ impl Config {
                     } = e.kind()
                     {
                         let ttl = time::Duration::from_secs(*ttl_secs as u64);
-                        let stream = stream! {
-                            loop {
-                                time::sleep(ttl).await;
-                                yield;
-                            }
-                        };
-                        return Ok(Either::Left(Box::pin(stream)));
+                        return Ok(Either::Left(time::interval(ttl).into_stream().map(|_| ())));
                     }
                 }
 


### PR DESCRIPTION
The `dns` module currently swallows resolution errors so that these
errors never hit the error handler.

This change modifies the `dns` module to propagate these errors so they
are handled by the resolver recovery module. The control plane's
recovery implementation is updated to log these errors and to use the
DNS TTL for backoffs, when present.

We now see errors like:

    WARN ThreadId(01) identity: linkerd_app_core::control: Failed to resolve control-plane component error=no record found for name: linkerd-identity-headless.linkerd.svc.cluster.local. type: SRV class: IN