### PR TITLE
[WIP] ci: try to speed up builds by caching deps

### DIFF
--- a/.github/workflows/advisory.yml
+++ b/.github/workflows/advisory.yml
@@ -19,6 +19,16 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
+    - name: cache Rust dependencies
+      uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - uses: EmbarkStudios/cargo-deny-action@0ca727bbae7b7b578b9a5f98186caac35aa2a00d
       with:
         command: check advisories
@@ -46,6 +56,17 @@ jobs:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
       - run: rustup toolchain add nightly
       - run: cargo install cargo-fuzz
+      - name: cache Rust dependencies
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          # use a separate cache key because we're on nightly here
+          key: ${{ runner.os }}-cargo-nightly-${{ hashFiles('**/Cargo.lock') }}
       # Iterate through all fuzz crates to ensure each compiles independently.
       - run: cd linkerd/${{matrix.dir}}/fuzz && cargo +nightly fuzz build
 
@@ -59,6 +80,16 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
+      - name: cache Rust dependencies
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: make build
         env:
           CARGO_RELEASE: true

--- a/.github/workflows/advisory.yml
+++ b/.github/workflows/advisory.yml
@@ -19,16 +19,7 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
-    - name: cache Rust dependencies
-      uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383
     - uses: EmbarkStudios/cargo-deny-action@0ca727bbae7b7b578b9a5f98186caac35aa2a00d
       with:
         command: check advisories
@@ -56,17 +47,6 @@ jobs:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
       - run: rustup toolchain add nightly
       - run: cargo install cargo-fuzz
-      - name: cache Rust dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          # use a separate cache key because we're on nightly here
-          key: ${{ runner.os }}-cargo-nightly-${{ hashFiles('**/Cargo.lock') }}
       # Iterate through all fuzz crates to ensure each compiles independently.
       - run: cd linkerd/${{matrix.dir}}/fuzz && cargo +nightly fuzz build
 
@@ -80,16 +60,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
-      - name: cache Rust dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383
       - run: make build
         env:
           CARGO_RELEASE: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,6 +21,16 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
+    - name: cache Rust dependencies
+      uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
     - uses: EmbarkStudios/cargo-deny-action@0ca727bbae7b7b578b9a5f98186caac35aa2a00d
       with:
         command: check bans licenses sources
@@ -36,6 +46,16 @@ jobs:
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
       - run: rustup component add clippy
+      - name: cache Rust dependencies
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: make lint
 
   # Iterate through all (non-fuzzer) sub-crates to ensure each compiles independently.
@@ -48,6 +68,16 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
+      - name: cache Rust dependencies
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: for d in $(for toml in $(find . -mindepth 2 -name Cargo.toml -not -path '*/fuzz/*') ; do echo ${toml%/*} ; done | sort -r ) ; do echo "# $d" ; (cd $d ; cargo check --all-targets) ; done
 
   # Enforce automated formatting.
@@ -61,6 +91,15 @@ jobs:
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
       - run: rustup component add rustfmt
+      - name: cache Rust dependencies
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
       - run: make check-fmt
 
   # Run all tests.
@@ -71,6 +110,15 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
+      - name: cache Rust dependencies
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
       - run: make test
 
   # Generate docs
@@ -81,4 +129,13 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
+      - name: cache Rust dependencies
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
       - run: cargo doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: for d in $(for toml in $(find . -mindepth 2 -name Cargo.toml -not -path '*/fuzz/*') ; do echo ${toml%/*} ; done | sort -r ) ; do echo "# $d" ; (cd $d ; cargo check --all-targets) ; done
 
   # Enforce automated formatting.
@@ -100,6 +100,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: make check-fmt
 
   # Run all tests.
@@ -119,6 +120,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: make test
 
   # Generate docs
@@ -138,4 +140,5 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo doc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: for d in $(for toml in $(find . -mindepth 2 -name Cargo.toml -not -path '*/fuzz/*') ; do echo ${toml%/*} ; done | sort -r ) ; do echo "# $d" ; (cd $d ; cargo check --all-targets) ; done
 
   # Enforce automated formatting.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,16 +21,7 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
-    - name: cache Rust dependencies
-      uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383
     - uses: EmbarkStudios/cargo-deny-action@0ca727bbae7b7b578b9a5f98186caac35aa2a00d
       with:
         command: check bans licenses sources
@@ -46,16 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
       - run: rustup component add clippy
-      - name: cache Rust dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383
       - run: make lint
 
   # Iterate through all (non-fuzzer) sub-crates to ensure each compiles independently.
@@ -68,16 +50,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
-      - name: cache Rust dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383
       - run: for d in $(for toml in $(find . -mindepth 2 -name Cargo.toml -not -path '*/fuzz/*') ; do echo ${toml%/*} ; done | sort -r ) ; do echo "# $d" ; (cd $d ; cargo check --all-targets) ; done
 
   # Enforce automated formatting.
@@ -91,16 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
       - run: rustup component add rustfmt
-      - name: cache Rust dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383
       - run: make check-fmt
 
   # Run all tests.
@@ -111,16 +75,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
-      - name: cache Rust dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383
       - run: make test
 
   # Generate docs
@@ -131,14 +86,5 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@1e204e9a9253d643386038d443f96446fa156a97
-      - name: cache Rust dependencies
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@d12701459954fec471b2d34cdf7ea3374b026383
       - run: cargo doc


### PR DESCRIPTION
This branch is an experiment with using https://github.com/actions/cache/blob/main/examples.md#rust---cargo to cache dependencies on CI. 

If this makes a significant impact on CI build times, we may want to consider moving forwards with this.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>