### PR TITLE
stack: make `Either` services always return boxed futures

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -4,8 +4,8 @@ pub use crate::proxy::http;
 use crate::{cache, Error};
 pub use linkerd_concurrency_limit::ConcurrencyLimit;
 pub use linkerd_stack::{
-    self as stack, layer, BoxNewService, BoxService, BoxServiceLayer, Fail, Filter, MapTargetLayer,
-    NewRouter, NewService, Param, Predicate, UnwrapOr,
+    self as stack, layer, BoxNewService, BoxService, BoxServiceLayer, Either, Fail, Filter,
+    MapTargetLayer, NewRouter, NewService, Param, Predicate, UnwrapOr,
 };
 pub use linkerd_stack_tracing::{NewInstrument, NewInstrumentLayer};
 pub use linkerd_timeout::{self as timeout, FailFast};
@@ -19,11 +19,7 @@ use tower::{
     make::MakeService,
 };
 pub use tower::{
-    layer::Layer,
-    service_fn as mk,
-    spawn_ready::SpawnReady,
-    util::{Either, MapErrLayer},
-    Service, ServiceExt,
+    layer::Layer, service_fn as mk, spawn_ready::SpawnReady, util::MapErrLayer, Service, ServiceExt,
 };
 
 pub type Buffer<Req, Rsp, E> = TowerBuffer<BoxService<Req, Rsp, E>, Req>;

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -232,7 +232,6 @@ where
         )
         .push_http_server()
         .into_stack()
-        .push_on_response(svc::BoxService::layer())
         .push(svc::BoxNewService::layer())
         .push_switch(
             |GatewayTransportHeader {
@@ -250,19 +249,14 @@ where
                 })),
                 None => Ok::<_, Never>(svc::Either::B(target)),
             },
-            tcp.push_on_response(svc::BoxService::layer())
-                .push(svc::BoxNewService::layer())
-                .into_inner(),
+            tcp.push(svc::BoxNewService::layer()).into_inner(),
         )
         .push_switch(
             |gw| match gw {
                 GatewayConnection::TransportHeader(t) => Ok::<_, Never>(svc::Either::A(t)),
                 GatewayConnection::Legacy(c) => Ok(svc::Either::B(c)),
             },
-            legacy_http
-                .push_on_response(svc::BoxService::layer())
-                .push(svc::BoxNewService::layer())
-                .into_inner(),
+            legacy_http.push(svc::BoxNewService::layer()).into_inner(),
         )
         .into_inner()
 }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -244,7 +244,6 @@ where
                     .push_tcp_forward(server_port)
                     .stack
                     .push_map_target(TcpEndpoint::from)
-                    .push_on_response(svc::BoxService::layer())
                     .push(svc::BoxNewService::layer())
                     .into_inner(),
             ))
@@ -261,7 +260,6 @@ where
                 config.detect_protocol_timeout,
             ))
             .instrument(|_: &_| debug_span!("proxy"))
-            .push_on_response(svc::BoxService::layer())
             .push_switch(
                 disable_detect,
                 self.clone()
@@ -272,7 +270,6 @@ where
                     .push_map_target(TcpAccept::port_skipped)
                     .check_new_service::<T, _>()
                     .instrument(|_: &T| debug_span!("forward"))
-                    .push_on_response(svc::BoxService::layer())
                     .push(svc::BoxNewService::layer())
                     .into_inner(),
             )
@@ -283,7 +280,6 @@ where
                     .push_direct(gateway)
                     .stack
                     .instrument(|_: &_| debug_span!("direct"))
-                    .push_on_response(svc::BoxService::layer())
                     .into_inner(),
             )
             .instrument(|a: &T| {

--- a/linkerd/app/outbound/src/switch_logical.rs
+++ b/linkerd/app/outbound/src/switch_logical.rs
@@ -25,10 +25,10 @@ impl<S> Outbound<S> {
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + fmt::Debug + Send + Unpin + 'static,
         N: svc::NewService<tcp::Logical, Service = NSvc> + Clone,
         NSvc: svc::Service<I, Response = (), Error = Error>,
-        NSvc::Future: Send,
+        NSvc::Future: Send + 'static,
         S: svc::NewService<tcp::Endpoint, Service = SSvc> + Clone,
         SSvc: svc::Service<I, Response = (), Error = Error>,
-        SSvc::Future: Send,
+        SSvc::Future: Send + 'static,
     {
         let no_tls_reason = self.no_tls_reason();
         let Self {

--- a/linkerd/stack/src/either.rs
+++ b/linkerd/stack/src/either.rs
@@ -1,10 +1,80 @@
-use crate::{layer, NewService};
-pub use tower::util::Either;
+use crate::{layer, NewService, Service};
+use futures::TryFutureExt;
+use linkerd_error::Error;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 #[derive(Clone, Debug)]
 pub struct NewEither<L, R> {
     left: L,
     right: R,
+}
+
+/// Combine two different service types into a single type.
+///
+/// Both services must be of the same request, response, and error types.
+/// [`Either`] is useful for handling conditional branching in service middleware
+/// to different inner service types.
+///
+/// *Unlike* Tower's `Either` type, the future returned by the `Service` impl
+/// for `Either` is boxed, rather than an `Either` future.
+#[derive(Clone, Debug)]
+pub enum Either<A, B> {
+    /// One type of backing [`Service`].
+    A(A),
+    /// The other type of backing [`Service`].
+    B(B),
+}
+
+impl<A, B, Request> Service<Request> for Either<A, B>
+where
+    A: Service<Request>,
+    A::Error: Into<Error> + 'static,
+    A::Future: Send + 'static,
+    B: Service<Request, Response = A::Response>,
+    B::Error: Into<Error> + 'static,
+    B::Future: Send + 'static,
+{
+    type Response = A::Response;
+    type Error = Error;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        use self::Either::*;
+
+        match self {
+            A(service) => service.poll_ready(cx).map(|res| res.map_err(Into::into)),
+            B(service) => service.poll_ready(cx).map(|res| res.map_err(Into::into)),
+        }
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        use self::Either::*;
+
+        match self {
+            A(service) => Box::pin(service.call(request).map_err(Into::into)),
+            B(service) => Box::pin(service.call(request).map_err(Into::into)),
+        }
+    }
+}
+
+impl<S, A, B> layer::Layer<S> for Either<A, B>
+where
+    A: layer::Layer<S>,
+    B: layer::Layer<S>,
+{
+    type Service = Either<A::Service, B::Service>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        match self {
+            Either::A(layer) => Either::A(layer.layer(inner)),
+            Either::B(layer) => Either::B(layer.layer(inner)),
+        }
+    }
 }
 
 // === impl NewEither ===


### PR DESCRIPTION
In PR #1005, we added `BoxService` layers before most `push_switch`
layers, to erase large nested future types to reduce rustc memory use.
This helped, but it requires manually adding the `BoxService` layers
around switches.

This branch changes the `Either` implementation from
`tower::util::Either`, whose `Service` impl returns an enum response
future, to a `linkerd_stack::Either` type, whose service impl just
always returns a boxed response future. This way, we don't need to
remember to manually add the boxing before the switch.

Hopefully when the compiler regression that causes it to get OOM killed
gets sorted out, we can replace this with the upstream implementation
again...