### PR TITLE
Suggestions for #1180

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -796,7 +796,6 @@ dependencies = [
  "linkerd-http-retry",
  "linkerd-identity",
  "linkerd-io",
- "linkerd-proxy-http",
  "linkerd-tracing",
  "pin-project",
  "thiserror",

--- a/linkerd/app/core/src/retry.rs
+++ b/linkerd/app/core/src/retry.rs
@@ -139,9 +139,8 @@ where
         *clone.headers_mut() = req.headers().clone();
         *clone.version_mut() = req.version();
 
-        // The cloned request may also need the ability to tear down the
-        // client connection if the response from a peer proxy has the
-        // l5d-proxy-error header, so ensure it also has a `ClientHandle`.
+        // The HTTP server sets a ClientHandle with the client's address and a means to close the
+        // server-side connection.
         if let Some(client_handle) = req.extensions().get::<ClientHandle>().cloned() {
             clone.extensions_mut().insert(client_handle);
         }

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -21,7 +21,6 @@ futures = { version = "0.3", default-features = false }
 linkerd-app-core = { path = "../core" }
 linkerd-http-retry = { path = "../../http-retry" }
 linkerd-identity = { path = "../../identity" }
-linkerd-proxy-http = { path = "../../proxy/http" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["sync"] }
 tower = { version = "0.4.8", features = ["util"] }

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -1,4 +1,3 @@
-use super::peer_proxy_errors;
 use super::require_id_header;
 use crate::Outbound;
 use linkerd_app_core::{
@@ -40,7 +39,6 @@ impl<C> Outbound<C> {
                 .push_on_response(svc::MapErrLayer::new(Into::<Error>::into))
                 .check_service::<T>()
                 .into_new_service()
-                .push(peer_proxy_errors::PeerProxyErrors::layer())
                 .push_new_reconnect(backoff)
                 .push(tap::NewTapHttp::layer(rt.tap.clone()))
                 .push(
@@ -107,12 +105,11 @@ mod test {
             metadata: Metadata::default(),
         });
 
-        let mut req = http::Request::builder()
+        let req = http::Request::builder()
             .version(::http::Version::HTTP_11)
             .uri("http://foo.example.com")
             .body(http::BoxBody::default())
             .unwrap();
-        let _ = set_client_handle(&mut req, addr);
         let rsp = svc.oneshot(req).await.unwrap();
         assert_eq!(rsp.status(), http::StatusCode::NO_CONTENT);
         assert!(rsp.headers().get(WAS_ORIG_PROTO).is_none());
@@ -144,12 +141,11 @@ mod test {
             metadata: Metadata::default(),
         });
 
-        let mut req = http::Request::builder()
+        let req = http::Request::builder()
             .version(::http::Version::HTTP_2)
             .uri("http://foo.example.com")
             .body(http::BoxBody::default())
             .unwrap();
-        let _ = set_client_handle(&mut req, addr);
         let rsp = svc.oneshot(req).await.unwrap();
         assert_eq!(rsp.status(), http::StatusCode::NO_CONTENT);
         assert!(rsp.headers().get(WAS_ORIG_PROTO).is_none());
@@ -189,12 +185,11 @@ mod test {
             ),
         });
 
-        let mut req = http::Request::builder()
+        let req = http::Request::builder()
             .version(::http::Version::HTTP_11)
             .uri("http://foo.example.com")
             .body(http::BoxBody::default())
             .unwrap();
-        let _ = set_client_handle(&mut req, addr);
         let rsp = svc.oneshot(req).await.unwrap();
         assert_eq!(rsp.status(), http::StatusCode::NO_CONTENT);
         assert_eq!(
@@ -238,12 +233,11 @@ mod test {
             ),
         });
 
-        let mut req = http::Request::builder()
+        let req = http::Request::builder()
             .version(::http::Version::HTTP_2)
             .uri("http://foo.example.com")
             .body(http::BoxBody::default())
             .unwrap();
