### PR TITLE
inbound: only build profile route stacks when a profile is resolved

### DIFF
--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -154,7 +154,6 @@ where
             .push_on_response(http::BoxResponse::layer())
             .check_new_service::<Target, http::Request<_>>()
             .into_inner();
-            
         // Attempts to discover a service profile for each logical target (as
         // informed by the request's headers). The stack is cached until a
         // request has not been received for `cache_max_idle_age`.

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -148,11 +148,13 @@ where
             .push_on_response(http_tracing::client(rt.span_sink.clone(), trace_labels()))
             .push_on_response(http::BoxResponse::layer())
             .check_new_service::<Target, http::Request<_>>();
+
         let no_profile = target
             .clone()
             .push_on_response(http::BoxResponse::layer())
             .check_new_service::<Target, http::Request<_>>()
             .into_inner();
+            
         // Attempts to discover a service profile for each logical target (as
         // informed by the request's headers). The stack is cached until a
         // request has not been received for `cache_max_idle_age`.

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -148,7 +148,11 @@ where
             .push_on_response(http_tracing::client(rt.span_sink.clone(), trace_labels()))
             .push_on_response(http::BoxResponse::layer())
             .check_new_service::<Target, http::Request<_>>();
-
+        let no_profile = target
+            .clone()
+            .push_on_response(http::BoxResponse::layer())
+            .check_new_service::<Target, http::Request<_>>()
+            .into_inner();
         // Attempts to discover a service profile for each logical target (as
         // informed by the request's headers). The stack is cached until a
         // request has not been received for `cache_max_idle_age`.
@@ -173,6 +177,9 @@ where
                     .into_inner(),
             ))
             .push_map_target(Logical::from)
+            .push_on_response(http::BoxResponse::layer())
+            .check_new_service::<(profiles::Receiver, Target), _>()
+            .push(svc::UnwrapOr::layer(no_profile))
             .push(profiles::discover::layer(
                 profiles,
                 AllowProfile(config.allow_discovery.clone()),
@@ -191,7 +198,7 @@ where
                     .push_on_response(svc::layer::mk(svc::SpawnReady::new))
                     .into_inner(),
             )
-            .check_new_service::<Target, http::Request<http::BoxBody>>()
+            .check_new_service::<Target, http::Request<BoxBody>>()
             .push_on_response(
                 svc::layers()
                     .push(

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -37,7 +37,7 @@ pub struct Target {
 #[derive(Clone, Debug)]
 pub struct Logical {
     target: Target,
-    profiles: Option<profiles::Receiver>,
+    profiles: profiles::Receiver,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -351,14 +351,14 @@ impl<A> svc::stack::RecognizeRoute<http::Request<A>> for RequestTarget {
 
 // === impl Logical ===
 
-impl From<(Option<profiles::Receiver>, Target)> for Logical {
-    fn from((profiles, target): (Option<profiles::Receiver>, Target)) -> Self {
+impl From<(profiles::Receiver, Target)> for Logical {
+    fn from((profiles, target): (profiles::Receiver, Target)) -> Self {
         Self { profiles, target }
     }
 }
 
 impl Param<Option<profiles::Receiver>> for Logical {
     fn param(&self) -> Option<profiles::Receiver> {
-        self.profiles.clone()
+        Some(self.profiles.clone())
     }
 }


### PR DESCRIPTION
This is similar to PR #963 but on the inbound side. Since the inbound
proxy only requires logical targets in the HTTP profile route layers,
this change is much simpler --- protocol detection etc are all above the
profile resolution layer. We can simply add an `UnwrapOr` layer that
skips the profile route layers.

This change is much less important than the corresponding outbound
change, but the two changes together will permit us to simplify the
profile route layer by taking a `Param<profiles::Receiver>` rather than
a `Param<Option<profiles::Receiver>>`.

This does also require adding an additional `BoxResponse` layer to erase
differing response body types based on whether or not profile route
metrics are recorded.