### PR TITLE
transport: Replace async-stream with tokio-stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,7 +1222,6 @@ dependencies = [
 name = "linkerd-proxy-transport"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "bytes",
  "futures",
  "libc",
@@ -1234,6 +1233,7 @@ dependencies = [
  "pin-project 1.0.4",
  "socket2",
  "tokio",
+ "tokio-stream",
  "tower",
  "tracing",
 ]

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -15,7 +15,6 @@ Transport-level implementations that rely on core proxy infrastructure
 mock-orig-dst  = []
 
 [dependencies]
-async-stream = "0.3"
 bytes = "1"
 futures = "0.3.9"
 linkerd-errno = { path = "../../errno" }
@@ -26,6 +25,7 @@ linkerd-stack = { path = "../../stack" }
 pin-project = "1"
 socket2 = "0.3"
 tokio = { version = "1", features = ["macros", "net"] }
+tokio-stream = { version = "0.1", features = ["net"] }
 tower = { version = "0.4", features = ["make"] }
 tracing = "0.1.23"
 

--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -83,16 +83,16 @@ impl<A: OrigDstAddr> BindTcp<A> {
 
     fn accept(tcp: TcpStream, keepalive: Option<Duration>, get_orig: A) -> io::Result<Connection> {
         let addrs = {
-            let local_addr = tcp.local_addr()?;
-            let peer_addr = tcp.peer_addr()?;
+            let local = tcp.local_addr()?;
+            let peer = tcp.peer_addr()?;
             let orig_dst = get_orig.orig_dst_addr(&tcp);
             trace!(
-                local.addr = %local_addr,
-                peer.addr = %peer_addr,
+                local.addr = %local,
+                peer.addr = %peer,
                 orig.addr = ?orig_dst,
                 "Accepted",
             );
-            Addrs::new(local_addr, peer_addr, orig_dst)
+            Addrs::new(local, peer, orig_dst)
         };
 
         super::set_nodelay_or_warn(&tcp);


### PR DESCRIPTION
The TCP listener creates an async-stream of accepted connections; but
the tokio-stream crate provides a stream utilitity for TCP listeners.

This change swaps the implementation of BindTcp. The tokio-stream
implementation should be lighter-weight to compile; and this sets up for
refactoring the listener so that TCP binding is not required for tests.