### PR TITLE
deny: Don't skip everything in hyper's tree

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -36,7 +36,7 @@ name = "ring"
 version = "*"
 expression = "MIT AND ISC AND OpenSSL"
 license-files = [
-    { path = "LICENSE", hash = 0xbd0eed23 }
+    { path = "LICENSE", hash = 0xbd0eed23 },
 ]
 
 [bans]
@@ -45,13 +45,15 @@ multiple-versions = "deny"
 wildcards = "allow"
 highlight = "all"
 deny = [
-    { name = "rustls", wrappers = ["tokio-rustls"] }
+    { name = "rustls", wrappers = ["tokio-rustls"] },
+]
+skip = [
+    # Waiting on a hyper release that updates itoa to v1.
+    { name = "itoa", version = "0.4" },
 ]
 skip-tree = [
-    # Waiting on a release that updates itoa to v1.
-    { name = "hyper" },
     # Hasn't seen a new release since 2017. Pulls in an older version of nom.
-    { name = "procinfo" }
+    { name = "procinfo" },
 ]
 
 [sources]


### PR DESCRIPTION
When we skip-tree hyper, we miss out on all dupes that may impact tokio,
etc.

Thsi change narrowly exempts the use of iota v4.

Signed-off-by: Oliver Gould <ver@buoyant.io>