### PR TITLE
Replace the `request_errors_total` metric

### DIFF
--- a/linkerd/error-metrics/Cargo.toml
+++ b/linkerd/error-metrics/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 [dependencies]
 futures = { version = "0.3", default-features = false }
 linkerd-metrics = { path = "../metrics" }
-tower = { version = "0.4.8", default-features = false }
 pin-project = "1"
+tower = { version = "0.4.8", default-features = false }

--- a/linkerd/error-metrics/src/lib.rs
+++ b/linkerd/error-metrics/src/lib.rs
@@ -8,7 +8,7 @@ mod service;
 pub use self::layer::RecordErrorLayer;
 pub use self::service::RecordError;
 pub use linkerd_metrics::FmtLabels;
-use linkerd_metrics::{metrics, Counter, FmtMetrics};
+use linkerd_metrics::{self as metrics, Counter, FmtMetrics};
 use std::{
     collections::HashMap,
     fmt,
@@ -16,35 +16,34 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-metrics! {
-    request_errors_total: Counter {
-        "The total number of HTTP requests that could not be processed due to a proxy error."
-    }
-}
-
 pub trait LabelError<E> {
     type Labels: FmtLabels + Hash + Eq;
 
     fn label_error(&self, error: &E) -> Self::Labels;
 }
 
+type Metric = metrics::Metric<'static, &'static str, Counter>;
+
 /// Produces layers and reports results.
 #[derive(Debug)]
-pub struct Registry<K: Hash + Eq> {
+pub struct Registry<K>
+where
+    K: Hash + Eq,
+{
     errors: Arc<Mutex<HashMap<K, Counter>>>,
+    metric: Metric,
 }
 
 impl<K: Hash + Eq> Registry<K> {
-    pub fn layer<L>(&self, label: L) -> RecordErrorLayer<L, K> {
-        RecordErrorLayer::new(label, self.errors.clone())
-    }
-}
-
-impl<K: Hash + Eq> Default for Registry<K> {
-    fn default() -> Self {
+    pub fn new(metric: Metric) -> Self {
         Self {
             errors: Default::default(),
+            metric,
         }
+    }
+
+    pub fn layer<L>(&self, label: L) -> RecordErrorLayer<L, K> {
+        RecordErrorLayer::new(label, self.errors.clone())
     }
 }
 
@@ -52,6 +51,7 @@ impl<K: Hash + Eq> Clone for Registry<K> {
     fn clone(&self) -> Self {
         Self {
             errors: self.errors.clone(),
+            metric: self.metric,
         }
     }
 }
@@ -66,8 +66,8 @@ impl<K: FmtLabels + Hash + Eq> FmtMetrics for Registry<K> {
             return Ok(());
         }
 
-        request_errors_total.fmt_help(f)?;
-        request_errors_total.fmt_scopes(f, errors.iter(), |c| &c)?;
+        self.metric.fmt_help(f)?;
+        self.metric.fmt_scopes(f, errors.iter(), |c| &c)?;
 
         Ok(())
     }

--- a/linkerd/metrics/src/prom.rs
+++ b/linkerd/metrics/src/prom.rs
@@ -124,6 +124,28 @@ impl<'a, N: fmt::Display, M: FmtMetric> Metric<'a, N, M> {
     }
 }
 
+impl<N: fmt::Display, M: FmtMetric> fmt::Debug for Metric<'_, N, M> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Metric")
+            .field("name", &format_args!("{}", self.name))
+            .field("help", &self.help)
+            .field("type", &std::any::type_name::<M>())
+            .finish()
+    }
+}
+
+impl<N: Clone + fmt::Display, M: FmtMetric> Clone for Metric<'_, N, M> {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name.clone(),
+            help: self.help,
+            _p: self._p,
+        }
+    }
+}
+
+impl<N: Copy + fmt::Display, M: FmtMetric> Copy for Metric<'_, N, M> {}
+
 // ===== impl FmtLabels =====
 
 impl<'a, A: FmtLabels + 'a> FmtLabels for &'a A {


### PR DESCRIPTION
We currently expose a single `request_errors_total` metric with a
`direction` label that indicates whether the error is on the inbound or
outbound proxy. This is in-line with many of our other metrics; but this
conflicts with prometheus best practices as we do not necessarily
maintain a uniform set of labels for all instances of a metric.  To
correct this, we want to adopt a scheme of using distinct metrics for
differing scopes with differing labels.

This change replaces the single `request_errors_total` metric with two
new metrics: `inbound_http_errors_total` and
`outbound_http_errors_total`.

As it turns out, the `request_errors_total` metric isn't actually
consumed anywhere in the _linkerd2_ repo, so this change can be made
safely without requiring control-plane changes. In follow-up changes, we
should probably include additional labels on these metrics to reflect
the stack targets; and then we should surface these errors elsewhere in
Linkerd.

This change also sets up introducing additional error metrics, for
instance to surface TLS detection errors, by decoupling the error-metrics
middleware from a specific metric.