### PR TITLE
outbound: fix profile endpoint overrides

### DIFF
--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -29,7 +29,7 @@ pub struct Endpoint<P> {
 /// `Param<SkipHttpDetection>` for it.
 #[derive(Clone, Debug)]
 pub struct ProfileOverride {
-    endpoint: Endpoint<()>,
+    pub(crate) endpoint: Endpoint<()>,
     opaque_protocol: bool,
 }
 #[derive(Copy, Clone)]

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -86,11 +86,14 @@ impl<C> Outbound<C> {
 impl svc::Param<normalize_uri::DefaultAuthority> for Endpoint {
     fn param(&self) -> normalize_uri::DefaultAuthority {
         use std::str::FromStr;
-        let authority = self.logical_addr.as_ref().map(|logical| {
-            uri::Authority::from_str(&logical.to_string())
-                .expect("Address must be a valid authority")
-        });
-        normalize_uri::DefaultAuthority(authority)
+        let authority = self
+            .logical_addr
+            .as_ref()
+            .map(ToString::to_string)
+            .unwrap_or_else(|| self.addr.to_string());
+        normalize_uri::DefaultAuthority(Some(
+            uri::Authority::from_str(&authority).expect("Address must be a valid authority"),
+        ))
     }
 }
 

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -52,9 +52,12 @@ where
     R::Resolution: Send,
     R::Future: Send + Unpin,
 {
-    build_accept(cfg, rt, resolver, connect)
-        .push_discover(profiles)
-        .into_inner()
+    Outbound::new(cfg, rt).into_server_with(
+        resolver,
+        profiles,
+        connect,
+        support::connect::no_raw_tcp(),
+    )
 }
 
 fn build_accept<I, R>(

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -513,9 +513,11 @@ mod profile_endpoint {
         let (mut client, bg) =
             http_util::connect_and_accept(&mut ClientBuilder::new(), server).await;
 
-        let rsp = http_util::http_request(&mut client, Request::default()).await;
+        let rsp = http_util::http_request(&mut client, Request::default())
+            .await
+            .unwrap();
         assert_eq!(rsp.status(), http::StatusCode::OK);
-        let body = http_util::body_to_string(rsp.into_body()).await;
+        let body = http_util::body_to_string(rsp.into_body()).await.unwrap();
         assert_eq!(body, "Hello world!");
 
         drop(client);

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -97,7 +97,7 @@ where
 
     let http = connect
         .push_http_endpoint()
-        .push_http_logical(resolver.clone())
+        .push_http_logical(resolver)
         .push_http_server()
         .into_inner();
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -175,7 +175,7 @@ impl Outbound<()> {
         N::Future: Send + 'static,
     {
         let tcp_endpoint = self.clone().with_stack(tcp_endpoint);
-        let http_endpoint = self.clone().with_stack(http_endpoint).push_http_endpoint();
+        let http_endpoint = self.with_stack(http_endpoint).push_http_endpoint();
 
         // HTTP per-endpoint stack used when a profile is not discovered.
         let http_no_profile = http_endpoint

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -192,14 +192,14 @@ impl Outbound<()> {
             .into_inner();
 
         let endpoint_override = tcp_forward
-            .push_detect_http::<endpoint::ProfileOverride<()>, _, _, _, _, _, _>(
+            .push_detect_http::<endpoint::ProfileOverride, _, _, _, _, _, _>(
                 http_endpoint
                     .clone()
                     .push_http_server::<http::Endpoint, _>()
                     .into_inner(),
             )
             .into_stack()
-            .check_new_service::<endpoint::ProfileOverride<()>, _>()
+            .check_new_service::<endpoint::ProfileOverride, _>()
             .into_inner();
 
         // HTTP stack for logical targets (with service profiles).

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -204,6 +204,9 @@ impl Outbound<()> {
                     .into_inner(),
             )
             .into_stack()
+            .instrument(|ep: &endpoint::ProfileOverride| {
+                tracing::debug_span!("endpoint_override", addr = %ep.endpoint.addr)
+            })
             .check_new_service::<endpoint::ProfileOverride, _>()
             .into_inner();
 

--- a/linkerd/app/outbound/src/tcp/mod.rs
+++ b/linkerd/app/outbound/src/tcp/mod.rs
@@ -33,3 +33,9 @@ impl Param<Option<SessionProtocol>> for Endpoint {
         None
     }
 }
+
+impl Param<()> for Accept {
+    fn param(&self) -> () {
+        self.protocol
+    }
+}

--- a/linkerd/app/outbound/src/tcp/mod.rs
+++ b/linkerd/app/outbound/src/tcp/mod.rs
@@ -35,7 +35,7 @@ impl Param<Option<SessionProtocol>> for Endpoint {
 }
 
 impl Param<()> for Accept {
-    fn param(&self) -> () {
+    fn param(&self) {
         self.protocol
     }
 }

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -718,7 +718,7 @@ async fn no_discovery_when_profile_has_an_endpoint() {
     );
 }
 
-mod profile_endpoint_override {
+mod profile_endpoin {
     use super::*;
 
     #[tokio::test(flavor = "current_thread")]
@@ -784,7 +784,10 @@ mod profile_endpoint_override {
         );
     }
 
-    async fn test_endpoint_override(profile: profile::Profile) {
+    /// Tests that when a service profile contains an endpoint, the proxy
+    /// forwards to that endpoint directly without performing destination
+    /// resolution or building a logical stack.
+    async fn test_profile_endpoint(profile: profile::Profile) {
         let _trace = support::trace_init();
 
         let orig_dst = SocketAddr::new([10, 0, 0, 41].into(), 5550);
@@ -834,15 +837,19 @@ mod profile_endpoint_override {
         hello_world_client(orig_dst, &mut server).await
     }
 
+    /// Forwarding to a profile endpoint when the profile does not have a
+    /// logical address and its' opaque protocol flag is set.
     #[tokio::test(flavor = "current_thread")]
     async fn opaque_no_logical() {
-        test_endpoint_override(profile::Profile {
+        test_profile_endpoint(profile::Profile {
             opaque_protocol: true,
             ..Default::default()
         })
         .await
     }
 
+    /// Forwarding to a profile endpoint when the profile includes a
+    /// logical address and its' opaque protocol flag is set.
     #[tokio::test(flavor = "current_thread")]
     async fn opaque_with_logical_addr() {
         let addr = NameAddr::from_str("foo.ns1.svc.example.com:5550").unwrap();
@@ -851,14 +858,18 @@ mod profile_endpoint_override {
             opaque_protocol: true,
             ..Default::default()
         };
-        test_endpoint_override(profile).await
+        test_profile_endpoint(profile).await
     }
 
+    /// Forwarding to a profile endpoint when the profile does not have a
+    /// logical address and its' opaque protocol flag is not set.
     #[tokio::test(flavor = "current_thread")]
     async fn no_logical() {
-        test_endpoint_override(Default::default()).await
+        test_profile_endpoint(Default::default()).await
     }
 
+    /// Forwarding to a profile endpoint when the profile includes a
+    /// logical address and its' opaque protocol flag is not set.
     #[tokio::test(flavor = "current_thread")]
     async fn with_logical_addr() {
         let addr = NameAddr::from_str("foo.ns1.svc.example.com:5550").unwrap();
@@ -866,7 +877,7 @@ mod profile_endpoint_override {
             addr: Some(LogicalAddr(addr)),
             ..Default::default()
         };
-        test_endpoint_override(profile).await
+        test_profile_endpoint(profile).await
     }
 }
 

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -997,19 +997,12 @@ impl<P, D> Server<P, D> {
             connect,
         } = self;
         let (rt, _) = runtime();
-        let connect = Outbound::new(cfg, rt).with_stack(connect);
-        let endpoint = connect
-            .clone()
-            .push_tcp_forward()
-            .push_into_endpoint::<(), super::Accept>()
-            .push_detect_http::<_, _, _, _, _, crate::http::Accept, _>(support::service::no_http())
-            .into_inner();
-        connect
-            .push_tcp_logical(resolver)
-            .push_detect_http(support::service::no_http::<crate::http::Logical>())
-            .push_unwrap_logical(endpoint)
-            .push_discover(profiles)
-            .into_inner()
+        Outbound::new(cfg, rt).into_server_with(
+            resolver,
+            profiles,
+            support::connect::no_http(),
+            connect,
+        )
     }
 }
 

--- a/linkerd/app/test/src/connect.rs
+++ b/linkerd/app/test/src/connect.rs
@@ -26,6 +26,17 @@ pub struct Connect<E> {
 #[derive(Clone)]
 pub struct NoRawTcp;
 
+#[derive(Clone, Debug)]
+pub struct NoConnect(&'static str);
+
+pub fn no_raw_tcp() -> NoConnect {
+    NoConnect("raw TCP")
+}
+
+pub fn no_http() -> NoConnect {
+    NoConnect("HTTP")
+}
+
 impl<E> tower::Service<E> for Connect<E>
 where
     E: Clone + fmt::Debug + Param<Remote<ServerAddr>>,
@@ -57,19 +68,19 @@ where
     }
 }
 
-impl<E: fmt::Debug> tower::Service<E> for NoRawTcp {
+impl<E: fmt::Debug> tower::Service<E> for NoConnect {
     type Response = BoxedIo;
     type Future = Instrumented<ConnectFuture>;
     type Error = Error;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        panic!("no raw TCP connections expected in this test");
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, endpoint: E) -> Self::Future {
         panic!(
-            "no raw TCP connections expected in this test, but tried to connect to {:?}",
-            endpoint
+            "no {} connections expected in this test, but the {} stack tried to connect to {:?}",
+            self.0, self.0, endpoint
         );
     }
 }


### PR DESCRIPTION
PR #963 introduced a bug where, when a service profile contains an
endpoint override but no logical address, the proxy would ignore the
overridden endpoint. This is because the `unwrap_logical` layer checked
for the existence of the profile's logical address, as the `Logical`
target type has been changed to require a logical address. This means
that we would skip the logical stack correctly for endpoint overrides,
but would forward to the original destination address *without* honoring
the overridden address or any metadata provided by the profile. This bug
was detected by the control plane integration tests in the
linkerd/linkerd2 repo.

This branch fixes this by introducing a new stack for endpoint
overrides, which is now pushed *before* the `unwrap_logical` layer. Now,
we will first check if a profile with an endpoint override was
discovered, and if one was, we will build a stack for forwarding to that
endpoint, bypassing the logical stack. If there wasn't an endpoint
override, we will check if there is a profile, and build either a
logical stack or a direct endpoint stack. This required some
restructuring of the existing stacks.

I've also added new tests for profile endpoint overrides, with and
without logical addresses in the profile. This includes HTTP *and* TCP
stack tests, and the tests without logical overrides all fail prior to
this change. While I was working on wiring up these tests, I noticed
that the current stack tests all build their own custom server stacks,
rather than using the `Outbound::into_server` function. This means any
changes to the overall structure of the outbound stack *also* requires
updating the tests to match...so even after fixing the bug, the tests
continued to fail until the test stacks were changed to match the actual
ones. Rather than continuing to manually keep these in sync, I did some
additional refactoring to allow the tests to just call
`Outbound::into_server`, passing in HTTP and TCP endpoint stacks. Now,
the overall stack structure that is actually built in a real proxy is
always used in the tests without having to keep them in sync manually.

I think in a follow-up we may be able to remove additional logic for
handling endpoint overrides from the logical stack. However, I didn't
remove this code in this branch because I believe it's used by the
gateway and ingress code. I'll do some additional refactors in a
follow-up PR.