### PR TITLE
inbound: Load policies lazily

### DIFF
--- a/linkerd/app/inbound/src/metrics/authz.rs
+++ b/linkerd/app/inbound/src/metrics/authz.rs
@@ -26,7 +26,7 @@ metrics! {
 }
 
 #[derive(Clone, Debug, Default)]
-pub(crate) struct HttpAuthzMetrics(Arc<HttpInner>);
+pub struct HttpAuthzMetrics(Arc<HttpInner>);
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct TcpAuthzMetrics(Arc<TcpInner>);

--- a/linkerd/app/inbound/src/policy/authorize/http.rs
+++ b/linkerd/app/inbound/src/policy/authorize/http.rs
@@ -36,9 +36,7 @@ pub struct AuthorizeHttp<T, N> {
 // === impl NewAuthorizeHttp ===
 
 impl<N> NewAuthorizeHttp<N> {
-    pub(crate) fn layer(
-        metrics: HttpAuthzMetrics,
-    ) -> impl svc::layer::Layer<N, Service = Self> + Clone {
+    pub fn layer(metrics: HttpAuthzMetrics) -> impl svc::layer::Layer<N, Service = Self> + Clone {
         svc::layer::mk(move |inner| Self {
             metrics: metrics.clone(),
             inner,

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -1,7 +1,5 @@
 use super::{discover::Discover, DefaultPolicy, ServerPolicy, Store};
-use linkerd_app_core::{
-    control, dns, metrics, proxy::identity::LocalCrtKey, svc::NewService, Result,
-};
+use linkerd_app_core::{control, dns, metrics, proxy::identity::LocalCrtKey, svc::NewService};
 use std::collections::{HashMap, HashSet};
 
 /// Configures inbound policies.
@@ -25,12 +23,12 @@ pub enum Config {
 // === impl Config ===
 
 impl Config {
-    pub(crate) async fn build(
+    pub(crate) fn build(
         self,
         dns: dns::Resolver,
         metrics: metrics::ControlHttp,
         identity: Option<LocalCrtKey>,
-    ) -> Result<Store> {
+    ) -> Store {
         match self {
             Self::Fixed { default, ports } => {
                 let (store, tx) = Store::fixed(default, ports);
@@ -39,7 +37,7 @@ impl Config {
                         tx.closed().await;
                     });
                 }
-                Ok(store)
+                store
             }
             Self::Discover {
                 control,
@@ -52,7 +50,7 @@ impl Config {
                     let c = control.build(dns, metrics, identity).new_service(());
                     Discover::new(workload, c).into_watch(backoff)
                 };
-                Store::spawn_discover(default, ports, watch).await
+                Store::spawn_discover(default, ports, watch)
             }
         }
     }

--- a/linkerd/app/inbound/src/policy/mod.rs
+++ b/linkerd/app/inbound/src/policy/mod.rs
@@ -63,6 +63,19 @@ impl From<ServerPolicy> for DefaultPolicy {
     }
 }
 
+impl From<DefaultPolicy> for ServerPolicy {
+    fn from(d: DefaultPolicy) -> Self {
+        match d {
+            DefaultPolicy::Allow(p) => p,
+            DefaultPolicy::Deny => ServerPolicy {
+                protocol: Protocol::Opaque,
+                authorizations: vec![],
+                name: "default:deny".to_string(),
+            },
+        }
+    }
+}
+
 // === impl AllowPolicy ===
 
 impl AllowPolicy {

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -16,7 +16,7 @@ struct TcpEndpoint {
 // === impl Inbound ===
 
 impl Inbound<()> {
-    pub async fn build_policies(
+    pub fn build_policies(
         &self,
         dns: dns::Resolver,
         control_metrics: metrics::ControlHttp,
@@ -25,8 +25,6 @@ impl Inbound<()> {
             .policy
             .clone()
             .build(dns, control_metrics, self.runtime.identity.clone())
-            .await
-            .expect("Failed to fetch port policy")
     }
 
     pub async fn serve<A, I, G, GSvc, P>(

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -210,10 +210,8 @@ impl Config {
                         .instrument(info_span!("outbound")),
                 );
 
-                let inbound_policies = inbound
-                    .build_policies(dns, control_metrics)
-                    .instrument(info_span!("policy"))
-                    .await;
+                let inbound_policies =
+                    info_span!("policy").in_scope(|| inbound.build_policies(dns, control_metrics));
 
                 tokio::spawn(
                     inbound

--- a/linkerd/tonic-watch/src/lib.rs
+++ b/linkerd/tonic-watch/src/lib.rs
@@ -48,7 +48,7 @@ where
         S: Service<T, Response = InnerRsp<U>, Error = tonic::Status>,
         S::Future: Send,
     {
-        // Get an update and stream or return None.
+        // Get an update and stream.
         let (init, rsp) = self.init(&target, None).await?;
 
         Ok(rsp.map(move |inner| {
@@ -58,6 +58,34 @@ where
             tokio::spawn(self.publish_updates(target, tx, inner).in_current_span());
             rx
         }))
+    }
+
+    /// Returns a watch using the provided initial value.
+    ///
+    /// The watch is spawned on a background task that completes when the watch service errors in an
+    /// unrecoverable way or all receivers are dropped.
+    pub fn spawn_with_init<T, U>(mut self, target: T, init: U) -> watch::Receiver<U>
+    where
+        T: Clone + Send + Sync + 'static,
+        U: Send + Sync + 'static,
+        S: Service<T, Response = InnerRsp<U>, Error = tonic::Status>,
+        S::Future: Send,
+    {
+        let (tx, rx) = watch::channel(init);
+
+        // Spawn a background task to watch the inner service.
+        tokio::spawn(
+            async move {
+                let (up, rsp) = self.init(&target, None).await?;
+                if tx.send(up).is_ok() {
+                    self.publish_updates(target, tx, rsp.into_inner()).await;
+                }
+                Ok::<_, tonic::Status>(())
+            }
+            .in_current_span(),
+        );
+
+        rx
     }
 
     /// Initiates a lookup stream and obtains the first profile from it.


### PR DESCRIPTION
Rather than block inbound communication on policy discovery, this change
modifies policy initialization to use the default policy until policy
has been synced from the control plane. This will allow us to use
policies with the admin server.