### PR TITLE
Disable incremental compilation in CI

### DIFF
--- a/.github/workflows/advisory.yml
+++ b/.github/workflows/advisory.yml
@@ -4,6 +4,12 @@ name: Advisory
 on:
   pull_request: {}
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
 jobs:
   # Prevent sudden announcement of a new advisory from failing Ci.
   advisories:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "release/*"
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
 jobs:
   package:
     permissions:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,6 +3,12 @@ name: Rust PR
 on:
   pull_request: {}
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
 jobs:
 
   ## Required builds


### PR DESCRIPTION
There's no reason to use Rust's incremental compilation in CI. According
to matklad's blog post on [fast Rust builds][fastbuilds]:

> CI builds often are closer to from-scratch builds, as changes are
> typically much bigger than from a local edit-compile cycle. For
> from-scratch builds, incremental adds an extra dependency-tracking
> overhead. It also significantly increases the amount of IO and the
> size of ./target, which make caching less effective.

[fastbuilds]: https://matklad.github.io/2021/09/04/fast-rust-builds.html