### PR TITLE
policy: Add support for cluster-scoped default policies

### DIFF
--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -378,11 +378,12 @@ mod tests {
                 protocol: Protocol::Detect {
                     timeout: std::time::Duration::from_secs(10),
                 },
-                labels: None.into_iter().collect(),
                 tls: tls::ConditionalServerTls::Some(tls::ServerTls::Established {
                     client_id: Some(client_id()),
                     negotiated_protocol: None,
                 }),
+                server_labels: None.into_iter().collect(),
+                authz_labels: None.into_iter().collect(),
             },
         };
 
@@ -410,11 +411,12 @@ mod tests {
                 protocol: Protocol::Detect {
                     timeout: std::time::Duration::from_secs(10),
                 },
-                labels: None.into_iter().collect(),
                 tls: tls::ConditionalServerTls::Some(tls::ServerTls::Established {
                     client_id: Some(client_id()),
                     negotiated_protocol: None,
                 }),
+                server_labels: None.into_iter().collect(),
+                authz_labels: None.into_iter().collect(),
             },
         };
 
@@ -440,11 +442,12 @@ mod tests {
             orig_dst_addr: orig_dst_addr(),
             permit: Permitted {
                 protocol: Protocol::Http1,
-                labels: None.into_iter().collect(),
                 tls: tls::ConditionalServerTls::Some(tls::ServerTls::Established {
                     client_id: Some(client_id()),
                     negotiated_protocol: None,
                 }),
+                server_labels: None.into_iter().collect(),
+                authz_labels: None.into_iter().collect(),
             },
         };
 
@@ -470,11 +473,12 @@ mod tests {
             orig_dst_addr: orig_dst_addr(),
             permit: Permitted {
                 protocol: Protocol::Http1,
-                labels: None.into_iter().collect(),
                 tls: tls::ConditionalServerTls::Some(tls::ServerTls::Established {
                     client_id: Some(client_id()),
                     negotiated_protocol: None,
                 }),
+                server_labels: None.into_iter().collect(),
+                authz_labels: None.into_iter().collect(),
             },
         };
 
@@ -500,11 +504,12 @@ mod tests {
             orig_dst_addr: orig_dst_addr(),
             permit: Permitted {
                 protocol: Protocol::Http2,
-                labels: None.into_iter().collect(),
                 tls: tls::ConditionalServerTls::Some(tls::ServerTls::Established {
                     client_id: Some(client_id()),
                     negotiated_protocol: None,
                 }),
+                server_labels: None.into_iter().collect(),
+                authz_labels: None.into_iter().collect(),
             },
         };
 

--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -1,53 +1,82 @@
-use linkerd_app_core::{Ipv4Net, Ipv6Net};
+use linkerd_app_core::{IpNet, Ipv4Net, Ipv6Net};
 use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy, Suffix};
 use std::time::Duration;
 
