### PR TITLE
admin: Handle connections that fail protocol detection

### DIFF
--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -5,7 +5,7 @@ use crate::core::{
     metrics::{self, FmtMetrics},
     serve, tls, trace,
     transport::listen,
-    Error,
+    Error, Never,
 };
 use crate::{
     http,
@@ -64,11 +64,10 @@ impl Config {
                 |(version, tcp): (Result<Option<http::Version>, detect::DetectTimeout<_>>, _)| {
                     match version {
                         Ok(Some(version)) => Ok(HttpAccept::from((version, tcp))),
-                        Ok(None) => {
-                            debug!("Failed to parse HTTP request; handling as HTTP/1.1");
-                            Ok(HttpAccept::from((http::Version::Http1, tcp)))
+                        Ok(None) | Err(_) => {
+                            debug!("Failed to parse HTTP request; handling as HTTP/1");
+                            Ok::<_, Never>(HttpAccept::from((http::Version::Http1, tcp)))
                         }
-                        Err(timeout) => Err(Error::from(timeout)),
                     }
                 },
             ))


### PR DESCRIPTION
The HTTP detect module may fail to detect an HTTP protocol if the first
read does not return at least 14 bytes. This has caused spurious
failures as described in linkerd/linkerd2#5672.

This change updates the admin server's protocol detection to handle
these connections as HTTP/1 so that the HTTP server can try to process
them and fail on its own if the connection really is not HTTP.