### PR TITLE
Add BoxTcp and BoxNewTcp service type aliases

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -36,6 +36,10 @@ pub type BoxHttp<B = http::BoxBody> =
 
 pub type BoxNewHttp<T, B = http::BoxBody> = BoxNewService<T, BoxHttp<B>>;
 
+pub type BoxTcp<I> = BoxService<I, (), Error>;
+
+pub type BoxNewTcp<T, I> = BoxNewService<T, BoxTcp<I>>;
+
 #[derive(Clone, Debug)]
 pub struct Layers<L>(L);
 

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -74,7 +74,7 @@ pub fn stack<I, O, P, R>(
     outbound: Outbound<O>,
     profiles: P,
     resolve: R,
-) -> svc::BoxNewService<GatewayConnection, svc::BoxService<I, (), Error>>
+) -> svc::BoxNewTcp<GatewayConnection, I>
 where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + fmt::Debug + Send + Sync + Unpin + 'static,
     O: Clone + Send + Sync + Unpin + 'static,

--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -23,9 +23,7 @@ use linkerd_app_core::{
 use tracing::debug_span;
 
 impl<H> Inbound<H> {
-    pub fn push_http_server<T, I, HSvc>(
-        self,
-    ) -> Inbound<svc::BoxNewService<T, svc::BoxService<I, (), Error>>>
+    pub fn push_http_server<T, I, HSvc>(self) -> Inbound<svc::BoxNewTcp<T, I>>
     where
         T: Param<Version>
             + Param<http::normalize_uri::DefaultAuthority>
@@ -351,7 +349,7 @@ pub mod fuzz_logic {
         rt: ProxyRuntime,
         profiles: resolver::Profiles,
         connect: Connect<Remote<ServerAddr>>,
-    ) -> svc::BoxNewService<HttpAccept, svc::BoxService<I, (), linkerd_app_core::Error>>
+    ) -> svc::BoxNewTcp<HttpAccept, I>
     where
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
     {

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -13,7 +13,7 @@ use linkerd_app_core::{
     svc::{self, NewService, Param},
     tls,
     transport::{ClientAddr, Remote, ServerAddr},
-    Conditional, Error, NameAddr, ProxyRuntime,
+    Conditional, NameAddr, ProxyRuntime,
 };
 use linkerd_app_test::connect::ConnectFuture;
 use linkerd_tracing::test::trace_init;
@@ -24,7 +24,7 @@ fn build_server<I>(
     rt: ProxyRuntime,
     profiles: resolver::Profiles,
     connect: Connect<Remote<ServerAddr>>,
-) -> svc::BoxNewService<HttpAccept, svc::BoxService<I, (), Error>>
+) -> svc::BoxNewTcp<HttpAccept, I>
 where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
 {

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -222,7 +222,7 @@ where
         proxy_port: u16,
         profiles: P,
         gateway: G,
-    ) -> Inbound<svc::BoxNewService<T, svc::BoxService<I, (), Error>>>
+    ) -> Inbound<svc::BoxNewTcp<T, I>>
     where
         T: svc::Param<Remote<ClientAddr>> + svc::Param<OrigDstAddr>,
         T: Clone + Send + 'static,
@@ -280,6 +280,7 @@ where
                         detect_timeout,
                         http::DetectHttp::default(),
                     ))
+                    .check_new_service::<TcpAccept, _>()
                     .push_request_filter(require_id)
                     .push(rt.metrics.transport.layer_accept())
                     .push_request_filter(TcpAccept::try_from)

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -5,7 +5,7 @@ use linkerd_app_core::{
     proxy::{api_resolve::Metadata, resolve::map_endpoint::MapEndpoint},
     svc, tls,
     transport::{self, addrs::*},
-    transport_header, Conditional, Error,
+    transport_header, Conditional,
 };
 use std::{fmt, net::SocketAddr};
 
