### PR TITLE
Use the connection's HTTP version in transport header

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -83,6 +83,7 @@ impl Config {
         svc::stack(ConnectTcp::new(self.connect.keepalive))
             .push(tls::Client::layer(identity))
             .push_connect_timeout(self.connect.timeout)
+            .push_map_target(|(_version, target)| target)
             .push(self::client::layer())
             .push_on_service(svc::MapErr::layer(Into::into))
             .into_new_service()

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -100,6 +100,7 @@ impl<C> Inbound<C> {
                 .check_service::<Http>()
                 .push(transport::metrics::Client::layer(rt.metrics.proxy.transport.clone()))
                 .check_service::<Http>()
+                .push_map_target(|(_version, target)| target)
                 .push(http::client::layer(
                     config.proxy.connect.h1_settings,
                     config.proxy.connect.h2_settings,

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -38,5 +38,5 @@ linkerd-meshtls = { path = "../../meshtls", features = ["rustls"] }
 linkerd-meshtls-rustls = { path = "../../meshtls/rustls", features = ["test-util"] }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }
 parking_lot = "0.12"
-tokio = { version = "1", features = ["time", "macros"] }
+tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-test = "0.4"

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -218,7 +218,7 @@ impl<S> Outbound<S> {
     {
         let http = self
             .clone()
-            .push_tcp_endpoint::<http::Endpoint>()
+            .push_tcp_endpoint::<http::Connect>()
             .push_http_endpoint()
             .push_http_server()
             .into_inner();

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -19,9 +19,7 @@ use linkerd_app_core::{
     profiles::{self, LogicalAddr},
     proxy::{api_resolve::ProtocolHint, tap},
     svc::Param,
-    tls,
-    transport_header::SessionProtocol,
-    Addr, Conditional, CANONICAL_DST_HEADER,
+    tls, Addr, Conditional, CANONICAL_DST_HEADER,
 };
 use std::{net::SocketAddr, str::FromStr};
 
@@ -29,6 +27,8 @@ pub type Accept = crate::Accept<Version>;
 pub type Logical = crate::logical::Logical<Version>;
 pub type Concrete = crate::logical::Concrete<Version>;
 pub type Endpoint = crate::endpoint::Endpoint<Version>;
+
+pub type Connect = self::endpoint::Connect<Endpoint>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct Route {
@@ -145,18 +145,6 @@ impl Param<client::Settings> for Endpoint {
             Version::Http1 => match self.metadata.protocol_hint() {
                 ProtocolHint::Unknown => client::Settings::Http1,
                 ProtocolHint::Http2 => client::Settings::OrigProtoUpgrade,
-            },
-        }
-    }
-}
-
-impl Param<Option<SessionProtocol>> for Endpoint {
-    fn param(&self) -> Option<SessionProtocol> {
-        match self.protocol {
-            Version::H2 => Some(SessionProtocol::Http2),
-            Version::Http1 => match self.metadata.protocol_hint() {
-                ProtocolHint::Http2 => Some(SessionProtocol::Http2),
-                ProtocolHint::Unknown => Some(SessionProtocol::Http1),
             },
         }
     }

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -193,7 +193,7 @@ impl<T: svc::Param<transport::labels::Key>> svc::Param<transport::labels::Key> f
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{http, test_util::*, transport::addrs::*};
+    use crate::{http, test_util::*};
     use linkerd_app_core::{
         io,
         proxy::api_resolve::Metadata,
@@ -212,7 +212,7 @@ mod test {
         let addr = SocketAddr::new([192, 0, 2, 41].into(), 2041);
 
         let connect = support::connect()
-            .endpoint_fn_boxed(addr, |_: http::Endpoint| serve(::http::Version::HTTP_11));
+            .endpoint_fn_boxed(addr, |_: http::Connect| serve(::http::Version::HTTP_11));
 
         // Build the outbound server
         let (rt, _shutdown) = runtime();
@@ -249,7 +249,7 @@ mod test {
         let addr = SocketAddr::new([192, 0, 2, 41].into(), 2042);
 
         let connect = support::connect()
-            .endpoint_fn_boxed(addr, |_: http::Endpoint| serve(::http::Version::HTTP_2));
+            .endpoint_fn_boxed(addr, |_: http::Connect| serve(::http::Version::HTTP_2));
 
         // Build the outbound server
         let (rt, _shutdown) = runtime();
@@ -288,7 +288,7 @@ mod test {
 
         // Pretend the upstream is a proxy that supports proto upgrades...
         let connect = support::connect()
-            .endpoint_fn_boxed(addr, |_: http::Endpoint| serve(::http::Version::HTTP_2));
+            .endpoint_fn_boxed(addr, |_: http::Connect| serve(::http::Version::HTTP_2));
 
         // Build the outbound server
         let (rt, _shutdown) = runtime();
@@ -337,7 +337,7 @@ mod test {
 
         // Pretend the upstream is a proxy that supports proto upgrades...
         let connect = support::connect()
-            .endpoint_fn_boxed(addr, |_: http::Endpoint| serve(::http::Version::HTTP_2));
+            .endpoint_fn_boxed(addr, |_: http::Connect| serve(::http::Version::HTTP_2));
 
         // Build the outbound server
         let (rt, _shutdown) = runtime();

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -146,6 +146,7 @@ impl errors::HttpRescue<Error> for ClientRescue {
 // === impl Connect ===
 
 impl<T> svc::Param<Option<SessionProtocol>> for Connect<T> {
+    #[inline]
     fn param(&self) -> Option<SessionProtocol> {
         match self.version {
             http::Version::Http1 => Some(SessionProtocol::Http1),
@@ -155,6 +156,7 @@ impl<T> svc::Param<Option<SessionProtocol>> for Connect<T> {
 }
 
 impl<T: svc::Param<Remote<ServerAddr>>> svc::Param<Remote<ServerAddr>> for Connect<T> {
+    #[inline]
     fn param(&self) -> Remote<ServerAddr> {
         self.inner.param()
     }
@@ -163,6 +165,7 @@ impl<T: svc::Param<Remote<ServerAddr>>> svc::Param<Remote<ServerAddr>> for Conne
 impl<T: svc::Param<tls::ConditionalClientTls>> svc::Param<tls::ConditionalClientTls>
     for Connect<T>
 {
+    #[inline]
     fn param(&self) -> tls::ConditionalClientTls {
         self.inner.param()
     }
@@ -171,6 +174,7 @@ impl<T: svc::Param<tls::ConditionalClientTls>> svc::Param<tls::ConditionalClient
 impl<T: svc::Param<Option<opaque_transport::PortOverride>>>
     svc::Param<Option<opaque_transport::PortOverride>> for Connect<T>
 {
+    #[inline]
     fn param(&self) -> Option<opaque_transport::PortOverride> {
         self.inner.param()
     }
@@ -179,12 +183,14 @@ impl<T: svc::Param<Option<opaque_transport::PortOverride>>>
 impl<T: svc::Param<Option<http::AuthorityOverride>>> svc::Param<Option<http::AuthorityOverride>>
     for Connect<T>
 {
+    #[inline]
     fn param(&self) -> Option<http::AuthorityOverride> {
         self.inner.param()
     }
 }
 
 impl<T: svc::Param<transport::labels::Key>> svc::Param<transport::labels::Key> for Connect<T> {
+    #[inline]
     fn param(&self) -> transport::labels::Key {
         self.inner.param()
     }

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -67,7 +67,7 @@ impl<C, T, B> tower::Service<T> for MakeClient<C, B>
 where
     T: Clone + Send + Sync + 'static,
     T: Param<Settings>,
-    C: MakeConnection<T> + Clone + Unpin + Send + Sync + 'static,
+    C: MakeConnection<(crate::Version, T)> + Clone + Unpin + Send + Sync + 'static,
     C::Connection: Unpin + Send,
     C::Metadata: Send,
     C::Future: Unpin + Send + 'static,
@@ -133,7 +133,7 @@ type RspFuture = Pin<Box<dyn Future<Output = Result<http::Response<BoxBody>>> + 
 impl<C, T, B> Service<http::Request<B>> for Client<C, T, B>
 where
     T: Clone + Send + Sync + 'static,
-    C: MakeConnection<T> + Clone + Send + Sync + 'static,
+    C: MakeConnection<(crate::Version, T)> + Clone + Send + Sync + 'static,
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
     C::Error: Into<Error>,

--- a/linkerd/proxy/http/src/glue.rs
+++ b/linkerd/proxy/http/src/glue.rs
@@ -163,15 +163,15 @@ impl<C, T> HyperConnect<C, T> {
     pub(super) fn new(connect: C, target: T, absolute_form: bool) -> Self {
         HyperConnect {
             connect,
-            absolute_form,
             target,
+            absolute_form,
         }
     }
 }
 
 impl<C, T> Service<hyper::Uri> for HyperConnect<C, T>
 where
-    C: MakeConnection<T> + Clone + Send + Sync,
+    C: MakeConnection<(crate::Version, T)> + Clone + Send + Sync,
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
     T: Clone + Send + Sync,
@@ -186,7 +186,9 @@ where
 
     fn call(&mut self, _dst: hyper::Uri) -> Self::Future {
         HyperConnectFuture {
-            inner: self.connect.connect(self.target.clone()),
+            inner: self
+                .connect
+                .connect((crate::Version::Http1, self.target.clone())),
             absolute_form: self.absolute_form,
         }
     }

--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -66,7 +66,7 @@ type RspFuture = Pin<Box<dyn Future<Output = Result<http::Response<BoxBody>>> + 
 impl<C, T, B> Client<C, T, B>
 where
     T: Clone + Send + Sync + 'static,
-    C: MakeConnection<T> + Clone + Send + Sync + 'static,
+    C: MakeConnection<(crate::Version, T)> + Clone + Send + Sync + 'static,
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
     B: hyper::body::HttpBody + Send + 'static,

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -62,7 +62,7 @@ type ConnectFuture<B> = Pin<Box<dyn Future<Output = Result<Connection<B>>> + Sen
 
 impl<C, B, T> Service<T> for Connect<C, B>
 where
-    C: MakeConnection<T>,
+    C: MakeConnection<(crate::Version, T)>,
     C::Connection: Send + Unpin + 'static,
     C::Metadata: Send,
     C::Future: Send + 'static,
@@ -88,7 +88,7 @@ where
 
         let connect = self
             .connect
-            .connect(target)
+            .connect((crate::Version::H2, target))
             .instrument(trace_span!("connect"));
 
         Box::pin(

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -50,7 +50,7 @@ impl<C, T, B> Upgrade<C, T, B> {
 impl<C, T, B> Service<http::Request<B>> for Upgrade<C, T, B>
 where
     T: Clone + Send + Sync + 'static,
-    C: MakeConnection<T> + Clone + Send + Sync + 'static,
+    C: MakeConnection<(crate::Version, T)> + Clone + Send + Sync + 'static,
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
     B: hyper::body::HttpBody + Send + 'static,

--- a/linkerd/stack/src/map_target.rs
+++ b/linkerd/stack/src/map_target.rs
@@ -39,6 +39,7 @@ where
 {
     type Service = S::Service;
 
+    #[inline]
     fn new_service(&self, target: T) -> Self::Service {
         self.inner.new_service(self.map_target.map_target(target))
     }
@@ -53,10 +54,12 @@ where
     type Error = S::Error;
     type Future = S::Future;
 
+    #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.inner.poll_ready(cx)
     }
 
+    #[inline]
     fn call(&mut self, target: T) -> Self::Future {
         self.inner.call(self.map_target.map_target(target))
     }
@@ -73,6 +76,7 @@ where
     type Error = P::Error;
     type Future = P::Future;
 
+    #[inline]
     fn proxy(&self, svc: &mut S, req: T) -> Self::Future {
         self.inner.proxy(svc, self.map_target.map_target(req))
     }


### PR DESCRIPTION
Currently, when the outbound proxy communicates with a meshed endpoint
that uses opaque transport (i.e. multi-cluster gateways), it *always*
sets the gateway header's session protocol to HTTP/2, since the meshed
endpoint supports HTTP/2 protocol upgrading. But the HTTP client may
choose not to use HTTP/2 if the request includes the `Upgrade` header,
as it does for WebSocket connections. In these cases, the transport
header should indicate that the connection is HTTP/1.

This change modifies the HTTP client to pass the used protocol version
when building a connection. This value is then used to set the session
protocol header when it is required..

Signed-off-by: Oliver Gould <ver@buoyant.io>