### PR TITLE
Fix caching in ingress mode

### DIFF
--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -61,8 +61,8 @@ where
             None => return Gateway::NoIdentity,
         };
 
-        let dst = match profile.as_ref().and_then(|p| p.borrow().addr.clone()) {
-            Some(profiles::LogicalAddr(addr)) => addr,
+        let addr = match profile.as_ref().and_then(|p| p.borrow().addr.clone()) {
+            Some(addr) => addr,
             None => return Gateway::BadDomain(http.target.name().clone()),
         };
 
@@ -73,7 +73,8 @@ where
         let svc = self.outbound.new_service(outbound::http::Logical {
             profile,
             protocol: http.version,
-            orig_dst: OrigDstAddr(([0, 0, 0, 0], dst.port()).into()),
+            orig_dst: OrigDstAddr(([0, 0, 0, 0], addr.0.port()).into()),
+            logical_addr: Some(addr),
         });
 
         Gateway::new(svc, http.target, local_id)

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -118,12 +118,12 @@ where
         .push_request_filter(|(p, _): (Option<profiles::Receiver>, _)| match p {
             Some(rx) if rx.borrow().addr.is_some() => {
                 let logical_addr = rx.borrow().addr.clone();
-                return Ok(outbound::tcp::Logical {
+                Ok(outbound::tcp::Logical {
                     profile: Some(rx),
                     orig_dst: OrigDstAddr(std::net::SocketAddr::from(([0, 0, 0, 0], 0))),
                     protocol: (),
                     logical_addr,
-                });
+                })
             }
             _ => Err(discovery_rejected()),
         })

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -116,11 +116,15 @@ where
         .push_tcp_logical(resolve.clone())
         .into_stack()
         .push_request_filter(|(p, _): (Option<profiles::Receiver>, _)| match p {
-            Some(rx) if rx.borrow().addr.is_some() => Ok(outbound::tcp::Logical {
-                profile: Some(rx),
-                orig_dst: OrigDstAddr(std::net::SocketAddr::from(([0, 0, 0, 0], 0))),
-                protocol: (),
-            }),
+            Some(rx) if rx.borrow().addr.is_some() => {
+                let logical_addr = rx.borrow().addr.clone();
+                return Ok(outbound::tcp::Logical {
+                    profile: Some(rx),
+                    orig_dst: OrigDstAddr(std::net::SocketAddr::from(([0, 0, 0, 0], 0))),
+                    protocol: (),
+                    logical_addr,
+                });
+            }
             _ => Err(discovery_rejected()),
         })
         .push(profiles::discover::layer(profiles.clone(), {

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -65,6 +65,7 @@ impl From<(Version, tcp::Logical)> for Logical {
             protocol,
             orig_dst: logical.orig_dst,
             profile: logical.profile,
+            logical_addr: logical.logical_addr,
         }
     }
 }

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -183,11 +183,13 @@ impl From<(Option<profiles::Receiver>, Target)> for http::Logical {
         } else {
             OrigDstAddr(([0, 0, 0, 0], dst.port()).into())
         };
+        let logical_addr = profile.as_ref().and_then(|p| p.borrow().addr.clone());
 
         Self {
             orig_dst,
             profile,
             protocol: version,
+            logical_addr,
         }
     }
 }

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -37,10 +37,13 @@ async fn plaintext_tcp() {
     // ports or anything. These will just be used so that the proxy has a socket
     // address to resolve, etc.
     let target_addr = SocketAddr::new([0, 0, 0, 0].into(), 666);
+    let recv = profile::only_default();
+    let logical_addr = recv.borrow().addr.clone();
     let logical = Logical {
         orig_dst: OrigDstAddr(target_addr),
-        profile: Some(profile::only_default()),
+        profile: Some(recv),
         protocol: (),
+        logical_addr,
     };
 
     // Configure mock IO for the upstream "server". It will read "hello" and
@@ -80,17 +83,23 @@ async fn tls_when_hinted() {
     let _trace = support::trace_init();
 
     let tls_addr = SocketAddr::new([0, 0, 0, 0].into(), 5550);
+    let tls_recv = profile::only_with_addr("tls:5550");
+    let tls_logical_addr = tls_recv.borrow().addr.clone();
     let tls = Logical {
         orig_dst: OrigDstAddr(tls_addr),
-        profile: Some(profile::only_with_addr("tls:5550")),
+        profile: Some(tls_recv),
         protocol: (),
+        logical_addr: tls_logical_addr,
     };
 
     let plain_addr = SocketAddr::new([0, 0, 0, 0].into(), 5551);
+    let plain_recv = profile::only_with_addr("plain:5551");
+    let plain_logical_addr = plain_recv.borrow().addr.clone();
     let plain = Logical {
         orig_dst: OrigDstAddr(plain_addr),
-        profile: Some(profile::only_with_addr("plain:5551")),
+        profile: Some(plain_recv),
         protocol: (),
+        logical_addr: plain_logical_addr,
     };
 
     let id_name = tls::ServerId::from_str("foo.ns1.serviceaccount.identity.linkerd.cluster.local")


### PR DESCRIPTION
When the proxy is in `ingress` mode, requests with different `l5d-dst-override` headers but the same address share the same key in the cache. This causes consecutive requests to the same address to all go to the value of the first `l5d-dst-override` header, ignoring the header values of later requests—unless the services are evicted from the cache.

This occurs because each key into the cache is calculated based off `LogicalAddr`'s `orig_dst` and `protocol` fields ([source](https://github.com/linkerd/linkerd2-proxy/blob/main/linkerd/app/outbound/src/target.rs#L115-L120)). When the proxy is in `ingress` mode, the value of `orig_dst` is overridden to `0.0.0.0:port` ([source](https://github.com/linkerd/linkerd2-proxy/blob/main/linkerd/app/outbound/src/ingress.rs#L180-L185)). This results in an easy key conflict: two different requests with the same port and protocol with result in the same key.

To fix this, the `logical_addr` field is added to `LogicalAddr` and is used as a third field in calculating the cache key. `logical_addr` is the value of the `l5d-dst-override` header which means requests to the same address but with different header values will result in different keys.

Fixes linkerd/linkerd2#5975

### Testing

For manual testing, Linkerd can be installed with this version of the proxy:

```bash
linkerd install --set proxy.image.name='ghcr.io/kleimkuhler/proxy',proxy.image.version='5381fd45' |kubectl apply -f -
```

Then, apply this [manifest](https://gist.github.com/kleimkuhler/b92386a12277ab90032a38a6ad25621a) which creates two 3 deployments and 2 services:

1. injected nginx server and service
  
2. injected nginx server and service
  
3. injected `ingress` pod with `curl` used to send requests to `1` and `2`
  

From the `curl` pod, send requests with the `l5d-dst-override` header set and observer with `linkerd viz tap` that the requests are received by the correct pods:

```bash
$ curl-5ffd49f57-fwk2d:/$ curl -H "l5d-dst-override: svc-1.default.svc.cluster.local:8000" 10.0.0.1
$ curl-5ffd469f57-fwk2d:/$ curl -H "l5d-dst-override: svc-2.default.svc.cluster.local:8000" 10.0.0.1
```

#### Proxy tests

There are currently no tests for the `l5d-dst-override` header. I'll keep working on adding some additional tests for this, but those may come as a follow-up