### PR TITLE
Fix dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      DOCKER_BUILDKIT: "1"
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
       - run: docker build .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,16 @@
+name: docker
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
+      - run: docker build .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,4 +16,4 @@ jobs:
       DOCKER_BUILDKIT: "1"
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
-      - run: docker build .
+      - run: docker build . --build-arg PROXY_UNOPTIMIZED=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,16 +61,7 @@ RUN --mount=type=cache,target=target \
 ## Install the proxy binary into the base runtime image.
 FROM $RUNTIME_IMAGE as runtime
 
-# When set, causes the proxy to remove the identity wrapper responsible for
-# CSR and key generation.
-ARG SKIP_IDENTITY_WRAPPER
-
 WORKDIR /linkerd
 COPY --from=build /out/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy
 ENV LINKERD2_PROXY_LOG=warn,linkerd=info
-RUN \
-  if [ -n "$SKIP_IDENTITY_WRAPPER" ] ; then \
-    rm -f /usr/bin/linkerd2-proxy-run && \
-    ln /usr/lib/linkerd/linkerd2-proxy /usr/bin/linkerd2-proxy-run ; \
-  fi
 # Inherits the ENTRYPOINT from the runtime image.


### PR DESCRIPTION
PR #1479 changed the docker base image to not include a shell, which
broke the dockerfile's logic for skipping the identity wrapper. It's no
longer possible to run the proxy without identity, so this functionality
isn't needed in any case.

This change fixes the Dockerfile and adds a CI workflow to test docker
builds on Dockerfile changes.

Signed-off-by: Oliver Gould <ver@buoyant.io>