### PR TITLE
Use `AHash` for caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +870,7 @@ dependencies = [
 name = "linkerd-app-inbound"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "arbitrary",
  "bytes",
  "futures",
@@ -917,6 +929,7 @@ dependencies = [
 name = "linkerd-app-outbound"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bytes",
  "futures",
  "http",
@@ -966,6 +979,7 @@ dependencies = [
 name = "linkerd-cache"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "futures",
  "linkerd-error",
  "linkerd-stack",
@@ -1088,6 +1102,7 @@ dependencies = [
 name = "linkerd-http-metrics"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bytes",
  "futures",
  "http",
@@ -1206,6 +1221,7 @@ dependencies = [
 name = "linkerd-metrics"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "deflate",
  "hdrhistogram",
  "http",
@@ -1456,6 +1472,7 @@ dependencies = [
 name = "linkerd-service-profiles"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bytes",
  "futures",
  "http",
@@ -1510,6 +1527,7 @@ dependencies = [
 name = "linkerd-stack-metrics"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "linkerd-metrics",
  "parking_lot",
  "tokio",
@@ -1630,6 +1648,7 @@ dependencies = [
 name = "linkerd-transport-metrics"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "futures",
  "linkerd-errno",
  "linkerd-io",

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -10,6 +10,7 @@ Configures and runs the inbound proxy
 """
 
 [dependencies]
+ahash = "0.7"
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }

--- a/linkerd/app/inbound/src/metrics/authz.rs
+++ b/linkerd/app/inbound/src/metrics/authz.rs
@@ -1,10 +1,11 @@
 use crate::policy::{AllowPolicy, Permit};
+use ahash::AHashMap as HashMap;
 use linkerd_app_core::{
     metrics::{metrics, AuthzLabels, Counter, FmtMetrics, ServerLabel, TargetAddr, TlsAccept},
     tls,
 };
 use parking_lot::Mutex;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 metrics! {
     inbound_http_authz_allow_total: Counter {

--- a/linkerd/app/inbound/src/metrics/error/http.rs
+++ b/linkerd/app/inbound/src/metrics/error/http.rs
@@ -1,4 +1,5 @@
 use super::ErrorKind;
+use ahash::AHashMap as HashMap;
 use linkerd_app_core::{
     metrics::{metrics, Counter, FmtMetrics, ServerLabel},
     svc::{self, stack::NewMonitor},
@@ -6,7 +7,7 @@ use linkerd_app_core::{
     Error,
 };
 use parking_lot::Mutex;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 metrics! {
     inbound_http_errors_total: Counter {

--- a/linkerd/app/inbound/src/metrics/error/tcp.rs
+++ b/linkerd/app/inbound/src/metrics/error/tcp.rs
@@ -1,4 +1,5 @@
 use super::ErrorKind;
+use ahash::AHashMap as HashMap;
 use linkerd_app_core::{
     metrics::{metrics, Counter, FmtMetrics},
     svc::{self, stack::NewMonitor},
@@ -6,7 +7,7 @@ use linkerd_app_core::{
     Error,
 };
 use parking_lot::Mutex;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 metrics! {
     inbound_tcp_errors_total: Counter {

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -1,6 +1,7 @@
 use super::{discover::Discover, DefaultPolicy, ServerPolicy, Store};
+use ahash::AHashMap as HashMap;
 use linkerd_app_core::{control, dns, identity, metrics, svc::NewService};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 /// Configures inbound policies.
 ///

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -15,6 +15,7 @@ allow-loopback = []
 test-subscriber = []
 
 [dependencies]
+ahash = "0.7"
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }

--- a/linkerd/app/outbound/src/metrics/error/http.rs
+++ b/linkerd/app/outbound/src/metrics/error/http.rs
@@ -1,10 +1,11 @@
 use super::ErrorKind;
+use ahash::AHashMap as HashMap;
 use linkerd_app_core::{
     metrics::{metrics, Counter, FmtMetrics},
     svc, Error,
 };
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 metrics! {
     outbound_http_errors_total: Counter {

--- a/linkerd/app/outbound/src/metrics/error/tcp.rs
+++ b/linkerd/app/outbound/src/metrics/error/tcp.rs
@@ -1,4 +1,5 @@
 use super::ErrorKind;
+use ahash::AHashMap as HashMap;
 use linkerd_app_core::{
     metrics::{metrics, Counter, FmtMetrics},
     svc,
@@ -6,7 +7,7 @@ use linkerd_app_core::{
     Error,
 };
 use parking_lot::RwLock;
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 metrics! {
     outbound_tcp_errors_total: Counter {

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+ahash = "0.7"
 futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -1,10 +1,11 @@
 #![deny(warnings, rust_2018_idioms)]
 #![forbid(unsafe_code)]
 
+use ahash::AHashMap as HashMap;
 use linkerd_stack::{layer, NewService};
 use parking_lot::RwLock;
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::hash_map::Entry,
     hash::Hash,
     sync::{Arc, Weak},
     task::{Context, Poll},

--- a/linkerd/http-metrics/Cargo.toml
+++ b/linkerd/http-metrics/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+ahash = "0.7"
 bytes = "1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"

--- a/linkerd/http-metrics/src/requests.rs
+++ b/linkerd/http-metrics/src/requests.rs
@@ -3,11 +3,11 @@ mod service;
 
 pub use self::service::{NewHttpMetrics, ResponseBody};
 use super::Report;
+use ahash::AHashMap as HashMap;
 use linkerd_http_classify::ClassifyResponse;
 use linkerd_metrics::{latency, Counter, FmtMetrics, Histogram, LastUpdate, NewMetrics};
 use linkerd_stack::{self as svc, layer};
 use std::{
-    collections::HashMap,
     fmt::Debug,
     hash::Hash,
     time::{Duration, Instant},

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -12,6 +12,7 @@ summary = ["hdrhistogram", "tokio"]
 test_util = []
 
 [dependencies]
+ahash = "0.7"
 deflate = { version = "1.0.0", features = ["gzip"] }
 hdrhistogram = { version = "7.4", default-features = false, optional = true }
 http = "0.2"

--- a/linkerd/metrics/src/scopes.rs
+++ b/linkerd/metrics/src/scopes.rs
@@ -1,5 +1,6 @@
 use super::prom::FmtLabels;
-use std::{collections::HashMap, hash::Hash};
+use ahash::AHashMap as HashMap;
+use std::hash::Hash;
 
 /// Holds an `S`-typed scope for each `L`-typed label set.
 ///

--- a/linkerd/metrics/src/store.rs
+++ b/linkerd/metrics/src/store.rs
@@ -1,13 +1,7 @@
 use crate::{FmtLabels, FmtMetric, Metric};
+use ahash::AHashMap as HashMap;
 use parking_lot::Mutex;
-use std::{
-    borrow::Borrow,
-    collections::hash_map::{self, HashMap},
-    fmt,
-    hash::Hash,
-    sync::Arc,
-    time::Instant,
-};
+use std::{borrow::Borrow, collections::hash_map, fmt, hash::Hash, sync::Arc, time::Instant};
 
 pub trait LastUpdate {
     fn last_update(&self) -> Instant;

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -13,6 +13,7 @@ Implements client layers for Linkerd ServiceProfiles.
 rustfmt = ["linkerd2-proxy-api/rustfmt"]
 
 [dependencies]
+ahash = "0.7"
 bytes = "1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"

--- a/linkerd/service-profiles/src/http/proxy.rs
+++ b/linkerd/service-profiles/src/http/proxy.rs
@@ -1,10 +1,11 @@
 use super::{RequestMatch, Route};
 use crate::{Profile, Receiver, ReceiverStream};
+use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use futures::{future, prelude::*};
 use linkerd_error::{Error, Result};
 use linkerd_stack::{layer, NewService, Param, Proxy, Service};
 use std::{
-    collections::{hash_map, HashMap, HashSet},
+    collections::hash_map,
     task::{Context, Poll},
 };
 use tracing::{debug, trace};

--- a/linkerd/service-profiles/src/http/service.rs
+++ b/linkerd/service-profiles/src/http/service.rs
@@ -1,9 +1,10 @@
 use super::{RequestMatch, Route};
 use crate::{Profile, Receiver, ReceiverStream};
+use ahash::{AHashMap as HashMap, AHashSet as HashSet};
 use futures::prelude::*;
 use linkerd_stack::{layer, NewService, Oneshot, Param, Service, ServiceExt};
 use std::{
-    collections::{hash_map, HashMap, HashSet},
+    collections::hash_map,
     task::{Context, Poll},
 };
 use tracing::{debug, trace};

--- a/linkerd/stack/metrics/Cargo.toml
+++ b/linkerd/stack/metrics/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
+ahash = "0.7"
 linkerd-metrics = { path = "../../metrics" }
 parking_lot = "0.11"
 tower = { version = "0.4.11", default-features = false }

--- a/linkerd/stack/metrics/src/lib.rs
+++ b/linkerd/stack/metrics/src/lib.rs
@@ -6,9 +6,10 @@ mod service;
 
 pub use self::layer::TrackServiceLayer;
 pub use self::service::TrackService;
+use ahash::AHashMap as HashMap;
 use linkerd_metrics::{metrics, Counter, FmtLabels, FmtMetrics};
 use parking_lot::Mutex;
-use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};
+use std::{fmt, hash::Hash, sync::Arc};
 
 metrics! {
     stack_create_total: Counter { "Total number of services created" },

--- a/linkerd/transport-metrics/Cargo.toml
+++ b/linkerd/transport-metrics/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 description = """Transport-level metrics"""
 
 [dependencies]
+ahash = "0.7"
 futures = { version = "0.3", default-features = false }
 linkerd-errno = { path = "../errno" }
 linkerd-io = { path = "../io" }

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -12,11 +12,11 @@ pub use self::{
     sensor::{Sensor, SensorIo},
     server::NewServer,
 };
+use ahash::AHashMap as HashMap;
 use linkerd_errno::Errno;
 use linkerd_metrics::{metrics, Counter, FmtLabels, Gauge, LastUpdate, Store};
 use parking_lot::Mutex;
 use std::{
-    collections::HashMap,
     fmt,
     hash::Hash,
     sync::Arc,


### PR DESCRIPTION
[`AHash`][ahash] pruports to the be "the fastest DoS-resistant hash currently
available in Rust." It boasts substantial (~10x) latency improvements
over the default hash implementation (SipHash-1-3). It appears to be
an obvious choice for use in our maps, especially where hashing is
frequent and/or performed while a lock is held.

According to <https://lib.rs/crates/ahash>, it has substantial usage.

This change replaces the hash implementation for our metrics stores
and service cache (where locks are employed). It also updates the
service-profile router and traffic splitter, where potentially large
targets may be hashed for each request.

Other uses of the standard `HashMap`--mostly in metadata labels, where
hashing is not performed frequently--are currently left unchanged.

Signed-off-by: Oliver Gould <ver@buoyant.io>

[ahash]: https://github.com/tkaitchuck/aHash/blob/e77cab8c1e15bfc9f54dfd28bd8820c2a7bb27c4/compare/readme.md