### PR TITLE
tower: update dependency to 0.4.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -11,7 +11,7 @@ futures = "0.3.9"
 http = "0.2"
 hyper = "0.14.2"
 pin-project = "1"
-tower = { version = "0.4.5", default-features = false, features = ["load"] }
+tower = { version = "0.4.7", default-features = false, features = ["load"] }
 tokio = { version = "1", features = ["macros"] }
 
 [dev-dependencies]

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -29,5 +29,5 @@ thiserror = "1.0"
 tokio = { version = "1", features = ["rt"] }
 tokio-stream = { version = "0.1.5", features = ["time", "sync"] }
 tonic = { version = "0.4", default-features = false, features = ["prost"] }
-tower = "0.4"
+tower = "0.4.7"
 tracing = "0.1.23"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -70,9 +70,7 @@ tracing = "0.1.23"
 pin-project = "1"
 
 [dependencies.tower]
-version = "0.4"
-# disable tower's tracing `log` integration for performance reasons, since we
-# will consume tower's traces as traces.
+version = "0.4.7"
 default-features = false
 features = [
     "buffer",

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -15,12 +15,12 @@ linkerd-app-inbound = { path = "../inbound" }
 linkerd-app-outbound = { path = "../outbound" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["sync"] }
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }
 tracing = "0.1.23"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
 tokio-test = "0.4"
-tower = { version = "0.4.5", default-features = false, features = ["util"] }
+tower = { version = "0.4.7", default-features = false, features = ["util"] }
 tower-test = "0.4"
 linkerd-app-test = { path = "../test" }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -17,6 +17,7 @@ indexmap = "1.0"
 linkerd-app-core = { path = "../core" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["sync"] }
+tower = { version = "0.4.7", features = ["util"] }
 tracing = "0.1.23"
 
 [target.'cfg(fuzzing)'.dependencies]
@@ -24,15 +25,6 @@ hyper = { version = "0.14.2", features = ["http1", "http2"] }
 linkerd-app-test = { path = "../test" }
 arbitrary = { version = "1",  features = ["derive"] }
 libfuzzer-sys = { version = "0.4.0", features = ["arbitrary-derive"] }
-
-[dependencies.tower]
-version = "0.4"
-# disable tower's tracing `log` integration for performance reasons, since we
-# will consume tower's traces as traces.
-default-features = false
-features = [
-    "util",
-]
 
 [dev-dependencies]
 hyper = { version = "0.14.2", features = ["http1", "http2"] }

--- a/linkerd/app/inbound/fuzz/Cargo.lock
+++ b/linkerd/app/inbound/fuzz/Cargo.lock
@@ -2069,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -34,7 +34,7 @@ rustls = "0.19"
 tokio = { version = "1", features = ["io-util", "net", "rt", "macros"]}
 tokio-stream = { version = "0.1.5", features = ["sync"] }
 tokio-rustls = "0.22"
-tower = { version = "0.4.5", default-features = false}
+tower = { version = "0.4.7", default-features = false}
 tonic = { version = "0.4", default-features = false }
 tracing = "0.1.23"
 webpki = "0.21"

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -24,17 +24,9 @@ linkerd-identity = { path = "../../identity" }
 linkerd-retry = { path = "../../retry" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["sync"]}
+tower = { version = "0.4.7", features = ["util"]}
 tracing = "0.1.23"
 pin-project = "1"
-
-[dependencies.tower]
-version = "0.4"
-# disable tower's tracing `log` integration for performance reasons, since we
-# will consume tower's traces as traces.
-default-features = false
-features = [
-    "util",
-]
 
 [dev-dependencies]
 hyper = { version = "0.14.2", features = ["http1", "http2"] }

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -29,7 +29,7 @@ regex = "1"
 tokio = { version = "1", features = ["io-util", "net", "rt", "sync"]}
 tokio-test = "0.4"
 tokio-stream = { version = "0.1.5", features = ["sync"] }
-tower = { version = "0.4.5", default-features = false}
+tower = { version = "0.4.7", default-features = false}
 tracing = "0.1.23"
 tracing-subscriber = "0.2.16"
 thiserror = "1"

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -12,7 +12,7 @@ linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 parking_lot = "0.11"
 tokio = { version = "1", default-features = false, features = ["rt", "sync", "time"] }
-tower = { version = "0.4.5", default-features = false, features = ["util"] }
+tower = { version = "0.4.7", default-features = false, features = ["util"] }
 tracing = "0.1.23"
 
 [dev-dependencies]

--- a/linkerd/concurrency-limit/Cargo.toml
+++ b/linkerd/concurrency-limit/Cargo.toml
@@ -12,6 +12,6 @@ futures = "0.3.9"
 linkerd-stack = { path = "../stack" }
 tokio = { version = "1", features = ["sync"] }
 tokio-util = "0.6.5"
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }
 tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/detect/Cargo.toml
