### PR TITLE
dns: Log TTL with resolution

### DIFF
--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -95,7 +95,7 @@ impl Resolver {
             .into_iter()
             .map(Self::srv_to_socket_addr)
             .collect::<Result<_, InvalidSrv>>()?;
-        debug!(?addrs);
+        debug!(ttl = ?valid_until - time::Instant::now(), ?addrs);
         Ok((addrs, time::sleep_until(valid_until)))
     }
 


### PR DESCRIPTION
When debugging DNS issues, it's useful to know the TTL for a resolution.