### PR TITLE
admin: Remove unused types

### DIFF
--- a/linkerd/app/admin/src/server/mod.rs
+++ b/linkerd/app/admin/src/server/mod.rs
@@ -23,7 +23,6 @@ use linkerd_app_core::{
 };
 use std::{
     future::Future,
-    net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -40,18 +39,6 @@ pub struct Admin<M> {
     tracing: trace::Handle,
     ready: Readiness,
     shutdown_tx: mpsc::UnboundedSender<()>,
-}
-
-#[derive(Clone)]
-pub struct Accept<S> {
-    service: S,
-    server: hyper::server::conn::Http,
-}
-
-#[derive(Clone)]
-pub struct Serve<S> {
-    client_addr: SocketAddr,
-    inner: S,
 }
 
 pub type ResponseFuture =


### PR DESCRIPTION
Rust nightly catches a few unused types that are apparently not caught
on the most recent stable releases.