### PR TITLE
ci: Run dependabot updates at 2AM PST

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,41 +1,59 @@
+# Dependabot are scheduled to avoid contention with normal workday CI usage. We
+# start running updates at 10AM UTC (2AM PST).
 version: 2
 updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: daily
+      time: "10:00"
+      timezone: "UTC"
 
   - package-ecosystem: cargo
     directory: /linkerd/addr/fuzz
     schedule:
       interval: daily
+      time: "10:00"
+      timezone: "UTC"
 
   - package-ecosystem: cargo
     directory: /linkerd/app/inbound/fuzz
     schedule:
       interval: daily
+      time: "10:00"
+      timezone: "UTC"
 
   - package-ecosystem: cargo
     directory: /linkerd/dns/fuzz
     schedule:
       interval: daily
+      time: "10:00"
+      timezone: "UTC"
 
   - package-ecosystem: cargo
     directory: /linkerd/proxy/http/fuzz
     schedule:
       interval: daily
+      time: "10:00"
+      timezone: "UTC"
 
   - package-ecosystem: cargo
     directory: /linkerd/tls/fuzz
     schedule:
       interval: daily
+      time: "10:00"
+      timezone: "UTC"
 
   - package-ecosystem: cargo
     directory: /linkerd/transport-header/fuzz
     schedule:
       interval: daily
+      time: "10:00"
+      timezone: "UTC"
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: daily
+      time: "10:00"
+      timezone: "UTC"


### PR DESCRIPTION
In order to prevent dependabot updates from consuming CI resources
during working hours, this change schedules dependabot updates to run at
10:00 UTC.