### PR TITLE
ci: Check test coverage weekly

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,9 +1,9 @@
 name: Coverage
 
+# Run weekly on Sunday at midnight (UTC).
 on:
   schedule:
-  # Run weekly on Sunday at midnight (UTC).
-  - cron: '0 0 * * 7'
+    - cron: '0 0 * * 7'
 
 jobs:
   test:
@@ -14,7 +14,7 @@ jobs:
       image: docker://rust:1.54.0-buster
       options: --security-opt seccomp=unconfined
     steps:
-    - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
-    - run: cargo install cargo-tarpaulin
-    - run: cargo tarpaulin --verbose --workspace --out Xml
-    - uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
+      - run: cargo install cargo-tarpaulin
+      - run: cargo tarpaulin --verbose --workspace --out Xml
+      - uses: codecov/codecov-action@51d810878be5422784e86451c0e7c14e5860ec47

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,14 +1,12 @@
 name: Coverage
 
 on:
-  push:
-    branches: [main]
-  pull_request: {}
+  schedule:
+  # Run weekly on Sunday at midnight (UTC).
+  - cron: "0 0 * * 7"
 
 jobs:
   test:
-    if: |
-      !startsWith(github.event.pull_request.title, 'build(deps): ')
     name: codecov
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: Coverage
 on:
   schedule:
   # Run weekly on Sunday at midnight (UTC).
-  - cron: "0 0 * * 7"
+  - cron: '0 0 * * 7'
 
 jobs:
   test:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,7 @@ name: Coverage
 # Run weekly on Sunday at midnight (UTC).
 on:
   schedule:
-    - cron: '0 0 * * 7'
+    - cron: '0 0 * * 0'
 
 jobs:
   test:


### PR DESCRIPTION
Our coverage action is quite slow and is generally low-value in the
context of a review. Instead of running it on every push to every PR,
let's conserve our CI resources and generate coverage weekly.