### PR TITLE
Use FromIterator for NameAddr construction

### DIFF
--- a/linkerd/app/gateway/src/tests.rs
+++ b/linkerd/app/gateway/src/tests.rs
@@ -171,7 +171,9 @@ impl Test {
     }
 
     fn with_profile(mut self, profile: profiles::Receiver) -> Self {
-        let allow = NameMatch::new(Some(dns::Suffix::from_str(self.suffix).unwrap()));
+        let allow = Some(dns::Suffix::from_str(self.suffix).unwrap())
+            .into_iter()
+            .collect::<NameMatch>();
         if allow.matches(self.target.name()) {
             self.profile = Some(profile);
         }

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -9,7 +9,7 @@ use linkerd_app_core::{
         tap,
     },
     transport::{Keepalive, ListenAddr},
-    NameMatch, ProxyRuntime,
+    ProxyRuntime,
 };
 pub use linkerd_app_test as support;
 use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy};
@@ -20,7 +20,7 @@ pub fn default_config() -> Config {
         .parse::<Suffix>()
         .expect("`svc.cluster.local.` suffix is definitely valid");
     Config {
-        allow_discovery: NameMatch::new(Some(cluster_local)),
+        allow_discovery: Some(cluster_local).into_iter().collect(),
         proxy: config::ProxyConfig {
             server: config::ServerConfig {
                 addr: ListenAddr(([0, 0, 0, 0], 0).into()),

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -5,7 +5,7 @@ use crate::core::{
     proxy::http::{h1, h2},
     tls,
     transport::{Keepalive, ListenAddr},
-    Addr, AddrMatch, Conditional, IpNet, NameMatch,
+    Addr, AddrMatch, Conditional, IpNet,
 };
 use crate::{dns, gateway, identity, inbound, oc_collector, outbound};
 use inbound::port_policies;
@@ -449,7 +449,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     };
 
     let gateway = gateway::Config {
-        allow_discovery: NameMatch::new(gateway_suffixes?.unwrap_or_default()),
+        allow_discovery: gateway_suffixes?.into_iter().flatten().collect(),
     };
 
     let inbound = {
@@ -570,7 +570,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         };
 
         inbound::Config {
-            allow_discovery: NameMatch::new(dst_profile_suffixes),
+            allow_discovery: dst_profile_suffixes.into_iter().collect(),
             proxy: ProxyConfig {
                 server,
                 connect,


### PR DESCRIPTION
If we provide a `FromIterator` implementation for `NameAddr`, we need
not have an extra import to construct `NameAddr`s when the type is
known.

No functional changes.