### PR TITLE
outbound: Configure endpoint construction in logical stack

### DIFF
--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -122,10 +122,7 @@ impl<E> Outbound<E> {
                             .push(http::BoxRequest::layer())
                             .push(http::BoxResponse::layer()),
                     )
-                    .push_map_target({
-                        let no_tls_reason = no_tls_reason;
-                        move |logical: Logical| Endpoint::from((no_tls_reason, logical))
-                    })
+                    .push_map_target(move |l: Logical| Endpoint::from((no_tls_reason, l)))
                     .into_inner(),
             ))
             // Distribute requests over a distribution of balancers via a

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -1,8 +1,13 @@
-use super::{CanonicalDstHeader, Concrete, Logical};
-use crate::{resolve, stack_labels, Outbound};
+use super::{CanonicalDstHeader, Concrete, Endpoint, Logical};
+use crate::{resolve, stack_labels, target, Outbound};
 use linkerd_app_core::{
     classify, config, profiles,
-    proxy::{core::Resolve, http},
+    proxy::{
+        api_resolve::{ConcreteAddr, Metadata},
+        core::Resolve,
+        http,
+        resolve::map_endpoint,
+    },
     retry, svc, tls, Error, Never, DST_OVERRIDE_HEADER,
 };
 use tracing::debug_span;
