### PR TITLE
Add trace-level logging around discovery updates

### DIFF
--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -71,6 +71,7 @@ async fn resolution(dns: dns::Resolver, na: NameAddr) -> Result<UpdateStream, Er
     //
     // Note: this can't be an async_stream, due to pinniness.
     let (addrs, expiry) = dns.resolve_addrs(na.name(), na.port()).await?;
+    debug!(?addrs, name = %na);
     let (tx, rx) = mpsc::channel(1);
     tokio::spawn(
         async move {
@@ -84,7 +85,7 @@ async fn resolution(dns: dns::Resolver, na: NameAddr) -> Result<UpdateStream, Er
             loop {
                 match dns.resolve_addrs(na.name(), na.port()).await {
                     Ok((addrs, expiry)) => {
-                        debug!(?addrs);
+                        debug!(?addrs, name = %na);
                         let eps = addrs.into_iter().map(|a| (a, ())).collect();
                         if tx.send(Ok(Update::Reset(eps))).await.is_err() {
                             trace!("Closed");

--- a/linkerd/proxy/resolve/src/map_endpoint.rs
+++ b/linkerd/proxy/resolve/src/map_endpoint.rs
@@ -107,6 +107,7 @@ where
     R: TryStream<Ok = resolve::Update<E>>,
     R::Error: Into<Error>,
     M: MapEndpoint<T, E>,
+    M::Out: std::fmt::Debug,
 {
     type Item = Result<resolve::Update<M::Out>, R::Error>;
 
@@ -135,6 +136,7 @@ where
             },
             None => return Poll::Ready(None),
         };
+        tracing::trace!(?update);
         Poll::Ready(Some(Ok(update)))
     }
 }


### PR DESCRIPTION
It's helpful to have more insight into what's going on during endpoint
resolution. This change adds trace-level logging messages to various
resolver modules.