### PR TITLE
ingress: Restore original dst address routing

### DIFF
--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -52,7 +52,6 @@ pub mod transport;
 pub use self::addr_match::{AddrMatch, IpMatch, NameMatch};
 
 pub const CANONICAL_DST_HEADER: &str = "l5d-dst-canonical";
-pub const DST_OVERRIDE_HEADER: &str = "l5d-dst-override";
 
 const DEFAULT_PORT: u16 = 80;
 
@@ -63,17 +62,6 @@ pub struct ProxyRuntime {
     pub tap: proxy::tap::Registry,
     pub span_sink: http_tracing::OpenCensusSink,
     pub drain: drain::Watch,
-}
-
-pub fn http_request_l5d_override_dst_name_addr<B>(
-    req: &http::Request<B>,
-) -> Result<NameAddr, addr::Error> {
-    proxy::http::authority_from_header(req, DST_OVERRIDE_HEADER)
-        .ok_or_else(|| {
-            tracing::trace!("{} not in request headers", DST_OVERRIDE_HEADER);
-            addr::Error::InvalidHost
-        })
-        .and_then(|a| NameAddr::from_authority_with_default_port(&a, DEFAULT_PORT))
 }
 
 pub fn http_request_authority_addr<B>(req: &http::Request<B>) -> Result<Addr, addr::Error> {

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -28,6 +28,11 @@ pub use tower::{
 
 pub type Buffer<Req, Rsp, E> = TowerBuffer<BoxService<Req, Rsp, E>, Req>;
 
+pub type BoxHttp<B = http::BoxBody> =
+    BoxService<http::Request<B>, http::Response<http::BoxBody>, Error>;
+
+pub type BoxNewHttp<T, B = http::BoxBody> = BoxNewService<T, BoxHttp<B>>;
+
 #[derive(Clone, Debug)]
 pub struct Layers<L>(L);
 

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -19,7 +19,7 @@ use linkerd_app_core::{
     proxy::{http, tap},
     reconnect,
     svc::{self, Param},
-    Error, DST_OVERRIDE_HEADER,
+    Error,
 };
 use tracing::debug_span;
 
@@ -227,9 +227,6 @@ where
                     .push(http::BoxResponse::layer()),
             )
             .check_new_service::<Target, http::Request<http::BoxBody>>()
-            // Removes the override header after it has been used to
-            // determine a request target.
-            .push_on_response(strip_header::request::layer(DST_OVERRIDE_HEADER))
             // Routes each request to a target, obtains a service for that
             // target, and dispatches the request.
             .instrument_from_target()

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -8,14 +8,7 @@ use linkerd_app_core::{
 use tokio::io;
 
 impl<C> Outbound<C> {
-    pub fn push_http_endpoint<T, B>(
-        self,
-    ) -> Outbound<
-        svc::BoxNewService<
-            T,
-            svc::BoxService<http::Request<B>, http::Response<http::BoxBody>, Error>,
-        >,
-    >
+    pub fn push_http_endpoint<T, B>(self) -> Outbound<svc::BoxNewHttp<T, B>>
     where
         T: Clone + Send + Sync + 'static,
         T: svc::Param<http::client::Settings>

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -8,20 +8,12 @@ use linkerd_app_core::{
         http,
         resolve::map_endpoint,
     },
-    retry, svc, Error, Never, DST_OVERRIDE_HEADER,
+    retry, svc, Error, Never,
 };
 use tracing::debug_span;
 
 impl<E> Outbound<E> {
-    pub fn push_http_logical<B, ESvc, R>(
-        self,
-        resolve: R,
-    ) -> Outbound<
-        svc::BoxNewService<
-            Logical,
-            svc::BoxService<http::Request<B>, http::Response<http::BoxBody>, Error>,
-        >,
-    >
+    pub fn push_http_logical<B, ESvc, R>(self, resolve: R) -> Outbound<svc::BoxNewHttp<Logical, B>>
     where
         B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
         B::Data: Send + 'static,
@@ -144,11 +136,7 @@ impl<E> Outbound<E> {
             // canonical-dst-header. The response body is boxed unify the profile
             // stack's response type. withthat of to endpoint stack.
             .push(http::NewHeaderFromTarget::<CanonicalDstHeader, _>::layer())
-            .push_on_response(
-                svc::layers()
-                    .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER))
-                    .push(http::BoxResponse::layer()),
-            )
+            .push_on_response(svc::layers().push(http::BoxResponse::layer()))
             .instrument(|l: &Logical| debug_span!("logical", dst = %l.logical_addr))
             .push_on_response(svc::BoxService::layer())
             .push(svc::BoxNewService::layer());

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -172,7 +172,10 @@ impl Outbound<svc::BoxNewHttp<http::Endpoint>> {
                     .into_inner(),
             )
             .push(svc::BoxNewService::layer())
-            // Obtain a new inner service for each request (fom the above cache).
+            // Obtain a new inner service for each request. Override stacks are cached, as they
+            // depend on discovery that should not be performed many times. Forwarding stacks are
+            // not cached explicitly, as there are no real resources we need to share across
+            // connections. This allows us to avoid buffering requests to these endpoints.
             .push(svc::NewRouter::layer(
                 |http::Accept { orig_dst, protocol }| {
                     move |req: &http::Request<_>| {

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -1,14 +1,16 @@
 use crate::{http, stack_labels, tcp, trace_labels, Config, Outbound};
 use linkerd_app_core::{
     config::{ProxyConfig, ServerConfig},
-    detect, errors, http_request_l5d_override_dst_name_addr, http_tracing, io, profiles,
-    proxy::api_resolve::Metadata,
+    detect, errors, http_tracing, io, profiles,
+    proxy::{
+        api_resolve::{ConcreteAddr, Metadata},
+        core::Resolve,
+    },
     svc::{self, stack::Param},
     tls,
     transport::{OrigDstAddr, Remote, ServerAddr},
-    AddrMatch, Conditional, Error, NameAddr,
+    AddrMatch, Error, NameAddr,
 };
-use std::convert::TryFrom;
 use thiserror::Error;
 use tracing::{debug_span, info_span};
 
@@ -16,55 +18,62 @@ use tracing::{debug_span, info_span};
 struct AllowHttpProfile(AddrMatch);
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct Target {
-    dst: NameAddr,
+struct Http {
+    target: Target,
     version: http::Version,
 }
 
-#[derive(Clone)]
-struct TargetPerRequest(http::Accept);
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum Target {
+    Forward(OrigDstAddr),
+    Override(NameAddr),
+}
 
 #[derive(Debug, Error)]
 #[error("ingress-mode routing requires a service profile")]
 struct ProfileRequired;
 
-#[derive(Debug, Error)]
-#[error("ingress-mode routing requires the l5d-dst-override header")]
-struct DstOverrideRequired;
-
 #[derive(Debug, Default, Error)]
 #[error("ingress-mode routing is HTTP-only")]
 struct IngressHttpOnly;
 
+#[derive(Debug, Default, Error)]
+#[error("l5d-dst-override is not a valid host:port")]
+struct InvalidOverrideHeader;
+
+const DST_OVERRIDE_HEADER: &str = "l5d-dst-override";
+
 // === impl Outbound ===
 
-impl<H> Outbound<H> {
+impl Outbound<svc::BoxNewHttp<http::Endpoint>> {
     /// Routes HTTP requests according to the l5d-dst-override header.
     ///
     /// This is only intended for Ingress configurations, where we assume all
     /// outbound traffic is HTTP.
-    pub fn into_ingress<T, I, HSvc, P>(
+    pub fn into_ingress<T, I, P, R>(
         self,
         profiles: P,
+        resolve: R,
     ) -> svc::BoxNewService<T, svc::BoxService<I, (), Error>>
     where
         T: Param<OrigDstAddr> + Clone + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
-        H: svc::NewService<http::Logical, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
-        HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
-            + Send
-            + 'static,
-        HSvc::Error: Into<Error>,
-        HSvc::Future: Send,
         P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + Unpin + 'static,
         P::Error: Send,
         P::Future: Send,
+        R: Clone + Send + Sync + 'static,
+        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
+        R::Resolution: Send,
+        R::Future: Send + Unpin,
     {
-        let Self {
+        let Outbound {
             config,
             runtime: rt,
-            stack: http,
-        } = self;
+            stack: http_logical,
+        } = self.clone().push_http_logical(resolve);
+
+        let http_endpoint = self.into_inner();
+
         let Config {
             allow_discovery,
             proxy:
@@ -79,142 +88,143 @@ impl<H> Outbound<H> {
                 },
             ..
         } = config;
-
         let profile_domains = allow_discovery.names().clone();
-        http.push_on_response(
-            svc::layers()
-                .push(http::BoxRequest::layer())
-                .push(svc::MapErrLayer::new(Into::<Error>::into)),
-        )
-        // Lookup the profile for the outbound HTTP target, if appropriate.
-        //
-        // This service is buffered because it needs to initialize the profile resolution and a
-        // fail-fast is instrumented in case it becomes unavailable. When this service is in
-        // fail-fast, ensure that we drive the inner service to readiness even if new requests
-        // aren't received.
-        .push_request_filter(http::Logical::try_from)
-        .check_new_service::<(Option<profiles::Receiver>, Target), _>()
-        .push(profiles::discover::layer(
-            profiles,
-            move |target: Target| {
-                if profile_domains.matches(target.dst.name()) {
-                    Ok(profiles::LookupAddr(target.dst.into()))
-                } else {
-                    tracing::debug!(
-                        name = %target.dst.name(),
-                        domains = %profile_domains,
-                        "Address not in a configured domain",
-                    );
-                    Err(profiles::DiscoveryRejected::new(
-                        "not in configured ingress search addresses",
-                    ))
+
+        // Route requests with destinations that can be discovered via the `l5d-dst-override` header
+        // through a logical stack and route requests without the `l5d-dst-override` header through
+        // the endpoint stack.
+        http_logical
+            .push_switch(
+                |(profile, Http { target, version }): (Option<profiles::Receiver>, _)| {
+                    // If the target did not include an override header, build an endpoint stack
+                    // with the original destination address (ignoring all headers, etc).
+                    if let Target::Forward(OrigDstAddr(addr)) = target {
+                        return Ok(svc::Either::B(http::Endpoint {
+                            addr: Remote(ServerAddr(addr)),
+                            metadata: Metadata::default(),
+                            logical_addr: None,
+                            protocol: version,
+                            opaque_protocol: false,
+                            tls: tls::ConditionalClientTls::None(
+                                tls::NoClientTls::IngressWithoutOverride,
+                            ),
+                        }));
+                    }
+
+                    // Otherwise, if a profile was discovered, use it to build a logical stack.
+                    if let Some(profile) = profile {
+                        let addr = profile.borrow().addr.clone();
+                        if let Some(logical_addr) = addr {
+                            return Ok(svc::Either::A(http::Logical {
+                                profile,
+                                logical_addr,
+                                protocol: version,
+                            }));
+                        }
+                    }
+
+                    // Otherwise, the override header was present but no profile information could
+                    // be discovered, so fail the request.
+                    Err(ProfileRequired)
+                },
+                http_endpoint,
+            )
+            .push(profiles::discover::layer(profiles, move |h: Http| {
+                // Lookup the profile if the override header was set and it is in the configured
+                // profile domains. Otherwise, profile discovery is skipped.
+                if let Target::Override(dst) = h.target {
+                    if profile_domains.matches(dst.name()) {
+                        return Ok(profiles::LookupAddr(dst.into()));
+                    }
                 }
-            },
-        ))
-        .push_on_response(
-            svc::layers()
-                .push(rt.metrics.stack.layer(stack_labels("http", "logical")))
-                .push(svc::layer::mk(svc::SpawnReady::new))
-                .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
-                .push_spawn_buffer(buffer_capacity),
-        )
-        .push_cache(cache_max_idle_age)
-        .push_on_response(http::Retain::layer())
-        .instrument(|t: &Target| info_span!("target", dst = %t.dst))
-        .push(svc::BoxNewService::layer())
-        // Obtain a new inner service for each request (fom the above cache).
-        //
-        // Note that the router service is always ready, so the `FailFast` layer
-        // need not use a `SpawnReady` to drive the service to ready.
-        .push(svc::NewRouter::layer(TargetPerRequest::accept))
-        .push(http::NewNormalizeUri::layer())
-        .push_on_response(
-            svc::layers()
-                .push(http::MarkAbsoluteForm::layer())
-                .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
-                .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
-                .push(rt.metrics.http_errors.clone())
-                .push(errors::layer())
-                .push(http_tracing::server(rt.span_sink, trace_labels()))
-                .push(http::BoxResponse::layer()),
-        )
-        .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
-        .push(http::NewServeHttp::layer(h2_settings, rt.drain))
-        .push_request_filter(|(http, accept): (Option<http::Version>, _)| {
-            http.map(|h| http::Accept::from((h, accept)))
-                .ok_or(IngressHttpOnly)
-        })
-        .push_cache(cache_max_idle_age)
-        .push_map_target(detect::allow_timeout)
-        .push(svc::BoxNewService::layer())
-        .push(detect::NewDetectService::layer(
-            detect_protocol_timeout,
-            http::DetectHttp::default(),
-        ))
-        .push(rt.metrics.transport.layer_accept())
-        .instrument(|a: &tcp::Accept| info_span!("ingress", orig_dst = %a.orig_dst))
-        .push_map_target(|a: T| {
-            let orig_dst = Param::<OrigDstAddr>::param(&a);
-            tcp::Accept::from(orig_dst)
-        })
-        .push_on_response(svc::BoxService::layer())
-        .push(svc::BoxNewService::layer())
-        .check_new_service::<T, I>()
-        .into_inner()
-    }
-}
 
-// === impl Target ===
-
-impl TryFrom<(Option<profiles::Receiver>, Target)> for http::Logical {
-    type Error = ProfileRequired;
-    fn try_from(
-        (profile, Target { version, .. }): (Option<profiles::Receiver>, Target),
-    ) -> Result<Self, Self::Error> {
-        let profile = profile.ok_or(ProfileRequired)?;
-        let logical_addr = profile.borrow().addr.clone().ok_or(ProfileRequired)?;
-
-        Ok(Self {
-            profile,
-            protocol: version,
-            logical_addr,
-        })
-    }
-}
-
-impl From<(tls::NoClientTls, Target)> for http::Endpoint {
-    fn from((reason, Target { dst, version }): (tls::NoClientTls, Target)) -> Self {
-        // XXX This is a hack to fix caching when an dst-override is set.
-        let addr = Remote(ServerAddr(([0, 0, 0, 0], dst.port()).into()));
-
-        Self {
-            addr,
-            metadata: Metadata::default(),
-            tls: Conditional::None(reason),
-            logical_addr: None,
-            protocol: version,
-            // The endpoint is HTTP and definitely not opaque.
-            opaque_protocol: false,
-        }
-    }
-}
-
-// === TargetPerRequest ===
-
-impl TargetPerRequest {
-    fn accept(a: http::Accept) -> Self {
-        Self(a)
-    }
-}
-
-impl<B> svc::stack::RecognizeRoute<http::Request<B>> for TargetPerRequest {
-    type Key = Target;
-
-    fn recognize(&self, req: &http::Request<B>) -> Result<Self::Key, Error> {
-        let dst = http_request_l5d_override_dst_name_addr(req).map_err(|_| DstOverrideRequired)?;
-        Ok(Target {
-            dst,
-            version: self.0.protocol,
-        })
+                tracing::debug!(
+                    domains = %profile_domains,
+                    "Address not in a configured domain",
+                );
+                Err(profiles::DiscoveryRejected::new(
+                    "not in configured ingress search addresses",
+                ))
+            }))
+            // This service is buffered because it needs to initialize the profile resolution and a
+            // fail-fast is instrumented in case it becomes unavailable. When this service is in
+            // fail-fast, ensure that we drive the inner service to readiness even if new requests
+            // aren't received.
+            .push_on_response(
+                svc::layers()
+                    .push(rt.metrics.stack.layer(stack_labels("http", "logical")))
+                    .push(svc::layer::mk(svc::SpawnReady::new))
+                    .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
+                    .push_spawn_buffer(buffer_capacity),
+            )
+            .push_cache(cache_max_idle_age)
+            .push_on_response(
+                svc::layers()
+                    .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER))
+                    .push(http::Retain::layer()),
+            )
+            .instrument(|h: &Http| match h.target {
+                Target::Forward(_) => info_span!("forward"),
+                Target::Override(ref dst) => info_span!("override", %dst),
+            })
+            .push(svc::BoxNewService::layer())
+            // Obtain a new inner service for each request (fom the above cache).
+            .push(svc::NewRouter::layer(
+                |http::Accept { orig_dst, protocol }| {
+                    move |req: &http::Request<_>| {
+                        // Use either the override header or the original destination address.
+                        let target = match http::authority_from_header(req, DST_OVERRIDE_HEADER) {
+                            None => Target::Forward(orig_dst),
+                            Some(a) => {
+                                let dst = NameAddr::from_authority_with_default_port(&a, 80)
+                                    .map_err(|_| InvalidOverrideHeader)?;
+                                Target::Override(dst)
+                            }
+                        };
+                        Ok(Http {
+                            target,
+                            version: protocol,
+                        })
+                    }
+                },
+            ))
+            .push(http::NewNormalizeUri::layer())
+            .push_on_response(
+                svc::layers()
+                    .push(http::MarkAbsoluteForm::layer())
+                    // The concurrency-limit can force the service into fail-fast, but it need not
+                    // be driven to readiness on a background task (i.e., by `SpawnReady`).
+                    // Otherwise, the inner service is always ready (because it's a router).
+                    .push(svc::ConcurrencyLimit::layer(max_in_flight_requests))
+                    .push(svc::FailFast::layer("Ingress server", dispatch_timeout))
+                    .push(rt.metrics.http_errors.clone())
+                    .push(errors::layer())
+                    .push(http_tracing::server(rt.span_sink, trace_labels()))
+                    .push(http::BoxResponse::layer())
+                    .push(http::BoxRequest::layer()),
+            )
+            .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
+            .push(http::NewServeHttp::layer(h2_settings, rt.drain))
+            .push_request_filter(|(http, accept): (Option<http::Version>, _)| {
+                http.map(|h| http::Accept::from((h, accept)))
+                    .ok_or(IngressHttpOnly)
+            })
+            .push_cache(cache_max_idle_age)
+            .push_map_target(detect::allow_timeout)
+            .push(svc::BoxNewService::layer())
+            .push(detect::NewDetectService::layer(
+                detect_protocol_timeout,
+                http::DetectHttp::default(),
+            ))
+            .push(rt.metrics.transport.layer_accept())
+            .instrument(|a: &tcp::Accept| info_span!("ingress", orig_dst = %a.orig_dst))
+            .push_map_target(|a: T| {
+                let orig_dst = Param::<OrigDstAddr>::param(&a);
+                tcp::Accept::from(orig_dst)
+            })
+            .push_on_response(svc::BoxService::layer())
+            .push(svc::BoxNewService::layer())
+            .check_new_service::<T, I>()
+            .into_inner()
     }
 }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -142,8 +142,7 @@ impl Outbound<()> {
                     .to_tcp_connect()
                     .push_tcp_endpoint()
                     .push_http_endpoint()
-                    .push_http_logical(resolve)
-                    .into_ingress(profiles);
+                    .into_ingress(profiles, resolve);
                 let shutdown = self.runtime.drain.signaled();
                 serve::serve(listen, stack, shutdown).await;
             } else {

--- a/linkerd/tls/src/client.rs
+++ b/linkerd/tls/src/client.rs
@@ -45,6 +45,9 @@ pub enum NoClientTls {
     /// The destination service didn't give us the identity, which is its way
     /// of telling us that we shouldn't do TLS for this endpoint.
     NotProvidedByServiceDiscovery,
+
+    /// No discovery was attempted.
+    IngressWithoutOverride,
 }
 
 /// A stack paramater that indicates whether the target server endpoint has a
@@ -194,6 +197,9 @@ impl fmt::Display for NoClientTls {
             Self::Loopback => write!(f, "loopback"),
             Self::NotProvidedByServiceDiscovery => {
                 write!(f, "not_provided_by_service_discovery")
+            }
+            Self::IngressWithoutOverride => {
+                write!(f, "ingress_without_override")
             }
         }
     }


### PR DESCRIPTION
In f8cc918e, we started requiring the `l5d-dst-override` header. As
described in linkerd/linkerd2#6157, this breaks some ingress
configurations, especially those that may route to out-of-cluster
resources.

This change restores original-dst-addr routing for requests that do not
include the `l5d-dst-override` header.

Internally, this change centralizes the `DST_OVERRIDE_HEADER` and
related utilities to the ingress module, as no other modules should have
to know anything about it.