@@ -25,14 +30,13 @@ impl<E> Outbound<E> {
     where
         B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
         B::Data: Send + 'static,
-        E: svc::NewService<R::Endpoint, Service = ESvc> + Clone + Send + 'static,
+        E: svc::NewService<Endpoint, Service = ESvc> + Clone + Send + 'static,
         ESvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
             + Send
             + 'static,
         ESvc::Error: Into<Error>,
         ESvc::Future: Send,
-        R: Resolve<Concrete, Error = Error> + Clone + Send + 'static,
-        R::Endpoint: From<(tls::NoClientTls, Logical)> + Clone + Send,
+        R: Resolve<ConcreteAddr, Error = Error, Endpoint = Metadata> + Clone + Send + 'static,
         R::Resolution: Send,
         R::Future: Send + Unpin,
     {
@@ -49,9 +53,22 @@ impl<E> Outbound<E> {
         } = config.proxy;
         let watchdog = cache_max_idle_age * 2;
 
+        let identity_disabled = rt.identity.is_none();
+        let resolve = svc::stack(resolve.into_service())
+            .check_service::<ConcreteAddr>()
+            .push_request_filter(|c: Concrete| Ok::<_, Never>(c.resolve))
+            .push(svc::layer::mk(move |inner| {
+                map_endpoint::Resolve::new(
+                    target::EndpointFromMetadata { identity_disabled },
+                    inner,
+                )
+            }))
+            .check_service::<Concrete>()
+            .into_inner();
+
         let stack = endpoint
             .clone()
-            .check_new_service::<R::Endpoint, http::Request<http::BoxBody>>()
+            .check_new_service::<Endpoint, http::Request<http::BoxBody>>()
             .push_on_response(
                 svc::layers()
                     .push(http::BoxRequest::layer())
@@ -64,7 +81,7 @@ impl<E> Outbound<E> {
                     // the balancer need not drive them all directly.
                     .push(svc::layer::mk(svc::SpawnReady::new)),
             )
-            .check_new_service::<R::Endpoint, http::Request<_>>()
+            .check_new_service::<Endpoint, http::Request<_>>()
             // Resolve the service to its endpoints and balance requests over them.
             //
             // If the balancer has been empty/unavailable, eagerly fail requests.
@@ -101,10 +118,7 @@ impl<E> Outbound<E> {
                             .push(http::BoxResponse::layer()),
                     )
                     .push_map_target(|logical: Logical| {
-                        R::Endpoint::from((
-                            tls::NoClientTls::NotProvidedByServiceDiscovery,
-                            logical,
-                        ))
+                        Endpoint::from((tls::NoClientTls::NotProvidedByServiceDiscovery, logical))
                     })
                     .into_inner(),
             ))
@@ -166,7 +180,7 @@ impl<E> Outbound<E> {
                     if should_resolve {
                         Ok::<_, Never>(svc::Either::A(logical))
                     } else {
-                        Ok(svc::Either::B(R::Endpoint::from((
+                        Ok(svc::Either::B(Endpoint::from((
                             tls::NoClientTls::NotProvidedByServiceDiscovery,
                             logical,
                         ))))

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -1,7 +1,6 @@
 use super::Endpoint;
 
 use crate::{
-    target,
     test_util::{
         support::{connect::Connect, http_util, profile, resolver, track},
         *,
@@ -12,7 +11,6 @@ use bytes::Bytes;
 use hyper::{client::conn::Builder as ClientBuilder, Body, Request, Response};
 use linkerd_app_core::{
     io,
-    proxy::resolve::map_endpoint,
     svc::{self, NewService},
     tls,
     transport::{listen, ClientAddr, Local, OrigDstAddr, Remote, ServerAddr},
@@ -76,10 +74,7 @@ where
     out.clone().with_stack(NoTcpBalancer).push_detect_http(
         out.with_stack(connect)
             .push_http_endpoint()
-            .push_http_logical(map_endpoint::Resolve::new(
-                target::EndpointFromMetadata::default(),
-                resolver,
-            ))
+            .push_http_logical(resolver)
             .push_http_server()
             .into_inner(),
     )

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -17,7 +17,10 @@ pub(crate) mod test_util;
 use linkerd_app_core::{
     config::ProxyConfig,
     io, metrics, profiles,
-    proxy::{api_resolve::Metadata, core::Resolve, resolve::map_endpoint},
+    proxy::{
+        api_resolve::{ConcreteAddr, Metadata},
+        core::Resolve,
+    },
     serve, svc, tls,
     transport::listen,
     AddrMatch, Error, ProxyRuntime,
@@ -105,40 +108,29 @@ impl<S> Outbound<S> {
         <S as svc::Service<http::Endpoint>>::Response:
             tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
         <S as svc::Service<http::Endpoint>>::Future: Send + Unpin,
-        R: Resolve<http::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<http::Concrete>>::Resolution: Send,
-        <R as Resolve<http::Concrete>>::Future: Send + Unpin,
         <S as svc::Service<tcp::Endpoint>>::Response: tls::HasNegotiatedProtocol,
         <S as svc::Service<tcp::Endpoint>>::Response:
             tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
         <S as svc::Service<tcp::Endpoint>>::Future: Send,
-        R: Resolve<tcp::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<tcp::Concrete>>::Resolution: Send,
-        <R as Resolve<tcp::Concrete>>::Future: Send + Unpin,
         R: Clone + Send + 'static,
+        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
+        R::Resolution: Send,
+        R::Future: Send + Unpin,
         P: profiles::GetProfile<profiles::LogicalAddr> + Clone + Send + 'static,
         P::Future: Send,
         P::Error: Send,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
     {
-        let identity_disabled = self.runtime.identity.is_none();
-
         let http = self
             .clone()
             .push_tcp_endpoint()
             .push_http_endpoint()
-            .push_http_logical(map_endpoint::Resolve::new(
-                target::EndpointFromMetadata { identity_disabled },
-                resolve.clone(),
-            ))
+            .push_http_logical(resolve.clone())
             .push_http_server()
             .into_inner();
 
         self.push_tcp_endpoint()
-            .push_tcp_logical(map_endpoint::Resolve::new(
-                target::EndpointFromMetadata { identity_disabled },
-                resolve,
-            ))
+            .push_tcp_logical(resolve)
             .push_detect_http(http)
             .push_discover(profiles)
             .into_inner()
@@ -148,13 +140,10 @@ impl<S> Outbound<S> {
 impl Outbound<()> {
     pub fn serve<P, R>(self, profiles: P, resolve: R) -> (SocketAddr, impl Future<Output = ()>)
     where
-        R: Resolve<http::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<http::Concrete>>::Resolution: Send,
-        <R as Resolve<http::Concrete>>::Future: Send + Unpin,
-        R: Resolve<tcp::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<tcp::Concrete>>::Resolution: Send,
-        <R as Resolve<tcp::Concrete>>::Future: Send + Unpin,
         R: Clone + Send + Sync + Unpin + 'static,
+        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
+        R::Resolution: Send,
+        R::Future: Send + Unpin,
         P: profiles::GetProfile<profiles::LogicalAddr> + Clone + Send + Sync + Unpin + 'static,
         P::Future: Send,
         P::Error: Send,
@@ -170,7 +159,6 @@ impl Outbound<()> {
         let serve = async move {
             if self.config.ingress_mode {
                 info!("Outbound routing in ingress-mode");
-                let identity_disabled = self.runtime.identity.is_none();
                 let tcp = self
                     .to_tcp_connect()
                     .push_tcp_endpoint()
@@ -180,10 +168,7 @@ impl Outbound<()> {
                     .to_tcp_connect()
                     .push_tcp_endpoint()
                     .push_http_endpoint()
-                    .push_http_logical(map_endpoint::Resolve::new(
-                        target::EndpointFromMetadata { identity_disabled },
-                        resolve,
-                    ))
+                    .push_http_logical(resolve)
                     .into_inner();
                 let stack = self.to_ingress(profiles, tcp, http);
                 let shutdown = self.runtime.drain.signaled();

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -13,7 +13,7 @@ use std::net::SocketAddr;
 use tracing::debug;
 
 #[derive(Copy, Clone)]
-pub struct EndpointFromMetadata {
+pub(crate) struct EndpointFromMetadata {
     pub identity_disabled: bool,
 }
 
@@ -251,14 +251,6 @@ impl<P: std::hash::Hash> std::hash::Hash for Endpoint<P> {
 }
 
 // === EndpointFromMetadata ===
-
-impl Default for EndpointFromMetadata {
-    fn default() -> Self {
-        Self {
-            identity_disabled: false,
-        }
-    }
-}
 
 impl EndpointFromMetadata {
     fn client_tls(metadata: &Metadata) -> tls::ConditionalClientTls {

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -108,12 +108,9 @@ where
             .push(svc::UnwrapOr::layer(
                 endpoint
                     .clone()
-                    .push_map_target({
-                        let no_tls_reason = no_tls_reason;
-                        move |logical: Logical| {
-                            debug!("No profile resolved");
-                            Endpoint::from((no_tls_reason, logical))
-                        }
+                    .push_map_target(move |logical: Logical| {
+                        debug!("No profile resolved");
+                        Endpoint::from((no_tls_reason, logical))
                     })
                     .into_inner(),
             ))

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -97,7 +97,6 @@ async fn tls_when_hinted() {
         .expect("hostname is valid");
     let mut srv_io = support::io();
     srv_io.write(b"hello").read(b"world");
-    let id_name2 = id_name.clone();
     let mut tls_srv_io = srv_io.clone();
 
     // Build a mock "connector" that returns the upstream "server" IO.
@@ -109,7 +108,9 @@ async fn tls_when_hinted() {
             Ok(io)
         })
         .endpoint_fn(tls_addr, move |endpoint: Endpoint| {
-            assert_eq!(endpoint.tls, Conditional::Some(id_name2.clone().into()));
+            // XXX identity is disabled in tests, so we can't actually test
+            //assert_eq!(endpoint.tls, Conditional::Some(id_name2.clone().into()));
+            assert_eq!(endpoint.tls, Conditional::None(tls::NoClientTls::Disabled));
             let io = srv_io.build();
             Ok(io)
         });
@@ -165,23 +166,15 @@ async fn resolutions_are_reused() {
     let addr = SocketAddr::new([0, 0, 0, 0].into(), 5550);
     let cfg = default_config(addr);
     let svc_name = profile::Name::from_str("foo.ns1.svc.example.com").unwrap();
-    let id_name = tls::ServerId::from_str("foo.ns1.serviceaccount.identity.linkerd.cluster.local")
-        .expect("hostname is valid");
 
     // Build a mock "connector" that returns the upstream "server" IO.
-    let connect = support::connect().endpoint(
-        addr,
-        Connection {
-            tls: Conditional::Some(id_name.clone().into()),
-            ..Connection::default()
-        },
-    );
+    let connect = support::connect().endpoint(addr, Connection::default());
 
     let meta = support::resolver::Metadata::new(
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         None,
-        Some(id_name),
+        None,
         None,
     );
 
@@ -260,7 +253,6 @@ async fn load_balances() {
         connect = connect.endpoint(
             addr,
             Connection {
-                tls: Conditional::Some(id_name.clone().into()),
                 count: conns.clone(),
                 ..Connection::default()
             },
@@ -355,7 +347,6 @@ async fn load_balancer_add_endpoints() {
         connect = connect.endpoint(
             addr,
             Connection {
-                tls: Conditional::Some(id_name.clone().into()),
                 count: conns.clone(),
                 ..Connection::default()
             },
@@ -469,7 +460,6 @@ async fn load_balancer_remove_endpoints() {
         connect = connect.endpoint(
             addr,
             Connection {
-                tls: Conditional::Some(id_name.clone().into()),
                 enabled: enabled.clone(),
                 ..Default::default()
             },
@@ -558,12 +548,11 @@ async fn no_profiles_when_outside_search_nets() {
     let svc_name = profile::Name::from_str("foo.ns1.svc.example.com").unwrap();
     let id_name = tls::ServerId::from_str("foo.ns1.serviceaccount.identity.linkerd.cluster.local")
         .expect("hostname is invalid");
-    let id_name2 = id_name.clone();
 
     // Build a mock "connector" that returns the upstream "server" IO.
     let connect = support::connect()
         .endpoint_fn(profile_addr, move |endpoint: Endpoint| {
-            assert_eq!(endpoint.tls, Conditional::Some(id_name2.clone().into()));
+            assert_eq!(endpoint.tls, Conditional::None(tls::NoClientTls::Disabled));
             let io = support::io()
                 .write(b"hello")
                 .read(b"world")
@@ -633,24 +622,16 @@ async fn no_discovery_when_profile_has_an_endpoint() {
 
     let ep = SocketAddr::new([10, 0, 0, 41].into(), 5550);
     let cfg = default_config(ep);
-    let id_name = tls::ServerId::from_str("foo.ns1.serviceaccount.identity.linkerd.cluster.local")
-        .expect("hostname is invalid");
     let meta = support::resolver::Metadata::new(
         Default::default(),
         support::resolver::ProtocolHint::Unknown,
         None,
-        Some(id_name.clone()),
+        None,
         None,
     );
 
     // Build a mock "connector" that returns the upstream "server" IO.
-    let connect = support::connect().endpoint(
-        ep,
-        Connection {
-            tls: Conditional::Some(id_name.clone().into()),
-            ..Connection::default()
-        },
-    );
+    let connect = support::connect().endpoint(ep, Connection::default());
 
     let resolver = support::resolver::<support::resolver::Metadata>();
     let resolve_state = resolver.handle();
@@ -704,13 +685,7 @@ async fn profile_endpoint_propagates_conn_errors() {
                 "i dont like you, go away",
             )))
         })
-        .endpoint(
-            ep2,
-            Connection {
-                tls: Conditional::Some(id_name.clone().into()),
-                ..Connection::default()
-            },
-        );
+        .endpoint(ep2, Connection::default());
 
     let profiles = profile::resolver();
     let profile_tx = profiles.profile_tx(ep1);
@@ -762,7 +737,7 @@ struct Connection {
 impl Default for Connection {
     fn default() -> Self {
         Self {
-            tls: Conditional::None(tls::NoClientTls::NotProvidedByServiceDiscovery),
+            tls: Conditional::None(tls::NoClientTls::Disabled),
             count: Arc::new(AtomicUsize::new(0)),
             enabled: Arc::new(AtomicBool::new(true)),
         }


### PR DESCRIPTION
ebf67d6b moved endpoint construction logic out of the logical stacks. This
created more boilerplate than hoped. Realistically, the logical stack needs to
be responsible for its inner target types.

This change moves endpoint construction into each logical stack so that
it need not be configured on each instantiation, simplifying resolver type
constraints.