### PR TITLE
outbound: Do not support TCP-forwarding in ingress-mode

### DIFF
--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -42,10 +42,8 @@ struct IngressHttpOnly;
 impl<H> Outbound<H> {
     /// Routes HTTP requests according to the l5d-dst-override header.
     ///
-    /// Forwards TCP connections without discovery/routing (or mTLS).
-    ///
     /// This is only intended for Ingress configurations, where we assume all
-    /// outbound traffic is either HTTP or TLS'd by the ingress proxy.
+    /// outbound traffic is HTTP.
     pub fn into_ingress<T, I, HSvc, P>(
         self,
         profiles: P,

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -1,30 +1,54 @@
 use crate::{http, stack_labels, tcp, trace_labels, Config, Outbound};
 use linkerd_app_core::{
     config::{ProxyConfig, ServerConfig},
-    detect, discovery_rejected, drain, errors, http_request_l5d_override_dst_name_addr,
-    http_tracing, io, profiles,
+    detect, discovery_rejected, errors, http_request_l5d_override_dst_name_addr, http_tracing, io,
+    profiles,
     proxy::api_resolve::Metadata,
     svc::{self, stack::Param},
     tls,
-    transport::{self, OrigDstAddr, Remote, ServerAddr},
+    transport::{OrigDstAddr, Remote, ServerAddr},
     AddrMatch, Conditional, Error, NameAddr,
 };
 use std::convert::TryFrom;
 use thiserror::Error;
 use tracing::{debug_span, info_span};
 
-impl Outbound<()> {
+#[derive(Clone)]
+struct AllowHttpProfile(AddrMatch);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct Target {
+    dst: NameAddr,
+    version: http::Version,
+}
+
+#[derive(Clone)]
+struct TargetPerRequest(http::Accept);
+
+#[derive(Debug, Error)]
+#[error("ingress-mode routing requires a service profile")]
+struct ProfileRequired;
+
+#[derive(Debug, Error)]
+#[error("ingress-mode routing requires the l5d-dst-override header")]
+struct DstOverrideRequired;
+
+#[derive(Debug, Default, Error)]
+#[error("ingress-mode routing is HTTP-only")]
+struct IngressHttpOnly;
+
+// === impl Outbound ===
+
+impl<H> Outbound<H> {
     /// Routes HTTP requests according to the l5d-dst-override header.
     ///
     /// Forwards TCP connections without discovery/routing (or mTLS).
     ///
     /// This is only intended for Ingress configurations, where we assume all
     /// outbound traffic is either HTTP or TLS'd by the ingress proxy.
-    pub fn to_ingress<T, I, N, NSvc, H, HSvc, P>(
-        &self,
+    pub fn into_ingress<T, I, HSvc, P>(
+        self,
         profiles: P,
-        tcp: N,
-        http: H,
     ) -> impl svc::NewService<
         T,
         Service = impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
@@ -32,14 +56,6 @@ impl Outbound<()> {
     where
         T: Param<OrigDstAddr> + Clone + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
-        N: svc::NewService<tcp::Endpoint, Service = NSvc> + Clone + Send + Sync + 'static,
-        NSvc: svc::Service<io::PrefixedIo<transport::metrics::SensorIo<I>>, Response = ()>
-            + Clone
-            + Send
-            + Sync
-            + 'static,
-        NSvc::Error: Into<Error>,
-        NSvc::Future: Send,
         H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
         HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
             + Send
@@ -50,6 +66,11 @@ impl Outbound<()> {
         P::Error: Send,
         P::Future: Send,
     {
+        let Self {
+            config,
+            runtime: rt,
+            stack: http,
+        } = self;
         let Config {
             allow_discovery,
             proxy:
@@ -63,105 +84,76 @@ impl Outbound<()> {
                     ..
                 },
             ..
-        } = self.config.clone();
+        } = config;
         let allow = AllowHttpProfile(allow_discovery);
 
-        let tcp = svc::stack(tcp)
-            .push_on_response(drain::Retain::layer(self.runtime.drain.clone()))
-            .push_map_target(|a: tcp::Accept| {
-                tcp::Endpoint::from((tls::NoClientTls::IngressNonHttp, a))
-            })
-            .into_inner();
-
-        svc::stack(http)
-            .push_on_response(
-                svc::layers()
-                    .push(http::BoxRequest::layer())
-                    .push(svc::MapErrLayer::new(Into::<Error>::into)),
-            )
-            // Lookup the profile for the outbound HTTP target, if appropriate.
-            //
-            // This service is buffered because it needs to initialize the profile
-            // resolution and a failfast is instrumented in case it becomes
-            // unavailable
-            // When this service is in failfast, ensure that we drive the
-            // inner service to readiness even if new requests aren't
-            // received.
-            .push_request_filter(http::Logical::try_from)
-            .check_new_service::<(Option<profiles::Receiver>, Target), _>()
-            .push(profiles::discover::layer(profiles, allow))
-            .push_on_response(
-                svc::layers()
-                    .push(
-                        self.runtime
-                            .metrics
-                            .stack
-                            .layer(stack_labels("http", "logical")),
-                    )
-                    .push(svc::layer::mk(svc::SpawnReady::new))
-                    .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
-                    .push_spawn_buffer(buffer_capacity),
-            )
-            .push_cache(cache_max_idle_age)
-            .push_on_response(http::Retain::layer())
-            .instrument(|t: &Target| info_span!("target", dst = %t.dst))
-            // Obtain a new inner service for each request (fom the above cache).
-            //
-            // Note that the router service is always ready, so the `FailFast` layer
-            // need not use a `SpawnReady` to drive the service to ready.
-            .push(svc::NewRouter::layer(TargetPerRequest::accept))
-            .push(http::NewNormalizeUri::layer())
-            .push_on_response(
-                svc::layers()
-                    .push(http::MarkAbsoluteForm::layer())
-                    .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
-                    .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
-                    .push(self.runtime.metrics.http_errors.clone())
-                    .push(errors::layer())
-                    .push(http_tracing::server(
-                        self.runtime.span_sink.clone(),
-                        trace_labels(),
-                    ))
-                    .push(http::BoxResponse::layer()),
-            )
-            .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
-            .push(http::NewServeHttp::layer(
-                h2_settings,
-                self.runtime.drain.clone(),
-            ))
-            .push_map_target(http::Accept::from)
-            .push(svc::UnwrapOr::layer(tcp))
-            .push_cache(cache_max_idle_age)
-            .push_map_target(detect::allow_timeout)
-            .push(detect::NewDetectService::layer(
-                detect_protocol_timeout,
-                http::DetectHttp::default(),
-            ))
-            .push(self.runtime.metrics.transport.layer_accept())
-            .instrument(|a: &tcp::Accept| info_span!("ingress", orig_dst = %a.orig_dst))
-            .push_map_target(|a: T| {
-                let orig_dst = Param::<OrigDstAddr>::param(&a);
-                tcp::Accept::from(orig_dst)
-            })
-            // Boxing is necessary purely to limit the link-time overhead of
-            // having enormous types.
-            .push(svc::BoxNewService::layer())
-            .check_new_service::<T, I>()
-            .into_inner()
+        http.push_on_response(
+            svc::layers()
+                .push(http::BoxRequest::layer())
+                .push(svc::MapErrLayer::new(Into::<Error>::into)),
+        )
+        // Lookup the profile for the outbound HTTP target, if appropriate.
+        //
+        // This service is buffered because it needs to initialize the profile
+        // resolution and a failfast is instrumented in case it becomes
+        // unavailable
+        // When this service is in failfast, ensure that we drive the
+        // inner service to readiness even if new requests aren't
+        // received.
+        .push_request_filter(http::Logical::try_from)
+        .check_new_service::<(Option<profiles::Receiver>, Target), _>()
+        .push(profiles::discover::layer(profiles, allow))
+        .push_on_response(
+            svc::layers()
+                .push(rt.metrics.stack.layer(stack_labels("http", "logical")))
+                .push(svc::layer::mk(svc::SpawnReady::new))
+                .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
+                .push_spawn_buffer(buffer_capacity),
+        )
+        .push_cache(cache_max_idle_age)
+        .push_on_response(http::Retain::layer())
+        .instrument(|t: &Target| info_span!("target", dst = %t.dst))
+        // Obtain a new inner service for each request (fom the above cache).
+        //
+        // Note that the router service is always ready, so the `FailFast` layer
+        // need not use a `SpawnReady` to drive the service to ready.
+        .push(svc::NewRouter::layer(TargetPerRequest::accept))
+        .push(http::NewNormalizeUri::layer())
+        .push_on_response(
+            svc::layers()
+                .push(http::MarkAbsoluteForm::layer())
+                .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
+                .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
+                .push(rt.metrics.http_errors.clone())
+                .push(errors::layer())
+                .push(http_tracing::server(rt.span_sink, trace_labels()))
+                .push(http::BoxResponse::layer()),
+        )
+        .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
+        .push(http::NewServeHttp::layer(h2_settings, rt.drain))
+        .push_map_target(http::Accept::from)
+        .push(svc::UnwrapOr::layer(
+            svc::Fail::<_, IngressHttpOnly>::default(),
+        ))
+        .push_cache(cache_max_idle_age)
+        .push_map_target(detect::allow_timeout)
+        .push(detect::NewDetectService::layer(
+            detect_protocol_timeout,
+            http::DetectHttp::default(),
+        ))
+        .push(rt.metrics.transport.layer_accept())
+        .instrument(|a: &tcp::Accept| info_span!("ingress", orig_dst = %a.orig_dst))
+        .push_map_target(|a: T| {
+            let orig_dst = Param::<OrigDstAddr>::param(&a);
+            tcp::Accept::from(orig_dst)
+        })
+        // Boxing is necessary purely to limit the link-time overhead of
+        // having enormous types.
+        .push(svc::BoxNewService::layer())
+        .check_new_service::<T, I>()
+        .into_inner()
     }
 }
-
-#[derive(Clone)]
-struct AllowHttpProfile(AddrMatch);
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct Target {
-    dst: NameAddr,
-    version: http::Version,
-}
-
-#[derive(Clone)]
-struct TargetPerRequest(http::Accept);
 
 // === AllowHttpProfile ===
 
@@ -233,13 +225,3 @@ impl<B> svc::stack::RecognizeRoute<http::Request<B>> for TargetPerRequest {
         })
     }
 }
-
-// === impl ProfileRequired ===
-
-#[derive(Debug, Error)]
-#[error("ingress routing requires a service profile")]
-struct ProfileRequired;
-
-#[derive(Debug, Error)]
-#[error("ingress routing requires the l5d-dst-override header")]
-struct DstOverrideRequired;

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -196,18 +196,12 @@ impl Outbound<()> {
         let serve = async move {
             if self.config.ingress_mode {
                 info!("Outbound routing in ingress-mode");
-                let tcp = self
-                    .to_tcp_connect()
-                    .push_tcp_endpoint()
-                    .push_tcp_forward()
-                    .into_inner();
-                let http = self
+                let stack = self
                     .to_tcp_connect()
                     .push_tcp_endpoint()
                     .push_http_endpoint()
                     .push_http_logical(resolve)
-                    .into_inner();
-                let stack = self.to_ingress(profiles, tcp, http);
+                    .into_ingress(profiles);
                 let shutdown = self.runtime.drain.signaled();
                 serve::serve(listen, stack, shutdown).await;
             } else {

--- a/linkerd/tls/src/client.rs
+++ b/linkerd/tls/src/client.rs
@@ -42,9 +42,6 @@ pub enum NoClientTls {
     /// doesn't need or support TLS.
     Loopback,
 
-    // Discovery is not performed for non-HTTP connections when in "ingress mode".
-    IngressNonHttp,
-
     /// The destination service didn't give us the identity, which is its way
     /// of telling us that we shouldn't do TLS for this endpoint.
     NotProvidedByServiceDiscovery,
@@ -198,7 +195,6 @@ impl fmt::Display for NoClientTls {
             Self::NotProvidedByServiceDiscovery => {
                 write!(f, "not_provided_by_service_discovery")
             }
-            Self::IngressNonHttp => write!(f, "ingress_non_http"),
         }
     }
 }


### PR DESCRIPTION
The ingress-mode proxy has some simplistic support for TCP forwarding;
but this is somewhat of a misfeature. Specifically, we don't do any
mTLS/discovery for these connections, so detection failures can manifest
as unexpected insecure connections.

For now, we should remove TCP-forwarding support from ingress-mode
proxies. This will help support further simplifications to the
ingress-mode proxy.