### PR TITLE
metrics: rework `LabelError` for composability

### DIFF
--- a/linkerd/error-metrics/src/lib.rs
+++ b/linkerd/error-metrics/src/lib.rs
@@ -10,12 +10,19 @@ pub use self::service::RecordError;
 pub use linkerd_metrics::FmtLabels;
 use linkerd_metrics::{self as metrics, Counter, FmtMetrics};
 use parking_lot::Mutex;
-use std::{collections::HashMap, error::Error, fmt, hash::Hash, sync::Arc};
+use std::{collections::HashMap, error::Error, fmt, hash::Hash, marker::PhantomData, sync::Arc};
 
 pub trait LabelError {
     type Labels: FmtLabels + Hash + Eq;
 
     fn label_error(&self, error: &(dyn Error + 'static)) -> Option<Self::Labels>;
+
+    fn or_else<B>(self, other: B) -> OrElse<Self, B>
+    where
+        Self: Sized,
+    {
+        OrElse { a: self, b: other }
+    }
 }
 
 pub type Metric = metrics::Metric<'static, &'static str, Counter>;
@@ -28,6 +35,18 @@ where
 {
     errors: Arc<Mutex<HashMap<K, Counter>>>,
     metric: Metric,
+}
+
+#[derive(Debug, Copy, Clone, Default)]
+pub struct OrElse<A, B> {
+    a: A,
+    b: B,
+}
+
+#[derive(Clone)]
+pub struct LabelFn<L, F = fn(&(dyn Error + 'static)) -> Option<L>> {
+    f: F,
+    _p: PhantomData<fn(L)>,
 }
 
 impl<K: Hash + Eq> Registry<K> {
@@ -63,5 +82,55 @@ impl<K: FmtLabels + Hash + Eq> FmtMetrics for Registry<K> {
         self.metric.fmt_scopes(f, errors.iter(), |c| &c)?;
 
         Ok(())
+    }
+}
+
+// === impl OrElse ===
+
+impl<A, B> LabelError for OrElse<A, B>
+where
+    A: LabelError,
+    B: LabelError<Labels = A::Labels>,
+{
+    type Labels = A::Labels;
+
+    #[inline]
+    fn label_error(&self, error: &(dyn Error + 'static)) -> Option<Self::Labels> {
+        self.a
+            .label_error(error)
+            .or_else(|| self.b.label_error(error))
+    }
+}
+
+// === impl LabelFn ===
+
+pub fn label_fn<L, F>(f: F) -> LabelFn<L, F>
+where
+    F: Fn(&(dyn Error + 'static)) -> Option<L>,
+    L: FmtLabels + Hash + Eq,
+{
+    LabelFn { f, _p: PhantomData }
+}
+
+impl<L, F> LabelError for LabelFn<L, F>
+where
+    F: Fn(&(dyn Error + 'static)) -> Option<L>,
+    L: FmtLabels + Hash + Eq,
+{
+    type Labels = L;
+
+    #[inline]
+    fn label_error(&self, error: &(dyn Error + 'static)) -> Option<Self::Labels> {
+        (self.f)(error)
+    }
+}
+
+impl<L, F> fmt::Debug for LabelFn<L, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use std::any::type_name;
+        f.debug_struct(type_name::<Self>())
+            .field("label_type", &format_args!("{}", type_name::<L>()))
+            .field("f", &format_args!("{}", type_name::<F>()))
+            .finish()
     }
 }

--- a/linkerd/error-metrics/src/lib.rs
+++ b/linkerd/error-metrics/src/lib.rs
@@ -10,12 +10,12 @@ pub use self::service::RecordError;
 pub use linkerd_metrics::FmtLabels;
 use linkerd_metrics::{self as metrics, Counter, FmtMetrics};
 use parking_lot::Mutex;
-use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};
+use std::{collections::HashMap, error::Error, fmt, hash::Hash, sync::Arc};
 
-pub trait LabelError<E> {
+pub trait LabelError {
     type Labels: FmtLabels + Hash + Eq;
 
-    fn label_error(&self, error: &E) -> Self::Labels;
+    fn label_error(&self, error: &(dyn Error + 'static)) -> Option<Self::Labels>;
 }
 
 pub type Metric = metrics::Metric<'static, &'static str, Counter>;


### PR DESCRIPTION
Currently, the `LabelError` trait works by taking a reference to an
error (of a generic type) and returning a `Labels` type. When the error
being labeled is a `dyn Error`, the type implementing `LabelError` must
loop over the error and its sources, and attempt to downcast the error
to various types.

The current design works fine, but it's difficult to compose multiple
`LabelError` types together. In particular, the looping over the source
chain currently has to be repeated in every `LabelError` type that's
composed together. This is kind of a pain and is potentially
inefficient.

This change moves the loop out of each individual implementation of
`LabelError`, and into the `RecordError` middleware. The `LabelError`
trait is changed to return an `Option<Self::Labels>`, and is called by
the loop for each source in the error's source chain. If `LabelError`
returns `Some`, the loop stops. This allows us to compose together
multiple `LabelError` implemetations in such a way that we break out of
the loop if either one wants to stop iterating. The `Labels` type is now
required to implement `Default`, and the default value is returned if
the whole source chain has been traversed without the `LabelError` type
returning any labels.

On top of this, I've added an `or_else` combinator for combining two
`LabelError` implementations with the same `Labels` type. This isn't
currently unused, but it will make sense in context with PR #1161.