### PR TITLE
so it turns out that everything is always Bytes

### DIFF
--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -23,8 +23,8 @@ impl<E> Outbound<E> {
         >,
     >
     where
-        B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
-        B::Data: Send + 'static,
+        B: http::HttpBody<Data = bytes::Bytes, Error = Error>,
+        B: std::fmt::Debug + Default + Send + 'static,
         E: svc::NewService<Endpoint, Service = ESvc> + Clone + Send + Sync + 'static,
         ESvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
             + Send

--- a/linkerd/http-box/src/request.rs
+++ b/linkerd/http-box/src/request.rs
@@ -25,8 +25,7 @@ impl<S: Clone, B> Clone for BoxRequest<S, B> {
 
 impl<S, B> tower::Service<http::Request<B>> for BoxRequest<S, B>
 where
-    B: http_body::Body + Send + 'static,
-    B::Data: Send + 'static,
+    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<Error>,
     S: tower::Service<http::Request<BoxBody>>,
 {

--- a/linkerd/http-box/src/response.rs
+++ b/linkerd/http-box/src/response.rs
@@ -18,8 +18,7 @@ impl<S> BoxResponse<S> {
 impl<S, Req, B> tower::Service<Req> for BoxResponse<S>
 where
     S: tower::Service<Req, Response = http::Response<B>>,
-    B: http_body::Body + Send + 'static,
-    B::Data: Send + 'static,
+    B: http_body::Body<Data = bytes::Bytes> + Send + 'static,
     B::Error: Into<Error> + 'static,
 {
     type Response = http::Response<BoxBody>;


### PR DESCRIPTION
Currently, the `http_box::BoxBody` type erases both the type of the
`http_body::Body` _and_ the `Body::Data` associated type (to
`Box<dyn Buf + Send>`). However, it turns out that erasing the `Data`
type isn't actually necessary: _all_ `Body` types in Linkerd use
`Bytes` as the `Data` type.

This branch changes `BoxBody` to just require that `B::Data` is `Bytes`,
and always produce `Bytes` as its data type. This will enable a much
more performant implementation of request body buffering for POST
retries (linkerd/linkerd2#6130). Rather than copying all the bytes from
a `dyn Buf` `Data` type into an additional buffer, we can just clone the
`Bytes`, increasing the reference count for that buffer, and return the
original `Bytes`. This means we don't need to perform additional memcpys
to buffer bodies for retries; we just hold onto the already-allocated
`Bytes` buffers.

The cloned `Bytes` can then be stored in a vector, and if we have to
write them out again for a retry, we can do one big vectored write :)

![image](https://user-images.githubusercontent.com/2796466/119053310-bfcd8d00-b97a-11eb-8430-b3a8b95d8ba6.png)