-pub fn all_authenticated(timeout: Duration) -> ServerPolicy {
+fn all_nets() -> impl Iterator<Item = IpNet> {
+    vec![Ipv4Net::default().into(), Ipv6Net::default().into()].into_iter()
+}
+
+pub fn all_authenticated(name: impl Into<String>, timeout: Duration) -> ServerPolicy {
+    authenticated(name, all_nets(), timeout)
+}
+
+pub fn all_unauthenticated(name: impl Into<String>, timeout: Duration) -> ServerPolicy {
+    unauthenticated(name, all_nets(), timeout)
+}
+
+pub fn authenticated(
+    name: impl Into<String>,
+    nets: impl IntoIterator<Item = IpNet>,
+    timeout: Duration,
+) -> ServerPolicy {
     ServerPolicy {
         protocol: Protocol::Detect { timeout },
         authorizations: vec![Authorization {
-            networks: vec![Ipv4Net::default().into(), Ipv6Net::default().into()],
+            networks: nets.into_iter().map(Into::into).collect(),
             authentication: Authentication::TlsAuthenticated {
                 identities: Default::default(),
                 suffixes: vec![Suffix::from(vec![])],
             },
-            labels: Some(("authz".to_string(), "_all-authenticated".to_string()))
-                .into_iter()
-                .collect(),
+            labels: Some((
+                "authorization".to_string(),
+                "default:all-authenticated".to_string(),
+            ))
+            .into_iter()
+            .collect(),
         }],
-        labels: Some(("server".to_string(), "_default".to_string()))
+        labels: Some(("server".to_string(), name.into()))
             .into_iter()
             .collect(),
     }
 }
 
-pub fn all_unauthenticated(timeout: Duration) -> ServerPolicy {
+pub fn unauthenticated(
+    name: impl Into<String>,
+    nets: impl IntoIterator<Item = IpNet>,
+    timeout: Duration,
+) -> ServerPolicy {
     ServerPolicy {
         protocol: Protocol::Detect { timeout },
         authorizations: vec![Authorization {
-            networks: vec![Ipv4Net::default().into(), Ipv6Net::default().into()],
+            networks: nets.into_iter().map(Into::into).collect(),
             authentication: Authentication::Unauthenticated,
-            labels: Some(("authz".to_string(), "_all-unauthenticated".to_string()))
-                .into_iter()
-                .collect(),
+            labels: Some((
+                "authorization".to_string(),
+                "default:all-unauthenticated".to_string(),
+            ))
+            .into_iter()
+            .collect(),
         }],
-        labels: Some(("server".to_string(), "_default".to_string()))
+        labels: Some(("server".to_string(), name.into()))
             .into_iter()
             .collect(),
     }
 }
 
-pub fn all_mtls_unauthenticated(timeout: Duration) -> ServerPolicy {
+pub fn all_mtls_unauthenticated(name: impl Into<String>, timeout: Duration) -> ServerPolicy {
     ServerPolicy {
         protocol: Protocol::Detect { timeout },
         authorizations: vec![Authorization {
-            networks: vec![Ipv4Net::default().into(), Ipv6Net::default().into()],
+            networks: all_nets().map(Into::into).collect(),
             authentication: Authentication::TlsUnauthenticated,
-            labels: Some(("authz".to_string(), "_all-unauthenticated-tls".to_string()))
-                .into_iter()
-                .collect(),
+            labels: Some((
+                "authorization".to_string(),
+                "default:all-tls-unauthenticated".to_string(),
+            ))
+            .into_iter()
+            .collect(),
         }],
-        labels: Some(("server".to_string(), "_default".to_string()))
+        labels: Some(("server".to_string(), name.into()))
             .into_iter()
             .collect(),
     }

--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -1,89 +1,86 @@
 use linkerd_app_core::{IpNet, Ipv4Net, Ipv6Net};
 use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy, Suffix};
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 pub fn all_authenticated(timeout: Duration) -> ServerPolicy {
-    authenticated("default:all-authenticated", all_nets(), timeout)
+    mk(
+        "default:all-authenticated",
+        all_nets(),
+        authenticated(),
+        timeout,
+    )
 }
 
 pub fn all_unauthenticated(timeout: Duration) -> ServerPolicy {
-    unauthenticated("default:all-unauthenticated", all_nets(), timeout)
+    mk(
+        "default:all-unauthenticated",
+        all_nets(),
+        Authentication::Unauthenticated,
+        timeout,
+    )
 }
 
 pub fn cluster_authenticated(
     nets: impl IntoIterator<Item = IpNet>,
     timeout: Duration,
 ) -> ServerPolicy {
-    authenticated("default:cluster-authenticated", nets, timeout)
+    mk(
+        "default:cluster-authenticated",
+        nets,
+        authenticated(),
+        timeout,
+    )
 }
 
 pub fn cluster_unauthenticated(
     nets: impl IntoIterator<Item = IpNet>,
     timeout: Duration,
 ) -> ServerPolicy {
-    unauthenticated("default:cluster-unauthenticated", nets, timeout)
+    mk(
+        "default:cluster-unauthenticated",
+        nets,
+        Authentication::Unauthenticated,
+        timeout,
+    )
 }
 
 pub fn all_mtls_unauthenticated(timeout: Duration) -> ServerPolicy {
-    ServerPolicy {
-        protocol: Protocol::Detect { timeout },
-        authorizations: vec![Authorization {
-            networks: all_nets().map(Into::into).collect(),
-            authentication: Authentication::TlsUnauthenticated,
-            labels: Some((
-                "name".to_string(),
-                "default:all-tls-unauthenticated".to_string(),
-            ))
-            .into_iter()
-            .collect(),
-        }],
-        labels: Some(("name".to_string(), "default:all-tls-unauthenticated".into()))
-            .into_iter()
-            .collect(),
-    }
+    mk(
+        "default:all-tls-unauthenticated",
+        all_nets(),
+        Authentication::TlsUnauthenticated,
+        timeout,
+    )
 }
 
 fn all_nets() -> impl Iterator<Item = IpNet> {
     vec![Ipv4Net::default().into(), Ipv6Net::default().into()].into_iter()
 }
 
-fn authenticated(
-    name: impl Into<String>,
-    nets: impl IntoIterator<Item = IpNet>,
-    timeout: Duration,
-) -> ServerPolicy {
-    let name = name.into();
-    ServerPolicy {
-        protocol: Protocol::Detect { timeout },
-        authorizations: vec![Authorization {
-            networks: nets.into_iter().map(Into::into).collect(),
-            authentication: Authentication::TlsAuthenticated {
-                identities: Default::default(),
-                suffixes: vec![Suffix::from(vec![])],
-            },
-            labels: Some(("name".to_string(), name.clone()))
-                .into_iter()
-                .collect(),
-        }],
-        labels: Some(("name".to_string(), name)).into_iter().collect(),
+fn authenticated() -> Authentication {
+    Authentication::TlsAuthenticated {
+        identities: Default::default(),
+        suffixes: vec![Suffix::from(vec![])],
     }
 }
 
-fn unauthenticated(
-    name: impl Into<String>,
+fn mk(
+    name: &str,
     nets: impl IntoIterator<Item = IpNet>,
+    authentication: Authentication,
     timeout: Duration,
 ) -> ServerPolicy {
-    let name = name.into();
+    let labels = Some(("name".to_string(), name.to_string()))
+        .into_iter()
+        .collect::<HashMap<_, _>>();
+
     ServerPolicy {
         protocol: Protocol::Detect { timeout },
         authorizations: vec![Authorization {
             networks: nets.into_iter().map(Into::into).collect(),
-            authentication: Authentication::Unauthenticated,
-            labels: Some(("name".to_string(), name.clone()))
-                .into_iter()
-                .collect(),
+            authentication,
+            labels: labels.clone(),
         }],
-        labels: Some(("name".to_string(), name)).into_iter().collect(),
+        labels,
     }
 }

--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -27,14 +27,11 @@ pub fn authenticated(
                 identities: Default::default(),
                 suffixes: vec![Suffix::from(vec![])],
             },
-            labels: Some((
-                "authorization".to_string(),
-                "default:all-authenticated".to_string(),
-            ))
-            .into_iter()
-            .collect(),
+            labels: Some(("name".to_string(), "default:all-authenticated".to_string()))
+                .into_iter()
+                .collect(),
         }],
-        labels: Some(("server".to_string(), name.into()))
+        labels: Some(("name".to_string(), name.into()))
             .into_iter()
             .collect(),
     }
@@ -51,13 +48,13 @@ pub fn unauthenticated(
             networks: nets.into_iter().map(Into::into).collect(),
             authentication: Authentication::Unauthenticated,
             labels: Some((
-                "authorization".to_string(),
+                "name".to_string(),
                 "default:all-unauthenticated".to_string(),
             ))
             .into_iter()
             .collect(),
         }],
-        labels: Some(("server".to_string(), name.into()))
+        labels: Some(("name".to_string(), name.into()))
             .into_iter()
             .collect(),
     }
@@ -70,13 +67,13 @@ pub fn all_mtls_unauthenticated(name: impl Into<String>, timeout: Duration) -> S
             networks: all_nets().map(Into::into).collect(),
             authentication: Authentication::TlsUnauthenticated,
             labels: Some((
-                "authorization".to_string(),
+                "name".to_string(),
                 "default:all-tls-unauthenticated".to_string(),
             ))
             .into_iter()
             .collect(),
         }],
