### PR TITLE
Set tracing spans on policy client

### DIFF
--- a/linkerd/app/inbound/src/policy/store.rs
+++ b/linkerd/app/inbound/src/policy/store.rs
@@ -9,6 +9,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::watch;
+use tracing::{info_span, Instrument};
 
 #[derive(Clone, Debug)]
 pub struct Store {
@@ -93,6 +94,7 @@ impl Store {
                 discover
                     .clone()
                     .spawn_watch(port)
+                    .instrument(info_span!("watch", %port))
                     .map_ok(move |rsp| (port, rsp.into_inner()))
             });
 

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -210,7 +210,11 @@ impl Config {
                         .instrument(info_span!("outbound")),
                 );
 
-                let inbound_policies = inbound.build_policies(dns, control_metrics).await;
+                let inbound_policies = inbound
+                    .build_policies(dns, control_metrics)
+                    .instrument(info_span!("policy"))
+                    .await;
+
                 tokio::spawn(
                     inbound
                         .serve(

--- a/linkerd/tonic-watch/src/lib.rs
+++ b/linkerd/tonic-watch/src/lib.rs
@@ -6,7 +6,7 @@ use linkerd_error::Recover;
 use linkerd_stack::{Service, ServiceExt};
 use std::task::{Context, Poll};
 use tokio::sync::watch;
-use tracing::{debug, trace};
+use tracing::{debug, trace, Instrument};
 
 /// A service that streams updates from an inner service into a `tokio::sync::watch::Receiver` on a
 /// background task.
@@ -55,7 +55,7 @@ where
             // Spawn a background task to keep the profile watch up-to-date until all copies of `rx`
             // have dropped.
             let (tx, rx) = watch::channel(init);
-            tokio::spawn(self.publish_updates(target, tx, inner));
+            tokio::spawn(self.publish_updates(target, tx, inner).in_current_span());
             rx
         }))
     }


### PR DESCRIPTION
This change ensures that policy watches include tracing spans.