### PR TITLE
Reduce HTTP retry buffer to 16KB

### DIFF
--- a/linkerd/app/core/src/retry.rs
+++ b/linkerd/app/core/src/retry.rs
@@ -31,7 +31,7 @@ pub struct RetryPolicy {
 }
 
 /// Allow buffering requests up to 64 kb
-const MAX_BUFFERED_BYTES: usize = 64 * 1024;
+const MAX_BUFFERED_BYTES: usize = 16 * 1024;
 
 // === impl NewRetryPolicy ===
 


### PR DESCRIPTION
64KB is quite large for a default buffering strategy. Let's reduce this
to 16KB until we merge a more configurable solution.