### PR TITLE
duplex: Reduce copy buffer size from 64KB to 8KB

### DIFF
--- a/linkerd/duplex/src/lib.rs
+++ b/linkerd/duplex/src/lib.rs
@@ -287,7 +287,7 @@ fn write_zero() -> io::Error {
 impl CopyBuf {
     fn new() -> Self {
         CopyBuf {
-            buf: Box::new([0; 64 * 1024]),
+            buf: Box::new([0; 8 * 1024]),
             read_pos: 0,
             write_pos: 0,
         }


### PR DESCRIPTION
Each forward TCP connection currently allocates 128KB--64KB for each
direction, client-to-server and server-to-client. This is an excessive
amount to allocate, especially since this buffer can currently hold only
a single `read(2)`'s worth of data.

This change reduces the buffer size to 8KB so that each connection
allocates only 16KB. This will substantially reduce memory overhead when
a server must serve many concurrent non-HTTP connections.