### PR TITLE
build(deps): Update trust-dns to v0.21.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -2447,8 +2447,8 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.20.1"
-source = "git+https://github.com/bluejekyll/trust-dns?branch=main#bbc9d5e9156f48102d246791e4ffa6e94962eebc"
+version = "0.21.0-alpha.1"
+source = "git+https://github.com/bluejekyll/trust-dns?branch=main#ed9f05b102755178f3aa23f09c368b66d5972950"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2471,8 +2471,8 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.20.1"
-source = "git+https://github.com/bluejekyll/trust-dns?branch=main#bbc9d5e9156f48102d246791e4ffa6e94962eebc"
+version = "0.21.0-alpha.1"
+source = "git+https://github.com/bluejekyll/trust-dns?branch=main#ed9f05b102755178f3aa23f09c368b66d5972950"
 dependencies = [
  "cfg-if",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,4 @@ debug = false
 debug = false
 
 [patch.crates-io]
-trust-dns-proto = { git = "https://github.com/bluejekyll/trust-dns", branch = "main" }
-trust-dns-resolver = { git = "https://github.com/bluejekyll/trust-dns", branch = "main" }
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.21" }

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -16,8 +16,9 @@ tokio = { version = "1", features = ["rt", "sync", "time"] }
 pin-project = "1"
 
 [dependencies.trust-dns-resolver]
-# Pinned until 0.21.0 is released with
-# https://github.com/bluejekyll/trust-dns/commit/6dfc6713.
-version = "=0.20.1"
+# We need to use a git dependency to pick up bluejekyll/trust-dns@6dfc6713.
+version = "0.21.0-alpha.1"
+git = "https://github.com/bluejekyll/trust-dns"
+branch = "main"
 default-features = false
 features = ["system-config", "tokio-runtime"]

--- a/linkerd/dns/fuzz/Cargo.toml
+++ b/linkerd/dns/fuzz/Cargo.toml
@@ -26,7 +26,3 @@ name = "fuzz_target_1"
 path = "fuzz_targets/fuzz_target_1.rs"
 test = false
 doc = false
-
-[patch.crates-io]
-trust-dns-proto = { git = "https://github.com/bluejekyll/trust-dns", branch = "main" }
-trust-dns-resolver = { git = "https://github.com/bluejekyll/trust-dns", branch = "main" }


### PR DESCRIPTION
trust-dns has begun preparations for the v0.21.0 release. This change
updates our git dependency to use the most recent version.