### PR TITLE
meshtls: allow building without any TLS impls enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,7 @@ dependencies = [
  "linkerd-app",
  "linkerd-app-core",
  "linkerd-app-test",
+ "linkerd-meshtls",
  "linkerd-metrics",
  "linkerd-tracing",
  "linkerd2-proxy-api",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,6 +1494,7 @@ dependencies = [
  "futures",
  "jemallocator",
  "linkerd-app",
+ "linkerd-meshtls",
  "linkerd-signal",
  "num_cpus",
  "tokio",

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -42,4 +42,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["f
 
 [dev-dependencies]
 flate2 = { version = "1.0.22", default-features = false, features = ["rust_backend"] }
+# No code from this crate is actually used; only necessary to enable the Rustls
+# implementation.
+linkerd-meshtls = { path = "../../meshtls", features = ["rustls"] }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }

--- a/linkerd/meshtls/Cargo.toml
+++ b/linkerd/meshtls/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2018"
 publish = false
 
 [features]
-rustls = ["linkerd-meshtls-rustls"]
+rustls = ["linkerd-meshtls-rustls", "has_any_tls_impls"]
+# Enabled if *any* TLS impl is enabled.
+has_any_tls_impls = []
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/meshtls/Cargo.toml
+++ b/linkerd/meshtls/Cargo.toml
@@ -7,9 +7,7 @@ edition = "2018"
 publish = false
 
 [features]
-default = ["rustls"]
 rustls = ["linkerd-meshtls-rustls"]
-
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/meshtls/Cargo.toml
+++ b/linkerd/meshtls/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 publish = false
 
 [features]
-rustls = ["linkerd-meshtls-rustls", "has_any_tls_impls"]
+rustls = ["linkerd-meshtls-rustls", "__has_any_tls_impls"]
 # Enabled if *any* TLS impl is enabled.
-has_any_tls_impls = []
+__has_any_tls_impls = []
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/meshtls/src/client.rs
+++ b/linkerd/meshtls/src/client.rs
@@ -3,6 +3,7 @@ use linkerd_stack::{NewService, Service};
 use linkerd_tls::{ClientTls, HasNegotiatedProtocol, NegotiatedProtocolRef};
 use std::{
     future::Future,
+    marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
 };
@@ -14,18 +15,21 @@ use crate::rustls;
 pub enum NewClient {
     #[cfg(feature = "rustls")]
     Rustls(rustls::NewClient),
+    NoTls,
 }
 
 #[derive(Clone)]
 pub enum Connect {
     #[cfg(feature = "rustls")]
     Rustls(rustls::Connect),
+    NoTls,
 }
 
 #[pin_project::pin_project(project = ConnectFutureProj)]
 pub enum ConnectFuture<I> {
     #[cfg(feature = "rustls")]
     Rustls(#[pin] rustls::ConnectFuture<I>),
+    NoTls(PhantomData<fn(I)>),
 }
 
 #[pin_project::pin_project(project = ClientIoProj)]
@@ -33,6 +37,7 @@ pub enum ConnectFuture<I> {
 pub enum ClientIo<I> {
     #[cfg(feature = "rustls")]
     Rustls(#[pin] rustls::ClientIo<I>),
+    NoTls(PhantomData<fn(I)>),
 }
 
 // === impl NewClient ===
@@ -44,6 +49,11 @@ impl NewService<ClientTls> for NewClient {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(new_client) => Connect::Rustls(new_client.new_service(target)),
+
+            Self::NoTls => {
+                let _ = target;
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 }
@@ -62,6 +72,10 @@ where
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(connect) => <rustls::Connect as Service<I>>::poll_ready(connect, cx),
+            Self::NoTls => {
+                let _ = cx;
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 
@@ -70,6 +84,10 @@ where
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(connect) => ConnectFuture::Rustls(connect.call(io)),
+            Self::NoTls => {
+                let _ = io;
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 }
@@ -89,6 +107,10 @@ where
                 let res = futures::ready!(f.poll(cx));
                 Poll::Ready(res.map(ClientIo::Rustls))
             }
+            ConnectFutureProj::NoTls(_) => {
+                let _ = cx;
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 }
@@ -105,6 +127,11 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncRead for ClientIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ClientIoProj::Rustls(io) => io.poll_read(cx, buf),
+            ClientIoProj::NoTls(_) => {
+                let _ = buf;
+                let _ = cx;
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 }
@@ -115,6 +142,10 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ClientIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ClientIoProj::Rustls(io) => io.poll_flush(cx),
+            ClientIoProj::NoTls(_) => {
+                let _ = cx;
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 
@@ -123,6 +154,10 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ClientIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ClientIoProj::Rustls(io) => io.poll_shutdown(cx),
+            ClientIoProj::NoTls(_) => {
+                let _ = cx;
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 
@@ -131,6 +166,11 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ClientIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ClientIoProj::Rustls(io) => io.poll_write(cx, buf),
+            ClientIoProj::NoTls(_) => {
+                let _ = cx;
+                let _ = buf;
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 
@@ -143,6 +183,11 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ClientIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ClientIoProj::Rustls(io) => io.poll_write_vectored(cx, bufs),
+            ClientIoProj::NoTls(_) => {
+                let _ = cx;
+                let _ = bufs;
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 
@@ -151,6 +196,9 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ClientIo<I> {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(io) => io.is_write_vectored(),
+            Self::NoTls(_) => {
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 }
@@ -161,6 +209,9 @@ impl<I> HasNegotiatedProtocol for ClientIo<I> {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(io) => io.negotiated_protocol(),
+            Self::NoTls(_) => {
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 }
@@ -171,6 +222,9 @@ impl<I: io::PeerAddr> io::PeerAddr for ClientIo<I> {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(io) => io.peer_addr(),
+            Self::NoTls(_) => {
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 }

--- a/linkerd/meshtls/src/client.rs
+++ b/linkerd/meshtls/src/client.rs
@@ -7,7 +7,7 @@ use std::{
     task::{Context, Poll},
 };
 
-#[cfg(not(feature = "has_any_tls_impls"))]
+#[cfg(not(feature = "__has_any_tls_impls"))]
 use std::marker::PhantomData;
 
 #[cfg(feature = "rustls")]
@@ -18,7 +18,7 @@ pub enum NewClient {
     #[cfg(feature = "rustls")]
     Rustls(rustls::NewClient),
 
-    #[cfg(not(feature = "has_any_tls_impls"))]
+    #[cfg(not(feature = "__has_any_tls_impls"))]
     NoTls,
 }
 
@@ -27,7 +27,7 @@ pub enum Connect {
     #[cfg(feature = "rustls")]
     Rustls(rustls::Connect),
 
-    #[cfg(not(feature = "has_any_tls_impls"))]
+    #[cfg(not(feature = "__has_any_tls_impls"))]
     NoTls,
 }
 
@@ -36,7 +36,7 @@ pub enum ConnectFuture<I> {
     #[cfg(feature = "rustls")]
     Rustls(#[pin] rustls::ConnectFuture<I>),
 
-    #[cfg(not(feature = "has_any_tls_impls"))]
+    #[cfg(not(feature = "__has_any_tls_impls"))]
     NoTls(PhantomData<fn(I)>),
 }
 
@@ -46,7 +46,7 @@ pub enum ClientIo<I> {
     #[cfg(feature = "rustls")]
     Rustls(#[pin] rustls::ClientIo<I>),
 
-    #[cfg(not(feature = "has_any_tls_impls"))]
+    #[cfg(not(feature = "__has_any_tls_impls"))]
     NoTls(PhantomData<fn(I)>),
 }
 
@@ -60,7 +60,7 @@ impl NewService<ClientTls> for NewClient {
             #[cfg(feature = "rustls")]
             Self::Rustls(new_client) => Connect::Rustls(new_client.new_service(target)),
 
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(target),
         }
     }
@@ -80,7 +80,7 @@ where
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(connect) => <rustls::Connect as Service<I>>::poll_ready(connect, cx),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx),
         }
     }
@@ -90,7 +90,7 @@ where
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(connect) => ConnectFuture::Rustls(connect.call(io)),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(io),
         }
     }
@@ -111,7 +111,7 @@ where
                 let res = futures::ready!(f.poll(cx));
                 Poll::Ready(res.map(ClientIo::Rustls))
             }
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx),
         }
     }
@@ -129,7 +129,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncRead for ClientIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ClientIoProj::Rustls(io) => io.poll_read(cx, buf),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx, buf),
         }
     }
@@ -141,7 +141,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ClientIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ClientIoProj::Rustls(io) => io.poll_flush(cx),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx),
         }
     }
