### PR TITLE
Eliminate needless compiler directives

### DIFF
--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -2,10 +2,6 @@
 
 #![deny(warnings, rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![recursion_limit = "256"]
-#![type_length_limit = "16289823"]
-// It's not clear where this originates.
-#![allow(clippy::eval_order_dependence)]
 
 mod test_env;
 

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1,6 +1,3 @@
-// It's not clear where this originates.
-#![allow(clippy::redundant_closure_call)]
-
 use crate::*;
 use std::error::Error as _;
 use tokio::sync::mpsc;
@@ -345,7 +342,8 @@ macro_rules! http1_tests {
             let _trace = trace_init();
 
             let srv = server::http1().route("/", "hello h1").run().await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             assert_eq!(client.get("/").await, "hello h1");
@@ -371,7 +369,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let res = client
@@ -415,7 +414,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
             let client = client::http1(proxy.inbound, host);
 
             let res = client
@@ -450,7 +450,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
             let client = client::http1_absolute_uris(proxy.inbound, auth);
 
             let res = client
@@ -520,7 +521,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
 
             let client = client::tcp(proxy.inbound);
 
@@ -561,7 +563,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
 
             let host = "transparency.test.svc.cluster.local";
             let client = client::http1(proxy.inbound, host);
@@ -597,7 +600,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
 
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
@@ -673,7 +677,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
 
             let client = client::tcp(proxy.inbound);
 
@@ -712,7 +717,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
 
             // A TCP client is used since the HTTP client would stop these requests
             // from ever touching the network.
@@ -781,7 +787,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let req = client
@@ -816,7 +823,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let req = client
@@ -854,7 +862,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let methods = &["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"];
@@ -891,7 +900,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let methods = &["GET", "POST", "PUT", "DELETE", "HEAD", "PATCH"];
@@ -935,7 +945,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             // https://tools.ietf.org/html/rfc7230#section-3.3.3
@@ -998,7 +1009,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 
             let resp = client
@@ -1039,7 +1051,8 @@ macro_rules! http1_tests {
                 })
                 .run()
                 .await;
-            let proxy = ($proxy)(srv).await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
 
             let client = client::http1(proxy.inbound, "transparency.test.svc.cluster.local");
 

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -317,7 +317,6 @@ mod test {
 
     /// Helper server that reads the l5d-orig-proto header on requests and uses it to set the header
     /// value in `WAS_ORIG_PROTO`.
-    #[allow(clippy::unnecessary_wraps)]
     fn serve(version: ::http::Version) -> io::Result<io::BoxedIo> {
         let svc = hyper::service::service_fn(move |req: http::Request<_>| {
             tracing::debug!(?req);

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -118,7 +118,6 @@ impl<S> PreventLoopback<S> {
     #[cfg(feature = "allow-loopback")]
     // the Result is necessary to have the same type signature regardless of
     // whether or not the `allow-loopback` feature is enabled...
-    #[allow(clippy::unnecessary_wraps)]
     fn check_loopback(_: Remote<ServerAddr>) -> io::Result<()> {
         Ok(())
     }

--- a/linkerd/duplex/src/lib.rs
+++ b/linkerd/duplex/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This module uses unsafe code to implement [`BufMut`].
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, unsafe_code)]
 
 use bytes::{Buf, BufMut};
 use futures::ready;
@@ -315,6 +315,7 @@ impl Buf for CopyBuf {
     }
 }
 
+#[allow(unsafe_code)]
 unsafe impl BufMut for CopyBuf {
     fn remaining_mut(&self) -> usize {
         self.buf.len() - self.write_pos

--- a/linkerd/http-retry/src/lib.rs
+++ b/linkerd/http-retry/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![allow(clippy::type_complexity)]
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use http::HeaderMap;

--- a/linkerd/proxy/api-resolve/src/lib.rs
+++ b/linkerd/proxy/api-resolve/src/lib.rs
@@ -1,6 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![recursion_limit = "512"]
 
 use linkerd2_proxy_api as api;
 use linkerd_addr::NameAddr;

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -2,8 +2,7 @@
 //!
 //! Uses unsafe code to interact with socket options for SO_ORIGINAL_DST.
 
-#![deny(warnings, rust_2018_idioms)]
-// #![forbid(unsafe_code)]
+#![deny(warnings, rust_2018_idioms, unsafe_code)]
 
 pub mod addrs;
 mod connect;

--- a/linkerd/proxy/transport/src/orig_dst.rs
+++ b/linkerd/proxy/transport/src/orig_dst.rs
@@ -77,6 +77,7 @@ where
 }
 
 #[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
 fn orig_dst_addr(sock: &TcpStream) -> io::Result<OrigDstAddr> {
     use std::os::unix::io::AsRawFd;
 
@@ -94,6 +95,7 @@ fn orig_dst_addr(_: &TcpStream) -> io::Result<OrigDstAddr> {
 }
 
 #[cfg(target_os = "linux")]
+#[allow(unsafe_code)]
 mod linux {
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
     use std::os::unix::io::RawFd;

--- a/linkerd/system/src/lib.rs
+++ b/linkerd/system/src/lib.rs
@@ -1,6 +1,6 @@
 //! Unsafe code for accessing system-level counters for memory & CPU usage.
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, unsafe_code)]
 
 #[cfg(target_os = "linux")]
 mod linux;

--- a/linkerd/system/src/linux.rs
+++ b/linkerd/system/src/linux.rs
@@ -44,6 +44,7 @@ pub fn max_fds() -> io::Result<Option<u64>> {
     Ok(max_fds)
 }
 
+#[allow(unsafe_code)]
 fn sysconf(num: libc::c_int, name: &'static str) -> Result<u64, io::Error> {
     match unsafe { libc::sysconf(num) } {
         e if e <= 0 => {

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -2,7 +2,6 @@
 
 #![deny(warnings, rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![type_length_limit = "16289823"]
 
 // Emit a compile-time error if no TLS implementations are enabled. When adding
 // new implementations, add their feature flags here!

--- a/opencensus-proto/src/lib.rs
+++ b/opencensus-proto/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![deny(warnings, rust_2018_idioms)]
 #![forbid(unsafe_code)]
-#![allow(clippy::inconsistent_struct_constructor, rustdoc::bare_urls)]
 
 pub mod agent {
     pub mod trace {
@@ -15,6 +14,7 @@ pub mod agent {
             ));
         }
     }
+
     pub mod common {
         pub mod v1 {
             include!(concat!(
@@ -24,11 +24,13 @@ pub mod agent {
         }
     }
 }
+
 pub mod trace {
     pub mod v1 {
         include!(concat!(env!("OUT_DIR"), "/opencensus.proto.trace.v1.rs"));
     }
 }
+
 pub mod resource {
     pub mod v1 {
         include!(concat!(env!("OUT_DIR"), "/opencensus.proto.resource.v1.rs"));


### PR DESCRIPTION
We've accrued various compiler directives and clippy exceptions that are
no longer necesary. This change removes these unnecessary settings.

This change also addresses a lint in our integration tests.