-        labels: Some(("server".to_string(), name.into()))
+        labels: Some(("name".to_string(), name.into()))
             .into_iter()
             .collect(),
     }

--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -1,6 +1,8 @@
 use linkerd_app_core::{IpNet, Ipv4Net, Ipv6Net};
-use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy, Suffix};
-use std::{collections::HashMap, time::Duration};
+use linkerd_server_policy::{
+    Authentication, Authorization, Labels, Protocol, ServerPolicy, Suffix,
+};
+use std::time::Duration;
 
 pub fn all_authenticated(timeout: Duration) -> ServerPolicy {
     mk(
@@ -72,7 +74,7 @@ fn mk(
 ) -> ServerPolicy {
     let labels = Some(("name".to_string(), name.to_string()))
         .into_iter()
-        .collect::<HashMap<_, _>>();
+        .collect::<Labels>();
 
     ServerPolicy {
         protocol: Protocol::Detect { timeout },

--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -2,65 +2,29 @@ use linkerd_app_core::{IpNet, Ipv4Net, Ipv6Net};
 use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy, Suffix};
 use std::time::Duration;
 
-fn all_nets() -> impl Iterator<Item = IpNet> {
-    vec![Ipv4Net::default().into(), Ipv6Net::default().into()].into_iter()
+pub fn all_authenticated(timeout: Duration) -> ServerPolicy {
+    authenticated("default:all-authenticated", all_nets(), timeout)
 }
 
-pub fn all_authenticated(name: impl Into<String>, timeout: Duration) -> ServerPolicy {
-    authenticated(name, all_nets(), timeout)
+pub fn all_unauthenticated(timeout: Duration) -> ServerPolicy {
+    unauthenticated("default:all-unauthenticated", all_nets(), timeout)
 }
 
-pub fn all_unauthenticated(name: impl Into<String>, timeout: Duration) -> ServerPolicy {
-    unauthenticated(name, all_nets(), timeout)
-}
-
-pub fn authenticated(
-    name: impl Into<String>,
+pub fn cluster_authenticated(
     nets: impl IntoIterator<Item = IpNet>,
     timeout: Duration,
 ) -> ServerPolicy {
-    ServerPolicy {
-        protocol: Protocol::Detect { timeout },
-        authorizations: vec![Authorization {
-            networks: nets.into_iter().map(Into::into).collect(),
-            authentication: Authentication::TlsAuthenticated {
-                identities: Default::default(),
-                suffixes: vec![Suffix::from(vec![])],
-            },
-            labels: Some(("name".to_string(), "default:all-authenticated".to_string()))
-                .into_iter()
-                .collect(),
-        }],
-        labels: Some(("name".to_string(), name.into()))
-            .into_iter()
-            .collect(),
-    }
+    authenticated("default:cluster-authenticated", nets, timeout)
 }
 
-pub fn unauthenticated(
-    name: impl Into<String>,
+pub fn cluster_unauthenticated(
     nets: impl IntoIterator<Item = IpNet>,
     timeout: Duration,
 ) -> ServerPolicy {
-    ServerPolicy {
-        protocol: Protocol::Detect { timeout },
-        authorizations: vec![Authorization {
-            networks: nets.into_iter().map(Into::into).collect(),
-            authentication: Authentication::Unauthenticated,
-            labels: Some((
-                "name".to_string(),
-                "default:all-unauthenticated".to_string(),
-            ))
-            .into_iter()
-            .collect(),
-        }],
-        labels: Some(("name".to_string(), name.into()))
-            .into_iter()
-            .collect(),
-    }
+    unauthenticated("default:cluster-unauthenticated", nets, timeout)
 }
 
-pub fn all_mtls_unauthenticated(name: impl Into<String>, timeout: Duration) -> ServerPolicy {
+pub fn all_mtls_unauthenticated(timeout: Duration) -> ServerPolicy {
     ServerPolicy {
         protocol: Protocol::Detect { timeout },
         authorizations: vec![Authorization {
@@ -73,8 +37,53 @@ pub fn all_mtls_unauthenticated(name: impl Into<String>, timeout: Duration) -> S
             .into_iter()
             .collect(),
         }],
-        labels: Some(("name".to_string(), name.into()))
+        labels: Some(("name".to_string(), "default:all-tls-unauthenticated".into()))
             .into_iter()
             .collect(),
+    }
+}
+
+fn all_nets() -> impl Iterator<Item = IpNet> {
+    vec![Ipv4Net::default().into(), Ipv6Net::default().into()].into_iter()
+}
+
+fn authenticated(
+    name: impl Into<String>,
+    nets: impl IntoIterator<Item = IpNet>,
+    timeout: Duration,
+) -> ServerPolicy {
+    let name = name.into();
+    ServerPolicy {
+        protocol: Protocol::Detect { timeout },
+        authorizations: vec![Authorization {
+            networks: nets.into_iter().map(Into::into).collect(),
+            authentication: Authentication::TlsAuthenticated {
+                identities: Default::default(),
+                suffixes: vec![Suffix::from(vec![])],
+            },
+            labels: Some(("name".to_string(), name.clone()))
+                .into_iter()
+                .collect(),
+        }],
+        labels: Some(("name".to_string(), name)).into_iter().collect(),
+    }
+}
+
+fn unauthenticated(
+    name: impl Into<String>,
+    nets: impl IntoIterator<Item = IpNet>,
+    timeout: Duration,
+) -> ServerPolicy {
+    let name = name.into();
+    ServerPolicy {
+        protocol: Protocol::Detect { timeout },
+        authorizations: vec![Authorization {
+            networks: nets.into_iter().map(Into::into).collect(),
+            authentication: Authentication::Unauthenticated,
+            labels: Some(("name".to_string(), name.clone()))
+                .into_iter()
+                .collect(),
+        }],
+        labels: Some(("name".to_string(), name)).into_iter().collect(),
     }
 }

--- a/linkerd/app/inbound/src/policy/discover.rs
+++ b/linkerd/app/inbound/src/policy/discover.rs
@@ -162,7 +162,7 @@ fn to_policy(proto: api::Server) -> Result<ServerPolicy> {
                 Ok(Authorization {
                     networks,
                     authentication: authn,
-                    labels,
+                    labels: labels.into_iter().collect(),
                 })
             },
         )
@@ -171,7 +171,7 @@ fn to_policy(proto: api::Server) -> Result<ServerPolicy> {
     Ok(ServerPolicy {
         protocol,
         authorizations,
-        labels: proto.labels,
+        labels: proto.labels.into_iter().collect(),
     })
 }
 

--- a/linkerd/app/inbound/src/policy/tests.rs
+++ b/linkerd/app/inbound/src/policy/tests.rs
@@ -9,11 +9,11 @@ fn unauthenticated_allowed() {
         authorizations: vec![Authorization {
             authentication: Authentication::Unauthenticated,
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            labels: vec![("authz".to_string(), "unauth".to_string())]
+            labels: vec![("name".to_string(), "unauth".to_string())]
                 .into_iter()
                 .collect(),
         }],
-        labels: vec![("server".to_string(), "test".to_string())]
+        labels: vec![("name".to_string(), "test".to_string())]
             .into_iter()
             .collect(),
     };
@@ -33,12 +33,12 @@ fn unauthenticated_allowed() {
         Permitted {
             tls,
             protocol: policy.protocol,
-            labels: vec![
-                ("authz".to_string(), "unauth".to_string()),
-                ("server".to_string(), "test".to_string())
-            ]
-            .into_iter()
-            .collect()
+            server_labels: vec![("name".to_string(), "test".to_string())]
+                .into_iter()
+                .collect(),
+            authz_labels: vec![("name".to_string(), "unauth".to_string()),]
+                .into_iter()
+                .collect()
         }
     );
 }
@@ -53,11 +53,11 @@ fn authenticated_identity() {
                 identities: vec![client_id().to_string()].into_iter().collect(),
             },
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            labels: vec![("authz".to_string(), "tls-auth".to_string())]
+            labels: vec![("name".to_string(), "tls-auth".to_string())]
                 .into_iter()
                 .collect(),
         }],
-        labels: vec![("server".to_string(), "test".to_string())]
+        labels: vec![("name".to_string(), "test".to_string())]
             .into_iter()
             .collect(),
     };
@@ -80,12 +80,12 @@ fn authenticated_identity() {
         Permitted {
             tls,
             protocol: policy.protocol,
-            labels: vec![
-                ("authz".to_string(), "tls-auth".to_string()),
-                ("server".to_string(), "test".to_string())
-            ]
-            .into_iter()
-            .collect()
+            server_labels: vec![("name".to_string(), "test".to_string())]
+                .into_iter()
+                .collect(),
+            authz_labels: vec![("name".to_string(), "tls-auth".to_string()),]
+                .into_iter()
+                .collect()
         }
     );
 
@@ -115,11 +115,11 @@ fn authenticated_suffix() {
                 ])],
             },
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            labels: vec![("authz".to_string(), "tls-auth".to_string())]
+            labels: vec![("name".to_string(), "tls-auth".to_string())]
                 .into_iter()
                 .collect(),
         }],
