### PR TITLE
Prevent server errors from panicking the proxy

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -152,9 +152,7 @@ impl Inbound<()> {
                 .to_tcp_connect()
                 .into_server(listen_addr.port(), profiles, gateway);
             let shutdown = self.runtime.drain.signaled();
-            serve::serve(listen, stack, shutdown)
-                .await
-                .expect("Inbound server failed");
+            serve::serve(listen, stack, shutdown).await
         };
 
         (listen_addr, serve)

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -187,15 +187,11 @@ impl Outbound<()> {
                     .into_inner();
                 let stack = self.to_ingress(profiles, tcp, http);
                 let shutdown = self.runtime.drain.signaled();
-                serve::serve(listen, stack, shutdown)
-                    .await
-                    .expect("Outbound server failed");
+                serve::serve(listen, stack, shutdown).await;
             } else {
                 let stack = self.to_tcp_connect().into_server(resolve, profiles);
                 let shutdown = self.runtime.drain.signaled();
-                serve::serve(listen, stack, shutdown)
-                    .await
-                    .expect("Outbound server failed");
+                serve::serve(listen, stack, shutdown).await;
             }
         };
 

--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -25,7 +25,7 @@ pub struct Config {
 pub struct Admin {
     pub listen_addr: SocketAddr,
     pub latch: admin::Latch,
-    pub serve: Pin<Box<dyn std::future::Future<Output = Result<(), Error>> + Send + 'static>>,
+    pub serve: Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>,
 }
 
 #[derive(Debug, Default)]

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -20,7 +20,7 @@ use linkerd_channel::into_stream::IntoStream;
 use std::{net::SocketAddr, pin::Pin};
 use tokio::{sync::mpsc, time::Duration};
 use tracing::instrument::Instrument;
-use tracing::{debug, error, info, info_span};
+use tracing::{debug, info, info_span};
 
 /// Spawns a sidecar proxy.
 ///
@@ -255,7 +255,6 @@ impl App {
                         tokio::spawn(
                             admin
                                 .serve
-                                .map_err(|e| panic!("admin server died: {}", e))
                                 .instrument(info_span!("admin", listen.addr = %admin.listen_addr)),
                         );
 
@@ -293,11 +292,7 @@ impl App {
                                     )
                                     .instrument(info_span!("tap_clean")),
                             );
-                            tokio::spawn(
-                                serve
-                                    .map_err(|error| error!(%error, "server died"))
-                                    .instrument(info_span!("tap")),
-                            );
+                            tokio::spawn(serve.instrument(info_span!("tap")));
                         }
 
                         if let oc_collector::OcCollector::Enabled(oc) = oc_collector {

--- a/linkerd/app/src/tap.rs
+++ b/linkerd/app/src/tap.rs
@@ -23,7 +23,7 @@ pub enum Tap {
     Enabled {
         listen_addr: SocketAddr,
         registry: tap::Registry,
-        serve: Pin<Box<dyn std::future::Future<Output = Result<(), Error>> + Send + 'static>>,
+        serve: Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>,
     },
 }
 


### PR DESCRIPTION
The TCP server currently returns an error if an `accept(2)` call fails
with an error. This error can cause the proxy to panic.

This change handles this error gracefully, emitting a warning. The
server task no longer returns a Result-type.