### PR TITLE
Prevent fixed-address resolutions from ending

### DIFF
--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -54,7 +54,8 @@ impl<T: Param<Addr>> tower::Service<T> for DnsResolve {
             Addr::Name(na) => Box::pin(resolution(self.dns.clone(), na).in_current_span()),
             Addr::Socket(sa) => {
                 let eps = vec![(sa, ())];
-                let updates: UpdateStream = Box::pin(stream::iter(Some(Ok(Update::Reset(eps)))));
+                let updates: UpdateStream =
+                    Box::pin(stream::iter(Some(Ok(Update::Reset(eps)))).chain(stream::pending()));
                 Box::pin(future::ok(updates))
             }
         }


### PR DESCRIPTION
When a controller client is configured with a fixed IP address and not a
resolveable name, we build that client with a resolution that terminates
immediately after the client is configured with the fixed address. This
causes warnings to be emmited even though the client is configured
properly.

This change updates theses resolutions to avoid termination so these
warnings are not logged.