### PR TITLE
http: Remove `identity_from_header` helper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,7 +1150,6 @@ dependencies = [
  "linkerd-duplex",
  "linkerd-error",
  "linkerd-http-box",
- "linkerd-identity",
  "linkerd-io",
  "linkerd-proxy-transport",
  "linkerd-stack",

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -52,7 +52,6 @@ pub use self::addr_match::{AddrMatch, IpMatch, NameMatch};
 
 pub const CANONICAL_DST_HEADER: &str = "l5d-dst-canonical";
 pub const DST_OVERRIDE_HEADER: &str = "l5d-dst-override";
-pub const L5D_REQUIRE_ID: &str = "l5d-require-id";
 
 const DEFAULT_PORT: u16 = 80;
 

--- a/linkerd/app/inbound/fuzz/Cargo.lock
+++ b/linkerd/app/inbound/fuzz/Cargo.lock
@@ -1011,7 +1011,6 @@ dependencies = [
  "linkerd-duplex",
  "linkerd-error",
  "linkerd-http-box",
- "linkerd-identity",
  "linkerd-io",
  "linkerd-proxy-transport",
  "linkerd-stack",

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -1,9 +1,9 @@
-use super::require_identity_on_endpoint::NewRequireIdentity;
+use super::require_id_header;
 use crate::Outbound;
 use linkerd_app_core::{
     classify, config, http_tracing, metrics,
     proxy::{http, tap},
-    reconnect, svc, tls, Error, CANONICAL_DST_HEADER, L5D_REQUIRE_ID,
+    reconnect, svc, tls, Error, CANONICAL_DST_HEADER,
 };
 use tokio::io;
 
@@ -67,8 +67,7 @@ impl<C> Outbound<C> {
                 rt.span_sink.clone(),
                 crate::trace_labels(),
             ))
-            .push_on_response(http::strip_header::request::layer(L5D_REQUIRE_ID))
-            .push(NewRequireIdentity::layer())
+            .push(require_id_header::NewRequireIdentity::layer())
             .push(http::NewOverrideAuthority::layer(vec![
                 "host",
                 CANONICAL_DST_HEADER,

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -1,7 +1,7 @@
 pub mod detect;
 mod endpoint;
 pub mod logical;
-mod require_identity_on_endpoint;
+mod require_id_header;
 mod server;
 
 use crate::tcp;

--- a/linkerd/app/outbound/src/http/require_id_header.rs
+++ b/linkerd/app/outbound/src/http/require_id_header.rs
@@ -1,13 +1,9 @@
-use futures::{
-    future::{self, Either},
-    TryFutureExt,
-};
-use linkerd_app_core::{
-    errors::IdentityRequired, proxy::http::identity_from_header, svc, tls, Conditional, Error,
-    L5D_REQUIRE_ID,
-};
+use futures::{future, TryFutureExt};
+use linkerd_app_core::{errors::IdentityRequired, identity, svc, tls, Conditional, Error};
 use std::task::{Context, Poll};
-use tracing::debug;
+use tracing::{debug, trace};
+
+const HEADER_NAME: &str = "l5d-require-id";
 
 #[derive(Clone, Debug)]
 pub(super) struct NewRequireIdentity<N> {
@@ -49,11 +45,19 @@ where
 // === impl RequireIdentity ===
 
 type ResponseFuture<F, T, E> =
-    Either<future::Ready<Result<T, Error>>, future::MapErr<F, fn(E) -> Error>>;
+    future::Either<future::Ready<Result<T, Error>>, future::MapErr<F, fn(E) -> Error>>;
 
-impl<S, A> svc::Service<http::Request<A>> for RequireIdentity<S>
+impl<S> RequireIdentity<S> {
+    #[inline]
+    fn extract_id<B>(req: &mut http::Request<B>) -> Option<identity::Name> {
+        let v = req.headers_mut().remove(HEADER_NAME)?;
+        v.to_str().ok()?.parse().ok()
+    }
+}
+
+impl<S, B> svc::Service<http::Request<B>> for RequireIdentity<S>
 where
-    S: svc::Service<http::Request<A>>,
+    S: svc::Service<http::Request<B>>,
     S::Error: Into<Error>,
 {
     type Response = S::Response;
@@ -65,32 +69,41 @@ where
         self.inner.poll_ready(cx).map_err(Into::into)
     }
 
-    fn call(&mut self, request: http::Request<A>) -> Self::Future {
-        // If the `l5d-require-id` header is present, then we should expect
-        // the target's `peer_identity` to match; if the two values do not
-        // match or there is no `peer_identity`, then we fail the request
-        if let Some(require_id) = identity_from_header(&request, L5D_REQUIRE_ID) {
-            debug!("found l5d-require-id={:?}", require_id.as_ref());
+    fn call(&mut self, mut request: http::Request<B>) -> Self::Future {
+        // If the `l5d-require-id` header is present, then we should expect the target's
+        // `peer_identity` to match; if the two values do not match or there is no `peer_identity`,
+        // then we fail the request.
+        //
+        // In either case, we clear the header so it is not passed on outbound requests.
+        if let Some(require_id) = Self::extract_id(&mut request) {
             match self.tls.as_ref() {
                 Conditional::Some(tls::ClientTls { server_id, .. }) => {
                     if require_id != *server_id.as_ref() {
+                        debug!(
+                            required = %require_id,
+                            found = %server_id,
+                            "Identity required by header not satisfied"
+                        );
                         let e = IdentityRequired {
                             required: require_id.into(),
                             found: Some(server_id.clone()),
                         };
-                        return Either::Left(future::err(e.into()));
+                        return future::Either::Left(future::err(e.into()));
+                    } else {
+                        trace!(id = %require_id, "Identity required by header");
                     }
                 }
                 Conditional::None(_) => {
+                    debug!(id = %require_id, "Identity required by header not satisfied");
                     let e = IdentityRequired {
                         required: require_id.into(),
                         found: None,
                     };
-                    return Either::Left(future::err(e.into()));
+                    return future::Either::Left(future::err(e.into()));
                 }
             }
         }
 
-        Either::Right(self.inner.call(request).map_err(Into::into))
+        future::Either::Right(self.inner.call(request).map_err(Into::into))
     }
 }

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -19,7 +19,7 @@ h2 = "0.3"
 http = "0.2"
 http-body = "0.4"
 httparse = "1.2"
-hyper = { version ="0.14.2", features = ["client", "http1", "http2", "server", "stream", "runtime"] }
+hyper = { version = "0.14.2", features = ["client", "http1", "http2", "server", "stream", "runtime"] }
 hyper-balance = { path = "../../../hyper-balance" }
 indexmap = "1.0"
 linkerd-detect = { path = "../../detect" }
@@ -27,7 +27,6 @@ linkerd-drain = { path = "../../drain" }
 linkerd-duplex = { path = "../../duplex" }
 linkerd-error = { path = "../../error" }
 linkerd-http-box = { path = "../../http-box" }
-linkerd-identity = { path = "../../identity" }
 linkerd-io = { path = "../../io" }
 linkerd-proxy-transport = { path = "../transport" }
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/proxy/http/fuzz/Cargo.lock
+++ b/linkerd/proxy/http/fuzz/Cargo.lock
@@ -414,15 +414,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linkerd-dns-name"
-version = "0.1.0"
-dependencies = [
- "thiserror",
- "untrusted",
- "webpki",
-]
-
-[[package]]
 name = "linkerd-drain"
 version = "0.1.0"
 dependencies = [
@@ -465,19 +456,6 @@ dependencies = [
  "linkerd-stack",
  "pin-project",
  "tower",
-]
-
-[[package]]
-name = "linkerd-identity"
-version = "0.1.0"
-dependencies = [
- "linkerd-dns-name",
- "ring",
- "rustls",
- "thiserror",
- "tracing",
- "untrusted",
- "webpki",
 ]
 
 [[package]]
@@ -524,7 +502,6 @@ dependencies = [
  "linkerd-duplex",
  "linkerd-error",
  "linkerd-http-box",
- "linkerd-identity",
  "linkerd-io",
  "linkerd-proxy-transport",
  "linkerd-stack",

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -2,7 +2,6 @@
 use http::header::AsHeaderName;
 use http::uri::Authority;
 use linkerd_error::Error;
-use linkerd_identity as identity;
 
 pub mod balance;
 pub mod client;
@@ -42,7 +41,6 @@ pub use http::{
 };
 pub use hyper::body::HttpBody;
 pub use linkerd_http_box::{BoxBody, BoxRequest, BoxResponse};
-use std::str::FromStr;
 
 #[derive(Clone, Debug)]
 pub struct HeaderPair(pub HeaderName, pub HeaderValue);
@@ -78,24 +76,6 @@ pub fn authority_from_header<B, K>(req: &http::Request<B>, header: K) -> Option<
 where
     K: AsHeaderName,
 {
-    header_value_from_request(req, header, |s: &str| s.parse::<Authority>().ok())
-}
-
-pub fn identity_from_header<B, K>(req: &http::Request<B>, header: K) -> Option<identity::Name>
-where
-    K: AsHeaderName,
-{
-    header_value_from_request(req, header, |s: &str| identity::Name::from_str(s).ok())
-}
-
-fn header_value_from_request<B, K, F, T>(
-    req: &http::Request<B>,
-    header: K,
-    try_from: F,
-) -> Option<T>
-where
-    K: AsHeaderName,
-    F: FnOnce(&str) -> Option<T>,
-{
-    req.headers().get(header)?.to_str().ok().and_then(try_from)
+    let v = req.headers().get(header)?;
+    v.to_str().ok()?.parse().ok()
 }


### PR DESCRIPTION
The `proxy::http::identity_from_header` helper is only used in one place
and doesn't need to be exposed by the proxy::http module. Similarly the
`L5D_REQUIRE_ID` constant does not need to be used outside of the
outbound HTTP endpoint stack, though it is defined in `app::core`.

This change renames the `require_identity_on_endpoint` to
`require_id_header` and consolidates all related logic & constants into
the module. The module is now responsible for clearing the header as
well (rather than pairing the module with a generic strip-header layer).