### PR TITLE
tests: Use io::Error in mocked connector

### DIFF
--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -8,12 +8,11 @@ use crate::{
 };
 use hyper::{client::conn::Builder as ClientBuilder, Body, Request, Response};
 use linkerd_app_core::{
-    io::{self, BoxedIo},
-    proxy,
+    io, proxy,
     svc::{self, NewService, Param},
     tls,
     transport::{ClientAddr, Remote, ServerAddr},
-    Conditional, Error, NameAddr, ProxyRuntime,
+    Conditional, NameAddr, ProxyRuntime,
 };
 use tracing::Instrument;
 
@@ -190,7 +189,7 @@ async fn downgrade_absolute_form() {
 #[tracing::instrument]
 fn hello_server(
     http: hyper::server::conn::Http,
-) -> impl Fn(Remote<ServerAddr>) -> Result<BoxedIo, Error> {
+) -> impl Fn(Remote<ServerAddr>) -> io::Result<io::BoxedIo> {
     move |endpoint| {
         let span = tracing::info_span!("hello_server", ?endpoint);
         let _e = span.enter();
@@ -198,12 +197,12 @@ fn hello_server(
         let (client_io, server_io) = support::io::duplex(4096);
         let hello_svc = hyper::service::service_fn(|request: Request<Body>| async move {
             tracing::info!(?request);
-            Ok::<_, Error>(Response::new(Body::from("Hello world!")))
+            Ok::<_, io::Error>(Response::new(Body::from("Hello world!")))
         });
         tokio::spawn(
             http.serve_connection(server_io, hello_svc)
                 .in_current_span(),
         );
-        Ok(BoxedIo::new(client_io))
+        Ok(io::BoxedIo::new(client_io))
     }
 }

--- a/linkerd/app/outbound/src/tcp/tests.rs
+++ b/linkerd/app/outbound/src/tcp/tests.rs
@@ -737,10 +737,7 @@ async fn profile_endpoint_propagates_conn_errors() {
 
     // Build a mock "connector" that returns the upstream "server" IO.
     let connect = support::connect().endpoint_fn(ep1, |_| {
-        Err(Box::new(io::Error::new(
-            io::ErrorKind::ConnectionReset,
-            "i dont like you, go away",
-        )))
+        Err(io::Error::from(io::ErrorKind::ConnectionReset))
     });
 
     let profiles = profile::resolver();

--- a/linkerd/app/test/src/http_util.rs
+++ b/linkerd/app/test/src/http_util.rs
@@ -1,4 +1,4 @@
-use crate::app_core::{io::BoxedIo, svc::Param, tls, Error};
+use crate::app_core::{svc::Param, tls, Error};
 use crate::io;
 use crate::ContextError;
 use futures::FutureExt;
@@ -156,7 +156,7 @@ impl Server {
         }
     }
 
-    pub fn run<E>(self) -> impl (FnMut(E) -> Result<BoxedIo, Error>) + Send + 'static
+    pub fn run<E>(self) -> impl (FnMut(E) -> io::Result<io::BoxedIo>) + Send + 'static
     where
         E: std::fmt::Debug,
         E: Param<tls::ConditionalClientTls>,
@@ -176,7 +176,7 @@ impl Server {
                 }
             });
             tokio::spawn(settings.serve_connection(server_io, svc).in_current_span());
-            Ok(BoxedIo::new(client_io))
+            Ok(io::BoxedIo::new(client_io))
         }
     }
 }

--- a/linkerd/app/test/src/lib.rs
+++ b/linkerd/app/test/src/lib.rs
@@ -16,7 +16,7 @@ pub use tracing::*;
 pub use tracing_subscriber::prelude::*;
 
 pub mod io {
-    pub use tokio::io::*;
+    pub use linkerd_app_core::io::*;
     pub use tokio_test::io::*;
 }
 

--- a/linkerd/io/src/lib.rs
+++ b/linkerd/io/src/lib.rs
@@ -13,7 +13,9 @@ pub use self::{
 };
 pub use std::io::*;
 use std::net::SocketAddr;
-pub use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+pub use tokio::io::{
+    duplex, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, DuplexStream, ReadBuf,
+};
 pub use tokio_util::io::{poll_read_buf, poll_write_buf};
 
 pub type Poll<T> = std::task::Poll<Result<T>>;


### PR DESCRIPTION
The tcp endpoint stack requires that connectors return `io::Result`, but
the connector mock uses Boxed error types. This change modifies the
mocked connector to use io::Errors.

We also improve re-exports from the linkerd_io module to reduce import
boilerplate.