### PR TITLE
ci: Only run the release workflow on PRs that touch the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,11 @@
 name: release
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - .github/actions/package/*
+      - .github/actions/release-tag-meta/*
+      - .github/workflows/release.yml
   push:
     tags:
       - "release/*"


### PR DESCRIPTION
Signed-off-by: Oliver Gould <ver@buoyant.io>