### PR TITLE
admin: Fail connections when HTTP detection fails

### DIFF
--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -30,6 +30,9 @@ pub struct Admin {
     pub serve: Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>,
 }
 
+#[derive(Debug)]
+pub struct NonHttpClient(TcpAccept);
+
 // === impl Config ===
 
 impl Config {
@@ -65,14 +68,18 @@ impl Config {
             )
             .push_map_target(Target::from)
             .push(http::NewServeHttp::layer(Default::default(), drain.clone()))
-            .push_map_target(
-                |(version, tcp): (Result<Option<http::Version>, detect::DetectTimeout<_>>, _)| {
+            .push_request_filter(
+                |(version, tcp): (
+                    Result<Option<http::Version>, detect::DetectTimeout<_>>,
+                    TcpAccept,
+                )| {
                     match version {
-                        Ok(Some(version)) => HttpAccept::from((version, tcp)),
-                        Ok(None) | Err(_) => {
-                            debug!("Failed to parse HTTP request; handling as HTTP/1");
-                            HttpAccept::from((http::Version::Http1, tcp))
+                        Ok(Some(version)) => Ok(HttpAccept::from((version, tcp))),
+                        Err(_) => {
+                            debug!("HTTP detection timed out; handling as HTTP/1");
+                            Ok(HttpAccept::from((http::Version::Http1, tcp)))
                         }
+                        Ok(None) => Err(NonHttpClient(tcp)),
                     }
                 },
             )
@@ -101,3 +108,17 @@ impl Config {
         })
     }
 }
+
+// === impl NonHttpClient ===
+
+impl std::fmt::Display for NonHttpClient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Non-HTTP connection from {} (tls={:?})",
+            self.0.client_addr, self.0.tls
+        )
+    }
+}
+
+impl std::error::Error for NonHttpClient {}

--- a/linkerd/app/src/admin.rs
+++ b/linkerd/app/src/admin.rs
@@ -31,7 +31,7 @@ pub struct Admin {
 }
 
 #[derive(Debug)]
-pub struct NonHttpClient(TcpAccept);
+struct NonHttpClient(TcpAccept);
 
 // === impl Config ===
 


### PR DESCRIPTION
fce8c4ae updated the admin server to try to handle connections that fail
HTTP detection. The intent of this was to handle connections that
don't emit any HTTP request within the first few seconds of the
connection. However, we also try to handle connections on which we have
read data and affirmatively indicated that the connection is not HTTP.
These connections manifest with errors about an invalid HTTP method,
which can be ambiguous to users.

This change handles this latter case explicitly with an error that
describes the client so that users have better diagnostics without
having to enable debug logging.