### PR TITLE
tracing: update `tracing-subscriber` to v0.3.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1547,9 +1547,9 @@ checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
-version = "0.0.1"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata",
 ]
@@ -2388,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.25"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+checksum = "5cf865b5ddc38e503a29c41c4843e616a73028ae18c637bc3eb2afaef4909c84"
 dependencies = [
  "ansi_term",
  "lazy_static",

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -38,7 +38,7 @@ tower = { version = "0.4.10", default-features = false }
 tonic = { version = "0.5", default-features = false }
 tracing = "0.1.29"
 webpki = "0.21"
-tracing-subscriber = { version = "0.2", default-features = false, features = ["fmt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "std"] }
 
 [dev-dependencies]
 flate2 = { version = "1.0.22", default-features = false, features = ["rust_backend"] }

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -31,5 +31,5 @@ tokio-test = "0.4"
 tokio-stream = { version = "0.1.7", features = ["sync"] }
 tower = { version = "0.4.10", default-features = false}
 tracing = "0.1.29"
-tracing-subscriber = { version = "0.2.25", features = ["env-filter", "fmt"], default-features = false }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "std"], default-features = false }
 thiserror = "1"

--- a/linkerd/tracing/Cargo.toml
+++ b/linkerd/tracing/Cargo.toml
@@ -17,7 +17,6 @@ tracing = "0.1.29"
 tracing-log = "0.1.2"
 
 [dependencies.tracing-subscriber]
-version = "0.2.25"
-default-features = false
-features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot"]
+version = "0.3"
+features = ["env-filter","smallvec", "tracing-log", "json", "parking_lot"]
 

--- a/linkerd/tracing/src/uptime.rs
+++ b/linkerd/tracing/src/uptime.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use tokio::time::{Duration, Instant};
+use tracing_subscriber::fmt::{format, time::FormatTime};
 
 pub(crate) struct Uptime {
     start_time: Instant,
@@ -12,14 +13,14 @@ impl Uptime {
         }
     }
 
-    fn format(d: Duration, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn format(d: Duration, w: &mut impl fmt::Write) -> fmt::Result {
         let micros = d.subsec_micros();
         write!(w, "[{:>6}.{:06}s]", d.as_secs(), micros)
     }
 }
 
-impl tracing_subscriber::fmt::time::FormatTime for Uptime {
-    fn format_time(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+impl FormatTime for Uptime {
+    fn format_time(&self, w: &mut format::Writer<'_>) -> fmt::Result {
         Self::format(Instant::now() - self.start_time, w)
     }
 }


### PR DESCRIPTION
This branch updates `tracing-subscriber` to v0.3.x. Among other things,
this should resolve the security advisory for the `chrono` crate.

Turns out the upgrade was pretty mechanical!