### PR TITLE
Add support for TLS v1.3

### DIFF
--- a/linkerd/identity/src/lib.rs
+++ b/linkerd/identity/src/lib.rs
@@ -62,7 +62,10 @@ const SIGNATURE_ALG_RUSTLS_SCHEME: rustls::SignatureScheme =
     rustls::SignatureScheme::ECDSA_NISTP256_SHA256;
 const SIGNATURE_ALG_RUSTLS_ALGORITHM: rustls::internal::msgs::enums::SignatureAlgorithm =
     rustls::internal::msgs::enums::SignatureAlgorithm::ECDSA;
-const TLS_VERSIONS: &[rustls::ProtocolVersion] = &[rustls::ProtocolVersion::TLSv1_2];
+const TLS_VERSIONS: &[rustls::ProtocolVersion] = &[
+    rustls::ProtocolVersion::TLSv1_2,
+    rustls::ProtocolVersion::TLSv1_3,
+];
 
 // === impl Csr ===
 


### PR DESCRIPTION
TLS 1.3 has been available in rustls for a while now, giving us some
confidence that it's stable.

This change adds TLS 1.3 to the list of supported TLS versions. With
this change, proxies will prefer TLS 1.3 when both peers include this
change and will downgrade to TLS 1.2 when communicating with an older
proxy version.

I've tested that this behaves as expected by upgrading just the
emojivoto app's _web_ and _voting_ services with debug logging. Older
proxies communicate with newer proxies via TLS 1.2 and newer proxies
communicate via TLS 1.3.