### PR TITLE
Update h2 to use unpublished changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,8 +444,7 @@ dependencies = [
 [[package]]
 name = "h2"
 version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+source = "git+https://github.com/hyperium/h2?branch=master#b8eab381c053ccf3ebf99d3ef1c0fd27f5e11d89"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,4 +77,5 @@ debug = false
 lto = true
 
 [patch.crates-io]
+h2 = { git = "https://github.com/hyperium/h2", branch = "master" }
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.22" }

--- a/deny.toml
+++ b/deny.toml
@@ -63,6 +63,9 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = [
+    "https://github.com/hyperium/h2",
+]
 
 [sources.allow-org]
 github = [


### PR DESCRIPTION
`h2` has a few important changes since its last official release:

* hyperium/h2@4dc2b4a Avoids time operations that can panic
* hyperium/h2@85549fc Fixes an issue with header parsing
* hyperium/h2@b8eab38 Removes noise from tracing spans

This change patches our `h2` dependency to use the laster commit on the
master branch.

Signed-off-by: Oliver Gould <ver@buoyant.io>