### PR TITLE
tracing: use `Span::or_current` when spawning tasks

### DIFF
--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -39,39 +39,38 @@ pub async fn serve<M, S, I, A>(
                     };
 
                     // The local addr should be instrumented from the listener's context.
-                    debug_span!("accept", client.addr = %addrs.param()).in_scope(|| {
-                        let accept = new_accept.new_service(addrs);
+                    let span = debug_span!("accept", client.addr = %addrs.param()).entered();
+                    let accept = new_accept.new_service(addrs);
 
-                        // Dispatch all of the work for a given connection onto a
-                        // connection-specific task.
-                        tokio::spawn(
-                            async move {
-                                match accept.ready_oneshot().err_into::<Error>().await {
-                                    Ok(mut accept) => {
-                                        match accept
-                                            .call(io::ScopedIo::server(io))
-                                            .err_into::<Error>()
-                                            .await
-                                        {
-                                            Ok(()) => debug!("Connection closed"),
-                                            Err(reason) if is_io(&*reason) => {
-                                                debug!(%reason, "Connection closed")
-                                            }
-                                            Err(error) => info!(%error, "Connection closed"),
+                    // Dispatch all of the work for a given connection onto a
+                    // connection-specific task.
+                    tokio::spawn(
+                        async move {
+                            match accept.ready_oneshot().err_into::<Error>().await {
+                                Ok(mut accept) => {
+                                    match accept
+                                        .call(io::ScopedIo::server(io))
+                                        .err_into::<Error>()
+                                        .await
+                                    {
+                                        Ok(()) => debug!("Connection closed"),
+                                        Err(reason) if is_io(&*reason) => {
+                                            debug!(%reason, "Connection closed")
                                         }
-                                        // Hold the service until the connection is complete. This
-                                        // helps tie any inner cache lifetimes to the services they
-                                        // return.
-                                        drop(accept);
+                                        Err(error) => info!(%error, "Connection closed"),
                                     }
-                                    Err(error) => {
-                                        warn!(%error, "Server failed to become ready");
-                                    }
+                                    // Hold the service until the connection is complete. This
+                                    // helps tie any inner cache lifetimes to the services they
+                                    // return.
+                                    drop(accept);
+                                }
+                                Err(error) => {
+                                    warn!(%error, "Server failed to become ready");
                                 }
                             }
-                            .in_current_span(),
-                        );
-                    });
+                        }
+                        .instrument(span.exit().or_current()),
+                    );
                 }
             }
         }

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -360,7 +360,7 @@ fn connect_timeout(
                 // about returning a service here.
                 unreachable!();
             }
-            .instrument(span),
+            .instrument(span.or_current()),
         )
     })
 }

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -390,10 +390,10 @@ where
                         .map_err(|error| tracing::error!(%error, "serving connection failed."))?;
                     Ok::<(), ()>(())
                 };
-                tokio::spawn(cancelable(drain.clone(), f).instrument(span));
+                tokio::spawn(cancelable(drain.clone(), f).instrument(span).or_current());
             }
         })
-        .instrument(tracing::info_span!("controller", message = %name, %addr)),
+        .instrument(tracing::info_span!("controller", message = %name, %addr).or_current()),
     );
 
     listening_rx.await.expect("listening_rx");

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -390,7 +390,7 @@ where
                         .map_err(|error| tracing::error!(%error, "serving connection failed."))?;
                     Ok::<(), ()>(())
                 };
-                tokio::spawn(cancelable(drain.clone(), f).instrument(span).or_current());
+                tokio::spawn(cancelable(drain.clone(), f).instrument(span.or_current()));
             }
         })
         .instrument(tracing::info_span!("controller", message = %name, %addr).or_current()),

--- a/linkerd/app/integration/src/server.rs
+++ b/linkerd/app/integration/src/server.rs
@@ -253,10 +253,15 @@ impl Server {
                         tracing::trace!(?result, "serve done");
                         result
                     };
-                    tokio::spawn(cancelable(drain.clone(), f).instrument(span.clone()));
+                    tokio::spawn(
+                        cancelable(drain.clone(), f).instrument(span.clone().or_current()),
+                    );
                 }
             }
-            .instrument(tracing::info_span!("test_server", ?version, %addr, test = %thread_name())),
+            .instrument(
+                tracing::info_span!("test_server", ?version, %addr, test = %thread_name())
+                    .or_current(),
+            ),
         ));
 
         listening_rx.await.expect("listening_rx");

--- a/linkerd/app/integration/src/tcp.rs
+++ b/linkerd/app/integration/src/tcp.rs
@@ -106,7 +106,7 @@ impl TcpClient {
                     }
                 }
             }
-            .instrument(span),
+            .instrument(span.or_current()),
         );
         TcpConn {
             addr: self.addr,

--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -53,11 +53,9 @@ impl Config {
                 // Save to be spawned on an auxiliary runtime.
                 let task = {
                     let addr = addr.clone();
-                    Box::pin(
-                        daemon
-                            .run(svc)
-                            .instrument(tracing::debug_span!("identity", server.addr = %addr)),
-                    )
+                    Box::pin(daemon.run(svc).instrument(
+                        tracing::debug_span!("identity", server.addr = %addr).or_current(),
+                    ))
                 };
 
                 Ok(Identity::Enabled { addr, local, task })

--- a/linkerd/app/src/oc_collector.rs
+++ b/linkerd/app/src/oc_collector.rs
@@ -75,8 +75,9 @@ impl Config {
 
                     let addr = addr.clone();
                     Box::pin(
-                        opencensus::export_spans(svc, node, spans_rx, metrics)
-                            .instrument(tracing::debug_span!("opencensus", peer.addr = %addr)),
+                        opencensus::export_spans(svc, node, spans_rx, metrics).instrument(
+                            tracing::debug_span!("opencensus", peer.addr = %addr).or_current(),
+                        ),
                     )
                 };
 

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -119,8 +119,7 @@ where
 
                 tokio::spawn(
                     conn.map_err(|error| debug!(%error, "failed"))
-                        .instrument(trace_span!("conn"))
-                        .in_current_span(),
+                        .instrument(trace_span!("conn").or_current()),
                 );
 
                 Ok(Connection { tx })


### PR DESCRIPTION
`tracing` v0.1.27 added a new [`Span::or_current`] method to aid with
efficiently propagating spans to spawned tasks (or threads). The method
is intended to be used when a spawned task should be instrumented with a
provided span if it is enabled, or the current span if the provided span
is _not_ enabled. `span.or_current()` returns `span` if it is enabled,
or, if `span` is disabled, it clones the current span and returns it.

This offers better performance than writing code like this:
```rust
    .instrument(span)
    .in_current_span()
```

First, `or_current` will only look up the current span (requiring a
thread-local access) _if_ `span` is not enabled, while
`.instrument(span).in_current_span()` will do this unconditionally.

Second, and more importantly, using `.in_current_span()` will wrap the
spawned future in _two_ `Instrumented` futures. One will enter the
current span whenever the task is polled, and inside that, the second
`instrument` will enter the passed span. This means we are entering two
spans instead of one, in the case where both are enabled. That adds a
small amount of additional overhead in every poll.

Therefore, this branch changes code that instruments a future prior to
spawning it to use `Span::or_current`. A lot of this is test code, which
(it turns out) doesn't really handle span propagation at all. However,
this also touches the main accept loop, as well as where we spawn admin
background tasks.

[`Span::or_current`]: https://docs.rs/tracing/0.1.27/tracing/span/struct.Span.html#method.or_current