### PR TITLE
outbound: replace `sleep`s in test with `yield_now`

### DIFF
--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -248,7 +248,7 @@ mod tests {
         resolve_tx
             .add(Some((ep0_addr, Default::default())))
             .unwrap();
-        time::sleep(time::Duration::from_secs(1)).await; // Let the balancer observe the update.
+        tokio::task::yield_now().await; // Let the balancer observe the update.
         let (io, task) = spawn_io();
         svc.clone().oneshot(io).await.unwrap();
         let msg = task.await.unwrap().unwrap();
@@ -259,7 +259,7 @@ mod tests {
         resolve_tx
             .add(Some((ep1_addr, Default::default())))
             .unwrap();
-        time::sleep(time::Duration::from_secs(1)).await; // Let the balancer observe the update.
+        tokio::task::yield_now().await; // Let the balancer observe the update.
         let mut seen0 = false;
         let mut seen1 = false;
         for i in 1..=100 {
@@ -294,7 +294,7 @@ mod tests {
         // When we remove the ep0, all traffic goes to ep1:
 
         resolve_tx.remove(Some(ep0_addr)).unwrap();
-        time::sleep(time::Duration::from_secs(1)).await; // Let the balancer observe the update.
+        tokio::task::yield_now().await; // Let the balancer observe the update.
         for _ in 1..=100 {
             let (io, task) = spawn_io();
             svc.clone().oneshot(io).await.unwrap();
@@ -306,7 +306,7 @@ mod tests {
         // Empty load balancers hit fail-fast errors:
 
         resolve_tx.remove(Some(ep1_addr)).unwrap();
-        time::sleep(time::Duration::from_secs(1)).await; // Let the balancer observe the update.
+        tokio::task::yield_now().await; // Let the balancer observe the update.
         let (io, task) = spawn_io();
         let err = svc
             .clone()


### PR DESCRIPTION
These don't actually *need* to advance the mock clock --- they are just
intended to make the current task yield so the background task can
observe updates. Replacing them with `yield_now` expresses intent more
accurately.

Also, this seems to fix the test failing after upgrading to tokio
1.6.2+, presumably related to tokio-rs/tokio#3852. I'm still trying to
figure out _why_ exactly this fixes the test (and why it breaks in the
first place), but at least this PR will get CI passing on Tokio 1.7.0.

See here for details:
https://github.com/linkerd/linkerd2-proxy/pull/1079#issuecomment-862750060