### PR TITLE
Restore rustls credential tests

### DIFF
--- a/linkerd/meshtls/rustls/src/lib.rs
+++ b/linkerd/meshtls/rustls/src/lib.rs
@@ -4,6 +4,8 @@
 mod client;
 pub mod creds;
 mod server;
+#[cfg(test)]
+mod tests;
 
 pub use self::{
     client::{ClientIo, Connect, ConnectFuture, NewClient},

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(warnings, rust_2018_idioms)]
+#![forbid(unsafe_code)]
+
 mod network;
 
 pub use self::network::Network;

--- a/linkerd/tls/test-util/src/lib.rs
+++ b/linkerd/tls/test-util/src/lib.rs
@@ -19,6 +19,13 @@ pub static FOO_NS1: Entity = Entity {
     key: include_bytes!("testdata/foo-ns1-ca1/key.p8"),
 };
 
+pub static FOO_NS1_CA2: Entity = Entity {
+    name: "foo.ns1.serviceaccount.identity.linkerd.cluster.local",
+    trust_anchors: include_bytes!("testdata/ca2.pem"),
+    crt: include_bytes!("testdata/foo-ns1-ca2/crt.der"),
+    key: include_bytes!("testdata/foo-ns1-ca2/key.p8"),
+};
+
 pub static BAR_NS1: Entity = Entity {
     name: "bar.ns1.serviceaccount.identity.linkerd.cluster.local",
     trust_anchors: include_bytes!("testdata/ca1.pem"),

--- a/linkerd/tls/test-util/src/lib.rs
+++ b/linkerd/tls/test-util/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(warnings, rust_2018_idioms)]
+#![forbid(unsafe_code)]
+
 pub struct Entity {
     pub name: &'static str,
     pub trust_anchors: &'static [u8],


### PR DESCRIPTION
In a prior change, the rustls credential-loading tests were accidentally
disabled. This change restores these tests and updates them to use the
newer API.