### PR TITLE
Handle profile endpoint in Gateway outbound stack

### DIFF
--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -20,7 +20,6 @@ use tracing::{debug, warn};
 pub(crate) struct NewGateway<O> {
     outbound: O,
     local_id: Option<tls::LocalId>,
-    no_tls_reason: tls::NoClientTls,
 }
 
 #[derive(Clone, Debug)]
@@ -39,23 +38,12 @@ pub(crate) type Target = (Option<profiles::Receiver>, HttpTarget);
 // === impl NewGateway ===
 
 impl<O> NewGateway<O> {
-    pub fn new(
-        outbound: O,
-        local_id: Option<tls::LocalId>,
-        no_tls_reason: tls::NoClientTls,
-    ) -> Self {
-        Self {
-            outbound,
-            local_id,
-            no_tls_reason,
-        }
+    pub fn new(outbound: O, local_id: Option<tls::LocalId>) -> Self {
+        Self { outbound, local_id }
     }
 
-    pub fn layer(
-        local_id: Option<tls::LocalId>,
-        no_tls_reason: tls::NoClientTls,
-    ) -> impl layer::Layer<O, Service = Self> + Clone {
-        layer::mk(move |outbound| Self::new(outbound, local_id.clone(), no_tls_reason))
+    pub fn layer(local_id: Option<tls::LocalId>) -> impl layer::Layer<O, Service = Self> + Clone {
+        layer::mk(move |outbound| Self::new(outbound, local_id.clone()))
     }
 }
 
@@ -88,7 +76,7 @@ where
                     outbound::tcp::Endpoint::from_metadata(
                         addr,
                         metadata,
-                        self.no_tls_reason,
+                        tls::NoClientTls::NotProvidedByServiceDiscovery,
                         profile.is_opaque_protocol(),
                     ),
                 ))));

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -105,8 +105,7 @@ where
     // resolvable service name, then continue with TCP endpoint resolution,
     // balancing, and forwarding. If the profile includes an endpoint instead
     // of a logical address, then connect to endpoint directly and avoid
-    // balancing.  An invalid original destination address is used so that
-    // service discovery is *required* to provide a valid endpoint.
+    // balancing.
     //
     // TODO: We should use another target type that actually reflects
     // reality. But the outbound stack is currently pretty tightly

