### PR TITLE
Decouple application from TCP client

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -1,6 +1,6 @@
 pub use crate::exp_backoff::ExponentialBackoff;
 pub use crate::proxy::http::{h1, h2};
-pub use crate::transport::{BindTcp, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr};
+pub use crate::transport::{BindTcp, DefaultOrigDstAddr, Keepalive, NoOrigDstAddr, OrigDstAddr};
 use std::time::Duration;
 
 #[derive(Clone, Debug)]
@@ -13,7 +13,7 @@ pub struct ServerConfig<A: OrigDstAddr = NoOrigDstAddr> {
 pub struct ConnectConfig {
     pub backoff: ExponentialBackoff,
     pub timeout: Duration,
-    pub keepalive: Option<Duration>,
+    pub keepalive: Keepalive,
     pub h1_settings: h1::PoolSettings,
     pub h2_settings: h2::Settings,
 }

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -1,7 +1,10 @@
 // Possibly unused, but useful during development.
 
-pub use crate::proxy::http;
 use crate::{cache, Error};
+pub use crate::{
+    proxy::http,
+    transport::connect::{self, Connect, ConnectTcp},
+};
 pub use linkerd_buffer as buffer;
 pub use linkerd_concurrency_limit::ConcurrencyLimit;
 pub use linkerd_stack::{

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -56,10 +56,10 @@ struct RefusedNoTarget(());
 struct RefusedNotResolved(NameAddr);
 
 #[allow(clippy::clippy::too_many_arguments)]
-pub fn stack<I, O, P, R>(
+pub fn stack<I, C, P, R>(
     Config { allow_discovery }: Config,
     inbound: Inbound<()>,
-    outbound: Outbound<O>,
+    outbound: Outbound<C>,
     profiles: P,
     resolve: R,
 ) -> impl svc::NewService<
@@ -71,15 +71,9 @@ pub fn stack<I, O, P, R>(
        + Send
 where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + fmt::Debug + Send + Sync + Unpin + 'static,
-    O: svc::Service<outbound::http::Endpoint, Error = io::Error>
-        + svc::Service<outbound::tcp::Endpoint, Error = io::Error>,
-    O: Clone + Send + Sync + Unpin + 'static,
-    <O as svc::Service<outbound::http::Endpoint>>::Response:
-        io::AsyncRead + io::AsyncWrite + tls::HasNegotiatedProtocol + Send + Unpin + 'static,
-    <O as svc::Service<outbound::http::Endpoint>>::Future: Send + Unpin + 'static,
-    <O as svc::Service<outbound::tcp::Endpoint>>::Response:
-        io::AsyncRead + io::AsyncWrite + tls::HasNegotiatedProtocol + Send + Unpin + 'static,
-    <O as svc::Service<outbound::tcp::Endpoint>>::Future: Send + Unpin + 'static,
+    C: svc::Connect + Clone + Send + Sync + Unpin + 'static,
+    C::Io: 'static,
+    C::Future: Unpin + 'static,
     P: profiles::GetProfile<profiles::LogicalAddr> + Clone + Send + Sync + Unpin + 'static,
     P::Future: Send + 'static,
     P::Error: Send,

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -29,7 +29,7 @@ pub fn default_config(orig_dst: SocketAddr) -> Config {
                 h2_settings: h2::Settings::default(),
             },
             connect: config::ConnectConfig {
-                keepalive: None,
+                keepalive: None.into(),
                 timeout: Duration::from_secs(1),
                 backoff: exp_backoff::ExponentialBackoff::new(
                     Duration::from_millis(100),

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -1,20 +1,13 @@
 use super::{require_identity_on_endpoint::NewRequireIdentity, Endpoint};
 use crate::Outbound;
 use linkerd_app_core::{
-    classify, config, http_tracing,
+    classify, config, http_tracing, io,
     proxy::{http, tap},
     reconnect, svc, Error, CANONICAL_DST_HEADER, L5D_REQUIRE_ID,
 };
-use tokio::io;
 use tracing::debug_span;
 
-impl<C> Outbound<C>
-where
-    C: svc::Service<Endpoint> + Clone + Send + Sync + Unpin + 'static,
-    C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
-    C::Error: Into<Error>,
-    C::Future: Send + Unpin,
-{
+impl<C> Outbound<C> {
     pub fn push_http_endpoint<B>(
         self,
     ) -> Outbound<
@@ -29,6 +22,10 @@ where
             > + Clone,
     >
     where
+        C: svc::Service<Endpoint> + Clone + Send + Sync + Unpin + 'static,
+        C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
+        C::Error: Into<Error>,
+        C::Future: Send + Unpin,
         B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
         B::Data: Send + 'static,
     {

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -8,18 +8,17 @@ use linkerd_app_core::{
 };
 use tracing::{debug_span, info_span};
 
-impl Outbound<()> {
+impl<H> Outbound<H> {
     /// Routes HTTP requests according to the l5d-dst-override header.
     ///
     /// Forwards TCP connections without discovery/routing (or mTLS).
     ///
     /// This is only intended for Ingress configurations, where we assume all
     /// outbound traffic is either HTTP or TLS'd by the ingress proxy.
-    pub fn to_ingress<I, T, TSvc, H, HSvc, P>(
-        &self,
-        profiles: P,
+    pub fn into_ingress<I, T, TSvc, HSvc, P>(
+        self,
         tcp: T,
-        http: H,
+        profiles: P,
     ) -> impl svc::NewService<
         listen::Addrs,
         Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
@@ -44,6 +43,11 @@ impl Outbound<()> {
         P::Error: Send,
         P::Future: Send,
     {
+        let Outbound {
+            config,
+            runtime: rt,
+            stack: http,
+        } = self;
         let Config {
             allow_discovery,
             proxy:
@@ -57,86 +61,74 @@ impl Outbound<()> {
                     ..
                 },
             ..
-        } = self.config.clone();
+        } = config;
         let allow = AllowHttpProfile(allow_discovery);
 
         let tcp = svc::stack(tcp)
-            .push_on_response(drain::Retain::layer(self.runtime.drain.clone()))
+            .push_on_response(drain::Retain::layer(rt.drain.clone()))
             .push_map_target(tcp::Endpoint::from_accept(tls::NoClientTls::IngressNonHttp))
             .into_inner();
 
-        svc::stack(http)
-            .push_on_response(
-                svc::layers()
-                    .push(http::BoxRequest::layer())
-                    .push(svc::MapErrLayer::new(Into::into)),
-            )
-            // Lookup the profile for the outbound HTTP target, if appropriate.
-            //
-            // This service is buffered because it needs to initialize the profile
-            // resolution and a failfast is instrumented in case it becomes
-            // unavailable
-            // When this service is in failfast, ensure that we drive the
-            // inner service to readiness even if new requests aren't
-            // received.
-            .push_map_target(http::Logical::from)
-            .push(profiles::discover::layer(profiles, allow))
-            .push_on_response(
-                svc::layers()
-                    .push(
-                        self.runtime
-                            .metrics
-                            .stack
-                            .layer(stack_labels("http", "logical")),
-                    )
-                    .push(svc::layer::mk(svc::SpawnReady::new))
-                    .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
-                    .push_spawn_buffer(buffer_capacity),
-            )
-            .push_cache(cache_max_idle_age)
-            .push_on_response(http::Retain::layer())
-            .instrument(|t: &Target| info_span!("target", dst = %t.dst))
-            // Obtain a new inner service for each request (fom the above cache).
-            //
-            // Note that the router service is always ready, so the `FailFast` layer
-            // need not use a `SpawnReady` to drive the service to ready.
-            .push(svc::NewRouter::layer(TargetPerRequest::accept))
-            .push_on_response(
-                svc::layers()
-                    .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
-                    .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
-                    .push(self.runtime.metrics.http_errors.clone())
-                    .push(errors::layer())
-                    .push(http_tracing::server(
-                        self.runtime.span_sink.clone(),
-                        trace_labels(),
-                    ))
-                    .push(http::BoxResponse::layer()),
-            )
-            .check_new_service::<http::Accept, http::Request<_>>()
-            .push(http::NewNormalizeUri::layer())
-            .check_new_service::<http::Accept, http::Request<_>>()
-            .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
-            .check_new_service::<http::Accept, http::Request<_>>()
-            .push(http::NewServeHttp::layer(
-                h2_settings,
-                self.runtime.drain.clone(),
-            ))
-            .push_map_target(http::Accept::from)
-            .push(svc::UnwrapOr::layer(tcp))
-            .push_cache(cache_max_idle_age)
-            .push(detect::NewDetectService::layer(
-                detect_protocol_timeout,
-                http::DetectHttp::default(),
-            ))
-            .check_new_service::<tcp::Accept, transport::metrics::SensorIo<I>>()
-            .push(self.runtime.metrics.transport.layer_accept())
-            .push_map_target(tcp::Accept::from)
-            .check_new_service::<listen::Addrs, I>()
-            // Boxing is necessary purely to limit the link-time overhead of
-            // having enormous types.
-            .push(svc::BoxNewService::layer())
-            .into_inner()
+        http.push_on_response(
+            svc::layers()
+                .push(http::BoxRequest::layer())
+                .push(svc::MapErrLayer::new(Into::into)),
+        )
+        // Lookup the profile for the outbound HTTP target, if appropriate.
+        //
+        // This service is buffered because it needs to initialize the profile
+        // resolution and a failfast is instrumented in case it becomes
+        // unavailable
+        // When this service is in failfast, ensure that we drive the
+        // inner service to readiness even if new requests aren't
+        // received.
+        .push_map_target(http::Logical::from)
+        .push(profiles::discover::layer(profiles, allow))
+        .push_on_response(
+            svc::layers()
+                .push(rt.metrics.stack.layer(stack_labels("http", "logical")))
+                .push(svc::layer::mk(svc::SpawnReady::new))
+                .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
+                .push_spawn_buffer(buffer_capacity),
+        )
+        .push_cache(cache_max_idle_age)
+        .push_on_response(http::Retain::layer())
+        .instrument(|t: &Target| info_span!("target", dst = %t.dst))
+        // Obtain a new inner service for each request (fom the above cache).
+        //
+        // Note that the router service is always ready, so the `FailFast` layer
+        // need not use a `SpawnReady` to drive the service to ready.
+        .push(svc::NewRouter::layer(TargetPerRequest::accept))
+        .push_on_response(
+            svc::layers()
+                .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
+                .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
+                .push(rt.metrics.http_errors.clone())
+                .push(errors::layer())
+                .push(http_tracing::server(rt.span_sink.clone(), trace_labels()))
+                .push(http::BoxResponse::layer()),
+        )
+        .check_new_service::<http::Accept, http::Request<_>>()
+        .push(http::NewNormalizeUri::layer())
+        .check_new_service::<http::Accept, http::Request<_>>()
+        .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
+        .check_new_service::<http::Accept, http::Request<_>>()
+        .push(http::NewServeHttp::layer(h2_settings, rt.drain.clone()))
+        .push_map_target(http::Accept::from)
+        .push(svc::UnwrapOr::layer(tcp))
+        .push_cache(cache_max_idle_age)
+        .push(detect::NewDetectService::layer(
+            detect_protocol_timeout,
+            http::DetectHttp::default(),
+        ))
+        .check_new_service::<tcp::Accept, transport::metrics::SensorIo<I>>()
+        .push(rt.metrics.transport.layer_accept())
+        .push_map_target(tcp::Accept::from)
+        .check_new_service::<listen::Addrs, I>()
+        // Boxing is necessary purely to limit the link-time overhead of
+        // having enormous types.
+        .push(svc::BoxNewService::layer())
+        .into_inner()
     }
 }
 

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -26,7 +26,7 @@ pub fn default_config(orig_dst: SocketAddr) -> Config {
                 h2_settings: h2::Settings::default(),
             },
             connect: config::ConnectConfig {
-                keepalive: None,
+                keepalive: None.into(),
                 timeout: Duration::from_secs(1),
                 backoff: exp_backoff::ExponentialBackoff::new(
                     Duration::from_millis(100),

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -4,7 +4,7 @@ use crate::core::{
     control::{Config as ControlConfig, ControlAddr},
     proxy::http::{h1, h2},
     tls,
-    transport::BindTcp,
+    transport::{BindTcp, Keepalive},
     Addr, AddrMatch, Conditional, NameMatch,
 };
 use crate::{dns, gateway, identity, inbound, oc_collector, outbound};
@@ -404,7 +404,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             outbound_cache_max_idle_age?.unwrap_or(DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE);
         let max_idle =
             outbound_max_idle_per_endoint?.unwrap_or(DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT);
-        let keepalive = outbound_connect_keepalive?;
+        let keepalive = Keepalive(outbound_connect_keepalive?);
         let connect = ConnectConfig {
             keepalive,
             timeout: outbound_connect_timeout?.unwrap_or(DEFAULT_OUTBOUND_CONNECT_TIMEOUT),
@@ -414,7 +414,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 DEFAULT_OUTBOUND_CONNECT_BACKOFF,
             )?,
             h2_settings: h2::Settings {
-                keepalive_timeout: keepalive,
+                keepalive_timeout: keepalive.into(),
                 ..h2_settings
             },
             h1_settings: h1::PoolSettings {
@@ -466,7 +466,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             inbound_cache_max_idle_age?.unwrap_or(DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE);
         let max_idle =
             inbound_max_idle_per_endpoint?.unwrap_or(DEFAULT_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT);
-        let keepalive = inbound_connect_keepalive?;
+        let keepalive = Keepalive(inbound_connect_keepalive?);
         let connect = ConnectConfig {
             keepalive,
             timeout: inbound_connect_timeout?.unwrap_or(DEFAULT_INBOUND_CONNECT_TIMEOUT),
@@ -476,7 +476,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 DEFAULT_INBOUND_CONNECT_BACKOFF,
             )?,
             h2_settings: h2::Settings {
-                keepalive_timeout: keepalive,
+                keepalive_timeout: keepalive.into(),
                 ..h2_settings
             },
             h1_settings: h1::PoolSettings {

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -1,9 +1,6 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use std::time::Duration;
-use tokio::net::TcpStream;
-
-mod connect;
+pub mod connect;
 pub mod listen;
 pub mod metrics;
 
@@ -11,6 +8,23 @@ pub use self::{
     connect::{ConnectAddr, ConnectTcp},
     listen::{BindTcp, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr},
 };
+use std::time::Duration;
+use tokio::net::TcpStream;
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Keepalive(pub Option<Duration>);
+
+impl From<Option<Duration>> for Keepalive {
+    fn from(k: Option<Duration>) -> Self {
+        Self(k)
+    }
+}
+
+impl Into<Option<Duration>> for Keepalive {
+    fn into(self) -> Option<Duration> {
+        self.0
+    }
+}
 
 // Misc.
 

--- a/linkerd/tls/src/lib.rs
+++ b/linkerd/tls/src/lib.rs
@@ -77,30 +77,12 @@ impl<I> HasNegotiatedProtocol for self::server::TlsStream<I> {
     }
 }
 
-impl HasNegotiatedProtocol for tokio::net::TcpStream {
-    #[inline]
-    fn negotiated_protocol(&self) -> Option<NegotiatedProtocolRef<'_>> {
-        None
-    }
-}
-
-impl<I: HasNegotiatedProtocol> HasNegotiatedProtocol for io::ScopedIo<I> {
-    #[inline]
-    fn negotiated_protocol(&self) -> Option<NegotiatedProtocolRef<'_>> {
-        self.get_ref().negotiated_protocol()
-    }
-}
-
-impl<L, R> HasNegotiatedProtocol for io::EitherIo<L, R>
-where
-    L: HasNegotiatedProtocol,
-    R: HasNegotiatedProtocol,
-{
+impl<A, B: HasNegotiatedProtocol> HasNegotiatedProtocol for io::EitherIo<A, B> {
     #[inline]
     fn negotiated_protocol(&self) -> Option<NegotiatedProtocolRef<'_>> {
         match self {
-            io::EitherIo::Left(l) => l.negotiated_protocol(),
-            io::EitherIo::Right(r) => r.negotiated_protocol(),
+            io::EitherIo::Left(_) => None,
+            io::EitherIo::Right(b) => b.negotiated_protocol(),
         }
     }
 }


### PR DESCRIPTION
All clients--the inbound and outbound proxies, discovery clients,
etc--initiate TCP connections. This makes testing cumbersome, as the
application is tightly coupled to OS functionality.

This change makes the entire `App` generic over its connection strategy.
A `Connect` trait--a convenience over `Service`--is introduced so that
all of the relevant modules can be generic over the connector.