### PR TITLE
detect: Surface timeouts to inner stack

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -249,6 +249,7 @@ where
                     .into_inner(),
             ))
             .push_cache(config.cache_max_idle_age)
+            .push_map_target(detect::allow_timeout)
             .push(detect::NewDetectService::layer(
                 config.detect_protocol_timeout,
                 http::DetectHttp::default(),

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -10,7 +10,7 @@ use linkerd_app_core::{
     transport_header::TransportHeader,
     Addr, Conditional, Error, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER,
 };
-use std::{convert::TryInto, fmt, net::SocketAddr, str::FromStr, sync::Arc};
+use std::{convert::TryInto, net::SocketAddr, str::FromStr, sync::Arc};
 use tracing::debug;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -57,9 +57,6 @@ pub struct RequestTarget {
     accept: HttpAccept,
 }
 
-#[derive(Debug, Default)]
-pub struct AdminHttpOnly(());
-
 // === impl TcpAccept ===
 
 impl TcpAccept {
@@ -357,13 +354,3 @@ impl Param<Option<profiles::Receiver>> for Logical {
         self.profiles.clone()
     }
 }
-
-// === impl AdminHttpOnly ===
-
-impl fmt::Display for AdminHttpOnly {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad("proxy admin server is HTTP-only")
-    }
-}
-
-impl std::error::Error for AdminHttpOnly {}

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -10,13 +10,7 @@ use linkerd_app_core::{
     transport_header::TransportHeader,
     Addr, Conditional, Error, CANONICAL_DST_HEADER, DST_OVERRIDE_HEADER,
 };
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt,
-    net::SocketAddr,
-    str::FromStr,
-    sync::Arc,
-};
+use std::{convert::TryInto, fmt, net::SocketAddr, str::FromStr, sync::Arc};
 use tracing::debug;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -105,20 +99,6 @@ impl Param<transport::labels::Key> for TcpAccept {
 }
 
 // === impl HttpAccept ===
-
-impl<E: Into<Error>> TryFrom<(Result<Option<http::Version>, E>, TcpAccept)> for HttpAccept {
-    type Error = Error;
-
-    fn try_from(
-        (version, tcp): (Result<Option<http::Version>, E>, TcpAccept),
-    ) -> Result<Self, Error> {
-        match version {
-            Ok(Some(version)) => Ok(Self { version, tcp }),
-            Ok(None) => Err(AdminHttpOnly(()).into()),
-            Err(timeout) => Err(timeout.into()),
-        }
-    }
-}
 
 impl From<(http::Version, TcpAccept)> for HttpAccept {
     fn from((version, tcp): (http::Version, TcpAccept)) -> Self {

--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -50,6 +50,7 @@ impl<T> Outbound<T> {
                     .push_on_response(svc::MapTargetLayer::new(io::EitherIo::Right))
                     .into_inner(),
             ))
+            .push_map_target(detect::allow_timeout)
             .push(detect::NewDetectService::layer(
                 detect_protocol_timeout,
                 http::DetectHttp::default(),

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -125,6 +125,7 @@ impl Outbound<()> {
             .push_map_target(http::Accept::from)
             .push(svc::UnwrapOr::layer(tcp))
             .push_cache(cache_max_idle_age)
+            .push_map_target(detect::allow_timeout)
             .push(detect::NewDetectService::layer(
                 detect_protocol_timeout,
                 http::DetectHttp::default(),

--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -63,7 +63,7 @@ impl Config {
             .push_map_target(Target::from)
             .push(http::NewServeHttp::layer(Default::default(), drain.clone()))
             .push(svc::Filter::<TcpAccept, _>::layer(
-                |(version, tcp): (Result<Option<http::Version>, detect::DetectTimeout>, _)| {
+                |(version, tcp): (Result<Option<http::Version>, detect::DetectTimeout<_>>, _)| {
                     match version {
                         Ok(Some(version)) => Ok(HttpAccept::from((version, tcp))),
                         Ok(None) => Err(Error::from(AdminHttpOnly(()))),

--- a/linkerd/detect/src/lib.rs
+++ b/linkerd/detect/src/lib.rs
@@ -50,7 +50,11 @@ pub fn allow_timeout<P, T>((p, t): (Detected<P>, T)) -> (Option<P>, T) {
     match p {
         Ok(p) => (p, t),
         Err(DetectTimeout(timeout)) => {
-            info!(?timeout, "Protocol detection timeout");
+            info!(
+                ?timeout,
+                protocol = %std::any::type_name::<P>(),
+                "Protocol detection timeout"
+            );
             (None, t)
         }
     }
@@ -157,7 +161,7 @@ where
 
 impl fmt::Display for DetectTimeout {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Detection timed out after {:?}", self.0)
+        write!(f, "protocol detection timed out after {:?}", self.0)
     }
 }
 

--- a/linkerd/detect/src/lib.rs
+++ b/linkerd/detect/src/lib.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use tokio::time;
 use tower::util::ServiceExt;
-use tracing::{debug, trace};
+use tracing::{debug, info, trace};
 
 #[async_trait::async_trait]
 pub trait Detect<I>: Clone + Send + Sync + 'static {
@@ -50,7 +50,7 @@ pub fn allow_timeout<P, T>((p, t): (Detected<P>, T)) -> (Option<P>, T) {
     match p {
         Ok(p) => (p, t),
         Err(DetectTimeout(timeout)) => {
-            debug!(?timeout, "Detection timeout");
+            info!(?timeout, "Protocol detection timeout");
             (None, t)
         }
     }

--- a/linkerd/proxy/http/src/detect.rs
+++ b/linkerd/proxy/http/src/detect.rs
@@ -25,14 +25,10 @@ const SMALLEST_POSSIBLE_HTTP1_REQ: &str = "GET / HTTP/1.1";
 pub struct DetectHttp(());
 
 #[async_trait::async_trait]
-impl Detect for DetectHttp {
+impl<I: io::AsyncRead + Send + Unpin + 'static> Detect<I> for DetectHttp {
     type Protocol = Version;
 
-    async fn detect<I: io::AsyncRead + Send + Unpin + 'static>(
-        &self,
-        io: &mut I,
-        buf: &mut BytesMut,
-    ) -> Result<Option<Version>, Error> {
+    async fn detect(&self, io: &mut I, buf: &mut BytesMut) -> Result<Option<Version>, Error> {
         trace!(capacity = buf.capacity(), "Reading");
         let sz = io.read_buf(buf).await?;
         trace!(sz, "Read");


### PR DESCRIPTION
In 95498395, the detect service was modified to handle detect timeouts
gracefully; but, we can't differentiate this situration from other
detection mismatches.

In order to use the detect trait more generally--especially for TLS
detection, this change modifies the `Detect` trait to pass an error into
the inner stack when detection fails. Uses are updated to either fail on
or log when an error is countered, as appropriate. This will be relied
on in followup changes.

Furthermore, the `Detect` trait's I/O type is moved to be a
trait-generic (rather than a method-generic) so that implementations may
impose further type constraints.