### PR TITLE
Remove use of TLS 1.2

### DIFF
--- a/linkerd/app/integration/src/identity.rs
+++ b/linkerd/app/integration/src/identity.rs
@@ -34,7 +34,7 @@ type Certify = Box<
         > + Send,
 >;
 
-const TLS_VERSIONS: &[rustls::ProtocolVersion] = &[rustls::ProtocolVersion::TLSv1_2];
+const TLS_VERSIONS: &[rustls::ProtocolVersion] = &[rustls::ProtocolVersion::TLSv1_3];
 
 struct Certificates {
     pub leaf: Vec<u8>,

--- a/linkerd/identity/src/lib.rs
+++ b/linkerd/identity/src/lib.rs
@@ -66,10 +66,7 @@ const SIGNATURE_ALG_RUSTLS_SCHEME: rustls::SignatureScheme =
     rustls::SignatureScheme::ECDSA_NISTP256_SHA256;
 const SIGNATURE_ALG_RUSTLS_ALGORITHM: rustls::internal::msgs::enums::SignatureAlgorithm =
     rustls::internal::msgs::enums::SignatureAlgorithm::ECDSA;
-const TLS_VERSIONS: &[rustls::ProtocolVersion] = &[
-    rustls::ProtocolVersion::TLSv1_2,
-    rustls::ProtocolVersion::TLSv1_3,
-];
+const TLS_VERSIONS: &[rustls::ProtocolVersion] = &[rustls::ProtocolVersion::TLSv1_3];
 
 // === impl Csr ===
 


### PR DESCRIPTION
Now that stable-2.11.0 is out and TLSv1.3 has been supported since
2.10.0, this change removes TLSv1.2 from the set of TLS versions that
can be used by the proxy.