### PR TITLE
metrics: fix metrics test code allowing incomplete matches

### DIFF
--- a/linkerd/app/integration/src/tests/telemetry/mod.rs
+++ b/linkerd/app/integration/src/tests/telemetry/mod.rs
@@ -15,6 +15,7 @@ struct Fixture {
     _profile: controller::ProfileSender,
     dst_tx: Option<controller::DstSender>,
     labels: metrics::Labels,
+    tcp_labels: metrics::Labels,
 }
 
 struct TcpFixture {
@@ -50,10 +51,12 @@ impl Fixture {
         let metrics = client::http1(proxy.metrics, "localhost");
 
         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
-        let labels = metrics::labels()
-            .label("authority", "tele.test.svc.cluster.local")
+        let tcp_labels = metrics::labels()
             .label("direction", "inbound")
             .label("target_addr", orig_dst);
+        let labels = tcp_labels
+            .clone()
+            .label("authority", "tele.test.svc.cluster.local");
         Fixture {
             client,
             metrics,
@@ -61,6 +64,7 @@ impl Fixture {
             _profile,
             dst_tx: None,
             labels,
+            tcp_labels,
         }
     }
 
@@ -79,10 +83,10 @@ impl Fixture {
         let metrics = client::http1(proxy.metrics, "localhost");
 
         let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
-        let labels = metrics::labels()
+        let tcp_labels = metrics::labels()
             .label("direction", "outbound")
-            .label("authority", authority)
             .label("target_addr", orig_dst);
+        let labels = tcp_labels.clone().label("authority", authority);
         Fixture {
             client,
             metrics,
@@ -90,6 +94,7 @@ impl Fixture {
             _profile,
             dst_tx: Some(dest),
             labels,
+            tcp_labels,
         }
     }
 }
@@ -138,8 +143,7 @@ impl TcpFixture {
             .label("direction", "inbound")
             .label("peer", "dst")
             .label("tls", "no_identity")
-            .label("no_tls_reason", "loopback")
-            .label("authority", orig_dst);
+            .label("no_tls_reason", "loopback");
         TcpFixture {
             client,
             metrics,
@@ -175,8 +179,7 @@ impl TcpFixture {
             .label("target_addr", orig_dst);
         let dst_labels = metrics::labels()
             .label("direction", "outbound")
-            .label("peer", "dst")
-            .label("authority", orig_dst);
+            .label("peer", "dst");
 
         TcpFixture {
             client,
@@ -284,6 +287,7 @@ async fn test_http_count(metric: &str, fixture: impl Future<Output = Fixture>) {
         _profile,
         dst_tx: _dst_tx,
         labels,
+        ..
     } = fixture.await;
 
     let metric = labels.metric(metric);
@@ -352,6 +356,7 @@ mod response_classification {
             _profile,
             dst_tx: _dst_tx,
             labels,
+            ..
         } = fixture.await;
 
         for (i, status) in STATUSES.iter().enumerate() {
@@ -420,6 +425,7 @@ where
         _profile,
         dst_tx: _dst_tx,
         labels,
+        ..
     } = mk_fixture(srv).await;
 
     info!("client.get(/hey)");
@@ -523,16 +529,17 @@ mod outbound_dst_labels {
         let metrics = client::http1(proxy.metrics, "localhost");
 
         let client = client::new(proxy.outbound, dest);
-        let labels = metrics::labels()
+        let tcp_labels = metrics::labels()
             .label("direction", "outbound")
-            .label("authority", dest_and_port)
             .label("target_addr", addr);
+        let labels = tcp_labels.clone().label("authority", dest_and_port);
         let f = Fixture {
             client,
             metrics,
             proxy,
             _profile,
             labels,
+            tcp_labels,
             dst_tx: Some(dst_tx),
         };
 
@@ -550,6 +557,7 @@ mod outbound_dst_labels {
                 _profile,
                 dst_tx,
                 labels,
+                ..
             },
             addr,
         ) = fixture("labeled.test.svc.cluster.local").await;
@@ -588,6 +596,7 @@ mod outbound_dst_labels {
                 _profile,
                 dst_tx,
                 labels,
+                ..
             },
             addr,
         ) = fixture("labeled.test.svc.cluster.local").await;
@@ -627,6 +636,7 @@ mod outbound_dst_labels {
                 _profile,
                 dst_tx,
                 labels,
+                ..
             },
             addr,
         ) = fixture("labeled.test.svc.cluster.local").await;
@@ -674,6 +684,7 @@ mod outbound_dst_labels {
                 _profile,
                 dst_tx,
                 labels,
+                ..
             },
             addr,
         ) = fixture("labeled.test.svc.cluster.local").await;
@@ -756,6 +767,7 @@ mod outbound_dst_labels {
                 _profile,
                 dst_tx,
                 labels,
+                ..
             },
             addr,
         ) = fixture("labeled.test.svc.cluster.local").await;
@@ -887,10 +899,11 @@ mod transport {
             proxy: _proxy,
             _profile,
             dst_tx: _dst_tx,
-            labels,
+            tcp_labels,
+            ..
         } = fixture.await;
 
-        let labels = labels.and(extra_labels).label("peer", "dst");
+        let labels = tcp_labels.and(extra_labels).label("peer", "dst");
         let opens = labels.metric("tcp_open_total").value(1u64);
 
         info!("client.get(/)");
@@ -914,10 +927,11 @@ mod transport {
             proxy: _proxy,
             _profile,
             dst_tx: _dst_tx,
-            labels,
+            tcp_labels,
+            ..
         } = fixture.await;
 
-        let labels = labels.and(extra_labels).label("peer", "src");
+        let labels = tcp_labels.and(extra_labels).label("peer", "src");
         let mut opens = labels.metric("tcp_open_total").value(1u64);
         let mut closes = labels
             .metric("tcp_close_total")
@@ -1097,10 +1111,11 @@ mod transport {
             proxy: _proxy,
             _profile,
             dst_tx: _dst_tx,
-            labels,
+            tcp_labels,
+            ..
         } = fixture.await;
 
-        let mut open_conns = labels
+        let mut open_conns = tcp_labels
             .and(extra_labels)
             .metric("tcp_open_connections")
             .label("peer", "src");
@@ -1325,6 +1340,7 @@ async fn metrics_compression() {
         _profile,
         dst_tx: _dst_tx,
         labels,
+        ..
     } = Fixture::inbound().await;
 
     let do_scrape = |encoding: &str| {


### PR DESCRIPTION
Currently, there's a bug in the metrics test code where a metric can
match if it contains *any* of the expected labels, even if some are
missing. This is because the test code assumes a metric will match, and
sets the matched value to `false` if any expected label keys have
unexpected values. However, if a label that the matcher is configured to
expect isn't present *at all* in the actual metric, it is still
considered matched. This allows tests to pass even if required labels
aren't present, which is pretty bad.

This branch fixes that bug by counting how many matches were found, and
comparing it to the number of labels that are expected. If fewer labels
were found, then the metric is not a match, even if all the found labels
had the expected values.

It turns out that a lot of the existing tests expect labels that are not
actually present, and these were passing due to the bug. In particular,
we expected transport metrics to have `authority` labels, but we don't
actually add these to transport metrics, even when they were recorded
from HTTP connections for which we do know an authority. AFAICT, we
never added these labels, and it would be a pretty large change to add
them when possible, so I'm pretty sure the tests are just incorrect,
here. I've changed them not to expect these labels. But, if we actually
meant to be adding authority labels to these metrics all along, I can
try to fix that instead.

Similarly, we expected the inbound `target_addr` label to be added to
both `peer="src"` *and* `peer="dst"` transport metrics, but we don't
actually add it in the proxy. Again, I think this is just a bug in the test
code, so I've changed the tests to not expect it.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