+++ b/linkerd/detect/Cargo.toml
@@ -14,5 +14,5 @@ linkerd-io = { path = "../io" }
 linkerd-stack = { path = "../stack" }
 tokio = { version = "1", features = ["time"] }
 thiserror = "1.0"
-tower = "0.4"
+tower = "0.4.7"
 tracing = "0.1.23"

--- a/linkerd/drain/Cargo.toml
+++ b/linkerd/drain/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3.9"
 tokio = { version = "1", features = ["macros", "sync"] }
 
 linkerd-stack = { path = "../stack", optional = true }
-tower = { version = "0.4.5", default-features = false, optional = true }
+tower = { version = "0.4.7", default-features = false, optional = true }
 
 [dev-dependencies]
 pin-project = "1"

--- a/linkerd/error-metrics/Cargo.toml
+++ b/linkerd/error-metrics/Cargo.toml
@@ -11,5 +11,5 @@ publish = false
 futures = "0.3.9"
 indexmap = "1.0"
 linkerd-metrics = { path = "../metrics" }
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }
 pin-project = "1"

--- a/linkerd/error-respond/Cargo.toml
+++ b/linkerd/error-respond/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 [dependencies]
 futures = "0.3.9"
 linkerd-error = { path = "../error" }
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }
 pin-project = "1"

--- a/linkerd/http-classify/Cargo.toml
+++ b/linkerd/http-classify/Cargo.toml
@@ -10,4 +10,4 @@ publish = false
 http = "0.2"
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -17,11 +17,6 @@ linkerd-error = { path = "../error" }
 linkerd-http-classify = { path = "../http-classify" }
 linkerd-metrics = { path = "../metrics" }
 linkerd-stack = { path = "../stack" } 
+tower = "0.4.7"
 tracing = "0.1.23"
 pin-project = "1"
-
-[dependencies.tower]
-version = "0.4"
-# disable tower's tracing `log` integration for performance reasons, since we
-# will consume tower's traces as traces.
-default-features = false

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -14,7 +14,7 @@ linkerd-error = { path = "../error" }
 linkerd-metrics = { path = "../metrics" }
 opencensus-proto = { path = "../../opencensus-proto" }
 tonic = { version = "0.4", default-features = false, features = ["prost", "codegen"] }
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-stream = { version = "0.1.5", features = ["sync"] }
 tracing = "0.1.23"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -24,5 +24,5 @@ indexmap = "1.0"
 pin-project = "1"
 prost = "0.7"
 tonic = { version = "0.4", default-features = false }
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }
 tracing = "0.1.23"

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -12,5 +12,5 @@ Core interfaces needed to implement proxy components
 [dependencies]
 futures = "0.3.9"
 linkerd-error = { path = "../../error" }
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }
 pin-project = "1"

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -17,17 +17,11 @@ linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["sync", "time"] }
 tokio-util = "0.6.5"
+tower = { version = "0.4.7", features = ["discover"] }
 tracing = "0.1.23"
 pin-project = "1"
-
-[dependencies.tower]
-version = "0.4"
-# disable tower's tracing `log` integration for performance reasons, since we
-# will consume tower's traces as traces.
-default-features = false
-features = ["discover"]
 
 [dev-dependencies]
 async-stream = "0.3"
 tokio = { version = "1", features = ["macros", "rt"] }
-tower = { version = "0.4.5", default-features = false, features = ["discover", "util"]}
+tower = { version = "0.4.7", default-features = false, features = ["discover", "util"]}

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -18,10 +18,5 @@ linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["sync"] }
 tokio-stream = { version = "0.1.5", features = ["sync"]}
+tower = "0.4.7"
 tracing = "0.1.9"
-
-[dependencies.tower]
-version = "0.4"
-# disable tower's tracing `log` integration for performance reasons, since we
-# will consume tower's traces as traces.
-default-features = false

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -35,7 +35,7 @@ linkerd-timeout = { path = "../../timeout" }
 rand = "0.8"
 thiserror = "1.0"
 tokio = { version = "1", features = ["time", "rt"] }
-tower = { version = "0.4.5", default-features = false, features = ["balance", "load", "discover"] }
+tower = { version = "0.4.7", default-features = false, features = ["balance", "load", "discover"] }
 tracing = "0.1.23"
 try-lock = "0.2"
 pin-project = "1"

--- a/linkerd/proxy/http/fuzz/Cargo.lock
+++ b/linkerd/proxy/http/fuzz/Cargo.lock
@@ -1013,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/linkerd/proxy/resolve/Cargo.toml
+++ b/linkerd/proxy/resolve/Cargo.toml
@@ -14,11 +14,6 @@ futures = "0.3.9"
 linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 thiserror = "1.0"
+tower = "0.4.7"
 tracing = "0.1"
 pin-project = "1"
