### PR TITLE
make proxy builds work on windows

### DIFF
--- a/linkerd/signal/src/lib.rs
+++ b/linkerd/signal/src/lib.rs
@@ -39,7 +39,6 @@ mod imp {
 
 #[cfg(not(unix))]
 mod imp {
-    use futures::prelude::*;
     use tracing::info;
 
     pub(super) async fn shutdown() {
@@ -47,7 +46,10 @@ mod imp {
         // isn't our expected deployment target. This implementation allows
         // developers on Windows to simulate proxy graceful shutdown
         // by pressing Ctrl-C.
-        tokio::signal::ctrl_c().recv().await;
+        tokio::signal::windows::ctrl_c()
+            .expect("Failed to register signal handler")
+            .recv()
+            .await;
         info!(
             // use target to remove 'imp' from output
             target: "linkerd_proxy::signal",


### PR DESCRIPTION
Currently, The proxy builds fail on windows because of the absence
of `future::preludes`. That does not seem to be required anymore
and the windows ctrl_c signal can be used similar with that of
the unix signals.

This PR updates the `shutdown` fn in imp for windows to be just
like the unix ones. I'm aware that the proxy is not intended to be ran
on windows machines but this was a easy fix to make builds work.

Signed-off-by: Tarun Pothulapati <tarunpothulapati@outlook.com>