### PR TITLE
build(deps): update tokio-util to v0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ dependencies = [
  "linkerd-stack",
  "pin-project",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.0",
  "tower",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tracing",
 ]
 
@@ -1169,7 +1169,7 @@ dependencies = [
  "pin-project",
  "tokio",
  "tokio-test",
- "tokio-util",
+ "tokio-util 0.7.0",
 ]
 
 [[package]]
@@ -1304,7 +1304,7 @@ dependencies = [
  "linkerd-stack",
  "pin-project",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower",
  "tracing",
 ]
@@ -2460,7 +2460,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
+ "tokio-util 0.6.9",
 ]
 
 [[package]]
@@ -2481,6 +2481,20 @@ name = "tokio-util"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2513,7 +2527,7 @@ dependencies = [
  "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2548,7 +2562,7 @@ dependencies = [
  "slab",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.6.9",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/deny.toml
+++ b/deny.toml
@@ -53,6 +53,8 @@ skip = [
     # Waiting on a tokio release that updates parking_lot to v0.12.
     { name = "parking_lot", version = "0.11" },
     { name = "parking_lot_core", version = "0.8" },
+    # waiting on `h2` and `tower` releases that update h2 to v0.7
+    { name = "tokio-util", version = "0.6" }
 ]
 skip-tree = [
     # Hasn't seen a new release since 2017. Pulls in an older version of nom.

--- a/linkerd/io/Cargo.toml
+++ b/linkerd/io/Cargo.toml
@@ -19,7 +19,7 @@ bytes = "1"
 linkerd-errno = { path = "../errno" }
 tokio = { version = "1", features = ["io-util", "net"] }
 tokio-test = { version = "0.4", optional = true }
-tokio-util = { version = "0.6", features = ["io"] }
+tokio-util = { version = "0.7", features = ["io"] }
 pin-project = "1"
 
 [dev-dependencies]

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -16,7 +16,7 @@ linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["rt", "sync", "time"] }
-tokio-util = "0.6.9"
+tokio-util = "0.7"
 tower = { version = "0.4.11", features = ["discover"] }
 tracing = "0.1.30"
 pin-project = "1"

--- a/linkerd/proxy/discover/src/buffer.rs
+++ b/linkerd/proxy/discover/src/buffer.rs
@@ -136,7 +136,7 @@ where
             // The watchdog bounds the amount of time that the send buffer stays
             // full. This is designed to release the `discover` resources, i.e.
             // if we expect that the receiver has leaked.
-            match this.tx.poll_send_done(cx) {
+            match this.tx.poll_reserve(cx) {
                 Poll::Ready(Ok(())) => {
                     this.watchdog.as_mut().set(None);
                 }
@@ -181,7 +181,7 @@ where
                 }
             };
 
-            this.tx.start_send(up).ok().expect("sender must be ready");
+            this.tx.send_item(up).ok().expect("sender must be ready");
         }
     }
 }


### PR DESCRIPTION
This branch updates `tokio-util` to v0.7.0.

The dependabot-generated PR for this update doesn't work, because this
is a breaking API change. The only update that was necessary here was
changing the use of `tokio_util::sync::PollSender` in
`linkerd-proxy-discover` to use the updated method names.

Closes #240

`tokio-util` v0.6.9 is still in the dependency tree because `tower`
depends on it.