### PR TITLE
duplex: Ensure written data is flushed

### DIFF
--- a/linkerd/duplex/src/lib.rs
+++ b/linkerd/duplex/src/lib.rs
@@ -56,9 +56,9 @@ where
     In: AsyncRead + AsyncWrite + Unpin,
     Out: AsyncRead + AsyncWrite + Unpin,
 {
-    type Output = Result<(), io::Error>;
+    type Output = io::Result<()>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> io::Poll<()> {
         let mut this = self.project();
         // This purposefully ignores the Async part, since we don't want to
         // return early if the first half isn't ready, but the other half
@@ -91,7 +91,7 @@ where
         &mut self,
         dst: &mut HalfDuplex<U>,
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<()>> {
+    ) -> io::Poll<()> {
         // Since Duplex::poll() intentionally ignores the Async part of our
         // return value, we may be polled again after returning Ready, if the
         // other half isn't ready. In that case, if the destination has
@@ -131,7 +131,7 @@ where
         Poll::Pending
     }
 
-    fn poll_read(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+    fn poll_read(&mut self, cx: &mut Context<'_>) -> io::Poll<usize> {
         let mut is_eof = false;
         let mut sz = 0;
 
@@ -163,7 +163,7 @@ where
         &mut self,
         dst: &mut HalfDuplex<U>,
         cx: &mut Context<'_>,
-    ) -> Poll<io::Result<usize>> {
+    ) -> io::Poll<usize> {
         let mut sz = 0;
         if let Some(ref mut buf) = self.buf {
             while buf.has_remaining() {


### PR DESCRIPTION
In testing Postgres dumps through Linkerd, we see some situations where
data is written to rustls but does not become visible to the client.
Rustls documents that written data may need to be flushed.

This change updates the `HalfDuplex::copy_into` function to flush data
when all available data has been read. This change also increases the
copy buffer from 4KB to 64KB to reduce processing overhead.

---

Relates to linkerd/linkerd2#5539

Image available at `ghcr.io/olix0r/l2-proxy:flush.863b537b`