### PR TITLE
 addr: fix `to_http_authority` panic with IPv6

### DIFF
--- a/linkerd/addr/src/lib.rs
+++ b/linkerd/addr/src/lib.rs
@@ -283,27 +283,35 @@ mod tests {
     }
 
     #[test]
-    fn to_http_authority_ipv4_port_80() {
+    fn to_http_authority_names_port_80() {
         test_to_http_authority(&[
             "localhost:80",
             "localhost.:80",
             "LocalhOsT.:80",
             "mlocalhost.:80",
             "localhost1.:80",
-            "127.0.0.1:80",
         ])
     }
 
     #[test]
-    fn to_http_authority_ipv4() {
+    fn to_http_authority_names() {
         test_to_http_authority(&[
             "localhost:9090",
             "localhost.:9090",
             "LocalhOsT.:9090",
             "mlocalhost.:9090",
             "localhost1.:9090",
-            "127.0.0.1:9090",
         ])
+    }
+
+    #[test]
+    fn to_http_authority_ipv4_port_80() {
+        test_to_http_authority(&["10.7.0.42:80", "127.0.0.1:80"])
+    }
+
+    #[test]
+    fn to_http_authority_ipv4() {
+        test_to_http_authority(&["10.7.0.42:9090", "127.0.0.1:9090"])
     }
 
     #[test]

--- a/linkerd/addr/src/lib.rs
+++ b/linkerd/addr/src/lib.rs
@@ -257,6 +257,22 @@ mod tests {
             assert_eq!(a.is_loopback(), *expected_result, "{:?}", host)
         }
     }
+
+    #[test]
+    fn test_to_http_authority() {
+        let cases = &[
+            "localhost:80",
+            "localhost.:80",
+            "LocalhOsT.:80",
+            "mlocalhost.:80",
+            "localhost1.:80",
+            "127.0.0.1:80",
+            "[::1]:80",
+        ];
+        for host in cases {
+            Addr::from_str(host).unwrap().to_http_authority();
+        }
+    }
 }
 
 #[cfg(fuzzing)]

--- a/linkerd/addr/src/lib.rs
+++ b/linkerd/addr/src/lib.rs
@@ -82,11 +82,15 @@ impl Addr {
         match self {
             Addr::Name(n) => n.as_http_authority(),
             Addr::Socket(ref a) if a.port() == 80 => {
-                http::uri::Authority::from_str(&a.ip().to_string())
-                    .expect("SocketAddr must be valid authority")
+                http::uri::Authority::from_str(&a.ip().to_string()).unwrap_or_else(|err| {
+                    panic!("SocketAddr ({}) must be valid authority: {}", a, err)
+                })
             }
-            Addr::Socket(a) => http::uri::Authority::from_str(&a.to_string())
-                .expect("SocketAddr must be valid authority"),
+            Addr::Socket(a) => {
+                http::uri::Authority::from_str(&a.to_string()).unwrap_or_else(|err| {
+                    panic!("SocketAddr ({}) must be valid authority: {}", a, err)
+                })
+            }
         }
     }
 

--- a/linkerd/addr/src/lib.rs
+++ b/linkerd/addr/src/lib.rs
@@ -258,20 +258,55 @@ mod tests {
         }
     }
 
+    fn test_to_http_authority(cases: &[&str]) {
+        let width = cases.iter().map(|s| s.len()).max().unwrap_or(0);
+        for host in cases {
+            print!("trying {:width$?} ... ", host, width = width);
+            Addr::from_str(host).unwrap().to_http_authority();
+            println!("ok");
+        }
+    }
+
     #[test]
-    fn test_to_http_authority() {
-        let cases = &[
+    fn to_http_authority_ipv4_port_80() {
+        test_to_http_authority(&[
             "localhost:80",
             "localhost.:80",
             "LocalhOsT.:80",
             "mlocalhost.:80",
             "localhost1.:80",
             "127.0.0.1:80",
+        ])
+    }
+
+    #[test]
+    fn to_http_authority_ipv4() {
+        test_to_http_authority(&[
+            "localhost:9090",
+            "localhost.:9090",
+            "LocalhOsT.:9090",
+            "mlocalhost.:9090",
+            "localhost1.:9090",
+            "127.0.0.1:9090",
+        ])
+    }
+
+    #[test]
+    fn to_http_authority_ipv6_port_80() {
+        test_to_http_authority(&[
+            "[2001:0db8:0000:0000:0000:8a2e:0370:7334]:80",
+            "[2001:db8::8a2e:370:7334]:80",
             "[::1]:80",
-        ];
-        for host in cases {
-            Addr::from_str(host).unwrap().to_http_authority();
-        }
+        ])
+    }
+
+    #[test]
+    fn to_http_authority_ipv6() {
+        test_to_http_authority(&[
+            "[2001:0db8:0000:0000:0000:8a2e:0370:7334]:9090",
+            "[2001:db8::8a2e:370:7334]:9090",
+            "[::1]:9090",
+        ])
     }
 }
 

--- a/linkerd/addr/src/lib.rs
+++ b/linkerd/addr/src/lib.rs
@@ -276,7 +276,7 @@ mod tests {
     fn test_to_http_authority(cases: &[&str]) {
         let width = cases.iter().map(|s| s.len()).max().unwrap_or(0);
         for host in cases {
-            print!("trying {:width$?} ... ", host, width = width);
+            print!("trying {:1$} ... ", host, width);
             Addr::from_str(host).unwrap().to_http_authority();
             println!("ok");
         }


### PR DESCRIPTION
Currently, the `Addr::to_http_authority` method panics when called on a
`SocketAddr` which is an IPv6 address with port 80. This method does not
panic when called with IPv4 addresses, or with IPv6 addresses whose
ports are *not* port 80. This was initially caught by oss-fuzz; see
[here][1] for details.

The panic occurs because when an IPv6+ address occurs in an authority,
it must be within square brackets, as per [RFC3986, Section 3.2][2]. The
square brackets distinguish between colons in the IPv6 address and the
colon separating the address and port. When the `SocketAddr`'s port is
not port 80, we format it including the port, and the `fmt::Display`
output from IPv6 `SocketAddr`s includes the square brackets as expected.

However, when the socket's port *is* port 80, we have special logic for
eliding the port from the authority. This works fine for IPv4, where we
can just call `addr.ip().to_string()` to nicely format the address.
However, with IPv6 addresses, this only formats the address itself,
*not* the square brackets. According to RFC3986, square brackets are
mandatory for *all* IPv6 addresses, even when port 80 is elided.

This branch fixes the panic by changing `Addr::to_http_authority` to
include square brackets when formatting IPv6 `SocketAddr`s with port 80.

I've also improved on @olix0r's original test cases from
dbf898a to include IPv6 addrs with and without
shorthand, and to test ports that are and are not port 80. These tests
helped catch the panic, and may be useful to guard against future
regressions.

Fixes linkerd/linkerd2#6020

[1]: https://oss-fuzz.com/testcase-detail/6502844766224384
[2]: https://tools.ietf.org/html/rfc3986#section-3.2

Signed-off-by: Eliza Weisman <eliza@buoyant.io>

