### PR TITLE
Re-export stack::Param as svc::Param

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -2,7 +2,7 @@ use crate::{
     classify, config, control, dns, metrics,
     proxy::http,
     reconnect,
-    svc::{self, stack::Param, NewService},
+    svc::{self, NewService, Param},
     tls,
     transport::ConnectTcp,
     Addr, Error,
@@ -229,7 +229,7 @@ mod balance {
 mod client {
     use crate::{
         proxy::http,
-        svc::{self, stack::Param},
+        svc::{self, Param},
         tls,
         transport::ConnectAddr,
     };

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -3,7 +3,7 @@ pub use crate::{
     control, dst, errors, http_metrics, http_metrics as metrics, opencensus, proxy,
     proxy::identity,
     stack_metrics,
-    svc::stack::Param,
+    svc::Param,
     telemetry, tls,
     transport::{
         self,

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -6,7 +6,7 @@ pub use linkerd_buffer as buffer;
 pub use linkerd_concurrency_limit::ConcurrencyLimit;
 pub use linkerd_stack::{
     self as stack, layer, BoxNewService, Fail, Filter, MapTargetLayer, NewRouter, NewService,
-    Predicate, UnwrapOr,
+    Param, Predicate, UnwrapOr,
 };
 pub use linkerd_stack_tracing::{InstrumentMake, InstrumentMakeLayer};
 pub use linkerd_timeout::{self as timeout, FailFast};

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -9,7 +9,7 @@ use linkerd_app_core::{
     config::ProxyConfig,
     detect, discovery_rejected, io, metrics, profiles,
     proxy::{api_resolve::Metadata, core::Resolve, http},
-    svc::{self, stack::Param},
+    svc::{self, Param},
     tls,
     transport_header::SessionProtocol,
     Error, NameAddr, NameMatch, Never,

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -2,7 +2,7 @@ use crate::{target::TcpEndpoint, Inbound};
 use linkerd_app_core::{
     io,
     proxy::identity::LocalCrtKey,
-    svc::{self, stack::Param},
+    svc::{self, Param},
     tls,
     transport::{self, listen, metrics::SensorIo},
     transport_header::{self, NewTransportHeaderServer, SessionProtocol, TransportHeader},
@@ -221,7 +221,7 @@ impl Param<transport::labels::Key> for ClientInfo {
 
 // === impl WithTransportHeaderAlpn ===
 
-impl svc::stack::Param<tls::server::Config> for WithTransportHeaderAlpn {
+impl svc::Param<tls::server::Config> for WithTransportHeaderAlpn {
     fn param(&self) -> tls::server::Config {
         // Copy the underlying TLS config and set an ALPN value.
         //
@@ -236,7 +236,7 @@ impl svc::stack::Param<tls::server::Config> for WithTransportHeaderAlpn {
     }
 }
 
-impl svc::stack::Param<tls::LocalId> for WithTransportHeaderAlpn {
+impl svc::Param<tls::LocalId> for WithTransportHeaderAlpn {
     fn param(&self) -> tls::LocalId {
         self.0.id().clone()
     }

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -13,7 +13,7 @@ use linkerd_app_core::{
     dst, errors, http_tracing, io, profiles,
     proxy::{http, tap},
     reconnect,
-    svc::{self, stack::Param},
+    svc::{self, Param},
     Error, DST_OVERRIDE_HEADER,
 };
 use tracing::debug_span;

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -10,7 +10,7 @@ use hyper::{client::conn::Builder as ClientBuilder, Body, Request, Response};
 use linkerd_app_core::{
     io::{self, BoxedIo},
     proxy,
-    svc::{self, stack::Param, NewService},
+    svc::{self, NewService, Param},
     tls,
     transport::{self, ConnectAddr},
     Conditional, Error, NameAddr, ProxyRuntime,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -24,7 +24,7 @@ use linkerd_app_core::{
     config::{ConnectConfig, ProxyConfig},
     detect, drain, io, metrics, profiles,
     proxy::tcp,
-    svc::{self, stack::Param},
+    svc::{self, Param},
     tls,
     transport::{self, listen},
     Error, NameMatch, ProxyRuntime,

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -4,7 +4,7 @@ use linkerd_app_core::{
     http_request_l5d_override_dst_addr, metrics, profiles,
     proxy::{http, tap},
     stack_tracing,
-    svc::{self, stack::Param},
+    svc::{self, Param},
     tls,
     transport::{self, listen},
     transport_header::TransportHeader,

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -13,7 +13,7 @@ pub use linkerd_app_core::proxy::http::*;
 use linkerd_app_core::{
     dst, profiles,
     proxy::{api_resolve::ProtocolHint, tap},
-    svc::stack::Param,
+    svc::Param,
     tls,
     transport_header::SessionProtocol,
     Conditional,

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -4,7 +4,7 @@ use linkerd_app_core::{
         api_resolve::{ConcreteAddr, Metadata},
         resolve::map_endpoint::MapEndpoint,
     },
-    svc::{self, stack::Param},
+    svc::{self, Param},
     tls, transport, transport_header, Addr, Conditional, Error,
 };
 use std::net::SocketAddr;

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -24,7 +24,7 @@ impl<C> Outbound<C> {
             > + Clone,
     >
     where
-        Endpoint<P>: svc::stack::Param<Option<SessionProtocol>>,
+        Endpoint<P>: svc::Param<Option<SessionProtocol>>,
         C: svc::Service<Endpoint<P>, Error = io::Error> + Clone + Send + 'static,
         C::Response: tls::HasNegotiatedProtocol,
         C::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin + 'static,

--- a/linkerd/app/outbound/src/tcp/mod.rs
+++ b/linkerd/app/outbound/src/tcp/mod.rs
@@ -6,7 +6,7 @@ mod tests;
 
 use crate::target;
 pub use linkerd_app_core::proxy::tcp::Forward;
-use linkerd_app_core::{svc::stack::Param, transport::listen, transport_header::SessionProtocol};
+use linkerd_app_core::{svc::Param, transport::listen, transport_header::SessionProtocol};
 
 pub type Accept = target::Accept<()>;
 pub type Logical = target::Logical<()>;

--- a/linkerd/app/outbound/src/tcp/opaque_transport.rs
+++ b/linkerd/app/outbound/src/tcp/opaque_transport.rs
@@ -1,7 +1,7 @@
 use crate::target::Endpoint;
 use linkerd_app_core::{
     dns, io,
-    svc::{self, stack::Param},
+    svc::{self, Param},
     tls,
     transport_header::{SessionProtocol, TransportHeader, PROTOCOL},
     Error,

--- a/linkerd/app/test/src/connect.rs
+++ b/linkerd/app/test/src/connect.rs
@@ -1,4 +1,4 @@
-use linkerd_app_core::{io::BoxedIo, svc::stack::Param, transport::ConnectAddr, Error};
+use linkerd_app_core::{io::BoxedIo, svc::Param, transport::ConnectAddr, Error};
 use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;

--- a/linkerd/app/test/src/http_util.rs
+++ b/linkerd/app/test/src/http_util.rs
@@ -1,4 +1,4 @@
-use crate::app_core::{io::BoxedIo, svc::stack::Param, tls, Error};
+use crate::app_core::{io::BoxedIo, svc::Param, tls, Error};
 use crate::io;
 use futures::FutureExt;
 use hyper::{

--- a/linkerd/app/test/src/resolver.rs
+++ b/linkerd/app/test/src/resolver.rs
@@ -6,7 +6,7 @@ pub use linkerd_app_core::proxy::{
 };
 use linkerd_app_core::{
     profiles::{self, Profile},
-    svc::stack::Param,
+    svc::Param,
     Addr, Error,
 };
 use linkerd_channel::into_stream::{IntoStream, Streaming};


### PR DESCRIPTION
This is a purely superificial change that shortens a very common import.