### PR TITLE
ci: Fix coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  CARGO_TARPAULIN_VERSION: 0.18.5
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
 
@@ -26,7 +27,10 @@ jobs:
     steps:
       - run: apt update && apt install -y cmake clang golang # for boring
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      - run: cargo install cargo-tarpaulin
-      - run: cargo tarpaulin --verbose --workspace --no-run
-      - run: cargo tarpaulin --verbose --workspace --out Xml --ignore-tests --no-fail-fast
+      - name: install cargo-tarpaulin ${{ env.CARGO_TARPAULIN_VERSION }}
+        run: |
+          cd "${CARGO_HOME}/bin"
+          curl -sL https://github.com/xd009642/tarpaulin/releases/download/${CARGO_TARPAULIN_VERSION}/cargo-tarpaulin-${CARGO_TARPAULIN_VERSION}-travis.tar.gz | tar xzvf -
+      - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --no-run
+      - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --skip-clean --ignore-tests --no-fail-fast --out=Xml
       - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           cd "${CARGO_HOME}/bin"
           curl -sL https://github.com/xd009642/tarpaulin/releases/download/${CARGO_TARPAULIN_VERSION}/cargo-tarpaulin-${CARGO_TARPAULIN_VERSION}-travis.tar.gz | tar xzvf -
-      - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --no-run
+      - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --no-run
+      - run: cargo tarpaulin --locked --workspace --package=linkerd-app-integration --no-default-features --skip-clean --no-run
       - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --skip-clean --ignore-tests --no-fail-fast --out=Xml
+      - run: cargo tarpaulin --locked --workspace --package=linkerd-app-integration --no-default-features --skip-clean --ignore-tests --no-fail-fast --out=Xml
       - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,7 +32,7 @@ jobs:
           cd "${CARGO_HOME}/bin"
           curl -sL https://github.com/xd009642/tarpaulin/releases/download/${CARGO_TARPAULIN_VERSION}/cargo-tarpaulin-${CARGO_TARPAULIN_VERSION}-travis.tar.gz | tar xzvf -
       - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --no-run
-      - run: cargo tarpaulin --locked --workspace --package=linkerd-app-integration --no-default-features --skip-clean --no-run
       - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --skip-clean --ignore-tests --no-fail-fast --out=Xml
+      - run: cargo tarpaulin --locked --workspace --package=linkerd-app-integration --no-default-features --skip-clean --no-run
       - run: cargo tarpaulin --locked --workspace --package=linkerd-app-integration --no-default-features --skip-clean --ignore-tests --no-fail-fast --out=Xml
       - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,6 +33,6 @@ jobs:
           curl -sL https://github.com/xd009642/tarpaulin/releases/download/${CARGO_TARPAULIN_VERSION}/cargo-tarpaulin-${CARGO_TARPAULIN_VERSION}-travis.tar.gz | tar xzvf -
       - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --no-run
       - run: cargo tarpaulin --locked --workspace --package=linkerd-app-integration --no-default-features --skip-clean --no-run
-      - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --skip-clean --ignore-tests --no-fail-fast --out=Xml
+      - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --skip-clean --ignore-tests --no-fail-fast --out=Xml
       - run: cargo tarpaulin --locked --workspace --package=linkerd-app-integration --no-default-features --skip-clean --ignore-tests --no-fail-fast --out=Xml
       - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -72,6 +72,9 @@ jobs:
             --package=linkerd-app-inbound \
             --package=linkerd-app-outbound \
             --package=linkerd-app-test
+
+      # Integration: enable tests that are flakey in coverage, but disable tests
+      # that can be flakey in CI...
       - run: |
           cargo test --no-run \
             --package=linkerd-app-integration \

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -65,10 +65,6 @@ jobs:
             --package=linkerd-app-outbound \
             --package=linkerd-app-test
       - run: |
-          cargo test --no-run \
-            --package=linkerd-app-integration \
-            --no-default-features --features=flakey-in-coverage
-      - run: |
           cargo test \
             --package=linkerd-app \
             --package=linkerd-app-admin \
@@ -77,6 +73,10 @@ jobs:
             --package=linkerd-app-inbound \
             --package=linkerd-app-outbound \
             --package=linkerd-app-test
+      - run: |
+          cargo test --no-run \
+            --package=linkerd-app-integration \
+            --no-default-features --features=flakey-in-coverage
       - run: |
           cargo test \
             --package=linkerd-app-integration \

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -61,7 +61,6 @@ jobs:
             --package=linkerd-app-core \
             --package=linkerd-app-gateway \
             --package=linkerd-app-inbound \
-            --package=linkerd-app-integration \
             --package=linkerd-app-outbound \
             --package=linkerd-app-test
       - run: |

--- a/.github/workflows/slow.yml
+++ b/.github/workflows/slow.yml
@@ -65,13 +65,19 @@ jobs:
             --package=linkerd-app-outbound \
             --package=linkerd-app-test
       - run: |
