### PR TITLE
discover: replace `linkerd-channel` with `tokio-util` `PollSender`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,12 +1070,12 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "futures",
- "linkerd-channel",
  "linkerd-error",
  "linkerd-proxy-core",
  "linkerd-stack",
  "pin-project",
  "tokio",
+ "tokio-util",
  "tower",
  "tracing",
 ]
@@ -1369,6 +1369,7 @@ dependencies = [
  "linkerd-error",
  "linkerd-stack",
  "rand",
+ "tokio",
  "tower",
  "tracing",
 ]
@@ -2170,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "5143d049e85af7fbc36f5454d990e62c2df705b3589f123b71f441b6b59f443f"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1369,7 +1369,6 @@ dependencies = [
  "linkerd-error",
  "linkerd-stack",
  "rand",
- "tokio",
  "tower",
  "tracing",
 ]

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -12,11 +12,11 @@ Utilities to implement a Discover with the core Resolve type
 
 [dependencies]
 futures = "0.3.9"
-linkerd-channel = { path = "../../channel" }
 linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["sync", "time"] }
+tokio-util = "0.6.5"
 tracing = "0.1.23"
 pin-project = "1"
 

--- a/linkerd/proxy/discover/src/buffer.rs
+++ b/linkerd/proxy/discover/src/buffer.rs
@@ -119,7 +119,8 @@ impl<D> Future for Daemon<D>
 where
     D: discover::Discover,
     D::Error: Into<Error>,
-    discover::Change<D::Key, D::Service>: Send,
+    D::Service: Send + 'static,
+    D::Key: Send + 'static,
 {
     type Output = ();
 

--- a/linkerd/proxy/discover/src/buffer.rs
+++ b/linkerd/proxy/discover/src/buffer.rs
@@ -1,13 +1,13 @@
 use futures::{ready, Stream, TryFuture};
-use linkerd_channel as mpsc;
 use linkerd_error::{Error, Never};
 use pin_project::pin_project;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 use tokio::time::{self, Sleep};
+use tokio_util::sync::PollSender;
 use tower::discover;
 use tracing::instrument::Instrument;
 use tracing::warn;
@@ -42,7 +42,7 @@ pub struct Daemon<D: discover::Discover> {
     discover: D,
     #[pin]
     disconnect_rx: oneshot::Receiver<Never>,
-    tx: mpsc::Sender<discover::Change<D::Key, D::Service>>,
+    tx: PollSender<discover::Change<D::Key, D::Service>>,
     #[pin]
     watchdog: Option<Sleep>,
     watchdog_timeout: Duration,
@@ -100,6 +100,7 @@ where
         let discover = ready!(this.future.try_poll(cx))?;
 
         let (tx, rx) = mpsc::channel(*this.capacity);
+        let tx = PollSender::new(tx);
         let (_disconnect_tx, disconnect_rx) = oneshot::channel();
         let fut = Daemon {
             discover,
@@ -114,24 +115,11 @@ where
     }
 }
 
-// impl<D> Daemon<D>
-// where
-//     D: discover::Discover,
-//     D::Error: Into<Error>,
-// {
-//     async fn run(self) {
-//         loop {
-//             tokio::select! {
-//                 _ = self.disconnect => return,
-
-//             }
-//         }
-//     }
-
 impl<D> Future for Daemon<D>
 where
     D: discover::Discover,
     D::Error: Into<Error>,
+    discover::Change<D::Key, D::Service>: Send,
 {
     type Output = ();
 
@@ -147,7 +135,7 @@ where
             // The watchdog bounds the amount of time that the send buffer stays
             // full. This is designed to release the `discover` resources, i.e.
             // if we expect that the receiver has leaked.
-            match this.tx.poll_ready(cx) {
+            match this.tx.poll_send_done(cx) {
                 Poll::Ready(Ok(())) => {
                     this.watchdog.as_mut().set(None);
                 }
@@ -192,7 +180,7 @@ where
                 }
             };
 
-            this.tx.try_send(up).ok().expect("sender must be ready");
+            this.tx.start_send(up).ok().expect("sender must be ready");
         }
     }
 }
@@ -201,7 +189,7 @@ impl<K: std::hash::Hash + Eq, S> Stream for Discover<K, S> {
     type Item = Result<tower::discover::Change<K, S>, Error>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match self.project().rx.poll_next(cx) {
+        match self.project().rx.poll_recv(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Some(change)) => Poll::Ready(Some(Ok(change))),
             Poll::Ready(None) => Poll::Ready(None),


### PR DESCRIPTION
This commit replaces the use of `linkerd-channel`'s pollable MPSC in the
`linkerd_discover` crate's `buffer` module with `tokio-util`'s
[`sync::PollSender`][1] type, which also implements a pollable sender.
The `PollSender` type is likely more efficient than our channel
implementation, since it uses the [`ReusableBoxFuture`][2] type from
`tokio-util`, which avoids allocating a `Box` for _every_ message sent
to the channel, and instead reuses a single allocation. It also wraps
the `tokio::sync::mpsc` `Sender`, rather than reimplementing the
capacity limit on top of the `UnboundedSender` type. This reduces
complexity and should hopefully be less error-prone.

[1]: https://docs.rs/tokio-util/0.6.5/tokio_util/sync/struct.PollSender.html
[2]: https://docs.rs/tokio-util/0.6.5/tokio_util/sync/struct.ReusableBoxFuture.html

Signed-off-by: Eliza Weisman <eliza@buoyant.io>