### PR TITLE
Avoid attempting to reconnect to defunct endpoints

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -83,10 +83,13 @@ impl Config {
             .push(self::client::layer())
             .push_on_service(svc::MapErr::layer(Into::into))
             .into_new_service()
-            .push_new_reconnect(self.connect.backoff)
-            // Ensure individual endpoints are driven to readiness so that the balancer need not
-            // drive them all directly.
+            // Ensure that connection is driven independently of the load balancer; but don't drive
+            // reconnection independently of the balancer. This ensures that new connections are
+            // only initiated when the balancer tries to move pending endpoints to ready (i.e. after
+            // checking for discovery updates); but we don't want to continually reconnect without
+            // checking for discovery updates.
             .push_on_service(svc::layer::mk(svc::SpawnReady::new))
+            .push_new_reconnect(self.connect.backoff)
             .push(self::resolve::layer(dns, resolve_backoff))
             .push_on_service(self::control::balance::layer())
             .into_new_service()

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -45,6 +45,9 @@ impl<C> Outbound<C> {
                 .push_on_service(svc::MapErr::layer(Into::<Error>::into))
                 .check_service::<T>()
                 .into_new_service()
+                // Drive the connection to completion regardless of whether the reconnect is being
+                // actively polled.
+                .push_on_service(svc::layer::mk(svc::SpawnReady::new))
                 .push_new_reconnect(backoff)
                 // Set the TLS status on responses so that the stack can detect whether the request
                 // was sent over a meshed connection.


### PR DESCRIPTION
Load balanced clients can get stuck continually trying to reconnect to
defunct endpoints in situations like the following:

1. A balancer has an existing endpoint but it is pending;
2. A new ready endpoint is added to the balancer;
3. Requests are sent to the new endpoint and the balancer ends up with
   the new endpoint being ready.
4. Service discovery issues an update indicating that we should no
   longer use the old endpoint, which has now shutdown.

This discovery update won't be processed by the balancer until we
attempt to issue a request on the balancer. But, because each endpoint
uses `SpawnReady` to attempt reconnection on a background task, we
continually attempt to reconnect to the defunct endpoint even though
we'll never actually issue requests to it (because it will be removed as
soon as the balancer is polled again).

There's a simple fix to this: we shouldn't put reconnection inside of
`SpawnReady`. Instead, we use a `SpawnReady` to drive each individual
connection attempt to readiness, but we don't drive reconnect to drive a
failed connection to be retried until the balancer has a chance to be
updated.

This may address linkerd/linkerd2#6842 and should fix another issue
reported in Slack where controller pods would continually log connection
failures after the destination controller was rescheduled.