@@ -151,7 +151,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ClientIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ClientIoProj::Rustls(io) => io.poll_shutdown(cx),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx),
         }
     }
@@ -161,7 +161,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ClientIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ClientIoProj::Rustls(io) => io.poll_write(cx, buf),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx, buf),
         }
     }
@@ -175,7 +175,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ClientIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ClientIoProj::Rustls(io) => io.poll_write_vectored(cx, bufs),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx, bufs),
         }
     }
@@ -185,7 +185,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ClientIo<I> {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(io) => io.is_write_vectored(),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }
@@ -197,7 +197,7 @@ impl<I> HasNegotiatedProtocol for ClientIo<I> {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(io) => io.negotiated_protocol(),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }
@@ -209,7 +209,7 @@ impl<I: io::PeerAddr> io::PeerAddr for ClientIo<I> {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(io) => io.peer_addr(),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }

--- a/linkerd/meshtls/src/creds.rs
+++ b/linkerd/meshtls/src/creds.rs
@@ -8,6 +8,7 @@ pub use crate::rustls;
 pub enum Store {
     #[cfg(feature = "rustls")]
     Rustls(rustls::creds::Store),
+    #[cfg(not(feature = "has_any_tls_impls"))]
     NoTls,
 }
 
@@ -15,6 +16,7 @@ pub enum Store {
 pub enum Receiver {
     #[cfg(feature = "rustls")]
     Rustls(rustls::creds::Receiver),
+    #[cfg(not(feature = "has_any_tls_impls"))]
     NoTls,
 }
 
@@ -25,7 +27,8 @@ impl Credentials for Store {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(store) => store.dns_name(),
-            Self::NoTls => unreachable!("compiled with no TLS implementations enabled!"),
+            #[cfg(not(feature = "has_any_tls_impls"))]
+            _ => crate::no_tls!(),
         }
     }
 
