### PR TITLE
update tracing-futures, rm old pin-project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.5",
+ "pin-project",
  "socket2",
  "tokio",
  "tower-service",
@@ -481,7 +481,7 @@ dependencies = [
  "futures",
  "http",
  "hyper",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tokio-test",
  "tower",
@@ -670,7 +670,7 @@ dependencies = [
  "linkerd-tracing",
  "linkerd-transport-header",
  "linkerd2-proxy-api",
- "pin-project 1.0.5",
+ "pin-project",
  "procinfo",
  "prost-types",
  "regex",
@@ -761,7 +761,7 @@ dependencies = [
  "linkerd-identity",
  "linkerd-io",
  "linkerd-retry",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tokio-test",
  "tower",
@@ -797,7 +797,7 @@ dependencies = [
  "futures",
  "linkerd-channel",
  "linkerd-error",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tokio-test",
  "tower",
@@ -835,7 +835,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tower",
  "tracing",
@@ -866,7 +866,7 @@ dependencies = [
  "futures",
  "linkerd-dns-name",
  "linkerd-error",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tracing",
  "trust-dns-resolver",
@@ -886,7 +886,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tokio-test",
  "tower",
@@ -899,7 +899,7 @@ dependencies = [
  "bytes",
  "futures",
  "linkerd-io",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tracing",
 ]
@@ -922,7 +922,7 @@ dependencies = [
  "futures",
  "indexmap",
  "linkerd-metrics",
- "pin-project 1.0.5",
+ "pin-project",
  "tower",
 ]
 
@@ -932,7 +932,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-error",
- "pin-project 1.0.5",
+ "pin-project",
  "tower",
 ]
 
@@ -941,7 +941,7 @@ name = "linkerd-exp-backoff"
 version = "0.1.0"
 dependencies = [
  "futures",
- "pin-project 1.0.5",
+ "pin-project",
  "quickcheck",
  "rand",
  "tokio",
@@ -957,7 +957,7 @@ dependencies = [
  "http-body",
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "tower",
 ]
 
@@ -985,7 +985,7 @@ dependencies = [
  "linkerd-http-classify",
  "linkerd-metrics",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "tower",
  "tracing",
 ]
@@ -1010,7 +1010,7 @@ dependencies = [
  "bytes",
  "futures",
  "linkerd-errno",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tokio-rustls",
  "tokio-test",
@@ -1064,7 +1064,7 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tls",
  "linkerd2-proxy-api",
- "pin-project 1.0.5",
+ "pin-project",
  "prost",
  "tonic",
  "tower",
@@ -1077,7 +1077,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-error",
- "pin-project 0.4.27",
+ "pin-project",
  "tower",
 ]
 
@@ -1091,7 +1091,7 @@ dependencies = [
  "linkerd-error",
  "linkerd-proxy-core",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tower",
  "tracing",
@@ -1137,7 +1137,7 @@ dependencies = [
  "linkerd-proxy-transport",
  "linkerd-stack",
  "linkerd-timeout",
- "pin-project 1.0.5",
+ "pin-project",
  "rand",
  "tokio",
  "tokio-test",
@@ -1159,7 +1159,7 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tls",
  "linkerd2-proxy-api",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tonic",
  "tracing",
@@ -1172,7 +1172,7 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-proxy-core",
- "pin-project 1.0.5",
+ "pin-project",
  "tower",
  "tracing",
 ]
@@ -1195,7 +1195,7 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tls",
  "linkerd2-proxy-api",
- "pin-project 1.0.5",
+ "pin-project",
  "prost-types",
  "rand",
  "tokio",
@@ -1212,7 +1212,7 @@ dependencies = [
  "linkerd-duplex",
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "rand",
  "tokio",
  "tower",
@@ -1230,7 +1230,7 @@ dependencies = [
  "linkerd-io",
  "linkerd-metrics",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "socket2",
  "tokio",
  "tokio-stream",
@@ -1245,7 +1245,7 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "tower",
  "tracing",
 ]
@@ -1256,7 +1256,7 @@ version = "0.1.0"
 dependencies = [
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "tower",
  "tracing",
 ]
@@ -1277,7 +1277,7 @@ dependencies = [
  "linkerd-proxy-api-resolve",
  "linkerd-stack",
  "linkerd2-proxy-api",
- "pin-project 1.0.5",
+ "pin-project",
  "prost-types",
  "quickcheck",
  "rand",
@@ -1303,7 +1303,7 @@ dependencies = [
  "dyn-clone",
  "futures",
  "linkerd-error",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tokio-test",
  "tower",
@@ -1329,7 +1329,7 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "tower",
  "tracing",
 ]
@@ -1341,7 +1341,7 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-stack",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tokio-test",
  "tower",
@@ -1659,31 +1659,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
-dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 1.0.5",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "pin-project-internal",
 ]
 
 [[package]]
@@ -2244,7 +2224,7 @@ dependencies = [
  "http",
  "http-body",
  "percent-encoding",
- "pin-project 1.0.5",
+ "pin-project",
  "prost",
  "prost-derive",
  "tokio-stream",
@@ -2274,7 +2254,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "indexmap",
- "pin-project 1.0.5",
+ "pin-project",
  "rand",
  "slab",
  "tokio",
@@ -2303,7 +2283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4546773ffeab9e4ea02b8872faa49bb616a80a7da66afc2f32688943f97efa7"
 dependencies = [
  "futures-util",
- "pin-project 1.0.5",
+ "pin-project",
  "tokio",
  "tokio-test",
  "tower-layer",
@@ -2349,7 +2329,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 1.0.5",
+ "pin-project",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2345,11 +2345,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-futures"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project 1.0.5",
  "tracing",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -45,11 +45,7 @@ multiple-versions = "deny"
 wildcards = "allow"
 highlight = "all"
 deny = []
-skip = [
-    # Pulled in by tracing-futures v0.2
-    { name = "pin-project", version = "0.4.27" },
-    { name = "pin-project-internal", version = "0.4.27" },
-]
+skip = []
 skip-tree = []
 
 [sources]

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -13,4 +13,4 @@ Core interfaces needed to implement proxy components
 futures = "0.3.9"
 linkerd-error = { path = "../../error" }
 tower = { version = "0.4.5", default-features = false }
-pin-project = "0.4"
+pin-project = "1"


### PR DESCRIPTION
This PR updates the dependency on `tracing-futures` to 0.2.5, which
updates that crate to depend on `pin-project` 1.0. After removing one
last `pin-project` 0.4 dependency, we can now remove `pin-project` from
the duplicate dependency versions allowlist!