### PR TITLE
outbound: Decouple the resolver from concrete target types

### DIFF
--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -117,9 +117,7 @@ where
         .clone()
         .push_tcp_endpoint()
         .push_tcp_logical(map_endpoint::Resolve::new(
-            outbound::target::EndpointFromMetadata {
-                identity_disabled: false,
-            },
+            outbound::target::EndpointFromMetadata::default(),
             resolve.clone(),
         ))
         .into_stack()
@@ -166,9 +164,7 @@ where
         .push_tcp_endpoint()
         .push_http_endpoint()
         .push_http_logical(map_endpoint::Resolve::new(
-            outbound::target::EndpointFromMetadata {
-                identity_disabled: false,
-            },
+            outbound::target::EndpointFromMetadata::default(),
             resolve,
         ))
         .into_stack()

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -50,7 +50,6 @@ impl Fixture {
         let labels = metrics::labels()
             .label("authority", "tele.test.svc.cluster.local")
             .label("direction", "inbound")
-            .label("tls", "disabled")
             .label("target_addr", orig_dst);
         Fixture {
             client,
@@ -79,7 +78,6 @@ impl Fixture {
         let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
         let labels = metrics::labels()
             .label("direction", "outbound")
-            .label("tls", "disabled")
             .label("authority", authority)
             .label("target_addr", orig_dst);
         Fixture {
@@ -175,7 +173,6 @@ impl TcpFixture {
         let dst_labels = metrics::labels()
             .label("direction", "outbound")
             .label("peer", "dst")
-            .label("tls", "disabled")
             .label("authority", orig_dst);
 
         TcpFixture {
@@ -525,7 +522,6 @@ mod outbound_dst_labels {
         let client = client::new(proxy.outbound, dest);
         let labels = metrics::labels()
             .label("direction", "outbound")
-            .label("tls", "disabled")
             .label("authority", dest_and_port)
             .label("target_addr", addr);
         let f = Fixture {

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -37,7 +37,6 @@ where
             runtime: rt,
             stack: connect,
         } = self;
-        let identity_disabled = rt.identity.is_none();
         let config::ConnectConfig {
             h1_settings,
             h2_settings,
@@ -70,14 +69,7 @@ where
             ]))
             .push_on_response(http::BoxResponse::layer())
             .check_new::<Endpoint>()
-            .instrument(|e: &Endpoint| debug_span!("endpoint", peer.addr = %e.addr))
-            .push_map_target(move |e: Endpoint| {
-                if identity_disabled {
-                    e.identity_disabled()
-                } else {
-                    e
-                }
-            });
+            .instrument(|e: &Endpoint| debug_span!("endpoint", peer.addr = %e.addr));
 
         Outbound {
             config,

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -1,6 +1,7 @@
 use super::Endpoint;
 
 use crate::{
+    target,
     test_util::{
         support::{connect::Connect, http_util, profile, resolver, track},
         *,
@@ -11,6 +12,7 @@ use bytes::Bytes;
 use hyper::{client::conn::Builder as ClientBuilder, Body, Request, Response};
 use linkerd_app_core::{
     io,
+    proxy::resolve::map_endpoint,
     svc::{self, NewService},
     tls,
     transport::{listen, ClientAddr, Local, OrigDstAddr, Remote, ServerAddr},
@@ -74,7 +76,12 @@ where
     out.clone().with_stack(NoTcpBalancer).push_detect_http(
         out.with_stack(connect)
             .push_http_endpoint()
-            .push_http_logical(resolver)
+            .push_http_logical(map_endpoint::Resolve::new(
+                target::EndpointFromMetadata {
+                    identity_disabled: true,
+                },
+                resolver,
+            ))
             .push_http_server()
             .into_inner(),
     )

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -77,9 +77,7 @@ where
         out.with_stack(connect)
             .push_http_endpoint()
             .push_http_logical(map_endpoint::Resolve::new(
-                target::EndpointFromMetadata {
-                    identity_disabled: true,
-                },
+                target::EndpointFromMetadata::default(),
                 resolver,
             ))
             .push_http_server()

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -63,7 +63,9 @@ impl Outbound<()> {
 
         let tcp = svc::stack(tcp)
             .push_on_response(drain::Retain::layer(self.runtime.drain.clone()))
-            .push_map_target(tcp::Endpoint::from_accept(tls::NoClientTls::IngressNonHttp))
+            .push_map_target(|a: tcp::Accept| {
+                tcp::Endpoint::from((tls::NoClientTls::IngressNonHttp, a))
+            })
             .into_inner();
 
         svc::stack(http)

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -137,7 +137,7 @@ impl<S> Outbound<S> {
         self.push_tcp_endpoint()
             .push_tcp_logical(map_endpoint::Resolve::new(
                 target::EndpointFromMetadata { identity_disabled },
-                resolve.clone(),
+                resolve,
             ))
             .push_detect_http(http)
             .push_discover(profiles)

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -250,6 +250,16 @@ impl<P: std::hash::Hash> std::hash::Hash for Endpoint<P> {
     }
 }
 
+// === EndpointFromMetadata ===
+
+impl Default for EndpointFromMetadata {
+    fn default() -> Self {
+        Self {
+            identity_disabled: false,
+        }
+    }
+}
+
 impl EndpointFromMetadata {
     fn client_tls(metadata: &Metadata) -> tls::ConditionalClientTls {
         // If we're transporting an opaque protocol OR we're communicating with

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -10,9 +10,12 @@ use linkerd_app_core::{
     transport_header, Addr, Conditional, Error,
 };
 use std::net::SocketAddr;
+use tracing::debug;
 
 #[derive(Copy, Clone)]
-pub struct EndpointFromMetadata;
+pub struct EndpointFromMetadata {
+    pub identity_disabled: bool,
+}
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Accept<P> {
@@ -149,7 +152,8 @@ impl<P> Logical<P> {
             if should_resolve {
                 Ok(svc::Either::A(logical))
             } else {
-                Ok(svc::Either::B(Endpoint::from_logical(reason)(logical)))
+                debug!(%reason, orig_dst = %logical.orig_dst, "Target is unresolveable");
+                Ok(svc::Either::B(Endpoint::from((reason, logical))))
             }
         }
     }
@@ -171,9 +175,9 @@ impl<P> Param<ConcreteAddr> for Concrete<P> {
 
 // === impl Endpoint ===
 
-impl<P> Endpoint<P> {
-    pub fn from_logical(reason: tls::NoClientTls) -> impl (Fn(Logical<P>) -> Self) + Clone {
-        move |logical| match logical
+impl<P> From<(tls::NoClientTls, Logical<P>)> for Endpoint<P> {
+    fn from((reason, logical): (tls::NoClientTls, Logical<P>)) -> Self {
+        match logical
             .profile
             .as_ref()
             .and_then(|p| p.borrow().endpoint.clone())
@@ -194,15 +198,11 @@ impl<P> Endpoint<P> {
             },
         }
     }
+}
 
-    pub fn from_accept(reason: tls::NoClientTls) -> impl (Fn(Accept<P>) -> Self) + Clone {
-        move |accept| Self::from_logical(reason)(Logical::from((None, accept)))
-    }
-
-    /// Marks identity as disabled.
-    pub fn identity_disabled(mut self) -> Self {
-        self.tls = Conditional::None(tls::NoClientTls::Disabled);
-        self
+impl<P> From<(tls::NoClientTls, Accept<P>)> for Endpoint<P> {
+    fn from((reason, accept): (tls::NoClientTls, Accept<P>)) -> Self {
+        Self::from((reason, Logical::from((None, accept))))
     }
 }
 
@@ -289,7 +289,11 @@ impl<P: Copy + std::fmt::Debug> MapEndpoint<Concrete<P>, Metadata> for EndpointF
         metadata: Metadata,
     ) -> Self::Out {
         tracing::trace!(%addr, ?metadata, ?concrete, "Resolved endpoint");
-        let tls = Self::client_tls(&metadata);
+        let tls = if self.identity_disabled {
+            tls::ConditionalClientTls::None(tls::NoClientTls::Disabled)
+        } else {
+            Self::client_tls(&metadata)
+        };
         Endpoint {
             addr: Remote(ServerAddr(addr)),
             tls,

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -47,7 +47,6 @@ impl<C> Outbound<C> {
             runtime: rt,
             stack: connect,
         } = self;
-        let identity_disabled = rt.identity.is_none();
 
         let stack = connect
             // Initiates mTLS if the target is configured with identity. The
@@ -61,14 +60,7 @@ impl<C> Outbound<C> {
             // Limits the time we wait for a connection to be established.
             .push_timeout(config.proxy.connect.timeout)
             .push(svc::stack::BoxFuture::layer())
-            .push(rt.metrics.transport.layer_connect())
-            .push_map_target(move |e: Endpoint<P>| {
-                if identity_disabled {
-                    e.identity_disabled()
-                } else {
-                    e
-                }
-            });
+            .push(rt.metrics.transport.layer_connect());
 
         Outbound {
             config,

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -62,9 +62,7 @@ async fn plaintext_tcp() {
     // Configure the mock destination resolver to just give us a single endpoint
     // for the target, which always exists and has no metadata.
     let resolver = map_endpoint::Resolve::new(
-        target::EndpointFromMetadata {
-            identity_disabled: false,
-        },
+        target::EndpointFromMetadata::default(),
         support::resolver().endpoint_exists(target_addr, target_addr, Default::default()),
     );
 
@@ -124,9 +122,7 @@ async fn tls_when_hinted() {
     // Configure the mock destination resolver to just give us a single endpoint
     // for the target, which always exists and has no metadata.
     let resolver = map_endpoint::Resolve::new(
-        target::EndpointFromMetadata {
-            identity_disabled: false,
-        },
+        target::EndpointFromMetadata::default(),
         support::resolver()
             .endpoint_exists(
                 Addr::from_str("plain:5551").unwrap(),
@@ -824,9 +820,7 @@ where
     Outbound::new(cfg, rt)
         .with_stack(connect)
         .push_tcp_logical(map_endpoint::Resolve::new(
-            target::EndpointFromMetadata {
-                identity_disabled: false,
-            },
+            target::EndpointFromMetadata::default(),
             resolver,
         ))
         .push_detect_http(support::service::no_http())

--- a/linkerd/app/test/src/profile.rs
+++ b/linkerd/app/test/src/profile.rs
@@ -22,6 +22,10 @@ pub fn resolver() -> crate::resolver::Profiles {
     crate::resolver::Resolver::default()
 }
 
+pub fn only_with_name(name: &str) -> Receiver {
+    only(with_name(name))
+}
+
 pub fn with_name(name: &str) -> Profile {
     use std::str::FromStr;
     let name = dns::Name::from_str(name).expect("non-ascii characters in DNS name! 😢");


### PR DESCRIPTION
The endpoint resolver module currently has a fixed dependency on the
`Concrete` and `Endpoint` target types.

This change extracts endpoint-type construction so that the HTTP logical
stack is agnostic of its endpoint target type. It also updates the
`EndpointFromMetadata` type to be responsible for marking identity as
disabled when appropriate. Finally, we are able to re-enable the
outbound TLS hinting test.