### PR TITLE
server: Log connection closed messages at DEBUG

### DIFF
--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -5,7 +5,7 @@ use linkerd_error::Error;
 use linkerd_proxy_transport::listen::Addrs;
 use tower::util::ServiceExt;
 use tracing::instrument::Instrument;
-use tracing::{debug, info, info_span, warn};
+use tracing::{debug, info_span, warn};
 
 /// Spawns a task that binds an `L`-typed listener with an `A`-typed
 /// connection-accepting service.

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -52,7 +52,7 @@ where
                                         .await
                                     {
                                         Ok(()) => debug!("Connection closed"),
-                                        Err(error) => info!(%error, "Connection closed"),
+                                        Err(reason) => debug!(%reason, "Connection closed"),
                                     }
                                     // Hold the service until the connection is
                                     // complete. This helps tie any inner cache


### PR DESCRIPTION
Per linkerd/linkerd2#5331, it seems that "Connection closed" log
messages, which in many cases are compltely innocuous, cause concern
when people see them in production.

This change moves these messages from the INFO to DEBUG log level so
that they are only observed when explicilty configured.