### PR TITLE
tracing: disable regular expression matching in log filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,9 +2632,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
+checksum = "b9df98b037d039d03400d9dd06b0f8ce05486b5f25e9a2d7d36196e142ebbc52"
 dependencies = [
  "ansi_term",
  "lazy_static",

--- a/linkerd/tracing/Cargo.toml
+++ b/linkerd/tracing/Cargo.toml
@@ -17,6 +17,6 @@ tracing = "0.1"
 tracing-log = "0.1"
 
 [dependencies.tracing-subscriber]
-version = "0.3"
+version = "0.3.10"
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot", "registry"]


### PR DESCRIPTION
[`tracing-subscriber` v0.3.10][1] introduces a new [builder API][2] for
configuring the `EnvFilter` type. One of the configurations that can now
be set using the builder is whether span field value filters for
`fmt::Debug` fields are interpreted as precise string matching or as
regular expressions.

Disabling regular expressions is strongly recommended in cases where
filter configurations can come from an untrusted source, as a malicious
regular expression is a potential denial-of-service vector. In the
proxy, we already implement a form of access control for setting the
filter --- the `/admin/log-level` endpoint denies requests that did not
originate from localhost, so it's only possible to set the log level
when SSHed into the pod. However, it's probably wise to disable regex
filters here as well, as a form of additional defense in depth.

Therefore, this branch updates the `tracing-subscriber` dependency to
v0.3.10, and disables regular expression filters.

[1]: https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.3.10
[2]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.Builder.html