### PR TITLE
RetryPolicy refactor suggestions

### DIFF
--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -125,7 +125,7 @@ impl<E> Outbound<E> {
                     // any `Body` type into `BoxBody` so that the rest of the
                     // stack doesn't have to implement `Service` for requests
                     // with both body types.
-                    .push_on_response(http::EraseRequest::layer())
+                    .push_on_response(http::BoxRequest::erased())
                     // Sets an optional retry policy.
                     .push(retry::layer(rt.metrics.http_route_retry.clone()))
                     // Sets an optional request timeout.
@@ -140,7 +140,7 @@ impl<E> Outbound<E> {
             ))
             // Strips headers that may be set by this proxy and add an outbound
             // canonical-dst-header. The response body is boxed unify the profile
-            // stack's response type. withthat of to endpoint stack.
+            // stack's response type with that of to endpoint stack.
             .push(http::NewHeaderFromTarget::<CanonicalDstHeader, _>::layer())
             .push_on_response(svc::layers().push(http::BoxResponse::layer()))
             .instrument(|l: &Logical| debug_span!("logical", dst = %l.logical_addr))

--- a/linkerd/http-box/src/erase_request.rs
+++ b/linkerd/http-box/src/erase_request.rs
@@ -27,8 +27,12 @@ use std::task::{Context, Poll};
 pub struct EraseRequest<S>(S);
 
 impl<S> EraseRequest<S> {
+    pub fn new(inner: S) -> Self {
+        Self(inner)
+    }
+
     pub fn layer() -> impl layer::Layer<S, Service = Self> + Clone + Copy {
-        layer::mk(EraseRequest)
+        layer::mk(Self::new)
     }
 }
 

--- a/linkerd/http-box/src/erase_request.rs
+++ b/linkerd/http-box/src/erase_request.rs
@@ -5,7 +5,7 @@ use linkerd_error::Error;
 use linkerd_stack::{layer, Proxy};
 use std::task::{Context, Poll};
 
-/// A middleware that boxes HTTP request bodies.
+/// Boxes request bodies, erasing the original type.
 ///
 /// This is *very* similar to the [`BoxRequest`] middleware. However, that
 /// middleware is generic over a specific body type that is erased. A given
@@ -53,10 +53,12 @@ where
     type Error = S::Error;
     type Future = S::Future;
 
+    #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.0.poll_ready(cx)
     }
 
+    #[inline]
     fn call(&mut self, req: http::Request<B>) -> Self::Future {
         self.0.call(req.map(BoxBody::new))
     }
@@ -75,6 +77,7 @@ where
     type Error = P::Error;
     type Future = P::Future;
 
+    #[inline]
     fn proxy(&self, inner: &mut S, req: http::Request<B>) -> Self::Future {
         self.0.proxy(inner, req.map(BoxBody::new))
     }

--- a/linkerd/http-box/src/request.rs
+++ b/linkerd/http-box/src/request.rs
@@ -34,10 +34,12 @@ where
     type Error = S::Error;
     type Future = S::Future;
 
+    #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.0.poll_ready(cx)
     }
 
+    #[inline]
     fn call(&mut self, req: http::Request<B>) -> Self::Future {
         self.0.call(req.map(BoxBody::new))
     }

--- a/linkerd/http-box/src/request.rs
+++ b/linkerd/http-box/src/request.rs
@@ -1,6 +1,6 @@
 //! A middleware that boxes HTTP request bodies.
 
-use crate::BoxBody;
+use crate::{erase_request::EraseRequest, BoxBody};
 use linkerd_error::Error;
 use linkerd_stack::layer;
 use std::{
@@ -14,6 +14,13 @@ pub struct BoxRequest<S, B>(S, PhantomData<fn(B)>);
 impl<S, B> BoxRequest<S, B> {
     pub fn layer() -> impl layer::Layer<S, Service = Self> + Clone + Copy {
         layer::mk(|inner| BoxRequest(inner, PhantomData))
+    }
+}
+
+impl<S> BoxRequest<S, ()> {
+    /// Constructs a boxing layer that erases the inner request type with [`EraseRequest`].
+    pub fn erased() -> impl layer::Layer<S, Service = EraseRequest<S>> + Clone + Copy {
+        EraseRequest::layer()
     }
 }
 

--- a/linkerd/http-box/src/response.rs
+++ b/linkerd/http-box/src/response.rs
@@ -26,10 +26,12 @@ where
     type Error = S::Error;
     type Future = future::MapOk<S::Future, fn(S::Response) -> Self::Response>;
 
+    #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.0.poll_ready(cx)
     }
 
+    #[inline]
     fn call(&mut self, req: Req) -> Self::Future {
         self.0.call(req).map_ok(|rsp| rsp.map(BoxBody::new))
     }

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -42,7 +42,7 @@ pub use http::{
     uri, Request, Response, StatusCode,
 };
 pub use hyper::body::HttpBody;
-pub use linkerd_http_box::{BoxBody, BoxRequest, BoxResponse, EraseRequest};
+pub use linkerd_http_box::{BoxBody, BoxRequest, BoxResponse};
 
 #[derive(Clone, Debug)]
 pub struct HeaderPair(pub HeaderName, pub HeaderValue);

--- a/linkerd/retry/Cargo.toml
+++ b/linkerd/retry/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 pin-project = "1"
-tower = { version = "0.4.7", default-features = false, features = ["retry", "util"] }
+tower = { version = "0.4.7", default-features = false, features = ["retry"] }
 tracing = "0.1.23"

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -41,7 +41,7 @@ pub use self::{
     unwrap_or::UnwrapOr,
 };
 pub use tower::{
-    util::{future_service, FutureService, MapErr, MapErrLayer, ServiceExt},
+    util::{future_service, FutureService, MapErr, MapErrLayer, Oneshot, ServiceExt},
     Service,
 };
 


### PR DESCRIPTION
A few suggestions on #1043 

- Expose `EraseRequest` via `BoxRequest::erased` -- we don't actually care about the different types--the behavior is basically the same -- there's just some minor differences with regards to preserving marker types. It reads a little bit more naturally if we just hang it all off BoxRequest.
- Renamed the `linkerd_retry::RetryPolicy` trait to `linkerd_retry::PrepareRequest` (to match its only method). It's a bit... _malkovich_ to have both `tower::retry::Policy` and `linkerd_retry::RetryPolicy` which are closely related but different.
- `linkerd_retry` now re-exports relevant `tower::retry` types.
- Renames in `app::core::retry` to reflect actual types. For instance, `NewRetry` is now `NewRetryPolicy` -- since it actually implements `NewPolicy` and has nothing to do with the `retry::NewRetry` type.
- `NewRetryLayer` eliminated in favor of an anonymous type.
- Various `inlines` on pass-through service/proxy methods