### PR TITLE
dependabot: Ignore leaf updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,16 @@ updates:
       timezone: "UTC"
     allow:
       - dependency-type: "all"
+    ignore:
+      - dependency-name: "futures-channel"
+      - dependency-name: "futures-core"
+      - dependency-name: "futures-io"
+      - dependency-name: "futures-sink"
+      - dependency-name: "futures-task"
+      - dependency-name: "futures-util"
+      - dependency-name: "prost-derive"
+      - dependency-name: "tracing-attributes"
+      - dependency-name: "tracing-core"
 
   - package-ecosystem: cargo
     directory: /linkerd/addr/fuzz

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,7 @@ updates:
       - dependency-name: "prost-derive"
       - dependency-name: "tracing-attributes"
       - dependency-name: "tracing-core"
+      - dependency-name: "tracing-serde"
 
   - package-ecosystem: cargo
     directory: /linkerd/addr/fuzz


### PR DESCRIPTION
`futures`, `prost, and `tracing` release top level crates, so there's no
need to be notified of leaf crate updates.

Signed-off-by: Oliver Gould <ver@buoyant.io>