### PR TITLE
inbound: Remove unnecessary connection stack cache

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -248,7 +248,6 @@ where
                     .push_map_target(TcpEndpoint::from)
                     .into_inner(),
             ))
-            .push_cache(config.cache_max_idle_age)
             .push_map_target(detect::allow_timeout)
             .push(detect::NewDetectService::layer(
                 config.detect_protocol_timeout,


### PR DESCRIPTION
The inbound proxy caches each HTTP server stack, but this stack's cache
key includes client address information, so this cache ends up requiring
an entry per connection and stacks are not reused.

This change removes this unnecessary cache.