--- a/linkerd/app/gateway/src/tests.rs
+++ b/linkerd/app/gateway/src/tests.rs
@@ -163,13 +163,10 @@ impl Test {
     }
 
     async fn run_default_profile(self) -> Result<http::Response<http::BoxBody>, Error> {
-        let target = self.target.clone();
-        let suffix = self.suffix.clone();
-
-        let allow = NameMatch::new(Some(dns::Suffix::from_str(suffix).unwrap()));
-        let profile = if allow.matches(target.name()) {
+        let allow = NameMatch::new(Some(dns::Suffix::from_str(self.suffix).unwrap()));
+        let profile = if allow.matches(self.target.name()) {
             Some(support::profile::only(profiles::Profile {
-                addr: Some(target.clone().into()),
+                addr: Some(self.target.clone().into()),
                 ..profiles::Profile::default()
             }))
         } else {

--- a/linkerd/app/gateway/src/tests.rs
+++ b/linkerd/app/gateway/src/tests.rs
@@ -122,7 +122,6 @@ impl Test {
                 outbound.clone()
             },
             Some(tls::LocalId(id::Name::from_str("gateway.id.test").unwrap())),
-            linkerd_app_core::tls::NoClientTls::NotProvidedByServiceDiscovery,
         );
 
         let t = HttpTarget {

--- a/linkerd/app/gateway/src/tests.rs
+++ b/linkerd/app/gateway/src/tests.rs
@@ -12,7 +12,8 @@ use tower_test::mock;
 async fn gateway() {
     assert_eq!(
         Test::default()
-            .run_default_profile()
+            .with_default_profile()
+            .run()
             .await
             .unwrap()
             .status(),
@@ -23,13 +24,18 @@ async fn gateway() {
 #[tokio::test]
 async fn gateway_endpoint() {
     let addr = std::net::SocketAddr::new([192, 0, 2, 10].into(), 777);
-    let profile = Some(support::profile::only(profiles::Profile {
+    let profile = support::profile::only(profiles::Profile {
         endpoint: Some((addr, Metadata::default())),
         ..profiles::Profile::default()
-    }));
+    });
 
     assert_eq!(
-        Test::default().run(profile).await.unwrap().status(),
+        Test::default()
+            .with_profile(profile)
+            .run()
+            .await
+            .unwrap()
+            .status(),
         http::StatusCode::NO_CONTENT
     );
 }
@@ -41,7 +47,8 @@ async fn bad_domain() {
         ..Default::default()
     };
     let status = test
-        .run_default_profile()
+        .with_default_profile()
+        .run()
         .await
         .unwrap_err()
         .downcast_ref::<HttpError>()
@@ -57,7 +64,8 @@ async fn no_identity() {
         ..Default::default()
     };
     let status = test
-        .run_default_profile()
+        .with_default_profile()
+        .run()
         .await
         .unwrap_err()
         .downcast_ref::<HttpError>()
@@ -75,7 +83,8 @@ async fn forward_loop() {
         ..Default::default()
     };
     let status = test
-        .run_default_profile()
+        .with_default_profile()
+        .run()
         .await
         .unwrap_err()
         .downcast_ref::<HttpError>()
@@ -89,6 +98,7 @@ struct Test {
     target: NameAddr,
     client_id: Option<tls::ClientId>,
     orig_fwd: Option<&'static str>,
+    profile: Option<profiles::Receiver>,
 }
 
 impl Default for Test {
@@ -98,20 +108,19 @@ impl Default for Test {
             target: NameAddr::from_str("dst.test.example.com:4321").unwrap(),
             client_id: Some(tls::ClientId::from_str("client.id.test").unwrap()),
             orig_fwd: None,
+            profile: None,
         }
     }
 }
 
 impl Test {
-    async fn run(
-        self,
-        profile: Option<profiles::Receiver>,
-    ) -> Result<http::Response<http::BoxBody>, Error> {
+    async fn run(self) -> Result<http::Response<http::BoxBody>, Error> {
         let Self {
             suffix: _,
             target,
             client_id,
             orig_fwd,
+            profile,
         } = self;
 
         let (outbound, mut handle) =
@@ -161,18 +170,19 @@ impl Test {
         Ok(rsp)
     }
 
-    async fn run_default_profile(self) -> Result<http::Response<http::BoxBody>, Error> {
+    fn with_profile(mut self, profile: profiles::Receiver) -> Self {
         let allow = NameMatch::new(Some(dns::Suffix::from_str(self.suffix).unwrap()));
-        let profile = if allow.matches(self.target.name()) {
-            Some(support::profile::only(profiles::Profile {
-                addr: Some(self.target.clone().into()),
-                ..profiles::Profile::default()
-            }))
-        } else {
-            None
-        };
+        if allow.matches(self.target.name()) {
+            self.profile = Some(profile);
+        }
+        self
+    }
 
-        let resp = self.run(profile).await;
-        resp
+    fn with_default_profile(self) -> Self {
+        let target = self.target.clone();
+        self.with_profile(support::profile::only(profiles::Profile {
+            addr: Some(target.into()),
+            ..profiles::Profile::default()
+        }))
     }
 }

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -38,7 +38,7 @@ impl Endpoint<()> {
         }
     }
 
-    pub(crate) fn from_metadata(
+    pub fn from_metadata(
         addr: impl Into<SocketAddr>,
         metadata: Metadata,
         reason: tls::NoClientTls,

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -99,6 +99,7 @@ impl<E> Outbound<E> {
                 // If the traffic split is empty/unavailable, eagerly fail requests.
                 // When the split is in failfast, spawn the service in a background
                 // task so it becomes ready without new requests.
+                .check_new_service::<(ConcreteAddr, Logical), _>()
                 .push(profiles::split::layer())
                 .push_on_response(
                     svc::layers()

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -93,7 +93,7 @@ impl<S> Outbound<S> {
         self.stack.into_inner()
     }
 
-    fn no_tls_reason(&self) -> tls::NoClientTls {
+    pub fn no_tls_reason(&self) -> tls::NoClientTls {
         if self.runtime.identity.is_none() {
             tls::NoClientTls::Disabled
         } else {

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -93,7 +93,7 @@ impl<S> Outbound<S> {
         self.stack.into_inner()
     }
 
-    pub fn no_tls_reason(&self) -> tls::NoClientTls {
+    fn no_tls_reason(&self) -> tls::NoClientTls {
         if self.runtime.identity.is_none() {
             tls::NoClientTls::Disabled
         } else {


### PR DESCRIPTION
## What

When testing [linkerd2/PR#6090](https://github.com/linkerd/linkerd2/pull/6090) we noticed that requests to a mirror service from a source cluster to a target cluster would fail on the outbound side of the gateway (in the target cluster) if the profile returned contains an endpoint. [[1]](https://github.com/linkerd/linkerd2/pull/6090#issuecomment-871754124). The failure is related to some changes that we have made previously to support StatefulSets across multicluster ([PR#6260 in linkerd2](https://github.com/linkerd/linkerd2/pull/6260)); when we send a request to an endpoint mirror service (a mirror service that corresponds to a pod), we expect the proxy to connect to it directly instead of building a logical stack.

Currently, the outbound proxy does not handle endpoints when running in gateway mode. This change is focused on adding support for direct endpoint communication; when a profile contains an endpoint, we will establish a connection directly to the endpoint and avoid building a load balancer.

## How

The change adds two `push_switch` layers: one for the TCP stack and one for the HTTP stack.

### TCP stack

* Replaced the request filter with a push switch. Before, the request filter would fail if the resolved profile would not have a logical address or if no profile would be discovered for the target. Now, we handle the `no discovery` case in the `push_switch`, however, we no longer error out when the profile does not contain a logical address.

* Created a logical and an endpoint stack. If the profile contains an endpoint, then we use the endpoint stack. If it contains a logical address, we use the logical stack instead.

* Changed the visibility for `Endpoint::from_metadata()` and `Outbound::no_tls_reason()` so we can construct the endpoints more easily (in both the TCP and HTTP stacks).

### HTTP stack

* Largely the same concept as above; to make it easier to build the endpoints, we're passing the `no_tls_message` through to the `NewGateway` type. 

* Changed the trait bounds for the `NewService` impl on the gateway to be an `Either`. When we create the new gateway,  if the profile has an endpoint, we return an `Either::B::<HttpEndpoint>` otherwise we return an `Either::A::<HttpLogical`. In the switch layer, we simply return the service as a result; this is because the compiler couldn't refer the return type, making it a result explicitly seemed to help.

Lastly, changed the unit tests a bit, first to accommodate the new constructor changes for `NewGateway` and then to add a new case for the endpoint stack.

### Manual testing
---

To see the changes play out in an actual multicluster scenario, I deployed linkerd in two clusters using the [PR branch build](https://github.com/linkerd/linkerd2/pull/6090). I applied two manifests to the target cluster: an nginx statefulset and an nginx deployment (manifests for the statefulset are taken from Kevin's comment [here](https://github.com/linkerd/linkerd2/pull/6090#pullrequestreview-695516895)). I then mirrored the statefulset service and the deployment service in the source cluster and also created a curl pod to send requests to the mirror services.

Without the proxy changes, I expected the following scenarios:
  1. For `nginx-deployment`: exec onto curl pod, send a request to the mirror service (nginx deployment) and look at the gateway logs in the target cluster to see if the request was redirected on the outbound side to its exported service. Since the deployment service is _not_ headless, we expect this to **succeed* (it has a logical addr in the response).
  2. For `nginx-statefulset`: exec onto curl pod, send a request to an endpoint mirror service (a clusterIP service for a specific pod in the target cluster). In the logs, we expect this to **fail** with a 404 status code and a `BadDomain` error since the profile will contain an endpoint in the response.

Logs:
```
# services, pods & control plane version
# east = source cluster, west = target cluster

❯ k get svc --context=k3d-east
NAME                    TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
kubernetes              ClusterIP   10.43.0.1       <none>        443/TCP   22h
nginx-svc-west          ClusterIP   None            <none>        80/TCP    22h
nginx-deploy-svc-west   ClusterIP   10.43.155.254   <none>        80/TCP    21h
nginx-ss-0-west         ClusterIP   10.43.145.231   <none>        80/TCP    15m
nginx-ss-1-west         ClusterIP   10.43.138.0     <none>        80/TCP    15m
nginx-ss-2-west         ClusterIP   10.43.238.163   <none>        80/TCP    15m

❯ k get po --context=k3d-east
NAME                    READY   STATUS    RESTARTS   AGE
curl-56dc7d945d-qv7dd   2/2     Running   0          22h

❯ bin/linkerd version
Client version: git-5bfe4252
Server version: git-5bfe4252

-----


# exec curl pod
$ curl  http://nginx-deploy-svc-west.default.svc.east.cluster.local:80

# expect it to work
[   211.010516s] TRACE ThreadId(01) inbound:accept{client.addr=10.42.0.1:54684}:server{port=4143}:direct:gateway{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-deploy-svc.default.svc.west.cluster.local:80 v=1.x}:logical{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}: linkerd_timeout::failfast: HTTP Logical has become ready
[   211.010565s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:54684}:server{port=4143}:direct:gateway{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-deploy-svc.default.svc.west.cluster.local:80 v=1.x}:logical{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:concrete{addr=nginx-deploy-svc.default.svc.west.cluster.local:80}:endpoint{server.addr=10.42.0.19:80}:orig-proto-upgrade: linkerd_proxy_http::client: method=GET uri=http://nginx-deploy-svc.default.svc.west.cluster.local:80/ version=HTTP/1.1
[   211.010598s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:54684}:server{port=4143}:direct:gateway{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-deploy-svc.default.svc.west.cluster.local:80 v=1.x}:logical{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:concrete{addr=nginx-deploy-svc.default.svc.west.cluster.local:80}:endpoint{server.addr=10.42.0.19:80}:orig-proto-upgrade: linkerd_proxy_http::client: headers={"accept": "*/*", "user-agent": "curl/7.77.0-DEV", "l5d-client-id": "default.default.serviceaccount.identity.linkerd.east.cluster.local", "forwarded": "by=linkerd-gateway.linkerd-multicluster.serviceaccount.identity.linkerd.west.cluster.local;for=default.default.serviceaccount.identity.linkerd.east.cluster.local;host=nginx-deploy-svc.default.svc.west.cluster.local;proto=https", "host": "nginx-deploy-svc.default.svc.west.cluster.local", "l5d-dst-canonical": "nginx-deploy-svc.default.svc.west.cluster.local:80"}
[   211.010655s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:54684}:server{port=4143}:direct:gateway{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-deploy-svc.default.svc.west.cluster.local:80 v=1.x}:logical{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:concrete{addr=nginx-deploy-svc.default.svc.west.cluster.local:80}:endpoint{server.addr=10.42.0.19:80}:orig-proto-upgrade: linkerd_proxy_http::orig_proto: Upgrading request version=HTTP/1.1 absolute_form=false
[   211.012597s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:54684}:server{port=4143}:direct:gateway{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-deploy-svc.default.svc.west.cluster.local:80 v=1.x}:logical{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:concrete{addr=nginx-deploy-svc.default.svc.west.cluster.local:80}:endpoint{server.addr=10.42.0.20:80}:h2: linkerd_proxy_transport::metrics: client connection open
[   211.014500s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:54684}:server{port=4143}:direct:gateway{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-deploy-svc.default.svc.west.cluster.local:80 v=1.x}:logical{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:concrete{addr=nginx-deploy-svc.default.svc.west.cluster.local:80}:endpoint{server.addr=10.42.0.21:80}:h2: linkerd_proxy_transport::metrics: client connection open
[   211.014931s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:54684}:server{port=4143}:direct:gateway{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-deploy-svc.default.svc.west.cluster.local:80 v=1.x}:logical{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:concrete{addr=nginx-deploy-svc.default.svc.west.cluster.local:80}:endpoint{server.addr=10.42.0.20:80}: linkerd_reconnect: Connected
[   211.014977s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:54684}:server{port=4143}:direct:gateway{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-deploy-svc.default.svc.west.cluster.local:80 v=1.x}:logical{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:concrete{addr=nginx-deploy-svc.default.svc.west.cluster.local:80}:endpoint{server.addr=10.42.0.21:80}: linkerd_reconnect: Connected

---

$ curl http://nginx-ss-0.nginx-svc-west.default.svc.east.cluster.local:80

# expect it to fail
[   411.043980s] TRACE ThreadId(01) inbound:accept{client.addr=10.42.0.1:64673}:server{port=4143}:direct:gateway{dst=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80}:http{v=h2}: linkerd_timeout::failfast: Gateway has become ready
[   411.044186s]  WARN ThreadId(01) inbound:accept{client.addr=10.42.0.1:64673}:server{port=4143}:direct:gateway{dst=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80}:http{v=h2}: linkerd_app_core::errors: Failed to proxy request: bad domain client.addr=10.42.0.1:64673
[   411.044216s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:64673}:server{port=4143}:direct:gateway{dst=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80}:http{v=h2}: linkerd_app_core::errors: Closing server-side connection
[   411.044229s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:64673}:server{port=4143}:direct:gateway{dst=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80}:http{v=h2}: linkerd_app_core::errors: Handling error with HTTP response status=404 Not Found version=HTTP/2.0
```

With the proxy changes, we expect both to succeed:

```
# proxy version tagged as dev:
$ k get po linkerd-gateway-58c968f4f8-7cgmr -o yaml | rg 'image'
    image: cr.l5d.io/linkerd/proxy:dev
    ... 

# nginx-deployment
 $ curl http://nginx-deploy-svc-west.default.svc.east.cluster.local:80
[   106.607344s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:46152}:server{port=4143}:direct:gateway{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-deploy-svc.default.svc.west.cluster.local:80 v=1.x}:logical{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:concrete{addr=nginx-deploy-svc.default.svc.west.cluster.local:80}:endpoint{server.addr=10.42.0.20:80}: linkerd_reconnect: Connected
[   106.607396s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:46152}:server{port=4143}:direct:gateway{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-deploy-svc.default.svc.west.cluster.local:80 v=1.x}:logical{dst=nginx-deploy-svc.default.svc.west.cluster.local:80}:concrete{addr=nginx-deploy-svc.default.svc.west.cluster.local:80}:endpoint{server.addr=10.42.0.21:80}: linkerd_reconnect: Connected


# nginx statefulset instance
$ curl http://nginx-ss-0.nginx-svc-west.default.svc.east.cluster.local:80
[   122.744939s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:6030}:server{port=4143}:direct:gateway{dst=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80 v=1.x}: linkerd_app_gateway::gateway: Passing request to outbound
[   122.744971s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:6030}:server{port=4143}:direct:gateway{dst=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80 v=1.x}:orig-proto-upgrade: linkerd_proxy_http::client: method=GET uri=http://nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80/ version=HTTP/1.1
[   122.744992s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:6030}:server{port=4143}:direct:gateway{dst=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80 v=1.x}:orig-proto-upgrade: linkerd_proxy_http::client: headers={"accept": "*/*", "user-agent": "curl/7.77.0-DEV", "l5d-client-id": "default.default.serviceaccount.identity.linkerd.east.cluster.local", "forwarded": "by=linkerd-gateway.linkerd-multicluster.serviceaccount.identity.linkerd.west.cluster.local;for=default.default.serviceaccount.identity.linkerd.east.cluster.local;host=nginx-ss-0.nginx-svc.default.svc.west.cluster.local;proto=https", "host": "nginx-ss-0.nginx-svc.default.svc.west.cluster.local"}
[   122.745016s] DEBUG ThreadId(01) inbound:accept{client.addr=10.42.0.1:6030}:server{port=4143}:direct:gateway{dst=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80}:http{v=h2}:gateway{target=nginx-ss-0.nginx-svc.default.svc.west.cluster.local:80 v=1.x}:orig-proto-upgrade: linkerd_proxy_http::orig_proto: Upgrading request version=HTTP/1.1 absolute_form=false
```

The assumptions I had around the tests seem to hold: when we were supposed to fail, we did and with the changes the request gets passed through. This is further verified by the responses we receive, without the changes we get no response from curl, with the changes, we get the nginx status page.

Signed-off-by: Matei David <matei@buoyant.io>