### PR TITLE
ingress: Instrument outbound TCP metrics

### DIFF
--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -169,6 +169,7 @@ impl Outbound<()> {
                     .into_inner();
                 let http = self
                     .to_tcp_connect()
+                    .push_tcp_endpoint()
                     .push_http_endpoint()
                     .push_http_logical(resolve)
                     .into_inner();


### PR DESCRIPTION
In ingress mode, the HTTP endpoint stack is not configured with the TCP
endpoint layers, so outbound connections are not properly tracked in
metrics.

This change restores this functionality.