### PR TITLE
ci: add `cargo build --release` check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,16 @@ jobs:
       with:
         command: check ${{ matrix.checks }}
 
+  build-release:
+    name: "cargo build --release"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make build
+        env:
+          CARGO_RELEASE: true
+
   clippy:
     timeout-minutes: 5
     runs-on: ubuntu-latest


### PR DESCRIPTION
Recent struggles with the Rust compiler getting OOM killed suggest that
we can't necessarily rely on release builds succeeding if dev builds do.
This PR adds a release build check to the PR CI run.

We can remove this later if this stops being an issue in the future.