### PR TITLE
retry: Simplify ReplayBody::poll_data for readability

### DIFF
--- a/linkerd/http-retry/src/lib.rs
+++ b/linkerd/http-retry/src/lib.rs
@@ -201,18 +201,20 @@ where
 
         // If the inner body has previously ended, don't poll it again.
         //
-        // NOTE(eliza): we would expect the inner body to just happily return `None` multiple times
-        // here, but `hyper::Body::channel` (which we use in the tests) will panic if it is polled
-        // after returning `None`, so we have to special-case this. :/
+        // NOTE(eliza): we would expect the inner body to just happily return
+        // `None` multiple times here, but `hyper::Body::channel` (which we use
+        // in the tests) will panic if it is polled after returning `None`, so
+        // we have to special-case this. :/
         if state.is_completed {
             return Poll::Ready(None);
         }
 
-        // Poll the inner body for more data. If the body has ended, remember that so that future
-        // clones will not try polling it again (as described above).
+        // Poll the inner body for more data. If the body has ended, remember
+        // that so that future clones will not try polling it again (as
+        // described above).
         let mut data = {
-            // Get access to the initial body. If we don't have access to the inner body, there's no
-            // more work to do.
+            // Get access to the initial body. If we don't have access to the
+            // inner body, there's no more work to do.
             let rest = match state.rest.as_mut() {
                 Some(rest) => rest,
                 None => return Poll::Ready(None),
@@ -230,13 +232,13 @@ where
             }
         };
 
-        // If we have buffered the maximum number of bytes, allow *this* body to continue, but
-        // don't buffer any more.
+        // If we have buffered the maximum number of bytes, allow *this* body to
+        // continue, but don't buffer any more.
         let length = data.remaining();
         state.max_bytes = state.max_bytes.saturating_sub(length);
         let chunk = if state.is_capped() {
-            // If there's data in the buffer, discard it now, since we won't allow any clones to
-            // have a complete body.
+            // If there's data in the buffer, discard it now, since we won't
+            // allow any clones to have a complete body.
             if state.buf.has_remaining() {
                 tracing::debug!(
                     buf.size = state.buf.remaining(),
@@ -317,16 +319,17 @@ where
             None => return self.shared.orig_size_hint.clone(),
         };
 
-        // Otherwise, if we're holding the state but have dropped the inner body, the entire body is
-        // buffered so we know the exact size hint.
+        // Otherwise, if we're holding the state but have dropped the inner
+        // body, the entire body is buffered so we know the exact size hint.
         let buffered = state.buf.remaining() as u64;
         let rest_hint = match state.rest.as_ref() {
             Some(rest) => rest.size_hint(),
             None => return SizeHint::with_exact(buffered),
         };
 
-        // Otherwise, add the inner body's size hint to the amount of buffered data. An upper limit
-        // is only set if the inner body has an upper limit.
+        // Otherwise, add the inner body's size hint to the amount of buffered
+        // data. An upper limit is only set if the inner body has an upper
+        // limit.
         let mut hint = SizeHint::default();
         hint.set_lower(buffered + rest_hint.lower());
         if let Some(rest_upper) = rest_hint.upper() {


### PR DESCRIPTION
`ReplayBody::poll_data` includes some deeply nested logic that can be
avoided with early returns. This restructures `ReplayBody::poll_data` so
that the control flow is easier to follow.