### PR TITLE
Update the devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,23 @@
-FROM docker.io/rust:1.56.1-bullseye
+ARG RUST_VERSION=1.56.1
+
+FROM docker.io/rust:${RUST_VERSION}-bullseye as kubectl
+ARG KUBECTL_VERSION=v1.23.2
+RUN curl --proto '=https' --tlsv1.3 -vsSfLo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+    && chmod 755 /usr/local/bin/kubectl
+
+FROM docker.io/rust:${RUST_VERSION}-bullseye as k3d
+RUN curl --proto '=https' --tlsv1.3 -vsSfL https://raw.githubusercontent.com/rancher/k3d/main/install.sh  | bash
+
+FROM docker.io/rust:${RUST_VERSION}-bullseye as cargo-deny
+ARG CARGO_DENY_VERSION=0.11.1
+RUN curl --proto '=https' --tlsv1.3 -vsSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+    | tar zvxf - --strip-components=1 -C /usr/local/bin "cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny"
+
+#
+# Main image
+#
+FROM docker.io/rust:${RUST_VERSION}-bullseye
+RUN rustup component add clippy rustfmt rust-analysis rust-std
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt upgrade -y
@@ -6,11 +25,14 @@ RUN apt install -y --no-install-recommends \
     clang \
     cmake \
     golang \
+    jo \
     jq \
-    lldb \
+    locales \
     lsb-release \
     sudo \
     time
+
+RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen && locale-gen
 
 ARG USER=code
 ARG USER_UID=1000
@@ -28,23 +50,13 @@ RUN curl --proto '=https' --tlsv1.3 -vsSfL https://raw.githubusercontent.com/mic
 
 USER $USER
 ENV HOME=/home/$USER
-RUN mkdir -p $HOME/bin
-ENV PATH=$HOME/bin:$PATH
 
-ARG KUBECTL_VERSION=v1.23.2
-RUN curl --proto '=https' --tlsv1.3 -vsSfLo $HOME/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
-    && chmod 755 $HOME/bin/kubectl
-RUN curl --proto '=https' --tlsv1.3 -vsSfL https://raw.githubusercontent.com/rancher/k3d/main/install.sh \
-    | USE_SUDO=false K3D_INSTALL_DIR=$HOME/bin bash
+RUN curl --proto '=https' --tlsv1.3 -vsSfL https://run.linkerd.io/install-edge | sh
+ENV PATH=$HOME/.linkerd2/bin:$PATH
 
-RUN rustup component add clippy rustfmt
-
-ARG CARGO_DENY_VERSION=0.11.0
-RUN curl --proto '=https' --tlsv1.3 -vsSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-    | tar zvxf - --strip-components=1 -C $HOME/bin "cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny"
-
-RUN curl --proto '=https' --tlsv1.3 -vsSfL https://run.linkerd.io/install-edge | sh \
-    && ln -s $(readlink ~/.linkerd2/bin/linkerd) ~/bin/linkerd
+COPY --from=cargo-deny /usr/local/bin/cargo-deny /usr/local/bin/cargo-deny
+COPY --from=k3d /usr/local/bin/k3d /usr/local/bin/k3d
+COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
 
 ENTRYPOINT ["/usr/local/share/docker-init.sh"]
 CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,12 @@
 {
 	"name": "linkerd2-proxy",
-	"image": "ghcr.io/linkerd/dev-proxy:v5",
+	"image": "ghcr.io/linkerd/dev-proxy:v6",
 	// "dockerFile": "./Dockerfile",
 	"extensions": [
-		"DavidAnson.vscode-markdownlint",
 		"matklad.rust-analyzer",
 		"NathanRidley.autotrim",
 		"samverschueren.final-newline",
-		"streetsidesoftware.code-spell-checker",
 		"tamasfe.even-better-toml",
-		"vadimcn.vscode-lldb",
 		"zxh404.vscode-proto3"
 	],
 	// Support docker + debugger

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -23,8 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: |
-          versions=$(sed -nE 's|^FROM (.*/)?rust:([^ -]+)|\2|p' .devcontainer/Dockerfile)
+          versions=$(sed -nE 's|^ARG +RUST_VERSION=([^ #]+)|\1|p' .devcontainer/Dockerfile)
           ex=0
+          if [ -z "$versions" ]; then
+              echo "::error file=.devcontainer/Dockerfile::No Rust versions specified in Dockerfile"
+              ex=1
+          fi
           for mismatch in $(echo "$versions" | grep -vF "$(cat rust-toolchain)" || true) ; do
             echo "::error file=.devcontainer/Dockerfile::Devcontainer uses incorrect rust version(s): $mismatch"
             ex=$((ex + 1))


### PR DESCRIPTION
* Set a default locale (en_US.UTF-8)
* Use multi-stage docker builds and install tools into /usr/local/bin
* Drop needless extensions
* Use a `RUST_VERSION` build-arg instead of inline version strings