### PR TITLE
outbound: Box HTTP endpoint stack

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -284,13 +284,13 @@ where
                     .stack
                     .instrument(|_: &_| debug_span!("direct"))
                     .push_on_response(svc::BoxService::layer())
-                    .push(svc::BoxNewService::layer())
                     .into_inner(),
             )
             .instrument(|a: &T| {
                 let OrigDstAddr(target_addr) = a.param();
                 info_span!("server", port = target_addr.port())
             })
+            .push(svc::BoxNewService::layer())
             .into_inner()
     }
 }

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -72,7 +72,12 @@ impl<C> Outbound<C> {
                 "host",
                 CANONICAL_DST_HEADER,
             ]))
-            .push_on_response(http::BoxResponse::layer());
+            .push_on_response(
+                svc::layers()
+                    .push(http::BoxResponse::layer())
+                    .push(svc::BoxService::layer()),
+            )
+            .push(svc::BoxNewService::layer());
 
         Outbound {
             config,

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -156,8 +156,8 @@ impl<E> Outbound<E> {
             .instrument(|l: &Logical| debug_span!("logical", dst = %l.logical_addr))
             // Boxing is necessary purely to limit the link-time overhead of
             // having enormous types.
-            .push(svc::BoxNewService::layer())
-            .push_on_response(svc::BoxService::layer());
+            .push_on_response(svc::BoxService::layer())
+            .push(svc::BoxNewService::layer());
 
         Outbound {
             config,


### PR DESCRIPTION
This change ~halves compile-time and memory usage of release builds

Before this change:

        Command being timed: "cargo build -p linkerd2-proxy --release"
        User time (seconds): 3233.32
        System time (seconds): 49.02
        Percent of CPU this job got: 583%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 9:22.92
        Maximum resident set size (kbytes): 57377268

With this change:

        Command being timed: "cargo build -p linkerd2-proxy --release"
        User time (seconds): 1935.21
        System time (seconds): 32.59
        Percent of CPU this job got: 594%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 5:31.18
        Maximum resident set size (kbytes): 23842208