### PR TITLE
service-profiles: Wrap receiver types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,7 +1303,6 @@ dependencies = [
 name = "linkerd-service-profiles"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "bytes",
  "futures",
  "http",
@@ -1323,6 +1322,7 @@ dependencies = [
  "regex",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tower",
  "tracing",

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -63,7 +63,7 @@ where
             None => return Gateway::BadDomain(http.target.name().clone()),
         };
 
-        let logical_addr = match profile.borrow().addr.clone() {
+        let logical_addr = match profile.logical_addr() {
             Some(addr) => addr,
             None => return Gateway::BadDomain(http.target.name().clone()),
         };

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -119,7 +119,7 @@ where
                 let profile = p.ok_or_else(|| {
                     DiscoveryRejected::new("no profile discovered for gateway target")
                 })?;
-                let logical_addr = profile.borrow().addr.clone().ok_or_else(|| {
+                let logical_addr = profile.logical_addr().ok_or_else(|| {
                     DiscoveryRejected::new(
                         "profile for gateway target does not have a logical address",
                     )

--- a/linkerd/app/inbound/fuzz/Cargo.lock
+++ b/linkerd/app/inbound/fuzz/Cargo.lock
@@ -1132,7 +1132,6 @@ dependencies = [
 name = "linkerd-service-profiles"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "bytes",
  "futures",
  "http",
@@ -1150,6 +1149,7 @@ dependencies = [
  "regex",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tonic",
  "tower",
  "tracing",

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -97,8 +97,7 @@ impl Outbound<svc::BoxNewHttp<http::Endpoint>> {
             .push_request_filter(
                 |(profile, http): (Option<profiles::Receiver>, Http<NameAddr>)| {
                     if let Some(profile) = profile {
-                        let addr = profile.borrow().addr.clone();
-                        if let Some(logical_addr) = addr {
+                        if let Some(logical_addr) = profile.logical_addr() {
                             return Ok(http::Logical {
                                 profile,
                                 logical_addr,

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -58,7 +58,7 @@ impl<P> svc::Param<LogicalAddr> for Logical<P> {
 // Used for skipping HTTP detection
 impl svc::Param<Option<http::detect::Skip>> for Logical<()> {
     fn param(&self) -> Option<http::detect::Skip> {
-        if self.profile.borrow().opaque_protocol {
+        if self.profile.is_opaque_protocol() {
             Some(http::detect::Skip)
         } else {
             None

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -140,12 +140,12 @@ mod tests {
 
         // We create a logical target to be resolved to endpoints.
         let logical_addr = LogicalAddr("xyz.example.com:4444".parse().unwrap());
-        let (_tx, profile) = tokio::sync::watch::channel(Profile {
+        let (_tx, rx) = tokio::sync::watch::channel(Profile {
             addr: Some(logical_addr.clone()),
             ..Default::default()
         });
         let logical = Logical {
-            profile,
+            profile: rx.into(),
             logical_addr: logical_addr.clone(),
             protocol: (),
         };
@@ -203,12 +203,12 @@ mod tests {
 
         // We create a logical target to be resolved to endpoints.
         let logical_addr = LogicalAddr("xyz.example.com:4444".parse().unwrap());
-        let (_tx, profile) = tokio::sync::watch::channel(Profile {
+        let (_tx, rx) = tokio::sync::watch::channel(Profile {
             addr: Some(logical_addr.clone()),
             ..Default::default()
         });
         let logical = Logical {
-            profile,
+            profile: rx.into(),
             logical_addr: logical_addr.clone(),
             protocol: (),
         };

--- a/linkerd/app/test/src/profile.rs
+++ b/linkerd/app/test/src/profile.rs
@@ -16,7 +16,7 @@ pub fn only_default() -> Receiver {
 pub fn only(profile: Profile) -> Receiver {
     let (tx, rx) = channel(profile);
     tokio::spawn(async move { tx.closed().await });
-    rx
+    rx.into()
 }
 
 pub fn resolver() -> crate::resolver::Profiles {

--- a/linkerd/app/test/src/resolver.rs
+++ b/linkerd/app/test/src/resolver.rs
@@ -158,7 +158,7 @@ impl Profiles {
             .endpoints
             .lock()
             .unwrap()
-            .insert(addr.into(), Some(rx));
+            .insert(addr.into(), Some(rx.into()));
         tx
     }
 
@@ -169,7 +169,7 @@ impl Profiles {
             .endpoints
             .lock()
             .unwrap()
-            .insert(addr.into(), Some(rx));
+            .insert(addr.into(), Some(rx.into()));
         self
     }
 

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -25,7 +25,7 @@ linkerd-tonic-watch = { path = "../tonic-watch" }
 rand = { version = "0.8", features = ["small_rng"] }
 regex = "1.0.0"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
-async-stream = "0.3"
+tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = { version = "0.4", default-features = false }
 tower = { version = "0.4.7", features = [ "ready-cache", "retry", "util"] }
 thiserror = "1"

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -73,7 +73,10 @@ where
         let w = self.watch.clone();
         Box::pin(async move {
             match w.spawn_watch(addr).await {
-                Ok(rsp) => Ok(Some(rsp.into_inner())),
+                Ok(rsp) => {
+                    let rx = rsp.into_inner();
+                    Ok(Some(rx.into()))
+                }
                 Err(status) => {
                     debug!(%status, "Ignoring profile");
                     Ok::<_, Never>(None)

--- a/linkerd/service-profiles/src/http/mod.rs
+++ b/linkerd/service-profiles/src/http/mod.rs
@@ -1,4 +1,3 @@
-use crate::Receiver;
 use indexmap::IndexMap;
 use regex::Regex;
 use std::{

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -2,7 +2,7 @@
 #![forbid(unsafe_code)]
 #![allow(clippy::inconsistent_struct_constructor)]
 
-use futures::stream::Stream;
+use futures::Stream;
 use linkerd_addr::{Addr, NameAddr};
 use linkerd_error::Error;
 use linkerd_proxy_api_resolve::Metadata;
@@ -15,6 +15,7 @@ use std::{
     task::{Context, Poll},
 };
 use thiserror::Error;
+use tokio::sync::watch;
 use tower::util::{Oneshot, ServiceExt};
 
 mod client;
@@ -26,7 +27,15 @@ pub mod split;
 
 pub use self::client::Client;
 
-pub type Receiver = tokio::sync::watch::Receiver<Profile>;
+#[derive(Clone, Debug)]
+pub struct Receiver {
+    inner: tokio::sync::watch::Receiver<Profile>,
+}
+
+#[derive(Debug)]
+struct ReceiverStream {
+    inner: tokio_stream::wrappers::WatchStream<Profile>,
+}
 
 #[derive(Clone, Debug, Default)]
 pub struct Profile {
@@ -113,20 +122,49 @@ where
     }
 }
 
-fn stream_profile(mut rx: Receiver) -> Pin<Box<dyn Stream<Item = Profile> + Send + Sync>> {
-    Box::pin(async_stream::stream! {
-        loop {
-            let val = rx.borrow().clone();
-            yield val;
-            // This is a loop with a return condition rather than a while loop,
-            // because we want to yield the *first* value immediately, rather
-            // than waiting for the profile to change again.
-            if let Err(_) = rx.changed().await {
-                tracing::trace!("profile sender dropped");
-                return;
-            }
-        }
-    })
+// === impl Receiver ===
+
+impl From<watch::Receiver<Profile>> for Receiver {
+    fn from(inner: watch::Receiver<Profile>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Receiver {
+    pub fn logical_addr(&self) -> Option<LogicalAddr> {
+        self.inner.borrow().addr.clone()
+    }
+
+    pub fn is_opaque_protocol(&self) -> bool {
+        self.inner.borrow().opaque_protocol
+    }
+
+    pub fn endpoint(&self) -> Option<(SocketAddr, Metadata)> {
+        self.inner.borrow().endpoint.clone()
+    }
+
+    fn targets(&self) -> Vec<Target> {
+        self.inner.borrow().targets.clone()
+    }
+
+}
+
+// === impl ReceiverStream ===
+
+impl From<Receiver> for ReceiverStream {
+    fn from(Receiver { inner }: Receiver) -> Self {
+        let inner = tokio_stream::wrappers::WatchStream::new(inner);
+        ReceiverStream { inner }
+    }
+
+}
+
+impl Stream for ReceiverStream {
+    type Item = Profile;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
 }
 
 // === impl LookupAddr ===


### PR DESCRIPTION
We should be able to cache profile resolutions independently of the
stack; but the fact that the the profile modue's `Receiver` type is just
an alias for `watch::Receiver<Profile>` means that we can't attach
the additional metadata needed for cache entry retention.

In anticipation of caching profiles by lookup address, this change
creates an explicit `Receiver` type that hides the underlying
`watch::Receiver`, exposing only methods used by other crates/modules.

This change also replaces the boxed watch stream with a
`tokio_stream::wrappers::WatchStream`--also wrapped by a
profile-specific type--to avoid needless allocation and support
retaining additional resources.