+          cargo test --no-run \
+            --package=linkerd-app-integration \
+            --no-default-features --features=flakey-in-coverage
+      - run: |
           cargo test \
             --package=linkerd-app \
             --package=linkerd-app-admin \
             --package=linkerd-app-core \
             --package=linkerd-app-gateway \
             --package=linkerd-app-inbound \
-            --package=linkerd-app-integration \
             --package=linkerd-app-outbound \
             --package=linkerd-app-test
-
+      - run: |
+          cargo test \
+            --package=linkerd-app-integration \
+            --no-default-features --features=flakey-in-coverage

--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,6 @@ shellcheck:
 test: fetch
 	$(CARGO_TEST)
 
-.PHONY: test-flakey
-test-flakey: fetch
-	$(CARGO_TEST) --features linkerd-app-integration/flaky_tests
-
 .PHONY: package
 package: $(PKG_ROOT)/$(PKG)
 

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -13,8 +13,7 @@ a dedicated crate to help the compiler cache dependencies properly.
 """
 
 [features]
-default = ["all-tests"]
-all-tests = ["flakey-in-ci"]
+default = ["flakey-in-ci"]
 flakey-in-ci = ["flakey-in-coverage"]
 flakey-in-coverage = []
 rustfmt = ["linkerd2-proxy-api/rustfmt"]

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -13,7 +13,10 @@ a dedicated crate to help the compiler cache dependencies properly.
 """
 
 [features]
-flaky_tests = [] # Disable to skip certain tests that should not be run on CI.
+default = ["all-tests"]
+all-tests = ["flakey-in-ci"]
+flakey-in-ci = ["flakey-in-coverage"]
+flakey-in-coverage = []
 rustfmt = ["linkerd2-proxy-api/rustfmt"]
 
 [dependencies]