-        labels: vec![("server".to_string(), "test".to_string())]
+        labels: vec![("name".to_string(), "test".to_string())]
             .into_iter()
             .collect(),
     };
@@ -141,12 +141,12 @@ fn authenticated_suffix() {
         Permitted {
             tls,
             protocol: policy.protocol,
-            labels: vec![
-                ("authz".to_string(), "tls-auth".to_string()),
-                ("server".to_string(), "test".to_string())
-            ]
-            .into_iter()
-            .collect()
+            server_labels: vec![("name".to_string(), "test".to_string())]
+                .into_iter()
+                .collect(),
+            authz_labels: vec![("name".to_string(), "tls-auth".to_string()),]
+                .into_iter()
+                .collect()
         }
     );
 
@@ -170,11 +170,11 @@ fn tls_unauthenticated() {
         authorizations: vec![Authorization {
             authentication: Authentication::TlsUnauthenticated,
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            labels: vec![("authz".to_string(), "tls-unauth".to_string())]
+            labels: vec![("name".to_string(), "tls-unauth".to_string())]
                 .into_iter()
                 .collect(),
         }],
-        labels: vec![("server".to_string(), "test".to_string())]
+        labels: vec![("name".to_string(), "test".to_string())]
             .into_iter()
             .collect(),
     };
