### PR TITLE
Expose policy labels on inbound transport metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "linkerd-proxy-transport",
  "linkerd-reconnect",
  "linkerd-retry",
+ "linkerd-server-policy",
  "linkerd-service-profiles",
  "linkerd-stack",
  "linkerd-stack-metrics",

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -157,11 +157,13 @@ impl Config {
 
 impl Param<transport::labels::Key> for Tcp {
     fn param(&self) -> transport::labels::Key {
-        transport::labels::Key::Accept {
-            direction: transport::labels::Direction::In,
-            tls: self.tls.clone(),
-            target_addr: self.addr.into(),
-        }
+        transport::labels::Key::inbound_server(
+            self.tls.clone(),
+            self.addr.into(),
+            // TODO(ver) enforce policies on the proxy's admin port.
+            Default::default(),
+            Default::default(),
+        )
     }
 }
 

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -50,6 +50,7 @@ linkerd-proxy-tcp = { path = "../../proxy/tcp" }
 linkerd-proxy-transport = { path = "../../proxy/transport" }
 linkerd-reconnect = { path = "../../reconnect" }
 linkerd-retry = { path = "../../retry" }
+linkerd-server-policy = { path = "../../server-policy" }
 linkerd-timeout = { path = "../../timeout" }
 linkerd-tracing = { path = "../../tracing" }
 linkerd-transport-header = { path = "../../transport-header" }

--- a/linkerd/app/core/src/metrics/tcp_accept_errors.rs
+++ b/linkerd/app/core/src/metrics/tcp_accept_errors.rs
@@ -95,11 +95,9 @@ impl LabelError<Error> for LabelAcceptErrors {
             } else if err.is::<std::io::Error>() {
                 // We ignore the error code because we want all labels to be consistent.
                 return AcceptErrors::Io;
-            } else if err.is::<DeniedUnknownPort>() {
+            } else if err.is::<DeniedUnknownPort>() || err.is::<DeniedUnauthorized>() {
                 // If the port is unknown, the default policy is `deny`; so handle it as
                 // unauthorized.
-                return AcceptErrors::Unauthorized;
-            } else if err.is::<DeniedUnauthorized>() {
                 return AcceptErrors::Unauthorized;
             }
             curr = err.source();

--- a/linkerd/app/core/src/metrics/tcp_accept_errors.rs
+++ b/linkerd/app/core/src/metrics/tcp_accept_errors.rs
@@ -1,7 +1,7 @@
 use crate::{
     metrics::{self, Counter, FmtMetrics},
     svc,
-    transport::{labels, OrigDstAddr},
+    transport::{labels, DeniedUnauthorized, DeniedUnknownPort, OrigDstAddr},
 };
 use linkerd_error::Error;
 use linkerd_error_metrics::{FmtLabels, LabelError, RecordError};
@@ -36,6 +36,7 @@ pub struct LabelAcceptErrors(());
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub enum AcceptErrors {
     TlsDetectTimeout,
+    Unauthorized,
     Io,
     Other,
 }
@@ -94,6 +95,12 @@ impl LabelError<Error> for LabelAcceptErrors {
             } else if err.is::<std::io::Error>() {
                 // We ignore the error code because we want all labels to be consistent.
                 return AcceptErrors::Io;
+            } else if err.is::<DeniedUnknownPort>() {
+                // If the port is unknown, the default policy is `deny`; so handle it as
+                // unauthorized.
+                return AcceptErrors::Unauthorized;
+            } else if err.is::<DeniedUnauthorized>() {
+                return AcceptErrors::Unauthorized;
             }
             curr = err.source();
         }
