### PR TITLE
tap: return an error when a `PortRange`'s min > max

### DIFF
--- a/linkerd/proxy/tap/src/grpc/match_.rs
+++ b/linkerd/proxy/tap/src/grpc/match_.rs
@@ -452,4 +452,20 @@ mod tests {
             err == HttpMatch::try_from(http).err()
         }
     }
+
+    #[test]
+    fn malformed_port_range() {
+        // This reproduces a bug found by quickcheck where a range's `min` >
+        // `max.
+
+        use self::observe_request::r#match::tcp;
+        let tcp = observe_request::r#match::Tcp {
+            r#match: Some(tcp::Match::Ports(tcp::PortRange { min: 1, max: 0 })),
+        };
+
+        assert_eq!(
+            TcpMatch::try_from(tcp).err(),
+            Some(InvalidMatch::InvalidPort)
+        )
+    }
 }

--- a/linkerd/proxy/tap/src/grpc/match_.rs
+++ b/linkerd/proxy/tap/src/grpc/match_.rs
@@ -365,6 +365,7 @@ mod tests {
                 tcp.r#match.as_ref()
                     .map(|m| match m {
                         tcp::Match::Ports(ps) => {
+                            #[allow(clippy::clippy::if_same_then_else)]
                             if ps.min == 0 && ps.max == 0 {
                                 Some(InvalidMatch::Empty)
                             } else if ps.min > ps.max && ps.max != 0 {

--- a/linkerd/proxy/tap/src/grpc/match_.rs
+++ b/linkerd/proxy/tap/src/grpc/match_.rs
@@ -365,7 +365,7 @@ mod tests {
                 tcp.r#match.as_ref()
                     .map(|m| match m {
                         tcp::Match::Ports(ps) => {
-                            #[allow(clippy::clippy::if_same_then_else)]
+                            #[allow(clippy::if_same_then_else)]
                             if ps.min == 0 && ps.max == 0 {
                                 Some(InvalidMatch::Empty)
                             } else if ps.min > ps.max && ps.max != 0 {

--- a/linkerd/proxy/tap/src/grpc/match_.rs
+++ b/linkerd/proxy/tap/src/grpc/match_.rs
@@ -180,13 +180,16 @@ impl TryFrom<observe_request::r#match::Tcp> for TcpMatch {
         m.r#match.ok_or(InvalidMatch::Empty).and_then(|t| match t {
             tcp::Match::Ports(range) => {
                 // If either a minimum or maximum is not specified, the range is considered to
-                // be over a discrete value.
+                // be over a discrete value.`
                 let min = if range.min == 0 { range.max } else { range.min };
                 let max = if range.max == 0 { range.min } else { range.max };
                 if min == 0 || max == 0 {
                     return Err(InvalidMatch::Empty);
                 }
                 if min > u32::from(::std::u16::MAX) || max > u32::from(::std::u16::MAX) {
+                    return Err(InvalidMatch::InvalidPort);
+                }
+                if min > max {
                     return Err(InvalidMatch::InvalidPort);
                 }
                 Ok(TcpMatch::PortRange(min as u16, max as u16))

--- a/linkerd/proxy/tap/src/grpc/match_.rs
+++ b/linkerd/proxy/tap/src/grpc/match_.rs
@@ -180,7 +180,7 @@ impl TryFrom<observe_request::r#match::Tcp> for TcpMatch {
         m.r#match.ok_or(InvalidMatch::Empty).and_then(|t| match t {
             tcp::Match::Ports(range) => {
                 // If either a minimum or maximum is not specified, the range is considered to
-                // be over a discrete value.`
+                // be over a discrete value.
                 let min = if range.min == 0 { range.max } else { range.min };
                 let max = if range.max == 0 { range.min } else { range.max };
                 if min == 0 || max == 0 {
@@ -459,16 +459,13 @@ mod tests {
     #[test]
     fn malformed_port_range() {
         // This reproduces a bug found by quickcheck where a range's `min` >
-        // `max.
+        // `max`.
 
         use self::observe_request::r#match::tcp;
         let tcp = observe_request::r#match::Tcp {
             r#match: Some(tcp::Match::Ports(tcp::PortRange { min: 1, max: 0 })),
         };
 
-        assert_eq!(
-            TcpMatch::try_from(tcp).err(),
-            Some(InvalidMatch::InvalidPort)
-        )
+        assert_eq!(TcpMatch::try_from(tcp).err(), None)
     }
 }

--- a/linkerd/proxy/tap/src/grpc/match_.rs
+++ b/linkerd/proxy/tap/src/grpc/match_.rs
@@ -365,7 +365,7 @@ mod tests {
                     .map(|m| match m {
                         tcp::Match::Ports(ps) => {
                             let ok = 0 < ps.min &&
-                                ps.min <= ps.max &&
+                                (ps.min <= ps.max || ps.max == 0) &&
                                 ps.max < u32::from(::std::u16::MAX);
                             if ok { None } else { Some(InvalidMatch::InvalidPort) }
                         }


### PR DESCRIPTION
The `quickcheck` tests for tap that were re-enabled in PR #1042 have
caught a bug: when a `PortMatch` message has a `min` value that's
greater than its `max` value, the tests expect that `TcpMatch::try_from`
should return an error (since the range is obviously invalid). However,
we don't currently do that.

This is causing CI to break on an unrelated change:
https://github.com/linkerd/linkerd2-proxy/runs/2797285941#step:3:907

This PR adds a new test reproducing the failing quickcheck inputs, and
fixes the bug (by making `TcpMatch::try_from` return an error in that
case).

Since `quickcheck` inputs are randomly generated and are not
deterministic, I thought it was probably a good idea to have a
hard-coded test to reproduce this case, just in case there are future
regressions. As a side note, we may want to consider switching from the
`quickcheck` crate to the [`proptest` crate] --- one nice feature of
`proptest` is that it automatically records failing inputs, which can be
checked in to git, and future test runs will try all the failing inputs
as well as randomly generating new ones.

[`proptest` crate]: https://github.com/AltSysrq/proptest