### PR TITLE
Reduce stack-builder boilerplate

### DIFF
--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -86,87 +86,79 @@ impl<N> Inbound<N> {
         GSvc::Error: Into<Error>,
         GSvc::Future: Send,
     {
-        let Self {
-            config,
-            runtime: rt,
-            stack: tcp,
-        } = self;
-        let detect_timeout = config.proxy.detect_protocol_timeout;
+        self.map_stack(|config, rt, tcp| {
+            let detect_timeout = config.proxy.detect_protocol_timeout;
 
-        let stack = tcp
-            .instrument(|_: &TcpEndpoint| debug_span!("opaque"))
-            // When the transport header is present, it may be used for either local
-            // TCP forwarding, or we may be processing an HTTP gateway connection.
-            // HTTP gateway connections that have a transport header must provide a
-            // target name as a part of the header.
-            .push_switch(
-                |(h, client): (TransportHeader, ClientInfo)| match h {
-                    TransportHeader {
-                        port,
-                        name: None,
-                        protocol: None,
-                    } => Ok(svc::Either::A(TcpEndpoint { port })),
-                    TransportHeader {
-                        port,
-                        name: Some(name),
-                        protocol,
-                    } => Ok(svc::Either::B(GatewayTransportHeader {
-                        target: NameAddr::from((name, port)),
-                        protocol,
-                        client,
-                    })),
-                    TransportHeader {
-                        name: None,
-                        protocol: Some(_),
-                        ..
-                    } => Err(RefusedNoTarget),
-                },
-                // HTTP detection is not necessary in this case, since the transport
-                // header indicates the connection's HTTP version.
-                svc::stack(gateway.clone())
-                    .push_on_response(svc::MapTargetLayer::new(io::EitherIo::Left))
-                    .push_map_target(GatewayConnection::TransportHeader)
-                    .instrument(|g: &GatewayTransportHeader| info_span!("gateway", dst = %g.target))
-                    .into_inner(),
-            )
-            // Use ALPN to determine whether a transport header should be read.
-            //
-            // When the transport header is not present, perform HTTP detection to
-            // support legacy gateway clients.
-            .push(NewTransportHeaderServer::layer(detect_timeout))
-            .push_switch(
-                |client: ClientInfo| {
-                    if client.header_negotiated() {
-                        Ok::<_, Never>(svc::Either::A(client))
-                    } else {
-                        Ok(svc::Either::B(GatewayConnection::Legacy(client)))
-                    }
-                },
-                // TODO: Remove this after we have at least one stable release out
-                // with transport header support.
-                svc::stack(gateway)
-                    .push_on_response(svc::MapTargetLayer::new(io::EitherIo::Right))
-                    .instrument(|_: &GatewayConnection| info_span!("gateway", legacy = true))
-                    .into_inner(),
-            )
-            .push(rt.metrics.transport.layer_accept())
-            // Build a ClientInfo target for each accepted connection. Refuse the
-            // connection if it doesn't include an mTLS identity.
-            .push_request_filter(ClientInfo::try_from)
-            .push(svc::BoxNewService::layer())
-            .push(tls::NewDetectTls::layer(
-                rt.identity.clone().map(WithTransportHeaderAlpn),
-                detect_timeout,
-            ))
-            .check_new_service::<T, I>()
-            .push_on_response(svc::BoxService::layer())
-            .push(svc::BoxNewService::layer());
-
-        Inbound {
-            config,
-            runtime: rt,
-            stack,
-        }
+            tcp.instrument(|_: &TcpEndpoint| debug_span!("opaque"))
+                // When the transport header is present, it may be used for either local
+                // TCP forwarding, or we may be processing an HTTP gateway connection.
+                // HTTP gateway connections that have a transport header must provide a
+                // target name as a part of the header.
+                .push_switch(
+                    |(h, client): (TransportHeader, ClientInfo)| match h {
+                        TransportHeader {
+                            port,
+                            name: None,
+                            protocol: None,
+                        } => Ok(svc::Either::A(TcpEndpoint { port })),
+                        TransportHeader {
+                            port,
+                            name: Some(name),
+                            protocol,
+                        } => Ok(svc::Either::B(GatewayTransportHeader {
+                            target: NameAddr::from((name, port)),
+                            protocol,
+                            client,
+                        })),
+                        TransportHeader {
+                            name: None,
+                            protocol: Some(_),
+                            ..
+                        } => Err(RefusedNoTarget),
+                    },
+                    // HTTP detection is not necessary in this case, since the transport
+                    // header indicates the connection's HTTP version.
+                    svc::stack(gateway.clone())
+                        .push_on_response(svc::MapTargetLayer::new(io::EitherIo::Left))
+                        .push_map_target(GatewayConnection::TransportHeader)
+                        .instrument(
+                            |g: &GatewayTransportHeader| info_span!("gateway", dst = %g.target),
+                        )
+                        .into_inner(),
+                )
+                // Use ALPN to determine whether a transport header should be read.
+                //
+                // When the transport header is not present, perform HTTP detection to
+                // support legacy gateway clients.
+                .push(NewTransportHeaderServer::layer(detect_timeout))
+                .push_switch(
+                    |client: ClientInfo| {
+                        if client.header_negotiated() {
+                            Ok::<_, Never>(svc::Either::A(client))
+                        } else {
+                            Ok(svc::Either::B(GatewayConnection::Legacy(client)))
+                        }
+                    },
+                    // TODO: Remove this after we have at least one stable release out
+                    // with transport header support.
+                    svc::stack(gateway)
+                        .push_on_response(svc::MapTargetLayer::new(io::EitherIo::Right))
+                        .instrument(|_: &GatewayConnection| info_span!("gateway", legacy = true))
+                        .into_inner(),
+                )
+                .push(rt.metrics.transport.layer_accept())
+                // Build a ClientInfo target for each accepted connection. Refuse the
+                // connection if it doesn't include an mTLS identity.
+                .push_request_filter(ClientInfo::try_from)
+                .push(svc::BoxNewService::layer())
+                .push(tls::NewDetectTls::layer(
+                    rt.identity.clone().map(WithTransportHeaderAlpn),
+                    detect_timeout,
+                ))
+                .check_new_service::<T, I>()
+                .push_on_response(svc::BoxService::layer())
+                .push(svc::BoxNewService::layer())
+        })
     }
 }
 

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -46,56 +46,46 @@ impl<H> Inbound<H> {
         HSvc::Error: Into<Error>,
         HSvc::Future: Send,
     {
-        let Self {
-            config,
-            runtime: rt,
-            stack: http,
-        } = self;
-        let ProxyConfig {
-            server: ServerConfig { h2_settings, .. },
-            dispatch_timeout,
-            max_in_flight_requests,
-            ..
-        } = config.proxy;
+        self.map_stack(|config, rt, http| {
+            let ProxyConfig {
+                server: ServerConfig { h2_settings, .. },
+                dispatch_timeout,
+                max_in_flight_requests,
+                ..
+            } = config.proxy;
 
-        let stack = http
-            .check_new_service::<T, http::Request<_>>()
-            // Convert origin form HTTP/1 URIs to absolute form for Hyper's
-            // `Client`. This must be below the `orig_proto::Downgrade` layer, since
-            // the request may have been downgraded from a HTTP/2 orig-proto request.
-            .push(http::NewNormalizeUri::layer())
-            .push(NewSetIdentityHeader::layer())
-            .push_on_response(
-                svc::layers()
-                    // Downgrades the protocol if upgraded by an outbound proxy.
-                    .push(http::orig_proto::Downgrade::layer())
-                    // Limit the number of in-flight requests. When the proxy is
-                    // at capacity, go into failfast after a dispatch timeout.
-                    // Note that the inner service _always_ returns ready (due
-                    // to `NewRouter`) and the concurrency limit need not be
-                    // driven outside of the request path, so there's no need
-                    // for SpawnReady
-                    .push(svc::ConcurrencyLimitLayer::new(max_in_flight_requests))
-                    .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
-                    .push(rt.metrics.http_errors.clone())
-                    // Synthesizes responses for proxy errors.
-                    .push(errors::layer())
-                    .push(http_tracing::server(rt.span_sink.clone(), trace_labels()))
-                    // Record when an HTTP/1 URI was in absolute form
-                    .push(http::normalize_uri::MarkAbsoluteForm::layer())
-                    .push(http::BoxRequest::layer())
-                    .push(http::BoxResponse::layer()),
-            )
-            .check_new_service::<T, http::Request<_>>()
-            .instrument(|t: &T| debug_span!("http", v=%Param::<Version>::param(t)))
-            .push(http::NewServeHttp::layer(h2_settings, rt.drain.clone()))
-            .push(svc::BoxNewService::layer());
-
-        Inbound {
-            config,
-            runtime: rt,
-            stack,
-        }
+            http.check_new_service::<T, http::Request<_>>()
+                // Convert origin form HTTP/1 URIs to absolute form for Hyper's
+                // `Client`. This must be below the `orig_proto::Downgrade` layer, since
+                // the request may have been downgraded from a HTTP/2 orig-proto request.
+                .push(http::NewNormalizeUri::layer())
+                .push(NewSetIdentityHeader::layer())
+                .push_on_response(
+                    svc::layers()
+                        // Downgrades the protocol if upgraded by an outbound proxy.
+                        .push(http::orig_proto::Downgrade::layer())
+                        // Limit the number of in-flight requests. When the proxy is
+                        // at capacity, go into failfast after a dispatch timeout.
+                        // Note that the inner service _always_ returns ready (due
+                        // to `NewRouter`) and the concurrency limit need not be
+                        // driven outside of the request path, so there's no need
+                        // for SpawnReady
+                        .push(svc::ConcurrencyLimitLayer::new(max_in_flight_requests))
+                        .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
+                        .push(rt.metrics.http_errors.clone())
+                        // Synthesizes responses for proxy errors.
+                        .push(errors::layer())
+                        .push(http_tracing::server(rt.span_sink.clone(), trace_labels()))
+                        // Record when an HTTP/1 URI was in absolute form
+                        .push(http::normalize_uri::MarkAbsoluteForm::layer())
+                        .push(http::BoxRequest::layer())
+                        .push(http::BoxResponse::layer()),
+                )
+                .check_new_service::<T, http::Request<_>>()
+                .instrument(|t: &T| debug_span!("http", v=%Param::<Version>::param(t)))
+                .push(http::NewServeHttp::layer(h2_settings, rt.drain.clone()))
+                .push(svc::BoxNewService::layer())
+        })
     }
 }
 
