### PR TITLE
Use `parking_lot::Mutex` in telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-metrics",
+ "parking_lot",
  "pin-project",
  "tower",
 ]
@@ -974,6 +975,7 @@ dependencies = [
  "linkerd-http-classify",
  "linkerd-metrics",
  "linkerd-stack",
+ "parking_lot",
  "pin-project",
  "tower",
  "tracing",
@@ -1200,6 +1202,7 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tls",
  "linkerd2-proxy-api",
+ "parking_lot",
  "pin-project",
  "prost-types",
  "quickcheck",
@@ -1237,6 +1240,7 @@ dependencies = [
  "linkerd-io",
  "linkerd-metrics",
  "linkerd-stack",
+ "parking_lot",
  "pin-project",
  "socket2 0.4.0",
  "tokio",
@@ -1331,6 +1335,7 @@ name = "linkerd-stack-metrics"
 version = "0.1.0"
 dependencies = [
  "linkerd-metrics",
+ "parking_lot",
  "tokio",
  "tower",
 ]

--- a/linkerd/error-metrics/Cargo.toml
+++ b/linkerd/error-metrics/Cargo.toml
@@ -10,5 +10,6 @@ publish = false
 [dependencies]
 futures = { version = "0.3", default-features = false }
 linkerd-metrics = { path = "../metrics" }
+parking_lot = "0.11"
 pin-project = "1"
 tower = { version = "0.4.8", default-features = false }

--- a/linkerd/error-metrics/src/layer.rs
+++ b/linkerd/error-metrics/src/layer.rs
@@ -1,10 +1,7 @@
 use crate::RecordError;
 use linkerd_metrics::Counter;
-use std::{
-    collections::HashMap,
-    hash::Hash,
-    sync::{Arc, Mutex},
-};
+use parking_lot::Mutex;
+use std::{collections::HashMap, hash::Hash, sync::Arc};
 
 #[derive(Debug)]
 pub struct RecordErrorLayer<L, K: Hash + Eq> {

--- a/linkerd/error-metrics/src/lib.rs
+++ b/linkerd/error-metrics/src/lib.rs
@@ -9,12 +9,8 @@ pub use self::layer::RecordErrorLayer;
 pub use self::service::RecordError;
 pub use linkerd_metrics::FmtLabels;
 use linkerd_metrics::{self as metrics, Counter, FmtMetrics};
-use std::{
-    collections::HashMap,
-    fmt,
-    hash::Hash,
-    sync::{Arc, Mutex},
-};
+use parking_lot::Mutex;
+use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};
 
 pub trait LabelError<E> {
     type Labels: FmtLabels + Hash + Eq;
@@ -58,10 +54,7 @@ impl<K: Hash + Eq> Clone for Registry<K> {
 
 impl<K: FmtLabels + Hash + Eq> FmtMetrics for Registry<K> {
     fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let errors = match self.errors.lock() {
-            Ok(errors) => errors,
-            Err(_) => return Ok(()),
-        };
+        let errors = self.errors.lock();
         if errors.is_empty() {
             return Ok(());
         }

--- a/linkerd/error-metrics/src/service.rs
+++ b/linkerd/error-metrics/src/service.rs
@@ -1,13 +1,14 @@
 use crate::LabelError;
 use futures::TryFuture;
 use linkerd_metrics::{Counter, FmtLabels};
+use parking_lot::Mutex;
 use pin_project::pin_project;
 use std::{
     collections::HashMap,
     future::Future,
     hash::Hash,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{Context, Poll},
 };
 
@@ -38,9 +39,11 @@ impl<L, K: FmtLabels + Hash + Eq, S> RecordError<L, K, S> {
         L: LabelError<E, Labels = K> + Clone,
     {
         let labels = label.label_error(&err);
-        if let Ok(mut errors) = errors.lock() {
-            errors.entry(labels).or_insert_with(Default::default).incr();
-        }
+        errors
+            .lock()
+            .entry(labels)
+            .or_insert_with(Default::default)
+            .incr();
     }
 }
 

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -15,7 +15,8 @@ hyper = { version = "0.14.10", features = ["http1", "http2"] }
 linkerd-error = { path = "../error" }
 linkerd-http-classify = { path = "../http-classify" }
 linkerd-metrics = { path = "../metrics" }
-linkerd-stack = { path = "../stack" } 
+linkerd-stack = { path = "../stack" }
+parking_lot = "0.11"
+pin-project = "1"
 tower = "0.4.8"
 tracing = "0.1.26"
-pin-project = "1"

--- a/linkerd/http-metrics/src/lib.rs
+++ b/linkerd/http-metrics/src/lib.rs
@@ -4,10 +4,8 @@
 
 pub use self::{requests::Requests, retries::Retries};
 use linkerd_metrics::{LastUpdate, Store};
-use std::fmt;
-use std::hash::Hash;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use parking_lot::Mutex;
+use std::{fmt, hash::Hash, sync::Arc, time::Duration};
 
 pub mod requests;
 pub mod retries;

--- a/linkerd/http-metrics/src/requests/mod.rs
+++ b/linkerd/http-metrics/src/requests/mod.rs
@@ -5,11 +5,12 @@ use super::{LastUpdate, Registry, Report};
 use linkerd_http_classify::ClassifyResponse;
 use linkerd_metrics::{latency, Counter, FmtMetrics, Histogram};
 use linkerd_stack::layer;
+use parking_lot::Mutex;
 use std::{
     collections::HashMap,
     fmt::Debug,
     hash::Hash,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, Instant},
 };
 

--- a/linkerd/http-metrics/src/requests/mod.rs
+++ b/linkerd/http-metrics/src/requests/mod.rs
@@ -145,7 +145,7 @@ mod tests {
         let retain_idle_for = Duration::from_secs(1);
         let r = super::Requests::<Target, Class>::default();
         let report = r.clone().into_report(retain_idle_for);
-        let mut registry = r.0.lock().unwrap();
+        let mut registry = r.0.lock();
 
         let before_update = Instant::now();
         let metrics = registry

--- a/linkerd/http-metrics/src/requests/report.rs
+++ b/linkerd/http-metrics/src/requests/report.rs
@@ -66,12 +66,11 @@ where
         M: FmtMetric,
     {
         for (tgt, tm) in registry.iter() {
-            if let Ok(tm) = tm.lock() {
-                for (status, m) in &tm.by_status {
-                    let status = status.as_ref().map(|s| Status(*s));
-                    let labels = (tgt, status);
-                    get_metric(&*m).fmt_metric_labeled(f, &metric.name, labels)?;
-                }
+            let tm = tm.lock();
+            for (status, m) in &tm.by_status {
+                let status = status.as_ref().map(|s| Status(*s));
+                let labels = (tgt, status);
+                get_metric(&*m).fmt_metric_labeled(f, &metric.name, labels)?;
             }
         }
 
@@ -89,13 +88,12 @@ where
         M: FmtMetric,
     {
         for (tgt, tm) in registry.iter() {
-            if let Ok(tm) = tm.lock() {
-                for (status, sm) in &tm.by_status {
-                    for (cls, m) in &sm.by_class {
-                        let status = status.as_ref().map(|s| Status(*s));
-                        let labels = (tgt, (status, cls));
-                        get_metric(&*m).fmt_metric_labeled(f, &metric.name, labels)?;
-                    }
+            let tm = tm.lock();
+            for (status, sm) in &tm.by_status {
+                for (cls, m) in &sm.by_class {
+                    let status = status.as_ref().map(|s| Status(*s));
+                    let labels = (tgt, (status, cls));
+                    get_metric(&*m).fmt_metric_labeled(f, &metric.name, labels)?;
                 }
             }
         }
@@ -110,10 +108,7 @@ where
     C: FmtLabels + Hash + Eq,
 {
     fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut registry = match self.registry.lock() {
-            Err(_) => return Ok(()),
-            Ok(r) => r,
-        };
+        let mut registry = self.registry.lock();
         trace!(
             prefix = self.prefix,
             targets = registry.len(),

--- a/linkerd/http-metrics/src/retries.rs
+++ b/linkerd/http-metrics/src/retries.rs
@@ -1,9 +1,12 @@
 use super::{LastUpdate, Prefixed, Registry, Report};
 use linkerd_metrics::{Counter, FmtLabels, FmtMetric, FmtMetrics, Metric};
-use std::fmt;
-use std::hash::Hash;
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use parking_lot::Mutex;
+use std::{
+    fmt,
+    hash::Hash,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 use tracing::trace;
 
 #[derive(Debug)]
@@ -37,7 +40,7 @@ impl<T: Hash + Eq> Retries<T> {
     }
 
     pub fn get_handle(&self, target: T) -> Handle {
-        let mut reg = self.0.lock().expect("retry metrics registry poisoned");
+        let mut reg = self.0.lock();
         Handle(reg.entry(target).or_default().clone())
     }
 }
@@ -52,12 +55,11 @@ impl<T: Hash + Eq> Clone for Retries<T> {
 
 impl Handle {
     pub fn incr_retryable(&self, has_budget: bool) {
-        if let Ok(mut m) = self.0.lock() {
-            m.last_update = Instant::now();
-            m.retryable.incr();
-            if !has_budget {
-                m.no_budget.incr();
-            }
+        let mut m = self.0.lock();
+        m.last_update = Instant::now();
+        m.retryable.incr();
+        if !has_budget {
+            m.no_budget.incr();
         }
     }
 }
@@ -99,10 +101,7 @@ where
     T: FmtLabels + Hash + Eq,
 {
     fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut registry = match self.registry.lock() {
-            Err(_) => return Ok(()),
-            Ok(r) => r,
-        };
+        let mut registry = self.registry.lock();
         trace!(
             prfefix = %self.prefix,
             targets = %registry.len(),
@@ -116,11 +115,10 @@ where
         let metric = self.retryable_total();
         metric.fmt_help(f)?;
         for (tgt, tm) in registry.iter() {
-            if let Ok(m) = tm.lock() {
-                m.retryable.fmt_metric_labeled(f, &metric.name, tgt)?;
-                m.no_budget
-                    .fmt_metric_labeled(f, &metric.name, (tgt, NoBudgetLabel))?;
-            }
+            let m = tm.lock();
+            m.retryable.fmt_metric_labeled(f, &metric.name, tgt)?;
+            m.no_budget
+                .fmt_metric_labeled(f, &metric.name, (tgt, NoBudgetLabel))?;
         }
 
         registry.retain_since(Instant::now() - self.retain_idle);

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [features]
 default = []
-summary = ["hdrhistogram", "parking_lot", "tokio"]
+summary = ["hdrhistogram", "tokio"]
 test_util = []
 
 [dependencies]
@@ -16,7 +16,7 @@ deflate = { version = "0.9.1", features = ["gzip"] }
 hdrhistogram = { version = "7.3", default-features = false, optional = true }
 http = "0.2"
 hyper = { version = "0.14.10", features = ["http1", "http2"] }
-parking_lot = { version = "0.11", optional = true }
+parking_lot = "0.11"
 tokio = { version = "1", features = ["time"], optional = true }
 tracing = "0.1.26"
 

--- a/linkerd/metrics/src/store.rs
+++ b/linkerd/metrics/src/store.rs
@@ -1,10 +1,11 @@
 use crate::{FmtLabels, FmtMetric, Metric};
+use parking_lot::Mutex;
 use std::{
     borrow::Borrow,
     collections::hash_map::{self, HashMap},
     fmt,
     hash::Hash,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::Instant,
 };
 
@@ -104,7 +105,7 @@ where
         M: FmtMetric,
     {
         for (key, m) in self.iter() {
-            let m = m.lock().unwrap();
+            let m = m.lock();
             get_metric(&*m).fmt_metric_labeled(f, &metric.name, key)?;
         }
 
@@ -127,7 +128,7 @@ where
 
 impl<M: LastUpdate> LastUpdate for Mutex<M> {
     fn last_update(&self) -> Instant {
-        self.lock().unwrap().last_update()
+        self.lock().last_update()
     }
 }
 

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -23,6 +23,7 @@ linkerd-proxy-http = { path = "../http" }
 linkerd-proxy-transport = { path = "../transport" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }
+parking_lot = "0.11"
 rand = { version = "0.8" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["time"]}

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -17,6 +17,7 @@ linkerd-error = { path = "../../error" }
 linkerd-io = { path = "../../io" }
 linkerd-metrics = { path = "../../metrics" }
 linkerd-stack = { path = "../../stack" }
+parking_lot = "0.11"
 pin-project = "1"
 socket2 = "0.4"
 tokio = { version = "1", features = ["macros", "net"] }

--- a/linkerd/proxy/transport/src/metrics.rs
+++ b/linkerd/proxy/transport/src/metrics.rs
@@ -5,15 +5,18 @@ use linkerd_metrics::{
     metrics, Counter, FmtLabels, FmtMetric, FmtMetrics, Gauge, LastUpdate, Metric, Store,
 };
 use linkerd_stack::{layer, NewService, Param};
+use parking_lot::Mutex;
 use pin_project::pin_project;
-use std::collections::HashMap;
-use std::fmt;
-use std::future::Future;
-use std::hash::Hash;
-use std::pin::Pin;
-use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll};
-use std::time::{Duration, Instant};
+use std::{
+    collections::HashMap,
+    fmt,
+    future::Future,
+    hash::Hash,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tracing::debug;
 
@@ -185,12 +188,7 @@ where
 
     fn new_service(&mut self, target: T) -> Self::Service {
         let labels = Param::<K>::param(&target);
-        let metrics = self
-            .registry
-            .lock()
-            .expect("metrics registry poisoned")
-            .get_or_default(labels)
-            .clone();
+        let metrics = self.registry.lock().get_or_default(labels).clone();
 
         let inner = self.inner.new_service(target);
         Accept { metrics, inner }
@@ -247,12 +245,7 @@ where
 
     fn call(&mut self, target: T) -> Self::Future {
         let labels = target.param();
-        let metrics = self
-            .registry
-            .lock()
-            .expect("metrics registr poisoned")
-            .get_or_default(labels)
-            .clone();
+        let metrics = self.registry.lock().get_or_default(labels).clone();
 
         Connecting {
             new_sensor: Some(NewSensor(metrics)),
@@ -300,10 +293,9 @@ impl<K: Eq + Hash + FmtLabels + 'static> Report<K> {
         M: FmtMetric,
     {
         for (key, metrics) in inner.iter() {
-            if let Ok(by_eos) = (*metrics).by_eos.lock() {
-                for (eos, m) in by_eos.metrics.iter() {
-                    get_metric(&*m).fmt_metric_labeled(f, &metric.name, (key, eos))?;
-                }
+            let by_eos = (*metrics).by_eos.lock();
+            for (eos, m) in by_eos.metrics.iter() {
+                get_metric(&*m).fmt_metric_labeled(f, &metric.name, (key, eos))?;
             }
         }
 
@@ -313,7 +305,7 @@ impl<K: Eq + Hash + FmtLabels + 'static> Report<K> {
 
 impl<K: Eq + Hash + FmtLabels + 'static> FmtMetrics for Report<K> {
     fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut metrics = self.metrics.lock().expect("metrics registry poisoned");
+        let mut metrics = self.metrics.lock();
         if metrics.is_empty() {
             return Ok(());
         }
@@ -345,9 +337,7 @@ impl Sensor {
     fn open(metrics: Arc<Metrics>) -> Self {
         metrics.open_total.incr();
         metrics.open_connections.incr();
-        if let Ok(mut by_eos) = metrics.by_eos.lock() {
-            by_eos.last_update = Instant::now();
-        }
+        metrics.by_eos.lock().last_update = Instant::now();
         Self {
             metrics: Some(metrics),
             opened_at: Instant::now(),
@@ -359,18 +349,14 @@ impl io::Sensor for Sensor {
     fn record_read(&mut self, sz: usize) {
         if let Some(ref m) = self.metrics {
             m.read_bytes_total.add(sz as u64);
-            if let Ok(mut by_eos) = m.by_eos.lock() {
-                by_eos.last_update = Instant::now();
-            }
+            m.by_eos.lock().last_update = Instant::now();
         }
     }
 
     fn record_write(&mut self, sz: usize) {
         if let Some(ref m) = self.metrics {
             m.write_bytes_total.add(sz as u64);
-            if let Ok(mut by_eos) = m.by_eos.lock() {
-                by_eos.last_update = Instant::now();
-            }
+            m.by_eos.lock().last_update = Instant::now();
         }
     }
 
@@ -381,7 +367,7 @@ impl io::Sensor for Sensor {
         if let Some(m) = self.metrics.take() {
             m.open_connections.decr();
 
-            let mut by_eos = m.by_eos.lock().expect("transport eos metrics lock");
+            let mut by_eos = m.by_eos.lock();
             let class = by_eos
                 .metrics
                 .entry(Eos(eos))
@@ -440,10 +426,7 @@ impl FmtLabels for Eos {
 
 impl LastUpdate for Metrics {
     fn last_update(&self) -> Instant {
-        self.by_eos
-            .lock()
-            .map(|metrics| metrics.last_update)
-            .unwrap_or_else(|_| Instant::now()) // XXX(eliza): ew
+        self.by_eos.lock().last_update
     }
 }
 
@@ -476,7 +459,7 @@ mod tests {
 
         let retain_idle_for = Duration::from_secs(1);
         let (r, report) = super::new(retain_idle_for);
-        let mut registry = r.0.lock().unwrap();
+        let mut registry = r.0.lock();
 
         let before_update = Instant::now();
         let metrics = registry.entry(Target(123)).or_default().clone();

--- a/linkerd/stack/metrics/Cargo.toml
+++ b/linkerd/stack/metrics/Cargo.toml
@@ -8,5 +8,6 @@ publish = false
 
 [dependencies]
 linkerd-metrics = { path = "../../metrics" }
+parking_lot = "0.11"
 tower = { version = "0.4.8", default-features = false }
 tokio = { version = "1", features = ["time"] }


### PR DESCRIPTION
PR #1117 includes a change to move some uses of `std::sync::Mutex` to
`parking_lot::Mutex`, as the latter implementation is generally more
efficient.

This change updates all telemetry-related uses of Mutex with the
implementation in `parking_lot`.

Co-authored-by: Eliza Weisman <eliza@buoyant.io>