### PR TITLE
transport: Introduce address new-types

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -1,10 +1,10 @@
 pub use crate::exp_backoff::ExponentialBackoff;
 pub use crate::proxy::http::{h1, h2};
-pub use crate::transport::{BindTcp, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr};
+pub use crate::transport::{BindTcp, DefaultOrigDstAddr, GetOrigDstAddr, NoOrigDstAddr};
 use std::time::Duration;
 
 #[derive(Clone, Debug)]
-pub struct ServerConfig<A: OrigDstAddr = NoOrigDstAddr> {
+pub struct ServerConfig<A = NoOrigDstAddr> {
     pub bind: BindTcp<A>,
     pub h2_settings: h2::Settings,
 }
@@ -31,8 +31,8 @@ pub struct ProxyConfig {
 
 // === impl ServerConfig ===
 
-impl<A: OrigDstAddr> ServerConfig<A> {
-    pub fn with_orig_dst_addr<B: OrigDstAddr>(self, orig_dst_addrs: B) -> ServerConfig<B> {
+impl<A: GetOrigDstAddr> ServerConfig<A> {
+    pub fn with_orig_dst_addr<B: GetOrigDstAddr>(self, orig_dst_addrs: B) -> ServerConfig<B> {
         ServerConfig {
             bind: self.bind.with_orig_dst_addr(orig_dst_addrs),
             h2_settings: self.h2_settings,

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -231,7 +231,7 @@ mod client {
         proxy::http,
         svc::{self, Param},
         tls,
-        transport::ConnectAddr,
+        transport::{Remote, ServerAddr},
     };
     use linkerd_proxy_http::h2::Settings as H2Settings;
     use std::{
@@ -258,9 +258,9 @@ mod client {
 
     // === impl Target ===
 
-    impl Param<ConnectAddr> for Target {
-        fn param(&self) -> ConnectAddr {
-            ConnectAddr(self.addr)
+    impl Param<Remote<ServerAddr>> for Target {
+        fn param(&self) -> Remote<ServerAddr> {
+            Remote(ServerAddr(self.addr))
         }
     }
 

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -35,7 +35,7 @@ where
                     // The local addr should be instrumented from the listener's context.
                     let span = info_span!(
                         "accept",
-                        peer.addr = %addrs.peer(),
+                        client.addr = %addrs.client(),
                         target.addr = %addrs.target_addr(),
                     );
 

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -4,7 +4,7 @@ use linkerd_app_core::{
     proxy::identity::LocalCrtKey,
     svc::{self, Param},
     tls,
-    transport::{self, listen, metrics::SensorIo},
+    transport::{self, listen, metrics::SensorIo, ClientAddr, Remote},
     transport_header::{self, NewTransportHeaderServer, SessionProtocol, TransportHeader},
     Conditional, Error, NameAddr, Never,
 };
@@ -45,7 +45,7 @@ pub struct GatewayTransportHeader {
 pub struct ClientInfo {
     pub client_id: tls::ClientId,
     pub alpn: Option<tls::NegotiatedProtocol>,
-    pub client_addr: SocketAddr,
+    pub client_addr: Remote<ClientAddr>,
     pub local_addr: SocketAddr,
 }
 
@@ -189,7 +189,7 @@ impl TryFrom<(tls::ConditionalServerTls, listen::Addrs)> for ClientInfo {
             }) => Ok(Self {
                 client_id,
                 alpn: negotiated_protocol,
-                client_addr: addrs.peer(),
+                client_addr: addrs.client(),
                 local_addr: addrs.target_addr(),
             }),
             _ => Err(RefusedNoIdentity(())),

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -12,7 +12,7 @@ use linkerd_app_core::{
     proxy,
     svc::{self, NewService, Param},
     tls,
-    transport::{self, ConnectAddr},
+    transport::{ClientAddr, Remote, ServerAddr},
     Conditional, Error, NameAddr, ProxyRuntime,
 };
 use tracing::Instrument;
@@ -21,7 +21,7 @@ fn build_server<I>(
     cfg: Config,
     rt: ProxyRuntime,
     profiles: resolver::Profiles,
-    connect: Connect<ConnectAddr>,
+    connect: Connect<Remote<ServerAddr>>,
 ) -> impl svc::NewService<
     HttpAccept,
     Service = impl tower::Service<
@@ -36,9 +36,7 @@ where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
 {
     let connect = svc::stack(connect)
-        .push_map_target(|t: TcpEndpoint| {
-            transport::ConnectAddr(([127, 0, 0, 1], t.param()).into())
-        })
+        .push_map_target(|t: TcpEndpoint| Remote(ServerAddr(([127, 0, 0, 1], t.param()).into())))
         .into_inner();
     Inbound::new(cfg, rt)
         .with_stack(connect)
@@ -58,7 +56,7 @@ async fn unmeshed_http1_hello_world() {
         version: proxy::http::Version::Http1,
         tcp: TcpAccept {
             target_addr: ([127, 0, 0, 1], 5550).into(),
-            client_addr: ([10, 0, 0, 41], 6894).into(),
+            client_addr: Remote(ClientAddr(([10, 0, 0, 41], 6894).into())),
             tls: Conditional::None(tls::server::NoServerTls::NoClientHello),
         },
     };
@@ -105,7 +103,7 @@ async fn downgrade_origin_form() {
         version: proxy::http::Version::H2,
         tcp: TcpAccept {
             target_addr: ([127, 0, 0, 1], 5550).into(),
-            client_addr: ([10, 0, 0, 41], 6894).into(),
+            client_addr: Remote(ClientAddr(([10, 0, 0, 41], 6894).into())),
             tls: Conditional::None(tls::server::NoServerTls::NoClientHello),
         },
     };
@@ -153,7 +151,7 @@ async fn downgrade_absolute_form() {
         version: proxy::http::Version::H2,
         tcp: TcpAccept {
             target_addr: ([127, 0, 0, 1], 5550).into(),
-            client_addr: ([10, 0, 0, 41], 6894).into(),
+            client_addr: Remote(ClientAddr(([10, 0, 0, 41], 6894).into())),
             tls: Conditional::None(tls::server::NoServerTls::NoClientHello),
         },
     };
@@ -190,7 +188,9 @@ async fn downgrade_absolute_form() {
 }
 
 #[tracing::instrument]
-fn hello_server(http: hyper::server::conn::Http) -> impl Fn(ConnectAddr) -> Result<BoxedIo, Error> {
+fn hello_server(
+    http: hyper::server::conn::Http,
+) -> impl Fn(Remote<ServerAddr>) -> Result<BoxedIo, Error> {
     move |endpoint| {
         let span = tracing::info_span!("hello_server", ?endpoint);
         let _e = span.enter();

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -27,7 +27,7 @@ use linkerd_app_core::{
     serve,
     svc::{self, Param},
     tls,
-    transport::{self, listen},
+    transport::{self, listen, Remote, ServerAddr},
     Error, NameMatch, ProxyRuntime,
 };
 use std::{fmt::Debug, future::Future, net::SocketAddr, time::Duration};
@@ -110,7 +110,7 @@ impl Inbound<()> {
         } = config.proxy.connect;
 
         let stack = svc::stack(transport::ConnectTcp::new(keepalive))
-            .push_map_target(|t: T| transport::ConnectAddr(([127, 0, 0, 1], t.param()).into()))
+            .push_map_target(|t: T| Remote(ServerAddr(([127, 0, 0, 1], t.param()).into())))
             // Limits the time we wait for a connection to be established.
             .push_timeout(timeout)
             .push(svc::stack::BoxFuture::layer());

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -8,7 +8,7 @@ use linkerd_app_core::{
         http::{h1, h2},
         tap,
     },
-    transport::BindTcp,
+    transport::{BindTcp, ListenAddr},
     NameMatch, ProxyRuntime,
 };
 pub use linkerd_app_test as support;
@@ -24,7 +24,7 @@ pub fn default_config(orig_dst: SocketAddr) -> Config {
         allow_discovery: NameMatch::new(Some(cluster_local)),
         proxy: config::ProxyConfig {
             server: config::ServerConfig {
-                bind: BindTcp::new(SocketAddr::new(LOCALHOST.into(), 0), None)
+                bind: BindTcp::new(ListenAddr(SocketAddr::new(LOCALHOST.into(), 0)), None)
                     .with_orig_dst_addr(orig_dst.into()),
                 h2_settings: h2::Settings::default(),
             },

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -5,7 +5,9 @@ use linkerd_app_core::{
         resolve::map_endpoint::MapEndpoint,
     },
     svc::{self, Param},
-    tls, transport, transport_header, Addr, Conditional, Error,
+    tls,
+    transport::{self, Remote, ServerAddr},
+    transport_header, Addr, Conditional, Error,
 };
 use std::net::SocketAddr;
 
@@ -222,9 +224,9 @@ impl<P> Endpoint<P> {
     }
 }
 
-impl<P> Param<transport::ConnectAddr> for Endpoint<P> {
-    fn param(&self) -> transport::ConnectAddr {
-        transport::ConnectAddr(self.addr)
+impl<P> Param<Remote<ServerAddr>> for Endpoint<P> {
+    fn param(&self) -> Remote<ServerAddr> {
+        Remote(ServerAddr(self.addr))
     }
 }
 

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -10,7 +10,11 @@ use crate::{
     Config, Outbound,
 };
 use linkerd_app_core::{
-    io, svc, svc::NewService, tls, transport::listen, Conditional, Error, IpMatch,
+    io, svc,
+    svc::NewService,
+    tls,
+    transport::{listen, ClientAddr, Local, OrigDstAddr, Remote, ServerAddr},
+    Conditional, Error, IpMatch,
 };
 use std::{
     future::Future,
@@ -721,9 +725,9 @@ async fn profile_endpoint_propagates_conn_errors() {
     let mut server = build_server(cfg, profiles, resolver, connect);
 
     let svc = server.new_service(listen::Addrs::new(
-        ([127, 0, 0, 1], 4140).into(),
-        ([127, 0, 0, 1], 666).into(),
-        Some(ep1),
+        Local(ServerAddr(([127, 0, 0, 1], 4140).into())),
+        Remote(ClientAddr(([127, 0, 0, 1], 666).into())),
+        Some(OrigDstAddr(ep1)),
     ));
 
     let res = svc
@@ -824,9 +828,9 @@ where
     let svc = {
         let _e = span.enter();
         let addrs = listen::Addrs::new(
-            ([127, 0, 0, 1], 4140).into(),
-            ([127, 0, 0, 1], 666).into(),
-            Some(orig_dst),
+            Local(ServerAddr(([127, 0, 0, 1], 4140).into())),
+            Remote(ClientAddr(([127, 0, 0, 1], 666).into())),
+            Some(OrigDstAddr(orig_dst)),
         );
         let svc = new_svc.new_service(addrs);
         tracing::trace!("new service");

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -7,7 +7,7 @@ use linkerd_app_core::{
         http::{h1, h2},
         tap,
     },
-    transport::BindTcp,
+    transport::{BindTcp, ListenAddr},
     IpMatch, ProxyRuntime,
 };
 pub use linkerd_app_test as support;
@@ -21,7 +21,7 @@ pub fn default_config(orig_dst: SocketAddr) -> Config {
         allow_discovery: IpMatch::new(Some(IpNet::from_str("0.0.0.0/0").unwrap())).into(),
         proxy: config::ProxyConfig {
             server: config::ServerConfig {
-                bind: BindTcp::new(SocketAddr::new(LOCALHOST.into(), 0), None)
+                bind: BindTcp::new(ListenAddr(SocketAddr::new(LOCALHOST.into(), 0)), None)
                     .with_orig_dst_addr(orig_dst.into()),
                 h2_settings: h2::Settings::default(),
             },

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -4,7 +4,7 @@ use crate::core::{
     control::{Config as ControlConfig, ControlAddr},
     proxy::http::{h1, h2},
     tls,
-    transport::BindTcp,
+    transport::{BindTcp, ListenAddr},
     Addr, AddrMatch, Conditional, NameMatch,
 };
 use crate::{dns, gateway, identity, inbound, oc_collector, outbound};
@@ -389,8 +389,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
         let keepalive = outbound_accept_keepalive?;
         let bind = BindTcp::new(
-            outbound_listener_addr?
-                .unwrap_or_else(|| parse_socket_addr(DEFAULT_OUTBOUND_LISTEN_ADDR).unwrap()),
+            ListenAddr(
+                outbound_listener_addr?
+                    .unwrap_or_else(|| parse_socket_addr(DEFAULT_OUTBOUND_LISTEN_ADDR).unwrap()),
+            ),
             keepalive,
         );
         let server = ServerConfig {
@@ -451,8 +453,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let inbound = {
         let keepalive = inbound_accept_keepalive?;
         let bind = BindTcp::new(
-            inbound_listener_addr?
-                .unwrap_or_else(|| parse_socket_addr(DEFAULT_INBOUND_LISTEN_ADDR).unwrap()),
+            ListenAddr(
+                inbound_listener_addr?
+                    .unwrap_or_else(|| parse_socket_addr(DEFAULT_INBOUND_LISTEN_ADDR).unwrap()),
+            ),
             keepalive,
         );
         let server = ServerConfig {
@@ -503,7 +507,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
         // Ensure that connections thaat directly target the inbound port are
         // secured (unless identity is disabled).
-        let inbound_port = server.bind.bind_addr().port();
+        let inbound_port = server.bind.addr().as_ref().port();
         if !id_disabled && !require_identity_for_inbound_ports.contains(&inbound_port) {
             debug!(
                 "Adding {} to {}",
@@ -563,8 +567,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         metrics_retain_idle: metrics_retain_idle?.unwrap_or(DEFAULT_METRICS_RETAIN_IDLE),
         server: ServerConfig {
             bind: BindTcp::new(
-                admin_listener_addr?
-                    .unwrap_or_else(|| parse_socket_addr(DEFAULT_ADMIN_LISTEN_ADDR).unwrap()),
+                ListenAddr(
+                    admin_listener_addr?
+                        .unwrap_or_else(|| parse_socket_addr(DEFAULT_ADMIN_LISTEN_ADDR).unwrap()),
+                ),
                 inbound.proxy.server.bind.keepalive(),
             ),
             h2_settings,
@@ -611,7 +617,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         .map(|(addr, ids)| super::tap::Config::Enabled {
             permitted_client_ids: ids,
             config: ServerConfig {
-                bind: BindTcp::new(addr, inbound.proxy.server.bind.keepalive()),
+                bind: BindTcp::new(ListenAddr(addr), inbound.proxy.server.bind.keepalive()),
                 h2_settings,
             },
         })

--- a/linkerd/app/test/src/connect.rs
+++ b/linkerd/app/test/src/connect.rs
@@ -1,4 +1,9 @@
-use linkerd_app_core::{io::BoxedIo, svc::Param, transport::ConnectAddr, Error};
+use linkerd_app_core::{
+    io::BoxedIo,
+    svc::Param,
+    transport::{Remote, ServerAddr},
+    Error,
+};
 use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
@@ -23,7 +28,7 @@ pub struct NoRawTcp;
 
 impl<E> tower::Service<E> for Connect<E>
 where
-    E: Clone + fmt::Debug + Param<ConnectAddr>,
+    E: Clone + fmt::Debug + Param<Remote<ServerAddr>>,
 {
     type Response = BoxedIo;
     type Future = Instrumented<ConnectFuture>;
@@ -34,7 +39,7 @@ where
     }
 
     fn call(&mut self, endpoint: E) -> Self::Future {
-        let ConnectAddr(addr) = endpoint.param();
+        let Remote(ServerAddr(addr)) = endpoint.param();
         let span = tracing::info_span!("connect", %addr);
         let f = span.in_scope(|| {
             tracing::trace!("connecting...");

--- a/linkerd/proxy/transport/src/addrs.rs
+++ b/linkerd/proxy/transport/src/addrs.rs
@@ -1,0 +1,157 @@
+use std::{
+    fmt, io,
+    net::{SocketAddr, ToSocketAddrs},
+};
+
+/// The address of a remote client.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ClientAddr(pub SocketAddr);
+
+/// The address for a listener to bind on.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ListenAddr(pub SocketAddr);
+
+/// The address of a local server.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ServerAddr(pub SocketAddr);
+
+/// An SO_ORIGINAL_DST address.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct OrigDstAddr(pub SocketAddr);
+
+/// Wraps an address type to indicate it describes an address describing this
+/// process.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Local<T>(pub T);
+
+/// Wraps an address type to indicate it describes another process.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct Remote<T>(pub T);
+
+// === impl ClientAddr ===
+
+impl AsRef<SocketAddr> for ClientAddr {
+    fn as_ref(&self) -> &SocketAddr {
+        &self.0
+    }
+}
+
+impl Into<SocketAddr> for ClientAddr {
+    fn into(self) -> SocketAddr {
+        self.0
+    }
+}
+
+impl fmt::Display for ClientAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// === impl ListenAddr ===
+
+impl AsRef<SocketAddr> for ListenAddr {
+    fn as_ref(&self) -> &SocketAddr {
+        &self.0
+    }
+}
+
+impl Into<SocketAddr> for ListenAddr {
+    fn into(self) -> SocketAddr {
+        self.0
+    }
+}
+
+impl ToSocketAddrs for ListenAddr {
+    type Iter = std::option::IntoIter<SocketAddr>;
+
+    fn to_socket_addrs(&self) -> io::Result<Self::Iter> {
+        Ok(Some(self.0).into_iter())
+    }
+}
+
+impl fmt::Display for ListenAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// === impl ServerAddr ===
+
+impl AsRef<SocketAddr> for ServerAddr {
+    fn as_ref(&self) -> &SocketAddr {
+        &self.0
+    }
+}
+
+impl Into<SocketAddr> for ServerAddr {
+    fn into(self) -> SocketAddr {
+        self.0
+    }
+}
+
+impl fmt::Display for ServerAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// === impl OrigDstAddr ===
+
+impl AsRef<SocketAddr> for OrigDstAddr {
+    fn as_ref(&self) -> &SocketAddr {
+        &self.0
+    }
+}
+
+impl Into<SocketAddr> for OrigDstAddr {
+    fn into(self) -> SocketAddr {
+        self.0
+    }
+}
+
+impl fmt::Display for OrigDstAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// === impl Local ===
+
+impl<T: AsRef<SocketAddr>> AsRef<SocketAddr> for Local<T> {
+    fn as_ref(&self) -> &SocketAddr {
+        self.0.as_ref()
+    }
+}
+
+impl<T: Into<SocketAddr>> Into<SocketAddr> for Local<T> {
+    fn into(self) -> SocketAddr {
+        self.0.into()
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Local<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+// === impl Remote ===
+
+impl<T: AsRef<SocketAddr>> AsRef<SocketAddr> for Remote<T> {
+    fn as_ref(&self) -> &SocketAddr {
+        self.0.as_ref()
+    }
+}
+
+impl<T: Into<SocketAddr>> Into<SocketAddr> for Remote<T> {
+    fn into(self) -> SocketAddr {
+        self.0.into()
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for Remote<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/linkerd/proxy/transport/src/connect.rs
+++ b/linkerd/proxy/transport/src/connect.rs
@@ -1,8 +1,8 @@
+use crate::{Remote, ServerAddr};
 use linkerd_io as io;
 use linkerd_stack::Param;
 use std::{
     future::Future,
-    net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -15,16 +15,13 @@ pub struct ConnectTcp {
     keepalive: Option<Duration>,
 }
 
-#[derive(Copy, Clone, Debug)]
-pub struct ConnectAddr(pub SocketAddr);
-
 impl ConnectTcp {
     pub fn new(keepalive: Option<Duration>) -> Self {
         Self { keepalive }
     }
 }
 
-impl<T: Param<ConnectAddr>> tower::Service<T> for ConnectTcp {
+impl<T: Param<Remote<ServerAddr>>> tower::Service<T> for ConnectTcp {
     type Response = io::ScopedIo<TcpStream>;
     type Error = io::Error;
     type Future =
@@ -36,7 +33,7 @@ impl<T: Param<ConnectAddr>> tower::Service<T> for ConnectTcp {
 
     fn call(&mut self, t: T) -> Self::Future {
         let keepalive = self.keepalive;
-        let ConnectAddr(addr) = t.param();
+        let Remote(ServerAddr(addr)) = t.param();
         debug!(server.addr = %addr, "Connecting");
         Box::pin(async move {
             let io = TcpStream::connect(&addr).await?;

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -3,13 +3,15 @@
 use std::time::Duration;
 use tokio::net::TcpStream;
 
+pub mod addrs;
 mod connect;
 pub mod listen;
 pub mod metrics;
 
 pub use self::{
-    connect::{ConnectAddr, ConnectTcp},
-    listen::{BindTcp, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr},
+    addrs::{ClientAddr, ListenAddr, Local, OrigDstAddr, Remote, ServerAddr},
+    connect::ConnectTcp,
+    listen::{BindTcp, DefaultOrigDstAddr, GetOrigDstAddr, NoOrigDstAddr},
 };
 
 // Misc.

--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -143,7 +143,7 @@ impl GetOrigDstAddr for NoOrigDstAddr {
 
 #[cfg(not(feature = "mock-orig-dst"))]
 mod sys {
-    use super::{GetOrigDstAddr, OrigDstAddr, SocketAddr, TcpStream};
+    use super::{GetOrigDstAddr, OrigDstAddr, TcpStream};
 
     #[derive(Copy, Clone, Debug, Default)]
     pub struct SysOrigDstAddr(());

--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -1,3 +1,4 @@
+use crate::addrs::*;
 use futures::prelude::*;
 use std::{io, net::SocketAddr, time::Duration};
 use tokio::net::TcpStream;
@@ -5,13 +6,13 @@ use tokio_stream::wrappers::TcpListenerStream;
 use tracing::trace;
 
 /// A mockable source for address info, i.e., for tests.
-pub trait OrigDstAddr: Clone {
-    fn orig_dst_addr(&self, socket: &TcpStream) -> Option<SocketAddr>;
+pub trait GetOrigDstAddr: Clone {
+    fn orig_dst_addr(&self, socket: &TcpStream) -> Option<OrigDstAddr>;
 }
 
 #[derive(Clone, Debug)]
-pub struct BindTcp<O: OrigDstAddr = NoOrigDstAddr> {
-    bind_addr: SocketAddr,
+pub struct BindTcp<O = NoOrigDstAddr> {
+    addr: ListenAddr,
     keepalive: Option<Duration>,
     orig_dst_addr: O,
 }
@@ -20,9 +21,9 @@ pub type Connection = (Addrs, TcpStream);
 
 #[derive(Clone, Debug)]
 pub struct Addrs {
-    local: SocketAddr,
-    peer: SocketAddr,
-    orig_dst: Option<SocketAddr>,
+    server: Local<ServerAddr>,
+    client: Remote<ClientAddr>,
+    orig_dst: Option<OrigDstAddr>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -38,26 +39,26 @@ pub use self::sys::SysOrigDstAddr as DefaultOrigDstAddr;
 pub use self::mock::MockOrigDstAddr as DefaultOrigDstAddr;
 
 impl BindTcp {
-    pub fn new(bind_addr: SocketAddr, keepalive: Option<Duration>) -> Self {
+    pub fn new(addr: ListenAddr, keepalive: Option<Duration>) -> Self {
         Self {
-            bind_addr,
+            addr,
             keepalive,
             orig_dst_addr: NoOrigDstAddr(()),
         }
     }
 }
 
-impl<A: OrigDstAddr> BindTcp<A> {
-    pub fn with_orig_dst_addr<B: OrigDstAddr>(self, orig_dst_addr: B) -> BindTcp<B> {
+impl<A: GetOrigDstAddr> BindTcp<A> {
+    pub fn with_orig_dst_addr<B: GetOrigDstAddr>(self, orig_dst_addr: B) -> BindTcp<B> {
         BindTcp {
             orig_dst_addr,
-            bind_addr: self.bind_addr,
+            addr: self.addr,
             keepalive: self.keepalive,
         }
     }
 
-    pub fn bind_addr(&self) -> SocketAddr {
-        self.bind_addr
+    pub fn addr(&self) -> ListenAddr {
+        self.addr
     }
 
     pub fn keepalive(&self) -> Option<Duration> {
@@ -66,7 +67,7 @@ impl<A: OrigDstAddr> BindTcp<A> {
 
     pub fn bind(&self) -> io::Result<(SocketAddr, impl Stream<Item = io::Result<Connection>>)> {
         let listen = {
-            let l = std::net::TcpListener::bind(self.bind_addr)?;
+            let l = std::net::TcpListener::bind(self.addr)?;
             // Ensure that O_NONBLOCK is set on the socket before using it with Tokio.
             l.set_nonblocking(true)?;
             tokio::net::TcpListener::from_std(l).expect("listener must be valid")
@@ -83,16 +84,16 @@ impl<A: OrigDstAddr> BindTcp<A> {
 
     fn accept(tcp: TcpStream, keepalive: Option<Duration>, get_orig: A) -> io::Result<Connection> {
         let addrs = {
-            let local = tcp.local_addr()?;
-            let peer = tcp.peer_addr()?;
+            let server = Local(ServerAddr(tcp.local_addr()?));
+            let client = Remote(ClientAddr(tcp.peer_addr()?));
             let orig_dst = get_orig.orig_dst_addr(&tcp);
             trace!(
-                local.addr = %local,
-                peer.addr = %peer,
+                server.addr = %server,
+                client.addr = %client,
                 orig.addr = ?orig_dst,
                 "Accepted",
             );
-            Addrs::new(local, peer, orig_dst)
+            Addrs::new(server, client, orig_dst)
         };
 
         super::set_nodelay_or_warn(&tcp);
@@ -103,86 +104,62 @@ impl<A: OrigDstAddr> BindTcp<A> {
 }
 
 impl Addrs {
-    pub fn new(local: SocketAddr, peer: SocketAddr, orig_dst: Option<SocketAddr>) -> Self {
+    pub fn new(
+        server: Local<ServerAddr>,
+        client: Remote<ClientAddr>,
+        orig_dst: Option<OrigDstAddr>,
+    ) -> Self {
         Self {
-            local,
-            peer,
+            server,
+            client,
             orig_dst,
         }
     }
 
-    pub fn local(&self) -> SocketAddr {
-        self.local
+    pub fn server(&self) -> Local<ServerAddr> {
+        self.server
     }
 
-    pub fn peer(&self) -> SocketAddr {
-        self.peer
+    pub fn client(&self) -> Remote<ClientAddr> {
+        self.client
     }
 
-    pub fn orig_dst(&self) -> Option<SocketAddr> {
+    pub fn orig_dst(&self) -> Option<OrigDstAddr> {
         self.orig_dst
     }
 
     pub fn target_addr(&self) -> SocketAddr {
-        self.orig_dst.unwrap_or(self.local)
-    }
-
-    pub fn target_addr_is_local(&self) -> bool {
         self.orig_dst
-            .map(|orig_dst| Self::same_addr(orig_dst, self.local))
-            .unwrap_or(true)
-    }
-
-    pub fn target_addr_if_not_local(&self) -> Option<SocketAddr> {
-        if !self.target_addr_is_local() {
-            Some(self.target_addr())
-        } else {
-            None
-        }
-    }
-
-    fn same_addr(a0: SocketAddr, a1: SocketAddr) -> bool {
-        use std::net::IpAddr::{V4, V6};
-        (a0.port() == a1.port())
-            && match (a0.ip(), a1.ip()) {
-                (V6(a0), V4(a1)) => a0.to_ipv4() == Some(a1),
-                (V4(a0), V6(a1)) => Some(a0) == a1.to_ipv4(),
-                (a0, a1) => (a0 == a1),
-            }
+            .map(Into::into)
+            .unwrap_or_else(|| self.server.into())
     }
 }
 
-impl Into<SocketAddr> for &'_ Addrs {
-    fn into(self) -> SocketAddr {
-        self.target_addr()
-    }
-}
-
-impl OrigDstAddr for NoOrigDstAddr {
-    fn orig_dst_addr(&self, _: &TcpStream) -> Option<SocketAddr> {
+impl GetOrigDstAddr for NoOrigDstAddr {
+    fn orig_dst_addr(&self, _: &TcpStream) -> Option<OrigDstAddr> {
         None
     }
 }
 
 #[cfg(not(feature = "mock-orig-dst"))]
 mod sys {
-    use super::{OrigDstAddr, SocketAddr, TcpStream};
+    use super::{GetOrigDstAddr, OrigDstAddr, SocketAddr, TcpStream};
 
     #[derive(Copy, Clone, Debug, Default)]
     pub struct SysOrigDstAddr(());
 
-    impl OrigDstAddr for SysOrigDstAddr {
+    impl GetOrigDstAddr for SysOrigDstAddr {
         #[cfg(target_os = "linux")]
-        fn orig_dst_addr(&self, sock: &TcpStream) -> Option<SocketAddr> {
+        fn orig_dst_addr(&self, sock: &TcpStream) -> Option<OrigDstAddr> {
             use std::os::unix::io::AsRawFd;
 
             let fd = sock.as_raw_fd();
             let r = unsafe { linux::so_original_dst(fd) };
-            r.ok()
+            r.map(OrigDstAddr).ok()
         }
 
         #[cfg(not(target_os = "linux"))]
-        fn orig_dst_addr(&self, _sock: &TcpStream) -> Option<SocketAddr> {
+        fn orig_dst_addr(&self, _sock: &TcpStream) -> Option<OrigDstAddr> {
             None
         }
     }
@@ -288,7 +265,7 @@ mod sys {
 
 #[cfg(feature = "mock-orig-dst")]
 mod mock {
-    use super::{OrigDstAddr, SocketAddr, TcpStream};
+    use super::{GetOrigDstAddr, OrigDstAddr, SocketAddr, TcpStream};
 
     #[derive(Copy, Clone, Debug)]
     pub struct MockOrigDstAddr(SocketAddr);
@@ -299,9 +276,9 @@ mod mock {
         }
     }
 
-    impl OrigDstAddr for MockOrigDstAddr {
-        fn orig_dst_addr(&self, _: &TcpStream) -> Option<SocketAddr> {
-            Some(self.0)
+    impl GetOrigDstAddr for MockOrigDstAddr {
+        fn orig_dst_addr(&self, _: &TcpStream) -> Option<OrigDstAddr> {
+            Some(OrigDstAddr(self.0))
         }
     }
 }

--- a/linkerd/tls/tests/tls_accept.rs
+++ b/linkerd/tls/tests/tls_accept.rs
@@ -10,7 +10,7 @@ use linkerd_conditional::Conditional;
 use linkerd_error::Never;
 use linkerd_identity as id;
 use linkerd_io::{self as io, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use linkerd_proxy_transport::{listen::Addrs, BindTcp, ConnectAddr, ConnectTcp};
+use linkerd_proxy_transport::{listen::Addrs, BindTcp, ConnectTcp, ListenAddr, Remote, ServerAddr};
 use linkerd_stack::{NewService, Param};
 use linkerd_tls as tls;
 use std::future::Future;
@@ -186,7 +186,9 @@ where
             std::time::Duration::from_secs(10),
         );
 
-        let (listen_addr, listen) = BindTcp::new(addr, None).bind().expect("must bind");
+        let (listen_addr, listen) = BindTcp::new(ListenAddr(addr), None)
+            .bind()
+            .expect("must bind");
         let server = async move {
             futures::pin_mut!(listen);
             let (meta, io) = listen
@@ -308,9 +310,9 @@ struct Target(SocketAddr, tls::ConditionalClientTls);
 #[derive(Clone)]
 struct Tls(id::CrtKey);
 
-impl Param<ConnectAddr> for Target {
-    fn param(&self) -> ConnectAddr {
-        ConnectAddr(self.0)
+impl Param<Remote<ServerAddr>> for Target {
+    fn param(&self) -> Remote<ServerAddr> {
+        Remote(ServerAddr(self.0))
     }
 }
 


### PR DESCRIPTION
Throughout the codebase, we handle many types of `SocketAddr`s. It's
easy to use these instances in an incorrect context.

In preparation for upcoming changes to listen module and target types,
this change introduces a family of new-types to disambiguate these uses:

- `ClientAddr`  -- a client's (ephemeral) address
- `ServerAddr`  -- a server's address
- `OrigDstAddr` -- an address set by the `SO_ORIGINAL_DST` socket option

Additionally, `Local` and `Remote` address types are introduced to
further disambiguate the above types:

- `Remote<ClientAddr>` -- a server connection's peer address
- `Local<ServerAddr>`  -- a server connection's local address
- `Remote<ServerAddr>` -- a client connection's peer address
- `Local<ClientAddr>`  -- a client connection's local address

A special `ListenAddr` type is introduced to indicate an unbound address
to be used to bind a server. The `OrigDstAddr` trait is renamed to
`GetOrigDstAddr`.

No functional change.