### PR TITLE
Fix misspecified dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,15 +401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "html-escape"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816ea801a95538fc5f53c836697b3f8b64a9d664c4f0b91efe1fe7c92e4dbcb7"
-dependencies = [
- "utf8-width",
-]
-
-[[package]]
 name = "http"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,7 +640,6 @@ name = "linkerd-app-admin"
 version = "0.1.0"
 dependencies = [
  "futures",
- "html-escape",
  "http",
  "hyper",
  "linkerd-app-core",
@@ -700,7 +690,6 @@ dependencies = [
  "linkerd-proxy-transport",
  "linkerd-reconnect",
  "linkerd-retry",
- "linkerd-server-policy",
  "linkerd-service-profiles",
  "linkerd-stack",
  "linkerd-stack-metrics",
@@ -885,7 +874,6 @@ dependencies = [
  "futures",
  "linkerd-dns-name",
  "linkerd-error",
- "pin-project",
  "thiserror",
  "tokio",
  "tracing",
@@ -999,7 +987,6 @@ dependencies = [
  "linkerd-error",
  "linkerd-tracing",
  "parking_lot",
- "pin-project",
  "thiserror",
  "tokio",
  "tracing",
@@ -1054,7 +1041,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tower",
  "tracing",
 ]
 
@@ -1085,7 +1071,6 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-error",
- "pin-project",
  "tower",
 ]
 
@@ -1140,7 +1125,6 @@ dependencies = [
  "linkerd-error",
  "linkerd-http-box",
  "linkerd-io",
- "linkerd-proxy-transport",
  "linkerd-stack",
  "linkerd-tracing",
  "pin-project",
@@ -1199,7 +1183,6 @@ dependencies = [
  "linkerd-identity",
  "linkerd-io",
  "linkerd-proxy-http",
- "linkerd-proxy-transport",
  "linkerd-stack",
  "linkerd-tls",
  "linkerd-tls-rustls",
@@ -2503,12 +2486,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf8-width"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
 
 [[package]]
 name = "want"

--- a/linkerd/app/admin/Cargo.toml
+++ b/linkerd/app/admin/Cargo.toml
@@ -10,7 +10,6 @@ The linkerd proxy's admin server.
 """
 
 [dependencies]
-html-escape = "0.2"
 http = "0.2"
 hyper = { version = "0.14", features = ["http1", "http2"] }
 futures = { version = "0.3", default-features = false }

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -49,7 +49,6 @@ linkerd-proxy-tcp = { path = "../../proxy/tcp" }
 linkerd-proxy-transport = { path = "../../proxy/transport" }
 linkerd-reconnect = { path = "../../reconnect" }
 linkerd-retry = { path = "../../retry" }
-linkerd-server-policy = { path = "../../server-policy" }
 linkerd-service-profiles = { path = "../../service-profiles" }
 linkerd-stack = { path = "../../stack" }
 linkerd-stack-metrics = { path = "../../stack/metrics" }

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -11,10 +11,10 @@ futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 parking_lot = "0.11"
-tokio = { version = "1", default-features = false, features = ["rt", "sync", "time"] }
+tokio = { version = "1", default-features = false, features = ["macros", "rt", "sync", "time"] }
 tower = { version = "0.4.10", default-features = false, features = ["util"] }
 tracing = "0.1.29"
 
 [dev-dependencies]
-tokio = { version = "1", default-features = false, features = ["macros", "test-util", "time"] }
+tokio = { version = "1", default-features = false, features = ["test-util", "time"] }
 linkerd-tracing = { path = "../tracing", features = ["ansi"] }

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -14,4 +14,3 @@ thiserror = "1.0"
 tracing = "0.1.29"
 trust-dns-resolver = "0.21.0-alpha.4"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
-pin-project = "1"

--- a/linkerd/http-retry/Cargo.toml
+++ b/linkerd/http-retry/Cargo.toml
@@ -12,7 +12,6 @@ futures = { version = "0.3", default-features = false }
 http-body = "0.4"
 http = "0.2"
 linkerd-error = { path = "../error" }
-pin-project = "1"
 parking_lot = "0.11"
 tracing = "0.1.29"
 thiserror = "1"

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -14,7 +14,6 @@ linkerd-error = { path = "../error" }
 linkerd-metrics = { path = "../metrics" }
 opencensus-proto = { path = "../../opencensus-proto" }
 tonic = { version = "0.5", default-features = false, features = ["prost", "codegen"] }
-tower = { version = "0.4.10", default-features = false }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-stream = { version = "0.1.7", features = ["sync"] }
 tracing = "0.1.29"

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -13,4 +13,3 @@ Core interfaces needed to implement proxy components
 futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 tower = { version = "0.4.10", default-features = false }
-pin-project = "1"

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -15,7 +15,7 @@ futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
-tokio = { version = "1", features = ["sync", "time"] }
+tokio = { version = "1", features = ["rt", "sync", "time"] }
 tokio-util = "0.6.8"
 tower = { version = "0.4.10", features = ["discover"] }
 tracing = "0.1.29"
@@ -23,5 +23,5 @@ pin-project = "1"
 
 [dev-dependencies]
 async-stream = "0.3"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros"] }
 tower = { version = "0.4.10", default-features = false, features = ["discover", "util"]}

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -27,7 +27,6 @@ linkerd-duplex = { path = "../../duplex" }
 linkerd-error = { path = "../../error" }
 linkerd-http-box = { path = "../../http-box" }
 linkerd-io = { path = "../../io" }
-linkerd-proxy-transport = { path = "../transport" }
 linkerd-stack = { path = "../../stack" }
 rand = "0.8"
 thiserror = "1.0"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -20,7 +20,6 @@ linkerd-error = { path = "../../error" }
 linkerd-identity = { path = "../../identity" }
 linkerd-io = { path = "../../io" }
 linkerd-proxy-http = { path = "../http" }
-linkerd-proxy-transport = { path = "../transport" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }
 linkerd-tls-rustls = { path = "../../tls/rustls" }


### PR DESCRIPTION
Some of our crates have unused dependencies or do not properly enumerate
all required features.

Found via

    for f in $(find . -mindepth 2 -name Cargo.toml |sort -rn ) ; do
      (cd ${f%%/Cargo.toml} && cargo +nightly udeps)
    done