### PR TITLE
inbound: Reduce needless allocation in stack targets

### DIFF
--- a/linkerd/app/core/src/metrics/mod.rs
+++ b/linkerd/app/core/src/metrics/mod.rs
@@ -13,6 +13,7 @@ pub use linkerd_metrics::*;
 use std::{
     fmt::{self, Write},
     net::SocketAddr,
+    sync::Arc,
     time::{Duration, SystemTime},
 };
 
@@ -65,13 +66,13 @@ pub struct InboundEndpointLabels {
 
 /// A label referencing an inbound `Server` (i.e. for policy).
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct ServerLabel(pub String);
+pub struct ServerLabel(pub Arc<str>);
 
 /// Labels referencing an inbound `ServerAuthorization.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct AuthzLabels {
     pub server: ServerLabel,
-    pub authz: String,
+    pub authz: Arc<str>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -194,7 +194,7 @@ mod tests {
                 negotiated_protocol: None,
             }),
             ([192, 0, 2, 4], 40000).into(),
-            PolicyServerLabel("testserver".to_string()),
+            PolicyServerLabel("testserver".into()),
         );
         assert_eq!(
             labels.to_string(),

--- a/linkerd/app/inbound/src/accept.rs
+++ b/linkerd/app/inbound/src/accept.rs
@@ -128,9 +128,9 @@ mod tests {
                 authorizations: vec![Authorization {
                     authentication: Authentication::Unauthenticated,
                     networks: vec![Default::default()],
-                    name: "testsaz".to_string(),
+                    name: "testsaz".into(),
                 }],
-                name: "testsrv".to_string(),
+                name: "testsrv".into(),
             },
             None,
         );

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -442,9 +442,9 @@ mod tests {
                 authorizations: vec![Authorization {
                     authentication: Authentication::Unauthenticated,
                     networks: vec![client_addr().ip().into()],
-                    name: "testsaz".to_string(),
+                    name: "testsaz".into(),
                 }],
-                name: "testsrv".to_string(),
+                name: "testsrv".into(),
             },
         );
         allow

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -419,9 +419,9 @@ impl svc::Param<policy::AllowPolicy> for Target {
                 authorizations: vec![policy::Authorization {
                     authentication: policy::Authentication::Unauthenticated,
                     networks: vec![std::net::IpAddr::from([192, 0, 2, 3]).into()],
-                    name: "testsaz".to_string(),
+                    name: "testsaz".into(),
                 }],
-                name: "testsrv".to_string(),
+                name: "testsrv".into(),
             },
         );
         policy
@@ -430,7 +430,7 @@ impl svc::Param<policy::AllowPolicy> for Target {
 
 impl svc::Param<policy::ServerLabel> for Target {
     fn param(&self) -> policy::ServerLabel {
-        policy::ServerLabel("testsrv".to_string())
+        policy::ServerLabel("testsrv".into())
     }
 }
 

--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -75,8 +75,8 @@ fn mk(
         authorizations: vec![Authorization {
             networks: nets.into_iter().map(Into::into).collect(),
             authentication,
-            name: name.to_string(),
+            name: name.into(),
         }],
-        name: name.to_string(),
+        name: name.into(),
     }
 }

