### PR TITLE
deps: update `tracing-subscriber` to 0.2.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
  "winapi",
 ]
 
@@ -2076,16 +2075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -2341,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
 dependencies = [
  "ansi_term",
  "chrono",

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -33,4 +33,4 @@ linkerd-app-test = { path = "../test" }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 tokio = { version = "1", features = ["full", "macros"]}
 tokio-test = "0.4"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.2.16"

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -42,4 +42,4 @@ linkerd-app-test = { path = "../test" }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 tokio = { version = "1", features = ["full", "macros"]}
 tokio-test = "0.4"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.2.16"

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -31,10 +31,10 @@ tokio = { version = "1", features = ["io-util", "net", "rt", "sync"]}
 tokio-test = "0.4"
 tower = { version = "0.4.5", default-features = false}
 tracing = "0.1.23"
-tracing-subscriber = "0.2.11"
+tracing-subscriber = "0.2.16"
 
 [dev-dependencies.tracing-subscriber]
-version = "0.2.14"
+version = "0.2.16"
 # turn on ANSI colors for tests :)
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "ansi", "tracing-log", "json", "parking_lot"]

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -17,4 +17,4 @@ tracing = "0.1.23"
 
 [dev-dependencies]
 tokio = { version = "1", default-features = false, features = ["macros", "test-util", "time"] }
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.2.16"

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -41,4 +41,4 @@ pin-project = "1"
 
 [dev-dependencies]
 tokio-test = "0.4"
-tracing-subscriber = "0.2"
+tracing-subscriber = "0.2.16"

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -21,5 +21,5 @@ tracing = "0.1"
 [dev-dependencies]
 tower-test = "0.4"
 tokio-test = "0.4"
-tracing-subscriber = "0.2.14"
+tracing-subscriber = "0.2.16"
 tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -29,4 +29,4 @@ linkerd-identity = { path = "../identity", features = ["test-util"] }
 linkerd-proxy-transport = { path = "../proxy/transport" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
 tower = { version = "0.4.5", default-features = false, features = ["util"] }
-tracing-subscriber = "0.2.14"
+tracing-subscriber = "0.2.16"


### PR DESCRIPTION
This picks up tokio-rs/tracing#1247, tokio-rs/tracing#1248,
tokio-rs/tracing#1251, and tokio-rs/tracing#1254. Collectively, these
changes should result in a significant performance improvement when
using `tracing-log`'s compatibility layer for converting legacy `log`
records to `tracing` events.

Since we have some dependencies which use the `log` crate, this should
hopefully reduce the overhead of those dependencies' logging. I'm not
sure how much `log` we have in the hot path by this point, but it's
probably a good idea to pick up the change regardless.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>