### PR TITLE
Make span name without query string

### DIFF
--- a/linkerd/trace-context/src/service.rs
+++ b/linkerd/trace-context/src/service.rs
@@ -96,10 +96,7 @@ where
                     let start = SystemTime::now();
                     let req_labels = Self::request_labels(&req);
                     let mut sink = self.sink.clone();
-                    let span_name = req
-                        .uri()
-                        .path()
-                        .to_owned();
+                    let span_name = req.uri().path().to_owned();
                     return Either::Right(Box::pin(self.inner.call(req).map_ok(move |rsp| {
                         // Emit the completed span with the response metadata.
                         let span = Span {

--- a/linkerd/trace-context/src/service.rs
+++ b/linkerd/trace-context/src/service.rs
@@ -98,9 +98,8 @@ where
                     let mut sink = self.sink.clone();
                     let span_name = req
                         .uri()
-                        .path_and_query()
-                        .map(|pq| pq.as_str().to_owned())
-                        .unwrap_or_default();
+                        .path()
+                        .to_owned();
                     return Either::Right(Box::pin(self.inner.call(req).map_ok(move |rsp| {
                         // Emit the completed span with the response metadata.
                         let span = Span {


### PR DESCRIPTION
Query string in Span name makes additional noise to Jaeger operation filter as on picture below.

<img width="320" alt="Screenshot 2021-05-19 at 16 15 26" src="https://user-images.githubusercontent.com/3737657/118818949-8be06200-b8bd-11eb-9408-02444ff58ad6.png">

Suggest to use path only for span name but still use path and query in `http.path` property.