### PR TITLE
metrics: Add `target_ip` and `target_port` labels

### DIFF
--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -177,7 +177,13 @@ impl<'t> FmtLabels for TlsConnect<'t> {
 
 impl FmtLabels for TargetAddr {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "target_addr=\"{}\"", self.0)
+        write!(
+            f,
+            "target_addr=\"{}\",target_ip=\"{}\",target_port=\"{}\"",
+            self.0,
+            self.0.ip(),
+            self.0.port()
+        )
     }
 }
 
@@ -210,8 +216,10 @@ mod tests {
         );
         assert_eq!(
             labels.to_string(),
-            "direction=\"inbound\",peer=\"src\",target_addr=\"192.0.2.4:40000\",tls=\"true\",\
-            client_id=\"foo.id.example.com\",srv_name=\"testserver\",saz_name=\"testauthz\""
+            "direction=\"inbound\",peer=\"src\",\
+            target_addr=\"192.0.2.4:40000\",target_ip=\"192.0.2.4\",target_port=\"40000\",\
+            tls=\"true\",client_id=\"foo.id.example.com\",\
+            srv_name=\"testserver\",saz_name=\"testauthz\""
         );
     }
 }


### PR DESCRIPTION
The `target_addr` label encodes both the IP address and port in a single
string. This makes certain grouping operations cumbersome.

In order to support more flexible queries, this change adds `target_ip`
and `target_port` labels in addition to the existing `target_addr`
label. This should have a negligible impact on prometheus, since it
doesn't actually increase timeseries cardinality.