### PR TITLE
trace: explicitly disable ANSI terminal colors

### DIFF
--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -31,7 +31,7 @@ tokio-test = "0.4"
 tokio-stream = { version = "0.1.5", features = ["sync"] }
 tower = { version = "0.4.7", default-features = false}
 tracing = "0.1.23"
-tracing-subscriber = "0.2.16"
+tracing-subscriber = { version = "0.2.16", features = ["env-filter", "fmt"], default-features = false }
 thiserror = "1"
 
 [dev-dependencies.tracing-subscriber]

--- a/linkerd/tracing/Cargo.toml
+++ b/linkerd/tracing/Cargo.toml
@@ -20,7 +20,6 @@ tracing-log = "0.1.2"
 
 [dependencies.tracing-subscriber]
 version = "0.2.16"
-# we don't need `chrono` time formatting or ANSI colored output
 default-features = false
-features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot"]
+features = ["ansi", "env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot"]
 

--- a/linkerd/tracing/src/lib.rs
+++ b/linkerd/tracing/src/lib.rs
@@ -123,7 +123,8 @@ impl Settings {
                     .event_format(fmt)
                     // Since we're using the JSON event formatter, we must also
                     // use the JSON field formatter.
-                    .fmt_fields(format::JsonFields::default());
+                    .fmt_fields(format::JsonFields::default())
+                    .with_ansi(false);
                 let registry = registry.with(tasks_layer);
                 let dispatch = if self.test {
                     registry.with(fmt.with_test_writer()).into()
@@ -135,7 +136,9 @@ impl Settings {
             _ => {
                 let (tasks, tasks_layer) = TasksLayer::<format::DefaultFields>::new();
                 let registry = registry.with(tasks_layer);
-                let fmt = tracing_subscriber::fmt::layer().event_format(fmt);
+                let fmt = tracing_subscriber::fmt::layer()
+                    .event_format(fmt)
+                    .with_ansi(self.test);
                 let dispatch = if self.test {
                     registry.with(fmt.with_test_writer()).into()
                 } else {


### PR DESCRIPTION
Currently, the use of ANSI terminal color codes by `tracing-subscriber`
is controlled by a feature flag, which is only eenabled by
`dev-dependencies` when building tests. However, despite this, the
feature flag appears to still be enabled in release builds --- despite
`cargo tree -e features -e no-dev -i tracing-subscriber` indicating that
it isn't enabled by any non-dev dependency.

Since this results in mangled logs in Kubernetes (fluentd doesn't handle
ANSI escape codes), this branch changes the proxy's tracing setup to
explicitly disable them outside of tests.