### PR TITLE
stack-tracing: Log when services are dropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,7 +1336,6 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-stack",
- "pin-project",
  "tower",
  "tracing",
 ]

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -27,7 +27,7 @@ impl<H> Inbound<H> {
             + Param<tls::ConditionalServerTls>
             + Param<ServerLabel>
             + Param<OrigDstAddr>,
-        T: Clone + Send + 'static,
+        T: Clone + Send + Unpin + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
         H: svc::NewService<T, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
         HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -12,4 +12,3 @@ linkerd-error = { path = "../../error" }
 linkerd-stack = { path = ".." }
 tower = "0.4.8"
 tracing = "0.1.28"
-pin-project = "1"

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -192,12 +192,8 @@ where
 
 impl<T, G: GetSpan<T>, S> Drop for Instrument<T, G, S> {
     fn drop(&mut self) {
-        if let Some(span) = self.current_span.take() {
-            trace!(parent: &span, "drop");
-        } else {
-            let _span = self.get_span().entered();
-            trace!("drop");
-        }
+        let span = self.current_span.take().unwrap_or_else(|| self.get_span());
+        trace!(parent: &span, "drop");
     }
 }
 

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -2,7 +2,6 @@
 #![forbid(unsafe_code)]
 
 use linkerd_stack::{layer, NewService, Proxy};
-use pin_project::pin_project;
 use std::task::{Context, Poll};
 use tracing::instrument::{Instrument as _, Instrumented};
 use tracing::{trace, Span};
@@ -25,9 +24,8 @@ pub struct NewInstrument<G, N> {
 }
 
 /// Instruments a service produced by `NewInstrument`.
-#[pin_project]
 #[derive(Debug)]
-pub struct Instrument<T, G, S> {
+pub struct Instrument<T, G: GetSpan<T>, S> {
     target: T,
     /// When this is a `Service` (and not a `Proxy`), we consider the `poll_ready`
     /// calls that drive the service to readiness and the `call` future that
@@ -40,7 +38,6 @@ pub struct Instrument<T, G, S> {
     /// in `call`.
     current_span: Option<Span>,
     get_span: G,
-    #[pin]
     inner: S,
 }
 
@@ -175,7 +172,7 @@ where
 impl<T, G, S> Clone for Instrument<T, G, S>
 where
     T: Clone,
-    G: Clone,
+    G: Clone + GetSpan<T>,
     S: Clone,
 {
     fn clone(&self) -> Self {
@@ -190,6 +187,17 @@ where
             // when it's first driven to readiness.
             current_span: None,
         }
+    }
+}
+
+impl<T, G: GetSpan<T>, S> Drop for Instrument<T, G, S> {
+    fn drop(&mut self) {
+        let _span = self
+            .current_span
+            .take()
+            .unwrap_or_else(|| self.get_span())
+            .entered();
+        trace!("drop");
     }
 }
 

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -193,7 +193,7 @@ where
 impl<T, G: GetSpan<T>, S> Drop for Instrument<T, G, S> {
     fn drop(&mut self) {
         if let Some(span) = self.current_span.take() {
-            trace!(parent: span, "drop");
+            trace!(parent: &span, "drop");
         } else {
             let _span = self.get_span().entered();
             trace!("drop");

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -192,12 +192,12 @@ where
 
 impl<T, G: GetSpan<T>, S> Drop for Instrument<T, G, S> {
     fn drop(&mut self) {
-        let _span = self
-            .current_span
-            .take()
-            .unwrap_or_else(|| self.get_span())
-            .entered();
-        trace!("drop");
+        if let Some(span) = self.current_span.take() {
+            trace!(parent: span, "drop");
+        } else {
+            let _span = self.get_span().entered();
+            trace!("drop");
+        }
     }
 }
 


### PR DESCRIPTION
This change modifies `stack-tracing`'s `Instrument` service type to log
a message as instances are dropped, which can be useful for diagnosing
stack retention issues.

This change also modifies this type to stop using `pin-project` (since
it wasn't actually using it).