### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
 
 [[package]]
 name = "httpdate"
@@ -466,7 +466,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "socket2",
  "tokio",
  "tower-service",
@@ -481,7 +481,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tokio-test",
  "tower",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -567,15 +567,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.84"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cca32fa0182e8c0989459524dc356b8f2b5c10f1b9eb521b7d182c03cf8c5ff"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.18"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151ff13433c4d403cb15d0e6fbda14b24d65bd1a5b33f7d52ec983cc00752d"
+checksum = "e58f42b6424a0ed536678c65fd97cd64b4344bcf86251e284f7c0ce9eee40e64"
 dependencies = [
  "cmake",
 ]
@@ -670,7 +670,7 @@ dependencies = [
  "linkerd-tracing",
  "linkerd-transport-header",
  "linkerd2-proxy-api",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "procinfo",
  "prost-types",
  "regex",
@@ -761,7 +761,7 @@ dependencies = [
  "linkerd-identity",
  "linkerd-io",
  "linkerd-retry",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tokio-test",
  "tower",
@@ -797,7 +797,7 @@ dependencies = [
  "futures",
  "linkerd-channel",
  "linkerd-error",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tokio-test",
  "tower",
@@ -835,7 +835,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tower",
  "tracing",
@@ -866,7 +866,7 @@ dependencies = [
  "futures",
  "linkerd-dns-name",
  "linkerd-error",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tracing",
  "trust-dns-resolver",
@@ -886,7 +886,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tokio-test",
  "tower",
@@ -899,7 +899,7 @@ dependencies = [
  "bytes",
  "futures",
  "linkerd-io",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tracing",
 ]
@@ -922,7 +922,7 @@ dependencies = [
  "futures",
  "indexmap",
  "linkerd-metrics",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tower",
 ]
 
@@ -932,7 +932,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-error",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tower",
 ]
 
@@ -941,7 +941,7 @@ name = "linkerd-exp-backoff"
 version = "0.1.0"
 dependencies = [
  "futures",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "quickcheck",
  "rand",
  "tokio",
@@ -957,7 +957,7 @@ dependencies = [
  "http-body",
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tower",
 ]
 
@@ -985,7 +985,7 @@ dependencies = [
  "linkerd-http-classify",
  "linkerd-metrics",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tower",
  "tracing",
 ]
@@ -1010,7 +1010,7 @@ dependencies = [
  "bytes",
  "futures",
  "linkerd-errno",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tokio-rustls",
  "tokio-test",
@@ -1064,7 +1064,7 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tls",
  "linkerd2-proxy-api",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "prost",
  "tonic",
  "tower",
@@ -1091,7 +1091,7 @@ dependencies = [
  "linkerd-error",
  "linkerd-proxy-core",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tower",
  "tracing",
@@ -1137,7 +1137,7 @@ dependencies = [
  "linkerd-proxy-transport",
  "linkerd-stack",
  "linkerd-timeout",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "rand",
  "tokio",
  "tokio-test",
@@ -1159,7 +1159,7 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tls",
  "linkerd2-proxy-api",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tonic",
  "tracing",
@@ -1172,7 +1172,7 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-proxy-core",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tower",
  "tracing",
 ]
@@ -1195,7 +1195,7 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tls",
  "linkerd2-proxy-api",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "prost-types",
  "rand",
  "tokio",
@@ -1212,7 +1212,7 @@ dependencies = [
  "linkerd-duplex",
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "rand",
  "tokio",
  "tower",
@@ -1230,7 +1230,7 @@ dependencies = [
  "linkerd-io",
  "linkerd-metrics",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "socket2",
  "tokio",
  "tokio-stream",
@@ -1245,7 +1245,7 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tower",
  "tracing",
 ]
@@ -1256,7 +1256,7 @@ version = "0.1.0"
 dependencies = [
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tower",
  "tracing",
 ]
@@ -1277,7 +1277,7 @@ dependencies = [
  "linkerd-proxy-api-resolve",
  "linkerd-stack",
  "linkerd2-proxy-api",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "prost-types",
  "quickcheck",
  "rand",
@@ -1303,7 +1303,7 @@ dependencies = [
  "dyn-clone",
  "futures",
  "linkerd-error",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tokio-test",
  "tower",
@@ -1329,7 +1329,7 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tower",
  "tracing",
 ]
@@ -1341,7 +1341,7 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tokio-test",
  "tower",
@@ -1509,9 +1509,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "mimalloc"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5d2c9cb18f9cdc6d88f4aca6d3d8ea89c4c8202d6facfc7e56efdee97b80fa"
+checksum = "757efec188b3d2088949d912e01ea2fe87164ed6376b6c5d7dd4f3ce1668a93d"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -1629,14 +1629,14 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall 0.1.57",
+ "redox_syscall",
  "smallvec",
  "winapi",
 ]
@@ -1668,11 +1668,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
+checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 1.0.4",
+ "pin-project-internal 1.0.5",
 ]
 
 [[package]]
@@ -1688,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
+checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1816,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1847,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom",
 ]
@@ -1865,15 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
 dependencies = [
  "bitflags",
 ]
@@ -1927,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.19"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
@@ -2007,9 +2001,9 @@ checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
  "itoa",
  "ryu",
@@ -2083,7 +2077,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "rand",
- "redox_syscall 0.2.4",
+ "redox_syscall",
  "remove_dir_all",
  "winapi",
 ]
@@ -2110,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
 ]
@@ -2144,9 +2138,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6714d663090b6b0acb0fa85841c6d66233d150cdb2602c8f9b8abb03370beb3f"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2165,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2187,9 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
+checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2250,7 +2244,7 @@ dependencies = [
  "http",
  "http-body",
  "percent-encoding",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "prost",
  "prost-derive",
  "tokio-stream",
@@ -2280,7 +2274,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "rand",
  "slab",
  "tokio",
@@ -2309,7 +2303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
 dependencies = [
  "futures-util",
- "pin-project 1.0.4",
+ "pin-project 1.0.5",
  "tokio",
  "tokio-test",
  "tower-layer",
@@ -2464,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]


### PR DESCRIPTION
This update addresses [RUSTSEC-2021-0023][1], which shouldn't actually
impact Linkerd's use of `rand`.

    Updating git repository `https://github.com/linkerd/webpki`
    Updating crates.io index
    Updating git repository `https://github.com/linkerd/linkerd2-proxy-api`
    Updating git repository `https://github.com/hawkw/tokio-trace`
    Updating httparse v1.3.4 -> v1.3.5
    Updating idna v0.2.0 -> v0.2.1
    Updating libc v0.2.84 -> v0.2.86
    Updating libmimalloc-sys v0.1.18 -> v0.1.20
    Updating mimalloc v0.1.22 -> v0.1.24
    Updating parking_lot_core v0.8.2 -> v0.8.3
    Updating pin-project v1.0.4 -> v1.0.5
    Updating pin-project-internal v1.0.4 -> v1.0.5
    Updating quote v1.0.8 -> v1.0.9
    Updating rand_core v0.6.1 -> v0.6.2
    Removing redox_syscall v0.1.57
    Removing redox_syscall v0.2.4
      Adding redox_syscall v0.2.5
    Updating ring v0.16.19 -> v0.16.20
    Updating serde_json v1.0.61 -> v1.0.62
    Updating thread_local v1.1.2 -> v1.1.3
    Updating tokio v1.1.1 -> v1.2.0
    Updating tokio-macros v1.0.0 -> v1.1.0
    Updating tokio-stream v0.1.2 -> v0.1.3
    Updating unicode-normalization v0.1.16 -> v0.1.17

[1]: https://rustsec.org/advisories/RUSTSEC-2021-0023