### PR TITLE
Move proxy stack initialization into modules

### DIFF
--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -56,6 +56,7 @@ impl Outbound<()> {
                     cache_max_idle_age,
                     ..
                 },
+            ..
         } = self.config.clone();
         let allow = AllowHttpProfile(allow_discovery);
 

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -17,6 +17,7 @@ const LOCALHOST: [u8; 4] = [127, 0, 0, 1];
 
 pub fn default_config(orig_dst: SocketAddr) -> Config {
     Config {
+        ingress_mode: false,
         allow_discovery: IpMatch::new(Some(IpNet::from_str("0.0.0.0/0").unwrap())).into(),
         proxy: config::ProxyConfig {
             server: config::ServerConfig {

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -384,9 +384,9 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         .unwrap_or_else(|| parse_dns_suffixes(DEFAULT_DESTINATION_PROFILE_SUFFIXES).unwrap());
     let dst_profile_networks = dst_profile_networks?.unwrap_or_default();
 
-    let ingress_mode = parse(strings, ENV_INGRESS_MODE, parse_bool)?.unwrap_or(false);
-
     let outbound = {
+        let ingress_mode = parse(strings, ENV_INGRESS_MODE, parse_bool)?.unwrap_or(false);
+
         let keepalive = outbound_accept_keepalive?;
         let bind = BindTcp::new(
             outbound_listener_addr?
@@ -429,6 +429,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             outbound_dispatch_timeout?.unwrap_or(DEFAULT_OUTBOUND_DISPATCH_TIMEOUT);
 
         outbound::Config {
+            ingress_mode,
             allow_discovery: AddrMatch::new(dst_profile_suffixes.clone(), dst_profile_networks),
             proxy: ProxyConfig {
                 server,
@@ -645,7 +646,6 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         outbound,
         gateway,
         inbound,
-        ingress_mode,
     })
 }
 


### PR DESCRIPTION
The inbound and outbound proxy stacks & servers are constructed in the
`app` module. This change moves all inbound & outbound server
initialization into the `inbound` and `outbound` modules.

This simplifies `app` initialization and removes redundant server address
logging.