### PR TITLE
outbound: Make the Endpoint::logical_addr field optional

### DIFF
--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -5,11 +5,12 @@ use crate::{
 };
 use linkerd_app_core::{
     metrics,
+    profiles::LogicalAddr,
     proxy::{api_resolve::Metadata, http, resolve::map_endpoint::MapEndpoint},
     svc::{self, Param},
     tls,
     transport::{self, Remote, ServerAddr},
-    transport_header, Addr, Conditional,
+    transport_header, Conditional,
 };
 use std::net::SocketAddr;
 
@@ -18,7 +19,7 @@ pub struct Endpoint<P> {
     pub addr: Remote<ServerAddr>,
     pub tls: tls::ConditionalClientTls,
     pub metadata: Metadata,
-    pub logical_addr: Addr,
+    pub logical_addr: Option<LogicalAddr>,
     pub protocol: P,
 }
 
@@ -71,14 +72,14 @@ impl<P> From<(tls::NoClientTls, Logical<P>)> for Endpoint<P> {
                 addr: Remote(ServerAddr(logical.orig_dst.into())),
                 metadata: Metadata::default(),
                 tls: Conditional::None(reason),
-                logical_addr: logical.addr(),
+                logical_addr: Some(logical.logical_addr),
                 protocol: logical.protocol,
             },
             Some((addr, metadata)) => Self {
                 addr: Remote(ServerAddr(addr)),
                 tls: FromMetadata::client_tls(&metadata, reason),
                 metadata,
-                logical_addr: logical.addr(),
+                logical_addr: Some(logical.logical_addr),
                 protocol: logical.protocol,
             },
         }
@@ -91,7 +92,7 @@ impl<P> From<(tls::NoClientTls, Accept<P>)> for Endpoint<P> {
             addr: Remote(ServerAddr(accept.orig_dst.into())),
             metadata: Metadata::default(),
             tls: Conditional::None(reason),
-            logical_addr: accept.orig_dst.0.into(),
+            logical_addr: None,
             protocol: accept.protocol,
         }
     }
@@ -134,11 +135,16 @@ impl<P> Param<transport::labels::Key> for Endpoint<P> {
 
 impl<P> Param<metrics::OutboundEndpointLabels> for Endpoint<P> {
     fn param(&self) -> metrics::OutboundEndpointLabels {
+        let target_addr = self.addr.into();
+        let authority = self
+            .logical_addr
+            .as_ref()
+            .map(|LogicalAddr(a)| a.as_http_authority());
         metrics::OutboundEndpointLabels {
-            authority: Some(self.logical_addr.to_http_authority()),
+            authority,
             labels: metrics::prefix_labels("dst", self.metadata.labels().iter()),
             server_id: self.tls.clone(),
-            target_addr: self.addr.into(),
+            target_addr,
         }
     }
 }
@@ -206,7 +212,7 @@ impl<P: Copy + std::fmt::Debug> MapEndpoint<Concrete<P>, Metadata> for FromMetad
             addr: Remote(ServerAddr(addr)),
             tls,
             metadata,
-            logical_addr: concrete.logical.addr(),
+            logical_addr: Some(concrete.logical.logical_addr.clone()),
             protocol: concrete.logical.protocol,
         }
     }

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -216,7 +216,7 @@ impl From<(tls::NoClientTls, Target)> for http::Endpoint {
             addr,
             metadata: Metadata::default(),
             tls: Conditional::None(reason),
-            logical_addr: dst,
+            logical_addr: None,
             protocol: version,
         }
     }

--- a/linkerd/app/outbound/src/tcp/opaque_transport.rs
+++ b/linkerd/app/outbound/src/tcp/opaque_transport.rs
@@ -149,7 +149,7 @@ mod test {
         tls,
         transport::{Remote, ServerAddr},
         transport_header::TransportHeader,
-        Addr, Conditional,
+        Conditional,
     };
     use pin_project::pin_project;
     use std::task::Context;
@@ -170,7 +170,7 @@ mod test {
                     tls::NoClientTls::NotProvidedByServiceDiscovery,
                 )),
             metadata,
-            logical_addr: Addr::Socket(([127, 0, 0, 2], 4321).into()),
+            logical_addr: None,
             protocol: (),
         }
     }


### PR DESCRIPTION
The `outbound::Endpoint::logical_addr` field must currently _always_ be
set, even when it just duplicates the endpoint's target address and
there is no "logical" address.

This change makes this field optional and changes its type to require a
`LogicalAddr` (as returned by a profile lookup).

As a result of this, the `authority` endpoint metrics label is now only
set when a logical address is present.