### PR TITLE
ci: Add workflows to run beta, nightly builds

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,0 +1,31 @@
+# Builds the proxy on the beta toolchain to help catch Rust regressions before they bite us hit stable.
+name: beta
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/beta.yml
+  schedule:
+    # Run weekly on wednesday @ midnightish Pacific-time.
+    - cron: "30 7 * * 3"
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: docker://rust:1.56.1-buster
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: rustup toolchain install --profile=minimal beta
+      - run: cargo +beta build --release -p linkerd2-proxy

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,5 +1,5 @@
-# Builds the proxy on the beta toolchain to help catch Rust regressions before they bite us hit stable.
-name: beta
+# Builds the proxy on the beta toolchain to help catch Rust regressions before they hit stable.
+name: rust-beta
 
 on:
   pull_request:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,6 +1,5 @@
-# Builds the proxy on the nightly toolchain to help catch Rust regressions before they bite us hit
-# stable.
-name: nightly
+# Builds the proxy on the nightly toolchain to help catch Rust regressions before they hit beta.
+name: rust-nightly
 
 on:
   pull_request:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,32 @@
+# Builds the proxy on the nightly toolchain to help catch Rust regressions before they bite us hit
+# stable.
+name: nightly
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/nightly.yml
+  schedule:
+    # Run daily @ midnightish Pacific-time.
+    - cron: "0 8 * * *"
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: docker://rust:1.56.1-buster
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: rustup toolchain install --profile=minimal nightly
+      - run: cargo +nightly build --release -p linkerd2-proxy


### PR DESCRIPTION
We currently only really catch Rust regressions as they hit stable. This
change adds workflows to build the proxy daily against `nightly` and
weekly against `beta`.

These workflows are separated so that they can run on different
schedules and so that a failure on one toolchain does not interfere with
the other.

Signed-off-by: Oliver Gould <ver@buoyant.io>