### PR TITLE
tracing: Avoid high-cardinality client in INFO spans

### DIFF
--- a/linkerd/app/core/src/errors.rs
+++ b/linkerd/app/core/src/errors.rs
@@ -4,7 +4,7 @@ use linkerd_error::Error;
 use linkerd_error_metrics as metrics;
 use linkerd_error_respond as respond;
 pub use linkerd_error_respond::RespondLayer;
-use linkerd_proxy_http::{client_handle::Close, ClientHandle, HasH2Reason};
+use linkerd_proxy_http::{ClientHandle, HasH2Reason};
 use linkerd_timeout::{error::ResponseTimeout, FailFastError};
 use linkerd_tls as tls;
 use pin_project::pin_project;
@@ -55,7 +55,7 @@ pub struct NewRespond(());
 pub struct Respond {
     version: http::Version,
     is_grpc: bool,
-    close: Option<Close>,
+    client: Option<ClientHandle>,
 }
 
 #[pin_project(project = ResponseBodyProj)]
@@ -142,10 +142,9 @@ impl<ReqB, RspB: Default + hyper::body::HttpBody>
     type Respond = Respond;
 
     fn new_respond(&self, req: &http::Request<ReqB>) -> Self::Respond {
-        let close = req
-            .extensions()
-            .get::<ClientHandle>()
-            .map(|h| h.close.clone());
+        let client = req.extensions().get::<ClientHandle>().cloned();
+        debug_assert!(client.is_some(), "Missing client handle");
+
         match req.version() {
             http::Version::HTTP_2 => {
                 let is_grpc = req
@@ -155,13 +154,13 @@ impl<ReqB, RspB: Default + hyper::body::HttpBody>
                     .unwrap_or(false);
                 Respond {
                     is_grpc,
-                    close,
+                    client,
                     version: http::Version::HTTP_2,
                 }
             }
             version => Respond {
                 version,
-                close,
+                client,
                 is_grpc: false,
             },
         }
@@ -181,7 +180,15 @@ impl<RspB: Default + hyper::body::HttpBody> respond::Respond<http::Response<RspB
                 _ => ResponseBody::NonGrpc(b),
             })),
             Err(error) => {
-                warn!("Failed to proxy request: {}", error);
+                let addr = self
+                    .client
+                    .as_ref()
+                    .map(|ClientHandle { ref addr, .. }| *addr)
+                    .unwrap_or_else(|| {
+                        debug!("Missing client address");
+                        ([0, 0, 0, 0], 0).into()
+                    });
+                warn!(client.addr = %addr, "Failed to proxy request: {}", error);
 
                 if self.version == http::Version::HTTP_2 {
                     if let Some(reset) = error.h2_reason() {
@@ -191,9 +198,9 @@ impl<RspB: Default + hyper::body::HttpBody> respond::Respond<http::Response<RspB
                 }
 
                 // Gracefully teardown the server-side connection.
-                if let Some(c) = self.close.as_ref() {
+                if let Some(ClientHandle { ref close, .. }) = self.client.as_ref() {
                     debug!("Closing server-side connection");
-                    c.close();
+                    close.close();
                 }
 
                 if self.is_grpc {

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -5,7 +5,7 @@ use linkerd_error::Error;
 use linkerd_proxy_transport::listen::Addrs;
 use tower::util::ServiceExt;
 use tracing::instrument::Instrument;
-use tracing::{debug, info, info_span, warn};
+use tracing::{debug, debug_span, info, warn};
 
 /// Spawns a task that binds an `L`-typed listener with an `A`-typed
 /// connection-accepting service.
@@ -38,13 +38,9 @@ pub async fn serve<M, A, I>(
                     };
 
                     // The local addr should be instrumented from the listener's context.
-                    let span = info_span!(
-                        "accept",
-                        client.addr = %addrs.client(),
-                        target.addr = %addrs.target_addr(),
-                    );
+                    let span = debug_span!("accept", client.addr = %addrs.client());
 
-                    let accept = new_accept.new_service(addrs);
+                    let accept = span.in_scope(|| new_accept.new_service(addrs));
 
                     // Dispatch all of the work for a given connection onto a connection-specific task.
                     tokio::spawn(

--- a/linkerd/app/inbound/src/prevent_loop.rs
+++ b/linkerd/app/inbound/src/prevent_loop.rs
@@ -50,11 +50,7 @@ impl Predicate<Addrs> for PreventLoop {
 
 impl std::fmt::Display for LoopPrevented {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "inbound requests must not target localhost:{}",
-            self.port
-        )
+        write!(f, "inbound connection must not target port {}", self.port)
     }
 }
 


### PR DESCRIPTION
Our default TCP server sets an info-level tracing span that includes the
client IP and port. This client-level metadata is potentially
high-cardinality, it's not helpful on the outbound side, and it is only
rendered in rare situations.

This change modifies the server to set its `accept` span on the debug
level. The inbound and outbound proxies handle setting info-level spans
with the relevant metadata -- the inbound proxy includes only a server
port, and the outbound includes the original dst address. The error
responder has been modified to include the client address in warning
messages so that it need not be derived from span metadata.