### PR TITLE
Handle FailedPrecondition errors from the control plane

### DIFF
--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -70,7 +70,10 @@ pub fn discovery_rejected() -> tonic::Status {
 
 pub fn is_discovery_rejected(err: &(dyn std::error::Error + 'static)) -> bool {
     if let Some(status) = err.downcast_ref::<tonic::Status>() {
+        // Address is not resolveable
         status.code() == tonic::Code::InvalidArgument
+            // Unexpected cluster state
+            || status.code() == tonic::Code::FailedPrecondition
     } else if let Some(err) = err.source() {
         is_discovery_rejected(err)
     } else {


### PR DESCRIPTION
The control plane may return a FailedPrecondition error when the cluster
is in an unexpected state -- when there are more than one pod for a
single IP address. The proxy currently retries these lookups ad nauseum.

This change updates the proxies error handling to avoid retries when
this error is returned.