### PR TITLE
Remove HTTP/2 keepalive configuration

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -391,10 +391,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         let server = ServerConfig {
             addr,
             keepalive,
-            h2_settings: h2::Settings {
-                keepalive_timeout: keepalive.into(),
-                ..h2_settings
-            },
+            h2_settings,
         };
         let cache_max_idle_age =
             outbound_cache_max_idle_age?.unwrap_or(DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE);
@@ -409,10 +406,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 OUTBOUND_CONNECT_BASE,
                 DEFAULT_OUTBOUND_CONNECT_BACKOFF,
             )?,
-            h2_settings: h2::Settings {
-                keepalive_timeout: keepalive.into(),
-                ..h2_settings
-            },
+            h2_settings,
             h1_settings: h1::PoolSettings {
                 max_idle,
                 idle_timeout: cache_max_idle_age,
@@ -453,10 +447,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         let server = ServerConfig {
             addr,
             keepalive,
-            h2_settings: h2::Settings {
-                keepalive_timeout: keepalive.into(),
-                ..h2_settings
-            },
+            h2_settings,
         };
         let cache_max_idle_age =
             inbound_cache_max_idle_age?.unwrap_or(DEFAULT_INBOUND_ROUTER_MAX_IDLE_AGE);
@@ -471,10 +462,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 INBOUND_CONNECT_BASE,
                 DEFAULT_INBOUND_CONNECT_BACKOFF,
             )?,
-            h2_settings: h2::Settings {
-                keepalive_timeout: keepalive.into(),
-                ..h2_settings
-            },
+            h2_settings,
             h1_settings: h1::PoolSettings {
                 max_idle,
                 idle_timeout: cache_max_idle_age,


### PR DESCRIPTION
linkerd/linkerd2#5988 describes a situation where our keepalive settings
are incompatible with with Go's gRPC library's behavior. Until we can
implement behavior that does not conflict with common client/server
implementations, it seems most prudent to simply disable these settings
by default (leaving TCP-level keepalives unchanged).