--- a/linkerd/app/inbound/src/policy/discover.rs
+++ b/linkerd/app/inbound/src/policy/discover.rs
@@ -164,7 +164,8 @@ fn to_policy(proto: api::Server) -> Result<ServerPolicy> {
                 let name = labels
                     .get("name")
                     .ok_or("authorization missing 'name' label")?
-                    .clone();
+                    .clone()
+                    .into();
 
                 Ok(Authorization {
                     networks,
@@ -179,7 +180,8 @@ fn to_policy(proto: api::Server) -> Result<ServerPolicy> {
         .labels
         .get("name")
         .ok_or("server missing 'name' label")?
-        .clone();
+        .clone()
+        .into();
 
     Ok(ServerPolicy {
         protocol,

--- a/linkerd/app/inbound/src/policy/mod.rs
+++ b/linkerd/app/inbound/src/policy/mod.rs
@@ -27,7 +27,7 @@ pub struct DeniedUnknownPort(pub u16);
 #[derive(Clone, Debug, Error)]
 #[error("unauthorized connection on server {server}")]
 pub struct DeniedUnauthorized {
-    server: String,
+    server: std::sync::Arc<str>,
 }
 
 pub trait CheckPolicy {
@@ -70,7 +70,7 @@ impl From<DefaultPolicy> for ServerPolicy {
             DefaultPolicy::Deny => ServerPolicy {
                 protocol: Protocol::Opaque,
                 authorizations: vec![],
-                name: "default:deny".to_string(),
+                name: "default:deny".into(),
             },
         }
     }

--- a/linkerd/app/inbound/src/policy/tests.rs
+++ b/linkerd/app/inbound/src/policy/tests.rs
@@ -9,9 +9,9 @@ fn unauthenticated_allowed() {
         authorizations: vec![Authorization {
             authentication: Authentication::Unauthenticated,
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            name: "unauth".to_string(),
+            name: "unauth".into(),
         }],
-        name: "test".to_string(),
+        name: "test".into(),
     };
 
     let (policies, _tx) = Store::fixed(policy.clone(), None);
@@ -30,8 +30,8 @@ fn unauthenticated_allowed() {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
             labels: AuthzLabels {
-                server: ServerLabel("test".to_string()),
-                authz: "unauth".to_string(),
+                server: ServerLabel("test".into()),
+                authz: "unauth".into(),
             }
         }
     );
@@ -47,9 +47,9 @@ fn authenticated_identity() {
                 identities: vec![client_id().to_string()].into_iter().collect(),
             },
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            name: "tls-auth".to_string(),
+            name: "tls-auth".into(),
         }],
-        name: "test".to_string(),
+        name: "test".into(),
     };
 
     let (policies, _tx) = Store::fixed(policy.clone(), None);
@@ -71,8 +71,8 @@ fn authenticated_identity() {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
             labels: AuthzLabels {
-                server: ServerLabel("test".to_string()),
-                authz: "tls-auth".to_string(),
+                server: ServerLabel("test".into()),
+                authz: "tls-auth".into(),
             }
         }
     );
@@ -97,15 +97,12 @@ fn authenticated_suffix() {
         authorizations: vec![Authorization {
             authentication: Authentication::TlsAuthenticated {
                 identities: HashSet::default(),
-                suffixes: vec![Suffix::from(vec![
-                    "cluster".to_string(),
-                    "local".to_string(),
-                ])],
+                suffixes: vec![Suffix::from(vec!["cluster".into(), "local".into()])],
             },
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            name: "tls-auth".to_string(),
+            name: "tls-auth".into(),
         }],
-        name: "test".to_string(),
+        name: "test".into(),
     };
 
     let (policies, _tx) = Store::fixed(policy.clone(), None);
@@ -126,8 +123,8 @@ fn authenticated_suffix() {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
             labels: AuthzLabels {
-                server: ServerLabel("test".to_string()),
-                authz: "tls-auth".to_string(),
+                server: ServerLabel("test".into()),
+                authz: "tls-auth".into(),
             }
         }
     );
@@ -152,9 +149,9 @@ fn tls_unauthenticated() {
         authorizations: vec![Authorization {
             authentication: Authentication::TlsUnauthenticated,
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            name: "tls-unauth".to_string(),
+            name: "tls-unauth".into(),
         }],
-        name: "test".to_string(),
+        name: "test".into(),
     };
 
     let (policies, _tx) = Store::fixed(policy.clone(), None);
@@ -175,8 +172,8 @@ fn tls_unauthenticated() {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
             labels: AuthzLabels {
-                server: ServerLabel("test".to_string()),
-                authz: "tls-unauth".to_string(),
+                server: ServerLabel("test".into()),
+                authz: "tls-unauth".into(),
             }
         }
     );

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -56,9 +56,9 @@ pub fn default_config() -> Config {
                 authorizations: vec![Authorization {
                     authentication: Authentication::Unauthenticated,
                     networks: vec![Default::default()],
-                    name: "testsaz".to_string(),
+                    name: "testsaz".into(),
                 }],
-                name: "testsrv".to_string(),
+                name: "testsrv".into(),
             }
             .into(),
             ports: Default::default(),

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -1,13 +1,13 @@
 mod network;
 
 pub use self::network::Network;
-use std::{collections::HashSet, hash::Hash, time};
+use std::{collections::HashSet, hash::Hash, sync::Arc, time};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ServerPolicy {
     pub protocol: Protocol,
     pub authorizations: Vec<Authorization>,
-    pub name: String,
+    pub name: Arc<str>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -24,7 +24,7 @@ pub enum Protocol {
 pub struct Authorization {
     pub networks: Vec<Network>,
     pub authentication: Authentication,
-    pub name: String,
+    pub name: Arc<str>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Inbound stacks include labels for the inbound server and authorization
names. Every time a stack target is cloned, however, these strings are
re-allocated.

This change modifies these label types to hold an `Arc<str>` so that
cloning the stack target is cheap, reusing the initial allocation.