@@ -33,7 +36,8 @@ impl Credentials for Store {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(store) => store.gen_certificate_signing_request(),
-            Self::NoTls => unreachable!("compiled with no TLS implementations enabled!"),
+            #[cfg(not(feature = "has_any_tls_impls"))]
+            _ => crate::no_tls!(),
         }
     }
 
@@ -46,12 +50,8 @@ impl Credentials for Store {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(store) => store.set_certificate(leaf, chain, expiry),
-            Self::NoTls => {
-                let _ = leaf;
-                let _ = chain;
-                let _ = expiry;
-                unreachable!("compiled with no TLS implementations enabled!")
-            }
+            #[cfg(not(feature = "has_any_tls_impls"))]
+            _ => crate::no_tls!(leaf, chain, expiry),
         }
     }
 }
@@ -70,8 +70,8 @@ impl Receiver {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(receiver) => receiver.name(),
-
-            Self::NoTls => unreachable!("compiled with no TLS implementations enabled!"),
+            #[cfg(not(feature = "has_any_tls_impls"))]
+            _ => crate::no_tls!(),
         }
     }
 
@@ -79,7 +79,8 @@ impl Receiver {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(receiver) => NewClient::Rustls(receiver.new_client()),
-            Self::NoTls => unreachable!("compiled with no TLS implementations enabled!"),
+            #[cfg(not(feature = "has_any_tls_impls"))]
+            _ => crate::no_tls!(),
         }
     }
 
