### PR TITLE
deps: update `futures` to 0.3.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -246,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -256,15 +256,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -273,16 +273,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -291,25 +292,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 http = "0.2"
 hyper = "0.14.2"
 pin-project = "1"

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -15,7 +15,7 @@ This is used by tests and the executable.
 allow-loopback = ["linkerd-app-outbound/allow-loopback"]
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 indexmap = "1.0"
 ipnet = "2.0"
 linkerd-app-core = { path = "./core" }

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "1"
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.2", features = ["http1", "http2"] }
-futures = "0.3.9"
+futures = "0.3.15"
 indexmap = "1.0"
 ipnet = "2.0"
 linkerd-addr = { path = "../../addr" }

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 http = "0.2"
-futures = "0.3.9"
+futures = "0.3.15"
 indexmap = "1.0"
 linkerd-app-core = { path = "../core" }
 linkerd-app-inbound = { path = "../inbound" }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -12,7 +12,7 @@ Configures and runs the inbound proxy
 [dependencies]
 bytes = "1"
 http = "0.2"
-futures = "0.3.9"
+futures = "0.3.15"
 indexmap = "1.0"
 linkerd-app-core = { path = "../core" }
 thiserror = "1.0"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -18,7 +18,7 @@ flaky_tests = []
 
 [dependencies]
 bytes = "1"
-futures = "0.3.9"
+futures = "0.3.15"
 h2 = "0.3"
 http = "0.2"
 http-body = "0.4"

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -17,7 +17,7 @@ test-subscriber = []
 [dependencies]
 bytes = "1"
 http = "0.2"
-futures = "0.3.9"
+futures = "0.3.15"
 indexmap = "1.0"
 linkerd-app-core = { path = "../core" }
 linkerd-http-retry = { path = "../../http-retry" }

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -17,7 +17,7 @@ a dedicated crate to help the compiler cache dependencies properly.
 flaky_tests = []
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 h2 = "0.3"
 http = "0.2"
 http-body = "0.4"

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 parking_lot = "0.11"

--- a/linkerd/concurrency-limit/Cargo.toml
+++ b/linkerd/concurrency-limit/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-stack = { path = "../stack" }
 tokio = { version = "1", features = ["sync"] }
 tokio-util = "0.6.5"

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-dns-name = { path = "./name" }
 linkerd-error = { path = "../error" }
 thiserror = "1.0"

--- a/linkerd/dns/fuzz/Cargo.lock
+++ b/linkerd/dns/fuzz/Cargo.lock
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -131,15 +131,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -148,16 +148,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -166,22 +167,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",

--- a/linkerd/drain/Cargo.toml
+++ b/linkerd/drain/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 retain = ["linkerd-stack", "tower"]
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 tokio = { version = "1", features = ["macros", "sync"] }
 
 linkerd-stack = { path = "../stack", optional = true }

--- a/linkerd/duplex/Cargo.toml
+++ b/linkerd/duplex/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 bytes = "1"
-futures = "0.3.9"
+futures = "0.3.15"
 tokio = { version = "1", features = ["io-util"] }
 pin-project = "1"
 tracing = "0.1.23"

--- a/linkerd/error-metrics/Cargo.toml
+++ b/linkerd/error-metrics/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 indexmap = "1.0"
 linkerd-metrics = { path = "../metrics" }
 tower = { version = "0.4.7", default-features = false }

--- a/linkerd/error-respond/Cargo.toml
+++ b/linkerd/error-respond/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-error = { path = "../error" }
 tower = { version = "0.4.7", default-features = false }
 pin-project = "1"

--- a/linkerd/error/Cargo.toml
+++ b/linkerd/error/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"