-        let _ = set_client_handle(&mut req, addr);
         let rsp = svc.oneshot(req).await.unwrap();
         assert_eq!(rsp.status(), http::StatusCode::NO_CONTENT);
         assert!(rsp.headers().get(WAS_ORIG_PROTO).is_none());

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -112,7 +112,7 @@ mod test {
             .uri("http://foo.example.com")
             .body(http::BoxBody::default())
             .unwrap();
-        req = add_client_handle(req, addr);
+        let _ = set_client_handle(&mut req, addr);
         let rsp = svc.oneshot(req).await.unwrap();
         assert_eq!(rsp.status(), http::StatusCode::NO_CONTENT);
         assert!(rsp.headers().get(WAS_ORIG_PROTO).is_none());
@@ -149,7 +149,7 @@ mod test {
             .uri("http://foo.example.com")
             .body(http::BoxBody::default())
             .unwrap();
-        req = add_client_handle(req, addr);
+        let _ = set_client_handle(&mut req, addr);
         let rsp = svc.oneshot(req).await.unwrap();
         assert_eq!(rsp.status(), http::StatusCode::NO_CONTENT);
         assert!(rsp.headers().get(WAS_ORIG_PROTO).is_none());
@@ -194,7 +194,7 @@ mod test {
             .uri("http://foo.example.com")
             .body(http::BoxBody::default())
             .unwrap();
-        req = add_client_handle(req, addr);
+        let _ = set_client_handle(&mut req, addr);
         let rsp = svc.oneshot(req).await.unwrap();
         assert_eq!(rsp.status(), http::StatusCode::NO_CONTENT);
         assert_eq!(
@@ -243,7 +243,7 @@ mod test {
             .uri("http://foo.example.com")
             .body(http::BoxBody::default())
             .unwrap();
-        req = add_client_handle(req, addr);
+        let _ = set_client_handle(&mut req, addr);
         let rsp = svc.oneshot(req).await.unwrap();
         assert_eq!(rsp.status(), http::StatusCode::NO_CONTENT);
         assert!(rsp.headers().get(WAS_ORIG_PROTO).is_none());

--- a/linkerd/app/outbound/src/http/peer_proxy_errors.rs
+++ b/linkerd/app/outbound/src/http/peer_proxy_errors.rs
@@ -42,7 +42,6 @@ where
     S: svc::Service<http::Request<A>, Response = http::Response<B>>,
     S::Response: Send,
     S::Future: Send + 'static,
-    A: Send + 'static,
     B: Send + 'static,
 {
     type Response = S::Response;

--- a/linkerd/app/outbound/src/http/peer_proxy_errors.rs
+++ b/linkerd/app/outbound/src/http/peer_proxy_errors.rs
@@ -59,9 +59,10 @@ where
 
         Box::pin(self.inner.call(req).map_ok(move |rsp| {
             if let Some(msg) = rsp.headers().get(L5D_PROXY_ERROR) {
-                tracing::debug!(header = %L5D_PROXY_ERROR, ?msg);
+                tracing::debug!(?msg, "Received an error response from a peer proxy");
 
-                // Gracefully teardown the accepted connection.
+                // Signal that the proxy's server-side connection should be terminated. This handles
+                // the remote error as if the local proxy encountered an error.
                 if let Some(ClientHandle { close, .. }) = client {
                     tracing::trace!("connection closed");
                     close.close();

--- a/linkerd/app/outbound/src/http/peer_proxy_errors.rs
+++ b/linkerd/app/outbound/src/http/peer_proxy_errors.rs
@@ -78,112 +78,49 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        http::{Endpoint, NewServeHttp, Request, Response, StatusCode, Version},
-        test_util::{
-            self, future,
-            support::{self, connect::Connect, http_util},
-        },
-        Config, Outbound,
-    };
-    use hyper::{client::conn::Builder, server::conn::Http, service, Body};
+    use super::*;
+    use crate::test_util;
+    use futures::future;
     use linkerd_app_core::{
-        errors::L5D_PROXY_ERROR,
-        io,
-        proxy::{api_resolve::Metadata, http::BoxRequest},
-        svc::{BoxNewService, BoxService, NewService},
-        tls::{ConditionalClientTls, NoClientTls},
-        transport::{Remote, ServerAddr},
-        Error, Infallible, ProxyRuntime,
+        svc::{self, ServiceExt},
+        Infallible,
     };
     use linkerd_tracing::test;
-    use std::net::SocketAddr;
 
     #[tokio::test(flavor = "current_thread")]
     async fn connection_closes_after_response_header() {
         let _trace = test::trace_init();
 
-        // Build the outbound server that responds with the l5d-proxy-error
-        // header set.
-        let (rt, _shutdown) = test_util::runtime();
-        let addr = SocketAddr::new([127, 0, 0, 1].into(), 12345);
-        let connect = support::connect().endpoint_fn_boxed(addr, |_: Endpoint| serve());
-        let config = test_util::default_config();
-        let mut outbound = build_outbound(config, rt, connect);
-
-        // Build the otubound service.
-        let service = outbound.new_service(Endpoint {
-            addr: Remote(ServerAddr(addr)),
-            tls: ConditionalClientTls::None(NoClientTls::Disabled),
-            metadata: Metadata::default(),
-            logical_addr: None,
-            protocol: Version::Http1,
-            opaque_protocol: false,
-        });
+        let service = PeerProxyErrors::new(svc::mk(move |_: http::Request<hyper::Body>| {
+            let response = http::Response::builder()
+                .status(http::StatusCode::BAD_GATEWAY)
+                .header(L5D_PROXY_ERROR, "proxy received invalid response")
+                .body(hyper::Body::default())
+                .unwrap();
+            future::ok::<_, Infallible>(response)
+        }));
 
         // Build the client that should be closed after receiving a response
         // with the l5d-proxy-error header.
-        let mut builder = Builder::new();
-        let (mut client, bg) = http_util::connect_and_accept(&mut builder, service).await;
-
-        let mut request = Request::builder()
+        let mut request = http::Request::builder()
             .uri("http://foo.example.com")
-            .body(Body::default())
+            .body(hyper::Body::default())
             .unwrap();
-        let closed = test_util::set_client_handle(&mut request, addr);
-        let response = http_util::http_request(&mut client, request).await.unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let closed = test_util::set_client_handle(&mut request, ([192, 0, 2, 3], 50000).into());
+        let response = service
+            .oneshot(request)
+            .await
+            .expect("request must succeed");
+        assert_eq!(response.status(), http::StatusCode::BAD_GATEWAY);
         let message = response
             .headers()
             .get(L5D_PROXY_ERROR)
             .expect("response did not contain l5d-proxy-error header");
         assert_eq!(message, "proxy received invalid response");
 
-        // The client's background task should be completed without dropping
-        // the client because the connection was closed after encountering a
-        // response that contains the l5d-proxy-error header.
-        let _ = bg.await;
-
         // The client handle close future should fire.
         tokio::time::timeout(tokio::time::Duration::from_secs(10), closed)
             .await
             .expect("client handle must close");
-    }
-
-    fn build_outbound<I>(
-        config: Config,
-        rt: ProxyRuntime,
-        connect: Connect<Endpoint>,
-    ) -> BoxNewService<Endpoint, BoxService<I, (), Error>>
-    where
-        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
-    {
-        Outbound::new(config.clone(), rt.clone())
-            .with_stack(connect)
-            .push_http_endpoint()
-            .push_http_server()
-            .map_stack(|_, _, s| s.push_on_response(BoxRequest::layer()))
-            .push(NewServeHttp::layer(
-                config.proxy.server.h2_settings,
-                rt.drain,
-            ))
-            .map_stack(|_, _, s| s.push_on_response(BoxService::layer()))
-            .push(BoxNewService::layer())
-            .into_inner()
-    }
-
-    fn serve() -> io::Result<io::BoxedIo> {
-        let (client_io, server_io) = io::duplex(4096);
-        let http = Http::new();
-        let service = service::service_fn(move |_: Request<Body>| {
-            let response = Response::builder()
-                .status(StatusCode::BAD_GATEWAY)
-                .header(L5D_PROXY_ERROR, "proxy received invalid response")
-                .body(hyper::Body::default())
-                .unwrap();
-            future::ok::<_, Infallible>(response)
-        });
-        tokio::spawn(http.serve_connection(server_io, service));
-        Ok(io::BoxedIo::new(client_io))
     }
 }

--- a/linkerd/app/outbound/src/http/peer_proxy_errors.rs
+++ b/linkerd/app/outbound/src/http/peer_proxy_errors.rs
@@ -77,7 +77,6 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::test_util;
     use futures::future;
     use linkerd_app_core::{
         svc::{self, ServiceExt},
@@ -96,7 +95,8 @@ mod test {
             .uri("http://foo.example.com")
             .body(hyper::Body::default())
             .unwrap();
-        let closed = test_util::set_client_handle(&mut req, ([192, 0, 2, 3], 50000).into());
+        let (handle, closed) = ClientHandle::new(([192, 0, 2, 3], 50000).into());
+        req.extensions_mut().insert(handle);
 
         const ERROR_MSG: &str = "something bad happened";
         let svc = PeerProxyErrors::new(svc::mk(move |_: http::Request<hyper::Body>| {

--- a/linkerd/app/outbound/src/http/peer_proxy_errors.rs
+++ b/linkerd/app/outbound/src/http/peer_proxy_errors.rs
@@ -1,9 +1,9 @@
 use http::{Request, Response};
 use linkerd_app_core::{
     errors::L5D_PROXY_ERROR,
+    proxy::http::ClientHandle,
     svc::{layer, NewService, Service},
 };
-use linkerd_proxy_http::ClientHandle;
 use std::{
     future::Future,
     pin::Pin,

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -1,17 +1,17 @@
-use crate::{http::Request, Config};
+use crate::Config;
 pub use futures::prelude::*;
 pub use ipnet::IpNet;
 use linkerd_app_core::{
     config, drain, exp_backoff, metrics,
     proxy::{
-        http::{h1, h2, ClientHandle},
+        http::{h1, h2},
         tap,
     },
     transport::{Keepalive, ListenAddr},
     IpMatch, ProxyRuntime,
 };
 pub use linkerd_app_test as support;
-use std::{net::SocketAddr, str::FromStr, time::Duration};
+use std::{str::FromStr, time::Duration};
 
 pub fn default_config() -> Config {
     Config {
@@ -59,10 +59,4 @@ pub fn runtime() -> (ProxyRuntime, drain::Signal) {
         drain,
     };
     (runtime, drain_tx)
-}
-
-pub fn set_client_handle<B>(req: &mut Request<B>, addr: SocketAddr) -> impl Future<Output = ()> {
-    let (handle, closed) = ClientHandle::new(addr);
-    req.extensions_mut().insert(handle);
-    closed
 }

--- a/linkerd/proxy/http/src/client_handle.rs
+++ b/linkerd/proxy/http/src/client_handle.rs
@@ -19,7 +19,7 @@ pub struct ClientHandle {
 
 /// A handle that signals the client connection to close.
 #[derive(Clone, Debug)]
-pub struct Close(pub Arc<Notify>);
+pub struct Close(Arc<Notify>);
 
 pub type Closed = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
@@ -39,10 +39,8 @@ impl Close {
     }
 }
 
-// === SetClientHandle ===
-
-impl<S> SetClientHandle<S> {
-    pub fn new(addr: SocketAddr, inner: S) -> (Self, Closed) {
+impl ClientHandle {
+    pub fn new(addr: SocketAddr) -> (ClientHandle, Closed) {
         let notify = Arc::new(Notify::new());
         let handle = ClientHandle {
             addr,
@@ -51,6 +49,15 @@ impl<S> SetClientHandle<S> {
         let closed = Box::pin(async move {
             notify.notified().await;
         });
+        (handle, closed)
+    }
+}
+
+// === SetClientHandle ===
+
+impl<S> SetClientHandle<S> {
+    pub fn new(addr: SocketAddr, inner: S) -> (Self, Closed) {
+        let (handle, closed) = ClientHandle::new(addr);
         (Self { inner, handle }, closed)
     }
 }

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -25,7 +25,7 @@ pub mod upgrade;
 mod version;
 
 pub use self::{
-    client_handle::{ClientHandle, Close, SetClientHandle},
+    client_handle::{ClientHandle, SetClientHandle},
     detect::DetectHttp,
     glue::{HyperServerSvc, UpgradeBody},
     header_from_target::NewHeaderFromTarget,


### PR DESCRIPTION
Suggestions for #1180 

* `outbound` should not pull in `proxy_http`. Instead, we use re-exports from `app_core` like `proxy::http`.
* We don't want to expose inner workings of how a `ClientHandle` is constructed. We have the `Close` & `Closed` types that hide the inner `Arc<Notify>`. This change adds `ClientHandle::new` to build these types without exposing the inner impl.
* I've renamed `add_client_handle` to `set_client_handle` and changed it to take a mutable reference and, rather than return the request, we return a future that fires when the client handle is closed.
* As discussed in https://github.com/linkerd/linkerd2-proxy/pull/1180/files#r683052774, the test seems a bit more complicated than it needs to be. I'd rather have a narrow unit test that exercises the behavior we care about without having to instrument a full proxy with TCP connections, etc. I've updated the test to only exercise the `PeerProxyErrors` logic without all of the extra proxy test scaffolding.