@@ -87,7 +88,8 @@ impl Receiver {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(receiver) => Server::Rustls(receiver.server()),
-            Self::NoTls => unreachable!("compiled with no TLS implementations enabled!"),
+            #[cfg(not(feature = "has_any_tls_impls"))]
+            _ => crate::no_tls!(),
         }
     }
 }

--- a/linkerd/meshtls/src/creds.rs
+++ b/linkerd/meshtls/src/creds.rs
@@ -8,7 +8,7 @@ pub use crate::rustls;
 pub enum Store {
     #[cfg(feature = "rustls")]
     Rustls(rustls::creds::Store),
-    #[cfg(not(feature = "has_any_tls_impls"))]
+    #[cfg(not(feature = "__has_any_tls_impls"))]
     NoTls,
 }
 
@@ -16,7 +16,7 @@ pub enum Store {
 pub enum Receiver {
     #[cfg(feature = "rustls")]
     Rustls(rustls::creds::Receiver),
-    #[cfg(not(feature = "has_any_tls_impls"))]
+    #[cfg(not(feature = "__has_any_tls_impls"))]
     NoTls,
 }
 
@@ -27,7 +27,7 @@ impl Credentials for Store {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(store) => store.dns_name(),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }
@@ -36,7 +36,7 @@ impl Credentials for Store {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(store) => store.gen_certificate_signing_request(),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }
@@ -50,7 +50,7 @@ impl Credentials for Store {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(store) => store.set_certificate(leaf, chain, expiry),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(leaf, chain, expiry),
         }
     }
@@ -70,7 +70,7 @@ impl Receiver {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(receiver) => receiver.name(),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }
@@ -79,7 +79,7 @@ impl Receiver {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(receiver) => NewClient::Rustls(receiver.new_client()),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }
@@ -88,7 +88,7 @@ impl Receiver {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(receiver) => Server::Rustls(receiver.server()),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }

--- a/linkerd/meshtls/src/creds.rs
+++ b/linkerd/meshtls/src/creds.rs
@@ -8,12 +8,14 @@ pub use crate::rustls;
 pub enum Store {
     #[cfg(feature = "rustls")]
     Rustls(rustls::creds::Store),
+    NoTls,
 }
 
 #[derive(Clone, Debug)]
 pub enum Receiver {
     #[cfg(feature = "rustls")]
     Rustls(rustls::creds::Receiver),
+    NoTls,
 }
 
 // === impl Store ===
@@ -23,6 +25,7 @@ impl Credentials for Store {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(store) => store.dns_name(),
+            Self::NoTls => unreachable!("compiled with no TLS implementations enabled!"),
         }
     }
 
@@ -30,6 +33,7 @@ impl Credentials for Store {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(store) => store.gen_certificate_signing_request(),
+            Self::NoTls => unreachable!("compiled with no TLS implementations enabled!"),
         }
     }
 
@@ -42,6 +46,12 @@ impl Credentials for Store {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(store) => store.set_certificate(leaf, chain, expiry),
+            Self::NoTls => {
+                let _ = leaf;
+                let _ = chain;
+                let _ = expiry;
+                unreachable!("compiled with no TLS implementations enabled!")
+            }
         }
     }
 }
@@ -60,6 +70,8 @@ impl Receiver {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(receiver) => receiver.name(),
+
+            Self::NoTls => unreachable!("compiled with no TLS implementations enabled!"),
         }
     }
 