@@ -196,12 +196,12 @@ fn tls_unauthenticated() {
         Permitted {
             tls,
             protocol: policy.protocol,
-            labels: vec![
-                ("authz".to_string(), "tls-unauth".to_string()),
-                ("server".to_string(), "test".to_string())
-            ]
-            .into_iter()
-            .collect()
+            server_labels: vec![("name".to_string(), "test".to_string())]
+                .into_iter()
+                .collect(),
+            authz_labels: vec![("name".to_string(), "tls-unauth".to_string()),]
+                .into_iter()
+                .collect()
         }
     );
 

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -17,7 +17,7 @@ pub struct ServerPolicy {
     pub labels: Labels,
 }
 
-/// Stores an ordered, cloneeable set of labels.
+/// Stores an ordered, cloneable set of labels.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Labels(Arc<BTreeMap<String, String>>);
 


### PR DESCRIPTION
The policy controller supports the default policies
`cluster-authenticated` and `cluster-unauthenticated` but the proxy
would error if configured with these policies. In order to use a single
policy annotation honored by both the policy controller and proxy, this
change adds support for a new configuration,
`LINKERD2_POLICY_CLUSTER_NETWORKS`, that allows the proxy to enforce
cluster-scoped defaults. When this configuration is not specified, the
cluster-scoped defaults are not supported.

This default will apply to all ports that are not documented in the
pod's spec (i.e. ports not in the `LINKERD2_PROXY_INBOUND_PORTS`
configuration).

This change also updates policy labeling to track server and authz labels
independently so that keys may overlap, as is required by https://github.com/linkerd/linkerd2/pull/6722