### PR TITLE
transport: Introduce a Keepalive type

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -1,6 +1,6 @@
 pub use crate::exp_backoff::ExponentialBackoff;
 pub use crate::proxy::http::{h1, h2};
-pub use crate::transport::{BindTcp, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr};
+pub use crate::transport::{BindTcp, DefaultOrigDstAddr, Keepalive, NoOrigDstAddr, OrigDstAddr};
 use std::time::Duration;
 
 #[derive(Clone, Debug)]
@@ -13,7 +13,7 @@ pub struct ServerConfig<A: OrigDstAddr = NoOrigDstAddr> {
 pub struct ConnectConfig {
     pub backoff: ExponentialBackoff,
     pub timeout: Duration,
-    pub keepalive: Option<Duration>,
+    pub keepalive: Keepalive,
     pub h1_settings: h1::PoolSettings,
     pub h2_settings: h2::Settings,
 }

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -8,7 +8,7 @@ use linkerd_app_core::{
         http::{h1, h2},
         tap,
     },
-    transport::BindTcp,
+    transport::{BindTcp, Keepalive},
     NameMatch, ProxyRuntime,
 };
 pub use linkerd_app_test as support;
@@ -24,12 +24,12 @@ pub fn default_config(orig_dst: SocketAddr) -> Config {
         allow_discovery: NameMatch::new(Some(cluster_local)),
         proxy: config::ProxyConfig {
             server: config::ServerConfig {
-                bind: BindTcp::new(SocketAddr::new(LOCALHOST.into(), 0), None)
+                bind: BindTcp::new(SocketAddr::new(LOCALHOST.into(), 0), Keepalive(None))
                     .with_orig_dst_addr(orig_dst.into()),
                 h2_settings: h2::Settings::default(),
             },
             connect: config::ConnectConfig {
-                keepalive: None,
+                keepalive: Keepalive(None),
                 timeout: Duration::from_secs(1),
                 backoff: exp_backoff::ExponentialBackoff::new(
                     Duration::from_millis(100),

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -7,7 +7,7 @@ use linkerd_app_core::{
         http::{h1, h2},
         tap,
     },
-    transport::BindTcp,
+    transport::{BindTcp, Keepalive},
     IpMatch, ProxyRuntime,
 };
 pub use linkerd_app_test as support;
@@ -21,12 +21,12 @@ pub fn default_config(orig_dst: SocketAddr) -> Config {
         allow_discovery: IpMatch::new(Some(IpNet::from_str("0.0.0.0/0").unwrap())).into(),
         proxy: config::ProxyConfig {
             server: config::ServerConfig {
-                bind: BindTcp::new(SocketAddr::new(LOCALHOST.into(), 0), None)
+                bind: BindTcp::new(SocketAddr::new(LOCALHOST.into(), 0), Keepalive(None))
                     .with_orig_dst_addr(orig_dst.into()),
                 h2_settings: h2::Settings::default(),
             },
             connect: config::ConnectConfig {
-                keepalive: None,
+                keepalive: Keepalive(None),
                 timeout: Duration::from_secs(1),
                 backoff: exp_backoff::ExponentialBackoff::new(
                     Duration::from_millis(100),

--- a/linkerd/proxy/transport/src/connect.rs
+++ b/linkerd/proxy/transport/src/connect.rs
@@ -1,3 +1,4 @@
+use crate::Keepalive;
 use linkerd_io as io;
 use linkerd_stack::Param;
 use std::{
@@ -5,21 +6,20 @@ use std::{
     net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
-    time::Duration,
 };
 use tokio::net::TcpStream;
 use tracing::debug;
 
 #[derive(Copy, Clone, Debug)]
 pub struct ConnectTcp {
-    keepalive: Option<Duration>,
+    keepalive: Keepalive,
 }
 
 #[derive(Copy, Clone, Debug)]
 pub struct ConnectAddr(pub SocketAddr);
 
 impl ConnectTcp {
-    pub fn new(keepalive: Option<Duration>) -> Self {
+    pub fn new(keepalive: Keepalive) -> Self {
         Self { keepalive }
     }
 }
@@ -35,7 +35,7 @@ impl<T: Param<ConnectAddr>> tower::Service<T> for ConnectTcp {
     }
 
     fn call(&mut self, t: T) -> Self::Future {
-        let keepalive = self.keepalive;
+        let Keepalive(keepalive) = self.keepalive;
         let ConnectAddr(addr) = t.param();
         debug!(server.addr = %addr, "Connecting");
         Box::pin(async move {

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -1,8 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use std::time::Duration;
-use tokio::net::TcpStream;
-
 mod connect;
 pub mod listen;
 pub mod metrics;
@@ -11,6 +8,17 @@ pub use self::{
     connect::{ConnectAddr, ConnectTcp},
     listen::{BindTcp, DefaultOrigDstAddr, NoOrigDstAddr, OrigDstAddr},
 };
+use std::time::Duration;
+use tokio::net::TcpStream;
+
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Keepalive(pub Option<Duration>);
+
+impl Into<Option<Duration>> for Keepalive {
+    fn into(self) -> Option<Duration> {
+        self.0
+    }
+}
 
 // Misc.
 

--- a/linkerd/tls/tests/tls_accept.rs
+++ b/linkerd/tls/tests/tls_accept.rs
@@ -10,7 +10,7 @@ use linkerd_conditional::Conditional;
 use linkerd_error::Never;
 use linkerd_identity as id;
 use linkerd_io::{self as io, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use linkerd_proxy_transport::{listen::Addrs, BindTcp, ConnectAddr, ConnectTcp};
+use linkerd_proxy_transport::{listen::Addrs, BindTcp, ConnectAddr, ConnectTcp, Keepalive};
 use linkerd_stack::{NewService, Param};
 use linkerd_tls as tls;
 use std::future::Future;
@@ -186,7 +186,9 @@ where
             std::time::Duration::from_secs(10),
         );
 
-        let (listen_addr, listen) = BindTcp::new(addr, None).bind().expect("must bind");
+        let (listen_addr, listen) = BindTcp::new(addr, Keepalive(None))
+            .bind()
+            .expect("must bind");
         let server = async move {
             futures::pin_mut!(listen);
             let (meta, io) = listen
@@ -215,7 +217,7 @@ where
         let tls = Some(client_server_id.clone().map(Into::into));
         let client = async move {
             let conn = tls::Client::layer(client_tls)
-                .layer(ConnectTcp::new(None))
+                .layer(ConnectTcp::new(Keepalive(None)))
                 .oneshot(Target(server_addr, client_server_id.map(Into::into)))
                 .await;
             match conn {


### PR DESCRIPTION
When handling `Duration` values, it can be ambiguous as to the value's
intended use.

This change introduces a `Keepalive` new-type that wraps an optional
`Duration`. This will allow keepalive values to be parameterized without
ambiguity (in future changes).

No functional changes.