### PR TITLE
http: Do not fail fuzz tests when all IO is not read

### DIFF
--- a/linkerd/proxy/http/fuzz/.gitignore
+++ b/linkerd/proxy/http/fuzz/.gitignore
@@ -1,4 +1,4 @@
-
+Cargo.lock
 target
 corpus
 artifacts


### PR DESCRIPTION
The HTTP detection fuzzer fails if all data is not read from the socket;
but there is no expectation that the `DetectHttp` will read all data
from the socket--it only reads to the point where it can make a
determination about whether the stream appears to be HTTP; and it may
leave unread data on the socket.

This change replaces the use of a mocked I/O type with a duplex stream
so that leftover data does not cause a test failure.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33130