@@ -125,128 +115,119 @@ where
         P::Future: Send,
         P::Error: Send,
     {
-        let Self {
-            config,
-            runtime: rt,
-            stack: connect,
-        } = self;
+        self.map_stack(|config, rt, connect| {
+            // Creates HTTP clients for each inbound port & HTTP settings.
+            let endpoint = connect
+                .push(rt.metrics.transport.layer_connect())
+                .push_map_target(TcpEndpoint::from)
+                .push(http::client::layer(
+                    config.proxy.connect.h1_settings,
+                    config.proxy.connect.h2_settings,
+                ))
+                .push_on_response(svc::MapErrLayer::new(Into::into))
+                .into_new_service()
+                .push_new_reconnect(config.proxy.connect.backoff)
+                .check_new_service::<HttpEndpoint, http::Request<_>>();
 
-        // Creates HTTP clients for each inbound port & HTTP settings.
-        let endpoint = connect
-            .push(rt.metrics.transport.layer_connect())
-            .push_map_target(TcpEndpoint::from)
-            .push(http::client::layer(
-                config.proxy.connect.h1_settings,
-                config.proxy.connect.h2_settings,
-            ))
-            .push_on_response(svc::MapErrLayer::new(Into::into))
-            .into_new_service()
-            .push_new_reconnect(config.proxy.connect.backoff)
-            .check_new_service::<HttpEndpoint, http::Request<_>>();
+            let target = endpoint
+                .push_map_target(HttpEndpoint::from)
+                // Registers the stack to be tapped.
+                .push(tap::NewTapHttp::layer(rt.tap.clone()))
+                // Records metrics for each `Target`.
+                .push(
+                    rt.metrics
+                        .http_endpoint
+                        .to_layer::<classify::Response, _, _>(),
+                )
+                .push_on_response(http_tracing::client(rt.span_sink.clone(), trace_labels()))
+                .push_on_response(http::BoxResponse::layer())
+                .check_new_service::<Target, http::Request<_>>();
 
-        let target = endpoint
-            .push_map_target(HttpEndpoint::from)
-            // Registers the stack to be tapped.
-            .push(tap::NewTapHttp::layer(rt.tap.clone()))
-            // Records metrics for each `Target`.
-            .push(
-                rt.metrics
-                    .http_endpoint
-                    .to_layer::<classify::Response, _, _>(),
-            )
-            .push_on_response(http_tracing::client(rt.span_sink.clone(), trace_labels()))
-            .push_on_response(http::BoxResponse::layer())
-            .check_new_service::<Target, http::Request<_>>();
+            let no_profile = target
+                .clone()
+                .push_on_response(http::BoxResponse::layer())
+                .check_new_service::<Target, http::Request<_>>()
+                .into_inner();
 
-        let no_profile = target
-            .clone()
-            .push_on_response(http::BoxResponse::layer())
-            .check_new_service::<Target, http::Request<_>>()
-            .into_inner();
-        // Attempts to discover a service profile for each logical target (as
-        // informed by the request's headers). The stack is cached until a
-        // request has not been received for `cache_max_idle_age`.
-        let stack = target
-            .clone()
-            .check_new_service::<Target, http::Request<http::BoxBody>>()
-            .push_on_response(http::BoxRequest::layer())
-            // The target stack doesn't use the profile resolution, so drop it.
-            .push_map_target(Target::from)
-            .push(profiles::http::route_request::layer(
-                svc::proxies()
-                    // Sets the route as a request extension so that it can be used
-                    // by tap.
-                    .push_http_insert_target::<dst::Route>()
-                    // Records per-route metrics.
-                    .push(
-                        rt.metrics
-                            .http_route
-                            .to_layer::<classify::Response, _, dst::Route>(),
-                    )
-                    // Sets the per-route response classifier as a request
-                    // extension.
-                    .push(classify::NewClassify::layer())
-                    .check_new_clone::<dst::Route>()
-                    .push_map_target(target::route)
-                    .into_inner(),
-            ))
-            .push_map_target(Logical::from)
-            .push_on_response(http::BoxResponse::layer())
-            .check_new_service::<(profiles::Receiver, Target), _>()
-            .push(svc::UnwrapOr::layer(no_profile))
-            .push(profiles::discover::layer(
-                profiles,
-                AllowProfile(config.allow_discovery.clone()),
-            ))
-            .instrument(|_: &Target| debug_span!("profile"))
-            .push_on_response(
-                svc::layers()
-                    .push(http::BoxResponse::layer())
-                    .push(svc::layer::mk(svc::SpawnReady::new)),
-            )
-            // Skip the profile stack if it takes too long to become ready.
-            .push_when_unready(
-                config.profile_idle_timeout,
-                target
-                    .clone()
-                    .push_on_response(svc::layer::mk(svc::SpawnReady::new))
-                    .into_inner(),
-            )
-            .check_new_service::<Target, http::Request<BoxBody>>()
-            .push_on_response(
-                svc::layers()
-                    .push(
-                        rt.metrics
-                            .stack
-                            .layer(crate::stack_labels("http", "logical")),
-                    )
-                    .push(svc::FailFast::layer(
-                        "HTTP Logical",
-                        config.proxy.dispatch_timeout,
-                    ))
-                    .push_spawn_buffer(config.proxy.buffer_capacity),
-            )
-            .push_cache(config.proxy.cache_max_idle_age)
-            .push_on_response(
-                svc::layers()
-                    .push(http::Retain::layer())
-                    .push(http::BoxResponse::layer()),
-            )
-            .check_new_service::<Target, http::Request<http::BoxBody>>()
-            // Routes each request to a target, obtains a service for that
-            // target, and dispatches the request.
-            .instrument_from_target()
-            .push(svc::BoxNewService::layer())
-            .push(svc::NewRouter::layer(RequestTarget::from))
-            // Used by tap.
-            .push_http_insert_target::<HttpAccept>()
-            .push(svc::BoxNewService::layer());
-
-        Inbound {
-            config,
-            runtime: rt,
-            stack,
-        }
+            // Attempts to discover a service profile for each logical target (as
+            // informed by the request's headers). The stack is cached until a
+            // request has not been received for `cache_max_idle_age`.
+            target
+                .clone()
+                .check_new_service::<Target, http::Request<http::BoxBody>>()
+                .push_on_response(http::BoxRequest::layer())
+                // The target stack doesn't use the profile resolution, so drop it.
+                .push_map_target(Target::from)
+                .push(profiles::http::route_request::layer(
+                    svc::proxies()
+                        // Sets the route as a request extension so that it can be used
+                        // by tap.
+                        .push_http_insert_target::<dst::Route>()
+                        // Records per-route metrics.
+                        .push(
+                            rt.metrics
+                                .http_route
+                                .to_layer::<classify::Response, _, dst::Route>(),
+                        )
+                        // Sets the per-route response classifier as a request
+                        // extension.
+                        .push(classify::NewClassify::layer())
+                        .check_new_clone::<dst::Route>()
+                        .push_map_target(target::route)
+                        .into_inner(),
+                ))
+                .push_map_target(Logical::from)
+                .push_on_response(http::BoxResponse::layer())
+                .check_new_service::<(profiles::Receiver, Target), _>()
+                .push(svc::UnwrapOr::layer(no_profile))
+                .push(profiles::discover::layer(
+                    profiles,
+                    AllowProfile(config.allow_discovery.clone()),
+                ))
+                .instrument(|_: &Target| debug_span!("profile"))
+                .push_on_response(
+                    svc::layers()
+                        .push(http::BoxResponse::layer())
+                        .push(svc::layer::mk(svc::SpawnReady::new)),
+                )
+                // Skip the profile stack if it takes too long to become ready.
+                .push_when_unready(
+                    config.profile_idle_timeout,
+                    target
+                        .clone()
+                        .push_on_response(svc::layer::mk(svc::SpawnReady::new))
+                        .into_inner(),
+                )
+                .check_new_service::<Target, http::Request<BoxBody>>()
+                .push_on_response(
+                    svc::layers()
+                        .push(
+                            rt.metrics
+                                .stack
+                                .layer(crate::stack_labels("http", "logical")),
+                        )
+                        .push(svc::FailFast::layer(
+                            "HTTP Logical",
+                            config.proxy.dispatch_timeout,
+                        ))
+                        .push_spawn_buffer(config.proxy.buffer_capacity),
+                )
+                .push_cache(config.proxy.cache_max_idle_age)
+                .push_on_response(
+                    svc::layers()
+                        .push(http::Retain::layer())
+                        .push(http::BoxResponse::layer()),
+                )
+                .check_new_service::<Target, http::Request<http::BoxBody>>()
+                // Routes each request to a target, obtains a service for that
+                // target, and dispatches the request.
+                .instrument_from_target()
+                .push(svc::BoxNewService::layer())
+                .push(svc::NewRouter::layer(RequestTarget::from))
+                // Used by tap.
+                .push_http_insert_target::<HttpAccept>()
+                .push(svc::BoxNewService::layer())
+        })
     }
 }
 

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -67,6 +67,19 @@ impl<S> Inbound<S> {
     pub fn into_inner(self) -> S {
         self.stack.into_inner()
     }
+
+    /// Creates a new `Inbound` by replacing the inner stack, as modified by `f`.
+    fn map_stack<T>(
+        self,
+        f: impl FnOnce(&Config, &ProxyRuntime, svc::Stack<S>) -> svc::Stack<T>,
+    ) -> Inbound<T> {
+        let stack = f(&self.config, &self.runtime, self.stack);
+        Inbound {
+            config: self.config,
+            runtime: self.runtime,
+            stack,
+        }
+    }
 }
 
 impl Inbound<()> {
@@ -79,11 +92,7 @@ impl Inbound<()> {
     }
 
     pub fn with_stack<S>(self, stack: S) -> Inbound<S> {
-        Inbound {
-            config: self.config,
-            runtime: self.runtime,
-            stack: svc::stack(stack),
-        }
+        self.map_stack(move |_, _, _| svc::stack(stack))
     }
 
     pub fn to_tcp_connect<T: svc::Param<u16>>(
@@ -96,29 +105,19 @@ impl Inbound<()> {
                 Future = impl Send,
             > + Clone,
     > {
-        let Self {
-            config,
-            runtime,
-            stack: _,
-        } = self.clone();
+        self.clone().map_stack(|config, _, _| {
+            // Establishes connections to remote peers (for both TCP
+            // forwarding and HTTP proxying).
+            let ConnectConfig {
+                keepalive, timeout, ..
+            } = config.proxy.connect.clone();
 
-        // Establishes connections to remote peers (for both TCP
-        // forwarding and HTTP proxying).
-        let ConnectConfig {
-            keepalive, timeout, ..
-        } = config.proxy.connect;
-
-        let stack = svc::stack(transport::ConnectTcp::new(keepalive))
-            .push_map_target(|t: T| Remote(ServerAddr(([127, 0, 0, 1], t.param()).into())))
-            // Limits the time we wait for a connection to be established.
-            .push_timeout(timeout)
-            .push(svc::stack::BoxFuture::layer());
-
-        Inbound {
-            config,
-            runtime,
-            stack,
-        }
+            svc::stack(transport::ConnectTcp::new(keepalive))
+                .push_map_target(|t: T| Remote(ServerAddr(([127, 0, 0, 1], t.param()).into())))
+                // Limits the time we wait for a connection to be established.
+                .push_timeout(timeout)
+                .push(svc::stack::BoxFuture::layer())
+        })
     }
 
     pub fn serve<B, G, GSvc, P>(
@@ -177,34 +176,25 @@ where
         I: io::AsyncRead + io::AsyncWrite,
         I: Debug + Send + Sync + Unpin + 'static,
     {
-        let Self {
-            config,
-            runtime: rt,
-            stack: connect,
-        } = self;
-        let prevent_loop = PreventLoop::from(server_port);
+        self.map_stack(|_, rt, connect| {
+            let prevent_loop = PreventLoop::from(server_port);
 
-        // Forwards TCP streams that cannot be decoded as HTTP.
-        //
-        // Looping is always prevented.
-        let stack = connect
-            .push_request_filter(prevent_loop)
-            .push(rt.metrics.transport.layer_connect())
-            .push_make_thunk()
-            .push_on_response(
-                svc::layers()
-                    .push(tcp::Forward::layer())
-                    .push(drain::Retain::layer(rt.drain.clone())),
-            )
-            .instrument(|_: &_| debug_span!("tcp"))
-            .push(svc::BoxNewService::layer())
-            .check_new::<TcpEndpoint>();
-
-        Inbound {
-            config,
-            runtime: rt,
-            stack,
-        }
+            // Forwards TCP streams that cannot be decoded as HTTP.
+            //
+            // Looping is always prevented.
+            connect
+                .push_request_filter(prevent_loop)
+                .push(rt.metrics.transport.layer_connect())
+                .push_make_thunk()
+                .push_on_response(
+                    svc::layers()
+                        .push(tcp::Forward::layer())
+                        .push(drain::Retain::layer(rt.drain.clone())),
+                )
+                .instrument(|_: &_| debug_span!("tcp"))
+                .push(svc::BoxNewService::layer())
+                .check_new::<TcpEndpoint>()
+        })
     }
 
     pub fn into_server<T, I, G, GSvc, P>(

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -28,129 +28,120 @@ impl<E> Outbound<E> {
         R::Resolution: Send,
         R::Future: Send + Unpin,
     {
-        let Self {
-            config,
-            runtime: rt,
-            stack: endpoint,
-        } = self;
-        let config::ProxyConfig {
-            buffer_capacity,
-            cache_max_idle_age,
-            dispatch_timeout,
-            ..
-        } = config.proxy;
-        let watchdog = cache_max_idle_age * 2;
+        self.map_stack(|config, rt, endpoint| {
+            let config::ProxyConfig {
+                buffer_capacity,
+                cache_max_idle_age,
+                dispatch_timeout,
+                ..
+            } = config.proxy;
+            let watchdog = cache_max_idle_age * 2;
 
-        let endpoint =
-            endpoint.instrument(|e: &Endpoint| debug_span!("endpoint", server.addr = %e.addr));
+            let endpoint =
+                endpoint.instrument(|e: &Endpoint| debug_span!("endpoint", server.addr = %e.addr));
 
-        let identity_disabled = rt.identity.is_none();
-        let resolve = svc::stack(resolve.into_service())
-            .check_service::<ConcreteAddr>()
-            .push_request_filter(|c: Concrete| Ok::<_, Never>(c.resolve))
-            .push(svc::layer::mk(move |inner| {
-                map_endpoint::Resolve::new(endpoint::FromMetadata { identity_disabled }, inner)
-            }))
-            .check_service::<Concrete>()
-            .into_inner();
+            let identity_disabled = rt.identity.is_none();
+            let resolve = svc::stack(resolve.into_service())
+                .check_service::<ConcreteAddr>()
+                .push_request_filter(|c: Concrete| Ok::<_, Never>(c.resolve))
+                .push(svc::layer::mk(move |inner| {
+                    map_endpoint::Resolve::new(endpoint::FromMetadata { identity_disabled }, inner)
+                }))
+                .check_service::<Concrete>()
+                .into_inner();
 
-        let stack = endpoint
-            .clone()
-            .check_new_service::<Endpoint, http::Request<http::BoxBody>>()
-            .push_on_response(
-                svc::layers()
-                    .push(http::BoxRequest::layer())
-                    .push(
-                        rt.metrics
-                            .stack
-                            .layer(stack_labels("http", "balance.endpoint")),
-                    )
-                    // Ensure individual endpoints are driven to readiness so that
-                    // the balancer need not drive them all directly.
-                    .push(svc::layer::mk(svc::SpawnReady::new)),
-            )
-            .check_new_service::<Endpoint, http::Request<_>>()
-            // Resolve the service to its endpoints and balance requests over them.
-            //
-            // If the balancer has been empty/unavailable, eagerly fail requests.
-            // When the balancer is in failfast, spawn the service in a background
-            // task so it becomes ready without new requests.
-            .push(resolve::layer(resolve, watchdog))
-            .push_on_response(
-                svc::layers()
-                    .push(http::balance::layer(
-                        crate::EWMA_DEFAULT_RTT,
-                        crate::EWMA_DECAY,
-                    ))
-                    .push(rt.metrics.stack.layer(stack_labels("http", "balancer")))
-                    .push(svc::layer::mk(svc::SpawnReady::new))
-                    .push(svc::FailFast::layer("HTTP Balancer", dispatch_timeout))
-                    .push(http::BoxResponse::layer()),
-            )
-            .check_make_service::<Concrete, http::Request<_>>()
-            .push(svc::MapErrLayer::new(Into::into))
-            // Drives the initial resolution via the service's readiness.
-            .into_new_service()
-            // The concrete address is only set when the profile could be
-            // resolved. Endpoint resolution is skipped when there is no
-            // concrete address.
-            .instrument(|c: &Concrete| debug_span!("concrete", addr = %c.resolve))
-            .push_map_target(Concrete::from)
-            .push(svc::BoxNewService::layer())
-            // Distribute requests over a distribution of balancers via a
-            // traffic split.
-            //
-            // If the traffic split is empty/unavailable, eagerly fail requests.
-            // When the split is in failfast, spawn the service in a background
-            // task so it becomes ready without new requests.
-            .push(profiles::split::layer())
-            .push_on_response(
-                svc::layers()
-                    .push(svc::layer::mk(svc::SpawnReady::new))
-                    .push(rt.metrics.stack.layer(stack_labels("http", "logical")))
-                    .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
-                    .push_spawn_buffer(buffer_capacity),
-            )
-            .push_cache(cache_max_idle_age)
-            // Note: routes can't exert backpressure.
-            .push(profiles::http::route_request::layer(
-                svc::proxies()
-                    .push(
-                        rt.metrics
-                            .http_route_actual
-                            .to_layer::<classify::Response, _, dst::Route>(),
-                    )
-                    // Depending on whether or not the request can be retried,
-                    // it may have one of two `Body` types. This layer unifies
-                    // any `Body` type into `BoxBody` so that the rest of the
-                    // stack doesn't have to implement `Service` for requests
-                    // with both body types.
-                    .push_on_response(http::BoxRequest::erased())
-                    // Sets an optional retry policy.
-                    .push(retry::layer(rt.metrics.http_route_retry.clone()))
-                    // Sets an optional request timeout.
-                    .push(http::MakeTimeoutLayer::default())
-                    // Records per-route metrics.
-                    .push(rt.metrics.http_route.to_layer::<classify::Response, _, _>())
-                    // Sets the per-route response classifier as a request
-                    // extension.
-                    .push(classify::NewClassify::layer())
-                    .push_map_target(Logical::mk_route)
-                    .into_inner(),
-            ))
-            // Strips headers that may be set by this proxy and add an outbound
-            // canonical-dst-header. The response body is boxed unify the profile
-            // stack's response type with that of to endpoint stack.
-            .push(http::NewHeaderFromTarget::<CanonicalDstHeader, _>::layer())
-            .push_on_response(svc::layers().push(http::BoxResponse::layer()))
-            .instrument(|l: &Logical| debug_span!("logical", dst = %l.logical_addr))
-            .push_on_response(svc::BoxService::layer())
-            .push(svc::BoxNewService::layer());
-
-        Outbound {
-            config,
-            runtime: rt,
-            stack,
-        }
+            endpoint
+                .clone()
+                .check_new_service::<Endpoint, http::Request<http::BoxBody>>()
+                .push_on_response(
+                    svc::layers()
+                        .push(http::BoxRequest::layer())
+                        .push(
+                            rt.metrics
+                                .stack
+                                .layer(stack_labels("http", "balance.endpoint")),
+                        )
+                        // Ensure individual endpoints are driven to readiness so that
+                        // the balancer need not drive them all directly.
+                        .push(svc::layer::mk(svc::SpawnReady::new)),
+                )
+                .check_new_service::<Endpoint, http::Request<_>>()
+                // Resolve the service to its endpoints and balance requests over them.
+                //
+                // If the balancer has been empty/unavailable, eagerly fail requests.
+                // When the balancer is in failfast, spawn the service in a background
+                // task so it becomes ready without new requests.
+                .push(resolve::layer(resolve, watchdog))
+                .push_on_response(
+                    svc::layers()
+                        .push(http::balance::layer(
+                            crate::EWMA_DEFAULT_RTT,
+                            crate::EWMA_DECAY,
+                        ))
+                        .push(rt.metrics.stack.layer(stack_labels("http", "balancer")))
+                        .push(svc::layer::mk(svc::SpawnReady::new))
+                        .push(svc::FailFast::layer("HTTP Balancer", dispatch_timeout))
+                        .push(http::BoxResponse::layer()),
+                )
+                .check_make_service::<Concrete, http::Request<_>>()
+                .push(svc::MapErrLayer::new(Into::into))
+                // Drives the initial resolution via the service's readiness.
+                .into_new_service()
+                // The concrete address is only set when the profile could be
+                // resolved. Endpoint resolution is skipped when there is no
+                // concrete address.
+                .instrument(|c: &Concrete| debug_span!("concrete", addr = %c.resolve))
+                .push_map_target(Concrete::from)
+                .push(svc::BoxNewService::layer())
+                // Distribute requests over a distribution of balancers via a
+                // traffic split.
+                //
+                // If the traffic split is empty/unavailable, eagerly fail requests.
+                // When the split is in failfast, spawn the service in a background
+                // task so it becomes ready without new requests.
+                .push(profiles::split::layer())
+                .push_on_response(
+                    svc::layers()
+                        .push(svc::layer::mk(svc::SpawnReady::new))
+                        .push(rt.metrics.stack.layer(stack_labels("http", "logical")))
+                        .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
+                        .push_spawn_buffer(buffer_capacity),
+                )
+                .push_cache(cache_max_idle_age)
+                // Note: routes can't exert backpressure.
+                .push(profiles::http::route_request::layer(
+                    svc::proxies()
+                        .push(
+                            rt.metrics
+                                .http_route_actual
+                                .to_layer::<classify::Response, _, dst::Route>(),
+                        )
+                        // Depending on whether or not the request can be retried,
+                        // it may have one of two `Body` types. This layer unifies
+                        // any `Body` type into `BoxBody` so that the rest of the
+                        // stack doesn't have to implement `Service` for requests
+                        // with both body types.
+                        .push_on_response(http::BoxRequest::erased())
+                        // Sets an optional retry policy.
+                        .push(retry::layer(rt.metrics.http_route_retry.clone()))
+                        // Sets an optional request timeout.
+                        .push(http::MakeTimeoutLayer::default())
+                        // Records per-route metrics.
+                        .push(rt.metrics.http_route.to_layer::<classify::Response, _, _>())
+                        // Sets the per-route response classifier as a request
+                        // extension.
+                        .push(classify::NewClassify::layer())
+                        .push_map_target(Logical::mk_route)
+                        .into_inner(),
+                ))
+                // Strips headers that may be set by this proxy and add an outbound
+                // canonical-dst-header. The response body is boxed unify the profile
+                // stack's response type with that of to endpoint stack.
+                .push(http::NewHeaderFromTarget::<CanonicalDstHeader, _>::layer())
+                .push_on_response(svc::layers().push(http::BoxResponse::layer()))
+                .instrument(|l: &Logical| debug_span!("logical", dst = %l.logical_addr))
+                .push_on_response(svc::BoxService::layer())
+                .push(svc::BoxNewService::layer())
+        })
     }
 }

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -23,52 +23,41 @@ impl<N> Outbound<N> {
         NSvc::Error: Into<Error>,
         NSvc::Future: Send,
     {
-        let Self {
-            config,
-            runtime: rt,
-            stack: http,
-        } = self;
+        self.map_stack(|config, rt, http| {
+            let config::ProxyConfig {
+                dispatch_timeout,
+                max_in_flight_requests,
+                buffer_capacity,
+                ..
+            } = config.proxy;
 
-        let config::ProxyConfig {
-            dispatch_timeout,
-            max_in_flight_requests,
-            buffer_capacity,
-            ..
-        } = config.proxy;
-
-        let stack = http
-            .check_new_service::<T, _>()
-            .push_on_response(
-                svc::layers()
-                    .push(http::BoxRequest::layer())
-                    // Limit the number of in-flight requests. When the proxy is
-                    // at capacity, go into failfast after a dispatch timeout. If
-                    // the router is unavailable, then spawn the service on a
-                    // background task to ensure it becomes ready without new
-                    // requests being processed.
-                    .push(svc::layer::mk(svc::SpawnReady::new))
-                    .push(svc::ConcurrencyLimitLayer::new(max_in_flight_requests))
-                    .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
-                    .push_spawn_buffer(buffer_capacity)
-                    .push(rt.metrics.http_errors.clone())
-                    // Synthesizes responses for proxy errors.
-                    .push(errors::layer())
-                    // Initiates OpenCensus tracing.
-                    .push(http_tracing::server(rt.span_sink.clone(), trace_labels()))
-                    .push(http::BoxResponse::layer()),
-            )
-            // Convert origin form HTTP/1 URIs to absolute form for Hyper's
-            // `Client`.
-            .push(http::NewNormalizeUri::layer())
-            // Record when a HTTP/1 URI originated in absolute form
-            .push_on_response(http::normalize_uri::MarkAbsoluteForm::layer())
-            .check_new_service::<T, http::Request<http::BoxBody>>()
-            .push(svc::BoxNewService::layer());
-
-        Outbound {
-            config,
-            runtime: rt,
-            stack,
-        }
+            http.check_new_service::<T, _>()
+                .push_on_response(
+                    svc::layers()
+                        .push(http::BoxRequest::layer())
+                        // Limit the number of in-flight requests. When the proxy is
+                        // at capacity, go into failfast after a dispatch timeout. If
+                        // the router is unavailable, then spawn the service on a
+                        // background task to ensure it becomes ready without new
+                        // requests being processed.
+                        .push(svc::layer::mk(svc::SpawnReady::new))
+                        .push(svc::ConcurrencyLimitLayer::new(max_in_flight_requests))
+                        .push(svc::FailFast::layer("HTTP Server", dispatch_timeout))
+                        .push_spawn_buffer(buffer_capacity)
+                        .push(rt.metrics.http_errors.clone())
+                        // Synthesizes responses for proxy errors.
+                        .push(errors::layer())
+                        // Initiates OpenCensus tracing.
+                        .push(http_tracing::server(rt.span_sink.clone(), trace_labels()))
+                        .push(http::BoxResponse::layer()),
+                )
+                // Convert origin form HTTP/1 URIs to absolute form for Hyper's
+                // `Client`.
+                .push(http::NewNormalizeUri::layer())
+                // Record when a HTTP/1 URI originated in absolute form
+                .push_on_response(http::normalize_uri::MarkAbsoluteForm::layer())
+                .check_new_service::<T, http::Request<http::BoxBody>>()
+                .push(svc::BoxNewService::layer())
+        })
     }
 }


### PR DESCRIPTION
We have 100+ lines of boilerplate from the inbound and outbound stack
builders. This change introduces helpers: `Inbound::map_stack` and
`Outbound::map_stack`. These helpers provide a way to map over the inner
stack type, which eliminates the boilerplate of de/re-structruring the
builder type.

No functional changes.