### PR TITLE
outbound: Add logging for endpoint opaqueness

### DIFF
--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -60,8 +60,10 @@ impl<N> Outbound<N> {
                     // detection and just use the TCP stack directly.
                     |target: T| -> Result<_, Infallible> {
                         if let Some(Skip) = target.param() {
+                            tracing::debug!("Skipping HTTP protocol detection");
                             return Ok(svc::Either::B(target));
                         }
+                        tracing::debug!("Attempting HTTP protocol detection");
                         Ok(svc::Either::A(target))
                     },
                     skipped,


### PR DESCRIPTION
The outbound proxy's logging doesn't make it clear how targets decide
whether protocol detection is employed. This change adds debug logging
to make it easier to understand these decisions.

Signed-off-by: Oliver Gould <ver@buoyant.io>