@@ -190,9 +190,7 @@ impl<P: Copy + std::fmt::Debug> MapEndpoint<Concrete<P>, Metadata> for FromMetad
 // === Outbound ===
 
 impl<S> Outbound<S> {
-    pub fn push_endpoint<I>(
-        self,
-    ) -> Outbound<svc::BoxNewService<tcp::Endpoint, svc::BoxService<I, (), Error>>>
+    pub fn push_endpoint<I>(self) -> Outbound<svc::BoxNewTcp<tcp::Endpoint, I>>
     where
         Self: Clone + 'static,
         S: svc::Service<tcp::Connect, Error = io::Error> + Clone + Send + Sync + Unpin + 'static,
@@ -220,7 +218,10 @@ pub mod tests {
     use super::*;
     use crate::test_util::*;
     use hyper::{client::conn::Builder as ClientBuilder, Body, Request};
-    use linkerd_app_core::svc::{NewService, Service, ServiceExt};
+    use linkerd_app_core::{
+        svc::{NewService, Service, ServiceExt},
+        Error,
+    };
     use tokio::time;
 
     /// Tests that socket errors cause HTTP clients to be disconnected.

--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -11,10 +11,7 @@ use tracing::debug_span;
 pub struct Skip;
 
 impl<N> Outbound<N> {
-    pub fn push_detect_http<T, U, NSvc, H, HSvc, I>(
-        self,
-        http: H,
-    ) -> Outbound<svc::BoxNewService<T, svc::BoxService<I, (), Error>>>
+    pub fn push_detect_http<T, U, NSvc, H, HSvc, I>(self, http: H) -> Outbound<svc::BoxNewTcp<T, I>>
     where
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr,
         I: std::fmt::Debug + Send + Sync + Unpin + 'static,

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -50,11 +50,7 @@ impl Outbound<svc::BoxNewHttp<http::Endpoint>> {
     ///
     /// This is only intended for Ingress configurations, where we assume all
     /// outbound traffic is HTTP.
-    pub fn into_ingress<T, I, P, R>(
-        self,
-        profiles: P,
-        resolve: R,
-    ) -> svc::BoxNewService<T, svc::BoxService<I, (), Error>>
+    pub fn into_ingress<T, I, P, R>(self, profiles: P, resolve: R) -> svc::BoxNewTcp<T, I>
     where
         T: Param<OrigDstAddr> + Clone + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -114,10 +114,7 @@ impl<P> svc::Param<ConcreteAddr> for Concrete<P> {
 // === impl Outbound ===
 
 impl<C> Outbound<C> {
-    pub fn push_logical<R, I>(
-        self,
-        resolve: R,
-    ) -> Outbound<svc::BoxNewService<tcp::Logical, svc::BoxService<I, (), Error>>>
+    pub fn push_logical<R, I>(self, resolve: R) -> Outbound<svc::BoxNewTcp<tcp::Logical, I>>
     where
         Self: Clone + 'static,
         C: Clone + Send + Sync + Unpin + 'static,

--- a/linkerd/app/outbound/src/switch_logical.rs
+++ b/linkerd/app/outbound/src/switch_logical.rs
@@ -13,7 +13,7 @@ impl<S> Outbound<S> {
     pub fn push_switch_logical<T, I, N, NSvc, SSvc>(
         self,
         logical: N,
-    ) -> Outbound<svc::BoxNewService<(Option<profiles::Receiver>, T), svc::BoxService<I, (), Error>>>
+    ) -> Outbound<svc::BoxNewTcp<(Option<profiles::Receiver>, T), I>>
     where
         Self: Clone + 'static,
         T: svc::Param<OrigDstAddr> + Clone + Send + Sync + 'static,

--- a/linkerd/app/test/src/http_util.rs
+++ b/linkerd/app/test/src/http_util.rs
@@ -1,13 +1,13 @@
-use crate::app_core::{svc::Param, tls, Error};
-use crate::io;
-use crate::ContextError;
+use crate::{
+    app_core::{svc, tls, Error},
+    io, ContextError,
+};
 use futures::FutureExt;
 use hyper::{
     body::HttpBody,
     client::conn::{Builder as ClientBuilder, SendRequest},
     Body, Request, Response,
 };
-use linkerd_app_core::svc::BoxService;
 use std::{
     future::Future,
     sync::{Arc, Mutex},
@@ -23,7 +23,7 @@ pub struct Server {
 
 type HandleFuture = Box<dyn (FnMut(Request<Body>) -> Result<Response<Body>, Error>) + Send>;
 
-type BoxServer = BoxService<io::DuplexStream, (), Error>;
+type BoxServer = svc::BoxTcp<io::DuplexStream>;
 
 impl Default for Server {
     fn default() -> Self {
@@ -149,7 +149,7 @@ impl Server {
     pub fn run<E>(self) -> impl (FnMut(E) -> io::Result<io::BoxedIo>) + Send + 'static
     where
         E: std::fmt::Debug,
-        E: Param<tls::ConditionalClientTls>,
+        E: svc::Param<tls::ConditionalClientTls>,
     {
         let Self { f, settings } = self;
         let f = Arc::new(Mutex::new(f));


### PR DESCRIPTION
We have BoxHttp and BoxNewHttp aliases that help reduce type
boilerplate. This change adds similar aliases for TCP-forwarding stacks.