### PR TITLE
rustls: Configure the initial TLS client with trust roots

### DIFF
--- a/linkerd/meshtls/rustls/src/creds.rs
+++ b/linkerd/meshtls/rustls/src/creds.rs
@@ -39,7 +39,12 @@ pub fn watch(
     let key = EcdsaKeyPair::from_pkcs8(params::SIGNATURE_ALG_RING_SIGNING, key_pkcs8)
         .map_err(InvalidKey)?;
 
-    let (client_tx, client_rx) = watch::channel(Arc::new(rustls::ClientConfig::new()));
+    let (client_tx, client_rx) = {
+        let mut c = rustls::ClientConfig::new();
+        c.root_store = roots.clone();
+        c.enable_tickets = false;
+        watch::channel(Arc::new(c))
+    };
     let (server_tx, server_rx) = watch::channel(Arc::new(rustls::ServerConfig::new(
         rustls::AllowAnyAnonymousOrAuthenticatedClient::new(roots.clone()),
     )));


### PR DESCRIPTION
2dd7bb8ff changed how rustls configurations are constructed; but it
didn't properly configure the default client configuration with the
proxy's trust root. This enables the identity client to establish TLS
connections with the identity controller during startup.