### PR TITLE
transport: Improve TCP server error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,6 +1447,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "libc",
+ "linkerd-error",
  "linkerd-io",
  "linkerd-stack",
  "socket2 0.4.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,6 +1450,7 @@ dependencies = [
  "linkerd-io",
  "linkerd-stack",
  "socket2 0.4.2",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -39,7 +39,8 @@ pub async fn serve<M, S, I, A>(
                     };
 
                     // The local addr should be instrumented from the listener's context.
-                    let span = debug_span!("accept", client.addr = %addrs.param()).entered();
+                    let Remote(ClientAddr(client_addr)) = addrs.param();
+                    let span = debug_span!("accept", client.addr = %client_addr).entered();
                     let accept = new_accept.new_service(addrs);
 
                     // Dispatch all of the work for a given connection onto a
@@ -57,7 +58,9 @@ pub async fn serve<M, S, I, A>(
                                         Err(reason) if is_io(&*reason) => {
                                             debug!(%reason, "Connection closed")
                                         }
-                                        Err(error) => info!(%error, "Connection closed"),
+                                        Err(error) => {
+                                            info!(%error, client.addr = %client_addr, "Connection closed")
+                                        }
                                     }
                                     // Hold the service until the connection is complete. This
                                     // helps tie any inner cache lifetimes to the services they
@@ -65,7 +68,7 @@ pub async fn serve<M, S, I, A>(
                                     drop(accept);
                                 }
                                 Err(error) => {
-                                    warn!(%error, "Server failed to become ready");
+                                    warn!(%error, client.addr = %client_addr, "Server failed to become ready");
                                 }
                             }
                         }

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -2,6 +2,7 @@ use crate::{
     io,
     svc::{self, Param},
     transport::{ClientAddr, Remote},
+    Result,
 };
 use futures::prelude::*;
 use linkerd_error::Error;
@@ -12,7 +13,7 @@ use tracing::{debug, debug_span, info, instrument::Instrument, warn};
 ///
 /// The task is driven until shutdown is signaled.
 pub async fn serve<M, S, I, A>(
-    listen: impl Stream<Item = std::io::Result<(A, I)>>,
+    listen: impl Stream<Item = Result<(A, I)>>,
     new_accept: M,
     shutdown: impl Future,
 ) where

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -3,7 +3,7 @@ use futures::Stream;
 use linkerd_app_core::{
     dns, io, metrics, profiles, serve, svc,
     transport::{self, ClientAddr, Local, OrigDstAddr, Remote, ServerAddr},
-    Error,
+    Error, Result,
 };
 use std::fmt::Debug;
 use tracing::debug_span;
@@ -30,7 +30,7 @@ impl Inbound<()> {
     pub async fn serve<A, I, G, GSvc, P>(
         self,
         addr: Local<ServerAddr>,
-        listen: impl Stream<Item = io::Result<(A, I)>> + Send + Sync + 'static,
+        listen: impl Stream<Item = Result<(A, I)>> + Send + Sync + 'static,
         policies: impl policy::CheckPolicy + Clone + Send + Sync + 'static,
         profiles: P,
         gateway: G,

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -33,7 +33,7 @@ use linkerd_app_core::{
     svc::{self, stack::Param},
     tls,
     transport::{self, addrs::*},
-    AddrMatch, Error, ProxyRuntime,
+    AddrMatch, Error, ProxyRuntime,Result
 };
 use std::{
     collections::{HashMap, HashSet},
@@ -149,7 +149,7 @@ impl<S> Outbound<S> {
 impl Outbound<()> {
     pub async fn serve<A, I, P, R>(
         self,
-        listen: impl Stream<Item = io::Result<(A, I)>> + Send + Sync + 'static,
+        listen: impl Stream<Item = Result<(A, I)>> + Send + Sync + 'static,
         profiles: P,
         resolve: R,
     ) where

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -33,7 +33,7 @@ use linkerd_app_core::{
     svc::{self, stack::Param},
     tls,
     transport::{self, addrs::*},
-    AddrMatch, Error, ProxyRuntime,Result
+    AddrMatch, Error, ProxyRuntime, Result,
 };
 use std::{
     collections::{HashMap, HashSet},

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -14,6 +14,7 @@ futures = { version = "0.3", default-features = false }
 linkerd-io = { path = "../../io" }
 linkerd-stack = { path = "../../stack" }
 socket2 = "0.4"
+thiserror = "1"
 tokio = { version = "1", features = ["macros", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 tracing = "0.1.29"

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -11,6 +11,7 @@ Transport-level implementations that rely on core proxy infrastructure
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
+linkerd-error = { path = "../../error" }
 linkerd-io = { path = "../../io" }
 linkerd-stack = { path = "../../stack" }
 socket2 = "0.4"

--- a/linkerd/proxy/transport/src/orig_dst.rs
+++ b/linkerd/proxy/transport/src/orig_dst.rs
@@ -3,6 +3,7 @@ use crate::{
     listen::{self, Bind, Bound},
 };
 use futures::prelude::*;
+use linkerd_error::Result;
 use linkerd_io as io;
 use linkerd_stack::Param;
 use std::pin::Pin;
@@ -60,9 +61,9 @@ where
     type Addrs = Addrs<B::Addrs>;
     type Io = TcpStream;
     type Incoming =
-        Pin<Box<dyn Stream<Item = io::Result<(Self::Addrs, TcpStream)>> + Send + Sync + 'static>>;
+        Pin<Box<dyn Stream<Item = Result<(Self::Addrs, TcpStream)>> + Send + Sync + 'static>>;
 
-    fn bind(self, t: &T) -> io::Result<Bound<Self::Incoming>> {
+    fn bind(self, t: &T) -> Result<Bound<Self::Incoming>> {
         let (addr, incoming) = self.inner.bind(t)?;
 
         let incoming = incoming.map(|res| {


### PR DESCRIPTION
The TCP server can fail connections in a few situations:

* `accept(2)` can fail
* setting thte TCP keepalive can fail
* getting the client peer address can fail

It's not easy to differentiate these errors when inspecting proxy logs.

This change adds wrapper error types with custom error messages that
disambiguate the error cause.

Additionally, this change includes the client address when logging
information/warnings about connection errors in general. This is
redundant when logging is set at debug, but will be helpful when logging
is set at the normal level.