### PR TITLE
ci: Only run checks on Cargo.toml changes

### DIFF
--- a/.github/workflows/check-each.yml
+++ b/.github/workflows/check-each.yml
@@ -1,4 +1,8 @@
 # Check each crate independently. Helps to catch dependency issues.
+#
+# Code changes are exercised via the `test` and `lint` workflows. This workflow just checks that
+# each crate's `Cargo.toml` is configured sufficiently so that each crate can be compiled on its
+# own.
 name: check-each
 
 permissions:
@@ -7,14 +11,13 @@ permissions:
 on:
   pull_request:
     paths:
-      - Cargo.lock
-      - "**/*.rs"
       - "**/Cargo.toml"
       - .github/workflows/check-each.yml
 
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
+  DEBIAN_FRONTEND: noninteractive
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
 
@@ -33,8 +36,9 @@ jobs:
       - name: list crates
         id: list-crates
         run: |
-          echo "::set-output name=crates::$(cargo metadata --frozen --format-version=1 \
-            | jq -cr "[.packages[] | select(.manifest_path | startswith(\"$PWD\")) | .name | select(. != \"linkerd-meshtls-boring\")]")"
+          crates=$(cargo metadata --frozen --format-version=1 \
+            | jq -cr "[.packages[] | select(.manifest_path | startswith(\"$PWD\")) | .name]")
+          echo "::set-output name=crates::$crates"
     outputs:
         crates: ${{ steps.list-crates.outputs.crates }}`
 
@@ -50,5 +54,8 @@ jobs:
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: cargo fetch
+      - name: install meshtls-boring build deps
+        if: matrix.crate == 'linkerd-meshtls-boring'
+        run: apt update && apt install -y clang cmake
       - run: cargo check -p ${{ matrix.crate }} --frozen --all-targets
 

--- a/.github/workflows/check-each.yml
+++ b/.github/workflows/check-each.yml
@@ -27,8 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: docker://rust:1.56.1-buster
-    env:
-        DEBIAN_FRONTEND: noninteractive
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: apt update && apt install -y jq


### PR DESCRIPTION
The point of this job is to check that each crate can be built
independently (i.e., that it doesn't depend on features pulled in by
another crate).

This change also updates the workflow to check linkerd-meshtls-boring by
installing its build deps.

Signed-off-by: Oliver Gould <ver@buoyant.io>