### PR TITLE
test: remove `env::set_var` call in test logging initialization 

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,8 @@
 type-complexity-threshold = 500
+disallowed-methods = [
+    # mutating environment variables in a multi-threaded context can
+    # cause data races.
+    # see https://github.com/rust-lang/rust/issues/90308 for details.
+    "std::env::set_var",
+    "std::env::remove_var",
+]

--- a/hyper-balance/src/lib.rs
+++ b/hyper-balance/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use hyper::body::HttpBody;

--- a/linkerd/addr/src/lib.rs
+++ b/linkerd/addr/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 use linkerd_dns_name::Name;
 use std::{

--- a/linkerd/app/admin/src/lib.rs
+++ b/linkerd/app/admin/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod server;

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -7,7 +7,7 @@
 //! - Tap
 //! - Metric labeling
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub use drain;

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod gateway;

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -3,7 +3,7 @@
 //! The inbound proxy is responsible for terminating traffic from other network
 //! endpoints inbound to the local application.
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod accept;

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -1,6 +1,6 @@
 //! Shared infrastructure for integration tests
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod test_env;

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! The outbound proxy is responsible for routing traffic from the local application to other hosts.
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod discover;

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -1,6 +1,6 @@
 //! Configures and executes the proxy
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub mod dst;

--- a/linkerd/app/test/src/lib.rs
+++ b/linkerd/app/test/src/lib.rs
@@ -1,6 +1,6 @@
 //! Shared infrastructure for integration tests
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub use futures::{future, FutureExt, TryFuture, TryFutureExt};

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use linkerd_stack::{layer, NewService};

--- a/linkerd/conditional/src/lib.rs
+++ b/linkerd/conditional/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 /// Like `std::option::Option<C>` but `None` carries a reason why the value

--- a/linkerd/detect/src/lib.rs
+++ b/linkerd/detect/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use bytes::BytesMut;

--- a/linkerd/dns/name/src/lib.rs
+++ b/linkerd/dns/name/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod name;

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use linkerd_dns_name::NameRef;

--- a/linkerd/errno/src/lib.rs
+++ b/linkerd/errno/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use std::fmt;

--- a/linkerd/error-respond/src/lib.rs
+++ b/linkerd/error-respond/src/lib.rs
@@ -1,6 +1,6 @@
 //! Layer to map service errors into responses.
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use futures::{ready, TryFuture};

--- a/linkerd/error/src/lib.rs
+++ b/linkerd/error/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub mod recover;

--- a/linkerd/exp-backoff/src/lib.rs
+++ b/linkerd/exp-backoff/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use futures::Stream;

--- a/linkerd/http-box/src/lib.rs
+++ b/linkerd/http-box/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod body;

--- a/linkerd/http-classify/src/lib.rs
+++ b/linkerd/http-classify/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod service;

--- a/linkerd/http-metrics/src/lib.rs
+++ b/linkerd/http-metrics/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub use self::{requests::Requests, retries::Retries};

--- a/linkerd/http-retry/src/lib.rs
+++ b/linkerd/http-retry/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};

--- a/linkerd/identity/src/lib.rs
+++ b/linkerd/identity/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod credentials;

--- a/linkerd/io/src/lib.rs
+++ b/linkerd/io/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod boxed;

--- a/linkerd/meshtls/boring/src/lib.rs
+++ b/linkerd/meshtls/boring/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 //! This crate provides an implementation of _meshtls_ backed by `boringssl` (as

--- a/linkerd/meshtls/rustls/src/lib.rs
+++ b/linkerd/meshtls/rustls/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod client;

--- a/linkerd/meshtls/src/lib.rs
+++ b/linkerd/meshtls/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 //! This crate provides a static interface for the proxy's x509 certificate

--- a/linkerd/meshtls/tests/boring.rs
+++ b/linkerd/meshtls/tests/boring.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "boring")]
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod util;

--- a/linkerd/meshtls/tests/rustls.rs
+++ b/linkerd/meshtls/tests/rustls.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "rustls")]
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod util;

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 //! Utilities for exposing metrics to Prometheus.

--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub mod metrics;

--- a/linkerd/proxy/api-resolve/src/lib.rs
+++ b/linkerd/proxy/api-resolve/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use linkerd2_proxy_api as api;

