### PR TITLE
Fix route labels on outbound tap metadata

### DIFF
--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -143,6 +143,7 @@ impl<E> Outbound<E> {
                         // stack doesn't have to implement `Service` for requests
                         // with both body types.
                         .push_on_service(http::BoxRequest::erased())
+                        .push_http_insert_target::<dst::Route>()
                         // Sets an optional retry policy.
                         .push(retry::layer(rt.metrics.proxy.http_route_retry.clone()))
                         // Sets an optional request timeout.


### PR DESCRIPTION
The outbound proxy did not properly expose route labels to tap on
outbound requests. This change ensures that route labels are set on
outbound requests for display by tap.