### PR TITLE
outbound: Use the OrigDstAddr type in stack targets

### DIFF
--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -6,7 +6,9 @@ use linkerd_app_core::{
     profiles,
     proxy::http,
     svc::{self, layer},
-    tls, Error, NameAddr,
+    tls,
+    transport::OrigDstAddr,
+    Error, NameAddr,
 };
 use linkerd_app_outbound as outbound;
 use std::{
@@ -71,7 +73,7 @@ where
         let svc = self.outbound.new_service(outbound::http::Logical {
             profile,
             protocol: http.version,
-            orig_dst: ([0, 0, 0, 0], dst.port()).into(),
+            orig_dst: OrigDstAddr(([0, 0, 0, 0], dst.port()).into()),
         });
 
         Gateway::new(svc, http.target, local_id)

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -11,6 +11,7 @@ use linkerd_app_core::{
     proxy::{api_resolve::Metadata, core::Resolve, http},
     svc::{self, Param},
     tls,
+    transport::OrigDstAddr,
     transport_header::SessionProtocol,
     Error, NameAddr, NameMatch, Never,
 };
@@ -120,7 +121,7 @@ where
         .push_request_filter(|(p, _): (Option<profiles::Receiver>, _)| match p {
             Some(rx) if rx.borrow().name.is_some() => Ok(outbound::tcp::Logical {
                 profile: Some(rx),
-                orig_dst: std::net::SocketAddr::from(([0, 0, 0, 0], 0)),
+                orig_dst: OrigDstAddr(std::net::SocketAddr::from(([0, 0, 0, 0], 0))),
                 protocol: (),
             }),
             _ => Err(discovery_rejected()),

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -87,7 +87,7 @@ impl Param<normalize_uri::DefaultAuthority> for Logical {
 
 impl Param<client::Settings> for Endpoint {
     fn param(&self) -> client::Settings {
-        match self.logical.protocol {
+        match self.protocol {
             Version::H2 => client::Settings::H2,
             Version::Http1 => match self.metadata.protocol_hint() {
                 ProtocolHint::Unknown => client::Settings::Http1,
@@ -99,7 +99,7 @@ impl Param<client::Settings> for Endpoint {
 
 impl Param<Option<SessionProtocol>> for Endpoint {
     fn param(&self) -> Option<SessionProtocol> {
-        match self.logical.protocol {
+        match self.protocol {
             Version::H2 => Some(SessionProtocol::Http2),
             Version::Http1 => match self.metadata.protocol_hint() {
                 ProtocolHint::Http2 => Some(SessionProtocol::Http2),
@@ -133,7 +133,7 @@ impl tap::Inspect for Endpoint {
     }
 
     fn dst_addr<B>(&self, _: &Request<B>) -> Option<SocketAddr> {
-        Some(self.addr)
+        Some(self.addr.into())
     }
 
     fn dst_labels<B>(&self, _: &Request<B>) -> Option<&IndexMap<String, String>> {

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -72,7 +72,7 @@ impl Param<normalize_uri::DefaultAuthority> for Logical {
         if let Some(p) = self.profile.as_ref() {
             if let Some(n) = p.borrow().name.as_ref() {
                 return normalize_uri::DefaultAuthority(Some(
-                    uri::Authority::from_str(&format!("{}:{}", n, self.orig_dst.port()))
+                    uri::Authority::from_str(&format!("{}:{}", n, self.orig_dst.0.port()))
                         .expect("Address must be a valid authority"),
                 ));
             }

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -133,7 +133,6 @@ impl Outbound<()> {
             ))
             .check_new_service::<tcp::Accept, transport::metrics::SensorIo<I>>()
             .push(self.runtime.metrics.transport.layer_accept())
-            .push_map_target(tcp::Accept::from)
             .push_request_filter(tcp::Accept::try_from)
             .check_new_service::<listen::Addrs, I>()
             // Boxing is necessary purely to limit the link-time overhead of

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -81,13 +81,6 @@ impl<P> Param<Option<profiles::Receiver>> for Logical<P> {
     }
 }
 
-// /// Used to determine whether detection should be skipped.
-// impl<P> Param<OrigDstAddr> for Logical<P> {
-//     fn param(&self) -> OrigDstAddr {
-//         self.orig_dst
-//     }
-// }
-
 /// Used for default traffic split
 impl<P> Param<profiles::LogicalAddr> for Logical<P> {
     fn param(&self) -> profiles::LogicalAddr {


### PR DESCRIPTION
The outbound stack is ambiguous about the type of orig_dst/target
address it uses.

This change modifies the outbound stack types to use the `OrigDstAddr`
type. The outbound stacks now error when an `OrigDstAddr` type is not
present.