### PR TITLE
stack: Introduce ExtractParam and InsertParam

### DIFF
--- a/linkerd/app/core/src/metrics/tcp_accept_errors.rs
+++ b/linkerd/app/core/src/metrics/tcp_accept_errors.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use linkerd_error::Error;
 use linkerd_error_metrics::{FmtLabels, LabelError, RecordError};
-use linkerd_tls::server::DetectTimeout as TlsDetectTimeout;
+use linkerd_tls::server::ServerTlsTimeoutError;
 use parking_lot::Mutex;
 use std::{collections::HashMap, fmt};
 
@@ -89,7 +89,7 @@ impl LabelError<Error> for LabelAcceptErrors {
     fn label_error(&self, err: &Error) -> Self::Labels {
         let mut curr: Option<&dyn std::error::Error> = Some(err.as_ref());
         while let Some(err) = curr {
-            if err.is::<TlsDetectTimeout>() {
+            if err.is::<ServerTlsTimeoutError>() {
                 return AcceptErrors::TlsDetectTimeout;
             } else if err.is::<std::io::Error>() {
                 // We ignore the error code because we want all labels to be consistent.

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -6,8 +6,9 @@ use linkerd_error::Recover;
 use linkerd_exp_backoff::{ExponentialBackoff, ExponentialBackoffStream};
 pub use linkerd_reconnect::NewReconnect;
 pub use linkerd_stack::{
-    self as stack, layer, BoxNewService, BoxService, BoxServiceLayer, Either, Fail, Filter,
-    MapErrLayer, MapTargetLayer, NewRouter, NewService, Param, Predicate, UnwrapOr,
+    self as stack, layer, BoxNewService, BoxService, BoxServiceLayer, Either, ExtractParam, Fail,
+    Filter, InsertParam, MapErrLayer, MapTargetLayer, NewRouter, NewService, Param, Predicate,
+    UnwrapOr,
 };
 pub use linkerd_stack_tracing::{NewInstrument, NewInstrumentLayer};
 pub use linkerd_timeout::{self as timeout, FailFast};

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -25,8 +25,10 @@ use self::{
 use linkerd_app_core::{
     config::{ConnectConfig, PortSet, ProxyConfig, ServerConfig},
     detect, drain, io, metrics, profiles,
-    proxy::tcp,
-    serve, svc, tls,
+    proxy::{identity::LocalCrtKey, tcp},
+    serve,
+    svc::{self, ExtractParam, InsertParam},
+    tls,
     transport::{self, listen::Bind, ClientAddr, Local, OrigDstAddr, Remote, ServerAddr},
     Error, Infallible, NameMatch, ProxyRuntime,
 };
@@ -47,6 +49,12 @@ pub struct Inbound<S> {
     config: Config,
     runtime: ProxyRuntime,
     stack: svc::Stack<S>,
+}
+
+#[derive(Clone)]
+struct TlsParams {
+    timeout: tls::server::Timeout,
+    identity: Option<LocalCrtKey>,
 }
 
 // === impl Inbound ===
@@ -272,10 +280,10 @@ where
                     .push(rt.metrics.transport.layer_accept())
                     .push_request_filter(TcpAccept::try_from)
                     .push(svc::BoxNewService::layer())
-                    .push(tls::NewDetectTls::layer(
-                        rt.identity.clone(),
-                        detect_timeout,
-                    ))
+                    .push(tls::NewDetectTls::layer(TlsParams {
+                        timeout: tls::server::Timeout(detect_timeout),
+                        identity: rt.identity.clone(),
+                    }))
             })
             .map_stack(|cfg, _, detect| {
                 let disable_detect = cfg.disable_protocol_detection_for_ports.clone();
@@ -317,4 +325,29 @@ where
 
 fn stack_labels(proto: &'static str, name: &'static str) -> metrics::StackLabels {
     metrics::StackLabels::inbound(proto, name)
+}
+
+// === TlsParams ===
+
+impl<T> ExtractParam<tls::server::Timeout, T> for TlsParams {
+    #[inline]
+    fn extract_param(&self, _: &T) -> tls::server::Timeout {
+        self.timeout
+    }
+}
+
+impl<T> ExtractParam<Option<LocalCrtKey>, T> for TlsParams {
+    #[inline]
+    fn extract_param(&self, _: &T) -> Option<LocalCrtKey> {
+        self.identity.clone()
+    }
+}
+
+impl<T> InsertParam<tls::ConditionalServerTls, T> for TlsParams {
+    type Target = (tls::ConditionalServerTls, T);
+
+    #[inline]
+    fn insert_param(&self, tls: tls::ConditionalServerTls, target: T) -> Self::Target {
+        (tls, target)
+    }
 }

--- a/linkerd/app/inbound/src/target.rs
+++ b/linkerd/app/inbound/src/target.rs
@@ -72,11 +72,11 @@ impl TcpAccept {
     }
 }
 
-impl<T> From<tls::server::Meta<T>> for TcpAccept
+impl<T> From<(tls::ConditionalServerTls, T)> for TcpAccept
 where
     T: Param<Remote<ClientAddr>> + Param<OrigDstAddr>,
 {
-    fn from((tls, addrs): tls::server::Meta<T>) -> Self {
+    fn from((tls, addrs): (tls::ConditionalServerTls, T)) -> Self {
         let OrigDstAddr(target_addr) = addrs.param();
         Self {
             target_addr,

--- a/linkerd/app/src/tap.rs
+++ b/linkerd/app/src/tap.rs
@@ -5,7 +5,7 @@ use linkerd_app_core::{
     proxy::identity::LocalCrtKey,
     proxy::tap,
     serve,
-    svc::{self, Param},
+    svc::{self, ExtractParam, InsertParam, Param},
     tls,
     transport::{listen::Bind, ClientAddr, Local, Remote, ServerAddr},
     Error,
@@ -31,6 +31,11 @@ pub enum Tap {
         registry: tap::Registry,
         serve: Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>,
     },
+}
+
+#[derive(Clone)]
+struct TlsParams {
+    identity: Option<LocalCrtKey>,
 }
 
 impl Config {
@@ -63,7 +68,7 @@ impl Config {
                         )
                     }))
                     .push(svc::layer::mk(|service: tap::AcceptPermittedClients| {
-                        move |meta: tls::server::Meta<B::Addrs>| {
+                        move |meta: (tls::ConditionalServerTls, B::Addrs)| {
                             let service = service.clone();
                             service_fn(move |io| {
                                 let fut = service.clone().oneshot((meta.clone(), io));
@@ -73,12 +78,8 @@ impl Config {
                             })
                         }
                     }))
-                    .check_new_service::<tls::server::Meta<B::Addrs>, _>()
                     .push(svc::BoxNewService::layer())
-                    .push(tls::NewDetectTls::layer(
-                        identity,
-                        std::time::Duration::from_secs(1),
-                    ))
+                    .push(tls::NewDetectTls::layer(TlsParams { identity }))
                     .check_new_service::<B::Addrs, _>()
                     .into_inner();
 
@@ -100,5 +101,30 @@ impl Tap {
             Tap::Disabled { ref registry } => registry.clone(),
             Tap::Enabled { ref registry, .. } => registry.clone(),
         }
+    }
+}
+
+// === TlsParams ===
+
+impl<T> ExtractParam<tls::server::Timeout, T> for TlsParams {
+    #[inline]
+    fn extract_param(&self, _: &T) -> tls::server::Timeout {
+        tls::server::Timeout(std::time::Duration::from_secs(1))
+    }
+}
+
+impl<T> ExtractParam<Option<LocalCrtKey>, T> for TlsParams {
+    #[inline]
+    fn extract_param(&self, _: &T) -> Option<LocalCrtKey> {
+        self.identity.clone()
+    }
+}
+
+impl<T> InsertParam<tls::ConditionalServerTls, T> for TlsParams {
+    type Target = (tls::ConditionalServerTls, T);
+
+    #[inline]
+    fn insert_param(&self, tls: tls::ConditionalServerTls, target: T) -> Self::Target {
+        (tls, target)
     }
 }

--- a/linkerd/detect/src/lib.rs
+++ b/linkerd/detect/src/lib.rs
@@ -25,11 +25,11 @@ pub trait Detect<I>: Clone + Send + Sync + 'static {
         -> Result<Option<Self::Protocol>, Error>;
 }
 
-pub type DetectResult<P> = Result<Option<P>, DetectTimeout<P>>;
+pub type DetectResult<P> = Result<Option<P>, DetectTimeoutError<P>>;
 
 #[derive(Error)]
 #[error("{} protocol detection timed out after {:?}", std::any::type_name::<P>(), .0)]
-pub struct DetectTimeout<P>(time::Duration, std::marker::PhantomData<P>);
+pub struct DetectTimeoutError<P>(time::Duration, std::marker::PhantomData<P>);
 
 #[derive(Copy, Clone, Debug)]
 pub struct NewDetectService<D, N> {
@@ -131,7 +131,7 @@ where
                     debug!(?protocol, elapsed = ?t0.elapsed(), "DetectResult");
                     Ok(protocol)
                 }
-                Err(_) => Err(DetectTimeout(timeout, std::marker::PhantomData)),
+                Err(_) => Err(DetectTimeoutError(timeout, std::marker::PhantomData)),
                 Ok(Err(e)) => return Err(e),
             };
 
@@ -157,9 +157,9 @@ where
     }
 }
 
-// === impl DetectTimeout ===
+// === impl DetectTimeoutError ===
 
-impl<P> fmt::Debug for DetectTimeout<P> {
+impl<P> fmt::Debug for DetectTimeoutError<P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple(std::any::type_name::<Self>())
             .field(&self.0)

--- a/linkerd/proxy/tap/src/accept.rs
+++ b/linkerd/proxy/tap/src/accept.rs
@@ -5,7 +5,7 @@ use linkerd_conditional::Conditional;
 use linkerd_error::Error;
 use linkerd_io as io;
 use linkerd_proxy_http::{trace, HyperServerSvc};
-use linkerd_tls::{self as tls, server::Connection};
+use linkerd_tls::{self as tls};
 use std::{
     collections::HashSet,
     future::Future,
@@ -20,6 +20,8 @@ pub struct AcceptPermittedClients {
     permitted_client_ids: Arc<HashSet<tls::ClientId>>,
     server: Server,
 }
+
+type Connection<T, I> = ((tls::ConditionalServerTls, T), tls::server::Io<I>);
 
 pub type ServeFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'static>>;
 

--- a/linkerd/tls/src/server/mod.rs
+++ b/linkerd/tls/src/server/mod.rs
@@ -8,7 +8,7 @@ use linkerd_dns_name as dns;
 use linkerd_error::Error;
 use linkerd_identity as id;
 use linkerd_io::{self as io, AsyncReadExt, EitherIo, PrefixedIo};
-use linkerd_stack::{layer, NewService, Param};
+use linkerd_stack::{layer, ExtractParam, InsertParam, NewService, Param};
 use std::{
     fmt,
     pin::Pin,
@@ -67,30 +67,31 @@ pub enum NoServerTls {
 /// Indicates whether TLS was established on an accepted connection.
 pub type ConditionalServerTls = Conditional<ServerTls, NoServerTls>;
 
-pub type Meta<T> = (ConditionalServerTls, T);
-
 type DetectIo<T> = EitherIo<T, PrefixedIo<T>>;
+
 pub type Io<T> = EitherIo<TlsStream<DetectIo<T>>, DetectIo<T>>;
 
-pub type Connection<T, I> = (Meta<T>, Io<I>);
-
 #[derive(Clone, Debug)]
-pub struct NewDetectTls<L, A> {
-    local_identity: Option<L>,
-    inner: A,
-    timeout: Duration,
+pub struct NewDetectTls<P, L, N> {
+    inner: N,
+    params: P,
+    _local_identity: std::marker::PhantomData<fn() -> L>,
 }
+
+#[derive(Copy, Clone, Debug)]
+pub struct Timeout(pub Duration);
 
 #[derive(Clone, Debug, Error)]
 #[error("TLS detection timed out")]
-pub struct DetectTimeout(());
+pub struct ServerTlsTimeoutError(());
 
 #[derive(Clone, Debug)]
-pub struct DetectTls<T, L, N> {
+pub struct DetectTls<T, P, L, N> {
     target: T,
     local_identity: Option<L>,
+    timeout: Timeout,
+    params: P,
     inner: N,
-    timeout: Duration,
 }
 
 // The initial peek buffer is statically allocated on the stack and is fairly small; but it is
@@ -101,52 +102,54 @@ const PEEK_CAPACITY: usize = 512;
 // insufficient. This is the same value used in HTTP detection.
 const BUFFER_CAPACITY: usize = 8192;
 
-impl<I, N> NewDetectTls<I, N> {
-    pub fn new(local_identity: Option<I>, inner: N, timeout: Duration) -> Self {
+impl<P, L, N> NewDetectTls<P, L, N> {
+    pub fn new(params: P, inner: N) -> Self {
         Self {
-            local_identity,
             inner,
-            timeout,
+            params,
+            _local_identity: std::marker::PhantomData,
         }
     }
 
-    pub fn layer(
-        local_identity: Option<I>,
-        timeout: Duration,
-    ) -> impl layer::Layer<N, Service = Self> + Clone
+    pub fn layer(params: P) -> impl layer::Layer<N, Service = Self> + Clone
     where
-        I: Clone,
+        P: Clone,
     {
-        layer::mk(move |inner| Self::new(local_identity.clone(), inner, timeout))
+        layer::mk(move |inner| Self::new(params.clone(), inner))
     }
 }
 
-impl<T, L, N> NewService<T> for NewDetectTls<L, N>
+impl<T, P, L, N> NewService<T> for NewDetectTls<P, L, N>
 where
-    L: Clone + Param<LocalId> + Param<Config>,
-    N: NewService<Meta<T>> + Clone,
+    P: ExtractParam<Timeout, T> + ExtractParam<Option<L>, T> + Clone,
+    N: Clone,
 {
-    type Service = DetectTls<T, L, N>;
+    type Service = DetectTls<T, P, L, N>;
 
     fn new_service(&mut self, target: T) -> Self::Service {
+        let timeout = self.params.extract_param(&target);
+        let local_identity = self.params.extract_param(&target);
         DetectTls {
             target,
-            local_identity: self.local_identity.clone(),
+            local_identity,
+            timeout,
+            params: self.params.clone(),
             inner: self.inner.clone(),
-            timeout: self.timeout,
         }
     }
 }
 
-impl<I, L, N, NSvc, T> tower::Service<I> for DetectTls<T, L, N>
+impl<I, T, P, L, N, NSvc> tower::Service<I> for DetectTls<T, P, L, N>
 where
     I: io::Peek + io::AsyncRead + io::AsyncWrite + Send + Sync + Unpin + 'static,
+    T: Clone + Send + 'static,
+    P: InsertParam<ConditionalServerTls, T> + Clone + Send + Sync + 'static,
+    P::Target: Send + 'static,
     L: Param<LocalId> + Param<Config>,
-    N: NewService<Meta<T>, Service = NSvc> + Clone + Send + 'static,
+    N: NewService<P::Target, Service = NSvc> + Clone + Send + 'static,
     NSvc: tower::Service<Io<I>, Response = ()> + Send + 'static,
     NSvc::Error: Into<Error>,
     NSvc::Future: Send,
-    T: Clone + Send + 'static,
 {
     type Response = ();
     type Error = Error;
@@ -158,6 +161,7 @@ where
 
     fn call(&mut self, io: I) -> Self::Future {
         let target = self.target.clone();
+        let params = self.params.clone();
         let mut new_accept = self.inner.clone();
 
         match self.local_identity.as_ref() {
@@ -166,9 +170,10 @@ where
                 let LocalId(local_id) = local.param();
 
                 // Detect the SNI from a ClientHello (or timeout).
-                let detect = time::timeout(self.timeout, detect_sni(io));
+                let Timeout(timeout) = self.timeout;
+                let detect = time::timeout(timeout, detect_sni(io));
                 Box::pin(async move {
-                    let (sni, io) = detect.await.map_err(|_| DetectTimeout(()))??;
+                    let (sni, io) = detect.await.map_err(|_| ServerTlsTimeoutError(()))??;
 
                     let (peer, io) = match sni {
                         // If we detected an SNI matching this proxy, terminate TLS.
@@ -192,7 +197,7 @@ where
                     };
 
                     new_accept
-                        .new_service((peer, target))
+                        .new_service(params.insert_param(peer, target))
                         .oneshot(io)
                         .err_into::<Error>()
                         .await
@@ -201,7 +206,7 @@ where
 
             None => {
                 let peer = Conditional::None(NoServerTls::Disabled);
-                let svc = new_accept.new_service((peer, target));
+                let svc = new_accept.new_service(params.insert_param(peer, target));
                 Box::pin(
                     svc.oneshot(EitherIo::Right(EitherIo::Left(io)))
                         .err_into::<Error>(),

--- a/linkerd/tls/tests/tls_accept.rs
+++ b/linkerd/tls/tests/tls_accept.rs
@@ -15,9 +15,9 @@ use linkerd_proxy_transport::{
     listen::{Addrs, Bind, BindTcp},
     ConnectTcp, Keepalive, ListenAddr,
 };
-use linkerd_stack::{NewService, Param};
+use linkerd_stack::{ExtractParam, InsertParam, NewService, Param};
 use linkerd_tls as tls;
-use std::future::Future;
+use std::{future::Future, time::Duration};
 use std::{net::SocketAddr, sync::mpsc};
 use tokio::net::TcpStream;
 use tower::{
@@ -25,6 +25,8 @@ use tower::{
     util::{service_fn, ServiceExt},
 };
 use tracing::instrument::Instrument;
+
+type ServerConn<T, I> = ((tls::ConditionalServerTls, T), tls::server::Io<I>);
 
 #[tokio::test(flavor = "current_thread")]
 async fn plaintext() {
@@ -118,6 +120,11 @@ struct Transported<I, R> {
     result: Result<R, io::Error>,
 }
 
+#[derive(Clone)]
+struct ServerParams {
+    identity: Option<id::CrtKey>,
+}
+
 /// Runs a test for a single TCP connection. `client` processes the connection
 /// on the client side and `server` processes the connection on the server
 /// side.
@@ -136,7 +143,7 @@ where
     CF: Future<Output = Result<CR, io::Error>> + Send + 'static,
     CR: Send + 'static,
     // Server
-    S: Fn(tls::server::Connection<Addrs, TcpStream>) -> SF + Clone + Send + 'static,
+    S: Fn(ServerConn<Addrs, TcpStream>) -> SF + Clone + Send + 'static,
     SF: Future<Output = Result<SR, io::Error>> + Send + 'static,
     SR: Send + 'static,
 {
@@ -153,8 +160,10 @@ where
         let (sender, receiver) = mpsc::channel::<Transported<tls::ConditionalServerTls, SR>>();
 
         let mut detect = tls::NewDetectTls::new(
-            server_tls.map(Tls),
-            move |meta: tls::server::Meta<Addrs>| {
+            ServerParams {
+                identity: server_tls,
+            },
+            move |meta: (tls::ConditionalServerTls, Addrs)| {
                 let server = server.clone();
                 let sender = sender.clone();
                 let tls = Some(meta.0.clone().map(Into::into));
@@ -175,7 +184,6 @@ where
                     )
                 })
             },
-            std::time::Duration::from_secs(10),
         );
 
         let (listen_addr, listen) = BindTcp::default().bind(&Server).expect("must bind");
@@ -351,5 +359,28 @@ impl Param<ListenAddr> for Server {
 impl Param<Keepalive> for Server {
     fn param(&self) -> Keepalive {
         Keepalive(None)
+    }
+}
+
+/// === impl ServerParams ===
+
+impl<T> ExtractParam<tls::server::Timeout, T> for ServerParams {
+    fn extract_param(&self, _: &T) -> tls::server::Timeout {
+        tls::server::Timeout(Duration::from_secs(10))
+    }
+}
+
+impl<T> ExtractParam<Option<Tls>, T> for ServerParams {
+    fn extract_param(&self, _: &T) -> Option<Tls> {
+        self.identity.clone().map(Tls)
+    }
+}
+
+impl<T> InsertParam<tls::ConditionalServerTls, T> for ServerParams {
+    type Target = (tls::ConditionalServerTls, T);
+
+    #[inline]
+    fn insert_param(&self, tls: tls::ConditionalServerTls, target: T) -> Self::Target {
+        (tls, target)
     }
 }


### PR DESCRIPTION
Stack modules that take configuration take one of two approaches: they
either use the `Param` trait to extract a configuration from the target
or they take configuration at construction-time. For example, the TLS
server module takes its detection timeout as an argument when
constructing its layer. But we want to modify the inbound stack to
configure detection timeouts dynamically, as informed by discovery; so
it will no longer be appropriate to take this configuration when
constructing the layer.

This change introduces the `stack::ExtactParam` trait which lets us
provide a _strategy_ to the TLS server layer. For now, strategy
implementations ignore the target type, continuing to use a fixed
timeout set during stack construction; but in an upcoming change we'll
be able to modify some of these stacks to use the target to configure
this value.

The `ExtractParam` trait decouples this decision from the stack module:
The TLS server module no longer cares whether the timeout is configured
statically or dynamically.

Furthermore, some stack modules may want to insert new paramters into
the target. For instance, the TLS server inserts the connections TLS
status into the target. We've generally managed this with tuples, but
this leads to some britleness around the shape of the target.

The `InsertParam` trait allows stacks to construct new target types
other than tuples, though the existing implementations continue to
construct tuples as before. This will support more complicated target
type construction.

This change updates the TLS server to use these new traits without
altering its prior functionality. While this incurs some param boilerplate,
this sets up followup changes that will use this flexbility to configure the
inbound stack based on per-port policies.