### PR TITLE
Fixes for compiling on macOS

### DIFF
--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -1199,10 +1199,7 @@ mod transport {
     async fn inbound_tcp_connect_err() {
         let _trace = trace_init();
         let srv = tcp::server()
-            .accept_fut(move |sock| {
-                drop(sock);
-                future::ok(())
-            })
+            .accept_fut(move |sock| async { drop(sock) })
             .run()
             .await;
         let proxy = proxy::new().inbound(srv).run().await;
@@ -1213,7 +1210,7 @@ mod transport {
         let tcp_client = client.connect().await;
 
         tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, &[]);
+        assert_eq!(tcp_client.read().await, &[] as &[u8]);
         // Connection to the server should be a failure with the EXFULL error
         metrics::metric("tcp_close_total")
             .label("peer", "dst")
@@ -1233,15 +1230,12 @@ mod transport {
             .await;
     }
 
-    #[test]
+    #[tokio::test]
     #[cfg(target_os = "macos")]
-    fn outbound_tcp_connect_err() {
+    async fn outbound_tcp_connect_err() {
         let _trace = trace_init();
         let srv = tcp::server()
-            .accept_fut(move |sock| {
-                drop(sock);
-                future::ok(())
-            })
+            .accept_fut(move |sock| async { drop(sock) })
             .run()
             .await;
         let proxy = proxy::new().outbound(srv).run().await;
@@ -1252,7 +1246,7 @@ mod transport {
         let tcp_client = client.connect().await;
 
         tcp_client.write(TcpFixture::HELLO_MSG).await;
-        assert_eq!(tcp_client.read().await, &[]);
+        assert_eq!(tcp_client.read().await, &[] as &[u8]);
         // Connection to the server should be a failure with the EXFULL error
         metrics::metric("tcp_close_total")
             .label("peer", "dst")


### PR DESCRIPTION
A few fixes to compile the integration tests on macOS. Unfortunately, [4 of the tests are failing](https://gist.github.com/tychedelia/301e82856d85c0f59d649e46c5d0c1ca) (2 intermittently so). I tried to dig in a bit, but wasn't able to figure out what was up. Happy to continue investigating with further direction.

This also includes an ugly Makefile hack to exclude the `linekerd-system` on macOS during tests. The conditional dependency inside `linkerd-app-core` works when running `cargo build`, but I guess `cargo test` wants to consume all workspace members (in order to run tests inside the crate, presumably).

(Also, for any future readers I had to increase the file descriptor limit in order to get these to run -- the default on macOS is randomly super low).

Signed-off-by: Jem McElwain <jmcelwain@gmail.com>