@@ -67,6 +79,7 @@ impl Receiver {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(receiver) => NewClient::Rustls(receiver.new_client()),
+            Self::NoTls => unreachable!("compiled with no TLS implementations enabled!"),
         }
     }
 
@@ -74,6 +87,7 @@ impl Receiver {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(receiver) => Server::Rustls(receiver.server()),
+            Self::NoTls => unreachable!("compiled with no TLS implementations enabled!"),
         }
     }
 }

--- a/linkerd/meshtls/src/lib.rs
+++ b/linkerd/meshtls/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
-#[cfg(not(feature = "has_any_tls_impls"))]
+#[cfg(not(feature = "__has_any_tls_impls"))]
 #[macro_export]
 macro_rules! no_tls {
     ($($field:ident),*) => {
@@ -33,7 +33,7 @@ pub enum Mode {
     #[cfg(feature = "rustls")]
     Rustls,
 
-    #[cfg(not(feature = "has_any_tls_impls"))]
+    #[cfg(not(feature = "__has_any_tls_impls"))]
     NoTls,
 }
 
@@ -45,7 +45,7 @@ impl Default for Mode {
         return Self::Rustls;
 
         // This may not be unreachable if no feature flags are enabled.
-        #[cfg(not(feature = "has_any_tls_impls"))]
+        #[cfg(not(feature = "__has_any_tls_impls"))]
         Self::NoTls
     }
 }
@@ -68,7 +68,7 @@ impl Mode {
                 ))
             }
 
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => no_tls!(identity, roots_pem, key_pkcs8, csr),
         }
     }

--- a/linkerd/meshtls/src/server.rs
+++ b/linkerd/meshtls/src/server.rs
@@ -9,7 +9,7 @@ use std::{
     task::{Context, Poll},
 };
 
-#[cfg(not(feature = "has_any_tls_impls"))]
+#[cfg(not(feature = "__has_any_tls_impls"))]
 use std::marker::PhantomData;
 
 #[cfg(feature = "rustls")]
@@ -20,7 +20,7 @@ pub enum Server {
     #[cfg(feature = "rustls")]
     Rustls(rustls::Server),
 
-    #[cfg(not(feature = "has_any_tls_impls"))]
+    #[cfg(not(feature = "__has_any_tls_impls"))]
     NoTls,
 }
 
@@ -29,7 +29,7 @@ pub enum TerminateFuture<I> {
     #[cfg(feature = "rustls")]
     Rustls(#[pin] rustls::TerminateFuture<I>),
 
-    #[cfg(not(feature = "has_any_tls_impls"))]
+    #[cfg(not(feature = "__has_any_tls_impls"))]
     NoTls(PhantomData<fn(I)>),
 }
 
@@ -39,7 +39,7 @@ pub enum ServerIo<I> {
     #[cfg(feature = "rustls")]
     Rustls(#[pin] rustls::ServerIo<I>),
 
-    #[cfg(not(feature = "has_any_tls_impls"))]
+    #[cfg(not(feature = "__has_any_tls_impls"))]
     NoTls(PhantomData<fn(I)>),
 }
 
@@ -51,7 +51,7 @@ impl Param<LocalId> for Server {
             #[cfg(feature = "rustls")]
             Self::Rustls(srv) => srv.param(),
 
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }
@@ -66,7 +66,7 @@ impl Server {
                 .map(Self::Rustls)
                 .map_err(Into::into),
 
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(alpn_protocols),
         }
     }
@@ -85,7 +85,7 @@ where
             #[cfg(feature = "rustls")]
             Self::Rustls(svc) => <rustls::Server as Service<I>>::poll_ready(svc, cx),
 
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx),
         }
     }
@@ -96,7 +96,7 @@ where
             #[cfg(feature = "rustls")]
             Self::Rustls(svc) => TerminateFuture::Rustls(svc.call(io)),
 
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(io),
         }
     }
@@ -118,7 +118,7 @@ where
                 Poll::Ready(res.map(|(tls, io)| (tls, ServerIo::Rustls(io))))
             }
 
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx),
         }
     }
