### PR TITLE
tap: Restore tap matching tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
  "linkerd2-proxy-api",
  "pin-project",
  "prost-types",
+ "quickcheck",
  "rand",
  "thiserror",
  "tokio",

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -32,3 +32,4 @@ pin-project = "1"
 [dev-dependencies]
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["arbitrary"] }
 prost-types = "0.7.0"
+quickcheck = { version = "1", default-features = false }


### PR DESCRIPTION
The tap tests were disabled in #568. This change restores these tests,
updating them to use quickcheck v1.