### PR TITLE
Use `ExtractParam` in transport metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,20 +1238,13 @@ dependencies = [
 name = "linkerd-proxy-transport"
 version = "0.1.0"
 dependencies = [
- "bytes",
  "futures",
  "libc",
- "linkerd-errno",
- "linkerd-error",
  "linkerd-io",
- "linkerd-metrics",
  "linkerd-stack",
- "parking_lot",
- "pin-project",
  "socket2 0.4.1",
  "tokio",
  "tokio-stream",
- "tower",
  "tracing",
 ]
 
@@ -1486,7 +1479,6 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-errno",
- "linkerd-error",
  "linkerd-io",
  "linkerd-metrics",
  "linkerd-stack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,7 @@ dependencies = [
  "linkerd-trace-context",
  "linkerd-tracing",
  "linkerd-transport-header",
+ "linkerd-transport-metrics",
  "parking_lot",
  "pin-project",
  "quickcheck",
@@ -1476,6 +1477,21 @@ dependencies = [
  "prost-build",
  "tokio",
  "tokio-test",
+ "tracing",
+]
+
+[[package]]
+name = "linkerd-transport-metrics"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "linkerd-errno",
+ "linkerd-error",
+ "linkerd-io",
+ "linkerd-metrics",
+ "linkerd-stack",
+ "parking_lot",
+ "pin-project",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ members = [
     "linkerd/cache",
     "linkerd/conditional",
     "linkerd/detect",
-    "linkerd/transport-header",
     "linkerd/dns/name",
     "linkerd/dns",
     "linkerd/duplex",
@@ -57,6 +56,8 @@ members = [
     "linkerd/tonic-watch",
     "linkerd/tls",
     "linkerd/tracing",
+    "linkerd/transport-header",
+    "linkerd/transport-metrics",
     "linkerd2-proxy",
     "opencensus-proto",
 ]

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -130,7 +130,7 @@ impl Config {
             )
             .push(svc::BoxNewService::layer())
             .push(detect::NewDetectService::layer(detect::Config::<http::DetectHttp>::from_timeout(DETECT_TIMEOUT)))
-            .push(metrics.transport.layer_accept())
+            .push(transport::metrics::NewServer::layer(metrics.transport))
             .push_map_target(|(tls, addrs): (tls::ConditionalServerTls, B::Addrs)| {
                 Tcp {
                     tls,

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -37,7 +37,6 @@ linkerd-http-retry = { path = "../../http-retry" }
 linkerd-identity = { path = "../../identity" }
 linkerd-io = { path = "../../io" }
 linkerd-metrics = { path = "../../metrics", features = ["linkerd-stack"] }
-linkerd-transport-header = { path = "../../transport-header" }
 linkerd-opencensus = { path = "../../opencensus" }
 linkerd-proxy-core = { path = "../../proxy/core" }
 linkerd-proxy-api-resolve = { path = "../../proxy/api-resolve" }
@@ -53,6 +52,8 @@ linkerd-reconnect = { path = "../../reconnect" }
 linkerd-retry = { path = "../../retry" }
 linkerd-timeout = { path = "../../timeout" }
 linkerd-tracing = { path = "../../tracing" }
+linkerd-transport-header = { path = "../../transport-header" }
+linkerd-transport-metrics = { path = "../../transport-metrics" }
 linkerd-service-profiles = { path = "../../service-profiles" }
 linkerd-stack = { path = "../../stack" }
 linkerd-stack-metrics = { path = "../../stack/metrics" }

--- a/linkerd/app/core/src/metrics/mod.rs
+++ b/linkerd/app/core/src/metrics/mod.rs
@@ -173,7 +173,7 @@ impl Metrics {
                 http_route_retry: http_route_retry.clone(),
                 http_errors: http_errors.inbound(),
                 stack: stack.clone(),
-                transport: transport.clone(),
+                transport: transport.clone().into(),
                 tcp_accept_errors: inbound_tcp_accept_errors.clone(),
             },
             outbound: Proxy {
@@ -183,7 +183,7 @@ impl Metrics {
                 http_route_actual,
                 http_errors: http_errors.outbound(),
                 stack: stack.clone(),
-                transport,
+                transport: transport.into(),
                 tcp_accept_errors: outbound_tcp_accept_errors.clone(),
             },
             control,

--- a/linkerd/app/core/src/transport/mod.rs
+++ b/linkerd/app/core/src/transport/mod.rs
@@ -1,6 +1,29 @@
 pub use linkerd_proxy_transport::*;
+use linkerd_stack::{ExtractParam, Param};
 pub use linkerd_transport_metrics as metrics;
+use std::sync::Arc;
 
 pub mod labels;
 
-pub type Metrics = metrics::Registry<labels::Key>;
+#[derive(Clone, Debug)]
+pub struct Metrics(metrics::Registry<labels::Key>);
+
+impl From<metrics::Registry<labels::Key>> for Metrics {
+    fn from(reg: metrics::Registry<labels::Key>) -> Self {
+        Self(reg)
+    }
+}
+
+impl<T: Param<labels::Key>> ExtractParam<Arc<metrics::Metrics>, T> for Metrics {
+    fn extract_param(&self, t: &T) -> Arc<metrics::Metrics> {
+        self.0.metrics(t.param())
+    }
+}
+
+impl std::ops::Deref for Metrics {
+    type Target = metrics::Registry<labels::Key>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/linkerd/app/core/src/transport/mod.rs
+++ b/linkerd/app/core/src/transport/mod.rs
@@ -19,11 +19,3 @@ impl<T: Param<labels::Key>> ExtractParam<Arc<metrics::Metrics>, T> for Metrics {
         self.0.metrics(t.param())
     }
 }
-
-impl std::ops::Deref for Metrics {
-    type Target = metrics::Registry<labels::Key>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}

--- a/linkerd/app/core/src/transport/mod.rs
+++ b/linkerd/app/core/src/transport/mod.rs
@@ -1,4 +1,5 @@
 pub use linkerd_proxy_transport::*;
+pub use linkerd_transport_metrics as metrics;
 
 pub mod labels;
 

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -201,7 +201,7 @@ impl<N> Inbound<N> {
                         .push_map_target(detect::allow_timeout)
                         .push(detect::NewDetectService::layer(ConfigureHttpDetect)),
                 )
-                .push(rt.metrics.transport.layer_accept())
+                .push((&*rt.metrics.transport).layer_accept())
                 .push_on_response(svc::BoxService::layer())
                 .push(svc::BoxNewService::layer())
         })

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -201,7 +201,9 @@ impl<N> Inbound<N> {
                         .push_map_target(detect::allow_timeout)
                         .push(detect::NewDetectService::layer(ConfigureHttpDetect)),
                 )
-                .push((&*rt.metrics.transport).layer_accept())
+                .push(transport::metrics::NewServer::layer(
+                    rt.metrics.transport.clone(),
+                ))
                 .push_on_response(svc::BoxService::layer())
                 .push(svc::BoxNewService::layer())
         })

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -205,7 +205,9 @@ impl<N> Inbound<N> {
                         .instrument(|_: &GatewayConnection| info_span!("gateway", legacy = true))
                         .into_inner(),
                 )
-                .push(rt.metrics.transport.layer_accept())
+                .push(transport::metrics::NewServer::layer(
+                    rt.metrics.transport.clone(),
+                ))
                 // Build a ClientInfo target for each accepted connection. Refuse the
                 // connection if it doesn't include an mTLS identity.
                 .push_request_filter(ClientInfo::try_from)

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -81,7 +81,7 @@ impl<C> Inbound<C> {
             // Creates HTTP clients for each inbound port & HTTP settings.
             let http = connect
                 .push(svc::stack::BoxFuture::layer())
-                .push(rt.metrics.transport.layer_connect())
+                .push(transport::metrics::Connect::layer(rt.metrics.transport.clone()))
                 .push(http::client::layer(
                     config.proxy.connect.h1_settings,
                     config.proxy.connect.h2_settings,

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -81,7 +81,7 @@ impl<C> Inbound<C> {
             // Creates HTTP clients for each inbound port & HTTP settings.
             let http = connect
                 .push(svc::stack::BoxFuture::layer())
-                .push(transport::metrics::Connect::layer(rt.metrics.transport.clone()))
+                .push(transport::metrics::Client::layer(rt.metrics.transport.clone()))
                 .push(http::client::layer(
                     config.proxy.connect.h1_settings,
                     config.proxy.connect.h2_settings,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -160,8 +160,11 @@ impl<S> Inbound<S> {
         S::Error: Into<Error>,
         S::Future: Send,
     {
-        self.map_stack(|_, rt, conn| {
-            conn.push(rt.metrics.transport.layer_connect())
+        self.map_stack(|_, rt, connect| {
+            connect
+                .push(transport::metrics::Connect::layer(
+                    rt.metrics.transport.clone(),
+                ))
                 .push_make_thunk()
                 .push_on_response(
                     svc::layers()

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -162,7 +162,7 @@ impl<S> Inbound<S> {
     {
         self.map_stack(|_, rt, connect| {
             connect
-                .push(transport::metrics::Connect::layer(
+                .push(transport::metrics::Client::layer(
                     rt.metrics.transport.clone(),
                 ))
                 .push_make_thunk()

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -2,7 +2,7 @@ use crate::{tcp, Outbound};
 use linkerd_app_core::{
     io, profiles,
     svc::{self, stack::Param},
-    transport::{metrics::SensorIo, OrigDstAddr},
+    transport::{self, metrics::SensorIo, OrigDstAddr},
     Error,
 };
 use std::convert::TryFrom;
@@ -72,7 +72,9 @@ impl<N> Outbound<N> {
                         ))
                         .push_spawn_buffer(config.proxy.buffer_capacity),
                 )
-                .push((&*rt.metrics.transport).layer_accept())
+                .push(transport::metrics::NewServer::layer(
+                    rt.metrics.transport.clone(),
+                ))
                 .push_cache(config.proxy.cache_max_idle_age)
                 .instrument(|a: &tcp::Accept| info_span!("server", orig_dst = %a.orig_dst))
                 .push_request_filter(|t: T| tcp::Accept::try_from(t.param()))

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -72,7 +72,7 @@ impl<N> Outbound<N> {
                         ))
                         .push_spawn_buffer(config.proxy.buffer_capacity),
                 )
-                .push(rt.metrics.transport.layer_accept())
+                .push((&*rt.metrics.transport).layer_accept())
                 .push_cache(config.proxy.cache_max_idle_age)
                 .instrument(|a: &tcp::Accept| info_span!("server", orig_dst = %a.orig_dst))
                 .push_request_filter(|t: T| tcp::Accept::try_from(t.param()))

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -8,7 +8,7 @@ use linkerd_app_core::{
     },
     svc::{self, stack::Param},
     tls,
-    transport::{OrigDstAddr, Remote, ServerAddr},
+    transport::{self, OrigDstAddr, Remote, ServerAddr},
     AddrMatch, Error, Infallible, NameAddr,
 };
 use thiserror::Error;
@@ -220,7 +220,9 @@ impl Outbound<svc::BoxNewHttp<http::Endpoint>> {
             .push_map_target(detect::allow_timeout)
             .push(svc::BoxNewService::layer())
             .push(detect::NewDetectService::layer(detect_http))
-            .push(rt.metrics.transport.layer_accept())
+            .push(transport::metrics::NewServer::layer(
+                rt.metrics.transport.clone(),
+            ))
             .instrument(|a: &tcp::Accept| info_span!("ingress", orig_dst = %a.orig_dst))
             .push_map_target(|a: T| {
                 let orig_dst = Param::<OrigDstAddr>::param(&a);

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -68,7 +68,7 @@ impl<C> Outbound<C> {
                 // Limits the time we wait for a connection to be established.
                 .push_timeout(config.proxy.connect.timeout)
                 .push(svc::stack::BoxFuture::layer())
-                .push(transport::metrics::Connect::layer(
+                .push(transport::metrics::Client::layer(
                     rt.metrics.transport.clone(),
                 ))
         })

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -68,7 +68,9 @@ impl<C> Outbound<C> {
                 // Limits the time we wait for a connection to be established.
                 .push_timeout(config.proxy.connect.timeout)
                 .push(svc::stack::BoxFuture::layer())
-                .push(rt.metrics.transport.layer_connect())
+                .push(transport::metrics::Connect::layer(
+                    rt.metrics.transport.clone(),
+                ))
         })
     }
 

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -10,19 +10,12 @@ Transport-level implementations that rely on core proxy infrastructure
 """
 
 [dependencies]
-bytes = "1"
 futures = { version = "0.3", default-features = false }
-linkerd-errno = { path = "../../errno" }
-linkerd-error = { path = "../../error" }
 linkerd-io = { path = "../../io" }
-linkerd-metrics = { path = "../../metrics", features = ["linkerd-stack"] }
 linkerd-stack = { path = "../../stack" }
-parking_lot = "0.11"
-pin-project = "1"
 socket2 = "0.4"
 tokio = { version = "1", features = ["macros", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tower = { version = "0.4", features = ["make"] }
 tracing = "0.1.26"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/linkerd/proxy/transport/src/connect.rs
+++ b/linkerd/proxy/transport/src/connect.rs
@@ -1,6 +1,6 @@
 use crate::{Keepalive, Remote, ServerAddr};
 use linkerd_io as io;
-use linkerd_stack::Param;
+use linkerd_stack::{Param, Service};
 use std::{
     future::Future,
     pin::Pin,
@@ -20,7 +20,7 @@ impl ConnectTcp {
     }
 }
 
-impl<T: Param<Remote<ServerAddr>>> tower::Service<T> for ConnectTcp {
+impl<T: Param<Remote<ServerAddr>>> Service<T> for ConnectTcp {
     type Response = io::ScopedIo<TcpStream>;
     type Error = io::Error;
     type Future =

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -8,7 +8,6 @@
 pub mod addrs;
 mod connect;
 pub mod listen;
-pub mod metrics;
 pub mod orig_dst;
 
 pub use self::{

--- a/linkerd/transport-metrics/Cargo.toml
+++ b/linkerd/transport-metrics/Cargo.toml
@@ -10,7 +10,6 @@ description = """Transport-level metrics"""
 [dependencies]
 futures = { version = "0.3", default-features = false }
 linkerd-errno = { path = "../errno" }
-linkerd-error = { path = "../error" }
 linkerd-io = { path = "../io" }
 linkerd-metrics = { path = "../metrics" }
 linkerd-stack = { path = "../stack" }

--- a/linkerd/transport-metrics/Cargo.toml
+++ b/linkerd/transport-metrics/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "linkerd-transport-metrics"
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+license = "Apache-2.0"
+edition = "2018"
+publish = false
+description = """Transport-level metrics"""
+
+[dependencies]
+futures = { version = "0.3", default-features = false }
+linkerd-errno = { path = "../errno" }
+linkerd-error = { path = "../error" }
+linkerd-io = { path = "../io" }
+linkerd-metrics = { path = "../metrics", features = ["linkerd-stack"] }
+linkerd-stack = { path = "../stack" }
+parking_lot = "0.11"
+pin-project = "1"
+tracing = "0.1.26"

--- a/linkerd/transport-metrics/Cargo.toml
+++ b/linkerd/transport-metrics/Cargo.toml
@@ -12,7 +12,7 @@ futures = { version = "0.3", default-features = false }
 linkerd-errno = { path = "../errno" }
 linkerd-error = { path = "../error" }
 linkerd-io = { path = "../io" }
-linkerd-metrics = { path = "../metrics", features = ["linkerd-stack"] }
+linkerd-metrics = { path = "../metrics" }
 linkerd-stack = { path = "../stack" }
 parking_lot = "0.11"
 pin-project = "1"

--- a/linkerd/transport-metrics/src/client.rs
+++ b/linkerd/transport-metrics/src/client.rs
@@ -1,0 +1,78 @@
+use super::{Metrics, Sensor, SensorIo};
+use futures::{ready, TryFuture};
+use linkerd_stack::{layer, ExtractParam, Service};
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tracing::debug;
+
+#[derive(Clone, Debug)]
+pub struct Client<P, S> {
+    inner: S,
+    params: P,
+}
+
+#[pin_project]
+pub struct Connect<F> {
+    #[pin]
+    inner: F,
+    metrics: Option<Arc<Metrics>>,
+}
+
+// === impl Client ===
+
+impl<P: Clone, S> Client<P, S> {
+    pub fn layer(params: P) -> impl layer::Layer<S, Service = Self> + Clone {
+        layer::mk(move |inner| Self {
+            inner,
+            params: params.clone(),
+        })
+    }
+}
+
+impl<T, P, S> Service<T> for Client<P, S>
+where
+    P: ExtractParam<Arc<Metrics>, T>,
+    S: Service<T>,
+{
+    type Response = SensorIo<S::Response>;
+    type Error = S::Error;
+    type Future = Connect<S::Future>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, target: T) -> Self::Future {
+        let metrics = self.params.extract_param(&target);
+        let inner = self.inner.call(target);
+        Connect {
+            metrics: Some(metrics),
+            inner,
+        }
+    }
+}
+
+// === impl Connect ===
+
+impl<F: TryFuture> Future for Connect<F> {
+    type Output = Result<SensorIo<F::Ok>, F::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let io = ready!(this.inner.try_poll(cx))?;
+        debug!("client connection open");
+
+        let metrics = this
+            .metrics
+            .take()
+            .expect("future must not be polled after ready");
+        let t = SensorIo::new(io, Sensor::open(metrics));
+        Poll::Ready(Ok(t))
+    }
+}

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -60,7 +60,7 @@ struct ByEos {
     metrics: HashMap<Eos, EosMetrics>,
 }
 
-/// Describes a classtransport end.
+/// Describes a class of transport end.
 ///
 /// An `EosMetrics` type exists for each unique `Key` and `Eos` pair.
 ///

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -10,11 +10,10 @@ pub use self::{
     client::Client,
     report::Report,
     sensor::{Sensor, SensorIo},
-    server::{NewServer, Server},
+    server::NewServer,
 };
 use linkerd_errno::Errno;
 use linkerd_metrics::{metrics, Counter, FmtLabels, Gauge, LastUpdate, Store};
-use linkerd_stack::{layer, NewService};
 use parking_lot::Mutex;
 use std::{
     collections::HashMap,
@@ -78,15 +77,6 @@ struct EosMetrics {
 // === impl Registry ===
 
 impl<K: Eq + Hash + FmtLabels> Registry<K> {
-    pub fn layer_accept<M, T>(
-        &self,
-    ) -> impl layer::Layer<M, Service = NewServer<M, K, M::Service>> + Clone
-    where
-        M: NewService<T>,
-    {
-        NewServer::layer(self.0.clone())
-    }
-
     pub fn metrics(&self, labels: K) -> Arc<Metrics> {
         self.0.lock().get_or_default(labels).clone()
     }

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -1,27 +1,28 @@
 #![deny(warnings, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
-use futures::{ready, TryFuture};
-use linkerd_errno::Errno;
-use linkerd_io as io;
-use linkerd_metrics::{
-    metrics, Counter, FmtLabels, FmtMetric, FmtMetrics, Gauge, LastUpdate, Metric, NewMetrics,
-    Store,
+mod client;
+mod report;
+mod sensor;
+mod server;
+
+pub use self::{
+    client::Client,
+    report::Report,
+    sensor::{Sensor, SensorIo},
+    server::{NewServer, Server},
 };
-use linkerd_stack::{layer, ExtractParam, NewService, Service};
+use linkerd_errno::Errno;
+use linkerd_metrics::{metrics, Counter, FmtLabels, Gauge, LastUpdate, Store};
+use linkerd_stack::{layer, NewService};
 use parking_lot::Mutex;
-use pin_project::pin_project;
 use std::{
     collections::HashMap,
     fmt,
-    future::Future,
     hash::Hash,
-    pin::Pin,
     sync::Arc,
-    task::{Context, Poll},
     time::{Duration, Instant},
 };
-use tracing::debug;
 
 metrics! {
     tcp_open_total: Counter { "Total count of opened connections" },
@@ -34,45 +35,14 @@ metrics! {
 
 pub fn new<K: Eq + Hash + FmtLabels>(retain_idle: Duration) -> (Registry<K>, Report<K>) {
     let inner = Arc::new(Mutex::new(Inner::new()));
-    let report = Report {
-        metrics: inner.clone(),
-        retain_idle,
-    };
+    let report = Report::new(inner.clone(), retain_idle);
     (Registry(inner), report)
-}
-
-/// Implements `FmtMetrics` to render prometheus-formatted metrics for all transports.
-#[derive(Clone, Debug)]
-pub struct Report<K: Eq + Hash + FmtLabels> {
-    metrics: Arc<Mutex<Inner<K>>>,
-    retain_idle: Duration,
 }
 
 #[derive(Clone, Debug)]
 pub struct Registry<K: Eq + Hash + FmtLabels>(Arc<Mutex<Inner<K>>>);
 
 type Inner<K> = Store<K, Metrics>;
-
-pub type MakeAccept<N, K, S> = NewMetrics<N, K, Metrics, Accept<S>>;
-
-#[derive(Clone, Debug)]
-pub struct Accept<A> {
-    inner: A,
-    metrics: Arc<Metrics>,
-}
-
-#[derive(Clone, Debug)]
-pub struct Connect<P, S> {
-    inner: S,
-    params: P,
-}
-
-#[pin_project]
-pub struct Connecting<F> {
-    #[pin]
-    inner: F,
-    new_sensor: Option<NewSensor>,
-}
 
 /// Stores a class of transport's metrics.
 #[derive(Debug, Default)]
@@ -105,247 +75,20 @@ struct EosMetrics {
     close_total: Counter,
 }
 
-/// Tracks the state of a single instance of `Io` throughout its lifetime.
-#[derive(Debug)]
-pub struct Sensor {
-    metrics: Option<Arc<Metrics>>,
-    opened_at: Instant,
-}
-
-pub type SensorIo<T> = io::SensorIo<T, Sensor>;
-
-/// Lazily builds instances of `Sensor`.
-#[derive(Clone, Debug)]
-struct NewSensor(Arc<Metrics>);
-
 // === impl Registry ===
 
 impl<K: Eq + Hash + FmtLabels> Registry<K> {
     pub fn layer_accept<M, T>(
         &self,
-    ) -> impl layer::Layer<M, Service = MakeAccept<M, K, M::Service>> + Clone
+    ) -> impl layer::Layer<M, Service = NewServer<M, K, M::Service>> + Clone
     where
         M: NewService<T>,
     {
-        MakeAccept::layer(self.0.clone())
+        NewServer::layer(self.0.clone())
     }
 
     pub fn metrics(&self, labels: K) -> Arc<Metrics> {
         self.0.lock().get_or_default(labels).clone()
-    }
-}
-
-// === impl Accept ===
-
-impl<I, A> Service<I> for Accept<A>
-where
-    A: Service<SensorIo<I>, Response = ()>,
-{
-    type Response = ();
-    type Error = A::Error;
-    type Future = A::Future;
-
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, io: I) -> Self::Future {
-        let io = SensorIo::new(io, Sensor::open(self.metrics.clone()));
-        self.inner.call(io)
-    }
-}
-
-impl<A> From<(A, Arc<Metrics>)> for Accept<A> {
-    fn from((inner, metrics): (A, Arc<Metrics>)) -> Self {
-        Self { inner, metrics }
-    }
-}
-
-// === impl Connect ===
-
-impl<P: Clone, S> Connect<P, S> {
-    pub fn layer(params: P) -> impl layer::Layer<S, Service = Self> + Clone {
-        layer::mk(move |inner| Self {
-            inner,
-            params: params.clone(),
-        })
-    }
-}
-
-impl<T, P, S> Service<T> for Connect<P, S>
-where
-    P: ExtractParam<Arc<Metrics>, T>,
-    S: Service<T>,
-{
-    type Response = SensorIo<S::Response>;
-    type Error = S::Error;
-    type Future = Connecting<S::Future>;
-
-    #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
-    }
-
-    fn call(&mut self, target: T) -> Self::Future {
-        let metrics = self.params.extract_param(&target);
-        let inner = self.inner.call(target);
-        Connecting {
-            new_sensor: Some(NewSensor(metrics)),
-            inner,
-        }
-    }
-}
-
-// === impl Connecting ===
-
-impl<F: TryFuture> Future for Connecting<F> {
-    type Output = Result<SensorIo<F::Ok>, F::Error>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        let io = ready!(this.inner.try_poll(cx))?;
-        debug!("client connection open");
-
-        let sensor = this
-            .new_sensor
-            .take()
-            .expect("future must not be polled after ready")
-            .new_sensor();
-        let t = SensorIo::new(io, sensor);
-        Poll::Ready(Ok(t))
-    }
-}
-
-// === impl Report ===
-
-impl<K: Eq + Hash + FmtLabels + 'static> Report<K> {
-    /// Formats a metric across all instances of `EosMetrics` in the registry.
-    fn fmt_eos_by<N, M>(
-        inner: &Inner<K>,
-        f: &mut fmt::Formatter<'_>,
-        metric: Metric<'_, N, M>,
-        get_metric: impl Fn(&EosMetrics) -> &M,
-    ) -> fmt::Result
-    where
-        N: fmt::Display,
-        M: FmtMetric,
-    {
-        for (key, metrics) in inner.iter() {
-            let by_eos = (*metrics).by_eos.lock();
-            for (eos, m) in by_eos.metrics.iter() {
-                get_metric(&*m).fmt_metric_labeled(f, &metric.name, (key, eos))?;
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl<K: Eq + Hash + FmtLabels + 'static> FmtMetrics for Report<K> {
-    fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut metrics = self.metrics.lock();
-        if metrics.is_empty() {
-            return Ok(());
-        }
-
-        tcp_open_total.fmt_help(f)?;
-        metrics.fmt_by(f, tcp_open_total, |m| &m.open_total)?;
-
-        tcp_open_connections.fmt_help(f)?;
-        metrics.fmt_by(f, tcp_open_connections, |m| &m.open_connections)?;
-
-        tcp_read_bytes_total.fmt_help(f)?;
-        metrics.fmt_by(f, tcp_read_bytes_total, |m| &m.read_bytes_total)?;
-
-        tcp_write_bytes_total.fmt_help(f)?;
-        metrics.fmt_by(f, tcp_write_bytes_total, |m| &m.write_bytes_total)?;
-
-        tcp_close_total.fmt_help(f)?;
-        Self::fmt_eos_by(&*metrics, f, tcp_close_total, |e| &e.close_total)?;
-
-        metrics.retain_since(Instant::now() - self.retain_idle);
-
-        Ok(())
-    }
-}
-
-// === impl Sensor ===
-
-impl Sensor {
-    fn open(metrics: Arc<Metrics>) -> Self {
-        metrics.open_total.incr();
-        metrics.open_connections.incr();
-        metrics.by_eos.lock().last_update = Instant::now();
-        Self {
-            metrics: Some(metrics),
-            opened_at: Instant::now(),
-        }
-    }
-}
-
-impl io::Sensor for Sensor {
-    fn record_read(&mut self, sz: usize) {
-        if let Some(ref m) = self.metrics {
-            m.read_bytes_total.add(sz as u64);
-            m.by_eos.lock().last_update = Instant::now();
-        }
-    }
-
-    fn record_write(&mut self, sz: usize) {
-        if let Some(ref m) = self.metrics {
-            m.write_bytes_total.add(sz as u64);
-            m.by_eos.lock().last_update = Instant::now();
-        }
-    }
-
-    fn record_close(&mut self, eos: Option<Errno>) {
-        // When closed, the metrics structure is dropped so that no further
-        // updates can occur (i.e. so that an additional close won't be recorded
-        // on Drop).
-        if let Some(m) = self.metrics.take() {
-            m.open_connections.decr();
-
-            let mut by_eos = m.by_eos.lock();
-            let class = by_eos
-                .metrics
-                .entry(Eos(eos))
-                .or_insert_with(EosMetrics::default);
-            class.close_total.incr();
-            by_eos.last_update = Instant::now();
-        }
-    }
-
-    /// Wraps an operation on the underlying transport with error telemetry.
-    ///
-    /// If the transport operation results in a non-recoverable error, record a
-    /// transport closure.
-    fn record_error<T>(&mut self, op: Poll<std::io::Result<T>>) -> Poll<std::io::Result<T>> {
-        match op {
-            Poll::Ready(Ok(v)) => Poll::Ready(Ok(v)),
-            Poll::Ready(Err(e)) => {
-                if e.kind() != std::io::ErrorKind::WouldBlock {
-                    let eos = e.raw_os_error().map(|e| e.into());
-                    self.record_close(eos);
-                }
-
-                Poll::Ready(Err(e))
-            }
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-impl Drop for Sensor {
-    fn drop(&mut self) {
-        io::Sensor::record_close(self, None)
-    }
-}
-
-// === impl NewSensor ===
-
-impl NewSensor {
-    fn new_sensor(self) -> Sensor {
-        Sensor::open(self.0)
     }
 }
 

--- a/linkerd/transport-metrics/src/report.rs
+++ b/linkerd/transport-metrics/src/report.rs
@@ -1,0 +1,81 @@
+use super::{
+    tcp_close_total, tcp_open_connections, tcp_open_total, tcp_read_bytes_total,
+    tcp_write_bytes_total, EosMetrics, Inner,
+};
+use linkerd_metrics::{FmtLabels, FmtMetric, FmtMetrics, Metric};
+use parking_lot::Mutex;
+use std::{
+    fmt,
+    hash::Hash,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+/// Implements `FmtMetrics` to render prometheus-formatted metrics for all transports.
+#[derive(Clone, Debug)]
+pub struct Report<K: Eq + Hash + FmtLabels> {
+    metrics: Arc<Mutex<Inner<K>>>,
+    retain_idle: Duration,
+}
+
+// === impl Report ===
+
+impl<K: Eq + Hash + FmtLabels> Report<K> {
+    pub(super) fn new(metrics: Arc<Mutex<Inner<K>>>, retain_idle: Duration) -> Self {
+        Self {
+            metrics,
+            retain_idle,
+        }
+    }
+}
+
+impl<K: Eq + Hash + FmtLabels + 'static> Report<K> {
+    /// Formats a metric across all instances of `EosMetrics` in the registry.
+    fn fmt_eos_by<N, M>(
+        inner: &Inner<K>,
+        f: &mut fmt::Formatter<'_>,
+        metric: Metric<'_, N, M>,
+        get_metric: impl Fn(&EosMetrics) -> &M,
+    ) -> fmt::Result
+    where
+        N: fmt::Display,
+        M: FmtMetric,
+    {
+        for (key, metrics) in inner.iter() {
+            let by_eos = (*metrics).by_eos.lock();
+            for (eos, m) in by_eos.metrics.iter() {
+                get_metric(&*m).fmt_metric_labeled(f, &metric.name, (key, eos))?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<K: Eq + Hash + FmtLabels + 'static> FmtMetrics for Report<K> {
+    fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut metrics = self.metrics.lock();
+        if metrics.is_empty() {
+            return Ok(());
+        }
+
+        tcp_open_total.fmt_help(f)?;
+        metrics.fmt_by(f, tcp_open_total, |m| &m.open_total)?;
+
+        tcp_open_connections.fmt_help(f)?;
+        metrics.fmt_by(f, tcp_open_connections, |m| &m.open_connections)?;
+
+        tcp_read_bytes_total.fmt_help(f)?;
+        metrics.fmt_by(f, tcp_read_bytes_total, |m| &m.read_bytes_total)?;
+
+        tcp_write_bytes_total.fmt_help(f)?;
+        metrics.fmt_by(f, tcp_write_bytes_total, |m| &m.write_bytes_total)?;
+
+        tcp_close_total.fmt_help(f)?;
+        Self::fmt_eos_by(&*metrics, f, tcp_close_total, |e| &e.close_total)?;
+
+        metrics.retain_since(Instant::now() - self.retain_idle);
+
+        Ok(())
+    }
+}

--- a/linkerd/transport-metrics/src/sensor.rs
+++ b/linkerd/transport-metrics/src/sensor.rs
@@ -1,0 +1,85 @@
+use super::{Eos, EosMetrics, Metrics};
+use linkerd_errno::Errno;
+use linkerd_io as io;
+use std::{sync::Arc, task::Poll, time::Instant};
+
+/// Tracks the state of a single instance of `Io` throughout its lifetime.
+#[derive(Debug)]
+pub struct Sensor {
+    metrics: Option<Arc<Metrics>>,
+    opened_at: Instant,
+}
+
+pub type SensorIo<T> = io::SensorIo<T, Sensor>;
+
+// === impl Sensor ===
+
+impl Sensor {
+    pub(crate) fn open(metrics: Arc<Metrics>) -> Self {
+        metrics.open_total.incr();
+        metrics.open_connections.incr();
+        metrics.by_eos.lock().last_update = Instant::now();
+        Self {
+            metrics: Some(metrics),
+            opened_at: Instant::now(),
+        }
+    }
+}
+
+impl io::Sensor for Sensor {
+    fn record_read(&mut self, sz: usize) {
+        if let Some(ref m) = self.metrics {
+            m.read_bytes_total.add(sz as u64);
+            m.by_eos.lock().last_update = Instant::now();
+        }
+    }
+
+    fn record_write(&mut self, sz: usize) {
+        if let Some(ref m) = self.metrics {
+            m.write_bytes_total.add(sz as u64);
+            m.by_eos.lock().last_update = Instant::now();
+        }
+    }
+
+    fn record_close(&mut self, eos: Option<Errno>) {
+        // When closed, the metrics structure is dropped so that no further
+        // updates can occur (i.e. so that an additional close won't be recorded
+        // on Drop).
+        if let Some(m) = self.metrics.take() {
+            m.open_connections.decr();
+
+            let mut by_eos = m.by_eos.lock();
+            let class = by_eos
+                .metrics
+                .entry(Eos(eos))
+                .or_insert_with(EosMetrics::default);
+            class.close_total.incr();
+            by_eos.last_update = Instant::now();
+        }
+    }
+
+    /// Wraps an operation on the underlying transport with error telemetry.
+    ///
+    /// If the transport operation results in a non-recoverable error, record a
+    /// transport closure.
+    fn record_error<T>(&mut self, op: Poll<std::io::Result<T>>) -> Poll<std::io::Result<T>> {
+        match op {
+            Poll::Ready(Ok(v)) => Poll::Ready(Ok(v)),
+            Poll::Ready(Err(e)) => {
+                if e.kind() != std::io::ErrorKind::WouldBlock {
+                    let eos = e.raw_os_error().map(|e| e.into());
+                    self.record_close(eos);
+                }
+
+                Poll::Ready(Err(e))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+impl Drop for Sensor {
+    fn drop(&mut self) {
+        io::Sensor::record_close(self, None)
+    }
+}

--- a/linkerd/transport-metrics/src/server.rs
+++ b/linkerd/transport-metrics/src/server.rs
@@ -1,0 +1,41 @@
+use super::{Metrics, Sensor, SensorIo};
+use linkerd_metrics::NewMetrics;
+use linkerd_stack::Service;
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+pub type NewServer<N, K, S> = NewMetrics<N, K, Metrics, Server<S>>;
+
+#[derive(Clone, Debug)]
+pub struct Server<S> {
+    inner: S,
+    metrics: Arc<Metrics>,
+}
+
+// === impl Accept ===
+
+impl<A> From<(A, Arc<Metrics>)> for Server<A> {
+    fn from((inner, metrics): (A, Arc<Metrics>)) -> Self {
+        Self { inner, metrics }
+    }
+}
+
+impl<I, A> Service<I> for Server<A>
+where
+    A: Service<SensorIo<I>, Response = ()>,
+{
+    type Response = ();
+    type Error = A::Error;
+    type Future = A::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, io: I) -> Self::Future {
+        let io = SensorIo::new(io, Sensor::open(self.metrics.clone()));
+        self.inner.call(io)
+    }
+}


### PR DESCRIPTION
Our transport metrics code is fairly old and doesn't take advantage of
newer primitives, namely `ExtractParam`.

This change:
* Moves transport metrics code into a dedicated `transport-metrics crate` (it's got nothing in common with the rest of the proxy-transport code). Each logical chunk of functionality is moved into its own module.
* Renames the `Connect` type to `Client; and `Accept` to `Server` -- this is where we've gone with TLS code, etc.
* Updates both the Connect and Server layers to be parameterized on an `ExtractParams` that is responsible for producing a metrics instance for each target. This eliminates the awkward mapping from target type to label type and in general decouples these layers from the details of how metrics are acquired.
* The `app_core::transport::metrics` module provides an implementation of `ExtractParams` that can be used to build transport labels.

This sets up upcoming changes to metrics infrastructure with the eventual goal being to decouple the metric names definition from the metrics tracking code.

No functional changes.