### PR TITLE
tracing: record errors as `&dyn Error`s when possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2566,9 +2566,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.22"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
  "valuable",

--- a/linkerd/app/admin/src/server.rs
+++ b/linkerd/app/admin/src/server.rs
@@ -169,7 +169,7 @@ where
                         let rsp = match level {
                             Some(level) => {
                                 level::serve(&level, req).await.unwrap_or_else(|error| {
-                                    tracing::error!(%error, "Failed to get/set tracing level");
+                                    tracing::error!(error, "Failed to get/set tracing level");
                                     Self::internal_error_rsp(error)
                                 })
                             }

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -296,7 +296,7 @@ impl errors::HttpRescue<Error> for Rescue {
             return Ok(errors::SyntheticHttpResponse::permission_denied(error));
         }
 
-        tracing::warn!(%error, "Unexpected error");
+        tracing::warn!(error, "Unexpected error");
         Ok(errors::SyntheticHttpResponse::unexpected_error())
     }
 }

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -60,7 +60,7 @@ impl Config {
         let resolve_backoff = {
             let backoff = self.connect.backoff;
             move |error: Error| {
-                warn!(%error, "Failed to resolve control-plane component");
+                warn!(error, "Failed to resolve control-plane component");
                 if let Some(e) = error.downcast_ref::<dns::ResolveError>() {
                     if let dns::ResolveErrorKind::NoRecordsFound {
                         negative_ttl: Some(ttl_secs),

--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -323,7 +323,7 @@ where
         };
 
         let rsp = info_span!("rescue", client.addr = %self.client_addr()).in_scope(|| {
-            tracing::info!(%error, "Request failed");
+            tracing::info!(error, "Request failed");
             self.rescue.rescue(error)
         })?;
 

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -34,7 +34,7 @@ pub async fn serve<M, S, I, A>(
                     let (addrs, io) = match conn {
                         Ok(conn) => conn,
                         Err(error) => {
-                            warn!(%error, "Server failed to accept connection");
+                            warn!(error, "Server failed to accept connection");
                             continue;
                         }
                     };
@@ -60,7 +60,7 @@ pub async fn serve<M, S, I, A>(
                                             debug!(%reason, "Connection closed")
                                         }
                                         Err(error) => {
-                                            info!(%error, client.addr = %client_addr, "Connection closed")
+                                            info!(error, client.addr = %client_addr, "Connection closed")
                                         }
                                     }
                                     // Hold the service until the connection is complete. This
@@ -69,7 +69,7 @@ pub async fn serve<M, S, I, A>(
                                     drop(accept);
                                 }
                                 Err(error) => {
-                                    warn!(%error, client.addr = %client_addr, "Server failed to become ready");
+                                    warn!(error, client.addr = %client_addr, "Server failed to become ready");
                                 }
                             }
                         }

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -147,7 +147,7 @@ impl errors::HttpRescue<Error> for ServerRescue {
             return Err(error);
         }
 
-        tracing::warn!(%error, "Unexpected error");
+        tracing::warn!(error, "Unexpected error");
         Ok(errors::SyntheticHttpResponse::unexpected_error())
     }
 }

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -382,7 +382,10 @@ where
                 let f = async move {
                     serve
                         .await
-                        .map_err(|error| tracing::error!(%error, "serving connection failed."))?;
+                        .map_err(|error| tracing::error!(
+                            error = &error as &dyn std::error::Error,
+                            "serving connection failed."
+                        ))?;
                     Ok::<(), ()>(())
                 };
                 tokio::spawn(cancelable(drain.clone(), f).instrument(span.or_current()));

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -380,12 +380,12 @@ where
                 let span = tracing::debug_span!("conn", %addr);
                 let serve = http.serve_connection(sock, svc.clone());
                 let f = async move {
-                    serve
-                        .await
-                        .map_err(|error| tracing::error!(
+                    serve.await.map_err(|error| {
+                        tracing::error!(
                             error = &error as &dyn std::error::Error,
                             "serving connection failed."
-                        ))?;
+                        )
+                    })?;
                     Ok::<(), ()>(())
                 };
                 tokio::spawn(cancelable(drain.clone(), f).instrument(span.or_current()));

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -119,7 +119,7 @@ impl errors::HttpRescue<Error> for ServerRescue {
             return Err(error);
         }
 
-        tracing::warn!(%error, "Unexpected error");
+        tracing::warn!(error, "Unexpected error");
         Ok(errors::SyntheticHttpResponse::unexpected_error())
     }
 }

--- a/linkerd/app/src/dst.rs
+++ b/linkerd/app/src/dst.rs
@@ -70,7 +70,7 @@ impl Recover<Error> for BackoffUnlessInvalidArgument {
             return Err(error);
         }
 
-        tracing::trace!(%error, "Recovering");
+        tracing::trace!(error, "Recovering");
         Ok(self.0.stream())
     }
 }

--- a/linkerd/proxy/discover/src/buffer.rs
+++ b/linkerd/proxy/discover/src/buffer.rs
@@ -172,7 +172,7 @@ where
                 Some(Ok(up)) => up,
                 Some(Err(e)) => {
                     let error: Error = e.into();
-                    warn!(%error, "Discovery task failed");
+                    warn!(error, "Discovery task failed");
                     return Poll::Ready(());
                 }
                 None => {

--- a/linkerd/proxy/identity-client/src/certify.rs
+++ b/linkerd/proxy/identity-client/src/certify.rs
@@ -73,7 +73,7 @@ impl Certify {
                     curr_expiry = expiry
                 }
                 Err(error) => {
-                    error!(%error, "Failed to obtain identity");
+                    error!(error, "Failed to obtain identity");
                 }
             }
 

--- a/linkerd/reconnect/src/lib.rs
+++ b/linkerd/reconnect/src/lib.rs
@@ -113,7 +113,7 @@ where
                     Err(e) => {
                         // If the service fails, try to recover.
                         let error: Error = e.into();
-                        warn!(%error, "Service failed");
+                        warn!(error, "Service failed");
                         let backoff = self.recover.recover(error)?;
                         debug!("Recovering");
                         State::Disconnected {
@@ -137,7 +137,7 @@ where
                         // If the service cannot be built, try to recover using
                         // the existing backoff.
                         let error: Error = e.into();
-                        warn!(%error, "Failed to connect");
+                        warn!(error, "Failed to connect");
                         let new_backoff = self.recover.recover(error)?;
                         debug!("Recovering");
                         State::Disconnected {

--- a/linkerd/service-profiles/src/default.rs
+++ b/linkerd/service-profiles/src/default.rs
@@ -37,7 +37,7 @@ where
         self.0.get_profile(dst).or_else(|e| {
             let error: Error = e.into();
             if crate::DiscoveryRejected::is_rejected(error.as_ref()) {
-                debug!(%error, "Handling rejected discovery");
+                debug!(error, "Handling rejected discovery");
                 return future::ok(None);
             }
 


### PR DESCRIPTION
`tracing-core` v0.1.26 improved support for recording
`std::error::Error` trait objects as structured values rather than as
`fmt::Display` or `fmt::Debug`. This allows the `tracing` subscriber to
log these errors somewhat nicer, such as including the error's `cause`
as a separate field (if it has one).

This branch updates the `tracing-core` dependency to v0.1.26, and
changes `tracing` events that previously recorded `dyn Error`s using
`fmt::Display` to record them using the `Value` impl for `dyn Error`
instead. I didn't touch any errors that had not already been converted
to a `Box<dyn Error + ...>`.