### PR TITLE
fuzz: fix inbound fuzz logic expecting wrong IP address

### DIFF
--- a/linkerd/app/inbound/src/http/mod.rs
+++ b/linkerd/app/inbound/src/http/mod.rs
@@ -124,11 +124,7 @@ pub mod fuzz {
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
     {
         let connect = svc::stack(connect)
-            .map_stack(|cfg, _, s| {
-                s.push_map_target(|p| Remote(ServerAddr(([127, 0, 0, 1], p).into())))
-                    .push_map_target(|t| Param::<u16>::param(&t))
-                    .push_connect_timeout(cfg.proxy.connect.timeout)
-            })
+            .push_map_target(|t: Http| Remote(ServerAddr(([127, 0, 0, 1], t.param()).into())))
             .into_inner();
         Inbound::new(cfg, rt)
             .with_stack(connect)


### PR DESCRIPTION
PR #1179 changed the inbound HTTP fuzz logic, and added a mocked
`Target` type similar to other stack tests. However, this introduced a
bug, because the `Target::addr()` function, which returns the socket
address that the mock TCP connector should expect the proxy to try to
connect to, returns the (mocked) original destination address. Since the
stack we build for the fuzz test maps the target IP address to localhost
before calling into the connect stack (as the real proxy currently
does), this means that we attempt to connect to an address the mock
connector doesn't expect. Then, it panics and the fuzz test fails.

This branch fixes this issue by changing `Target::addr` to return
127.0.0.1:80 instead of 192.0.2.2:80. This should match what the proxy
will actually attempt to connect to.

I also updated the fuzz logic to use exactly the same connect stack as
the HTTP stack tests (including a timeout). Although this shouldn't be
exercised, it makes the fuzz test more closely match the stack tests and
thus the real life proxy. I wonder if we can eventually share more code
between the tests and the fuzzers, but that seems like a follow-up.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>