### PR TITLE
Log discovery changes at DEBUG

### DIFF
--- a/linkerd/proxy/discover/src/from_resolve.rs
+++ b/linkerd/proxy/discover/src/from_resolve.rs
@@ -9,7 +9,7 @@ use std::{
     task::{Context, Poll},
 };
 use tower::discover::Change;
-use tracing::trace;
+use tracing::{debug, trace};
 
 #[derive(Clone, Debug)]
 pub struct FromResolve<R, E> {
@@ -106,7 +106,7 @@ where
         loop {
             let this = self.as_mut().project();
             if let Some(change) = this.pending.pop_front() {
-                trace!(?change, "Changed");
+                debug!(?change, "Changed");
                 return Poll::Ready(Some(Ok(change)));
             }
 


### PR DESCRIPTION
It seems that we no longer log specific discovery changes at DEBUG
anywhere. We probably ought to revisit the discovery pipeline more
holistically and ensure that we're logging in strategic places, but for
now this will help users diagnose discovery updates without subscribing
to the much noisier TRACE stream.

Relates to linkerd/linkerd2#6842