### PR TITLE
config: add a `PortSet` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +715,7 @@ dependencies = [
  "linkerd-tracing",
  "linkerd-transport-header",
  "pin-project",
+ "quickcheck",
  "regex",
  "serde_json",
  "thiserror",
@@ -1835,6 +1846,8 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
+ "env_logger",
+ "log",
  "rand",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,16 +197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,8 +1836,6 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger",
- "log",
  "rand",
 ]
 

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -84,4 +84,4 @@ features = [
 linkerd-system = { path = "../../system" }
 
 [dev-dependencies]
-quickcheck = "1.0"
+quickcheck = { version = "1", default-features = false }

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -82,3 +82,6 @@ features = [
 
 [target.'cfg(target_os = "linux")'.dependencies]
 linkerd-system = { path = "../../system" }
+
+[dev-dependencies]
+quickcheck = "1.0"

--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -7,7 +7,6 @@ use crate::{
 use std::{
     collections::HashSet,
     hash::{BuildHasherDefault, Hasher},
-    iter::FromIterator,
     time::Duration,
 };
 
@@ -42,13 +41,14 @@ pub struct ProxyConfig {
 ///
 /// Because ports are `u16` values, this type avoids the overhead of actually
 /// hashing ports.
-#[derive(Clone, Debug, Default)]
-pub struct PortSet(HashSet<u16, BuildHasherDefault<PortHasher>>);
+pub type PortSet = HashSet<u16, BuildHasherDefault<PortHasher>>;
 
+/// A hasher for ports.
+///
 /// Because ports are single `u16` values, we don't have to hash them; we can just use
 /// the integer values as hashes directly.
 #[derive(Default)]
-struct PortHasher(u64);
+pub struct PortHasher(u64);
 
 // === impl ServerConfig ===
 
@@ -64,23 +64,6 @@ impl Param<Keepalive> for ServerConfig {
     }
 }
 
-// === impl PortSet ===
-
-impl PortSet {
-    #[inline]
-    pub fn contains(&self, port: u16) -> bool {
-        self.0.contains(&port)
-    }
-}
-
-impl FromIterator<u16> for PortSet {
-    fn from_iter<T>(iter: T) -> Self
-    where
-        T: IntoIterator<Item = u16>,
-    {
-        Self(HashSet::from_iter(iter))
-    }
-}
 // === impl PortHasher ===
 
 impl Hasher for PortHasher {

--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -81,3 +81,25 @@ impl Hasher for PortHasher {
         self.0 as u64
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quickcheck::*;
+
+    quickcheck! {
+        fn portset_contains_all_ports(ports: Vec<u16>) -> bool {
+            // Make a port set containing the generated port numbers.
+            let portset = ports.iter().cloned().collect::<PortSet>();
+            for port in ports {
+                // If the port set doesn't contain one of the ports it was
+                // created with, that's bad news!
+                if !portset.contains(&port) {
+                    return false;
+                }
+            }
+
+            true
+        }
+    }
+}

--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -48,7 +48,7 @@ pub type PortSet = HashSet<u16, BuildHasherDefault<PortHasher>>;
 /// Because ports are single `u16` values, we don't have to hash them; we can just use
 /// the integer values as hashes directly.
 #[derive(Default)]
-pub struct PortHasher(u64);
+pub struct PortHasher(u16);
 
 // === impl ServerConfig ===
 
@@ -73,11 +73,11 @@ impl Hasher for PortHasher {
 
     #[inline]
     fn write_u16(&mut self, port: u16) {
-        self.0 = port as u64;
+        self.0 = port;
     }
 
     #[inline]
     fn finish(&self) -> u64 {
-        self.0
+        self.0 as u64
     }
 }

--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -4,7 +4,12 @@ use crate::{
     svc::Param,
     transport::{Keepalive, ListenAddr},
 };
-use std::time::Duration;
+use std::{
+    collections::HashSet,
+    hash::{BuildHasherDefault, Hasher},
+    iter::FromIterator,
+    time::Duration,
+};
 
 #[derive(Clone, Debug)]
 pub struct ServerConfig {
@@ -33,6 +38,18 @@ pub struct ProxyConfig {
     pub detect_protocol_timeout: Duration,
 }
 
+/// A `HashSet` specialized for ports.
+///
+/// Because ports are `u16` values, this type avoids the overhead of actually
+/// hashing ports.
+#[derive(Clone, Debug, Default)]
+pub struct PortSet(HashSet<u16, BuildHasherDefault<PortHasher>>);
+
+/// Because ports are single `u16` values, we don't have to hash them; we can just use
+/// the integer values as hashes directly.
+#[derive(Default)]
+struct PortHasher(u64);
+
 // === impl ServerConfig ===
 
 impl Param<ListenAddr> for ServerConfig {
@@ -44,5 +61,40 @@ impl Param<ListenAddr> for ServerConfig {
 impl Param<Keepalive> for ServerConfig {
     fn param(&self) -> Keepalive {
         self.keepalive
+    }
+}
+
+// === impl PortSet ===
+
+impl PortSet {
+    #[inline]
+    pub fn contains(&self, port: u16) -> bool {
+        self.0.contains(&port)
+    }
+}
+
+impl FromIterator<u16> for PortSet {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = u16>,
+    {
+        Self(HashSet::from_iter(iter))
+    }
+}
+// === impl PortHasher ===
+
+impl Hasher for PortHasher {
+    fn write(&mut self, _: &[u8]) {
+        unreachable!("hashing a `u16` calls `write_u16`");
+    }
+
+    #[inline]
+    fn write_u16(&mut self, port: u16) {
+        self.0 = port as u64;
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
     }
 }

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -23,14 +23,14 @@ use self::{
     target::{HttpAccept, TcpAccept},
 };
 use linkerd_app_core::{
-    config::{ConnectConfig, ProxyConfig, ServerConfig},
+    config::{ConnectConfig, PortSet, ProxyConfig, ServerConfig},
     detect, drain, io, metrics, profiles,
     proxy::tcp,
     serve, svc, tls,
     transport::{self, listen::Bind, ClientAddr, Local, OrigDstAddr, Remote, ServerAddr},
     Error, NameMatch, Never, ProxyRuntime,
 };
-use std::{collections::HashSet, convert::TryFrom, fmt::Debug, future::Future, time::Duration};
+use std::{convert::TryFrom, fmt::Debug, future::Future, time::Duration};
 use tracing::{debug_span, info_span};
 
 #[derive(Clone, Debug)]
@@ -38,7 +38,7 @@ pub struct Config {
     pub allow_discovery: NameMatch,
     pub proxy: ProxyConfig,
     pub require_identity_for_inbound_ports: RequireIdentityForPorts,
-    pub disable_protocol_detection_for_ports: HashSet<u16>,
+    pub disable_protocol_detection_for_ports: PortSet,
     pub profile_idle_timeout: Duration,
 }
 
@@ -262,7 +262,7 @@ where
             .push_switch(
                 move |t: T| {
                     let OrigDstAddr(addr) = t.param();
-                    if !disable_detect.contains(&addr.port()) {
+                    if !disable_detect.contains(addr.port()) {
                         Ok::<_, Never>(svc::Either::A(t))
                     } else {
                         Ok(svc::Either::B(TcpAccept::port_skipped(t)))

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -262,7 +262,7 @@ where
             .push_switch(
                 move |t: T| {
                     let OrigDstAddr(addr) = t.param();
-                    if !disable_detect.contains(addr.port()) {
+                    if !disable_detect.contains(&addr.port()) {
                         Ok::<_, Never>(svc::Either::A(t))
                     } else {
                         Ok(svc::Either::B(TcpAccept::port_skipped(t)))

--- a/linkerd/app/inbound/src/require_identity.rs
+++ b/linkerd/app/inbound/src/require_identity.rs
@@ -29,7 +29,7 @@ impl Predicate<TcpAccept> for RequireIdentityForPorts {
 
     fn check(&mut self, meta: TcpAccept) -> Result<TcpAccept, Error> {
         let port = meta.target_addr.port();
-        let id_required = self.ports.contains(port);
+        let id_required = self.ports.contains(&port);
 
         tracing::debug!(%port, tls = ?meta.tls, %id_required);
         if id_required {

--- a/linkerd/app/inbound/src/require_identity.rs
+++ b/linkerd/app/inbound/src/require_identity.rs
@@ -1,13 +1,13 @@
 use crate::target::TcpAccept;
-use linkerd_app_core::{svc::stack::Predicate, tls, Conditional, Error};
-use std::{collections::HashSet, sync::Arc};
+use linkerd_app_core::{config::PortSet, svc::stack::Predicate, tls, Conditional, Error};
+use std::sync::Arc;
 use thiserror::Error;
 
 /// A connection policy that fails connections that don't have a client identity
 /// if they target one of the configured local ports.
 #[derive(Clone, Debug)]
 pub struct RequireIdentityForPorts {
-    ports: Arc<HashSet<u16>>,
+    ports: Arc<PortSet>,
 }
 
 #[derive(Debug, Error)]
@@ -29,7 +29,7 @@ impl Predicate<TcpAccept> for RequireIdentityForPorts {
 
     fn check(&mut self, meta: TcpAccept) -> Result<TcpAccept, Error> {
         let port = meta.target_addr.port();
-        let id_required = self.ports.contains(&port);
+        let id_required = self.ports.contains(port);
 
         tracing::debug!(%port, tls = ?meta.tls, %id_required);
         if id_required {


### PR DESCRIPTION
This branch adds a `PortSet` type that's a simple wrapper around
`std::collections::HashSet` but specialized for storing ports (`u16`
values). The `PortSet` type overrides the default hasher so that we
don't have to actually hash ports, and just use their numeric value.

See here for details:
https://github.com/linkerd/linkerd2-proxy/pull/1048#discussion_r653855672

Depends on #1048