### PR TITLE
Avoid emitting informational headers to untrusted clients

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -63,6 +63,9 @@ struct TlsParams {
 
 const DETECT_TIMEOUT: Duration = Duration::from_secs(1);
 
+#[derive(Copy, Clone, Debug)]
+struct Rescue;
+
 // === impl Config ===
 
 impl Config {
@@ -94,13 +97,7 @@ impl Config {
             .push(metrics.proxy.http_endpoint.to_layer::<classify::Response, _, Permitted>())
             .push_map_target(|(permit, http)| Permitted { permit, http })
             .push(inbound::policy::NewAuthorizeHttp::layer(metrics.http_authz.clone()))
-            .push(errors::respond::layer(|error: Error| -> Result<_> {
-                if error.is::<inbound::policy::DeniedUnauthorized> () {
-                    return Ok(errors::SyntheticHttpResponse::permission_denied(error));
-                }
-                tracing::warn!(%error, "Unexpected error");
-                Ok(errors::SyntheticHttpResponse::unexpected_error())
-            }))
+            .push(Rescue::layer())
             .push_on_service(http::BoxResponse::layer())
             .push(http::NewServeHttp::layer(Default::default(), drain.clone()))
             .push_request_filter(
@@ -145,7 +142,7 @@ impl Config {
                 },
             )
             .push(svc::ArcNewService::layer())
-            .push(detect::NewDetectService::layer(detect::Config::<http::DetectHttp>::from_timeout(DETECT_TIMEOUT)))
+            .push(detect::NewDetectService::layer(svc::stack::CloneParam::from(detect::Config::<http::DetectHttp>::from_timeout(DETECT_TIMEOUT))))
             .push(transport::metrics::NewServer::layer(metrics.proxy.transport))
             .push_map_target(move |(tls, addrs): (tls::ConditionalServerTls, B::Addrs)| {
                 Tcp {
@@ -256,5 +253,50 @@ impl<T> InsertParam<tls::ConditionalServerTls, T> for TlsParams {
     #[inline]
     fn insert_param(&self, tls: tls::ConditionalServerTls, target: T) -> Self::Target {
         (tls, target)
+    }
+}
+
+// === impl Rescue ===
+
+impl Rescue {
+    /// Synthesizes responses for HTTP requests that encounter errors.
+    pub fn layer<N>(
+    ) -> impl svc::layer::Layer<N, Service = errors::NewRespondService<Self, Self, N>> + Clone {
+        errors::respond::layer(Self)
+    }
+}
+
+impl<T> ExtractParam<Self, T> for Rescue {
+    #[inline]
+    fn extract_param(&self, _: &T) -> Self {
+        Self
+    }
+}
+
+impl<T: Param<tls::ConditionalServerTls>> ExtractParam<errors::respond::EmitHeaders, T> for Rescue {
+    #[inline]
+    fn extract_param(&self, t: &T) -> errors::respond::EmitHeaders {
+        // Only emit informational headers to meshed peers.
+        let emit = t
+            .param()
+            .value()
+            .map(|tls| match tls {
+                tls::ServerTls::Established { client_id, .. } => client_id.is_some(),
+                _ => false,
+            })
+            .unwrap_or(false);
+        errors::respond::EmitHeaders(emit)
+    }
+}
+
+impl errors::HttpRescue<Error> for Rescue {
+    fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
+        let cause = errors::root_cause(&*error);
+        if cause.is::<inbound::policy::DeniedUnauthorized>() {
+            return Ok(errors::SyntheticHttpResponse::permission_denied(error));
+        }
+
+        tracing::warn!(%error, "Unexpected error");
+        Ok(errors::SyntheticHttpResponse::unexpected_error())
     }
 }

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -260,7 +260,7 @@ impl<T> InsertParam<tls::ConditionalServerTls, T> for TlsParams {
 
 impl Rescue {
     /// Synthesizes responses for HTTP requests that encounter errors.
-    pub fn layer<N>(
+    fn layer<N>(
     ) -> impl svc::layer::Layer<N, Service = errors::NewRespondService<Self, Self, N>> + Clone {
         errors::respond::layer(Self)
     }

--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -1,7 +1,7 @@
 pub use crate::exp_backoff::ExponentialBackoff;
 use crate::{
     proxy::http::{self, h1, h2},
-    svc::Param,
+    svc::{stack::CloneParam, Param},
     transport::{Keepalive, ListenAddr},
 };
 use std::time::Duration;
@@ -36,8 +36,8 @@ pub struct ProxyConfig {
 // === impl ProxyConfig ===
 
 impl ProxyConfig {
-    pub fn detect_http(&self) -> linkerd_detect::Config<http::DetectHttp> {
-        linkerd_detect::Config::from_timeout(self.detect_protocol_timeout)
+    pub fn detect_http(&self) -> CloneParam<linkerd_detect::Config<http::DetectHttp>> {
+        linkerd_detect::Config::from_timeout(self.detect_protocol_timeout).into()
     }
 }
 

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -51,9 +51,7 @@ impl<H> Inbound<H> {
                 // `Client`. This must be below the `orig_proto::Downgrade` layer, since
                 // the request may have been downgraded from a HTTP/2 orig-proto request.
                 .push(http::NewNormalizeUri::layer())
-                .check_new_service::<T, http::Request<_>>()
                 .push(NewSetIdentityHeader::layer(()))
-                .check_new_service::<T, http::Request<_>>()
                 .push_on_service(
                     svc::layers()
                         .push(http::BoxRequest::layer())

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -100,7 +100,7 @@ impl ServerRescue {
 impl<T> ExtractParam<Self, T> for ServerRescue {
     #[inline]
     fn extract_param(&self, _: &T) -> Self {
-        Self
+        *self
     }
 }
 
@@ -125,13 +125,6 @@ impl<T: Param<tls::ConditionalServerTls>> ExtractParam<errors::respond::EmitHead
 impl errors::HttpRescue<Error> for ServerRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
         let cause = errors::root_cause(&*error);
-
-        if cause.is::<std::io::Error>() {
-            return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
-        }
-        if cause.is::<errors::ConnectTimeout>() {
-            return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
-        }
         if cause.is::<crate::policy::DeniedUnauthorized>() {
             return Ok(errors::SyntheticHttpResponse::permission_denied(cause));
         }

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -102,16 +102,6 @@ impl<T> ExtractParam<errors::respond::EmitHeaders, T> for ServerRescue {
 impl errors::HttpRescue<Error> for ServerRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
         let cause = errors::root_cause(&*error);
-
-        if cause.is::<http::orig_proto::DowngradedH2Error>() {
-            return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
-        }
-        if cause.is::<std::io::Error>() {
-            return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
-        }
-        if cause.is::<errors::ConnectTimeout>() {
-            return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
-        }
         if cause.is::<http::ResponseTimeoutError>() {
             return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
         }

--- a/linkerd/stack/src/arc_new_service.rs
+++ b/linkerd/stack/src/arc_new_service.rs
@@ -8,7 +8,7 @@ pub struct ArcNewService<T, S> {
 impl<T, S> ArcNewService<T, S> {
     pub fn layer<N>() -> impl layer::Layer<N, Service = Self> + Clone + Copy
     where
-        N: NewService<T, Service = S> + Clone + Send + Sync + 'static,
+        N: NewService<T, Service = S> + Send + Sync + 'static,
         S: Send + 'static,
     {
         layer::mk(Self::new)


### PR DESCRIPTION
The inbound proxy sets the `l5d-proxy-error` and `l5d-proxy-connection`
headers when an error is encountered. This leaks information about the
proxy to potentially untrusted clients.

This change modifies the error handling behavior to only emit these
headers from the inbound proxy when the client uses mesh identity.

In doing so, we modify the `inbound::NewSetIdentiyHeader` layer to use
`ExtractParam<tls::ConditionalServerTls, _>` to parameterize the server
connection's identity to be consistent with the rescue parameters. This
precipitated modifying the default impls for `ExtractParam` so that we
can provide an impl for `()` that simply uses the target type. A new
`CloneParam` type is introduced to replicate the former behavior.