### PR TITLE
outbound: Strip peer-sent `l5d-proxy-error` headers

### DIFF
--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -1,4 +1,4 @@
-use super::{NewRequireIdentity, ProxyConnectionClose};
+use super::{NewRequireIdentity, NewStripProxyError, ProxyConnectionClose};
 use crate::Outbound;
 use linkerd_app_core::{
     classify, config, errors, http_tracing, metrics,
@@ -49,6 +49,9 @@ impl<C> Outbound<C> {
                 // Set the TLS status on responses so that the stack can detect whether the request
                 // was sent over a meshed connection.
                 .push_http_response_insert_target::<tls::ConditionalClientTls>()
+                // If the outbound proxy is not configured to emit headers, then strip the
+                // `l5d-proxy-errors` header if set by the peer.
+                .push(NewStripProxyError::layer(config.emit_headers))
                 // Tear down server connections when a peer proxy generates an error.
                 // TODO(ver) this should only be honored when forwarding and not when the connection
                 // is part of a balancer.

--- a/linkerd/app/outbound/src/http/mod.rs
+++ b/linkerd/app/outbound/src/http/mod.rs
@@ -4,8 +4,12 @@ pub mod logical;
 mod proxy_connection_close;
 mod require_id_header;
 mod server;
+mod strip_proxy_error;
 
-use self::{proxy_connection_close::ProxyConnectionClose, require_id_header::NewRequireIdentity};
+use self::{
+    proxy_connection_close::ProxyConnectionClose, require_id_header::NewRequireIdentity,
+    strip_proxy_error::NewStripProxyError,
+};
 pub(crate) use self::{require_id_header::IdentityRequired, server::ServerRescue};
 use crate::tcp;
 pub use linkerd_app_core::proxy::http::*;

--- a/linkerd/app/outbound/src/http/strip_proxy_error.rs
+++ b/linkerd/app/outbound/src/http/strip_proxy_error.rs
@@ -1,0 +1,37 @@
+use linkerd_app_core::{
+    errors::respond::L5D_PROXY_ERROR,
+    proxy::http,
+    svc::{self, NewService},
+};
+
+#[derive(Clone, Debug)]
+pub struct NewStripProxyError<N> {
+    strip: bool,
+    inner: N,
+}
+
+impl<N> NewStripProxyError<N> {
+    pub fn layer(emit_headers: bool) -> impl svc::layer::Layer<N, Service = Self> + Clone {
+        svc::layer::mk(move |inner| Self {
+            strip: !emit_headers,
+            inner,
+        })
+    }
+}
+
+impl<T, N> NewService<T> for NewStripProxyError<N>
+where
+    N: NewService<T>,
+{
+    type Service = http::strip_header::response::StripHeader<&'static str, N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let header = if self.strip {
+            Some(L5D_PROXY_ERROR)
+        } else {
+            None
+        };
+        let inner = self.inner.new_service(target);
+        http::StripHeader::response(header, inner)
+    }
+}

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -33,6 +33,7 @@ pub use self::{
     override_authority::{AuthorityOverride, NewOverrideAuthority},
     retain::Retain,
     server::NewServeHttp,
+    strip_header::StripHeader,
     timeout::{NewTimeout, ResponseTimeout, ResponseTimeoutError},
     version::Version,
 };


### PR DESCRIPTION
If the outbound proxy is not configured to emit headers, then we
shouldn't surface `l5d-proxy-error` headers sent by peer proxies.

This change adds a module to the outbound HTTP endpoint stack to strip
these headers when appropriate.