### PR TITLE
Fix inbound fuzzing build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,6 +18,12 @@ ARG YQ_VERSION=v4.2.0
 RUN curl --proto '=https' --tlsv1.3 -vsSfLo /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
     && chmod +x /usr/local/bin/yq
 
+FROM docker.io/rust:${RUST_VERSION}-bullseye as nightly
+RUN rustup toolchain add nightly
+
+FROM nightly as fuzz
+RUN cargo +nightly install cargo-fuzz
+
 #
 # Main image
 #
@@ -63,6 +69,8 @@ COPY --from=cargo-deny /usr/local/bin/cargo-deny /usr/local/bin/cargo-deny
 COPY --from=k3d /usr/local/bin/k3d /usr/local/bin/k3d
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/kubectl
 COPY --from=yq /usr/local/bin/yq /usr/local/bin/yq
+COPY --from=nightly /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu
+COPY --from=fuzz /usr/local/cargo/bin/cargo-fuzz /usr/local/cargo/bin/cargo-fuzz
 
 ENTRYPOINT ["/usr/local/share/docker-init.sh"]
 CMD ["sleep", "infinity"]

--- a/linkerd/app/inbound/src/http.rs
+++ b/linkerd/app/inbound/src/http.rs
@@ -219,6 +219,7 @@ pub mod fuzz {
                         kind: "server".into(),
                         name: "testsaz".into(),
                     }],
+                    kind: "server".into(),
                     name: "testsrv".into(),
                 },
             );
@@ -228,7 +229,10 @@ pub mod fuzz {
 
     impl svc::Param<policy::ServerLabel> for Target {
         fn param(&self) -> policy::ServerLabel {
-            policy::ServerLabel("testsrv".into())
+            policy::ServerLabel {
+                kind: "server".into(),
+                name: "testsrv".into(),
+            }
         }
     }
 


### PR DESCRIPTION
Nightly builds were broken when 279b301 landed, so we missed
the regression. This change fixes the inbound fuzzer build. It also
updates the devcontainer build to include a nightly toolchain with
cargo-fuzz.

Signed-off-by: Oliver Gould <ver@buoyant.io>