### PR TITLE
outbound: Decouple the TCP connect stack from the target type

### DIFF
--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -75,15 +75,11 @@ pub fn stack<I, O, P, R>(
        + Send
 where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + fmt::Debug + Send + Sync + Unpin + 'static,
-    O: svc::Service<outbound::http::Endpoint, Error = io::Error>
-        + svc::Service<outbound::tcp::Endpoint, Error = io::Error>,
     O: Clone + Send + Sync + Unpin + 'static,
-    <O as svc::Service<outbound::http::Endpoint>>::Response:
+    O: svc::Service<outbound::tcp::Connect, Error = io::Error>,
+    O::Response:
         io::AsyncRead + io::AsyncWrite + tls::HasNegotiatedProtocol + Send + Unpin + 'static,
-    <O as svc::Service<outbound::http::Endpoint>>::Future: Send + Unpin + 'static,
-    <O as svc::Service<outbound::tcp::Endpoint>>::Response:
-        io::AsyncRead + io::AsyncWrite + tls::HasNegotiatedProtocol + Send + Unpin + 'static,
-    <O as svc::Service<outbound::tcp::Endpoint>>::Future: Send + Unpin + 'static,
+    O::Future: Send + Unpin + 'static,
     P: profiles::GetProfile<profiles::LogicalAddr> + Clone + Send + Sync + Unpin + 'static,
     P::Future: Send + 'static,
     P::Error: Send,

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -8,13 +8,7 @@ use linkerd_app_core::{
 use tokio::io;
 use tracing::debug_span;
 
-impl<C> Outbound<C>
-where
-    C: svc::Service<Endpoint> + Clone + Send + Sync + Unpin + 'static,
-    C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
-    C::Error: Into<Error>,
-    C::Future: Send + Unpin,
-{
+impl<C> Outbound<C> {
     pub fn push_http_endpoint<B>(
         self,
     ) -> Outbound<
@@ -31,6 +25,10 @@ where
     where
         B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
         B::Data: Send + 'static,
+        C: svc::Service<Endpoint> + Clone + Send + Sync + Unpin + 'static,
+        C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin,
+        C::Error: Into<Error>,
+        C::Future: Send + Unpin,
     {
         let Self {
             config,

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -135,15 +135,6 @@ impl Param<Option<SessionProtocol>> for Endpoint {
     }
 }
 
-impl Param<Option<AuthorityOverride>> for Endpoint {
-    fn param(&self) -> Option<AuthorityOverride> {
-        self.metadata
-            .authority_override()
-            .cloned()
-            .map(AuthorityOverride)
-    }
-}
-
 impl tap::Inspect for Endpoint {
     fn src_addr<B>(&self, req: &Request<B>) -> Option<SocketAddr> {
         req.extensions().get::<ClientHandle>().map(|c| c.addr)

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -98,20 +98,14 @@ impl<S> Outbound<S> {
         Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
     >
     where
-        S: svc::Service<http::Endpoint, Error = io::Error>
-            + svc::Service<tcp::Endpoint, Error = io::Error>,
         S: Clone + Send + Sync + Unpin + 'static,
-        <S as svc::Service<http::Endpoint>>::Response: tls::HasNegotiatedProtocol,
-        <S as svc::Service<http::Endpoint>>::Response:
-            tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
-        <S as svc::Service<http::Endpoint>>::Future: Send + Unpin,
+        S: svc::Service<tcp::Connect, Error = io::Error>,
+        S::Response: tls::HasNegotiatedProtocol,
+        S::Response: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
+        S::Future: Send + Unpin,
         R: Resolve<http::Concrete, Endpoint = Metadata, Error = Error>,
         <R as Resolve<http::Concrete>>::Resolution: Send,
         <R as Resolve<http::Concrete>>::Future: Send + Unpin,
-        <S as svc::Service<tcp::Endpoint>>::Response: tls::HasNegotiatedProtocol,
-        <S as svc::Service<tcp::Endpoint>>::Response:
-            tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Unpin,
-        <S as svc::Service<tcp::Endpoint>>::Future: Send,
         R: Resolve<tcp::Concrete, Endpoint = Metadata, Error = Error>,
         <R as Resolve<tcp::Concrete>>::Resolution: Send,
         <R as Resolve<tcp::Concrete>>::Future: Send + Unpin,

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -1,7 +1,9 @@
+use crate::tcp::opaque_transport;
 use linkerd_app_core::{
     metrics, profiles,
     proxy::{
         api_resolve::{ConcreteAddr, Metadata},
+        http,
         resolve::map_endpoint::MapEndpoint,
     },
     svc::{self, Param},
@@ -11,11 +13,6 @@ use linkerd_app_core::{
 };
 use std::net::SocketAddr;
 use tracing::debug;
-
-#[derive(Copy, Clone)]
-pub struct EndpointFromMetadata {
-    pub identity_disabled: bool,
-}
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Accept<P> {
@@ -43,6 +40,11 @@ pub struct Endpoint<P> {
     pub metadata: Metadata,
     pub logical_addr: Addr,
     pub protocol: P,
+}
+
+#[derive(Copy, Clone)]
+pub struct EndpointFromMetadata {
+    pub identity_disabled: bool,
 }
 
 // === impl Accept ===
@@ -215,6 +217,23 @@ impl<P> Param<Remote<ServerAddr>> for Endpoint<P> {
 impl<P> Param<tls::ConditionalClientTls> for Endpoint<P> {
     fn param(&self) -> tls::ConditionalClientTls {
         self.tls.clone()
+    }
+}
+
+impl<P> Param<Option<opaque_transport::PortOverride>> for Endpoint<P> {
+    fn param(&self) -> Option<opaque_transport::PortOverride> {
+        self.metadata
+            .opaque_transport_port()
+            .map(opaque_transport::PortOverride)
+    }
+}
+
+impl<P> Param<Option<http::AuthorityOverride>> for Endpoint<P> {
+    fn param(&self) -> Option<http::AuthorityOverride> {
+        self.metadata
+            .authority_override()
+            .cloned()
+            .map(http::AuthorityOverride)
     }
 }
 

--- a/linkerd/app/outbound/src/tcp/mod.rs
+++ b/linkerd/app/outbound/src/tcp/mod.rs
@@ -4,6 +4,7 @@ pub mod opaque_transport;
 #[cfg(test)]
 mod tests;
 
+pub use self::connect::Connect;
 use crate::target;
 pub use linkerd_app_core::proxy::tcp::Forward;
 use linkerd_app_core::{

--- a/linkerd/app/outbound/src/tcp/opaque_transport.rs
+++ b/linkerd/app/outbound/src/tcp/opaque_transport.rs
@@ -66,8 +66,8 @@ where
 
     fn call(&mut self, ep: T) -> Self::Future {
         let tls: tls::ConditionalClientTls = ep.param();
-        if tls.is_none() {
-            trace!("Not attempting opaque transport");
+        if let tls::ConditionalClientTls::None(reason) = tls {
+            trace!(%reason, "Not attempting opaque transport");
             let target = Connect {
                 addr: ep.param(),
                 tls,


### PR DESCRIPTION
In order to make the server and logical stack more flexible, we need to
make stacks generic over their input target type.

This change modifies the innermost `tcp::connect` stack to not depend on
a concrete target type, instead relying on `Param` constraints. A new
`tcp::Connect` target type is introduced to be constructed by the TCP
connect stack.