### PR TITLE
Fix lints found on nightly

### DIFF
--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -22,7 +22,6 @@ pub struct Http {
 /// Builds `Logical` targets for each HTTP request.
 #[derive(Clone, Debug)]
 struct LogicalPerRequest {
-    client: Remote<ClientAddr>,
     server: Remote<ServerAddr>,
     tls: tls::ConditionalServerTls,
     permit: policy::Permit,
@@ -247,7 +246,6 @@ impl<C> Inbound<C> {
 impl<T> From<(policy::Permit, T)> for LogicalPerRequest
 where
     T: Param<Remote<ServerAddr>>,
-    T: Param<Remote<ClientAddr>>,
     T: Param<tls::ConditionalServerTls>,
 {
     fn from((permit, t): (policy::Permit, T)) -> Self {
@@ -257,7 +255,6 @@ where
         ];
 
         Self {
-            client: t.param(),
             server: t.param(),
             tls: t.param(),
             permit,

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -27,7 +27,7 @@ pub struct Upgrade<C, T, B> {
 pub struct DowngradedH2Error(h2::Reason);
 
 #[pin_project::pin_project]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct UpgradeResponseBody {
     inner: hyper::Body,
 }
@@ -146,14 +146,6 @@ fn downgrade_h2_error(error: hyper::Error) -> Error {
 }
 
 // === impl UpgradeResponseBody ===
-
-impl Default for UpgradeResponseBody {
-    fn default() -> Self {
-        UpgradeResponseBody {
-            inner: Default::default(),
-        }
-    }
-}
 
 impl HttpBody for UpgradeResponseBody {
     type Data = bytes::Bytes;

--- a/linkerd/proxy/tap/src/grpc/server.rs
+++ b/linkerd/proxy/tap/src/grpc/server.rs
@@ -64,10 +64,7 @@ pub struct TapResponse {
 }
 
 #[derive(Debug)]
-pub struct TapRequestPayload {
-    base_event: api::TapEvent,
-    tap: TapTx,
-}
+pub struct TapRequestPayload {}
 
 #[derive(Debug)]
 pub struct TapResponsePayload {
@@ -334,10 +331,7 @@ impl iface::Tap for Tap {
 
         let tap = TapTx { id, tx: events_tx };
 
-        let req = TapRequestPayload {
-            tap: tap.clone(),
-            base_event: base_event.clone(),
-        };
+        let req = TapRequestPayload {};
         let rsp = TapResponse {
             tap,
             base_event,

--- a/linkerd/transport-metrics/src/sensor.rs
+++ b/linkerd/transport-metrics/src/sensor.rs
@@ -7,7 +7,6 @@ use std::{sync::Arc, task::Poll, time::Instant};
 #[derive(Debug)]
 pub struct Sensor {
     metrics: Option<Arc<Metrics>>,
-    opened_at: Instant,
 }
 
 pub type SensorIo<T> = io::SensorIo<T, Sensor>;
@@ -21,7 +20,6 @@ impl Sensor {
         metrics.by_eos.lock().last_update = Instant::now();
         Self {
             metrics: Some(metrics),
-            opened_at: Instant::now(),
         }
     }
 }


### PR DESCRIPTION
Rust nightly now catches some warnings that can cause fuzer builds to
fail. This change addresses these issues.