@@ -137,7 +137,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncRead for ServerIo<I> {
             #[cfg(feature = "rustls")]
             ServerIoProj::Rustls(io) => io.poll_read(cx, buf),
 
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx, buf),
         }
     }
@@ -149,7 +149,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ServerIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ServerIoProj::Rustls(io) => io.poll_flush(cx),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx),
         }
     }
@@ -159,7 +159,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ServerIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ServerIoProj::Rustls(io) => io.poll_shutdown(cx),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx),
         }
     }
@@ -169,7 +169,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ServerIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ServerIoProj::Rustls(io) => io.poll_write(cx, buf),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx, buf),
         }
     }
@@ -183,7 +183,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ServerIo<I> {
         match self.project() {
             #[cfg(feature = "rustls")]
             ServerIoProj::Rustls(io) => io.poll_write_vectored(cx, bufs),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(cx, bufs),
         }
     }
@@ -193,7 +193,7 @@ impl<I: io::AsyncRead + io::AsyncWrite + Unpin> io::AsyncWrite for ServerIo<I> {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(io) => io.is_write_vectored(),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }
@@ -205,7 +205,7 @@ impl<I: io::PeerAddr> io::PeerAddr for ServerIo<I> {
         match self {
             #[cfg(feature = "rustls")]
             Self::Rustls(io) => io.peer_addr(),
-            #[cfg(not(feature = "has_any_tls_impls"))]
+            #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
     }

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -8,13 +8,17 @@ publish = false
 description = "The main proxy executable"
 
 [features]
-default = ["multicore"]
+default = ["multicore", "meshtls-rustls"]
 multicore = ["tokio/rt-multi-thread", "num_cpus"]
+meshtls-rustls = ["linkerd-meshtls/rustls"]
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
 num_cpus = { version = "1", optional = true }
 linkerd-app = { path = "../linkerd/app" }
+# We don't actually use code from this crate in `main`; it's here only so we can
+# control its feature flags.
+linkerd-meshtls = { path = "../linkerd/meshtls" }
 linkerd-signal = { path = "../linkerd/signal" }
 tokio = { version = "1", features = ["rt", "time", "net"] }
 tracing = "0.1.29"

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -4,6 +4,13 @@
 #![forbid(unsafe_code)]
 #![type_length_limit = "16289823"]
 
+// Emit a compile-time error if no TLS implementations are enabled. When adding
+// new implementations, add their feature flags here!
+#[cfg(not(any(feature = "meshtls-rustls")))]
+compile_error!(
+    "at least one of the following TLS implementations must be enabled: 'meshtls-rustls'"
+);
+
 use linkerd_app::{core::transport::BindTcp, trace, Config};
 use linkerd_signal as signal;
 use tokio::sync::mpsc;


### PR DESCRIPTION
Currently, the `linkerd-meshtls` crate cannot be compiled when no TLS
implementation feature flags are enabled. This is an issue, since it
means the `rustls` implementation must be enabled by default, requiring
all crates that depend on `meshtls`, or on a crate that depends on it,
to expose feature flags for controlling what TLS implementation(s) are
enabled. This is not ideal.

This branch changes the `meshtls` so that it can compile even when no
TLS implementations are enabled. The crates which actually need TLS
implementations to be enabled (the `linkerd2-proxy` application crate,
and `linkerd-app-integration`) now depend on the `linkerd-meshtls` crate
for the purposes of enabling feature flags. Other crates that depend on
`meshtls` can do so without having to propagate its feature flags.

The compile error when no TLS implementations are enabled is moved to
the `linkerd2-proxy` crate. `linkerd-meshtls` will now panic at runtime
(rather than failing to compile) if built with all TLS features disabled
(so that dependent crates don't have to enable its features), but the
proxy crate statically ensures that this cannot happen when building a
proxy.