### PR TITLE
Update tokio, hyper, and socket2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,9 +356,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
  "bytes",
  "fnv",
@@ -371,7 +371,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -457,21 +456,21 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -483,8 +482,8 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
- "socket2",
+ "pin-project-lite",
+ "socket2 0.4.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -540,7 +539,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "widestring",
  "winapi",
  "winreg",
@@ -787,7 +786,7 @@ dependencies = [
  "linkerd2-proxy-api",
  "regex",
  "rustls",
- "socket2",
+ "socket2 0.4.0",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -1276,7 +1275,7 @@ dependencies = [
  "linkerd-metrics",
  "linkerd-stack",
  "pin-project",
- "socket2",
+ "socket2 0.4.0",
  "tokio",
  "tokio-stream",
  "tower",
@@ -1588,7 +1587,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
- "socket2",
+ "socket2 0.3.19",
  "winapi",
 ]
 
@@ -2065,6 +2064,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,9 +2150,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2346,16 +2355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 http = "0.2"
-hyper = "0.14.2"
+hyper = "0.14"
 pin-project = "1"
 tower = { version = "0.4.7", default-features = false, features = ["load"] }
 tokio = { version = "1", features = ["macros"] }

--- a/linkerd/addr/fuzz/Cargo.lock
+++ b/linkerd/addr/fuzz/Cargo.lock
@@ -73,7 +73,6 @@ checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -97,34 +96,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
-dependencies = [
- "autocfg",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -145,18 +120,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
  "autocfg",
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
- "slab",
 ]
 
 [[package]]
@@ -300,12 +268,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
-
-[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -357,18 +319,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -474,12 +424,6 @@ checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -15,7 +15,7 @@ This is used by tests and the executable.
 allow-loopback = ["linkerd-app-outbound/allow-loopback"]
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 indexmap = "1.0"
 ipnet = "2.0"
 linkerd-app-admin = { path = "./admin" }

--- a/linkerd/app/admin/Cargo.toml
+++ b/linkerd/app/admin/Cargo.toml
@@ -13,7 +13,7 @@ The linkerd proxy's admin server.
 html-escape = "0.2"
 http = "0.2"
 hyper = { version = "0.14", features = ["http1", "http2"] }
-futures = "0.3"
+futures = { version = "0.3", default-features = false }
 linkerd-app-core = { path = "../core" }
 linkerd-app-inbound = { path = "../inbound" }
 serde_json = "1"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -18,7 +18,7 @@ drain = { version = "0.0.1", features = ["retain"] }
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.2", features = ["http1", "http2"] }
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 indexmap = "1.0"
 ipnet = "2.0"
 linkerd-addr = { path = "../../addr" }

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 http = "0.2"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 indexmap = "1.0"
 linkerd-app-core = { path = "../core" }
 linkerd-app-inbound = { path = "../inbound" }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -12,7 +12,7 @@ Configures and runs the inbound proxy
 [dependencies]
 bytes = "1"
 http = "0.2"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 indexmap = "1.0"
 linkerd-app-core = { path = "../core" }
 thiserror = "1.0"

--- a/linkerd/app/inbound/fuzz/Cargo.lock
+++ b/linkerd/app/inbound/fuzz/Cargo.lock
@@ -1109,7 +1109,7 @@ dependencies = [
  "linkerd-metrics",
  "linkerd-stack",
  "pin-project",
- "socket2 0.3.19",
+ "socket2 0.4.0",
  "tokio",
  "tokio-stream",
  "tower",

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -18,7 +18,7 @@ flaky_tests = []
 
 [dependencies]
 bytes = "1"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 h2 = "0.3"
 http = "0.2"
 http-body = "0.4"
@@ -30,7 +30,7 @@ linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", br
 linkerd-app-test = { path = "../test" }
 linkerd-tracing = { path = "../../tracing" }
 regex = "1"
-socket2 = "0.3.12"
+socket2 = "0.4"
 rustls = "0.19"
 tokio = { version = "1", features = ["io-util", "net", "rt", "macros"] }
 tokio-stream = { version = "0.1.5", features = ["sync"] }

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -286,13 +286,12 @@ pub(crate) fn bind_ephemeral() -> (Socket, SocketAddr) {
     use socket2::{Domain, Protocol, Type};
 
     let addr = SocketAddr::from(([127, 0, 0, 1], 0));
-    let sock =
-        Socket::new(Domain::ipv4(), Type::stream(), Some(Protocol::tcp())).expect("Socket::new");
+    let sock = Socket::new(Domain::IPV4, Type::STREAM, Some(Protocol::TCP)).expect("Socket::new");
     sock.bind(&addr.into()).expect("Socket::bind");
     let addr = sock
         .local_addr()
         .expect("Socket::local_addr")
-        .as_std()
+        .as_socket()
         .expect("must be AF_INET");
     (sock, addr)
 }
@@ -302,8 +301,7 @@ pub(crate) fn bind_ephemeral() -> (Socket, SocketAddr) {
 pub(crate) fn listen(sock: Socket) -> TcpListener {
     sock.listen(1024)
         .expect("socket should be able to start listening");
-    let sock = sock.into_tcp_listener();
     sock.set_nonblocking(true)
         .expect("socket should be able to set nonblocking");
-    TcpListener::from_std(sock).expect("socket should seem okay to tokio")
+    TcpListener::from_std(sock.into()).expect("socket should seem okay to tokio")
 }

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -17,7 +17,7 @@ test-subscriber = []
 [dependencies]
 bytes = "1"
 http = "0.2"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 indexmap = "1.0"
 linkerd-app-core = { path = "../core" }
 linkerd-http-retry = { path = "../../http-retry" }

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -17,7 +17,7 @@ a dedicated crate to help the compiler cache dependencies properly.
 flaky_tests = []
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 h2 = "0.3"
 http = "0.2"
 http-body = "0.4"

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 parking_lot = "0.11"

--- a/linkerd/concurrency-limit/Cargo.toml
+++ b/linkerd/concurrency-limit/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-stack = { path = "../stack" }
 tokio = { version = "1", features = ["sync"] }
 tokio-util = "0.6.5"

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-dns-name = { path = "./name" }
 linkerd-error = { path = "../error" }
 thiserror = "1.0"

--- a/linkerd/dns/fuzz/Cargo.lock
+++ b/linkerd/dns/fuzz/Cargo.lock
@@ -106,7 +106,6 @@ checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -130,34 +129,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
-dependencies = [
- "autocfg",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -178,17 +153,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
  "autocfg",
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -535,18 +504,6 @@ name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"

--- a/linkerd/duplex/Cargo.toml
+++ b/linkerd/duplex/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 bytes = "1"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["io-util"] }
 pin-project = "1"
 tracing = "0.1.23"

--- a/linkerd/error-metrics/Cargo.toml
+++ b/linkerd/error-metrics/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 indexmap = "1.0"
 linkerd-metrics = { path = "../metrics" }
 tower = { version = "0.4.7", default-features = false }

--- a/linkerd/error-respond/Cargo.toml
+++ b/linkerd/error-respond/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }
 tower = { version = "0.4.7", default-features = false }
 pin-project = "1"

--- a/linkerd/error/Cargo.toml
+++ b/linkerd/error/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }

--- a/linkerd/exp-backoff/Cargo.toml
+++ b/linkerd/exp-backoff/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 rand = { version = "0.8", features = ["small_rng"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["time"]}

--- a/linkerd/http-box/Cargo.toml
+++ b/linkerd/http-box/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 bytes = "1"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
 linkerd-error = { path = "../error" }

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 bytes = "1"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14.2", features = ["http1", "http2"] }

--- a/linkerd/io/Cargo.toml
+++ b/linkerd/io/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 
 [dependencies]
 async-trait = "0.1"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 bytes = "1"
 linkerd-errno = { path = "../errno" }
 tokio = { version = "1", features = ["io-util", "net"] }

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3"
+futures = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
 linkerd-error = { path = "../error" }

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -11,7 +11,7 @@ Implements the Resolve trait using the proxy's gRPC API
 
 [dependencies]
 async-stream = "0.3"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-addr = { path = "../../addr" }
 linkerd-error = { path = "../../error" }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["destination", "client"] }

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -10,7 +10,7 @@ Core interfaces needed to implement proxy components
 """
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 tower = { version = "0.4.7", default-features = false }
 pin-project = "1"

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -11,7 +11,7 @@ Utilities to implement a Discover with the core Resolve type
 
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -10,7 +10,7 @@ Service Dns Resolutions for the proxy
 """
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 linkerd-addr = { path = "../../addr" }
 linkerd-dns = { path = "../../dns" }

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -15,7 +15,7 @@ This should probably be decomposed into smaller, decoupled crates.
 async-trait = "0.1"
 bytes = "1"
 drain = "0.0.1"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 h2 = "0.3"
 http = "0.2"
 http-body = "0.4"

--- a/linkerd/proxy/http/fuzz/Cargo.lock
+++ b/linkerd/proxy/http/fuzz/Cargo.lock
@@ -335,7 +335,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project",
- "socket2 0.4.0",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -543,7 +543,7 @@ dependencies = [
  "linkerd-metrics",
  "linkerd-stack",
  "pin-project",
- "socket2 0.3.19",
+ "socket2",
  "tokio",
  "tokio-stream",
  "tower",
@@ -932,17 +932,6 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-
-[[package]]
-name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "socket2"

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["identity", "client"] }
 linkerd-error = { path = "../../error" }
 linkerd-identity = { path = "../../identity" }

--- a/linkerd/proxy/resolve/Cargo.toml
+++ b/linkerd/proxy/resolve/Cargo.toml
@@ -10,7 +10,7 @@ Utilities for working with `Resolve` implementations
 """
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 thiserror = "1.0"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 http = "0.2"
 hyper = { version = "0.14.2", features = ["http1", "http2"] }
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 indexmap = "1.0"
 ipnet = "2.0"
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["tap", "server"] }

--- a/linkerd/proxy/tcp/Cargo.toml
+++ b/linkerd/proxy/tcp/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-duplex = { path = "../../duplex" }
 linkerd-error = { path = "../../error" }
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -11,14 +11,14 @@ Transport-level implementations that rely on core proxy infrastructure
 
 [dependencies]
 bytes = "1"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-errno = { path = "../../errno" }
 linkerd-error = { path = "../../error" }
 linkerd-io = { path = "../../io" }
 linkerd-metrics = { path = "../../metrics" }
 linkerd-stack = { path = "../../stack" }
 pin-project = "1"
-socket2 = "0.3"
+socket2 = "0.4"
 tokio = { version = "1", features = ["macros", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tower = { version = "0.4", features = ["make"] }

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -18,6 +18,7 @@ pub use self::{
     listen::{Bind, BindTcp},
     orig_dst::BindWithOrigDst,
 };
+use socket2::TcpKeepalive;
 use std::time::Duration;
 use tokio::net::TcpStream;
 
@@ -38,7 +39,7 @@ fn set_nodelay_or_warn(socket: &TcpStream) {
     }
 }
 
-fn set_keepalive_or_warn(tcp: &TcpStream, ka: Option<Duration>) {
+fn set_keepalive_or_warn(tcp: &TcpStream, keepalive_duration: Option<Duration>) {
     // TODO(eliza): when https://github.com/tokio-rs/tokio/pull/3189 merges
     // upstream, we will be able to convert the Tokio `TcpStream` into a
     // `socket2::Socket` without unsafe, by converting it to a
@@ -72,7 +73,10 @@ fn set_keepalive_or_warn(tcp: &TcpStream, ka: Option<Duration>) {
         socket2::Socket::from_raw_socket(tcp.as_raw_socket())
     };
 
-    if let Err(e) = sock.set_keepalive(ka) {
+    let ka = keepalive_duration
+        .into_iter()
+        .fold(TcpKeepalive::new(), |k, t| k.with_time(t));
+    if let Err(e) = sock.set_tcp_keepalive(&ka) {
         tracing::warn!("failed to set keepalive: {}", e);
     }
 

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 tower = { version = "0.4.7", default-features = false }
 tracing = "0.1.23"
 pin-project = "1"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -11,7 +11,7 @@ Implements client layers for Linkerd ServiceProfiles.
 
 [dependencies]
 bytes = "1"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
 indexmap = "1.0"

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -11,7 +11,7 @@ Utilities for composing Tower services.
 
 [dependencies]
 dyn-clone = "1.0.3"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }
 pin-project = "1"
 tokio = { version = "1", features = ["time"] }

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 linkerd-stack = { path = ".." }
 tower = "0.4.7"

--- a/linkerd/timeout/Cargo.toml
+++ b/linkerd/timeout/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 thiserror = "1"

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 linkerd-conditional = { path = "../conditional" }
 linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }

--- a/linkerd/tls/fuzz/Cargo.lock
+++ b/linkerd/tls/fuzz/Cargo.lock
@@ -90,7 +90,6 @@ checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -114,34 +113,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
-dependencies = [
- "autocfg",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -162,18 +137,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
  "autocfg",
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
- "slab",
 ]
 
 [[package]]
@@ -477,18 +445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,12 +571,6 @@ checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
 dependencies = [
  "lazy_static",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 base64 = "0.13"
 bytes = "1"
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 hex = "0.3.2"
 http = "0.2"
 linkerd-error = { path = "../error" }

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 bytes = "1"
-futures = "0.3"
+futures = { version = "0.3", default-features = false }
 linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }
 linkerd-io = { path = "../io" }

--- a/linkerd/transport-header/fuzz/Cargo.lock
+++ b/linkerd/transport-header/fuzz/Cargo.lock
@@ -122,7 +122,6 @@ checksum = "0e7e43a803dae2fa37c1f6a8fe121e1f7bf9548b4dfc0522a42f34145dadfc27"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -146,34 +145,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
-name = "futures-executor"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "badaa6a909fac9e7236d0620a2f57f7664640c56575b71a7552fbd68deafab79"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
-dependencies = [
- "autocfg",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -194,18 +169,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
  "autocfg",
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
- "slab",
 ]
 
 [[package]]
@@ -558,18 +526,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,12 +761,6 @@ checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "slab"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -12,7 +12,7 @@ default = ["multicore"]
 multicore = ["tokio/rt-multi-thread", "num_cpus"]
 
 [dependencies]
-futures = "0.3.15"
+futures = { version = "0.3", default-features = false }
 mimalloc = { version = "0.1.19", optional = true }
 num_cpus = { version = "1", optional = true }
 linkerd-app = { path = "../linkerd/app" }


### PR DESCRIPTION
This change updates `tokio`, `hyper`, and `socket2` (from v0.3 to v0.4).
This has a few implications:

* `tokio::select!` can now be used in place of
  `futures::select_biased!`;
* We now only depend on the core `futures` functionality with all
  features disabled.
* `socket2` had several small API changes that have been addressed.