### PR TITLE
profiles: make receiver param in `route_request` non-optional 

### DIFF
--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -357,8 +357,8 @@ impl From<(profiles::Receiver, Target)> for Logical {
     }
 }
 
-impl Param<Option<profiles::Receiver>> for Logical {
-    fn param(&self) -> Option<profiles::Receiver> {
-        Some(self.profiles.clone())
+impl Param<profiles::Receiver> for Logical {
+    fn param(&self) -> profiles::Receiver {
+        self.profiles.clone()
     }
 }

--- a/linkerd/app/outbound/src/target.rs
+++ b/linkerd/app/outbound/src/target.rs
@@ -97,13 +97,6 @@ impl<P> Param<profiles::Receiver> for Logical<P> {
     }
 }
 
-// TODO(eliza): eventually we won't need this
-impl<P> Param<Option<profiles::Receiver>> for Logical<P> {
-    fn param(&self) -> Option<profiles::Receiver> {
-        Some(self.profile.clone())
-    }
-}
-
 /// Used for default traffic split
 impl<P> Param<profiles::LookupAddr> for Logical<P> {
     fn param(&self) -> profiles::LookupAddr {


### PR DESCRIPTION
This branch changes the `linkerd_service_profiles::http::route_request`
layer to require a `Param<profiles::Receiver>` rather than a
`Param<Option<profiles::Receiver>>` target type. This is possible
because the inbound and outbound logical destination stacks are now only
built when a profile is resolved (as of PRs #963 and #966).

Depends on #964
Depends on #966