### PR TITLE
build(deps): update `tonic`, `prost`, and  `linkerd2-proxy-api`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +545,15 @@ name = "itertools"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
 dependencies = [
  "either",
 ]
@@ -1059,7 +1080,7 @@ dependencies = [
  "linkerd-tls",
  "linkerd2-proxy-api",
  "pin-project",
- "prost",
+ "prost 0.8.0",
  "tonic",
  "tower",
  "tracing",
@@ -1189,7 +1210,7 @@ dependencies = [
  "linkerd-tls",
  "linkerd2-proxy-api",
  "pin-project",
- "prost-types",
+ "prost-types 0.8.0",
  "quickcheck",
  "rand",
  "thiserror",
@@ -1278,7 +1299,7 @@ dependencies = [
  "linkerd-tonic-watch",
  "linkerd2-proxy-api",
  "pin-project",
- "prost-types",
+ "prost-types 0.8.0",
  "quickcheck",
  "rand",
  "regex",
@@ -1442,8 +1463,8 @@ dependencies = [
  "linkerd-error",
  "linkerd-io",
  "linkerd-stack",
- "prost",
- "prost-build",
+ "prost 0.8.0",
+ "prost-build 0.7.0",
  "tokio",
  "tokio-test",
  "tracing",
@@ -1465,13 +1486,13 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.1.18"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#def4e323b26e04f177c53f8f14a9ff7c82830721"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#5e4e190df8fe3a2c869169a60b7ba78e2afe31b6"
 dependencies = [
  "h2",
  "http",
  "ipnet",
- "prost",
- "prost-types",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "quickcheck",
  "thiserror",
  "tonic",
@@ -1625,8 +1646,8 @@ name = "opencensus-proto"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "prost",
- "prost-types",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "tonic",
  "tonic-build",
 ]
@@ -1738,7 +1759,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.7.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
+dependencies = [
+ "bytes",
+ "prost-derive 0.8.0",
 ]
 
 [[package]]
@@ -1749,12 +1780,30 @@ checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.9.0",
  "log",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
+dependencies = [
+ "bytes",
+ "heck",
+ "itertools 0.10.1",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost 0.8.0",
+ "prost-types 0.8.0",
  "tempfile",
  "which",
 ]
@@ -1766,7 +1815,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.9.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -1779,7 +1841,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.7.0",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
+dependencies = [
+ "bytes",
+ "prost 0.8.0",
 ]
 
 [[package]]
@@ -2140,6 +2212,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,9 +2296,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac42cd97ac6bd2339af5bcabf105540e21e45636ec6fa6aae5e85d44db31be0"
+checksum = "b584f064fdfc50017ec39162d5aebce49912f1eb16fd128e04b7f4ce4907c7e5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2228,14 +2310,16 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
- "prost-derive",
+ "prost 0.8.0",
+ "prost-derive 0.8.0",
  "tokio",
  "tokio-stream",
  "tokio-util",
  "tower",
+ "tower-layer",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -2243,12 +2327,12 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695de27302f4697191dda1c7178131a8cb805463dda02864acb80fe1322fdcf"
+checksum = "25db9a497663a9a779693ef67b6e6aef8345b3d3ff8d50ef92eae6c88cb1e386"
 dependencies = [
  "proc-macro2",
- "prost-build",
+ "prost-build 0.8.0",
  "quote",
  "syn",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,15 +542,6 @@ checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
@@ -1080,7 +1071,7 @@ dependencies = [
  "linkerd-tls",
  "linkerd2-proxy-api",
  "pin-project",
- "prost 0.8.0",
+ "prost",
  "tonic",
  "tower",
  "tracing",
@@ -1210,7 +1201,7 @@ dependencies = [
  "linkerd-tls",
  "linkerd2-proxy-api",
  "pin-project",
- "prost-types 0.8.0",
+ "prost-types",
  "quickcheck",
  "rand",
  "thiserror",
@@ -1299,7 +1290,7 @@ dependencies = [
  "linkerd-tonic-watch",
  "linkerd2-proxy-api",
  "pin-project",
- "prost-types 0.8.0",
+ "prost-types",
  "quickcheck",
  "rand",
  "regex",
@@ -1463,8 +1454,8 @@ dependencies = [
  "linkerd-error",
  "linkerd-io",
  "linkerd-stack",
- "prost 0.8.0",
- "prost-build 0.7.0",
+ "prost",
+ "prost-build",
  "tokio",
  "tokio-test",
  "tracing",
@@ -1491,8 +1482,8 @@ dependencies = [
  "h2",
  "http",
  "ipnet",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "quickcheck",
  "thiserror",
  "tonic",
@@ -1646,8 +1637,8 @@ name = "opencensus-proto"
 version = "0.1.0"
 dependencies = [
  "bytes",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "tonic",
  "tonic-build",
 ]
@@ -1754,40 +1745,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
-dependencies = [
- "bytes",
- "prost-derive 0.7.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
- "prost-derive 0.8.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
-dependencies = [
- "bytes",
- "heck",
- "itertools 0.9.0",
- "log",
- "multimap",
- "petgraph",
- "prost 0.7.0",
- "prost-types 0.7.0",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -1798,27 +1761,14 @@ checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes",
  "heck",
- "itertools 0.10.1",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
- "prost 0.8.0",
- "prost-types 0.8.0",
+ "prost",
+ "prost-types",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
-dependencies = [
- "anyhow",
- "itertools 0.9.0",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1828,20 +1778,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools 0.10.1",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
-dependencies = [
- "bytes",
- "prost 0.7.0",
 ]
 
 [[package]]
@@ -1851,7 +1791,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
- "prost 0.8.0",
+ "prost",
 ]
 
 [[package]]
@@ -2313,8 +2253,8 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.8.0",
- "prost-derive 0.8.0",
+ "prost",
+ "prost-derive",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2332,7 +2272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25db9a497663a9a779693ef67b6e6aef8345b3d3ff8d50ef92eae6c88cb1e386"
 dependencies = [
  "proc-macro2",
- "prost-build 0.8.0",
+ "prost-build",
  "quote",
  "syn",
 ]

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -28,6 +28,6 @@ regex = "1.5.4"
 thiserror = "1.0"
 tokio = { version = "1", features = ["rt"] }
 tokio-stream = { version = "0.1.7", features = ["time", "sync"] }
-tonic = { version = "0.4", default-features = false, features = ["prost"] }
+tonic = { version = "0.5", default-features = false, features = ["prost"] }
 tower = "0.4.8"
 tracing = "0.1.26"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -64,7 +64,7 @@ serde_json = "1"
 thiserror = "1.0"
 tokio = { version = "1", features = ["macros", "sync", "parking_lot"]}
 tokio-stream = { version = "0.1.7", features = ["time"] }
-tonic = { version = "0.4", default-features = false, features = ["prost"] }
+tonic = { version = "0.5", default-features = false, features = ["prost"] }
 tracing = "0.1.26"
 pin-project = "1"
 

--- a/linkerd/app/core/src/errors.rs
+++ b/linkerd/app/core/src/errors.rs
@@ -325,7 +325,6 @@ fn code_header(code: grpc::Code) -> HeaderValue {
         Code::Unavailable => HeaderValue::from_static("14"),
         Code::DataLoss => HeaderValue::from_static("15"),
         Code::Unauthenticated => HeaderValue::from_static("16"),
-        Code::__NonExhaustive => unreachable!("Code::__NonExhaustive"),
     }
 }
 

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1", features = ["io-util", "net", "rt", "macros"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }
 tokio-rustls = "0.22"
 tower = { version = "0.4.8", default-features = false }
-tonic = { version = "0.4", default-features = false }
+tonic = { version = "0.5", default-features = false }
 tracing = "0.1.26"
 webpki = "0.21"
 tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt"] }

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -13,7 +13,7 @@ http-body = "0.4"
 linkerd-error = { path = "../error" }
 linkerd-metrics = { path = "../metrics" }
 opencensus-proto = { path = "../../opencensus-proto" }
-tonic = { version = "0.4", default-features = false, features = ["prost", "codegen"] }
+tonic = { version = "0.5", default-features = false, features = ["prost", "codegen"] }
 tower = { version = "0.4.8", default-features = false }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }

--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -24,7 +24,7 @@ where
     T: GrpcService<BoxBody> + Clone,
     T::Error: Into<Error>,
     <T::ResponseBody as HttpBody>::Error: Into<Error> + Send + Sync,
-    T::ResponseBody: 'static,
+    T::ResponseBody: Send + Sync + 'static,
     S: Stream<Item = Span> + Unpin,
 {
     debug!("Span exporter running");
@@ -49,7 +49,7 @@ where
     T: GrpcService<BoxBody>,
     T::Error: Into<Error>,
     <T::ResponseBody as HttpBody>::Error: Into<Error> + Send + Sync,
-    T::ResponseBody: 'static,
+    T::ResponseBody: Send + Sync + 'static,
     S: Stream<Item = Span> + Unpin,
 {
     const MAX_BATCH_SIZE: usize = 1000;

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -24,7 +24,7 @@ linkerd-tls = { path = "../../tls" }
 http = "0.2"
 http-body = "0.4"
 pin-project = "1"
-prost = "0.7"
-tonic = { version = "0.4", default-features = false }
+prost = "0.8"
+tonic = { version = "0.5", default-features = false }
 tower = { version = "0.4.8", default-features = false }
 tracing = "0.1.26"

--- a/linkerd/proxy/api-resolve/src/resolve.rs
+++ b/linkerd/proxy/api-resolve/src/resolve.rs
@@ -7,16 +7,12 @@ use crate::{
 use api::destination_client::DestinationClient;
 use async_stream::try_stream;
 use futures::prelude::*;
-use http_body::Body as HttpBody;
+use http_body::Body;
 use linkerd_error::Error;
 use linkerd_stack::Param;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tonic::{
-    self as grpc,
-    body::{Body, BoxBody},
-    client::GrpcService,
-};
+use tonic::{self as grpc, body::BoxBody, client::GrpcService};
 use tower::Service;
 use tracing::{debug, info, trace};
 
@@ -32,9 +28,9 @@ impl<S> Resolve<S>
 where
     S: GrpcService<BoxBody> + Clone + Send + 'static,
     S::Error: Into<Error> + Send,
-    S::ResponseBody: Send,
+    S::ResponseBody: Send + Sync,
     <S::ResponseBody as Body>::Data: Send,
-    <S::ResponseBody as HttpBody>::Error: Into<Error> + Send,
+    <S::ResponseBody as Body>::Error: Into<Error> + Send,
     S::Future: Send,
 {
     pub fn new(svc: S, context_token: String) -> Self {
@@ -56,9 +52,9 @@ where
     T: Param<ConcreteAddr>,
     S: GrpcService<BoxBody> + Clone + Send + 'static,
     S::Error: Into<Error> + Send,
-    S::ResponseBody: Send,
+    S::ResponseBody: Send + Sync,
     <S::ResponseBody as Body>::Data: Send,
-    <S::ResponseBody as HttpBody>::Error: Into<Error> + Send,
+    <S::ResponseBody as Body>::Error: Into<Error> + Send,
     S::Future: Send,
 {
     type Response = UpdatesStream;

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -18,7 +18,7 @@ linkerd-metrics = { path = "../../metrics" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }
 tokio = { version = "1", features = ["time", "sync"] }
-tonic = { version = "0.4", default-features = false }
+tonic = { version = "0.5", default-features = false }
 tracing = "0.1.26"
 http-body = "0.4"
 pin-project = "1"

--- a/linkerd/proxy/identity/src/certify.rs
+++ b/linkerd/proxy/identity/src/certify.rs
@@ -1,4 +1,4 @@
-use http_body::Body as HttpBody;
+use http_body::Body;
 use linkerd2_proxy_api::identity::{self as api, identity_client::IdentityClient};
 use linkerd_error::Error;
 use linkerd_identity as id;
@@ -11,11 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
 use tokio::time::{self, Sleep};
-use tonic::{
-    self as grpc,
-    body::{Body, BoxBody},
-    client::GrpcService,
-};
+use tonic::{self as grpc, body::BoxBody, client::GrpcService};
 use tracing::{debug, error, trace};
 
 /// Configures the Identity service and local identity.
@@ -88,9 +84,9 @@ impl Daemon {
     where
         N: NewService<(), Service = S>,
         S: GrpcService<BoxBody>,
-        S::ResponseBody: Send + 'static,
+        S::ResponseBody: Send + Sync + 'static,
         <S::ResponseBody as Body>::Data: Send,
-        <S::ResponseBody as HttpBody>::Error: Into<Error> + Send,
+        <S::ResponseBody as Body>::Error: Into<Error> + Send,
     {
         let Self {
             crt_key_watch,

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -27,11 +27,11 @@ rand = { version = "0.8" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["time"]}
 tower = { version = "0.4.8", default-features = false }
-tonic = { version = "0.4", default-features = false }
+tonic = { version = "0.5", default-features = false }
 tracing = "0.1.26"
 pin-project = "1"
 
 [dev-dependencies]
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["arbitrary"] }
-prost-types = "0.7.0"
+prost-types = "0.8.0"
 quickcheck = { version = "1", default-features = false }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -29,7 +29,7 @@ rand = { version = "0.8", features = ["small_rng"] }
 regex = "1.5.4"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tonic = { version = "0.4", default-features = false }
+tonic = { version = "0.5", default-features = false }
 tower = { version = "0.4.8", features = [ "ready-cache", "retry", "util"] }
 thiserror = "1"
 tracing = "0.1.26"
@@ -37,5 +37,5 @@ pin-project = "1"
 
 [dev-dependencies]
 linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main", features = ["arbitrary"] }
-prost-types = "0.7.0"
+prost-types = "0.8.0"
 quickcheck = { version = "1", default-features = false }

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -1,15 +1,12 @@
 use crate::{proto, LookupAddr, Profile, Receiver};
 use futures::prelude::*;
-use http_body::Body as HttpBody;
+use http_body::Body;
 use linkerd2_proxy_api::destination::{self as api, destination_client::DestinationClient};
 use linkerd_error::{Never, Recover};
 use linkerd_stack::{Param, Service};
 use linkerd_tonic_watch::StreamWatch;
 use std::task::{Context, Poll};
-use tonic::{
-    body::{Body, BoxBody},
-    client::GrpcService,
-};
+use tonic::{body::BoxBody, client::GrpcService};
 use tracing::debug;
 
 /// Creates watches on service profiles.
@@ -30,9 +27,9 @@ struct Inner<S> {
 impl<R, S> Client<R, S>
 where
     S: GrpcService<BoxBody> + Clone + Send + 'static,
-    S::ResponseBody: Send,
+    S::ResponseBody: Send + Sync,
     <S::ResponseBody as Body>::Data: Send,
-    <S::ResponseBody as HttpBody>::Error:
+    <S::ResponseBody as Body>::Error:
         Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send,
     S::Future: Send,
     R: Recover<tonic::Status> + Send + Clone + 'static,
@@ -49,9 +46,9 @@ impl<T, R, S> Service<T> for Client<R, S>
 where
     T: Param<LookupAddr>,
     S: GrpcService<BoxBody> + Clone + Send + 'static,
-    S::ResponseBody: Send,
+    S::ResponseBody: Send + Sync,
     <S::ResponseBody as Body>::Data: Send,
-    <S::ResponseBody as HttpBody>::Error:
+    <S::ResponseBody as Body>::Error:
         Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send,
     S::Future: Send,
     R: Recover<tonic::Status> + Send + Clone + 'static,
@@ -96,9 +93,9 @@ type InnerFuture =
 impl<S> Inner<S>
 where
     S: GrpcService<BoxBody> + Clone + Send + 'static,
-    S::ResponseBody: Send,
+    S::ResponseBody: Send + Sync,
     <S::ResponseBody as Body>::Data: Send,
-    <S::ResponseBody as HttpBody>::Error:
+    <S::ResponseBody as Body>::Error:
         Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send,
     S::Future: Send,
 {
@@ -113,9 +110,9 @@ where
 impl<S> Service<LookupAddr> for Inner<S>
 where
     S: GrpcService<BoxBody> + Clone + Send + 'static,
-    S::ResponseBody: Send,
+    S::ResponseBody: Send + Sync,
     <S::ResponseBody as Body>::Data: Send,
-    <S::ResponseBody as HttpBody>::Error:
+    <S::ResponseBody as Body>::Error:
         Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send,
     S::Future: Send,
 {

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -63,7 +63,7 @@ pub struct Target {
 #[derive(Clone, Debug)]
 pub struct GetProfileService<P>(P);
 
-#[derive(Clone, Debug, Error)]
+#[derive(Debug, Error)]
 pub enum DiscoveryRejected {
     #[error("discovery rejected by control plane: {0}")]
     Remote(

--- a/linkerd/tonic-watch/Cargo.toml
+++ b/linkerd/tonic-watch/Cargo.toml
@@ -13,7 +13,7 @@ Provides a utility for creating robust watches from a service that returns a str
 futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
-tonic = { version = "0.4", default-features = false }
+tonic = { version = "0.5", default-features = false }
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1"
 

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1", features = ["time"] }
 tracing = "0.1.26"
 
 [build-dependencies]
-prost-build = { version = "0.7", default-features = false }
+prost-build = { version = "0.8", default-features = false }
 
 [target.'cfg(fuzzing)'.dependencies]
 arbitrary = { version = "1",  features = ["derive"] }

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -14,7 +14,7 @@ linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }
 linkerd-io = { path = "../io" }
 linkerd-stack = { path = "../stack" }
-prost = "0.7"
+prost = "0.8"
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1.26"
 

--- a/opencensus-proto/Cargo.toml
+++ b/opencensus-proto/Cargo.toml
@@ -13,12 +13,12 @@ Vendored from https://github.com/census-instrumentation/opencensus-proto/.
 
 [dependencies]
 bytes = "1"
-tonic = { version = "0.4", default-features = false, features = ["prost", "codegen"] }
-prost = "0.7"
-prost-types = "0.7"
+tonic = { version = "0.5", default-features = false, features = ["prost", "codegen"] }
+prost = "0.8"
+prost-types = "0.8"
 
 [build-dependencies]
-tonic-build = { version = "0.4", features = ["prost"], default-features = false }
+tonic-build = { version = "0.5", features = ["prost"], default-features = false }
 
 [lib]
 doctest = false


### PR DESCRIPTION
This updates `prost`, `prost-types`, and `prost-build` to v0.8, which
includes a fix for a panic (and potential denial-of-service attack) when
converting a protobuf duration into a Rust `Duration`. Although we don't
use the vulnerable APIs in the proxy or in `linkerd2-proxy-api`, this is
necessary in order to fix a RUSTSEC advisory warning. In order to update
`prost`, we must also update `tonic` and `tonic-build` to v0.5, which
depends on `prost` 0.8, and update the `linkerd2-proxy-api` crate to
include linkerd/linkerd2-proxy-api#71.

Since these crates all depend on each other, we need to update them all
at the same time. Dependabot has opened separate PRs for these crates,
but none of them will pass CI, since they depend on incompatible
versions. This PR, on the other hand, should pass, since it updates all
the crates atomically in one commit. Also, some minor code changes
were required due to breaking API changes in `tonic` 0.5.

Closes #1134, #1135, and #1136; should fix CI.