### PR TITLE
ci: Make job names uniform

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -17,7 +17,7 @@ permissions:
   contents: read
 
 jobs:
-  binary:
+  check-release:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
 
   # Linting
-  clippy:
+  check-clippy:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     container:
@@ -26,7 +26,7 @@ jobs:
       - run: make lint
 
   # Iterate through all (non-fuzzer) sub-crates to ensure each compiles independently.
-  each-crate:
+  check-each-crate:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     container:
@@ -40,7 +40,7 @@ jobs:
           done
 
   # Enforce automated formatting.
-  fmt:
+  check-fmt:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     container:
@@ -51,7 +51,7 @@ jobs:
       - run: make check-fmt
 
   # Generate docs
-  docs:
+  check-docs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -16,7 +16,7 @@ jobs:
   # Check for security advisories.
   #
   # TODO(ver): This should open issues against the linkerd2 repo (and be run in a cron).
-  advisories:
+  deps-advisories:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     # Prevent sudden announcement of a new advisory from failing Ci.
@@ -28,7 +28,7 @@ jobs:
         command: check advisories
 
   # Audit licenses, unreleased crates, and unexpected duplicate versions.
-  bans:
+  deps-bans:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -17,7 +17,7 @@ jobs:
   # Ensure that all of the fuzzers continue to build.
   #
   # This is depends on the nightly toolchain, so it may break unexpectedly.
-  build:
+  fuzzers-build:
     timeout-minutes: 40
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
 
   # Run all non-integration tests.
-  unit:
+  test-unit:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -25,7 +25,7 @@ jobs:
 
   # Run only the integration tests. These have the potential to be flakey as they depend on opening
   # sockets and may have timing sensitivity.
-  integration:
+  test-integration:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It turns out that the github UI doesn't always scope a job's name to a
workflow (especially in the required checks UI). This change adds
prefixes to each job name so that jobs end up grouped by workflow in any
lexical ordering.