### PR TITLE
ci: Add a toolchain workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,6 +13,11 @@ ARG CARGO_DENY_VERSION=0.11.1
 RUN curl --proto '=https' --tlsv1.3 -vsSfL "https://github.com/EmbarkStudios/cargo-deny/releases/download/${CARGO_DENY_VERSION}/cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
     | tar zvxf - --strip-components=1 -C /usr/local/bin "cargo-deny-${CARGO_DENY_VERSION}-x86_64-unknown-linux-musl/cargo-deny"
 
+FROM docker.io/rust:${RUST_VERSION}-bullseye as yq
+ARG YQ_VERSION=v4.2.0
+RUN curl --proto '=https' --tlsv1.3 -vsSfLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+    && chmod +x /usr/local/bin/yq
+
 #
 # Main image
 #
@@ -57,6 +62,7 @@ ENV PATH=$HOME/.linkerd2/bin:$PATH
 COPY --from=cargo-deny /usr/local/bin/cargo-deny /usr/local/bin/cargo-deny
 COPY --from=k3d /usr/local/bin/k3d /usr/local/bin/k3d
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
+COPY --from=yq /usr/local/bin/yq /usr/local/bin/yq
 
 ENTRYPOINT ["/usr/local/share/docker-init.sh"]
 CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "linkerd2-proxy",
-	"image": "ghcr.io/linkerd/dev-proxy:v6",
+	"image": "ghcr.io/linkerd/dev-proxy:v7",
 	// "dockerFile": "./Dockerfile",
 	"extensions": [
 		"matklad.rust-analyzer",

--- a/.github/actions/package/Dockerfile
+++ b/.github/actions/package/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_IMAGE=rust:1.56.1-buster
+ARG RUST_VERSION=1.56.1
+ARG BASE_IMAGE=rust:${RUST_VERSION}-buster
 FROM $BASE_IMAGE
 WORKDIR /linkerd
 RUN apt-get update && \

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -18,23 +18,6 @@ jobs:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: docker build .devcontainer
 
-  rust-version:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      - run: |
-          versions=$(sed -nE 's|^ARG +RUST_VERSION=([^ #]+)|\1|p' .devcontainer/Dockerfile)
-          ex=0
-          if [ -z "$versions" ]; then
-              echo "::error file=.devcontainer/Dockerfile::No Rust versions specified in Dockerfile"
-              ex=1
-          fi
-          for mismatch in $(echo "$versions" | grep -vF "$(cat rust-toolchain)" || true) ; do
-            echo "::error file=.devcontainer/Dockerfile::Devcontainer uses incorrect rust version(s): $mismatch"
-            ex=$((ex + 1))
-          done
-          exit $ex
-
   devcontainer-image:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -1,0 +1,60 @@
+name: rust-toolchain
+
+on:
+  pull_request:
+    paths:
+      - rust-toolchain
+      - "**Dockerfile"
+      - ".github/workflows/*"
+      - ".github/**/Dockerfile"
+
+permissions:
+  contents: read
+
+env:
+  YQ_VERSION: v4.2.0
+
+jobs:
+  dockerfiles:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: |
+          VERSION="$(cat rust-toolchain)"
+          ex=0
+          for f in $(find . -name Dockerfile -and -not -path './.github/actions/release-tag-meta/*'); do
+            versions=$(sed -nE 's/^ARG RUST_VERSION=([^ ]+)/\1/p' $f)
+            if [ -z "$versions" ]; then
+              echo "::error file=$f::$f missing 'RUST_VERSION' argument"
+              ex=$((ex + 1))
+            fi
+            for mismatch in $(echo "$version" | grep -vF "$VERSION" || true) ; do
+              echo "::error file=$f::$f uses incorrect rust version(s): $mismatch"
+              ex=$((ex + 1))
+            done
+          done
+          exit $ex
+
+  workflows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: |
+          curl --proto '=https' --tlsv1.3 -vsSfLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            && chmod +x /usr/local/bin/yq
+      - run: |
+          VERSION="$(cat rust-toolchain)"
+          ex=0
+          for f in $(find .github/workflows -name '*.yml') ; do
+            echo "# $f"
+            for image in $(yq eval '.jobs[].container.image' $f) ; do
+              if [[ "$image" =~ "^docker://(docker.io/library/)?rust:" ]]; then
+                v="${${image##*rust:}%%-*}"
+                if [[ "$v" != "$VERSION" ]]; then
+                  echo "::warning file=$f::$f uses incorrect rust version: $v"
+                  ex=$((ex + 1))
+                fi
+              fi
+            done
+          done
+          exit $ex

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@
 #     :; docker buildx build . --load
 
 # Please make changes via update-rust-version.sh
-ARG RUST_IMAGE=rust:1.56.1-buster
+ARG RUST_VERSION=1.56.1
+ARG RUST_IMAGE=rust:${RUST_VERSION}-buster
 
 # Use an arbitrary ~recent edge release image to get the proxy
 # identity-initializing and linkerd-await wrappers.

--- a/update-rust-version.sh
+++ b/update-rust-version.sh
@@ -14,7 +14,7 @@ if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$' ; then
 fi
 
 echo "$VERSION" > rust-toolchain
-find . -name Dockerfile\* \
-    -exec sed -i'' -Ee "s|rust:[0-9]+\.[0-9]+\.[0-9]+|rust:$VERSION|" '{}' \;
+find . -name Dockerfile \
+    -exec sed -i'' -Ee "s|RUST_VERSION=[0-9]+\.[0-9]+\.[0-9]+|RUST_VERSION=$VERSION|" '{}' \;
 find .github -name \*.yml \
     -exec sed -i'' -Ee "s|rust:[0-9]+\.[0-9]+\.[0-9]+|rust:$VERSION|" '{}' \;


### PR DESCRIPTION
The toolchain workflow validates that the same rust toolchain version is
used in all docker images, matching the value in the `rust-toolchain`
file.

This change also updates the devcontainer to include the `yq` utility.

Signed-off-by: Oliver Gould <ver@buoyant.io>