### PR TITLE
proxy-api: Update proxy-api to use the main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,14 +1467,14 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.18"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.18#4c424593d934a22635c06706a3c399d0875a49a1"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#453ac1ea2b73fe12bb26a05c2bc6d44eb3d8c77b"
 dependencies = [
  "h2",
  "http",
+ "ipnet",
  "prost",
  "prost-types",
  "quickcheck",
- "rand",
  "tonic",
  "tonic-build",
 ]

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -43,7 +43,7 @@ linkerd-metrics = { path = "../../metrics" }
 linkerd-transport-header = { path = "../../transport-header" }
 linkerd-opencensus = { path = "../../opencensus" }
 linkerd-proxy-core = { path = "../../proxy/core" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main" }
 linkerd-proxy-api-resolve = { path = "../../proxy/api-resolve" }
 linkerd-proxy-discover = { path = "../../proxy/discover" }
 linkerd-proxy-identity = { path = "../../proxy/identity" }
@@ -86,5 +86,5 @@ features = [
 linkerd-system = { path = "../../system" }
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["arbitrary"] }
 prost-types = "0.7.0"

--- a/linkerd/app/inbound/fuzz/Cargo.lock
+++ b/linkerd/app/inbound/fuzz/Cargo.lock
@@ -1296,10 +1296,11 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.18"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?tag=v0.1.18#4c424593d934a22635c06706a3c399d0875a49a1"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#453ac1ea2b73fe12bb26a05c2bc6d44eb3d8c77b"
 dependencies = [
  "h2",
  "http",
+ "ipnet",
  "prost",
  "prost-types",
  "tonic",

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -26,7 +26,7 @@ hyper = { version = "0.14.2", features = ["http1", "http2", "stream", "client", 
 linkerd-app = { path = "..", features = ["allow-loopback"] }
 linkerd-app-core = { path = "../core" }
 linkerd-metrics = { path = "../../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["destination", "arbitrary"] }
 linkerd-app-test = { path = "../test" }
 linkerd-tracing = { path = "../../tracing" }
 regex = "1"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -14,7 +14,7 @@ async-stream = "0.3"
 futures = "0.3.15"
 linkerd-addr = { path = "../../addr" }
 linkerd-error = { path = "../../error" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["destination", "client"] }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 futures = "0.3.15"
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["identity", "client"] }
 linkerd-error = { path = "../../error" }
 linkerd-identity = { path = "../../identity" }
 linkerd-metrics = { path = "../../metrics" }

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -12,7 +12,7 @@ hyper = { version = "0.14.2", features = ["http1", "http2"] }
 futures = "0.3.15"
 indexmap = "1.0"
 ipnet = "2.0"
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["tap", "server"] }
 linkerd-conditional = { path = "../../conditional" }
 linkerd-error = { path = "../../error" }
 linkerd-identity = { path = "../../identity" }
@@ -30,5 +30,5 @@ tracing = "0.1.23"
 pin-project = "1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["arbitrary"] }
 prost-types = "0.7.0"

--- a/linkerd/proxy/tap/src/grpc/server.rs
+++ b/linkerd/proxy/tap/src/grpc/server.rs
@@ -3,7 +3,7 @@ use crate::{iface, Inspect, Registry};
 use futures::ready;
 use futures::stream::Stream;
 use hyper::body::{Buf, HttpBody};
-use linkerd2_proxy_api::{http_types, pb_duration, tap as api};
+use linkerd2_proxy_api::{http_types, tap as api};
 use linkerd_conditional::Conditional;
 use linkerd_proxy_http::HasH2Reason;
 use linkerd_tls as tls;
@@ -373,7 +373,7 @@ impl iface::TapResponse for TapResponse {
 
         let init = api::tap_event::http::Event::ResponseInit(api::tap_event::http::ResponseInit {
             id: Some(self.tap.id.clone()),
-            since_request_init: Some(pb_duration(response_init_at - self.request_init_at)),
+            since_request_init: Some((response_init_at - self.request_init_at).into()),
             http_status: rsp.status().as_u16().into(),
             headers,
         });
@@ -406,7 +406,7 @@ impl iface::TapResponse for TapResponse {
         let reason = err.h2_reason();
         let end = api::tap_event::http::Event::ResponseEnd(api::tap_event::http::ResponseEnd {
             id: Some(self.tap.id.clone()),
-            since_request_init: Some(pb_duration(response_end_at - self.request_init_at)),
+            since_request_init: Some((response_end_at - self.request_init_at).into()),
             since_response_init: None,
             response_bytes: 0,
             eos: Some(api::Eos {
@@ -472,8 +472,8 @@ impl TapResponsePayload {
         };
         let end = api::tap_event::http::ResponseEnd {
             id: Some(self.tap.id),
-            since_request_init: Some(pb_duration(response_end_at - self.request_init_at)),
-            since_response_init: Some(pb_duration(response_end_at - self.response_init_at)),
+            since_request_init: Some((response_end_at - self.request_init_at).into()),
+            since_response_init: Some((response_end_at - self.response_init_at).into()),
             response_bytes: self.response_bytes as u64,
             eos: Some(api::Eos { end }),
             trailers,

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -18,7 +18,7 @@ indexmap = "1.0"
 linkerd-addr = { path = "../addr" }
 linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18"  }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["destination", "client"] }
 linkerd-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd-stack = { path = "../stack" }
 rand = { version = "0.8", features = ["small_rng"] }
@@ -32,6 +32,6 @@ tracing = "0.1.23"
 pin-project = "1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", tag = "v0.1.18", features = ["arbitrary"] }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["arbitrary"] }
 prost-types = "0.7.0"
 quickcheck = { version = "1", default-features = false }


### PR DESCRIPTION
While we prepare for upcoming policy work, we should move the proxy to
use the updated crate from the main branch of the repo. This updated
version exposes a feature for each API--and for server- and
client-generation--so that we can more narrowly express dependencies in
the proxy.