### PR TITLE
fuzz: allow client requests to fail 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -818,6 +818,7 @@ dependencies = [
  "linkerd-identity",
  "linkerd-io",
  "regex",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-test",

--- a/linkerd/app/inbound/fuzz/Cargo.lock
+++ b/linkerd/app/inbound/fuzz/Cargo.lock
@@ -688,6 +688,7 @@ dependencies = [
  "linkerd-identity",
  "linkerd-io",
  "regex",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-test",

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -324,7 +324,10 @@ pub mod fuzz_logic {
                         {
                             let rsp = http_util::http_request(&mut client, req).await;
                             tracing::info!(?rsp);
-                            let _body = http_util::body_to_string(rsp.into_body()).await;
+                            if let Ok(rsp) = rsp {
+                                let body = http_util::body_to_string(rsp.into_body()).await;
+                                tracing::info!(?body);
+                            }
                         }
                     }
                 }

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -81,9 +81,9 @@ async fn unmeshed_http1_hello_world() {
         .uri("http://foo.svc.cluster.local:5550")
         .body(Body::default())
         .unwrap();
-    let rsp = http_util::http_request(&mut client, req).await;
+    let rsp = http_util::http_request(&mut client, req).await.unwrap();
     assert_eq!(rsp.status(), http::StatusCode::OK);
-    let body = http_util::body_to_string(rsp.into_body()).await;
+    let body = http_util::body_to_string(rsp.into_body()).await.unwrap();
     assert_eq!(body, "Hello world!");
 
     drop(client);
@@ -130,9 +130,9 @@ async fn downgrade_origin_form() {
         .header("l5d-orig-proto", "HTTP/1.1")
         .body(Body::default())
         .unwrap();
-    let rsp = http_util::http_request(&mut client, req).await;
+    let rsp = http_util::http_request(&mut client, req).await.unwrap();
     assert_eq!(rsp.status(), http::StatusCode::OK);
-    let body = http_util::body_to_string(rsp.into_body()).await;
+    let body = http_util::body_to_string(rsp.into_body()).await.unwrap();
     assert_eq!(body, "Hello world!");
 
     drop(client);
@@ -178,9 +178,9 @@ async fn downgrade_absolute_form() {
         .header("l5d-orig-proto", "HTTP/1.1; absolute-form")
         .body(Body::default())
         .unwrap();
-    let rsp = http_util::http_request(&mut client, req).await;
+    let rsp = http_util::http_request(&mut client, req).await.unwrap();
     assert_eq!(rsp.status(), http::StatusCode::OK);
-    let body = http_util::body_to_string(rsp.into_body()).await;
+    let body = http_util::body_to_string(rsp.into_body()).await.unwrap();
     assert_eq!(body, "Hello world!");
 
     drop(client);

--- a/linkerd/app/integration/src/client.rs
+++ b/linkerd/app/integration/src/client.rs
@@ -131,7 +131,7 @@ impl Client {
             res.status(),
         );
         let stream = res.into_parts().1;
-        http_util::body_to_string(stream).await
+        http_util::body_to_string(stream).await.unwrap()
     }
 
     pub fn request(

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -805,7 +805,7 @@ macro_rules! http1_tests {
             let srv = server::http1()
                 .route_async("/", |req| async move {
                     assert_eq!(req.headers()["transfer-encoding"], "chunked");
-                    let body = http_util::body_to_string(req.into_body()).await;
+                    let body = http_util::body_to_string(req.into_body()).await.unwrap();
                     assert_eq!(body, "hello");
                     Ok::<_, std::io::Error>(
                         Response::builder()
@@ -830,7 +830,7 @@ macro_rules! http1_tests {
 
             assert_eq!(resp.status(), StatusCode::OK);
             assert_eq!(resp.headers()["transfer-encoding"], "chunked");
-            let body = http_util::body_to_string(resp.into_body()).await;
+            let body = http_util::body_to_string(resp.into_body()).await.unwrap();
             assert_eq!(body, "world");
 
             // ensure panics from the server are propagated
@@ -1011,7 +1011,7 @@ macro_rules! http1_tests {
             assert_eq!(resp.status(), StatusCode::OK);
             assert_eq!(resp.headers()["content-length"], "55");
 
-            let body = http_util::body_to_string(resp.into_body()).await;
+            let body = http_util::body_to_string(resp.into_body()).await.unwrap();
 
             assert_eq!(body, "");
 
@@ -1076,7 +1076,7 @@ macro_rules! http1_tests {
                     v
                 );
 
-                let body = http_util::body_to_string(resp.into_body()).await;
+                let body = http_util::body_to_string(resp.into_body()).await.unwrap();
 
                 assert_eq!(body, "body till eof", "HTTP/{} body", v);
             }

--- a/linkerd/app/outbound/src/http/tests.rs
+++ b/linkerd/app/outbound/src/http/tests.rs
@@ -272,9 +272,11 @@ async fn meshed_hello_world() {
     let server = build_server(cfg, rt, profiles, resolver, connect).new_service(addrs(ep1));
     let (mut client, bg) = http_util::connect_and_accept(&mut ClientBuilder::new(), server).await;
 
-    let rsp = http_util::http_request(&mut client, Request::default()).await;
+    let rsp = http_util::http_request(&mut client, Request::default())
+        .await
+        .unwrap();
     assert_eq!(rsp.status(), http::StatusCode::OK);
-    let body = http_util::body_to_string(rsp.into_body()).await;
+    let body = http_util::body_to_string(rsp.into_body()).await.unwrap();
     assert_eq!(body, "Hello world!");
 
     drop(client);
@@ -332,9 +334,11 @@ async fn stacks_idle_out() {
 
     let server = svc.new_service(addrs(ep1));
     let (mut client, bg) = http_util::connect_and_accept(&mut ClientBuilder::new(), server).await;
-    let rsp = http_util::http_request(&mut client, Request::default()).await;
+    let rsp = http_util::http_request(&mut client, Request::default())
+        .await
+        .unwrap();
     assert_eq!(rsp.status(), http::StatusCode::OK);
-    let body = http_util::body_to_string(rsp.into_body()).await;
+    let body = http_util::body_to_string(rsp.into_body()).await.unwrap();
     assert_eq!(body, "Hello world!");
 
     drop(client);
@@ -405,11 +409,13 @@ async fn active_stacks_dont_idle_out() {
 
     let (mut client, client_bg) =
         http_util::connect_client(&mut ClientBuilder::new(), client_io).await;
-    let rsp = http_util::http_request(&mut client, Request::default()).await;
+    let rsp = http_util::http_request(&mut client, Request::default())
+        .await
+        .unwrap();
     assert_eq!(rsp.status(), http::StatusCode::OK);
     let body = http_util::body_to_string(rsp.into_body());
     let body_task = tokio::spawn(async move {
-        let body = body.await;
+        let body = body.await.unwrap();
         assert_eq!(body, "Hello world!");
     });
 
@@ -470,9 +476,11 @@ async fn unmeshed_hello_world(
     let server = build_server(cfg, rt, profiles, resolver, connect).new_service(addrs(ep1));
     let (mut client, bg) = http_util::connect_and_accept(&mut client_settings, server).await;
 
-    let rsp = http_util::http_request(&mut client, Request::default()).await;
+    let rsp = http_util::http_request(&mut client, Request::default())
+        .await
+        .unwrap();
     assert_eq!(rsp.status(), http::StatusCode::OK);
-    let body = http_util::body_to_string(rsp.into_body()).await;
+    let body = http_util::body_to_string(rsp.into_body()).await.unwrap();
     assert_eq!(body, "Hello world!");
 
     drop(client);

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -32,6 +32,7 @@ tokio-stream = { version = "0.1.5", features = ["sync"] }
 tower = { version = "0.4.5", default-features = false}
 tracing = "0.1.23"
 tracing-subscriber = "0.2.16"
+thiserror = "1"
 
 [dev-dependencies.tracing-subscriber]
 version = "0.2.16"


### PR DESCRIPTION
Currently, the inbound HTTP fuzz tests are failing when the fuzzer
generates invalid HTTP headers and the proxy rejects the request by
closing the connection:

<details>
<summary>Failing fuzz test logs:</summary>

```
Apr 26 10:06:12.697  INFO fuzz_target_1: running with input requests=[HttpRequestSpec { http_method: false, uri: "ookm$o", header_name: "o\"mooookm$o", header_value: " " }, HttpRequestSpec { http_method: false, uri: "o", header_name: "o", header_value: "" }]
Apr 26 10:06:12.701 DEBUG linkerd_proxy_http::server: Creating HTTP service version=Http1
Apr 26 10:06:12.701  INFO linkerd_app_test::http_util: connecting client with settings=Builder { exec: Exec, h09_responses: false, h1_title_case_headers: false, h1_read_buf_exact_size: None, h1_max_buf_size: None, h2_builder: Config { adaptive_window: false, initial_conn_window_size: 5242880, initial_stream_window_size: 2097152, max_frame_size: 16384, keep_alive_interval: None, keep_alive_timeout: 20s, keep_alive_while_idle: false }, version: Http1 }
Apr 26 10:06:12.701 DEBUG linkerd_proxy_http::server: Handling as HTTP version=Http1
Apr 26 10:06:12.702 DEBUG proxy: linkerd_proxy_http::server: The client is shutting down the connection res=Err(hyper::Error(Parse(Header)))
Apr 26 10:06:12.702 DEBUG proxy: linkerd_app_test::http_util: dropped server
Apr 26 10:06:12.702  INFO proxy: linkerd_app_test::http_util: proxy serve task complete res=Err(hyper::Error(Parse(Header)))
Apr 26 10:06:12.703  INFO client_bg: linkerd_app_test::http_util: Client background complete res=Ok(())
Apr 26 10:06:12.703  INFO http_request{request=Request { method: POST, uri: ookm$o, version: HTTP/1.1, headers: {"o\"mooookm$o": " "}, body: Body(Empty) }}: linkerd_app_test::http_util: rsp=Response { status: 400, version: HTTP/1.1, headers: {"content-length": "0", "date": "Mon, 26 Apr 2021 17:06:12 GMT"}, body: Body(Empty) }
Apr 26 10:06:12.703  INFO linkerd_app_inbound::http::fuzz_logic: rsp=Response { status: 400, version: HTTP/1.1, headers: {"content-length": "0", "date": "Mon, 26 Apr 2021 17:06:12 GMT"}, body: Body(Empty) }
thread '<unnamed>' panicked at 'Client must not fail: hyper::Error(ChannelClosed)', /home/eliza/Code/linkerd2-proxy/linkerd/app/test/src/http_util.rs:111:10
stack backtrace:
    ...
```

</details>

This is because the test-support HTTP request helper expects the client
request to never fail --- valid behavior for the tests where this is
used, but not for the fuzz logic. This branch changes these functions to
return `Result`s so that the test that uses them can choose whether or
not to panic.

The test helper code currently uses `expect` messages to provide context
for _where_ a particular error occurred (e.g. were we driving the client
to readiness, or actually making a request?). Changing the test helpers
to return `Result`s would remove some of this context. Therefore, I
added a quick error wrapper type to wrap an error with a message,
allowing us to indicate where an error occurred while still returning a
`Result` that the test can choose to unwrap.