### PR TITLE
Bump runtime image so that linkerd-await 0.2.5 is used

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ARG RUST_IMAGE=rust:1.56.1-buster
 
 # Use an arbitrary ~recent edge release image to get the proxy
 # identity-initializing and linkerd-await wrappers.
-ARG RUNTIME_IMAGE=ghcr.io/linkerd/proxy:edge-21.4.5
+ARG RUNTIME_IMAGE=ghcr.io/linkerd/proxy:edge-22.2.1
 
 # Build the proxy, leveraging (new, experimental) cache mounting.
 #


### PR DESCRIPTION
Recently a new `--timeout` flag was introduced to [linkerd-await](https://github.com/linkerd/linkerd-await/).

When building a custom image of the proxy and using that in an installation, the `--timeout` flag now used by the postStart hook is invalid because `--timeout` is an unrecognized flag. It's unrecognized because Docker is building the proxy image off a proxy that used a linkerd-await version that did _not_ have this flag.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>