### PR TITLE
fuzzing: change `linkerd_dns::fuzz_target_1` to single-threaded

### DIFF
--- a/linkerd/app/inbound/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/linkerd/app/inbound/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -13,7 +13,10 @@ fuzz_target!(|requests: Vec<http_fuzz::HttpRequestSpec>| {
         return;
     }
 
-    tokio::runtime::Runtime::new()
+    tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .enable_io()
+        .build()
         .unwrap()
         .block_on(http_fuzz::fuzz_entry_raw(requests));
 });

--- a/linkerd/dns/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/linkerd/dns/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -10,7 +10,10 @@ fuzz_target!(|data: &[u8]| {
     let _trace = linkerd_tracing::test::with_default_filter("off");
     if let Ok(s) = std::str::from_utf8(data) {
         tracing::info!(data = ?s, "running with input");
-        tokio::runtime::Runtime::new()
+        tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .enable_io()
+            .build()
             .unwrap()
             .block_on(linkerd_dns::fuzz_logic::fuzz_entry(s))
     }

--- a/linkerd/proxy/http/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/linkerd/proxy/http/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -8,7 +8,10 @@ fuzz_target!(|data: &[u8]| {
     // Don't enable tracing in `cluster-fuzz`, since we would emit verbose
     // traces for *every* generated fuzz input...
     let _trace = linkerd_tracing::test::with_default_filter("off");
-    tokio::runtime::Runtime::new()
+    tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .enable_io()
+        .build()
         .unwrap()
         .block_on(linkerd_proxy_http::detect::fuzz_logic::fuzz_entry(data))
 });


### PR DESCRIPTION
Something about the behavior of the fuzz logic for `linkerd_dns` is
hitting [a recently added assertion][1] in Tokio's multithreaded runtime
when shutting down. It's unclear what exactly triggers the assertion,
but it appears to be environment-dependent in some way: I can't
reproduce the failure on my machine using the reproducer generated by
`cargo-fuzz`, but it fails reliably in cluster-fuzz (possibly related to
the number of CPU cores on the cluster-fuzz servers?).

Since the purpose of this fuzz test is to fuzz the DNS name parsing
behavior, and this failure isn't actually related to the code being
fuzzed, just the environment the fuzz test runs in, this branch changes
the fuzz logic to use a single-threaded Tokio runtime. We'll continue
trying to get a minimal repro of the crash to report upstream, but this
should fix the fuzz test so that it can continue exercizing the DNS code
we actually care about here.

[1]: https://github.com/tokio-rs/tokio/blob/362df5a3172f6e1bdee2fd3808e5cfc730a111f6/tokio/src/runtime/thread_pool/worker.rs#L603