### PR TITLE
Simplify retry policy to use `Body::size_hint`

### DIFF
--- a/hyper-balance/src/lib.rs
+++ b/hyper-balance/src/lib.rs
@@ -127,6 +127,11 @@ where
 
         this.body.poll_trailers(cx)
     }
+
+    #[inline]
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.body.size_hint()
+    }
 }
 
 // ==== PendingUntilEosBody ====
@@ -147,6 +152,7 @@ impl<T: Send + 'static, B: HttpBody> HttpBody for PendingUntilEosBody<T, B> {
     type Data = B::Data;
     type Error = B::Error;
 
+    #[inline]
     fn is_end_stream(&self) -> bool {
         self.body.is_end_stream()
     }
@@ -180,6 +186,11 @@ impl<T: Send + 'static, B: HttpBody> HttpBody for PendingUntilEosBody<T, B> {
         drop(this.handle.take());
 
         Poll::Ready(ret)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.body.size_hint()
     }
 }
 

--- a/linkerd/http-box/src/body.rs
+++ b/linkerd/http-box/src/body.rs
@@ -45,10 +45,12 @@ impl Body for BoxBody {
     type Data = Data;
     type Error = Error;
 
+    #[inline]
     fn is_end_stream(&self) -> bool {
         self.inner.is_end_stream()
     }
 
+    #[inline]
     fn poll_data(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -56,6 +58,7 @@ impl Body for BoxBody {
         self.as_mut().inner.as_mut().poll_data(cx)
     }
 
+    #[inline]
     fn poll_trailers(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -63,6 +66,7 @@ impl Body for BoxBody {
         self.as_mut().inner.as_mut().poll_trailers(cx)
     }
 
+    #[inline]
     fn size_hint(&self) -> http_body::SizeHint {
         self.inner.size_hint()
     }
@@ -95,6 +99,7 @@ where
     type Data = Data;
     type Error = Error;
 
+    #[inline]
     fn is_end_stream(&self) -> bool {
         self.0.is_end_stream()
     }
@@ -111,6 +116,7 @@ where
         }))
     }
 
+    #[inline]
     fn poll_trailers(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -118,6 +124,7 @@ where
         Poll::Ready(futures::ready!(self.project().0.poll_trailers(cx)).map_err(Into::into))
     }
 
+    #[inline]
     fn size_hint(&self) -> http_body::SizeHint {
         self.0.size_hint()
     }

--- a/linkerd/http-metrics/src/requests/service.rs
+++ b/linkerd/http-metrics/src/requests/service.rs
@@ -283,6 +283,7 @@ where
         self.project().inner.poll_trailers(cx)
     }
 
+    #[inline]
     fn size_hint(&self) -> http_body::SizeHint {
         self.inner.size_hint()
     }
@@ -437,6 +438,11 @@ where
         }
 
         Poll::Ready(Ok(trls))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
     }
 }
 

--- a/linkerd/proxy/http/src/glue.rs
+++ b/linkerd/proxy/http/src/glue.rs
@@ -87,6 +87,11 @@ impl HttpBody for UpgradeBody {
                 e
             })
     }
+
+    #[inline]
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.body.size_hint()
+    }
 }
 
 impl Default for UpgradeBody {

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -218,6 +218,11 @@ impl HttpBody for UpgradeResponseBody {
             .poll_trailers(cx)
             .map_err(downgrade_h2_error)
     }
+
+    #[inline]
+    fn size_hint(&self) -> http_body::SizeHint {
+        HttpBody::size_hint(&self.inner)
+    }
 }
 
 // === impl Downgrade ===

--- a/linkerd/proxy/http/src/retain.rs
+++ b/linkerd/proxy/http/src/retain.rs
@@ -100,10 +100,12 @@ impl<T, B: http_body::Body> http_body::Body for RetainBody<T, B> {
     type Data = B::Data;
     type Error = B::Error;
 
+    #[inline]
     fn is_end_stream(&self) -> bool {
         self.inner.is_end_stream()
     }
 
+    #[inline]
     fn poll_data(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -111,6 +113,7 @@ impl<T, B: http_body::Body> http_body::Body for RetainBody<T, B> {
         self.project().inner.poll_data(cx)
     }
 
+    #[inline]
     fn poll_trailers(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -118,6 +121,7 @@ impl<T, B: http_body::Body> http_body::Body for RetainBody<T, B> {
         self.project().inner.poll_trailers(cx)
     }
 
+    #[inline]
     fn size_hint(&self) -> http_body::SizeHint {
         self.inner.size_hint()
     }

--- a/linkerd/proxy/tap/src/service.rs
+++ b/linkerd/proxy/tap/src/service.rs
@@ -164,6 +164,7 @@ where
     type Data = B::Data;
     type Error = B::Error;
 
+    #[inline]
     fn is_end_stream(&self) -> bool {
         self.inner.is_end_stream()
     }
@@ -197,6 +198,11 @@ where
             .map_err(|e| self.as_mut().project().err(e))?;
         self.as_mut().project().eos(trailers.as_ref());
         Poll::Ready(Ok(trailers))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.inner.size_hint()
     }
 }
 


### PR DESCRIPTION
This change rewrites `RetryPolicy::can_retry` as
`RetryPolicy::body_too_big` and updates it to avoid reading
`content-length` header, instead relying on the `Body::size_hint` value
(which is set by the HTTP server if a `content-length` header is
present.

Renaming the function helps us express what the function actually checks
to help disambiguate it from all of the other 'retry' related
terminology in this file and is more explicit about what it does: we
don't precicesly know if the request is retryable, rather we know
whether the request is obviously too large to be retried. This also lets
us simplify comments and logging as the flow is more self-explanatory.

This change also adds unit tests for `RetryPolicy::body_too_big` to
exercise the variety of scenarios this function handles..

Furthermore, this change ensures that all `Body` implementations
correctly proxy `Body::size_hint`. `ReplayBody` is updated to cache the
the inner body's size hint value in the shared state so it can be reused
across all clones of the `ReplayBody` regardless of whether the current
clone holds the body state or not.