### PR TITLE
bump `h2` to v0.3.12 and remove patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,8 +443,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.11"
-source = "git+https://github.com/hyperium/h2?branch=master#b8eab381c053ccf3ebf99d3ef1c0fd27f5e11d89"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,5 +77,4 @@ debug = false
 lto = true
 
 [patch.crates-io]
-h2 = { git = "https://github.com/hyperium/h2", branch = "master" }
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.22" }

--- a/deny.toml
+++ b/deny.toml
@@ -63,9 +63,6 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = [
-    "https://github.com/hyperium/h2",
-]
 
 [sources.allow-org]
 github = [


### PR DESCRIPTION
Version v0.3.12 of `h2` has been published, so we no longer need the
patch added in #1536 to pick up unreleased changes.