### PR TITLE
build: run linkerd-proxy as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,4 +72,7 @@ RUN \
     rm -f /usr/bin/linkerd2-proxy-run && \
     ln /usr/lib/linkerd/linkerd2-proxy /usr/bin/linkerd2-proxy-run ; \
   fi
+
+RUN useradd -r -u 1001 linkerd
+USER linkerd
 # Inherits the ENTRYPOINT from the runtime image.


### PR DESCRIPTION
This commit will add a non-root user called "linkerd" for running the
entrypoint of the linkerd-proxy.

This eliminates the potential security vulnerability described in [#7399](https://github.com/linkerd/linkerd2/issues/7399)

Signed-off-by: Wenliang Chen <wenliang.chen@personio.de>