### PR TITLE
outbound: skip logical stacks when no profile is discovered

### DIFF
--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -60,10 +60,14 @@ where
             Some(id) => id,
             None => return Gateway::NoIdentity,
         };
-
-        let dst = match profile.as_ref().and_then(|p| p.borrow().addr.clone()) {
-            Some(profiles::LogicalAddr(addr)) => addr,
+        let profile = match profile {
+            Some(profile) => profile,
             None => return Gateway::BadDomain(http.target.name().clone()),
+        };
+
+        let dst = match profile.borrow().addr.clone() {
+            Some(profiles::LogicalAddr(addr)) => addr,
+            _ => return Gateway::BadDomain(http.target.name().clone()),
         };
 
         // Create an outbound target using the resolved name and an address

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -67,7 +67,7 @@ where
 
         let addr = match profile.borrow().addr.clone() {
             Some(addr) => addr,
-            _ => return Gateway::BadDomain(http.target.name().clone()),
+            None => return Gateway::BadDomain(http.target.name().clone()),
         };
 
         // Create an outbound target using the resolved name and an address

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -116,8 +116,8 @@ where
         .push_tcp_logical(resolve.clone())
         .into_stack()
         .push_request_filter(|(p, _): (Option<profiles::Receiver>, _)| match p {
-            Some(rx) if rx.borrow().addr.is_some() => Ok(outbound::tcp::Logical {
-                profile: Some(rx),
+            Some(profile) if profile.borrow().addr.is_some() => Ok(outbound::tcp::Logical {
+                profile,
                 orig_dst: OrigDstAddr(std::net::SocketAddr::from(([0, 0, 0, 0], 0))),
                 protocol: (),
             }),

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -1,0 +1,33 @@
+use crate::{target::Endpoint, Outbound};
+use linkerd_app_core::{svc, tls};
+
+impl<E> Outbound<E> {
+    pub fn push_into_endpoint<P, T>(
+        self,
+    ) -> Outbound<
+        impl svc::NewService<T, Service = <E as svc::NewService<Endpoint<P>>>::Service> + Clone,
+    >
+    where
+        Endpoint<P>: From<(tls::NoClientTls, T)>,
+        E: svc::NewService<Endpoint<P>> + Clone,
+    {
+        let Self {
+            config,
+            runtime,
+            stack: endpoint,
+        } = self;
+        let identity_disabled = runtime.identity.is_none();
+        let no_tls_reason = if identity_disabled {
+            tls::NoClientTls::Disabled
+        } else {
+            tls::NoClientTls::NotProvidedByServiceDiscovery
+        };
+        let stack =
+            svc::stack(endpoint).push_map_target(move |t| Endpoint::<P>::from((no_tls_reason, t)));
+        Outbound {
+            config,
+            runtime,
+            stack,
+        }
+    }
+}

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -4,9 +4,7 @@ use linkerd_app_core::{svc, tls};
 impl<E> Outbound<E> {
     pub fn push_into_endpoint<P, T>(
         self,
-    ) -> Outbound<
-        impl svc::NewService<T, Service = <E as svc::NewService<Endpoint<P>>>::Service> + Clone,
-    >
+    ) -> Outbound<impl svc::NewService<T, Service = E::Service> + Clone>
     where
         Endpoint<P>: From<(tls::NoClientTls, T)>,
         E: svc::NewService<Endpoint<P>> + Clone,

--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -37,7 +37,7 @@ impl<N> Outbound<N> {
     {
         let Self {
             config,
-            runtime,
+            runtime: rt,
             stack: tcp,
         } = self;
         let ProxyConfig {
@@ -59,10 +59,7 @@ impl<N> Outbound<N> {
                     .push(svc::MapErrLayer::new(Into::into)),
             )
             .check_new_service::<HTgt, _>()
-            .push(http::NewServeHttp::layer(
-                h2_settings,
-                runtime.drain.clone(),
-            ))
+            .push(http::NewServeHttp::layer(h2_settings, rt.drain.clone()))
             .push_map_target(HTgt::from)
             .instrument(|(v, _): &(http::Version, _)| debug_span!("http", %v))
             .push(svc::UnwrapOr::layer(
@@ -96,7 +93,7 @@ impl<N> Outbound<N> {
 
         Outbound {
             config,
-            runtime,
+            runtime: rt,
             stack,
         }
     }

--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -50,7 +50,6 @@ impl<N> Outbound<N> {
             .clone()
             .push_on_response(svc::MapTargetLayer::new(io::EitherIo::Left))
             .push_map_target(NTgt::from)
-            .check_new_service::<T, _>()
             .into_inner();
         let stack = svc::stack(http)
             .push_on_response(
@@ -64,9 +63,7 @@ impl<N> Outbound<N> {
             .instrument(|(v, _): &(http::Version, _)| debug_span!("http", %v))
             .push(svc::UnwrapOr::layer(
                 tcp.push_on_response(svc::MapTargetLayer::new(io::EitherIo::Right))
-                    .check_new_service::<NTgt, _>()
                     .push_map_target(NTgt::from)
-                    .check_new_service::<T, _>()
                     .into_inner(),
             ))
             .check_new_service::<(Option<http::Version>, T), _>()
@@ -75,7 +72,6 @@ impl<N> Outbound<N> {
                 detect_protocol_timeout,
                 http::DetectHttp::default(),
             ))
-            .check_new_service::<T, _>()
             .push_switch(
                 // When the target is marked as as opaque, we skip HTTP
                 // detection and just use the TCP stack directly.

--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -71,6 +71,77 @@ impl<T> Outbound<T> {
             stack,
         }
     }
+
+    pub fn push_detect_stack<R, TSvc, TTgt, H, HSvc, HTgt, I>(
+        self,
+        http: H,
+    ) -> Outbound<
+        impl svc::NewService<
+                R,
+                Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
+            > + Clone,
+    >
+    where
+        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+        T: svc::NewService<TTgt, Service = TSvc> + Clone + Send + 'static,
+        TSvc: svc::Service<io::EitherIo<I, io::PrefixedIo<I>>, Response = ()> + Send + 'static,
+        TSvc::Error: Into<Error>,
+        TSvc::Future: Send,
+        TTgt: From<R> + 'static,
+        H: svc::NewService<HTgt, Service = HSvc> + Clone + Send + 'static,
+        HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>,
+        HSvc: Clone + Send + Sync + Unpin + 'static,
+        HSvc::Error: Into<Error>,
+        HSvc::Future: Send,
+        HTgt: From<(http::Version, R)> + svc::Param<http::Version> + 'static,
+        R: Clone + Send + Sync + 'static,
+    {
+        let Self {
+            config,
+            runtime,
+            stack: tcp,
+        } = self;
+        let ProxyConfig {
+            server: ServerConfig { h2_settings, .. },
+            detect_protocol_timeout,
+            ..
+        } = config.proxy;
+
+        let stack = svc::stack(http)
+            .push_on_response(
+                svc::layers()
+                    .push(http::BoxRequest::layer())
+                    .push(svc::MapErrLayer::new(Into::into)),
+            )
+            .check_new_service::<HTgt, _>()
+            .push(http::NewServeHttp::layer(
+                h2_settings,
+                runtime.drain.clone(),
+            ))
+            .push_map_target(HTgt::from)
+            .instrument(|(v, _): &(http::Version, _)| debug_span!("http", %v))
+            .push(svc::UnwrapOr::layer(
+                tcp.clone()
+                    .push_on_response(svc::MapTargetLayer::new(io::EitherIo::Right))
+                    .check_new_service::<TTgt, _>()
+                    .push_map_target(TTgt::from)
+                    .check_new_service::<R, _>()
+                    .into_inner(),
+            ))
+            .check_new_service::<(Option<http::Version>, R), _>()
+            .push_map_target(detect::allow_timeout)
+            .push(detect::NewDetectService::layer(
+                detect_protocol_timeout,
+                http::DetectHttp::default(),
+            ))
+            .check_new_service::<R, _>();
+
+        Outbound {
+            config,
+            runtime,
+            stack,
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -82,11 +153,7 @@ impl svc::Predicate<tcp::Logical> for SkipByProfile {
     type Request = svc::Either<tcp::Logical, tcp::Logical>;
 
     fn check(&mut self, l: tcp::Logical) -> Result<Self::Request, Error> {
-        if l.profile
-            .as_ref()
-            .map(|p| !p.borrow().opaque_protocol)
-            .unwrap_or(true)
-        {
+        if l.profile.borrow().opaque_protocol {
             Ok(svc::Either::A(l))
         } else {
             Ok(svc::Either::B(l))

--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -88,8 +88,7 @@ impl<T> Outbound<T> {
             .push_map_target(HTgt::from)
             .instrument(|(v, _): &(http::Version, _)| debug_span!("http", %v))
             .push(svc::UnwrapOr::layer(
-                tcp.clone()
-                    .push_on_response(svc::MapTargetLayer::new(io::EitherIo::Right))
+                tcp.push_on_response(svc::MapTargetLayer::new(io::EitherIo::Right))
                     .check_new_service::<TTgt, _>()
                     .push_map_target(TTgt::from)
                     .check_new_service::<R, _>()

--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -154,9 +154,9 @@ impl svc::Predicate<tcp::Logical> for SkipByProfile {
 
     fn check(&mut self, l: tcp::Logical) -> Result<Self::Request, Error> {
         if l.profile.borrow().opaque_protocol {
-            Ok(svc::Either::A(l))
-        } else {
             Ok(svc::Either::B(l))
+        } else {
+            Ok(svc::Either::A(l))
         }
     }
 }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -175,12 +175,9 @@ impl<E> Outbound<E> {
             .instrument(|l: &Logical| debug_span!("logical", dst = %l.addr()))
             .push_switch(
                 move |logical: Logical| {
-                    let should_resolve = match logical.profile.as_ref() {
-                        Some(p) => {
-                            let p = p.borrow();
-                            p.endpoint.is_none() && (p.addr.is_some() || !p.targets.is_empty())
-                        }
-                        None => false,
+                    let should_resolve = {
+                        let p = logical.profile.borrow();
+                        p.endpoint.is_none() && (p.addr.is_some() || !p.targets.is_empty())
                     };
 
                     if should_resolve {

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -7,6 +7,7 @@ mod server;
 #[cfg(test)]
 mod tests;
 
+pub use self::detect::SkipHttpDetection;
 use crate::tcp;
 use indexmap::IndexMap;
 pub use linkerd_app_core::proxy::http::*;

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -94,13 +94,11 @@ impl Logical {
 
 impl Param<normalize_uri::DefaultAuthority> for Logical {
     fn param(&self) -> normalize_uri::DefaultAuthority {
-        if let Some(p) = self.profile.as_ref() {
-            if let Some(LogicalAddr(a)) = p.borrow().addr.as_ref() {
-                return normalize_uri::DefaultAuthority(Some(
-                    uri::Authority::from_str(&a.to_string())
-                        .expect("Address must be a valid authority"),
-                ));
-            }
+        if let Some(LogicalAddr(a)) = self.profile.borrow().addr.as_ref() {
+            return normalize_uri::DefaultAuthority(Some(
+                uri::Authority::from_str(&a.to_string())
+                    .expect("Address must be a valid authority"),
+            ));
         }
 
         normalize_uri::DefaultAuthority(Some(

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -85,7 +85,6 @@ where
         .into_inner();
 
     let http = connect
-        .clone()
         .push_http_endpoint()
         .push_http_logical(resolver.clone())
         .push_http_server()

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -81,7 +81,7 @@ where
     let endpoint = out
         .clone()
         .with_stack(NoTcpBalancer)
-        .push_detect_stack::<_, _, crate::tcp::Accept, _, _, _, _>(http_endpoint)
+        .push_detect_http::<_, _, crate::tcp::Accept, _, _, _, _>(http_endpoint)
         .into_inner();
 
     let http = connect
@@ -93,7 +93,7 @@ where
 
     out.clone()
         .with_stack(NoTcpBalancer)
-        .push_detect_http(http)
+        .push_detect_with_skip(http)
         .push_unwrap_logical(endpoint)
 }
 

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -94,7 +94,7 @@ where
     out.clone()
         .with_stack(NoTcpBalancer)
         .push_detect_http(http)
-        .push_logical(endpoint)
+        .push_profile(endpoint)
 }
 
 #[derive(Clone, Debug)]

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -91,8 +91,7 @@ where
         .push_http_server()
         .into_inner();
 
-    out.clone()
-        .with_stack(NoTcpBalancer)
+    out.with_stack(NoTcpBalancer)
         .push_detect_with_skip(http)
         .push_unwrap_logical(endpoint)
 }

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -94,7 +94,7 @@ where
     out.clone()
         .with_stack(NoTcpBalancer)
         .push_detect_http(http)
-        .push_profile(endpoint)
+        .push_unwrap_logical(endpoint)
 }
 
 #[derive(Clone, Debug)]

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -95,8 +95,7 @@ impl Outbound<()> {
             )
             .into_inner();
 
-        http
-            .push_http_logical(resolve)
+        http.push_http_logical(resolve)
             .into_stack()
             .push_on_response(
                 svc::layers()

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -1,214 +1,214 @@
-// use crate::{http, stack_labels, tcp, trace_labels, Config, Outbound};
-// use linkerd_app_core::{
-//     config::{ProxyConfig, ServerConfig},
-//     detect, discovery_rejected, drain, errors, http_request_l5d_override_dst_addr, http_tracing,
-//     io, profiles,
-//     svc::{self, stack::Param},
-//     tls,
-//     transport::{self, ClientAddr, OrigDstAddr, Remote},
-//     Addr, AddrMatch, Error,
-// };
-// use tracing::{debug_span, info_span};
+use crate::{http, stack_labels, tcp, trace_labels, Config, Outbound};
+use linkerd_app_core::{
+    config::{ProxyConfig, ServerConfig},
+    detect, discovery_rejected, drain, errors, http_request_l5d_override_dst_addr, http_tracing,
+    io, profiles,
+    svc::{self, stack::Param},
+    tls,
+    transport::{self, ClientAddr, OrigDstAddr, Remote},
+    Addr, AddrMatch, Error,
+};
+use tracing::{debug_span, info_span};
 
-// impl Outbound<()> {
-//     /// Routes HTTP requests according to the l5d-dst-override header.
-//     ///
-//     /// Forwards TCP connections without discovery/routing (or mTLS).
-//     ///
-//     /// This is only intended for Ingress configurations, where we assume all
-//     /// outbound traffic is either HTTP or TLS'd by the ingress proxy.
-//     pub fn to_ingress<T, I, N, NSvc, H, HSvc, P>(
-//         &self,
-//         profiles: P,
-//         tcp: N,
-//         http: H,
-//     ) -> impl svc::NewService<
-//         T,
-//         Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
-//     >
-//     where
-//         T: Param<OrigDstAddr> + Param<Remote<ClientAddr>> + Clone + Send + Sync + 'static,
-//         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
-//         N: svc::NewService<tcp::Endpoint, Service = NSvc> + Clone + Send + Sync + 'static,
-//         NSvc: svc::Service<io::PrefixedIo<transport::metrics::SensorIo<I>>, Response = ()>
-//             + Clone
-//             + Send
-//             + Sync
-//             + 'static,
-//         NSvc::Error: Into<Error>,
-//         NSvc::Future: Send,
-//         H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
-//         HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
-//             + Send
-//             + 'static,
-//         HSvc::Error: Into<Error>,
-//         HSvc::Future: Send,
-//         P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + Unpin + 'static,
-//         P::Error: Send,
-//         P::Future: Send,
-//     {
-//         let Config {
-//             allow_discovery,
-//             proxy:
-//                 ProxyConfig {
-//                     server: ServerConfig { h2_settings, .. },
-//                     dispatch_timeout,
-//                     max_in_flight_requests,
-//                     detect_protocol_timeout,
-//                     buffer_capacity,
-//                     cache_max_idle_age,
-//                     ..
-//                 },
-//             ..
-//         } = self.config.clone();
-//         let allow = AllowHttpProfile(allow_discovery);
+impl Outbound<()> {
+    /// Routes HTTP requests according to the l5d-dst-override header.
+    ///
+    /// Forwards TCP connections without discovery/routing (or mTLS).
+    ///
+    /// This is only intended for Ingress configurations, where we assume all
+    /// outbound traffic is either HTTP or TLS'd by the ingress proxy.
+    pub fn to_ingress<T, I, N, NSvc, H, HSvc, P>(
+        &self,
+        profiles: P,
+        tcp: N,
+        http: H,
+    ) -> impl svc::NewService<
+        T,
+        Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
+    >
+    where
+        T: Param<OrigDstAddr> + Param<Remote<ClientAddr>> + Clone + Send + Sync + 'static,
+        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+        N: svc::NewService<tcp::Endpoint, Service = NSvc> + Clone + Send + Sync + 'static,
+        NSvc: svc::Service<io::PrefixedIo<transport::metrics::SensorIo<I>>, Response = ()>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
+        NSvc::Error: Into<Error>,
+        NSvc::Future: Send,
+        H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
+        HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+            + Send
+            + 'static,
+        HSvc::Error: Into<Error>,
+        HSvc::Future: Send,
+        P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + Unpin + 'static,
+        P::Error: Send,
+        P::Future: Send,
+    {
+        let Config {
+            allow_discovery,
+            proxy:
+                ProxyConfig {
+                    server: ServerConfig { h2_settings, .. },
+                    dispatch_timeout,
+                    max_in_flight_requests,
+                    detect_protocol_timeout,
+                    buffer_capacity,
+                    cache_max_idle_age,
+                    ..
+                },
+            ..
+        } = self.config.clone();
+        let allow = AllowHttpProfile(allow_discovery);
 
-//         let tcp = svc::stack(tcp)
-//             .push_on_response(drain::Retain::layer(self.runtime.drain.clone()))
-//             .push_map_target(|a: tcp::Accept| {
-//                 tcp::Endpoint::from((tls::NoClientTls::IngressNonHttp, a))
-//             })
-//             .into_inner();
+        let tcp = svc::stack(tcp)
+            .push_on_response(drain::Retain::layer(self.runtime.drain.clone()))
+            .push_map_target(|a: tcp::Accept| {
+                tcp::Endpoint::from((tls::NoClientTls::IngressNonHttp, a))
+            })
+            .into_inner();
 
-//         svc::stack(http)
-//             .push_on_response(
-//                 svc::layers()
-//                     .push(http::BoxRequest::layer())
-//                     .push(svc::MapErrLayer::new(Into::into)),
-//             )
-//             // Lookup the profile for the outbound HTTP target, if appropriate.
-//             //
-//             // This service is buffered because it needs to initialize the profile
-//             // resolution and a failfast is instrumented in case it becomes
-//             // unavailable
-//             // When this service is in failfast, ensure that we drive the
-//             // inner service to readiness even if new requests aren't
-//             // received.
-//             .push_map_target(http::Logical::from)
-//             .push(profiles::discover::layer(profiles, allow))
-//             .push_on_response(
-//                 svc::layers()
-//                     .push(
-//                         self.runtime
-//                             .metrics
-//                             .stack
-//                             .layer(stack_labels("http", "logical")),
-//                     )
-//                     .push(svc::layer::mk(svc::SpawnReady::new))
-//                     .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
-//                     .push_spawn_buffer(buffer_capacity),
-//             )
-//             .push_cache(cache_max_idle_age)
-//             .push_on_response(http::Retain::layer())
-//             .instrument(|t: &Target| info_span!("target", dst = %t.dst))
-//             // Obtain a new inner service for each request (fom the above cache).
-//             //
-//             // Note that the router service is always ready, so the `FailFast` layer
-//             // need not use a `SpawnReady` to drive the service to ready.
-//             .push(svc::NewRouter::layer(TargetPerRequest::accept))
-//             .push(http::NewNormalizeUri::layer())
-//             .push_on_response(
-//                 svc::layers()
-//                     .push(http::MarkAbsoluteForm::layer())
-//                     .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
-//                     .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
-//                     .push(self.runtime.metrics.http_errors.clone())
-//                     .push(errors::layer())
-//                     .push(http_tracing::server(
-//                         self.runtime.span_sink.clone(),
-//                         trace_labels(),
-//                     ))
-//                     .push(http::BoxResponse::layer()),
-//             )
-//             .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
-//             .push(http::NewServeHttp::layer(
-//                 h2_settings,
-//                 self.runtime.drain.clone(),
-//             ))
-//             .push_map_target(http::Accept::from)
-//             .push(svc::UnwrapOr::layer(tcp))
-//             .push_cache(cache_max_idle_age)
-//             .push_map_target(detect::allow_timeout)
-//             .push(detect::NewDetectService::layer(
-//                 detect_protocol_timeout,
-//                 http::DetectHttp::default(),
-//             ))
-//             .push(self.runtime.metrics.transport.layer_accept())
-//             .instrument(|a: &tcp::Accept| info_span!("ingress", orig_dst = %a.orig_dst))
-//             .push_map_target(|a: T| {
-//                 let orig_dst = Param::<OrigDstAddr>::param(&a);
-//                 tcp::Accept::from(orig_dst)
-//             })
-//             // Boxing is necessary purely to limit the link-time overhead of
-//             // having enormous types.
-//             .push(svc::BoxNewService::layer())
-//             .check_new_service::<T, I>()
-//             .into_inner()
-//     }
-// }
+        svc::stack(http)
+            .push_on_response(
+                svc::layers()
+                    .push(http::BoxRequest::layer())
+                    .push(svc::MapErrLayer::new(Into::into)),
+            )
+            // Lookup the profile for the outbound HTTP target, if appropriate.
+            //
+            // This service is buffered because it needs to initialize the profile
+            // resolution and a failfast is instrumented in case it becomes
+            // unavailable
+            // When this service is in failfast, ensure that we drive the
+            // inner service to readiness even if new requests aren't
+            // received.
+            .push_map_target(http::Logical::from)
+            .push(profiles::discover::layer(profiles, allow))
+            .push_on_response(
+                svc::layers()
+                    .push(
+                        self.runtime
+                            .metrics
+                            .stack
+                            .layer(stack_labels("http", "logical")),
+                    )
+                    .push(svc::layer::mk(svc::SpawnReady::new))
+                    .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
+                    .push_spawn_buffer(buffer_capacity),
+            )
+            .push_cache(cache_max_idle_age)
+            .push_on_response(http::Retain::layer())
+            .instrument(|t: &Target| info_span!("target", dst = %t.dst))
+            // Obtain a new inner service for each request (fom the above cache).
+            //
+            // Note that the router service is always ready, so the `FailFast` layer
+            // need not use a `SpawnReady` to drive the service to ready.
+            .push(svc::NewRouter::layer(TargetPerRequest::accept))
+            .push(http::NewNormalizeUri::layer())
+            .push_on_response(
+                svc::layers()
+                    .push(http::MarkAbsoluteForm::layer())
+                    .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
+                    .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
+                    .push(self.runtime.metrics.http_errors.clone())
+                    .push(errors::layer())
+                    .push(http_tracing::server(
+                        self.runtime.span_sink.clone(),
+                        trace_labels(),
+                    ))
+                    .push(http::BoxResponse::layer()),
+            )
+            .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
+            .push(http::NewServeHttp::layer(
+                h2_settings,
+                self.runtime.drain.clone(),
+            ))
+            .push_map_target(http::Accept::from)
+            .push(svc::UnwrapOr::layer(tcp))
+            .push_cache(cache_max_idle_age)
+            .push_map_target(detect::allow_timeout)
+            .push(detect::NewDetectService::layer(
+                detect_protocol_timeout,
+                http::DetectHttp::default(),
+            ))
+            .push(self.runtime.metrics.transport.layer_accept())
+            .instrument(|a: &tcp::Accept| info_span!("ingress", orig_dst = %a.orig_dst))
+            .push_map_target(|a: T| {
+                let orig_dst = Param::<OrigDstAddr>::param(&a);
+                tcp::Accept::from(orig_dst)
+            })
+            // Boxing is necessary purely to limit the link-time overhead of
+            // having enormous types.
+            .push(svc::BoxNewService::layer())
+            .check_new_service::<T, I>()
+            .into_inner()
+    }
+}
 
-// #[derive(Clone)]
-// struct AllowHttpProfile(AddrMatch);
+#[derive(Clone)]
+struct AllowHttpProfile(AddrMatch);
 
-// #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-// struct Target {
-//     dst: Addr,
-//     version: http::Version,
-// }
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct Target {
+    dst: Addr,
+    version: http::Version,
+}
 
-// #[derive(Clone)]
-// struct TargetPerRequest(http::Accept);
+#[derive(Clone)]
+struct TargetPerRequest(http::Accept);
 
-// // === AllowHttpProfile ===
+// === AllowHttpProfile ===
 
-// impl svc::stack::Predicate<Target> for AllowHttpProfile {
-//     type Request = profiles::LookupAddr;
+impl svc::stack::Predicate<Target> for AllowHttpProfile {
+    type Request = profiles::LookupAddr;
 
-//     fn check(&mut self, Target { dst, .. }: Target) -> Result<profiles::LookupAddr, Error> {
-//         if self.0.matches(&dst) {
-//             Ok(profiles::LookupAddr(dst))
-//         } else {
-//             Err(discovery_rejected().into())
-//         }
-//     }
-// }
+    fn check(&mut self, Target { dst, .. }: Target) -> Result<profiles::LookupAddr, Error> {
+        if self.0.matches(&dst) {
+            Ok(profiles::LookupAddr(dst))
+        } else {
+            Err(discovery_rejected().into())
+        }
+    }
+}
 
-// // === impl Target ===
+// === impl Target ===
 
-// impl From<(profiles::Receiver, Target)> for http::Logical {
-//     fn from((profile, Target { dst, version }): (profiles::Receiver, Target)) -> Self {
-//         // XXX This is a hack to fix caching when an dst-override is set.
-//         let orig_dst = if let Some(a) = dst.socket_addr() {
-//             OrigDstAddr(a)
-//         } else {
-//             OrigDstAddr(([0, 0, 0, 0], dst.port()).into())
-//         };
+impl From<(profiles::Receiver, Target)> for http::Logical {
+    fn from((profile, Target { dst, version }): (profiles::Receiver, Target)) -> Self {
+        // XXX This is a hack to fix caching when an dst-override is set.
+        let orig_dst = if let Some(a) = dst.socket_addr() {
+            OrigDstAddr(a)
+        } else {
+            OrigDstAddr(([0, 0, 0, 0], dst.port()).into())
+        };
 
-//         Self {
-//             orig_dst,
-//             profile,
-//             protocol: version,
-//         }
-//     }
-// }
+        Self {
+            orig_dst,
+            profile,
+            protocol: version,
+        }
+    }
+}
 
-// // === TargetPerRequest ===
+// === TargetPerRequest ===
 
-// impl TargetPerRequest {
-//     fn accept(a: http::Accept) -> Self {
-//         Self(a)
-//     }
-// }
+impl TargetPerRequest {
+    fn accept(a: http::Accept) -> Self {
+        Self(a)
+    }
+}
 
-// impl<B> svc::stack::RecognizeRoute<http::Request<B>> for TargetPerRequest {
-//     type Key = Target;
+impl<B> svc::stack::RecognizeRoute<http::Request<B>> for TargetPerRequest {
+    type Key = Target;
 
-//     fn recognize(&self, req: &http::Request<B>) -> Result<Self::Key, Error> {
-//         let dst =
-//             http_request_l5d_override_dst_addr(req).unwrap_or_else(|_| self.0.orig_dst.0.into());
-//         Ok(Target {
-//             dst,
-//             version: self.0.protocol,
-//         })
-//     }
-// }
+    fn recognize(&self, req: &http::Request<B>) -> Result<Self::Key, Error> {
+        let dst =
+            http_request_l5d_override_dst_addr(req).unwrap_or_else(|_| self.0.orig_dst.0.into());
+        Ok(Target {
+            dst,
+            version: self.0.protocol,
+        })
+    }
+}

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -1,214 +1,214 @@
-use crate::{http, stack_labels, tcp, trace_labels, Config, Outbound};
-use linkerd_app_core::{
-    config::{ProxyConfig, ServerConfig},
-    detect, discovery_rejected, drain, errors, http_request_l5d_override_dst_addr, http_tracing,
-    io, profiles,
-    svc::{self, stack::Param},
-    tls,
-    transport::{self, ClientAddr, OrigDstAddr, Remote},
-    Addr, AddrMatch, Error,
-};
-use tracing::{debug_span, info_span};
+// use crate::{http, stack_labels, tcp, trace_labels, Config, Outbound};
+// use linkerd_app_core::{
+//     config::{ProxyConfig, ServerConfig},
+//     detect, discovery_rejected, drain, errors, http_request_l5d_override_dst_addr, http_tracing,
+//     io, profiles,
+//     svc::{self, stack::Param},
+//     tls,
+//     transport::{self, ClientAddr, OrigDstAddr, Remote},
+//     Addr, AddrMatch, Error,
+// };
+// use tracing::{debug_span, info_span};
 
-impl Outbound<()> {
-    /// Routes HTTP requests according to the l5d-dst-override header.
-    ///
-    /// Forwards TCP connections without discovery/routing (or mTLS).
-    ///
-    /// This is only intended for Ingress configurations, where we assume all
-    /// outbound traffic is either HTTP or TLS'd by the ingress proxy.
-    pub fn to_ingress<T, I, N, NSvc, H, HSvc, P>(
-        &self,
-        profiles: P,
-        tcp: N,
-        http: H,
-    ) -> impl svc::NewService<
-        T,
-        Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
-    >
-    where
-        T: Param<OrigDstAddr> + Param<Remote<ClientAddr>> + Clone + Send + Sync + 'static,
-        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
-        N: svc::NewService<tcp::Endpoint, Service = NSvc> + Clone + Send + Sync + 'static,
-        NSvc: svc::Service<io::PrefixedIo<transport::metrics::SensorIo<I>>, Response = ()>
-            + Clone
-            + Send
-            + Sync
-            + 'static,
-        NSvc::Error: Into<Error>,
-        NSvc::Future: Send,
-        H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
-        HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
-            + Send
-            + 'static,
-        HSvc::Error: Into<Error>,
-        HSvc::Future: Send,
-        P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + Unpin + 'static,
-        P::Error: Send,
-        P::Future: Send,
-    {
-        let Config {
-            allow_discovery,
-            proxy:
-                ProxyConfig {
-                    server: ServerConfig { h2_settings, .. },
-                    dispatch_timeout,
-                    max_in_flight_requests,
-                    detect_protocol_timeout,
-                    buffer_capacity,
-                    cache_max_idle_age,
-                    ..
-                },
-            ..
-        } = self.config.clone();
-        let allow = AllowHttpProfile(allow_discovery);
+// impl Outbound<()> {
+//     /// Routes HTTP requests according to the l5d-dst-override header.
+//     ///
+//     /// Forwards TCP connections without discovery/routing (or mTLS).
+//     ///
+//     /// This is only intended for Ingress configurations, where we assume all
+//     /// outbound traffic is either HTTP or TLS'd by the ingress proxy.
+//     pub fn to_ingress<T, I, N, NSvc, H, HSvc, P>(
+//         &self,
+//         profiles: P,
+//         tcp: N,
+//         http: H,
+//     ) -> impl svc::NewService<
+//         T,
+//         Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
+//     >
+//     where
+//         T: Param<OrigDstAddr> + Param<Remote<ClientAddr>> + Clone + Send + Sync + 'static,
+//         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+//         N: svc::NewService<tcp::Endpoint, Service = NSvc> + Clone + Send + Sync + 'static,
+//         NSvc: svc::Service<io::PrefixedIo<transport::metrics::SensorIo<I>>, Response = ()>
+//             + Clone
+//             + Send
+//             + Sync
+//             + 'static,
+//         NSvc::Error: Into<Error>,
+//         NSvc::Future: Send,
+//         H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
+//         HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+//             + Send
+//             + 'static,
+//         HSvc::Error: Into<Error>,
+//         HSvc::Future: Send,
+//         P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + Unpin + 'static,
+//         P::Error: Send,
+//         P::Future: Send,
+//     {
+//         let Config {
+//             allow_discovery,
+//             proxy:
+//                 ProxyConfig {
+//                     server: ServerConfig { h2_settings, .. },
+//                     dispatch_timeout,
+//                     max_in_flight_requests,
+//                     detect_protocol_timeout,
+//                     buffer_capacity,
+//                     cache_max_idle_age,
+//                     ..
+//                 },
+//             ..
+//         } = self.config.clone();
+//         let allow = AllowHttpProfile(allow_discovery);
 
-        let tcp = svc::stack(tcp)
-            .push_on_response(drain::Retain::layer(self.runtime.drain.clone()))
-            .push_map_target(|a: tcp::Accept| {
-                tcp::Endpoint::from((tls::NoClientTls::IngressNonHttp, a))
-            })
-            .into_inner();
+//         let tcp = svc::stack(tcp)
+//             .push_on_response(drain::Retain::layer(self.runtime.drain.clone()))
+//             .push_map_target(|a: tcp::Accept| {
+//                 tcp::Endpoint::from((tls::NoClientTls::IngressNonHttp, a))
+//             })
+//             .into_inner();
 
-        svc::stack(http)
-            .push_on_response(
-                svc::layers()
-                    .push(http::BoxRequest::layer())
-                    .push(svc::MapErrLayer::new(Into::into)),
-            )
-            // Lookup the profile for the outbound HTTP target, if appropriate.
-            //
-            // This service is buffered because it needs to initialize the profile
-            // resolution and a failfast is instrumented in case it becomes
-            // unavailable
-            // When this service is in failfast, ensure that we drive the
-            // inner service to readiness even if new requests aren't
-            // received.
-            .push_map_target(http::Logical::from)
-            .push(profiles::discover::layer(profiles, allow))
-            .push_on_response(
-                svc::layers()
-                    .push(
-                        self.runtime
-                            .metrics
-                            .stack
-                            .layer(stack_labels("http", "logical")),
-                    )
-                    .push(svc::layer::mk(svc::SpawnReady::new))
-                    .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
-                    .push_spawn_buffer(buffer_capacity),
-            )
-            .push_cache(cache_max_idle_age)
-            .push_on_response(http::Retain::layer())
-            .instrument(|t: &Target| info_span!("target", dst = %t.dst))
-            // Obtain a new inner service for each request (fom the above cache).
-            //
-            // Note that the router service is always ready, so the `FailFast` layer
-            // need not use a `SpawnReady` to drive the service to ready.
-            .push(svc::NewRouter::layer(TargetPerRequest::accept))
-            .push(http::NewNormalizeUri::layer())
-            .push_on_response(
-                svc::layers()
-                    .push(http::MarkAbsoluteForm::layer())
-                    .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
-                    .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
-                    .push(self.runtime.metrics.http_errors.clone())
-                    .push(errors::layer())
-                    .push(http_tracing::server(
-                        self.runtime.span_sink.clone(),
-                        trace_labels(),
-                    ))
-                    .push(http::BoxResponse::layer()),
-            )
-            .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
-            .push(http::NewServeHttp::layer(
-                h2_settings,
-                self.runtime.drain.clone(),
-            ))
-            .push_map_target(http::Accept::from)
-            .push(svc::UnwrapOr::layer(tcp))
-            .push_cache(cache_max_idle_age)
-            .push_map_target(detect::allow_timeout)
-            .push(detect::NewDetectService::layer(
-                detect_protocol_timeout,
-                http::DetectHttp::default(),
-            ))
-            .push(self.runtime.metrics.transport.layer_accept())
-            .instrument(|a: &tcp::Accept| info_span!("ingress", orig_dst = %a.orig_dst))
-            .push_map_target(|a: T| {
-                let orig_dst = Param::<OrigDstAddr>::param(&a);
-                tcp::Accept::from(orig_dst)
-            })
-            // Boxing is necessary purely to limit the link-time overhead of
-            // having enormous types.
-            .push(svc::BoxNewService::layer())
-            .check_new_service::<T, I>()
-            .into_inner()
-    }
-}
+//         svc::stack(http)
+//             .push_on_response(
+//                 svc::layers()
+//                     .push(http::BoxRequest::layer())
+//                     .push(svc::MapErrLayer::new(Into::into)),
+//             )
+//             // Lookup the profile for the outbound HTTP target, if appropriate.
+//             //
+//             // This service is buffered because it needs to initialize the profile
+//             // resolution and a failfast is instrumented in case it becomes
+//             // unavailable
+//             // When this service is in failfast, ensure that we drive the
+//             // inner service to readiness even if new requests aren't
+//             // received.
+//             .push_map_target(http::Logical::from)
+//             .push(profiles::discover::layer(profiles, allow))
+//             .push_on_response(
+//                 svc::layers()
+//                     .push(
+//                         self.runtime
+//                             .metrics
+//                             .stack
+//                             .layer(stack_labels("http", "logical")),
+//                     )
+//                     .push(svc::layer::mk(svc::SpawnReady::new))
+//                     .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
+//                     .push_spawn_buffer(buffer_capacity),
+//             )
+//             .push_cache(cache_max_idle_age)
+//             .push_on_response(http::Retain::layer())
+//             .instrument(|t: &Target| info_span!("target", dst = %t.dst))
+//             // Obtain a new inner service for each request (fom the above cache).
+//             //
+//             // Note that the router service is always ready, so the `FailFast` layer
+//             // need not use a `SpawnReady` to drive the service to ready.
+//             .push(svc::NewRouter::layer(TargetPerRequest::accept))
+//             .push(http::NewNormalizeUri::layer())
+//             .push_on_response(
+//                 svc::layers()
+//                     .push(http::MarkAbsoluteForm::layer())
+//                     .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
+//                     .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
+//                     .push(self.runtime.metrics.http_errors.clone())
+//                     .push(errors::layer())
+//                     .push(http_tracing::server(
+//                         self.runtime.span_sink.clone(),
+//                         trace_labels(),
+//                     ))
+//                     .push(http::BoxResponse::layer()),
+//             )
+//             .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
+//             .push(http::NewServeHttp::layer(
+//                 h2_settings,
+//                 self.runtime.drain.clone(),
+//             ))
+//             .push_map_target(http::Accept::from)
+//             .push(svc::UnwrapOr::layer(tcp))
+//             .push_cache(cache_max_idle_age)
+//             .push_map_target(detect::allow_timeout)
+//             .push(detect::NewDetectService::layer(
+//                 detect_protocol_timeout,
+//                 http::DetectHttp::default(),
+//             ))
+//             .push(self.runtime.metrics.transport.layer_accept())
+//             .instrument(|a: &tcp::Accept| info_span!("ingress", orig_dst = %a.orig_dst))
+//             .push_map_target(|a: T| {
+//                 let orig_dst = Param::<OrigDstAddr>::param(&a);
+//                 tcp::Accept::from(orig_dst)
+//             })
+//             // Boxing is necessary purely to limit the link-time overhead of
+//             // having enormous types.
+//             .push(svc::BoxNewService::layer())
+//             .check_new_service::<T, I>()
+//             .into_inner()
+//     }
+// }
 
-#[derive(Clone)]
-struct AllowHttpProfile(AddrMatch);
+// #[derive(Clone)]
+// struct AllowHttpProfile(AddrMatch);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct Target {
-    dst: Addr,
-    version: http::Version,
-}
+// #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+// struct Target {
+//     dst: Addr,
+//     version: http::Version,
+// }
 
-#[derive(Clone)]
-struct TargetPerRequest(http::Accept);
+// #[derive(Clone)]
+// struct TargetPerRequest(http::Accept);
 
-// === AllowHttpProfile ===
+// // === AllowHttpProfile ===
 
-impl svc::stack::Predicate<Target> for AllowHttpProfile {
-    type Request = profiles::LookupAddr;
+// impl svc::stack::Predicate<Target> for AllowHttpProfile {
+//     type Request = profiles::LookupAddr;
 
-    fn check(&mut self, Target { dst, .. }: Target) -> Result<profiles::LookupAddr, Error> {
-        if self.0.matches(&dst) {
-            Ok(profiles::LookupAddr(dst))
-        } else {
-            Err(discovery_rejected().into())
-        }
-    }
-}
+//     fn check(&mut self, Target { dst, .. }: Target) -> Result<profiles::LookupAddr, Error> {
+//         if self.0.matches(&dst) {
+//             Ok(profiles::LookupAddr(dst))
+//         } else {
+//             Err(discovery_rejected().into())
+//         }
+//     }
+// }
 
-// === impl Target ===
+// // === impl Target ===
 
-impl From<(Option<profiles::Receiver>, Target)> for http::Logical {
-    fn from((profile, Target { dst, version }): (Option<profiles::Receiver>, Target)) -> Self {
-        // XXX This is a hack to fix caching when an dst-override is set.
-        let orig_dst = if let Some(a) = dst.socket_addr() {
-            OrigDstAddr(a)
-        } else {
-            OrigDstAddr(([0, 0, 0, 0], dst.port()).into())
-        };
+// impl From<(profiles::Receiver, Target)> for http::Logical {
+//     fn from((profile, Target { dst, version }): (profiles::Receiver, Target)) -> Self {
+//         // XXX This is a hack to fix caching when an dst-override is set.
+//         let orig_dst = if let Some(a) = dst.socket_addr() {
+//             OrigDstAddr(a)
+//         } else {
+//             OrigDstAddr(([0, 0, 0, 0], dst.port()).into())
+//         };
 
-        Self {
-            orig_dst,
-            profile,
-            protocol: version,
-        }
-    }
-}
+//         Self {
+//             orig_dst,
+//             profile,
+//             protocol: version,
+//         }
+//     }
+// }
 
-// === TargetPerRequest ===
+// // === TargetPerRequest ===
 
-impl TargetPerRequest {
-    fn accept(a: http::Accept) -> Self {
-        Self(a)
-    }
-}
+// impl TargetPerRequest {
+//     fn accept(a: http::Accept) -> Self {
+//         Self(a)
+//     }
+// }
 
-impl<B> svc::stack::RecognizeRoute<http::Request<B>> for TargetPerRequest {
-    type Key = Target;
+// impl<B> svc::stack::RecognizeRoute<http::Request<B>> for TargetPerRequest {
+//     type Key = Target;
 
-    fn recognize(&self, req: &http::Request<B>) -> Result<Self::Key, Error> {
-        let dst =
-            http_request_l5d_override_dst_addr(req).unwrap_or_else(|_| self.0.orig_dst.0.into());
-        Ok(Target {
-            dst,
-            version: self.0.protocol,
-        })
-    }
-}
+//     fn recognize(&self, req: &http::Request<B>) -> Result<Self::Key, Error> {
+//         let dst =
+//             http_request_l5d_override_dst_addr(req).unwrap_or_else(|_| self.0.orig_dst.0.into());
+//         Ok(Target {
+//             dst,
+//             version: self.0.protocol,
+//         })
+//     }
+// }

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -94,8 +94,10 @@ impl Outbound<()> {
                     .push(svc::MapErrLayer::new(Into::into)),
             )
             .into_inner();
-        let http_logical = http.push_http_logical(resolve).into_inner();
-        svc::stack(http_logical)
+
+        http
+            .push_http_logical(resolve)
+            .into_stack()
             .push_on_response(
                 svc::layers()
                     .push(http::BoxRequest::layer())

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -136,6 +136,7 @@ impl<S> Outbound<S> {
         P::Error: Send,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
     {
+        // HTTP per-endpoint stack used when a profile is not discovered.
         let http_endpoint = self
             .clone()
             .push_tcp_endpoint()
@@ -143,15 +144,19 @@ impl<S> Outbound<S> {
             .push_into_endpoint()
             .push_http_server::<http::Accept, _>()
             .into_inner();
+
+        // HTTP and TCP per-endpoint stack used when a profile is not discovered.
         let endpoint = self
             .clone()
             .push_tcp_endpoint()
             .push_tcp_forward()
             .push_into_endpoint::<(), tcp::Accept>()
+            // If HTTP is detected, use the `http_endpoint` stack
             .push_detect_http(http_endpoint)
             .into_inner();
 
-        let http = self
+        // HTTP stack for logical targets (with service profiles).
+        let http_logical = self
             .clone()
             .push_tcp_endpoint()
             .push_http_endpoint()
@@ -161,8 +166,13 @@ impl<S> Outbound<S> {
 
         self.push_tcp_endpoint()
             .push_tcp_logical(resolve)
-            .push_detect_with_skip(http)
+            // Try to detect HTTP and use the `http_logical` stack, skipping
+            // detection if it's disabled by the service profile.
+            .push_detect_with_skip(http_logical)
+            // If a service profile was not discovered, fall back to the
+            // per-endpoint stack.
             .push_unwrap_logical(endpoint)
+            // Discover service profiles for each original dst address
             .push_discover(profiles)
             .into_inner()
     }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -8,7 +8,7 @@
 mod discover;
 pub mod endpoint;
 pub mod http;
-// mod ingress;
+mod ingress;
 pub mod logical;
 mod resolve;
 pub mod target;
@@ -178,21 +178,14 @@ impl Outbound<()> {
         let serve = async move {
             if self.config.ingress_mode {
                 info!("Outbound routing in ingress-mode");
-                todo!("ELIZA FINISH INGRESS LOL");
-            // let tcp = self
-            //     .to_tcp_connect()
-            //     .push_tcp_endpoint()
-            //     .push_tcp_forward()
-            //     .into_inner();
-            // let http = self
-            //     .to_tcp_connect()
-            //     .push_tcp_endpoint()
-            //     .push_http_endpoint()
-            //     .push_http_logical(resolve)
-            //     .into_inner();
-            // let stack = self.to_ingress(profiles, tcp, http);
-            // let shutdown = self.runtime.drain.signaled();
-            // serve::serve(listen, stack, shutdown).await;
+                let tcp = self.to_tcp_connect().push_tcp_endpoint().push_tcp_forward();
+                let http = self
+                    .to_tcp_connect()
+                    .push_tcp_endpoint()
+                    .push_http_endpoint();
+                let stack = self.to_ingress(profiles, tcp, http, resolve.clone());
+                let shutdown = self.runtime.drain.signaled();
+                serve::serve(listen, stack, shutdown).await;
             } else {
                 let stack = self.to_tcp_connect().into_server(resolve, profiles);
                 let shutdown = self.runtime.drain.signaled();

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -168,7 +168,7 @@ impl<S> Outbound<S> {
             .push_tcp_logical(resolve)
             // Try to detect HTTP and use the `http_logical` stack, skipping
             // detection if it's disabled by the service profile.
-            .push_detect_with_skip(http_logical)
+            .push_detect_http(http_logical)
             // If a service profile was not discovered, fall back to the
             // per-endpoint stack.
             .push_unwrap_logical(no_profile)

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -164,8 +164,7 @@ impl<S> Outbound<S> {
             .push_http_server()
             .into_inner();
 
-        self.clone()
-            .push_tcp_endpoint()
+        self.push_tcp_endpoint()
             .push_tcp_logical(resolve)
             // Try to detect HTTP and use the `http_logical` stack, skipping
             // detection if it's disabled by the service profile.

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -147,7 +147,7 @@ impl<S> Outbound<S> {
         self.push_tcp_endpoint()
             .push_tcp_logical(resolve)
             .push_detect_http(http)
-            .push_logical(endpoint)
+            .push_profile(endpoint)
             .push_discover(profiles)
             .into_inner()
     }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -203,12 +203,18 @@ impl Outbound<()> {
         let serve = async move {
             if self.config.ingress_mode {
                 info!("Outbound routing in ingress-mode");
-                let tcp = self.to_tcp_connect().push_tcp_endpoint().push_tcp_forward();
+                let tcp = self
+                    .to_tcp_connect()
+                    .push_tcp_endpoint()
+                    .push_tcp_forward()
+                    .into_inner();
                 let http = self
                     .to_tcp_connect()
                     .push_tcp_endpoint()
-                    .push_http_endpoint();
-                let stack = self.to_ingress(profiles, tcp, http, resolve.clone());
+                    .push_http_endpoint()
+                    .push_http_logical(resolve)
+                    .into_inner();
+                let stack = self.to_ingress(profiles, tcp, http);
                 let shutdown = self.runtime.drain.signaled();
                 serve::serve(listen, stack, shutdown).await;
             } else {

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -147,7 +147,7 @@ impl<S> Outbound<S> {
         self.push_tcp_endpoint()
             .push_tcp_logical(resolve)
             .push_detect_http(http)
-            .push_profile(endpoint)
+            .push_unwrap_logical(endpoint)
             .push_discover(profiles)
             .into_inner()
     }

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -1,0 +1,38 @@
+use crate::{tcp, Outbound};
+use linkerd_app_core::{profiles, svc, Error};
+
+impl<L> Outbound<L> {
+    pub fn push_logical<T, I, E, ESvc, LSvc>(
+        self,
+        endpoint: E,
+    ) -> Outbound<
+        impl svc::NewService<
+                (Option<profiles::Receiver>, T),
+                Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
+            > + Clone,
+    >
+    where
+        tcp::Logical: From<(profiles::Receiver, T)>,
+        L: svc::NewService<tcp::Logical, Service = LSvc> + Clone,
+        LSvc: svc::Service<I, Response = (), Error = Error>,
+        LSvc::Future: Send,
+        E: svc::NewService<T, Service = ESvc> + Clone,
+        ESvc: svc::Service<I, Response = (), Error = Error>,
+        ESvc::Future: Send,
+    {
+        let Self {
+            config,
+            runtime,
+            stack: logical,
+        } = self;
+        let stack = svc::stack(logical)
+            .push_map_target(tcp::Logical::from)
+            .push(svc::UnwrapOr::layer(endpoint))
+            .check_new_service::<(Option<profiles::Receiver>, T), _>();
+        Outbound {
+            config,
+            runtime,
+            stack,
+        }
+    }
+}

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -2,7 +2,7 @@ use crate::{tcp, Outbound};
 use linkerd_app_core::{profiles, svc, Error};
 
 impl<L> Outbound<L> {
-    pub fn push_logical<T, I, E, ESvc, LSvc>(
+    pub fn push_profile<T, I, E, ESvc, LSvc>(
         self,
         endpoint: E,
     ) -> Outbound<

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -1,6 +1,8 @@
 use crate::{tcp, Outbound};
 use linkerd_app_core::{profiles, svc};
 
+pub type UnwrapLogical<L, E> = svc::stack::ResultService<svc::Either<L, E>>;
+
 impl<L> Outbound<L> {
     /// Pushes a layer that unwraps the [`Logical`] address of a given target
     /// from its profile resolution, or else falls back to the provided
@@ -11,7 +13,7 @@ impl<L> Outbound<L> {
     ) -> Outbound<
         impl svc::NewService<
                 (Option<profiles::Receiver>, T),
-                Service = svc::stack::ResultService<svc::Either<L::Service, E::Service>>,
+                Service = UnwrapLogical<L::Service, E::Service>,
             > + Clone,
     >
     where

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -1,27 +1,23 @@
 use crate::{tcp, Outbound};
-use linkerd_app_core::{profiles, svc, Error};
+use linkerd_app_core::{profiles, svc};
 
 impl<L> Outbound<L> {
     /// Pushes a layer that unwraps the [`Logical`] address of a given target
     /// from its profile resolution, or else falls back to the provided
     /// per-endpoint service if there was no profile resolution for that target.
-    pub fn push_unwrap_logical<T, I, E, ESvc, LSvc>(
+    pub fn push_unwrap_logical<T, E>(
         self,
         endpoint: E,
     ) -> Outbound<
         impl svc::NewService<
                 (Option<profiles::Receiver>, T),
-                Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
+                Service = svc::stack::ResultService<svc::Either<L::Service, E::Service>>,
             > + Clone,
     >
     where
         tcp::Logical: From<(profiles::Receiver, T)>,
-        L: svc::NewService<tcp::Logical, Service = LSvc> + Clone,
-        LSvc: svc::Service<I, Response = (), Error = Error>,
-        LSvc::Future: Send,
-        E: svc::NewService<T, Service = ESvc> + Clone,
-        ESvc: svc::Service<I, Response = (), Error = Error>,
-        ESvc::Future: Send,
+        L: svc::NewService<tcp::Logical> + Clone,
+        E: svc::NewService<T> + Clone,
     {
         let Self {
             config,
@@ -30,8 +26,7 @@ impl<L> Outbound<L> {
         } = self;
         let stack = logical
             .push_map_target(tcp::Logical::from)
-            .push(svc::UnwrapOr::layer(endpoint))
-            .check_new_service::<(Option<profiles::Receiver>, T), _>();
+            .push(svc::UnwrapOr::layer(endpoint));
         Outbound {
             config,
             runtime,

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -2,7 +2,10 @@ use crate::{tcp, Outbound};
 use linkerd_app_core::{profiles, svc, Error};
 
 impl<L> Outbound<L> {
-    pub fn push_profile<T, I, E, ESvc, LSvc>(
+    /// Pushes a layer that unwraps the [`Logical`] address of a given target
+    /// from its profile resolution, or else falls back to the provided
+    /// per-endpoint service if there was no profile resolution for that target.
+    pub fn push_unwrap_logical<T, I, E, ESvc, LSvc>(
         self,
         endpoint: E,
     ) -> Outbound<
@@ -25,7 +28,7 @@ impl<L> Outbound<L> {
             runtime,
             stack: logical,
         } = self;
-        let stack = svc::stack(logical)
+        let stack = logical
             .push_map_target(tcp::Logical::from)
             .push(svc::UnwrapOr::layer(endpoint))
             .check_new_service::<(Option<profiles::Receiver>, T), _>();

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -1,4 +1,4 @@
-use crate::tcp::opaque_transport;
+use crate::{http::SkipHttpDetection, tcp::opaque_transport};
 use linkerd_app_core::{
     metrics,
     profiles::{self, LogicalAddr},
@@ -62,6 +62,13 @@ impl<P> Param<transport::labels::Key> for Accept<P> {
     }
 }
 
+// When a profile is not discovered, always enable protocol detection.
+impl Param<SkipHttpDetection> for Accept<()> {
+    fn param(&self) -> SkipHttpDetection {
+        SkipHttpDetection(false)
+    }
+}
+
 // === impl Logical ===
 
 impl<P> From<(profiles::Receiver, Accept<P>)> for Logical<P> {
@@ -101,6 +108,13 @@ impl<P> Param<Option<profiles::Receiver>> for Logical<P> {
 impl<P> Param<profiles::LookupAddr> for Logical<P> {
     fn param(&self) -> profiles::LookupAddr {
         profiles::LookupAddr(self.addr())
+    }
+}
+
+// Used for skipping HTTP detection
+impl Param<SkipHttpDetection> for Logical<()> {
+    fn param(&self) -> SkipHttpDetection {
+        SkipHttpDetection(self.profile.borrow().opaque_protocol)
     }
 }
 

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -177,6 +177,7 @@ impl<P> Param<ConcreteAddr> for Concrete<P> {
 }
 
 // === impl Endpoint ===
+
 impl<P> Endpoint<P> {
     pub fn no_tls(reason: tls::NoClientTls) -> impl Fn(Accept<P>) -> Self {
         move |accept| Self::from((reason, accept))

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -776,7 +776,7 @@ where
         .into_inner();
     connect
         .push_tcp_logical(resolver)
-        .push_detect_with_skip(support::service::no_http())
+        .push_detect_http(support::service::no_http::<crate::http::Logical>())
         .push_unwrap_logical(endpoint)
         .push_discover(profiles)
         .into_inner()

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -779,11 +779,11 @@ where
         .clone()
         .push_tcp_forward()
         .push_into_endpoint::<(), super::Accept>()
-        .push_detect_stack::<_, _, _, _, _, crate::http::Accept, _>(support::service::no_http())
+        .push_detect_http::<_, _, _, _, _, crate::http::Accept, _>(support::service::no_http())
         .into_inner();
     connect
         .push_tcp_logical(resolver)
-        .push_detect_http(support::service::no_http())
+        .push_detect_with_skip(support::service::no_http())
         .push_unwrap_logical(endpoint)
         .push_discover(profiles)
         .into_inner()

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -784,7 +784,7 @@ where
     connect
         .push_tcp_logical(resolver)
         .push_detect_http(support::service::no_http())
-        .push_profile(endpoint)
+        .push_unwrap_logical(endpoint)
         .push_discover(profiles)
         .into_inner()
 }

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -784,7 +784,7 @@ where
     connect
         .push_tcp_logical(resolver)
         .push_detect_http(support::service::no_http())
-        .push_logical(endpoint)
+        .push_profile(endpoint)
         .push_discover(profiles)
         .into_inner()
 }

--- a/linkerd/app/test/src/service.rs
+++ b/linkerd/app/test/src/service.rs
@@ -4,21 +4,21 @@ use crate::{
 };
 
 /// Returns a mock HTTP router that asserts that the HTTP router is never used.
-pub fn no_http() -> NoHttp {
-    NoHttp
+pub fn no_http<T>() -> NoHttp<T> {
+    NoHttp(std::marker::PhantomData)
 }
 
-#[derive(Clone)]
-pub struct NoHttp;
+#[derive(Clone, Copy, Debug)]
+pub struct NoHttp<T>(std::marker::PhantomData<fn(T)>);
 
-impl<T: std::fmt::Debug> svc::NewService<T> for NoHttp {
+impl<T: std::fmt::Debug> svc::NewService<T> for NoHttp<T> {
     type Service = Self;
     fn new_service(&mut self, target: T) -> Self::Service {
         panic!("the HTTP router should not be used in this test, but we tried to build a service for {:?}", target)
     }
 }
 
-impl svc::Service<http::Request<http::BoxBody>> for NoHttp {
+impl<T> svc::Service<http::Request<http::BoxBody>> for NoHttp<T> {
     type Response = http::Response<http::BoxBody>;
     type Error = Error;
     type Future = futures::future::Ready<Result<Self::Response, Self::Error>>;


### PR DESCRIPTION
Currently, the outbound proxy's `Logical` target type contains an
`Option<profiles::Receiver>`. When no profile is discovered, this field
is set to `None`; the per-profile layers in the logical stack do nothing
when this field is `None`. However, we still *construct* this whole
stack for all destinations, even those without logical addresses.

This PR refactors the outbound proxy so that the `Logical` targets
*always* have discovered profiles, and the logical stack is skipped when
no profile is discovered. Profile discovery still returns an
`Option<profiles::Receiver>`, but we unwrap it in one place immediately
after the profile discovery layer, and skip directly to the endpoint
stack when it is `None`.

This means that we can now avoid constructing layers like traffic split
etc when there is no profile for a target, rather than building a
traffic split that does nothing.

Note that some of the layers in the logical stacks currently *do* still
have code for handling the case where a `Logical` target has no profile.
These layers currently take targets that are bounded with
`Param<Option<profiles::Receiver>>`. The `Logical` type still has its
`Param<Option<profiles::Receiver>>` impl, it just always returns `Some`
now. I chose to leave this code as-is since this branch is already a
fairly large refactor. We can simplify a lot of this code in a follow-up
(although some layers may also require a similar change on the inbound
side).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>