### PR TITLE
Support a `l5d-proxy-connection: close` header

### DIFF
--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -192,6 +192,7 @@ impl SyntheticHttpResponse {
 
         if self.close_connection {
             if version == http::Version::HTTP_11 {
+                // Notify the (proxy or non-proxy) client that the connection will be closed.
                 rsp = rsp.header(http::header::CONNECTION, "close");
             }
 

--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -12,6 +12,7 @@ use std::{
 };
 use tracing::{debug, info_span, warn};
 
+pub const L5D_PROXY_CONNECTION: &str = "l5d-proxy-connection";
 pub const L5D_PROXY_ERROR: &str = "l5d-proxy-error";
 
 pub fn layer<R, P: Clone, N>(
@@ -159,14 +160,22 @@ impl SyntheticHttpResponse {
     #[inline]
     fn grpc_response<B: Default>(&self) -> http::Response<B> {
         debug!(code = %self.grpc_status, "Handling error on gRPC connection");
-        http::Response::builder()
+        let mut rsp = http::Response::builder()
             .version(http::Version::HTTP_2)
             .header(http::header::CONTENT_LENGTH, "0")
             .header(http::header::CONTENT_TYPE, GRPC_CONTENT_TYPE)
             .header(GRPC_STATUS, code_header(self.grpc_status))
-            .header(GRPC_MESSAGE, self.message())
-            .header(L5D_PROXY_ERROR, self.message())
-            .body(B::default())
+            .header(GRPC_MESSAGE, self.message());
+
+        // TODO only set when client is trusted.
+        rsp = rsp.header(L5D_PROXY_ERROR, self.message());
+
+        if self.close_connection {
+            // TODO only set when meshed.
+            rsp = rsp.header(L5D_PROXY_CONNECTION, "close");
+        }
+
+        rsp.body(B::default())
             .expect("error response must be valid")
     }
 
@@ -176,11 +185,20 @@ impl SyntheticHttpResponse {
         let mut rsp = http::Response::builder()
             .status(self.http_status)
             .version(version)
-            .header(http::header::CONTENT_LENGTH, "0")
-            .header(L5D_PROXY_ERROR, self.message());
+            .header(http::header::CONTENT_LENGTH, "0");
 
-        if self.close_connection && version == http::Version::HTTP_11 {
-            rsp = rsp.header(http::header::CONNECTION, "close");
+        // TODO only set when client is trusted.
+        rsp = rsp.header(L5D_PROXY_ERROR, self.message());
+
+        if self.close_connection {
+            if version == http::Version::HTTP_11 {
+                rsp = rsp.header(http::header::CONNECTION, "close");
+            }
+
+            // Tell the remote outbound proxy that it should close the connection to its
+            // application, i.e. so the application can choose another replica.
+            // TODO only set when meshed.
+            rsp = rsp.header(L5D_PROXY_CONNECTION, "close");
         }
 
         rsp.body(B::default())

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -1,10 +1,11 @@
 pub mod detect;
 mod endpoint;
 pub mod logical;
-mod peer_proxy_errors;
+mod proxy_connection_close;
 mod require_id_header;
 mod server;
 
+use self::{proxy_connection_close::ProxyConnectionClose, require_id_header::NewRequireIdentity};
 pub(crate) use self::{require_id_header::IdentityRequired, server::ServerRescue};
 use crate::tcp;
 pub use linkerd_app_core::proxy::http::*;

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -1,4 +1,4 @@
-use super::{peer_proxy_errors::PeerProxyErrors, IdentityRequired};
+use super::{IdentityRequired, ProxyConnectionClose};
 use crate::{http, trace_labels, Outbound};
 use linkerd_app_core::{config, errors, http_tracing, svc, Error, Result};
 
@@ -50,7 +50,7 @@ impl<N> Outbound<N> {
                         .push_spawn_buffer(buffer_capacity)
                         .push(rt.metrics.http_errors.to_layer())
                         // Tear down server connections when a peer proxy generates an error.
-                        .push(PeerProxyErrors::layer()),
+                        .push(ProxyConnectionClose::layer()),
                 )
                 // Synthesizes responses for proxy errors.
                 .check_new_service::<T, http::Request<_>>()

--- a/linkerd/proxy/http/src/strip_header.rs
+++ b/linkerd/proxy/http/src/strip_header.rs
@@ -52,6 +52,7 @@ pub mod request {
         type Error = P::Error;
         type Future = P::Future;
 
+        #[inline]
         fn proxy(&self, svc: &mut S, mut req: http::Request<B>) -> Self::Future {
             req.headers_mut().remove(self.header.clone());
             self.inner.proxy(svc, req)
@@ -67,10 +68,12 @@ pub mod request {
         type Error = S::Error;
         type Future = S::Future;
 
+        #[inline]
         fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             self.inner.poll_ready(cx)
         }
 
+        #[inline]
         fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
             req.headers_mut().remove(self.header.clone());
             self.inner.call(req)
@@ -124,10 +127,12 @@ pub mod response {
         type Error = S::Error;
         type Future = ResponseFuture<S::Future, H>;
 
+        #[inline]
         fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             self.inner.poll_ready(cx)
         }
 
+        #[inline]
         fn call(&mut self, req: Req) -> Self::Future {
             ResponseFuture {
                 inner: self.inner.call(req),
@@ -143,6 +148,7 @@ pub mod response {
     {
         type Output = Result<F::Ok, F::Error>;
 
+        #[inline]
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             let this = self.project();
             let mut res = ready!(this.inner.try_poll(cx))?;


### PR DESCRIPTION
In 6cf1b2851, we updated the outbound proxy to automatically teardown
connections when the peer proxy sets the `l5d-proxy-error` response
header; but this header may be set in some situations when disconnecting
isn't appropriate and will only generate more load on the system.

This change introduces a `l5d-proxy-connection` header (like the
`connection` and `proxy-connection` headers) that the proxy can use to
signal that the proxied connection should be closed, independently of
the informational `l5d-proxy-error` message.

Some TODOs have been marked for followup improvements.