### PR TITLE
build(deps): Skip coverage by PR title

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     if: |
-      !contains(github.event.pull_request.labels.*.name, 'dependencies')
+      !startsWith(github.event.pull_request.title, 'build(deps): ')
     name: codecov
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
e0e2b3407 updated the coverage action to be skipped when the
`dependencies` label is set, but in practice dependabot sets labels
after the PR is actually created, so the action can fire before the
label is present.

This change updates the coverage action to look at the PR title and skip
coverage when the title begins with `build(deps): `.