### PR TITLE
Make stack trace initialization lazy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2266,9 +2266,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d40a22fd029e33300d8d89a5cc8ffce18bb7c587662f54629e94c9de5487f3"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if",
  "log",
@@ -2279,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f080ea7e4107844ef4766459426fa2d5c1ada2e47edba05dc7fa99d9629f47"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -7,7 +7,7 @@ pub use linkerd_stack::{
     self as stack, layer, BoxNewService, BoxService, BoxServiceLayer, Fail, Filter, MapTargetLayer,
     NewRouter, NewService, Param, Predicate, UnwrapOr,
 };
-pub use linkerd_stack_tracing::{InstrumentMake, InstrumentMakeLayer};
+pub use linkerd_stack_tracing::{NewInstrument, NewInstrumentLayer};
 pub use linkerd_timeout::{self as timeout, FailFast};
 use std::{
     task::{Context, Poll},
@@ -87,8 +87,8 @@ impl<L> Layers<L> {
         self.push(stack::OnResponseLayer::new(layer))
     }
 
-    pub fn push_instrument<G: Clone>(self, get_span: G) -> Layers<Pair<L, InstrumentMakeLayer<G>>> {
-        self.push(InstrumentMakeLayer::new(get_span))
+    pub fn push_instrument<G: Clone>(self, get_span: G) -> Layers<Pair<L, NewInstrumentLayer<G>>> {
+        self.push(NewInstrumentLayer::new(get_span))
     }
 }
 
@@ -122,12 +122,12 @@ impl<S> Stack<S> {
         self.push(layer::mk(stack::MakeThunk::new))
     }
 
-    pub fn instrument<G: Clone>(self, get_span: G) -> Stack<InstrumentMake<G, S>> {
-        self.push(InstrumentMakeLayer::new(get_span))
+    pub fn instrument<G: Clone>(self, get_span: G) -> Stack<NewInstrument<G, S>> {
+        self.push(NewInstrumentLayer::new(get_span))
     }
 
-    pub fn instrument_from_target(self) -> Stack<InstrumentMake<(), S>> {
-        self.push(InstrumentMakeLayer::from_target())
+    pub fn instrument_from_target(self) -> Stack<NewInstrument<(), S>> {
+        self.push(NewInstrumentLayer::from_target())
     }
 
     /// Wraps an inner `MakeService` to be a `NewService`.

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -31,7 +31,7 @@ impl<H> Inbound<H> {
             > + Clone,
     >
     where
-        T: Param<Version> + Param<http::normalize_uri::DefaultAuthority>,
+        T: Param<Version> + Param<http::normalize_uri::DefaultAuthority> + Clone + Send + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
         H: svc::NewService<T, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
         HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -46,14 +46,13 @@ where
         let endpoint = connect
             .clone()
             .push_make_thunk()
-            .push(svc::MapErrLayer::new(Into::into))
             .instrument(|t: &Endpoint| debug_span!("tcp.forward", server.addr = %t.addr))
             .push_on_response(
                 svc::layers()
+                    .push(svc::MapErrLayer::new(Into::into))
                     .push(tcp::Forward::layer())
                     .push(drain::Retain::layer(rt.drain.clone())),
-            )
-            .into_new_service();
+            );
 
         let stack = connect
             .push_make_thunk()

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 futures = "0.3.9"
 linkerd-error = { path = "../../error" }
 linkerd-stack = { path = ".." }
-tracing = "0.1.23"
+tracing = "0.1.25"
 pin-project = "1"
 
 [dependencies.tower]


### PR DESCRIPTION
The stack-tracing module eagerly initiates its spans once per service;
but when the service is cached, this locks the service to its original
parent span so that log messages from subsequent accessors appear to
have the wrong parent span information.

This change modifies the stack tracing helper to (1) be
NewService-specific and (2) to initiate unique spans for each call. The
instrumented `Service` constructs a new span the first time `poll_ready`
is called, and consumes that span in `call`, so the `poll_ready`s that
drive a service to readiness and the subsequent `call` that consumes
that readiness are both considered one individual span for that request.