### PR TITLE
trace: set `log` global max level when reloading

### DIFF
--- a/linkerd/tracing/Cargo.toml
+++ b/linkerd/tracing/Cargo.toml
@@ -16,10 +16,10 @@ serde_json = "1"
 tokio = { version = "1", features = ["time"] }
 tokio-trace = { git = "https://github.com/hawkw/tokio-trace", rev = "7d5998e7cb3beb06ada5983675319dc4853576c5", features = ["serde"] }
 tracing = "0.1.23"
-tracing-log = "0.1"
+tracing-log = "0.1.2"
 
 [dependencies.tracing-subscriber]
-version = "0.2.15"
+version = "0.2.16"
 # we don't need `chrono` time formatting or ANSI colored output
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot"]

--- a/linkerd/tracing/src/lib.rs
+++ b/linkerd/tracing/src/lib.rs
@@ -32,16 +32,27 @@ pub fn init() -> Result<Handle, Error> {
         .format(log_format)
         .build();
 
-    // Set up log compatibility.
-    init_log_compat()?;
     // Set the default subscriber.
     tracing::dispatcher::set_global_default(dispatch)?;
+
+    // Set up log compatibility.
+    init_log_compat()?;
 
     Ok(handle)
 }
 
+#[inline]
+pub(crate) fn update_max_level() {
+    use tracing::level_filters::LevelFilter;
+    use tracing_log::{log, AsLog};
+    log::set_max_level(LevelFilter::current().as_log());
+}
+
 pub fn init_log_compat() -> Result<(), Error> {
-    tracing_log::LogTracer::init().map_err(Error::from)
+    tracing_log::LogTracer::init()?;
+    // Set the initial max `log` level based on the subscriber settings.
+    update_max_level();
+    Ok(())
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
In order to ensure that disabled `log` records are skipped by taking the
fastest path the `log` crate offers whenever possible, we should set the
`log` max level every time the `tracing` filter is reloaded.

This branch changes the proxy to...do that.

I'll also add this in the reloading stuff upstream, but I wanted to get it 
working in the proxy first, before doing another `tracing-subscriber`
release.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>