### PR TITLE
outbound: Disable informational headers by config

### DIFF
--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -211,7 +211,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                     .push(svc::FailFast::layer("Ingress server", dispatch_timeout))
                     .push(rt.metrics.http_errors.to_layer()),
             )
-            .push(http::ServerRescue::layer())
+            .push(http::ServerRescue::layer(config.emit_headers))
             .push_on_service(
                 svc::layers()
                     .push(http_tracing::server(rt.span_sink, trace_labels()))

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -58,6 +58,9 @@ pub struct Config {
     // forwarded without discovery/routing/mTLS.
     pub ingress_mode: bool,
     pub inbound_ips: Arc<HashSet<IpAddr>>,
+
+    // Whether the proxy may include informational headers on HTTP responses.
+    pub emit_headers: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -15,6 +15,7 @@ use std::{str::FromStr, time::Duration};
 pub(crate) fn default_config() -> Config {
     Config {
         ingress_mode: false,
+        emit_headers: true,
         allow_discovery: IpMatch::new(Some(IpNet::from_str("0.0.0.0/0").unwrap())).into(),
         proxy: config::ProxyConfig {
             server: config::ServerConfig {


### PR DESCRIPTION
The proxy may set error messages in the outbound proxy's response
headers; but sometimes this isn't desirable, especially on ingresses
where the repsonses may be sent to external clients.

This change introduces a new configuration,
`LINKERD2_PROXY_OUTBOUND_DISABLE_INFORMATIONAL_HEADERS` that can be set
to `false` to disable these headers from being included in responses
from the outbound proxy. These headers are also disabled by default when
ingress mode is enabled.