### PR TITLE
inbound: Support multiple authorization types

### DIFF
--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -304,7 +304,7 @@ impl FmtLabels for AuthzLabels {
         self.server.fmt_labels(f)?;
         write!(
             f,
-            "authz_kind=\"{}\",authz_name=\"{}\"",
+            ",authz_kind=\"{}\",authz_name=\"{}\"",
             self.kind, self.name
         )
     }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -64,13 +64,17 @@ pub struct InboundEndpointLabels {
 
 /// A label referencing an inbound `Server` (i.e. for policy).
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct ServerLabel(pub Arc<str>);
+pub struct ServerLabel {
+    pub kind: Arc<str>,
+    pub name: Arc<str>,
+}
 
 /// Labels referencing an inbound `ServerAuthorization.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct AuthzLabels {
     pub server: ServerLabel,
-    pub authz: Arc<str>,
+    pub kind: Arc<str>,
+    pub name: Arc<str>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -289,22 +293,20 @@ impl FmtLabels for InboundEndpointLabels {
     }
 }
 
-impl fmt::Display for ServerLabel {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
 impl FmtLabels for ServerLabel {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "srv_name=\"{}\"", self.0)
+        write!(f, "srv_kind=\"{}\",srv_name=\"{}\"", self.kind, self.name)
     }
 }
 
 impl FmtLabels for AuthzLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.server.fmt_labels(f)?;
-        write!(f, ",saz_name=\"{}\"", self.authz)
+        write!(
+            f,
+            "authz_kind=\"{}\",authz_name=\"{}\"",
+            self.kind, self.name
+        )
     }
 }
 

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -194,14 +194,17 @@ mod tests {
                 negotiated_protocol: None,
             }),
             ([192, 0, 2, 4], 40000).into(),
-            PolicyServerLabel("testserver".into()),
+            PolicyServerLabel {
+                kind: "server".into(),
+                name: "testserver".into(),
+            },
         );
         assert_eq!(
             labels.to_string(),
             "direction=\"inbound\",peer=\"src\",\
             target_addr=\"192.0.2.4:40000\",target_ip=\"192.0.2.4\",target_port=\"40000\",\
             tls=\"true\",client_id=\"foo.id.example.com\",\
-            srv_name=\"testserver\""
+            srv_kind=\"server\",srv_name=\"testserver\""
         );
     }
 }

--- a/linkerd/app/inbound/src/accept.rs
+++ b/linkerd/app/inbound/src/accept.rs
@@ -129,8 +129,10 @@ mod tests {
                 authorizations: vec![Authorization {
                     authentication: Authentication::Unauthenticated,
                     networks: vec![Default::default()],
+                    kind: "serverauthorization".into(),
                     name: "testsaz".into(),
                 }],
+                kind: "server".into(),
                 name: "testsrv".into(),
             },
             None,

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -469,8 +469,10 @@ mod tests {
                 authorizations: vec![Authorization {
                     authentication: Authentication::Unauthenticated,
                     networks: vec![client_addr().ip().into()],
+                    kind: "serverathorizationu".into(),
                     name: "testsaz".into(),
                 }],
+                kind: "server".into(),
                 name: "testsrv".into(),
             },
         );

