### PR TITLE
Update deprecated codes

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -257,8 +257,8 @@ const DEFAULT_OUTBOUND_ROUTER_MAX_IDLE_AGE: Duration = Duration::from_secs(5);
 // use, as doing so can severely impact CPU utilization for applications with
 // many concurrent requests. It's generally preferable to use the MAX_IDLE_AGE
 // limitations to quickly drop idle connections.
-const DEFAULT_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = std::usize::MAX;
-const DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = std::usize::MAX;
+const DEFAULT_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = usize::MAX;
+const DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = usize::MAX;
 
 // These settings limit the number of requests that have not received responses,
 // including those buffered in the proxy and dispatched to the destination

--- a/linkerd/exp-backoff/src/lib.rs
+++ b/linkerd/exp-backoff/src/lib.rs
@@ -133,7 +133,7 @@ impl Stream for ExponentialBackoffStream {
                 *this.iterations += 1;
                 return Poll::Ready(Some(()));
             }
-            if *this.iterations == std::u32::MAX {
+            if *this.iterations == u32::MAX {
                 return Poll::Ready(None);
             }
 

--- a/linkerd/metrics/src/histogram.rs
+++ b/linkerd/metrics/src/histogram.rs
@@ -281,7 +281,6 @@ mod tests {
 
     use quickcheck::quickcheck;
     use std::collections::HashMap;
-    use std::u64;
 
     static BOUNDS: &Bounds = &Bounds(&[
         Bucket::Le(0.010),

--- a/linkerd/metrics/src/latency.rs
+++ b/linkerd/metrics/src/latency.rs
@@ -47,7 +47,7 @@ impl From<Us> for u64 {
         us.as_micros().try_into().unwrap_or_else(|_| {
             // These measurements should never be long enough to overflow
             tracing::warn!("Duration::as_micros would overflow u64");
-            std::u64::MAX
+            u64::MAX
         })
     }
 }

--- a/linkerd/proxy/api-resolve/src/pb.rs
+++ b/linkerd/proxy/api-resolve/src/pb.rs
@@ -35,7 +35,7 @@ pub fn to_addr_meta(
         }
 
         if let Some(OpaqueTransport { inbound_port }) = hint.opaque_transport {
-            if inbound_port > 0 && inbound_port < std::u16::MAX as u32 {
+            if inbound_port > 0 && inbound_port < u16::MAX as u32 {
                 opaque_transport_port = Some(inbound_port as u16);
             }
         }

--- a/linkerd/proxy/tap/src/grpc/match_.rs
+++ b/linkerd/proxy/tap/src/grpc/match_.rs
@@ -182,7 +182,7 @@ impl TryFrom<observe_request::r#match::Tcp> for TcpMatch {
                     debug_assert!(min == 0 && max == 0);
                     return Err(InvalidMatch::Empty);
                 }
-                if min > u32::from(::std::u16::MAX) || max > u32::from(::std::u16::MAX) {
+                if min > u32::from(u16::MAX) || max > u32::from(u16::MAX) {
                     return Err(InvalidMatch::InvalidPort);
                 }
                 if min > max {
@@ -219,7 +219,7 @@ impl TryFrom<observe_request::r#match::tcp::Netmask> for NetMatch {
     fn try_from(m: observe_request::r#match::tcp::Netmask) -> Result<Self, InvalidMatch> {
         let mask = if m.mask == 0 {
             return Err(InvalidMatch::Empty);
-        } else if m.mask > u32::from(::std::u8::MAX) {
+        } else if m.mask > u32::from(u8::MAX) {
             return Err(InvalidMatch::InvalidNetwork);
         } else {
             m.mask as u8
@@ -365,7 +365,7 @@ mod tests {
                                 Some(InvalidMatch::Empty)
                             } else if ps.min > ps.max && ps.max != 0 {
                                 Some(InvalidMatch::InvalidPort)
-                            } else if ps.min > u32::from(::std::u16::MAX) || ps.max > u32::from(::std::u16::MAX) {
+                            } else if ps.min > u32::from(u16::MAX) || ps.max > u32::from(u16::MAX) {
                                 Some(InvalidMatch::InvalidPort)
                             } else { None }
                         }

--- a/linkerd/service-profiles/src/proto.rs
+++ b/linkerd/service-profiles/src/proto.rs
@@ -168,7 +168,7 @@ fn convert_rsp_match(orig: api::ResponseMatch) -> Option<http::ResponseMatch> {
 }
 
 fn convert_retry_budget(orig: api::RetryBudget) -> Option<Arc<Budget>> {
-    let min_retries = if orig.min_retries_per_second <= ::std::i32::MAX as u32 {
+    let min_retries = if orig.min_retries_per_second <= i32::MAX as u32 {
         orig.min_retries_per_second
     } else {
         warn!(

--- a/linkerd/transport-header/src/lib.rs
+++ b/linkerd/transport-header/src/lib.rs
@@ -70,7 +70,7 @@ impl TransportHeader {
     pub fn encode_prefaced(&self, buf: &mut BytesMut) -> Result<(), Error> {
         let header = self.to_proto();
         let header_len = header.encoded_len();
-        if header_len > std::u32::MAX as usize {
+        if header_len > u32::MAX as usize {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Message length exceeds capacity",
@@ -176,7 +176,7 @@ impl TransportHeader {
             Some(n)
         };
 
-        if h.port <= 0 || h.port > std::u16::MAX as i32 {
+        if h.port <= 0 || h.port > u16::MAX as i32 {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "Invalid port value",


### PR DESCRIPTION
Signed-off-by: Haining <haining.cao@daocloud.io>

`std::usize::MAX` is a deprecated way.

https://doc.rust-lang.org/core/usize/constant.MAX.html