### PR TITLE
inbound: Simplify protocol-detection skipping

### DIFF
--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -1,4 +1,4 @@
-use crate::{Config, RequireIdentityForPorts, SkipByPort};
+use crate::{Config, RequireIdentityForPorts};
 pub use futures::prelude::*;
 use linkerd_app_core::{
     config,
@@ -48,7 +48,7 @@ pub fn default_config() -> Config {
             detect_protocol_timeout: Duration::from_secs(10),
         },
         require_identity_for_inbound_ports: RequireIdentityForPorts::from(None),
-        disable_protocol_detection_for_ports: SkipByPort::from(indexmap::IndexSet::default()),
+        disable_protocol_detection_for_ports: Default::default(),
         profile_idle_timeout: Duration::from_millis(500),
     }
 }

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -528,7 +528,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             require_identity_for_inbound_ports: require_identity_for_inbound_ports.into(),
             profile_idle_timeout: dst_profile_idle_timeout?
                 .unwrap_or(DEFAULT_DESTINATION_PROFILE_IDLE_TIMEOUT),
-            disable_protocol_detection_for_ports: inbound_opaque_ports.into(),
+            disable_protocol_detection_for_ports: inbound_opaque_ports.into_iter().collect(),
         }
     };
 


### PR DESCRIPTION
The inbound proxy's layer that switches between routed and passthru
stacks uses an unnecessary explict type for its predicate. In order to
setup for further changes to this stack, this change eliminate the
specialized type in favor of a closure.

We also ditch the use of IndexSet as there's no functional need for it.