### PR TITLE
Adopt Rust edition 2021

### DIFF
--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -3,7 +3,7 @@ name = "hyper-balance"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/addr/Cargo.toml
+++ b/linkerd/addr/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-addr"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/addr/fuzz/Cargo.toml
+++ b/linkerd/addr/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-addr-fuzz"
 version = "0.0.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-app"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Configures and executes the proxy

--- a/linkerd/app/admin/Cargo.toml
+++ b/linkerd/app/admin/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-app-admin"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 The linkerd proxy's admin server.

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-app-core"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Core infrastructure for the proxy application

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-app-gateway"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -26,10 +26,7 @@ use linkerd_app_inbound::{
     policy, Inbound,
 };
 use linkerd_app_outbound::{self as outbound, Outbound};
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt,
-};
+use std::fmt;
 use thiserror::Error;
 use tracing::debug_span;
 

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-app-inbound"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Configures and runs the inbound proxy

--- a/linkerd/app/inbound/fuzz/Cargo.toml
+++ b/linkerd/app/inbound/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "linkerd-app-inbound-fuzz"
 version = "0.0.0"
 authors = ["Automatically generated"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -271,7 +271,7 @@ impl<A> svc::stack::RecognizeRoute<http::Request<A>> for LogicalPerRequest {
         use linkerd_app_core::{
             http_request_authority_addr, http_request_host_addr, CANONICAL_DST_HEADER,
         };
-        use std::{convert::TryInto, str::FromStr};
+        use std::str::FromStr;
 
         // Try to read a logical named address from the request. First check the canonical-dst
         // header as set by the client proxy; otherwise fallback to the request's `:authority` or

--- a/linkerd/app/inbound/src/policy/discover.rs
+++ b/linkerd/app/inbound/src/policy/discover.rs
@@ -12,7 +12,7 @@ use linkerd_server_policy::{
     Authentication, Authorization, Network, Protocol, ServerPolicy, Suffix,
 };
 use linkerd_tonic_watch::StreamWatch;
-use std::{convert::TryInto, net::IpAddr};
+use std::net::IpAddr;
 
 #[derive(Clone, Debug)]
 pub(super) struct Discover<S> {

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-app-integration"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Proxy integration tests

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-app-outbound"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Configures and runs the outbound proxy

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-app-test"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Proxy integration tests

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-cache"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/conditional/Cargo.toml
+++ b/linkerd/conditional/Cargo.toml
@@ -3,6 +3,6 @@ name = "linkerd-conditional"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [dependencies]

--- a/linkerd/detect/Cargo.toml
+++ b/linkerd/detect/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-detect"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-dns"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/dns/fuzz/Cargo.toml
+++ b/linkerd/dns/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "linkerd-dns-fuzz"
 version = "0.0.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/dns/name/Cargo.toml
+++ b/linkerd/dns/name/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-dns-name"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/duplex/Cargo.toml
+++ b/linkerd/duplex/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-duplex"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/errno/Cargo.toml
+++ b/linkerd/errno/Cargo.toml
@@ -3,5 +3,5 @@ name = "linkerd-errno"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false

--- a/linkerd/error-respond/Cargo.toml
+++ b/linkerd/error-respond/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-error-respond"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 

--- a/linkerd/error/Cargo.toml
+++ b/linkerd/error/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-error"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/exp-backoff/Cargo.toml
+++ b/linkerd/exp-backoff/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-exp-backoff"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 

--- a/linkerd/http-box/Cargo.toml
+++ b/linkerd/http-box/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-http-box"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/http-classify/Cargo.toml
+++ b/linkerd/http-classify/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-http-classify"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-http-metrics"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/http-retry/Cargo.toml
+++ b/linkerd/http-retry/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-http-retry"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/identity/Cargo.toml
+++ b/linkerd/identity/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-identity"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = []

--- a/linkerd/io/Cargo.toml
+++ b/linkerd/io/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-io"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 General I/O primitives.

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-metrics"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/linkerd/metrics/src/latency.rs
+++ b/linkerd/metrics/src/latency.rs
@@ -44,7 +44,6 @@ pub struct Us(Duration);
 
 impl From<Us> for u64 {
     fn from(Us(us): Us) -> u64 {
-        use std::convert::TryInto;
         us.as_micros().try_into().unwrap_or_else(|_| {
             // These measurements should never be long enough to overflow
             tracing::warn!("Duration::as_micros would overflow u64");

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-opencensus"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-proxy-api-resolve"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Implements the Resolve trait using the proxy's gRPC API

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-proxy-core"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Core interfaces needed to implement proxy components

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-proxy-discover"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Utilities to implement a Discover with the core Resolve type

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-proxy-dns-resolve"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Service Dns Resolutions for the proxy

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-proxy-http"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 HTTP-specific implementations that rely on other proxy infrastructure

--- a/linkerd/proxy/http/fuzz/Cargo.toml
+++ b/linkerd/proxy/http/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "linkerd-proxy-http-fuzz"
 version = "0.0.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/proxy/identity/Cargo.toml
+++ b/linkerd/proxy/identity/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-proxy-identity"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/linkerd/proxy/resolve/Cargo.toml
+++ b/linkerd/proxy/resolve/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-proxy-resolve"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Utilities for working with `Resolve` implementations

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-proxy-tap"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/linkerd/proxy/tap/src/grpc/match_.rs
+++ b/linkerd/proxy/tap/src/grpc/match_.rs
@@ -2,13 +2,7 @@ use crate::Inspect;
 use ipnet::{Ipv4Net, Ipv6Net};
 use linkerd2_proxy_api::net::ip_address;
 use linkerd2_proxy_api::tap::observe_request;
-use std::{
-    boxed::Box,
-    collections::BTreeMap,
-    convert::{TryFrom, TryInto},
-    net,
-    str::FromStr,
-};
+use std::{boxed::Box, collections::BTreeMap, net, str::FromStr};
 use thiserror::Error;
 
 #[derive(Clone, Debug)]

--- a/linkerd/proxy/tcp/Cargo.toml
+++ b/linkerd/proxy/tcp/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-proxy-tcp"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-proxy-transport"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Transport-level implementations that rely on core proxy infrastructure

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-reconnect"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/retry/Cargo.toml
+++ b/linkerd/retry/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-retry"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/server-policy/Cargo.toml
+++ b/linkerd/server-policy/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-server-policy"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-service-profiles"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Implements client layers for Linkerd ServiceProfiles.

--- a/linkerd/service-profiles/src/proto.rs
+++ b/linkerd/service-profiles/src/proto.rs
@@ -4,7 +4,7 @@ use linkerd_addr::NameAddr;
 use linkerd_dns_name::Name;
 use linkerd_proxy_api_resolve::pb as resolve;
 use regex::Regex;
-use std::{convert::TryInto, str::FromStr, sync::Arc, time::Duration};
+use std::{str::FromStr, sync::Arc, time::Duration};
 use tower::retry::budget::Budget;
 use tracing::warn;
 

--- a/linkerd/signal/Cargo.toml
+++ b/linkerd/signal/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-signal"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-stack"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Utilities for composing Tower services.

--- a/linkerd/stack/metrics/Cargo.toml
+++ b/linkerd/stack/metrics/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-stack-metrics"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-stack-tracing"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/system/Cargo.toml
+++ b/linkerd/system/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-system"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Unsafe code for accessing system-level counters for memory & CPU usage.

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-tls"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/tls/fuzz/Cargo.toml
+++ b/linkerd/tls/fuzz/Cargo.toml
@@ -4,7 +4,7 @@ name = "linkerd-tls-fuzz"
 version = "0.0.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/tonic-watch/Cargo.toml
+++ b/linkerd/tonic-watch/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-tonic-watch"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 Provides a utility for creating robust watches from a service that returns a stream.

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-trace-context"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/trace-context/src/propagation.rs
+++ b/linkerd/trace-context/src/propagation.rs
@@ -3,7 +3,6 @@ use bytes::Bytes;
 use http::header::HeaderValue;
 use linkerd_error::Error;
 use rand::thread_rng;
-use std::convert::TryInto;
 use thiserror::Error;
 use tracing::{trace, warn};
 

--- a/linkerd/tracing/Cargo.toml
+++ b/linkerd/tracing/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-tracing"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-transport-header"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/linkerd/transport-header/fuzz/Cargo.toml
+++ b/linkerd/transport-header/fuzz/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-transport-header-fuzz"
 version = "0.0.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/transport-metrics/Cargo.toml
+++ b/linkerd/transport-metrics/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd-transport-metrics"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """Transport-level metrics"""
 

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -3,7 +3,7 @@ name = "linkerd2-proxy"
 version = "0.1.0"
 authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = "The main proxy executable"
 

--- a/opencensus-proto/Cargo.toml
+++ b/opencensus-proto/Cargo.toml
@@ -3,7 +3,7 @@ name = "opencensus-proto"
 version = "0.1.0"
 authors = ["The OpenCensus Authors"]
 license = "Apache-2.0"
-edition = "2018"
+edition = "2021"
 publish = false
 description = """
 gRPC bindings for OpenCensus.


### PR DESCRIPTION
Depends on Rust 1.56.0 which is due out on 10/09.