### PR TITLE
dev: Limit devcontainer memory usage to 8GB

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,9 @@
 	// Support docker + debugger
 	"runArgs": [
 		"--init",
+		// Limit container memory usage.
+		"--memory=8g",
+		"--memory-swap=8g",
 		// Use the host network so we can access k3d, etc.
 		"--net=host",
 		// For lldb


### PR DESCRIPTION
Devconatiner memory usage is currently unbounded. This allows runaway
processes (like rust-analyzer) to monopolize system resources, causing
memory exhaustion for the host OS.

This change adds a limit so that the oomkiller reaps devcontainer
processes when they exceed 8GB.

Signed-off-by: Oliver Gould <ver@buoyant.io>