--- a/linkerd/app/integration/src/tests/identity.rs
+++ b/linkerd/app/integration/src/tests/identity.rs
@@ -245,8 +245,9 @@ mod require_id_header {
             server: $make_server:path,
             tls_server: $make_tls_server:path,
         ) => {
+            // FIXME(ver) this test was marked flakey, but now it consistently fails.
+            #[ignore]
             #[tokio::test]
-            #[cfg_attr(not(feature = "flaky_tests"), ignore)]
             async fn orig_dst_client_connects_to_tls_server() {
                 let _trace = trace_init();
 
@@ -313,8 +314,9 @@ mod require_id_header {
                 );
             }
 
+            // FIXME(ver) this test was marked flakey, but now it consistently fails.
+            #[ignore]
             #[tokio::test]
-            #[cfg_attr(not(feature = "flaky_tests"), ignore)]
             async fn disco_client_connects_to_tls_server() {
                 let _trace = trace_init();
 
@@ -391,8 +393,9 @@ mod require_id_header {
                 );
             }
 
+            // FIXME(ver) this test was marked flakey, but now it consistently fails.
+            #[ignore]
             #[tokio::test]
-            #[cfg_attr(not(feature = "flaky_tests"), ignore)]
             async fn orig_dst_client_cannot_connect_to_plaintext_server() {
                 let _trace = trace_init();
 

--- a/linkerd/app/integration/src/tests/tap.rs
+++ b/linkerd/app/integration/src/tests/tap.rs
@@ -74,10 +74,9 @@ async fn rejects_incorrect_identity_when_identity_is_expected() {
     assert!(events.next().await.expect("next1").is_err());
 }
 
-// Flaky: sometimes the admin thread hasn't had a chance to register
-// the Taps before the `client.get` is called.
+// FIXME(ver) this test was marked flakey, but now it consistently fails.
+#[ignore]
 #[tokio::test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
 async fn inbound_http1() {
     let _trace = trace_init();
 
@@ -158,8 +157,9 @@ async fn inbound_http1() {
     assert_eq!(ev3.response_end_bytes(), 5);
 }
 
+// FIXME(ver) this test was marked flakey, but now it consistently fails.
+#[ignore]
 #[tokio::test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
 async fn grpc_headers_end() {
     let _trace = trace_init();
 

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -493,7 +493,7 @@ where
 // Eventually, we can add some kind of mock timer system for simulating latency
 // more reliably, and re-enable this test.
 #[tokio::test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+#[cfg_attr(not(feature = "flakey-in-ci"), ignore)]
 async fn inbound_response_latency() {
     test_response_latency(Fixture::inbound_with_server).await
 }
@@ -503,7 +503,7 @@ async fn inbound_response_latency() {
 // Eventually, we can add some kind of mock timer system for simulating latency
 // more reliably, and re-enable this test.
 #[tokio::test]
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+#[cfg_attr(not(feature = "flakey-in-ci"), ignore)]
 async fn outbound_response_latency() {
     test_response_latency(Fixture::outbound_with_server).await
 }
@@ -676,7 +676,7 @@ mod outbound_dst_labels {
     // the mock controller before the first request has finished.
     // See linkerd/linkerd2#751
     #[tokio::test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    #[cfg_attr(not(feature = "flakey-in-ci"), ignore)]
     async fn controller_updates_addr_labels() {
         let _trace = trace_init();
         info!("running test server");
@@ -755,12 +755,9 @@ mod outbound_dst_labels {
         }
     }
 
-    // Ignore this test on CI, as it may fail due to the reduced concurrency
-    // on CI containers causing the proxy to see both label updates from
-    // the mock controller before the first request has finished.
-    // See linkerd/linkerd2#751
+    // FIXME(ver) this test was marked flakey, but now it consistently fails.
+    #[ignore]
     #[tokio::test]
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     async fn controller_updates_set_labels() {
         let _trace = trace_init();
         info!("running test server");
@@ -1191,8 +1188,7 @@ mod transport {
         test_tcp_connect(TcpFixture::outbound()).await;
     }
 
-    // XXX This test is flakey when running coverage tests.
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    #[cfg_attr(not(feature = "flakey-in-coverage"), ignore)]
     #[tokio::test]
     async fn outbound_tcp_accept() {
         test_tcp_accept(TcpFixture::outbound()).await;
@@ -1296,8 +1292,7 @@ mod transport {
         test_read_bytes_total(TcpFixture::outbound()).await
     }
 
-    // XXX This test is flakey when running coverage tests.
-    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
+    #[cfg_attr(not(feature = "flakey-in-coverage"), ignore)]
     #[tokio::test]
     async fn outbound_tcp_open_connections() {
         test_tcp_open_conns(TcpFixture::outbound()).await

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -1191,6 +1191,8 @@ mod transport {
         test_tcp_connect(TcpFixture::outbound()).await;
     }
 
+    // XXX This test is flakey when running coverage tests.
+    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     #[tokio::test]
     async fn outbound_tcp_accept() {
         test_tcp_accept(TcpFixture::outbound()).await;
@@ -1294,6 +1296,8 @@ mod transport {
         test_read_bytes_total(TcpFixture::outbound()).await
     }
 
+    // XXX This test is flakey when running coverage tests.
+    #[cfg_attr(not(feature = "flaky_tests"), ignore)]
     #[tokio::test]
     async fn outbound_tcp_open_connections() {
         test_tcp_open_conns(TcpFixture::outbound()).await

--- a/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
+++ b/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
@@ -231,8 +231,7 @@ async fn inbound_multi() {
 }
 
 /// Tests that TLS detect failure metrics are collected for the direct stack.
-// XXX This test is flakey when running coverage tests.
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+#[cfg_attr(not(feature = "flakey-in-coverage"), ignore)]
 #[tokio::test]
 async fn inbound_direct_multi() {
     let _trace = trace_init();
@@ -316,8 +315,7 @@ async fn inbound_invalid_ip() {
 
 /// Tests that the detect metric is not incremented when TLS is successfully
 /// detected by the direct stack.
-// XXX This test is flakey when running coverage tests.
-#[cfg_attr(not(feature = "flaky_tests"), ignore)]
+#[cfg_attr(not(feature = "flakey-in-coverage"), ignore)]
 #[tokio::test]
 async fn inbound_direct_success() {
     let _trace = trace_init();

--- a/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
+++ b/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
@@ -231,6 +231,8 @@ async fn inbound_multi() {
 }
 
 /// Tests that TLS detect failure metrics are collected for the direct stack.
+// XXX This test is flakey when running coverage tests.
+#[cfg_attr(not(feature = "flaky_tests"), ignore)]
 #[tokio::test]
 async fn inbound_direct_multi() {
     let _trace = trace_init();
@@ -314,6 +316,8 @@ async fn inbound_invalid_ip() {
 
 /// Tests that the detect metric is not incremented when TLS is successfully
 /// detected by the direct stack.
+// XXX This test is flakey when running coverage tests.
+#[cfg_attr(not(feature = "flaky_tests"), ignore)]
 #[tokio::test]
 async fn inbound_direct_success() {
     let _trace = trace_init();

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -14,7 +14,7 @@ a dedicated crate to help the compiler cache dependencies properly.
 
 [features]
 # Disable to skip certain tests that should not be run on CI.
-flaky_tests = []
+flakey-in-ci = []
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -6,15 +6,8 @@ license = "Apache-2.0"
 edition = "2021"
 publish = false
 description = """
-Proxy integration tests
-
-The test utilities can be very costly to compile, so they are extracted into
-a dedicated crate to help the compiler cache dependencies properly.
+Proxy test helpers
 """
-
-[features]
-# Disable to skip certain tests that should not be run on CI.
-flakey-in-ci = []
 
 [dependencies]
 futures = { version = "0.3", default-features = false }


### PR DESCRIPTION
* Avoid building the binary target, since it slows down the build
* Use --skip-clean to use the cached build
* Fetch a pre-build tarpaulin binary (saves ~5m)
* Mark flakey tests as flakey