### PR TITLE
http: Parameterize authority overriding

### DIFF
--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -135,9 +135,12 @@ impl Param<Option<SessionProtocol>> for Endpoint {
     }
 }
 
-impl CanOverrideAuthority for Endpoint {
-    fn override_authority(&self) -> Option<uri::Authority> {
-        self.metadata.authority_override().cloned()
+impl Param<Option<AuthorityOverride>> for Endpoint {
+    fn param(&self) -> Option<AuthorityOverride> {
+        self.metadata
+            .authority_override()
+            .cloned()
+            .map(AuthorityOverride)
     }
 }
 

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -30,7 +30,7 @@ pub use self::{
     glue::{HyperServerSvc, UpgradeBody},
     header_from_target::NewHeaderFromTarget,
     normalize_uri::{MarkAbsoluteForm, NewNormalizeUri},
-    override_authority::{CanOverrideAuthority, NewOverrideAuthority},
+    override_authority::{AuthorityOverride, NewOverrideAuthority},
     retain::Retain,
     server::NewServeHttp,
     timeout::MakeTimeoutLayer,


### PR DESCRIPTION
The authority override module still uses a dedicated trait,
`CanOverrideAuthority`. This change replaces this trait with a newtype,
`AuthorityOverride`, which is provided via `Param`.