### PR TITLE
Fix MacOS conditional build in telemetry::process

### DIFF
--- a/linkerd/app/core/src/telemetry/process.rs
+++ b/linkerd/app/core/src/telemetry/process.rs
@@ -3,9 +3,6 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-#[cfg(not(target_os = "linux"))]
-use tracing::info;
-
 metrics! {
     process_start_time_seconds: Gauge {
         "Time that the process started (in seconds since the UNIX epoch)"
@@ -28,7 +25,7 @@ impl Report {
             .as_secs();
 
         #[cfg(not(target_os = "linux"))]
-        info!("System-level metrics are only supported on Linux");
+        tracing::info!("System-level metrics are only supported on Linux");
         Self {
             start_time: Arc::new(t0.into()),
 

--- a/linkerd/app/core/src/telemetry/process.rs
+++ b/linkerd/app/core/src/telemetry/process.rs
@@ -3,6 +3,9 @@ use std::fmt;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+#[cfg(not(target_os = "linux"))]
+use tracing::info;
+
 metrics! {
     process_start_time_seconds: Gauge {
         "Time that the process started (in seconds since the UNIX epoch)"


### PR DESCRIPTION
On MacOS, the module `telemetry::process` in `linkerd-app-core` fails
to build because the `info!` macro is used on non-Linux systems, but
it is not imported.