### PR TITLE
Change CODEOWNERS to @linkerd/maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @linkerd/proxy-maintainers
+* @linkerd/maintainers


### PR DESCRIPTION
It seems fine to broaden the review pool to all maintainers. As always,
good judgement about merging is expected :)

Signed-off-by: Oliver Gould <ver@buoyant.io>