### PR TITLE
Add Stack::push_connect_timeout

### DIFF
--- a/linkerd/app/core/src/errors.rs
+++ b/linkerd/app/core/src/errors.rs
@@ -512,11 +512,11 @@ impl HttpError {
 }
 
 #[derive(Debug)]
-pub struct ConnectTimeout();
+pub(crate) struct ConnectTimeout(pub std::time::Duration);
 
 impl fmt::Display for ConnectTimeout {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad("connect timed out")
+        write!(f, "connect timed out after {:?}", self.0)
     }
 }
 

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -174,6 +174,33 @@ impl<S> Stack<S> {
         self.push(tower::timeout::TimeoutLayer::new(timeout))
     }
 
+    /// Wraps the inner service with a response timeout such that timeout errors are surfaced as a
+    /// `ConnectTimeout` error.
+    ///
+    /// Note that any timeouts errors from the inner service will be wrapped as well.
+    pub fn push_connect_timeout<T>(
+        self,
+        timeout: Duration,
+    ) -> Stack<
+        stack::MapErr<
+            tower::timeout::Timeout<S>,
+            impl FnOnce(Error) -> Error + Clone + Send + Unpin,
+        >,
+    >
+    where
+        S: Service<T>,
+        S::Error: Into<Error>,
+    {
+        self.push_timeout(timeout)
+            .push(MapErrLayer::new(move |err: Error| {
+                if err.is::<tower::timeout::error::Elapsed>() {
+                    crate::errors::ConnectTimeout(timeout).into()
+                } else {
+                    err
+                }
+            }))
+    }
+
     pub fn push_http_insert_target<P>(self) -> Stack<http::insert::NewInsert<P, S>> {
         self.push(http::insert::NewInsert::layer())
     }

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -181,12 +181,7 @@ impl<S> Stack<S> {
     pub fn push_connect_timeout<T>(
         self,
         timeout: Duration,
-    ) -> Stack<
-        stack::MapErr<
-            tower::timeout::Timeout<S>,
-            impl FnOnce(Error) -> Error + Clone + Send + Unpin,
-        >,
-    >
+    ) -> Stack<stack::MapErr<tower::timeout::Timeout<S>, impl FnOnce(Error) -> Error + Clone>>
     where
         S: Service<T>,
         S::Error: Into<Error>,

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -104,7 +104,7 @@ where
     C: svc::Service<TcpEndpoint> + Clone + Send + Sync + Unpin + 'static,
     C::Response: io::AsyncRead + io::AsyncWrite + Send + Unpin + 'static,
     C::Error: Into<Error>,
-    C::Future: Send + Unpin,
+    C::Future: Send,
 {
     pub fn push_http_router<P>(
         self,
@@ -133,6 +133,7 @@ where
 
         // Creates HTTP clients for each inbound port & HTTP settings.
         let endpoint = connect
+            .push(svc::stack::BoxFuture::layer()) // Makes the response future `Unpin`.
             .push(rt.metrics.transport.layer_connect())
             .push_map_target(TcpEndpoint::from)
             .push(http::client::layer(

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -88,7 +88,7 @@ impl Inbound<()> {
 
     /// Readies the inbound stack to make TCP connections (for both TCP
     // forwarding and HTTP proxying).
-    pub fn to_tcp_connect<T>(
+    pub fn to_tcp_connect<T: svc::Param<u16>>(
         &self,
     ) -> Inbound<
         impl svc::Service<
@@ -97,10 +97,7 @@ impl Inbound<()> {
                 Error = Error,
                 Future = impl Send,
             > + Clone,
-    >
-    where
-        T: svc::Param<u16> + 'static,
-    {
+    > {
         let Self {
             config,
             runtime,


### PR DESCRIPTION
The connect-timeout logic isn't really inbound-specific and may be
useful elsewhere, like on the outbound stack.

This change moves this logic from `Inbound::to_tcp_connect` to
`Stack::push_connect_timeout` and restores `Inbound::to_tcp_connect` to
be responsible for building the TCP connection layer. Our tests go back
to mocking the `to_tcp_connect` layering (as it's quite simple).