### PR TITLE
Split out list-changed-crates into an action

### DIFF
--- a/.github/actions/list-changed-crates/Dockerfile
+++ b/.github/actions/list-changed-crates/Dockerfile
@@ -1,0 +1,8 @@
+ARG RUST_VERSION=1.59.0
+FROM docker.io/library/rust:${RUST_VERSION}-bullseye
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && \
+    apt install -y jq && \
+    rm -rf /var/lib/apt/lists/*
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/list-changed-crates/action.yml
+++ b/.github/actions/list-changed-crates/action.yml
@@ -1,0 +1,18 @@
+name: list-changed-crates
+description: List crates that have changed
+
+inputs:
+  files:
+    description: 'Space-separated list of changed files'
+    required: true
+
+outputs:
+  crates:
+    description: "A JSON list of crates that have changed"
+    value: ${{ steps.list-changed.outputs.crates }}
+
+runs:
+  using: docker
+  image: Dockerfile
+  args:
+    - ${{ inputs.files }}

--- a/.github/actions/list-changed-crates/entrypoint.sh
+++ b/.github/actions/list-changed-crates/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <changed-files>"
+    exit 1
+fi
+
+# Find the nearest Cargo.toml (except the root).
+find_manifest() {
+    p=$(dirname "$1")
+    if [ -f "$p/Cargo.toml" ]; then
+        realpath "$p/Cargo.toml"
+    else
+        find_manifest "$p"
+    fi
+}
+
+# Build an expression to match all changed manifests.
+manifest_expr() {
+    expr="false"
+
+    for file in "$@" ; do
+        # If the workflow changes or root Cargo.toml changes, run checks for all crates in the repo.
+        if [[ "$file" = .github/* ]] || [ "$file" = "$PWD/Cargo.toml" ]; then
+            expr="startswith(\"$PWD\")"
+            break
+        fi
+
+        # Otherwise, only run checks for changes to subcrates (and not the top-level crate).
+        m=$(find_manifest "$file")
+        if [ "$m" != "$PWD/Cargo.toml" ]; then
+            expr="$expr or (. == \"$m\")"
+        fi
+    done
+
+    echo "$expr"
+}
+
+files="$1"
+if [ -z "$files" ]; then
+    echo "No files specified" >&2
+    exit 1
+fi
+
+# Get the crate names for all changed manifest directories.
+crates=$(cargo metadata --locked --format-version=1 \
+    | jq -cr "[.packages[] | select(.manifest_path | $(manifest_expr "$files")) | .name]")
+
+echo "::set-output name=crates::$crates"
+echo "$crates" | jq .

--- a/.github/workflows/check-each.yml
+++ b/.github/workflows/check-each.yml
@@ -12,6 +12,8 @@ on:
   pull_request:
     paths:
       - "**/Cargo.toml"
+      - "**/*.rs"
+      - .github/actions/list-changed-crates/*
       - .github/workflows/check-each.yml
 
 env:
@@ -26,54 +28,21 @@ jobs:
   list-changed-crates:
     timeout-minutes: 3
     runs-on: ubuntu-latest
-    container:
-      image: docker://rust:1.59.0-buster
     steps:
-      - run: apt update && apt install -y jq
       - uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
-      - run: cargo fetch
       - uses: tj-actions/changed-files@a59f800cbb60ed483623848e31be67659a2940f8
         id: changed-files
         with:
           files: |
-            - Cargo.toml
-            - "**/Cargo.toml"
-            - "**/*.rs"
-            - .github/workflows/check-each.yml
-      - name: list changed crates
+            **/Cargo.toml
+            **/*.rs
+            .github/actions/list-changed-crates/*
+            .github/workflows/check-each.yml
+      - name: List changed crates
         id: list-changed
-        run: |
-          files="${{ steps.changed-files.outputs.all_changed_files }}"
-          # Find the nearest Cargo.toml (except the root).
-          find_manifest() {
-            p=$(dirname "$1")
-            if [ -f "$p/Cargo.toml" ]; then
-              realpath "$p/Cargo.toml"
-            else
-              find_manifest "$p"
-            fi
-          }
-          # Build an expression to match all changed manifests.
-          manifest_expr() {
-            expr="false"
-            for file in $(echo $*) ; do
-              # If the workflow changes or root Cargo.toml changes, run checks for all crates in the repo.
-              if [ "$file" = .github/workflows/check-each.yml ] || [ "$file" = "$PWD/Cargo.toml" ]; then
-                expr="startswith(\"$PWD\")"
-                break
-              fi
-              # Otherwise, only run checks for changes to subcrates (and not the top-level crate).
-              m=$(find_manifest "$file")
-              if [ "$m" != "$PWD/Cargo.toml" ]; then
-                expr="$expr or (. == \"$m\")"
-              fi
-            done
-            echo "$expr"
-          }
-          # Get the crate names for all changed manifest direcotires
-          crates=$(cargo metadata --frozen --format-version=1 \
-            | jq -cr "[.packages[] | select(.manifest_path | $(manifest_expr $files)) | .name]")
-          echo "::set-output name=crates::$crates"
+        uses: ./.github/actions/list-changed-crates
+        with:
+          files: ${{ steps.changed-files.outputs.all_changed_files }}
     outputs:
       crates: ${{ steps.list-changed.outputs.crates }}
 


### PR DESCRIPTION
Our check-each workflow is subtly broken: we specify a YAML list of
paths to watch for changes, but the `changed-files` action expects a
newline-separated list. This change fixes this configuration.

This change also moves the complicated `list-changed-crates` script into
its own (local) action so that the script is easier to read/test/maintain.