### PR TITLE
ci: Run the release workflow on changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: release
 
 on:
+  pull_request: {}
   push:
     tags:
       - "release/*"
@@ -70,6 +71,7 @@ jobs:
           path: target/${{ matrix.target }}/release/package/*
 
   release:
+    if: startsWith(github.ref, 'refs/tags/release/')
     needs: [package]
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
Currently we only exercise the release workflow on tagged releases, but
this makes it difficult to validate changes to the workflow itself.

This change updates the release workflow to run its build on pull
requests that change the workflow. The release-publishing step is only
run on tags, though.

Signed-off-by: Oliver Gould <ver@buoyant.io>