--- a/linkerd/exp-backoff/Cargo.toml
+++ b/linkerd/exp-backoff/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 rand = { version = "0.8", features = ["small_rng"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["time"]}

--- a/linkerd/http-box/Cargo.toml
+++ b/linkerd/http-box/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 bytes = "1"
-futures = "0.3.9"
+futures = "0.3.15"
 http = "0.2"
 http-body = "0.4"
 linkerd-error = { path = "../error" }

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 bytes = "1"
-futures = "0.3.9"
+futures = "0.3.15"
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.2", features = ["http1", "http2"] }

--- a/linkerd/io/Cargo.toml
+++ b/linkerd/io/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3.9"
+futures = "0.3.15"
 bytes = "1"
 linkerd-errno = { path = "../errno" }
 tokio = { version = "1", features = ["io-util", "net"] }

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -11,7 +11,7 @@ Implements the Resolve trait using the proxy's gRPC API
 
 [dependencies]
 async-stream = "0.3"
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-addr = { path = "../../addr" }
 linkerd-error = { path = "../../error" }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18" }

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -10,7 +10,7 @@ Core interfaces needed to implement proxy components
 """
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-error = { path = "../../error" }
 tower = { version = "0.4.7", default-features = false }
 pin-project = "1"

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -11,7 +11,7 @@ Utilities to implement a Discover with the core Resolve type
 
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -10,7 +10,7 @@ Service Dns Resolutions for the proxy
 """
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-error = { path = "../../error" }
 linkerd-addr = { path = "../../addr" }
 linkerd-dns = { path = "../../dns" }

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -14,7 +14,7 @@ This should probably be decomposed into smaller, decoupled crates.
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
-futures = "0.3.9"
+futures = "0.3.15"
 h2 = "0.3"
 http = "0.2"
 http-body = "0.4"

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18" }
 linkerd-error = { path = "../../error" }
 linkerd-identity = { path = "../../identity" }

--- a/linkerd/proxy/resolve/Cargo.toml
+++ b/linkerd/proxy/resolve/Cargo.toml
@@ -10,7 +10,7 @@ Utilities for working with `Resolve` implementations
 """
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 thiserror = "1.0"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 http = "0.2"
 hyper = { version = "0.14.2", features = ["http1", "http2"] }
-futures = "0.3.9"
+futures = "0.3.15"
 indexmap = "1.0"
 ipnet = "2.0"
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18" }

--- a/linkerd/proxy/tcp/Cargo.toml
+++ b/linkerd/proxy/tcp/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-duplex = { path = "../../duplex" }
 linkerd-error = { path = "../../error" }
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -11,7 +11,7 @@ Transport-level implementations that rely on core proxy infrastructure
 
 [dependencies]
 bytes = "1"
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-errno = { path = "../../errno" }
 linkerd-error = { path = "../../error" }
 linkerd-io = { path = "../../io" }

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
-futures = "0.3.9"
+futures = "0.3.15"
 tower = { version = "0.4.7", default-features = false }
 tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -11,7 +11,7 @@ Implements client layers for Linkerd ServiceProfiles.
 
 [dependencies]
 bytes = "1"
-futures = "0.3.9"
+futures = "0.3.15"
 http = "0.2"
 http-body = "0.4"
 indexmap = "1.0"

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -11,7 +11,7 @@ Utilities for composing Tower services.
 
 [dependencies]
 dyn-clone = "1.0.3"
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-error = { path = "../error" }
 pin-project = "1"
 tokio = { version = "1", features = ["time"] }

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-error = { path = "../../error" }
 linkerd-stack = { path = ".." }
 tower = "0.4.7"

--- a/linkerd/timeout/Cargo.toml
+++ b/linkerd/timeout/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 thiserror = "1"

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
-futures = "0.3.9"
+futures = "0.3.15"
 linkerd-conditional = { path = "../conditional" }
 linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }

--- a/linkerd/tls/fuzz/Cargo.lock
+++ b/linkerd/tls/fuzz/Cargo.lock
@@ -90,9 +90,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -105,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -115,15 +115,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -132,16 +132,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -150,22 +151,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 base64 = "0.13"
 bytes = "1"
-futures = "0.3.9"
+futures = "0.3.15"
 hex = "0.3.2"
 http = "0.2"
 linkerd-error = { path = "../error" }

--- a/linkerd/transport-header/fuzz/Cargo.lock
+++ b/linkerd/transport-header/fuzz/Cargo.lock
@@ -122,9 +122,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -137,9 +137,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -147,15 +147,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -164,16 +164,17 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
+checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
 dependencies = [
+ "autocfg",
  "proc-macro-hack",
  "proc-macro2",
  "quote",
@@ -182,22 +183,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-channel",
  "futures-core",
  "futures-io",

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -12,7 +12,7 @@ default = ["multicore"]
 multicore = ["tokio/rt-multi-thread", "num_cpus"]
 
 [dependencies]
-futures = "0.3.9"
+futures = "0.3.15"
 mimalloc = { version = "0.1.19", optional = true }
 num_cpus = { version = "1", optional = true }
 linkerd-app = { path = "../linkerd/app" }


### PR DESCRIPTION
This branch updates the `futures` crate to v0.3.15. This includes a fix
for task starvation with `FuturesUnordered` (added in 0.3.13). This may
or may not be related to issues that have been reported in the proxy
involving the load balancer (linkerd/linkerd2#6086), but we should
update to the fixed version regardless. This may also improve
performance in some cases, since we may now have to do fewer poll-wakeup
cycles when a load balancer has a large number of pending endpoints.