@@ -110,6 +117,7 @@ impl FmtLabels for AcceptErrors {
             Self::TlsDetectTimeout => fmt::Display::fmt("error=\"tls_detect_timeout\"", f),
             Self::Io => fmt::Display::fmt("error=\"io\"", f),
             Self::Other => fmt::Display::fmt("error=\"other\"", f),
+            Self::Unauthorized => fmt::Display::fmt("error=\"unauthorized\"", f),
         }
     }
 }

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -91,7 +91,7 @@ impl ServerLabels {
         policy: PolicyLabels,
     ) -> Self {
         ServerLabels {
-            direction: Direction::Out,
+            direction: Direction::In,
             tls,
             target_addr,
             policy: Some(policy),
@@ -216,7 +216,7 @@ mod tests {
         );
         assert_eq!(
             labels.to_string(),
-            "direction=\"outbound\",peer=\"src\",target_addr=\"192.0.2.4:40000\",tls=\"true\",\
+            "direction=\"inbound\",peer=\"src\",target_addr=\"192.0.2.4:40000\",tls=\"true\",\
             client_id=\"foo.id.example.com\",srv_name=\"testserver\",saz_name=\"testauthz\""
         );
     }

--- a/linkerd/app/core/src/transport/mod.rs
+++ b/linkerd/app/core/src/transport/mod.rs
@@ -2,11 +2,24 @@ pub use linkerd_proxy_transport::*;
 use linkerd_stack::{ExtractParam, Param};
 pub use linkerd_transport_metrics as metrics;
 use std::sync::Arc;
+use thiserror::Error;
 
 pub mod labels;
 
 #[derive(Clone, Debug)]
 pub struct Metrics(metrics::Registry<labels::Key>);
+
+#[derive(Clone, Debug, Error)]
+#[error("connection denied on unknown port {0}")]
+pub struct DeniedUnknownPort(pub u16);
+
+#[derive(Debug, Error)]
+#[error("unauthorized connection from {client_addr} with identity {tls:?} to {dst_addr}")]
+pub struct DeniedUnauthorized {
+    pub client_addr: Remote<ClientAddr>,
+    pub dst_addr: OrigDstAddr,
+    pub tls: Option<linkerd_tls::ConditionalServerTls>,
+}
 
 impl From<metrics::Registry<labels::Key>> for Metrics {
     fn from(reg: metrics::Registry<labels::Key>) -> Self {

--- a/linkerd/app/core/src/transport/mod.rs
+++ b/linkerd/app/core/src/transport/mod.rs
@@ -18,7 +18,7 @@ pub struct DeniedUnknownPort(pub u16);
 pub struct DeniedUnauthorized {
     pub client_addr: Remote<ClientAddr>,
     pub dst_addr: OrigDstAddr,
-    pub tls: Option<linkerd_tls::ConditionalServerTls>,
+    pub tls: linkerd_tls::ConditionalServerTls,
 }
 
 impl From<metrics::Registry<labels::Key>> for Metrics {

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -1,5 +1,5 @@
 use crate::{
-    policy::{AllowPolicy, DeniedUnauthorized, Permit},
+    policy::{AllowPolicy, Permit},
     Inbound,
 };
 use linkerd_app_core::{
@@ -9,7 +9,7 @@ use linkerd_app_core::{
     transport::{
         self,
         addrs::{ClientAddr, OrigDstAddr, Remote},
-        ServerAddr,
+        DeniedUnauthorized, ServerAddr,
     },
     Error, Infallible,
 };

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -30,8 +30,8 @@ struct RefusedNoTarget;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Local {
-    pub port: u16,
-    pub permit: policy::Permit,
+    port: u16,
+    permit: policy::Permit,
 }
 
 /// Gateway connections come in two variants: those with a transport header, and

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -293,7 +293,7 @@ impl Param<u16> for Logical {
 
 impl Param<transport::labels::Key> for Logical {
     fn param(&self) -> transport::labels::Key {
-        transport::labels::Key::InboundConnect
+        transport::labels::Key::InboundClient
     }
 }
 
@@ -379,6 +379,6 @@ impl From<Logical> for Http {
 
 impl Param<transport::labels::Key> for Http {
     fn param(&self) -> transport::labels::Key {
-        transport::labels::Key::InboundConnect
+        transport::labels::Key::InboundClient
     }
 }

--- a/linkerd/app/inbound/src/policy/mod.rs
+++ b/linkerd/app/inbound/src/policy/mod.rs
@@ -9,14 +9,13 @@ pub use self::config::Config;
 pub(crate) use self::store::Store;
 use linkerd_app_core::{
     tls,
-    transport::{ClientAddr, DeniedUnknownPort, DeniedUnknownPort, OrigDstAddr, Remote},
+    transport::{ClientAddr, DeniedUnauthorized, DeniedUnknownPort, OrigDstAddr, Remote},
     Result,
 };
 pub use linkerd_server_policy::{
     Authentication, Authorization, Labels, Protocol, ServerPolicy, Suffix,
 };
 use std::sync::Arc;
-use thiserror::Error;
 
 pub(crate) trait CheckPolicy {
     /// Checks that the destination address is configured to allow traffic.

--- a/linkerd/app/inbound/src/policy/tests.rs
+++ b/linkerd/app/inbound/src/policy/tests.rs
@@ -30,7 +30,7 @@ fn unauthenticated_allowed() {
         .expect("unauthenticated connection must be permitted");
     assert_eq!(
         permitted,
-        Permitted {
+        Permit {
             tls,
             protocol: policy.protocol,
             server_labels: vec![("name".to_string(), "test".to_string())]
@@ -77,7 +77,7 @@ fn authenticated_identity() {
         .expect("unauthenticated connection must be permitted");
     assert_eq!(
         permitted,
-        Permitted {
+        Permit {
             tls,
             protocol: policy.protocol,
             server_labels: vec![("name".to_string(), "test".to_string())]
@@ -138,7 +138,7 @@ fn authenticated_suffix() {
         allowed
             .check_authorized(client_addr(), tls.clone())
             .expect("unauthenticated connection must be permitted"),
-        Permitted {
+        Permit {
             tls,
             protocol: policy.protocol,
             server_labels: vec![("name".to_string(), "test".to_string())]
@@ -193,7 +193,7 @@ fn tls_unauthenticated() {
         allowed
             .check_authorized(client_addr(), tls.clone())
             .expect("unauthenticated connection must be permitted"),
-        Permitted {
+        Permit {
             tls,
             protocol: policy.protocol,
             server_labels: vec![("name".to_string(), "test".to_string())]

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -101,6 +101,6 @@ impl svc::Param<u16> for TcpEndpoint {
 
 impl svc::Param<transport::labels::Key> for TcpEndpoint {
     fn param(&self) -> transport::labels::Key {
-        transport::labels::Key::InboundConnect
+        transport::labels::Key::InboundClient
     }
 }

--- a/linkerd/app/integration/src/tests/telemetry/mod.rs
+++ b/linkerd/app/integration/src/tests/telemetry/mod.rs
@@ -143,7 +143,9 @@ impl TcpFixture {
             .label("direction", "inbound")
             .label("peer", "src")
             .label("tls", "disabled")
-            .label("target_addr", orig_dst);
+            .label("target_addr", orig_dst)
+            .label("srv_name", "default:all-unauthenticated")
+            .label("saz_name", "default:all-unauthenticated");
 
         let dst_labels = metrics::labels()
             .label("direction", "inbound")

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1348,6 +1348,8 @@ async fn retry_reconnect_errors() {
         .label("peer", "src")
         .label("direction", "inbound")
         .label("tls", "disabled")
+        .label("srv_name", "default:all-unauthenticated")
+        .label("saz_name", "default:all-unauthenticated")
         .value(1u64)
         .assert_in(&metrics)
         .await;

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -96,7 +96,7 @@ impl<P> svc::Param<Option<http::AuthorityOverride>> for Endpoint<P> {
 
 impl<P> svc::Param<transport::labels::Key> for Endpoint<P> {
     fn param(&self) -> transport::labels::Key {
-        transport::labels::Key::OutboundConnect(self.param())
+        transport::labels::Key::OutboundClient(self.param())
     }
 }
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -28,7 +28,7 @@ use linkerd_app_core::{
     svc::{self, stack::Param},
     tls,
     transport::{self, addrs::*},
-    AddrMatch, Conditional, Error, ProxyRuntime,
+    AddrMatch, Error, ProxyRuntime,
 };
 use std::{collections::HashMap, fmt::Debug, time::Duration};
 use tracing::info;
@@ -163,12 +163,7 @@ impl Outbound<()> {
 
 impl<P> Param<transport::labels::Key> for Accept<P> {
     fn param(&self) -> transport::labels::Key {
-        const NO_TLS: tls::ConditionalServerTls = Conditional::None(tls::NoServerTls::Loopback);
-        transport::labels::Key::accept(
-            transport::labels::Direction::Out,
-            NO_TLS,
-            self.orig_dst.into(),
-        )
+        transport::labels::Key::outbound_server(self.orig_dst.into())
     }
 }
 

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -2,10 +2,9 @@ mod network;
 
 pub use self::network::Network;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{btree_map, BTreeMap, HashSet},
     hash::Hash,
     iter::FromIterator,
-    ops::Deref,
     sync::Arc,
     time,
 };
@@ -55,17 +54,21 @@ pub struct Suffix {
 
 // === impl Labels ===
 
-impl FromIterator<(String, String)> for Labels {
-    fn from_iter<T: IntoIterator<Item = (String, String)>>(iter: T) -> Self {
-        Self(Arc::new(iter.into_iter().collect()))
+impl Labels {
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[inline]
+    pub fn iter(&self) -> btree_map::Iter<'_, String, String> {
+        self.0.iter()
     }
 }
 
-impl Deref for Labels {
-    type Target = BTreeMap<String, String>;
-
-    fn deref(&self) -> &Self::Target {
-        &*self.0
+impl FromIterator<(String, String)> for Labels {
+    fn from_iter<T: IntoIterator<Item = (String, String)>>(iter: T) -> Self {
+        Self(Arc::new(iter.into_iter().collect()))
     }
 }
 


### PR DESCRIPTION
The inbound server only permits connections that are allowed by a
policy, but this decision is not observable at runtime.

This change modifies the server transport labels to include server and
authorization labels--prefixed by `srv_` and `saz_`, respectively
(matching the shortnames of the `Server` and `ServerAuthorization`
resources).

Furthermore, this change updates the `inbound_tcp_acept_errors_total`
metric to include an `unauthorized` error variant to expose a counter of
connections that were not permitted.