--- a/linkerd/app/inbound/src/http.rs
+++ b/linkerd/app/inbound/src/http.rs
@@ -216,6 +216,7 @@ pub mod fuzz {
                     authorizations: vec![policy::Authorization {
                         authentication: policy::Authentication::Unauthenticated,
                         networks: vec![std::net::IpAddr::from([192, 0, 2, 3]).into()],
+                        kind: "server".into(),
                         name: "testsaz".into(),
                     }],
                     name: "testsrv".into(),

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -253,8 +253,16 @@ where
 {
     fn from((permit, t): (policy::Permit, T)) -> Self {
         let labels = vec![
-            ("srv_name".to_string(), permit.labels.server.to_string()),
-            ("saz_name".to_string(), permit.labels.authz.to_string()),
+            (
+                "srv_kind".to_string(),
+                permit.labels.server.kind.to_string(),
+            ),
+            (
+                "srv_name".to_string(),
+                permit.labels.server.name.to_string(),
+            ),
+            ("authz_kind".to_string(), permit.labels.kind.to_string()),
+            ("authz_name".to_string(), permit.labels.name.to_string()),
         ];
 
         Self {

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -610,8 +610,10 @@ impl svc::Param<policy::AllowPolicy> for Target {
                 authorizations: vec![policy::Authorization {
                     authentication: policy::Authentication::Unauthenticated,
                     networks: vec![std::net::IpAddr::from([192, 0, 2, 3]).into()],
+                    kind: "serverauthorization".into(),
                     name: "testsaz".into(),
                 }],
+                kind: "server".into(),
                 name: "testsrv".into(),
             },
         );
@@ -621,7 +623,10 @@ impl svc::Param<policy::AllowPolicy> for Target {
 
 impl svc::Param<policy::ServerLabel> for Target {
     fn param(&self) -> policy::ServerLabel {
-        policy::ServerLabel("testsrv".into())
+        policy::ServerLabel {
+            kind: "server".into(),
+            name: "testsrv".into(),
+        }
     }
 }
 

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -70,7 +70,8 @@ impl From<DefaultPolicy> for ServerPolicy {
             DefaultPolicy::Deny => ServerPolicy {
                 protocol: Protocol::Opaque,
                 authorizations: vec![],
-                name: "default:deny".into(),
+                kind: "default".into(),
+                name: "deny".into(),
             },
         }
     }
@@ -101,7 +102,11 @@ impl AllowPolicy {
 
     #[inline]
     pub fn server_label(&self) -> ServerLabel {
-        ServerLabel(self.server.borrow().name.clone())
+        let s = self.server.borrow();
+        ServerLabel {
+            kind: s.kind.clone(),
+            name: s.name.clone(),
+        }
     }
 
     async fn changed(&mut self) {
@@ -169,8 +174,12 @@ impl Permit {
             dst,
             protocol: server.protocol,
             labels: AuthzLabels {
-                server: ServerLabel(server.name.clone()),
-                authz: authz.name.clone(),
+                kind: authz.kind.clone(),
+                name: authz.name.clone(),
+                server: ServerLabel {
+                    kind: server.kind.clone(),
+                    name: server.name.clone(),
+                },
             },
         }
     }

--- a/linkerd/app/inbound/src/policy/authorize/http.rs
+++ b/linkerd/app/inbound/src/policy/authorize/http.rs
@@ -105,7 +105,7 @@ where
             }
             Err(e) => {
                 tracing::info!(
-                    server = %self.policy.server_label(),
+                    server = %format_args!("{}:{}", self.policy.server_label().kind, self.policy.server_label().name),
                     tls = ?self.tls,
                     client = %self.client_addr,
                     "Request denied",

--- a/linkerd/app/inbound/src/policy/authorize/tcp.rs
+++ b/linkerd/app/inbound/src/policy/authorize/tcp.rs
@@ -85,7 +85,11 @@ where
                 })
             }
             Err(deny) => {
-                tracing::info!(server = %policy.server_label(), ?tls, %client, "Connection denied");
+                tracing::info!(
+                    server = %format_args!("{}:{}", policy.server_label().kind, policy.server_label().name),
+                    ?tls, %client,
+                    "Connection denied"
+                );
                 self.metrics.deny(&policy, tls);
                 AuthorizeTcp::Unauthorized(Unauthorized { deny })
             }
@@ -150,7 +154,7 @@ where
                     _ = policy.changed() => {
                         if let Err(denied) = policy.check_authorized(client, &tls) {
                             tracing::info!(
-                                server = %policy.server_label(),
+                                server = %policy.server_label().name,
                                 ?tls,
                                 %client,
                                 "Connection terminated due to policy change",

--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -3,17 +3,12 @@ use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolic
 use std::time::Duration;
 
 pub fn all_authenticated(timeout: Duration) -> ServerPolicy {
-    mk(
-        "default:all-authenticated",
-        all_nets(),
-        authenticated(),
-        timeout,
-    )
+    mk("all-authenticated", all_nets(), authenticated(), timeout)
 }
 
 pub fn all_unauthenticated(timeout: Duration) -> ServerPolicy {
     mk(
-        "default:all-unauthenticated",
+        "all-unauthenticated",
         all_nets(),
         Authentication::Unauthenticated,
         timeout,
@@ -24,12 +19,7 @@ pub fn cluster_authenticated(
     nets: impl IntoIterator<Item = IpNet>,
     timeout: Duration,
 ) -> ServerPolicy {
-    mk(
-        "default:cluster-authenticated",
-        nets,
-        authenticated(),
-        timeout,
-    )
+    mk("cluster-authenticated", nets, authenticated(), timeout)
 }
 
 pub fn cluster_unauthenticated(
@@ -37,7 +27,7 @@ pub fn cluster_unauthenticated(
     timeout: Duration,
 ) -> ServerPolicy {
     mk(
-        "default:cluster-unauthenticated",
+        "cluster-unauthenticated",
         nets,
         Authentication::Unauthenticated,
         timeout,
@@ -46,7 +36,7 @@ pub fn cluster_unauthenticated(
 
 pub fn all_mtls_unauthenticated(timeout: Duration) -> ServerPolicy {
     mk(
-        "default:all-tls-unauthenticated",
+        "all-tls-unauthenticated",
         all_nets(),
         Authentication::TlsUnauthenticated,
         timeout,

--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -75,8 +75,10 @@ fn mk(
         authorizations: vec![Authorization {
             networks: nets.into_iter().map(Into::into).collect(),
             authentication,
+            kind: "default".into(),
             name: name.into(),
         }],
+        kind: "default".into(),
         name: name.into(),
     }
 }

--- a/linkerd/app/inbound/src/policy/tests.rs
+++ b/linkerd/app/inbound/src/policy/tests.rs
@@ -9,8 +9,10 @@ fn unauthenticated_allowed() {
         authorizations: vec![Authorization {
             authentication: Authentication::Unauthenticated,
             networks: vec!["192.0.2.0/24".parse().unwrap()],
+            kind: "serverauthorization".into(),
             name: "unauth".into(),
         }],
+        kind: "server".into(),
         name: "test".into(),
     };
 
@@ -30,8 +32,12 @@ fn unauthenticated_allowed() {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
             labels: AuthzLabels {
-                server: ServerLabel("test".into()),
-                authz: "unauth".into(),
+                kind: "serverauthorization".into(),
+                name: "unauth".into(),
+                server: ServerLabel {
+                    kind: "server".into(),
+                    name: "test".into(),
+                }
             }
         }
     );
@@ -47,8 +53,10 @@ fn authenticated_identity() {
                 identities: vec![client_id().to_string()].into_iter().collect(),
             },
             networks: vec!["192.0.2.0/24".parse().unwrap()],
+            kind: "serverauthorization".into(),
             name: "tls-auth".into(),
         }],
+        kind: "server".into(),
         name: "test".into(),
     };
 
@@ -71,8 +79,12 @@ fn authenticated_identity() {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
             labels: AuthzLabels {
-                server: ServerLabel("test".into()),
-                authz: "tls-auth".into(),
+                kind: "serverauthorization".into(),
+                name: "tls-auth".into(),
+                server: ServerLabel {
+                    kind: "server".into(),
+                    name: "test".into()
+                },
             }
         }
     );
@@ -100,8 +112,10 @@ fn authenticated_suffix() {
                 suffixes: vec![Suffix::from(vec!["cluster".into(), "local".into()])],
             },
             networks: vec!["192.0.2.0/24".parse().unwrap()],
+            kind: "serverauthorization".into(),
             name: "tls-auth".into(),
         }],
+        kind: "server".into(),
         name: "test".into(),
     };
 
@@ -123,8 +137,12 @@ fn authenticated_suffix() {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
             labels: AuthzLabels {
-                server: ServerLabel("test".into()),
-                authz: "tls-auth".into(),
+                kind: "serverauthorization".into(),
+                name: "tls-auth".into(),
+                server: ServerLabel {
+                    kind: "server".into(),
+                    name: "test".into()
+                }
             }
         }
     );
@@ -149,8 +167,10 @@ fn tls_unauthenticated() {
         authorizations: vec![Authorization {
             authentication: Authentication::TlsUnauthenticated,
             networks: vec!["192.0.2.0/24".parse().unwrap()],
+            kind: "serverauthorization".into(),
             name: "tls-unauth".into(),
         }],
+        kind: "server".into(),
         name: "test".into(),
     };
 
@@ -172,8 +192,12 @@ fn tls_unauthenticated() {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
             labels: AuthzLabels {
-                server: ServerLabel("test".into()),
-                authz: "tls-unauth".into(),
+                kind: "serverauthorization".into(),
+                name: "tls-unauth".into(),
+                server: ServerLabel {
+                    kind: "server".into(),
+                    name: "test".into(),
+                },
             }
         }
     );

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -58,8 +58,10 @@ pub fn default_config() -> Config {
                 authorizations: vec![Authorization {
                     authentication: Authentication::Unauthenticated,
                     networks: vec![Default::default()],
+                    kind: "serverauthorization".into(),
                     name: "testsaz".into(),
                 }],
+                kind: "server".into(),
                 name: "testsrv".into(),
             }
             .into(),

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -143,7 +143,8 @@ impl TcpFixture {
             .label("direction", "inbound")
             .label("peer", "src")
             .label("target_addr", orig_dst)
-            .label("srv_name", "default:all-unauthenticated");
+            .label("srv_kind", "default")
+            .label("srv_name", "all-unauthenticated");
 
         let dst_labels = metrics::labels()
             .label("direction", "inbound")

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1360,7 +1360,8 @@ async fn retry_reconnect_errors() {
     metrics::metric("tcp_open_total")
         .label("peer", "src")
         .label("direction", "inbound")
-        .label("srv_name", "default:all-unauthenticated")
+        .label("srv_kind", "default")
+        .label("srv_name", "all-unauthenticated")
         .value(1u64)
         .assert_in(&metrics)
         .await;

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -15,6 +15,7 @@ use std::{collections::HashSet, hash::Hash, sync::Arc, time};
 pub struct ServerPolicy {
     pub protocol: Protocol,
     pub authorizations: Vec<Authorization>,
+    pub kind: Arc<str>,
     pub name: Arc<str>,
 }
 
@@ -32,6 +33,7 @@ pub enum Protocol {
 pub struct Authorization {
     pub networks: Vec<Network>,
     pub authentication: Authentication,
+    pub kind: Arc<str>,
     pub name: Arc<str>,
 }
 


### PR DESCRIPTION
The inbound policy module uses the label `saz_name` to indicate the
authorization resource being employed to allow/deny traffic. This
corresponds to the `ServerAuthorization` kubernetes resource (with the
`saz` shortname). This resource type is going to be deprecated in favor
of a new, more general, `AuthorizationPolicy` resource.

When this change is made in the control plane, the policy controller
will include a `kind` label on gRPC messages indicating whether the
resource type, or `default` if a default policy is in effect.

This change honors this new `kind` field and adds a dedicated label to
indicate the kind.

Server labels are changed from:

    srv_name="default:foo"
    srv_name="fah"

to:

    srv_kind="default",srv_name="foo"
    srv_kind="server",srv_name="fah"

Authorization labels are changed from:

    saz_name="default:bar"
    saz_name="bah"

to:

    authz_kind="default",authz_name="bar"
    authz_kind="serverauthorization",authz_name="bah"

Signed-off-by: Oliver Gould <ver@buoyant.io>