### PR TITLE
outbound: Mock the original destination address in ingress-mode

### DIFF
--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -29,7 +29,7 @@ pub use self::{
     detect::DetectHttp,
     glue::{HyperServerSvc, UpgradeBody},
     header_from_target::NewHeaderFromTarget,
-    normalize_uri::NewNormalizeUri,
+    normalize_uri::{MarkAbsoluteForm, NewNormalizeUri},
     override_authority::{CanOverrideAuthority, NewOverrideAuthority},
     retain::Retain,
     server::NewServeHttp,


### PR DESCRIPTION
The ingress-mode outbound proxy currently does not work as expected:
resolutions are performed for each unique endpoint so that a service
with 10 endpoints would manifest as 10 distinct balancers (with 20
resolutions).

While we should ultimately rework the outbound stack to have target
types that prevent this problem (i.e. by removing the original
destination address from the Logical target type), this change
implements a hack to avoid the observed cardinality issues: In
ingress-mode, the original destination address is now mocked out with an
IP address of 0.0.0.0 so that only a single cache entry is created per
logical destination.