### PR TITLE
error-respond: Support stack target configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,8 +909,8 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-error",
+ "linkerd-stack",
  "pin-project",
- "tower",
 ]
 
 [[package]]

--- a/linkerd/app/core/src/errors/mod.rs
+++ b/linkerd/app/core/src/errors/mod.rs
@@ -1,6 +1,6 @@
 pub mod respond;
 
-pub use self::respond::{HttpRescue, NewRespond, SyntheticHttpResponse};
+pub use self::respond::{HttpRescue, NewRespond, NewRespondService, SyntheticHttpResponse};
 pub use linkerd_proxy_http::h2::H2Error;
 pub use linkerd_stack::FailFastError;
 use thiserror::Error;

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -66,9 +66,9 @@ impl<H> Inbound<H> {
                         .push(svc::FailFast::layer("HTTP Server", dispatch_timeout)),
                 )
                 .push(rt.metrics.http_errors.to_layer())
+                .push(ServerRescue::layer())
                 .push_on_service(
                     svc::layers()
-                        .push(ServerRescue::layer())
                         .push(http_tracing::server(
                             rt.span_sink.clone(),
                             super::trace_labels(),
@@ -90,8 +90,9 @@ impl<H> Inbound<H> {
 
 impl ServerRescue {
     /// Synthesizes responses for HTTP requests that encounter proxy errors.
-    pub fn layer() -> errors::respond::Layer<Self> {
-        errors::respond::NewRespond::layer(Self)
+    pub fn layer<N>(
+    ) -> impl svc::layer::Layer<N, Service = errors::NewRespondService<Self, Self, N>> + Clone {
+        errors::respond::layer(Self)
     }
 }
 

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -49,7 +49,7 @@ impl<C> Outbound<C> {
                 // and metrics. HTTP error metrics are not incremented here so that errors are not
                 // double-counted--i.e., endpoint metrics track these responses and error metrics
                 // track proxy errors that occur higher in the stack.
-                .push_on_service(ClientRescue::layer())
+                .push(ClientRescue::layer())
                 .push(tap::NewTapHttp::layer(rt.tap.clone()))
                 .push(
                     rt.metrics
@@ -80,8 +80,9 @@ impl<C> Outbound<C> {
 
 impl ClientRescue {
     /// Synthesizes responses for HTTP requests that encounter proxy errors.
-    pub fn layer() -> errors::respond::Layer<Self> {
-        errors::respond::NewRespond::layer(Self)
+    pub fn layer<N>(
+    ) -> impl svc::layer::Layer<N, Service = errors::NewRespondService<Self, Self, N>> + Clone {
+        errors::respond::layer(Self)
     }
 }
 

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -209,8 +209,11 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                     // Otherwise, the inner service is always ready (because it's a router).
                     .push(svc::ConcurrencyLimitLayer::new(max_in_flight_requests))
                     .push(svc::FailFast::layer("Ingress server", dispatch_timeout))
-                    .push(rt.metrics.http_errors.to_layer())
-                    .push(http::ServerRescue::layer())
+                    .push(rt.metrics.http_errors.to_layer()),
+            )
+            .push(http::ServerRescue::layer())
+            .push_on_service(
+                svc::layers()
                     .push(http_tracing::server(rt.span_sink, trace_labels()))
                     .push(http::BoxResponse::layer())
                     .push(http::BoxRequest::layer()),

--- a/linkerd/error-respond/Cargo.toml
+++ b/linkerd/error-respond/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 [dependencies]
 futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }
-tower = { version = "0.4.8", default-features = false }
+linkerd-stack = { path = "../stack" }
 pin-project = "1"


### PR DESCRIPTION
The error responder is currently a `Service` and not a `NewService`
meaning there's no means to configure the responder using the stack
target.

This change introduces a `NewRespondService` type that implements
`NewService` to instrument the error responder. This will be used in
follow-up changes to configure the error responder to only emit headers
in certain conditions.