--- a/linkerd/proxy/core/src/lib.rs
+++ b/linkerd/proxy/core/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub mod resolve;

--- a/linkerd/proxy/discover/src/lib.rs
+++ b/linkerd/proxy/discover/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use linkerd_proxy_core::Resolve;

--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use futures::{future, prelude::*, stream};

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 use http::header::AsHeaderName;
 use http::uri::Authority;

--- a/linkerd/proxy/identity-client/src/lib.rs
+++ b/linkerd/proxy/identity-client/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub mod certify;

--- a/linkerd/proxy/resolve/src/lib.rs
+++ b/linkerd/proxy/resolve/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub mod map_endpoint;

--- a/linkerd/proxy/tap/src/lib.rs
+++ b/linkerd/proxy/tap/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use linkerd_tls as tls;

--- a/linkerd/proxy/tcp/src/lib.rs
+++ b/linkerd/proxy/tcp/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub mod balance;

--- a/linkerd/reconnect/src/lib.rs
+++ b/linkerd/reconnect/src/lib.rs
@@ -1,5 +1,5 @@
 //! Conditionally reconnects with a pluggable recovery/backoff strategy.
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 #[cfg(test)]

--- a/linkerd/retry/src/lib.rs
+++ b/linkerd/retry/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use futures::future;

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod network;

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use futures::Stream;

--- a/linkerd/signal/src/lib.rs
+++ b/linkerd/signal/src/lib.rs
@@ -1,6 +1,6 @@
 //! Unix signal handling for the proxy binary.
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 /// Returns a `Future` that completes when the proxy should start to shutdown.

--- a/linkerd/stack/metrics/src/lib.rs
+++ b/linkerd/stack/metrics/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod layer;

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -1,6 +1,6 @@
 //! Utilities for composing Tower Services.
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod arc_new_service;

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use linkerd_stack::{layer, NewService, Proxy};

--- a/linkerd/tls/src/lib.rs
+++ b/linkerd/tls/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub mod client;

--- a/linkerd/tls/test-util/src/lib.rs
+++ b/linkerd/tls/test-util/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub struct Entity {

--- a/linkerd/tonic-watch/src/lib.rs
+++ b/linkerd/tonic-watch/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 use futures::prelude::*;

--- a/linkerd/trace-context/src/lib.rs
+++ b/linkerd/trace-context/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod propagation;

--- a/linkerd/tracing/src/lib.rs
+++ b/linkerd/tracing/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub mod level;

--- a/linkerd/tracing/src/test.rs
+++ b/linkerd/tracing/src/test.rs
@@ -11,7 +11,6 @@ pub fn trace_subscriber(default: impl ToString) -> (Dispatch, Handle) {
         .or_else(|_| env::var("RUST_LOG"))
         .unwrap_or_else(|_| default.to_string());
     let log_format = env::var("LINKERD2_PROXY_LOG_FORMAT").unwrap_or_else(|_| "PLAIN".to_string());
-    env::set_var("LINKERD2_PROXY_LOG_FORMAT", &log_format);
     // This may fail, since the global log compat layer may have been
     // initialized by another test.
     let _ = init_log_compat();

--- a/linkerd/transport-header/src/lib.rs
+++ b/linkerd/transport-header/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod server;

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 mod client;

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -1,6 +1,6 @@
 //! The main entrypoint for the proxy.
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 // Emit a compile-time error if no TLS implementations are enabled. When adding

--- a/opencensus-proto/src/lib.rs
+++ b/opencensus-proto/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Vendored from <https://github.com/census-instrumentation/opencensus-proto/>.
 
-#![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms, clippy::disallowed_method)]
 #![forbid(unsafe_code)]
 
 pub mod agent {


### PR DESCRIPTION
Per rust-lang/rust#90308, this is potentially a data race. In practice,
I don't think it was actually problematic here, but it also wasn't doing
anything of value, so we should remove it.

This is currently the only `env::set_var` or `env::remove_var` call in
the proxy.

To prevent uses of these functions in the future, I also added a 
`disallowed-methods` configuration in `.clippy.toml` to emit a
warning for any uses of `std::env::set_var` and
`std::env::remove_var`. Unfortunately, this required adding a
`deny` attribute basically everywhere, which is why this diff touches
so many files.

Closes linkerd/linkerd2#7651