### PR TITLE
outbound: Only honor the `l5d-proxy-connection` header when meshed

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -196,6 +196,12 @@ impl<S> Stack<S> {
         self.push(http::insert::NewInsert::layer())
     }
 
+    pub fn push_http_response_insert_target<P>(
+        self,
+    ) -> Stack<http::insert::NewResponseInsert<P, S>> {
+        self.push(http::insert::NewResponseInsert::layer())
+    }
+
     pub fn push_cache<T>(self, idle: Duration) -> Stack<cache::Cache<T, S>>
     where
         T: Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -43,6 +43,9 @@ impl<C> Outbound<C> {
                 .check_service::<T>()
                 .into_new_service()
                 .push_new_reconnect(backoff)
+                // Set the TLS status on responses so that the stack can detect whether the request
+                // was sent over a meshed connection.
+                .push_http_response_insert_target::<tls::ConditionalClientTls>()
                 // Tear down server connections when a peer proxy generates an error.
                 // TODO(ver) this should only be honored when forwarding and not when the connection
                 // is part of a balancer.

--- a/linkerd/app/outbound/src/http/proxy_connection_close.rs
+++ b/linkerd/app/outbound/src/http/proxy_connection_close.rs
@@ -2,7 +2,7 @@ use futures::prelude::*;
 use linkerd_app_core::{
     errors::respond::{L5D_PROXY_CONNECTION, L5D_PROXY_ERROR},
     proxy::http::ClientHandle,
-    svc,
+    svc, tls,
 };
 use std::{
     future::Future,
@@ -83,23 +83,43 @@ impl<B, F: TryFuture<Ok = http::Response<B>>> Future for ResponseFuture<F> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let rsp = futures::ready!(this.inner.try_poll(cx))?;
+        let mut rsp = futures::ready!(this.inner.try_poll(cx))?;
 
-        if let Some(proxy_conn) = rsp.headers().get(L5D_PROXY_CONNECTION) {
+        // Clear the header...
+        if let Some(proxy_conn) = rsp.headers_mut().remove(L5D_PROXY_CONNECTION) {
             if proxy_conn == "close" {
-                if let Some(error) = rsp
-                    .headers()
-                    .get(L5D_PROXY_ERROR)
-                    .and_then(|v| v.to_str().ok())
-                {
-                    tracing::info!(%error, "Closing application connection for remote proxy");
-                } else {
-                    tracing::info!("Closing application connection for remote proxy");
-                }
+                match rsp.extensions().get::<tls::ConditionalClientTls>() {
+                    Some(tls::ConditionalClientTls::Some(_)) => {
+                        if let Some(error) = rsp
+                            .headers()
+                            .get(L5D_PROXY_ERROR)
+                            .and_then(|v| v.to_str().ok())
+                        {
+                            tracing::info!(%error, "Closing application connection for remote proxy");
+                        } else {
+                            tracing::info!("Closing application connection for remote proxy");
+                        }
 
-                // Signal that the proxy's server-side connection should be terminated. This handles
-                // the remote error as if the local proxy encountered an error.
-                this.client.close.close();
+                        if rsp.version() == http::Version::HTTP_11 {
+                            // If the response is HTTP/1.1, we need to send a Connection: close
+                            // header to tell the application this connection is being closed.
+                            rsp.headers_mut().insert(
+                                http::header::CONNECTION,
+                                http::HeaderValue::from_static("close"),
+                            );
+                        }
+
+                        // Signal that the proxy's server-side connection should be terminated. This handles
+                        // the remote error as if the local proxy encountered an error.
+                        this.client.close.close();
+                    }
+                    _ => {
+                        tracing::info!(
+                            "Received unmeshed response with {} set",
+                            L5D_PROXY_CONNECTION
+                        );
+                    }
+                }
             }
         }
 
@@ -119,7 +139,45 @@ mod test {
     use tokio::time;
 
     #[tokio::test(flavor = "current_thread")]
-    async fn connection_closes_after_response_header() {
+    async fn connection_closes_after_meshed_response_header() {
+        let _trace = test::trace_init();
+
+        // Build the client that should be closed after receiving a response
+        // with the l5d-proxy-error header.
+        let mut req = http::Request::builder()
+            .uri("http://foo.example.com")
+            .body(hyper::Body::default())
+            .unwrap();
+        let (handle, closed) = ClientHandle::new(([192, 0, 2, 3], 50000).into());
+        req.extensions_mut().insert(handle);
+
+        let svc = ProxyConnectionClose::new(svc::mk(move |_: http::Request<hyper::Body>| {
+            future::ok::<_, Infallible>(
+                http::Response::builder()
+                    .status(http::StatusCode::BAD_GATEWAY)
+                    .header(L5D_PROXY_CONNECTION, "close")
+                    .extension(tls::ConditionalClientTls::Some(tls::ClientTls {
+                        server_id: "foosa.barns.serviceaccount.identity.linkerd.cluster.local"
+                            .parse()
+                            .unwrap(),
+                        alpn: None,
+                    }))
+                    .body(hyper::Body::default())
+                    .unwrap(),
+            )
+        }));
+
+        let rsp = svc.oneshot(req).await.expect("request must succeed");
+        assert_eq!(rsp.status(), http::StatusCode::BAD_GATEWAY);
+
+        // The client handle close future should fire.
+        time::timeout(time::Duration::from_secs(10), closed)
+            .await
+            .expect("client handle must close");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn header_ignored_in_unmeshed_response_header() {
         let _trace = test::trace_init();
 
         // Build the client that should be closed after receiving a response
@@ -143,16 +201,11 @@ mod test {
 
         let rsp = svc.oneshot(req).await.expect("request must succeed");
         assert_eq!(rsp.status(), http::StatusCode::BAD_GATEWAY);
-        assert_eq!(
-            rsp.headers()
-                .get(L5D_PROXY_CONNECTION)
-                .expect("response did not contain l5d-proxy-connection header"),
-            "close"
-        );
 
         // The client handle close future should fire.
-        time::timeout(time::Duration::from_secs(10), closed)
-            .await
-            .expect("client handle must close");
+        tokio::select! {
+            _ = time::sleep(time::Duration::from_secs(10)) => {},
+            _ = closed => panic!("connection shouldn't close"),
+        }
     }
 }

--- a/linkerd/proxy/http/src/insert.rs
+++ b/linkerd/proxy/http/src/insert.rs
@@ -1,20 +1,38 @@
+use futures::{Future, TryFuture};
 use linkerd_stack::{layer, NewService, Param, Proxy};
-use std::marker::PhantomData;
-use std::task::{Context, Poll};
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 pub trait Lazy<V>: Clone {
     fn value(&self) -> V;
 }
 
-/// Wraps an HTTP `Service` so that the `T -typed value` is cloned into
-/// each request's extensions.
-#[derive(Clone, Debug)]
-pub struct Layer<L, V> {
+/// Wraps an HTTP `Service` so that a `P`-typed `Param` is cloned into each
+/// request's extensions.
+#[derive(Debug)]
+pub struct NewInsert<P, N> {
+    inner: N,
+    _marker: PhantomData<fn() -> P>,
+}
+
+/// Wraps an HTTP `Service` so that a `P`-typed `Param` is cloned into each
+/// response's extensions.
+#[derive(Debug)]
+pub struct NewResponseInsert<P, N> {
+    inner: N,
+    _marker: PhantomData<fn() -> P>,
+}
+
+pub struct Insert<S, L, V> {
+    inner: S,
     lazy: L,
     _marker: PhantomData<fn() -> V>,
 }
 
-pub struct Insert<S, L, V> {
+pub struct ResponseInsert<S, L, V> {
     inner: S,
     lazy: L,
     _marker: PhantomData<fn() -> V>,
@@ -26,46 +44,83 @@ pub struct FnLazy<F>(F);
 #[derive(Clone, Debug)]
 pub struct ValLazy<V>(V);
 
-/// Wraps an HTTP `Service` so that a `P`-typed `Param` is cloned into each
-/// request's extensions.
+#[pin_project::pin_project]
 #[derive(Debug)]
-pub struct NewInsert<P, N> {
-    inner: N,
-    _marker: PhantomData<fn() -> P>,
+pub struct ResponseInsertFuture<F, L, V, B> {
+    #[pin]
+    inner: F,
+    lazy: L,
+    _marker: PhantomData<fn(B) -> V>,
 }
 
-pub fn layer<F, V>(f: F) -> Layer<FnLazy<F>, V>
-where
-    F: Fn() -> V + Clone,
-    V: Send + Sync + 'static,
-{
-    Layer::new(FnLazy(f))
-}
+// === impl NewInsert ===
 
-// === impl Layer ===
-
-impl<L, V> Layer<L, V>
-where
-    L: Lazy<V>,
-    V: Send + Sync + 'static,
-{
-    pub fn new(lazy: L) -> Self {
-        Self {
-            lazy,
+impl<P, N> NewInsert<P, N> {
+    pub fn layer() -> impl tower::layer::Layer<N, Service = Self> + Copy {
+        layer::mk(|inner| Self {
+            inner,
             _marker: PhantomData,
+        })
+    }
+}
+
+impl<T, P, N> NewService<T> for NewInsert<P, N>
+where
+    T: Param<P>,
+    P: Clone + Send + Sync + 'static,
+    N: NewService<T>,
+{
+    type Service = Insert<N::Service, ValLazy<P>, P>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let param = target.param();
+        let inner = self.inner.new_service(target);
+        Insert::new(inner, ValLazy(param))
+    }
+}
+
+impl<N: Clone, P> Clone for NewInsert<P, N> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _marker: self._marker,
         }
     }
 }
 
-impl<S, L, V> tower::layer::Layer<S> for Layer<L, V>
-where
-    L: Lazy<V>,
-    V: Send + Sync + 'static,
-{
-    type Service = Insert<S, L, V>;
+// === impl NewResponseInsert ===
 
-    fn layer(&self, inner: S) -> Self::Service {
-        Insert::new(inner, self.lazy.clone())
+impl<P, N> NewResponseInsert<P, N> {
+    pub fn layer() -> impl tower::layer::Layer<N, Service = Self> + Copy {
+        layer::mk(|inner| Self {
+            inner,
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<T, P, N> NewService<T> for NewResponseInsert<P, N>
+where
+    T: Param<P>,
+    P: Clone + Send + Sync + 'static,
+    N: NewService<T>,
+{
+    type Service = ResponseInsert<N::Service, ValLazy<P>, P>;
+
+    #[inline]
+    fn new_service(&self, target: T) -> Self::Service {
+        let param = target.param();
+        let inner = self.inner.new_service(target);
+        ResponseInsert::new(inner, ValLazy(param))
+    }
+}
+
+impl<N: Clone, P> Clone for NewResponseInsert<P, N> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _marker: self._marker,
+        }
     }
 }
 
@@ -109,6 +164,7 @@ where
     type Error = S::Error;
     type Future = S::Future;
 
+    #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
@@ -129,6 +185,93 @@ impl<S: Clone, L: Clone, V> Clone for Insert<S, L, V> {
     }
 }
 
+// === impl ResponseInsert ===
+
+impl<S, L, V> ResponseInsert<S, L, V> {
+    fn new(inner: S, lazy: L) -> Self {
+        Self {
+            inner,
+            lazy,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<Req, P, S, L, V, B> Proxy<Req, S> for ResponseInsert<P, L, V>
+where
+    P: Proxy<Req, S, Response = http::Response<B>>,
+    S: tower::Service<P::Request>,
+    L: Lazy<V>,
+    V: Clone + Send + Sync + 'static,
+{
+    type Request = P::Request;
+    type Response = P::Response;
+    type Error = P::Error;
+    type Future = ResponseInsertFuture<P::Future, L, V, B>;
+
+    fn proxy(&self, svc: &mut S, req: Req) -> Self::Future {
+        ResponseInsertFuture {
+            inner: self.inner.proxy(svc, req),
+            lazy: self.lazy.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<Req, S, L, V, B> tower::Service<Req> for ResponseInsert<S, L, V>
+where
+    S: tower::Service<Req, Response = http::Response<B>>,
+    L: Lazy<V>,
+    V: Clone + Send + Sync + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseInsertFuture<S::Future, L, V, B>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        ResponseInsertFuture {
+            inner: self.inner.call(req),
+            lazy: self.lazy.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<S: Clone, L: Clone, V> Clone for ResponseInsert<S, L, V> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            lazy: self.lazy.clone(),
+            _marker: self._marker,
+        }
+    }
+}
+
+// === impl ResponseInsertFuture ===
+
+impl<F, L, V, B> Future for ResponseInsertFuture<F, L, V, B>
+where
+    F: TryFuture<Ok = http::Response<B>>,
+    L: Lazy<V>,
+    V: Send + Sync + 'static,
+{
+    type Output = Result<F::Ok, F::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let mut rsp = futures::ready!(this.inner.try_poll(cx))?;
+        rsp.extensions_mut().insert(this.lazy.value());
+        Poll::Ready(Ok(rsp))
+    }
+}
+
+// === impl ValLazy ===
+
 impl<V> Lazy<V> for ValLazy<V>
 where
     V: Clone + Send + Sync + 'static,
@@ -138,6 +281,8 @@ where
     }
 }
 
+// === impl FnLazy ===
+
 impl<F, V> Lazy<V> for FnLazy<F>
 where
     F: Fn() -> V,
@@ -146,40 +291,5 @@ where
 {
     fn value(&self) -> V {
         (self.0)()
-    }
-}
-
-// === impl NewInsert ===
-
-impl<P, N> NewInsert<P, N> {
-    pub fn layer() -> impl tower::layer::Layer<N, Service = Self> + Copy {
-        layer::mk(|inner| Self {
-            inner,
-            _marker: PhantomData,
-        })
-    }
-}
-
-impl<T, P, N> NewService<T> for NewInsert<P, N>
-where
-    T: Param<P>,
-    P: Clone + Send + Sync + 'static,
-    N: NewService<T>,
-{
-    type Service = Insert<N::Service, ValLazy<P>, P>;
-
-    fn new_service(&self, target: T) -> Self::Service {
-        let param = target.param();
-        let inner = self.inner.new_service(target);
-        Insert::new(inner, ValLazy(param))
-    }
-}
-
-impl<N: Clone, P> Clone for NewInsert<P, N> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            _marker: self._marker,
-        }
     }
 }


### PR DESCRIPTION
The proxy uses the `l5d-proxy-connection` header to determine when
it should close proxied connections. This header must only be set by a
peer inbound proxy.

This change modifies the outbound proxy so that this connection is only
honored when the peer is actually meshed. If this header is set by an
unmeshed peer, the header is ignored.

This change also modifies the outbound proxy to always _clear_ this
header so that it can't be sent to the application.