### PR TITLE
concurrency-limit: use `tokio-util`'s `PollSemaphore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
  "linkerd-stack",
  "pin-project",
  "tokio",
+ "tokio-util",
  "tower",
  "tracing",
 ]
@@ -2170,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
 dependencies = [
  "bytes",
  "futures-core",

--- a/linkerd/concurrency-limit/Cargo.toml
+++ b/linkerd/concurrency-limit/Cargo.toml
@@ -11,6 +11,7 @@ publish = false
 futures = "0.3.9"
 linkerd-stack = { path = "../stack" }
 tokio = { version = "1", features = ["sync"] }
+tokio-util = "0.6.5"
 tower = { version = "0.4.5", default-features = false }
 tracing = "0.1.23"
 pin-project = "1"


### PR DESCRIPTION
Currently, our concurrency limit middleware uses
`tokio::sync::Semaphore` to implement the concurrency limit. Because
acquiring permits from the `Semaphore` type is only possible via the
`acquire` and `acquire_owned` methods, which are `async fn`s returning
unameable futures that are `!Unpin`, we cannot simply poll the semaphore
in `poll_ready`. Instead, to allow polling the concurrency limit service
to acquire a permit, we box the `acquire_owned` future in `poll_ready`.
This means that every time we try to acquire a new concurrency limit
permit, we must allocate a new box.

The `tokio-util` crate has a [`PollSemaphore`][1] type which allows
wrapping a `tokio::sync::Semaphore` to add a `poll_acquire` method to
poll the semaphore to acquire a permit. Unlike our implementation,
`PollSemaphore` uses the [`tokio_util::sync::ReusableBoxFuture`][2] type
for boxing the `acquire_owned` future returned by the `Semaphore`.
`ReusableBoxFuture` is a safe abstraction around unsafe code that allows
*one* allocation to be reused for storing multiple type-erased
`Box::pin`ned futures. This means creating a single allocation for each
clone of a `ConcurrencyLimit` service, rather than having each clone of
the concurrency limit service allocate once *every* time a new permit is
acquired and drop that allocation once the permit is acquired.

This should reduce the overhead of the concurrency limit layer a bit. It
also makes the code much simpler! :)

[1]: https://docs.rs/tokio-util/0.6.5/tokio_util/sync/struct.PollSemaphore.html
[2]: https://docs.rs/tokio-util/0.6.5/tokio_util/sync/struct.ReusableBoxFuture.html

Signed-off-by: Eliza Weisman <eliza@buoyant.io>