### PR TITLE
outbound: Prevent connections on the loopback interface

### DIFF
--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -12,6 +12,7 @@ This is used by tests and the executable.
 """
 
 [features]
+allow-loopback = ["linkerd-app-outbound/allow-loopback"]
 mock-orig-dst  = ["linkerd-app-core/mock-orig-dst"]
 
 [dependencies]

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -24,7 +24,7 @@ http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.2", features = ["http1", "http2", "stream", "client", "server"] }
 linkerd-channel = { path = "../../channel" }
-linkerd-app = { path = "..", features = ["mock-orig-dst"] }
+linkerd-app = { path = "..", features = ["allow-loopback", "mock-orig-dst"] }
 linkerd-app-core = { path = "../core", features = ["mock-orig-dst"] }
 linkerd-metrics = { path = "../../metrics", features = ["test_util"] }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18", features = ["arbitrary"] }

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -11,6 +11,7 @@ Configures and runs the outbound proxy
 
 [features]
 default = []
+allow-loopback = []
 test-subscriber = []
 
 [dependencies]


### PR DESCRIPTION
linkerd/linkerd2#5764 reports proxy OOMs, apparently caused by traffic
looping from the outbound proxy back to the inbound proxy. While we
don't understand the underlying circumstances, we should *never* proxy
outbound connections on the loopback interface in normal operation.

This change modifies the outbound TCP connection stack to prevent
connections on loopback addresses. A feature flag, `allow-loopback`, is
provided to disable this functionality. This is necessary so that our
local integration tests can continue to pass.