### PR TITLE
refactor: rename 'metrics' addr to 'admin' in tests

### DIFF
--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -37,7 +37,7 @@ pub struct Listening {
     pub tap: Option<SocketAddr>,
     pub inbound: SocketAddr,
     pub outbound: SocketAddr,
-    pub metrics: SocketAddr,
+    pub admin: SocketAddr,
 
     pub outbound_server: Option<server::Listening>,
     pub inbound_server: Option<server::Listening>,
@@ -411,7 +411,7 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
         })
         .expect("spawn");
 
-    let (tap_addr, identity_addr, inbound_addr, outbound_addr, metrics_addr) =
+    let (tap_addr, identity_addr, inbound_addr, outbound_addr, admin_addr) =
         running_rx.await.unwrap();
 
     tracing::info!(
@@ -421,14 +421,14 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
         inbound.orig_dst = ?inbound,
         outbound.addr = ?outbound_addr,
         outbound.orig_dst = ?outbound,
-        metrics.addr = ?metrics_addr,
+        metrics.addr = ?admin_addr,
     );
 
     Listening {
         tap: tap_addr.map(Into::into),
         inbound: inbound_addr.into(),
         outbound: outbound_addr.into(),
-        metrics: metrics_addr.into(),
+        admin: admin_addr.into(),
 
         outbound_server: proxy.outbound_server,
         inbound_server: proxy.inbound_server,

--- a/linkerd/app/integration/src/tests/discovery.rs
+++ b/linkerd/app/integration/src/tests/discovery.rs
@@ -373,7 +373,7 @@ mod http2 {
             .run()
             .await;
         let client = client::http2(proxy.outbound, host);
-        let metrics = client::http1(proxy.metrics, "localhost");
+        let metrics = client::http1(proxy.admin, "localhost");
 
         assert_eq!(client.get("/").await, "hello");
 

--- a/linkerd/app/integration/src/tests/identity.rs
+++ b/linkerd/app/integration/src/tests/identity.rs
@@ -61,8 +61,8 @@ macro_rules! generate_tls_accept_test {
             .run_with_test_env(id_svc.env)
             .await;
 
-        tracing::info!("non-tls request to {}", proxy.metrics);
-        let non_tls_client = $make_client_non_tls(proxy.metrics, "localhost");
+        tracing::info!("non-tls request to {}", proxy.admin);
+        let non_tls_client = $make_client_non_tls(proxy.admin, "localhost");
         assert_eventually!(
             non_tls_client
                 .request(non_tls_client.request_builder("/ready").method("GET"))
@@ -72,9 +72,9 @@ macro_rules! generate_tls_accept_test {
                 == http::StatusCode::OK
         );
 
-        tracing::info!("tls request to {}", proxy.metrics);
+        tracing::info!("tls request to {}", proxy.admin);
         let tls_client = $make_client_tls(
-            proxy.metrics,
+            proxy.admin,
             "localhost",
             client::TlsConfig::new(id_svc.client_config, id),
         );
@@ -111,7 +111,7 @@ macro_rules! generate_tls_reject_test {
         let proxy = proxy::new().identity(id_svc).run_with_test_env(env).await;
 
         let client = $make_client(
-            proxy.metrics,
+            proxy.admin,
             "localhost",
             client::TlsConfig::new(client_config, id),
         );
@@ -171,7 +171,7 @@ async fn ready() {
 
     let proxy = proxy::new().identity(id_svc).run_with_test_env(env).await;
 
-    let client = client::http1(proxy.metrics, "localhost");
+    let client = client::http1(proxy.admin, "localhost");
 
     let ready = || async {
         client

--- a/linkerd/app/integration/src/tests/profile_dst_overrides.rs
+++ b/linkerd/app/integration/src/tests/profile_dst_overrides.rs
@@ -87,7 +87,7 @@ async fn add_a_dst_override() {
         .run()
         .await;
     let client = client::http1(proxy.outbound, apex_svc.authority());
-    let metrics = client::http1(proxy.metrics, "localhost");
+    let metrics = client::http1(proxy.admin, "localhost");
 
     let n = 100;
 
@@ -149,7 +149,7 @@ async fn add_multiple_dst_overrides() {
         .await;
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
-    let metrics = client::http1(proxy.metrics, "localhost");
+    let metrics = client::http1(proxy.admin, "localhost");
 
     let n = 100;
 
@@ -214,7 +214,7 @@ async fn set_a_dst_override_weight_to_zero() {
         .await;
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
-    let metrics = client::http1(proxy.metrics, "localhost");
+    let metrics = client::http1(proxy.admin, "localhost");
 
     let n = 100;
 
@@ -284,7 +284,7 @@ async fn set_all_dst_override_weights_to_zero() {
         .await;
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
-    let metrics = client::http1(proxy.metrics, "localhost");
+    let metrics = client::http1(proxy.admin, "localhost");
 
     let n = 100;
 
@@ -346,7 +346,7 @@ async fn remove_a_dst_override() {
         .await;
 
     let client = client::http1(proxy.outbound, apex_svc.authority());
-    let metrics = client::http1(proxy.metrics, "localhost");
+    let metrics = client::http1(proxy.admin, "localhost");
 
     let n = 100;
 

--- a/linkerd/app/integration/src/tests/profiles.rs
+++ b/linkerd/app/integration/src/tests/profiles.rs
@@ -119,7 +119,7 @@ macro_rules! profile_test {
 
         let client = client::$http(proxy.outbound, host);
 
-        let metrics = client::http1(proxy.metrics, "localhost");
+        let metrics = client::http1(proxy.admin, "localhost");
 
         // Poll metrics until we recognize the profile is loaded...
         loop {

--- a/linkerd/app/integration/src/tests/tap.rs
+++ b/linkerd/app/integration/src/tests/tap.rs
@@ -123,7 +123,7 @@ async fn inbound_http1() {
         .await;
 
     // Wait for the server proxy to become ready
-    let client = client::http1(srv_proxy.metrics, "localhost");
+    let client = client::http1(srv_proxy.admin, "localhost");
     let ready = || async {
         client
             .request(client.request_builder("/ready").method("GET"))
@@ -214,7 +214,7 @@ async fn grpc_headers_end() {
         .await;
 
     // Wait for the server proxy to become ready
-    let client = client::http2(srv_proxy.metrics, "localhost");
+    let client = client::http2(srv_proxy.admin, "localhost");
     let ready = || async {
         client
             .request(client.request_builder("/ready").method("GET"))

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -49,7 +49,7 @@ impl Fixture {
             .inbound(srv)
             .run()
             .await;
-        let metrics = client::http1(proxy.metrics, "localhost");
+        let metrics = client::http1(proxy.admin, "localhost");
 
         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
         let tcp_dst_labels = metrics::labels().label("direction", "inbound");
@@ -83,7 +83,7 @@ impl Fixture {
             .outbound(srv)
             .run()
             .await;
-        let metrics = client::http1(proxy.metrics, "localhost");
+        let metrics = client::http1(proxy.admin, "localhost");
 
         let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
         let tcp_labels = metrics::labels()
@@ -137,7 +137,7 @@ impl TcpFixture {
             .await;
 
         let client = client::tcp(proxy.inbound);
-        let metrics = client::http1(proxy.metrics, "localhost");
+        let metrics = client::http1(proxy.admin, "localhost");
 
         let src_labels = metrics::labels()
             .label("direction", "inbound")
@@ -175,7 +175,7 @@ impl TcpFixture {
             .await;
 
         let client = client::tcp(proxy.outbound);
-        let metrics = client::http1(proxy.metrics, "localhost");
+        let metrics = client::http1(proxy.admin, "localhost");
 
         let src_labels = metrics::labels()
             .label("direction", "outbound")
@@ -530,7 +530,7 @@ mod outbound_dst_labels {
             .outbound(srv)
             .run()
             .await;
-        let metrics = client::http1(proxy.metrics, "localhost");
+        let metrics = client::http1(proxy.admin, "localhost");
 
         let client = client::new(proxy.outbound, dest);
         let tcp_labels = metrics::labels()
@@ -852,7 +852,7 @@ async fn metrics_have_no_double_commas() {
         .run()
         .await;
     let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
-    let metrics = client::http1(proxy.metrics, "localhost");
+    let metrics = client::http1(proxy.admin, "localhost");
 
     let scrape = metrics.get("/metrics").await;
     assert!(!scrape.contains(",,"));

--- a/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
+++ b/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
@@ -90,7 +90,7 @@ impl Test {
         let proxy = proxy.identity(id_svc).run_with_test_env(env).await;
 
         // Wait for the proxy's identity to be certified.
-        let admin_client = client::http1(proxy.metrics, "localhost");
+        let admin_client = client::http1(proxy.admin, "localhost");
         assert_eventually!(
             admin_client
                 .request(admin_client.request_builder("/ready").method("GET"))

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1351,7 +1351,7 @@ async fn retry_reconnect_errors() {
         .await;
     let proxy = proxy::new().inbound(srv).run().await;
     let client = client::http2(proxy.inbound, "transparency.example.com");
-    let metrics = client::http1(proxy.metrics, "localhost");
+    let metrics = client::http1(proxy.admin, "localhost");
 
     let fut = client.request(client.request_builder("/").version(http::Version::HTTP_2));
 


### PR DESCRIPTION
While working on #1428, I was a bit confused reading through tests and noticed that it looked like at some point the admin server was just a metrics server, or referred to as such. This refactor just renames the address in integration tests to be consistent with the name used in the proxy.

Signed-off-by: Aaron Friel <mayreply@aaronfriel.com>