### PR TITLE
Do not error when `LINKERD2_PROXY_INBOUND_PORTS` is empty

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -547,25 +547,18 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 Some(addr) => {
                     // If the inbound is proxy is configured to discover policies, then load the set
                     // of all known inbound ports to be discovered during initialization.
-                    let mut ports = match strings.get(ENV_INBOUND_PORTS)? {
-                        Some(s) => {
-                            if s.is_empty() {
-                                warn!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
-                                Default::default()
-                            } else {
-                                parse_port_set(&s).map_err(|parse_error| {
-                                    error!(
-                                        "{}={:?} is not valid: {:?}",
-                                        ENV_INBOUND_PORTS, s, parse_error
-                                    );
-                                    EnvError::InvalidEnvVar
-                                })?
-                            }
-                        }
-                        None => {
+                    let mut ports = match strings.get(ENV_INBOUND_PORTS)?.as_deref() {
+                        Some("") | None => {
                             warn!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
                             Default::default()
                         }
+                        Some(s) => parse_port_set(&s).map_err(|parse_error| {
+                            error!(
+                                "{}={:?} is not valid: {:?}",
+                                ENV_INBOUND_PORTS, s, parse_error
+                            );
+                            EnvError::InvalidEnvVar
+                        })?,
                     };
                     if !gateway.allow_discovery.is_empty() {
                         // Add the inbound port to the set of ports to be discovered if the proxy is

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -547,23 +547,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 Some(addr) => {
                     // If the inbound is proxy is configured to discover policies, then load the set
                     // of all known inbound ports to be discovered during initialization.
-                    let mut ports = match strings.get(ENV_INBOUND_PORTS)? {
-                        Some(s) => {
-                            if s.is_empty() {
-                                warn!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
-                                Default::default()
-                            } else {
-                                parse_port_set(&s).map_err(|parse_error| {
-                                    error!(
-                                        "{}={:?} is not valid: {:?}",
-                                        ENV_INBOUND_PORTS, s, parse_error
-                                    );
-                                    EnvError::InvalidEnvVar
-                                })?
-                            }
-                        }
+                    let mut ports = match parse(strings, ENV_INBOUND_PORTS, parse_port_set)? {
+                        Some(ports) => ports,
                         None => {
-                            warn!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
+                            error!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
                             Default::default()
                         }
                     };

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -935,8 +935,10 @@ fn parse_addr(s: &str) -> Result<Addr, ParseError> {
 
 fn parse_port_set(s: &str) -> Result<HashSet<u16>, ParseError> {
     let mut set = HashSet::new();
-    for num in s.split(',') {
-        set.insert(parse_number::<u16>(num)?);
+    if !s.is_empty() {
+        for num in s.split(',') {
+            set.insert(parse_number::<u16>(num)?);
+        }
     }
     Ok(set)
 }

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -547,18 +547,25 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 Some(addr) => {
                     // If the inbound is proxy is configured to discover policies, then load the set
                     // of all known inbound ports to be discovered during initialization.
-                    let mut ports = match strings.get(ENV_INBOUND_PORTS)?.as_deref() {
-                        Some("") | None => {
+                    let mut ports = match strings.get(ENV_INBOUND_PORTS)? {
+                        Some(s) => {
+                            if s.is_empty() {
+                                warn!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
+                                Default::default()
+                            } else {
+                                parse_port_set(&s).map_err(|parse_error| {
+                                    error!(
+                                        "{}={:?} is not valid: {:?}",
+                                        ENV_INBOUND_PORTS, s, parse_error
+                                    );
+                                    EnvError::InvalidEnvVar
+                                })?
+                            }
+                        }
+                        None => {
                             warn!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
                             Default::default()
                         }
-                        Some(s) => parse_port_set(&s).map_err(|parse_error| {
-                            error!(
-                                "{}={:?} is not valid: {:?}",
-                                ENV_INBOUND_PORTS, s, parse_error
-                            );
-                            EnvError::InvalidEnvVar
-                        })?,
                     };
                     if !gateway.allow_discovery.is_empty() {
                         // Add the inbound port to the set of ports to be discovered if the proxy is


### PR DESCRIPTION
As part of #7816, we want to be able to set the `LINKERD2_PROXY_INBOUND_PORTS` env var to `""` when an app does not specify its ports. This means that in the proxy environment, `LINKERD2_PROXY_INBOUND_PORTS = ""`.

In order to handle this case, we now need to handle `LINKERD2_PROXY_INBOUND_PORTS` being present or not; if it is present then we need to handle it being `""` or some other value.

With this change, we now parse `LINKERD2_PROXY_INBOUND_PORTS` and if it is empty, handle it the same way that we handle it being absent.

I've tested in this change in an install and the logs now report:

```
time="2022-02-09T22:59:34Z" level=info msg="running version edge-21.4.5"
[     0.000268s]  WARN ThreadId(01) linkerd_app::env: No inbound ports specified via LINKERD2_PROXY_INBOUND_PORTS
[     0.000412s]  INFO ThreadId(01) linkerd2_proxy::rt: Using single-threaded proxy runtime
[     0.000739s]  INFO ThreadId(01) linkerd2_proxy: Admin interface on 0.0.0.0:4191
[     0.000745s]  INFO ThreadId(01) linkerd2_proxy: Inbound interface on 0.0.0.0:4143
[     0.000746s]  INFO ThreadId(01) linkerd2_proxy: Outbound interface on 127.0.0.1:4140
[     0.000747s]  INFO ThreadId(01) linkerd2_proxy: Tap DISABLED
[     0.000748s]  INFO ThreadId(01) linkerd2_proxy: Local identity is default.default.serviceaccount.identity.linkerd.cluster.local
[     0.000750s]  INFO ThreadId(01) linkerd2_proxy: Identity verified via linkerd-identity-headless.linkerd.svc.cluster.local:8080 (linkerd-identity.linkerd.serviceaccount.identity.linkerd.cluster.local)
[     0.000751s]  INFO ThreadId(01) linkerd2_proxy: Destinations resolved via linkerd-dst-headless.linkerd.svc.cluster.local:8086 (linkerd-destination.linkerd.serviceaccount.identity.linkerd.cluster.local)
[     0.008245s]  INFO ThreadId(02) daemon:identity: linkerd_app: Certified identity id=default.default.serviceaccount.identity.linkerd.cluster.local
```

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>