### PR TITLE
app: Block proxy initialization on identity readiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,6 +1168,7 @@ dependencies = [
  "linkerd-tls",
  "linkerd2-proxy-api",
  "pin-project",
+ "thiserror",
  "tokio",
  "tonic",
  "tracing",

--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -8,8 +8,7 @@ use linkerd_app_core::{
     metrics::ControlHttp as Metrics,
     Error,
 };
-use std::future::Future;
-use std::pin::Pin;
+use std::{future::Future, pin::Pin};
 use tracing::Instrument;
 
 // The Disabled case is extraordinarily rare.
@@ -39,6 +38,8 @@ struct Recover(ExponentialBackoff);
 
 pub type Task = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
 
+// === impl Config ===
+
 impl Config {
     pub fn build(self, dns: dns::Resolver, metrics: Metrics) -> Result<Identity, Error> {
         match self {
@@ -55,7 +56,7 @@ impl Config {
                     Box::pin(
                         daemon
                             .run(svc)
-                            .instrument(tracing::debug_span!("identity_daemon", peer.addr = %addr)),
+                            .instrument(tracing::debug_span!("identity", server.addr = %addr)),
                     )
                 };
 
@@ -64,6 +65,8 @@ impl Config {
         }
     }
 }
+
+// === impl Identity ===
 
 impl Identity {
     pub fn local(&self) -> Option<LocalCrtKey> {
@@ -87,6 +90,8 @@ impl Identity {
         }
     }
 }
+
+// === impl Recover ===
 
 impl<E: Into<Error>> linkerd_error::Recover<E> for Recover {
     type Backoff = ExponentialBackoffStream;

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -17,6 +17,7 @@ linkerd-identity = { path = "../../identity" }
 linkerd-metrics = { path = "../../metrics" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }
+thiserror = "1"
 tokio = { version = "1", features = ["time", "sync"] }
 tonic = { version = "0.5", default-features = false }
 tracing = "0.1.26"


### PR DESCRIPTION
Currently, the proxy may start serving connections even before identity
is provisioned. This won't be feasible once we introduce policy
discovery--the proxy will have to establish its inbound policy before
serving inbound connections.

This change modifies proxy initialization to block proxy initialization
on identity. When identity isn't established, warnings are logged every
15s.

While this is a behavior change from the proxy's point of view, this
shouldn't be a user-facing change, as container initialization is
blocked on the proxy's readiness, which is dependent on identity
initialization.