### PR TITLE
inbound: support configurable default port policies

### DIFF
--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -90,6 +90,11 @@ impl<N> Inbound<N> {
                                 ..
                             }),
                         ) => Ok(Tls::from_params(&t, tls)),
+                        // Permit any TLS connection if TLS is required but
+                        // authentication is not.
+                        (AllowPolicy::TlsUnauthenticated, tls::ConditionalServerTls::Some(_)) => {
+                            Ok(Tls::from_params(&t, tls))
+                        }
                         // Otherwise, reject the connection.
                         _ => {
                             let OrigDstAddr(a) = t.param();

--- a/linkerd/app/inbound/src/port_policies.rs
+++ b/linkerd/app/inbound/src/port_policies.rs
@@ -23,6 +23,9 @@ pub enum AllowPolicy {
     Authenticated,
     /// Allows all unauthenticated connections.
     Unauthenticated { skip_detect: bool },
+    /// Allows all TLS connections (authenticated or otherwise), but denies
+    /// non-TLS unauthenticated connections.
+    TlsUnauthenticated,
 }
 
 /// A hasher for ports.

--- a/linkerd/app/inbound/src/port_policies.rs
+++ b/linkerd/app/inbound/src/port_policies.rs
@@ -42,7 +42,7 @@ type Map = HashMap<u16, AllowPolicy, BuildHasherDefault<PortHasher>>;
 #[error("connection denied on unknown port {0}")]
 pub struct DeniedUnknownPort(u16);
 
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[error("expected one of `deny`, `authenticated`, `unauthenticated`, or `tls-unauthenticated`")]
 pub struct ParsePolicyError(());
 
@@ -83,6 +83,15 @@ impl From<AllowPolicy> for PortPolicies {
 }
 
 // === impl DefaultPolicy ===
+
+impl Default for DefaultPolicy {
+    fn default() -> Self {
+        // XXX(eliza): defining this via a `Default` impl feels *idiomatic* but
+        // maybe it's more correct for the default value to be defined via a
+        // const in the `linkerd_app::env` module?
+        Self::Allow(AllowPolicy::Unauthenticated { skip_detect: false })
+    }
+}
 
 impl From<AllowPolicy> for DefaultPolicy {
     fn from(default: AllowPolicy) -> Self {

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -541,17 +541,14 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             })?
             .unwrap_or_default();
 
+            const ALLOW_OPAQUE: inbound::AllowPolicy =
+                inbound::AllowPolicy::Unauthenticated { skip_detect: true };
             inbound::PortPolicies::new(
                 default,
                 require_identity_for_inbound_ports
                     .into_iter()
                     .map(|p| (p, inbound::AllowPolicy::Authenticated))
-                    .chain(inbound_opaque_ports.into_iter().map(|p| {
-                        (
-                            p,
-                            inbound::AllowPolicy::Unauthenticated { skip_detect: true },
-                        )
-                    })),
+                    .chain(inbound_opaque_ports.into_iter().map(|p| (p, ALLOW_OPAQUE))),
             )
         };
 

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -537,8 +537,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             }
 
             let default = parse(strings, ENV_INBOUND_DEFAULT_POLICY, |s| {
-                s.parse::<inbound::port_policies::DefaultPolicy>()
-                    .map_err(ParseError::from)
+                s.parse().map_err(ParseError::from)
             })?
             .unwrap_or_default();
 


### PR DESCRIPTION
The proxy supports a [default port policy][1]. We currently hardcode a
[default policy permitting all connections][2]. We should make this
behavior configurable. This will enable the proxy-injector to set
default behavior for each workload and, more imminently, we will be able
to configure the identity proxy's behavior to require TLS. See
linkerd/linkerd2#6606 for details.

This branch adds a `LINKERD2_PROXY_INBOUND_DEFAULT_POLICY` environment
configuration supporting the following values:

* `authenticated`
* `deny`
* `tis-unauthenticated`
* `unauthenticated`

This was implemented by:

* Adding a new `TlsUnauthenticated` variant to `AllowPolicy`. This
  variant allows all TLS connections, regardless of whether they have
  valid client identities.
* Adding `FromStr` implementations for `AllowPolicy` and
  `DefaultPolicy` to allow them to be parsed from the environment
  variable.
* Changing the env module to parse the default policy from the env var,
  rather than hardcoding it.

Closes linkerd/linkerd2#6606

[1]: https://github.com/linkerd/linkerd2-proxy/blob/2eb1671f0fde62dae5fb272608a276ad21a598ba/linkerd/app/inbound/src/port_policies.rs#L14-L26
[2]: https://github.com/linkerd/linkerd2-proxy/blob/2eb1671f0fde62dae5fb272608a276ad21a598ba/linkerd/app/src/env.rs#L526