-
-[dependencies.tower]
-version = "0.4"
-# disable tower's tracing `log` integration for performance reasons, since we
-# will consume tower's traces as traces.
-default-features = false

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -24,7 +24,7 @@ linkerd-tls = { path = "../../tls" }
 rand = { version = "0.8" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["time"]}
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }
 tonic = { version = "0.4", default-features = false }
 tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/proxy/tcp/Cargo.toml
+++ b/linkerd/proxy/tcp/Cargo.toml
@@ -14,5 +14,5 @@ linkerd-error = { path = "../../error" }
 linkerd-stack = { path = "../../stack" }
 rand = "0.8"
 tokio = { version = "1" }
-tower = { version = "0.4.5", default-features = false, features = ["balance", "load", "discover"] }
+tower = { version = "0.4.7", default-features = false, features = ["balance", "load", "discover"] }
 pin-project = "1"

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -10,6 +10,6 @@ publish = false
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 futures = "0.3.9"
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }
 tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/retry/Cargo.toml
+++ b/linkerd/retry/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 [dependencies]
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
-tower = { version = "0.4.5", default-features = false, features = ["retry", "util"] }
+tower = { version = "0.4.7", default-features = false, features = ["retry", "util"] }
 tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -26,19 +26,9 @@ regex = "1.0.0"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 async-stream = "0.3"
 tonic = { version = "0.4", default-features = false }
+tower = { version = "0.4.7", features = [ "ready-cache", "retry", "util"] }
 tracing = "0.1.23"
 pin-project = "1"
-
-[dependencies.tower]
-version = "0.4"
-# disable tower's tracing `log` integration for performance reasons, since we
-# will consume tower's traces as traces.
-default-features = false
-features = [
-    "ready-cache",
-    "retry",
-    "util",
-]
 
 [dev-dependencies]
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18", features = ["arbitrary"] }

--- a/linkerd/stack/metrics/Cargo.toml
+++ b/linkerd/stack/metrics/Cargo.toml
@@ -9,5 +9,5 @@ publish = false
 [dependencies]
 indexmap = "1.0"
 linkerd-metrics = { path = "../../metrics" }
-tower = { version = "0.4.5", default-features = false }
+tower = { version = "0.4.7", default-features = false }
 tokio = { version = "1", features = ["time"] }

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -10,11 +10,6 @@ publish = false
 futures = "0.3.9"
 linkerd-error = { path = "../../error" }
 linkerd-stack = { path = ".." }
+tower = "0.4.7"
 tracing = "0.1.25"
 pin-project = "1"
-
-[dependencies.tower]
-version = "0.4"
-# disable tower's tracing `log` integration for performance reasons, since we
-# will consume tower's traces as traces.
-default-features = false

--- a/linkerd/timeout/Cargo.toml
+++ b/linkerd/timeout/Cargo.toml
@@ -14,16 +14,7 @@ thiserror = "1"
 tracing = "0.1.23"
 pin-project = "1"
 tokio = { version = "1", features = ["time"] }
-
-[dependencies.tower]
-version = "0.4"
-# disable tower's tracing `log` integration for performance reasons, since we
-# will consume tower's traces as traces.
-default-features = false
-features = [
-    "util",
-    "make",
-]
+tower = { version = "0.4.7", features = ["util", "make"] }
 
 [dev-dependencies]
 tower-test = "0.4"

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -20,7 +20,7 @@ rustls = "0.19"
 thiserror = "1.0"
 tokio = { version = "1", features = ["macros", "time"]}
 tokio-rustls = "0.22"
-tower = "0.4.5"
+tower = "0.4.7"
 tracing = "0.1.23"
 webpki = "0.21"
 untrusted = "0.7"
@@ -29,5 +29,5 @@ untrusted = "0.7"
 linkerd-identity = { path = "../identity", features = ["test-util"] }
 linkerd-proxy-transport = { path = "../proxy/transport" }
 tokio = { version = "1", features = ["rt-multi-thread"] }
-tower = { version = "0.4.5", default-features = false, features = ["util"] }
+tower = { version = "0.4.7", default-features = false, features = ["util"] }
 tracing-subscriber = "0.2.16"

--- a/linkerd/tls/fuzz/Cargo.lock
+++ b/linkerd/tls/fuzz/Cargo.lock
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f715efe02c0862926eb463e49368d38ddb119383475686178e32e26d15d06a66"
+checksum = "bf0aa6dfc29148c3826708dabbfa83c121eeb84df4d1468220825e3a33651687"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -16,5 +16,5 @@ linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 rand = "0.8"
 thiserror = "1.0"
-tower = { version = "0.4.5", default-features = false, features = ["util"] }
+tower = { version = "0.4.7", default-features = false, features = ["util"] }
 tracing = "0.1.2"


### PR DESCRIPTION
This updates `tower` to v0.4.7. This picks up tower-rs/tower#581, which
fixes a task leak in `SpawnReady` that resulted in a memory leak in the
proxy.