### PR TITLE
ci: Skip unit tests in coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,8 +31,12 @@ jobs:
         run: |
           cd "${CARGO_HOME}/bin"
           curl -sL https://github.com/xd009642/tarpaulin/releases/download/${CARGO_TARPAULIN_VERSION}/cargo-tarpaulin-${CARGO_TARPAULIN_VERSION}-travis.tar.gz | tar xzvf -
-      - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --no-run
-      - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --skip-clean --ignore-tests --no-fail-fast --out=Xml
-      - run: cargo tarpaulin --locked --workspace --package=linkerd-app-integration --no-default-features --skip-clean --no-run
-      - run: cargo tarpaulin --locked --workspace --package=linkerd-app-integration --no-default-features --skip-clean --ignore-tests --no-fail-fast --out=Xml
+      # XXX(ver) AFAICT, Tarpaulin doesn't allow us to compose a report over multiple invocations,
+      # so we have to choose between getting coverage from unit tests and integration tests (since
+      # integration tests require --no-default-features to avoid flakiness). Currently the
+      # integration tests seem to cover more code, so we skip the unit tests for now :(.
+      #- run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --no-run
+      #- run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --skip-clean --ignore-tests --no-fail-fast --out=Xml
+      - run: cargo tarpaulin --locked --packages=linkerd-app-integration --no-default-features --skip-clean --no-run
+      - run: cargo tarpaulin --locked --packages=linkerd-app-integration --no-default-features --skip-clean --ignore-tests --no-fail-fast --out=Xml
       - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b


### PR DESCRIPTION
The coverage workflow is misconfigured so that it fails to run:
`cargo-tarpaulin` has command line arguments that don't match other
cargo commands (`--packages` instead of `--package`, which cannot be
mixed with `--workspace`). Furthermore, it doesn't seem that we actually
benefit from running tarpaulin over our non-integration tests, since the
coverage reports are not merged.