### PR TITLE
ingress: Fall back to normal TCP forwarding

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -10,7 +10,7 @@ pub use linkerd_stack::{
     ExtractParam, Fail, FailFast, Filter, InsertParam, MakeConnection, MapErr, MapTargetLayer,
     NewRouter, NewService, Param, Predicate, UnwrapOr,
 };
-pub use linkerd_stack_tracing::{NewInstrument, NewInstrumentLayer};
+pub use linkerd_stack_tracing::{GetSpan, NewInstrument, NewInstrumentLayer};
 use std::{
     task::{Context, Poll},
     time::Duration,
@@ -258,6 +258,14 @@ impl<S> Stack<S> {
     where
         S: NewService<T>,
         S::Service: Service<Req>,
+    {
+        self
+    }
+
+    pub fn check_new_accept<T, I>(self) -> Self
+    where
+        S: NewService<T>,
+        S::Service: Service<I, Response = ()>,
     {
         self
     }

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -41,13 +41,13 @@ impl<N> Outbound<N> {
                         debug!("Allowing profile lookup");
                         return Ok(profiles::LookupAddr(addr.into()));
                     }
-                    tracing::debug!(
+                    debug!(
                         %addr,
                         networks = %allow.nets(),
-                        "Profile discovery not in configured search networks",
+                        "Address is not in discoverable networks",
                     );
                     Err(profiles::DiscoveryRejected::new(
-                        "not in configured search networks",
+                        "not in discoverable networks",
                     ))
                 }))
                 .push_on_service(

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -1,12 +1,11 @@
-use crate::{tcp, Outbound};
+use crate::Outbound;
 use linkerd_app_core::{
     io, profiles,
     svc::{self, stack::Param},
-    transport::{self, metrics::SensorIo, OrigDstAddr},
+    transport::OrigDstAddr,
     Error,
 };
-use std::convert::TryFrom;
-use tracing::{debug, debug_span, info_span};
+use tracing::debug;
 
 impl<N> Outbound<N> {
     /// Discovers the profile for a TCP endpoint.
@@ -23,41 +22,34 @@ impl<N> Outbound<N> {
     >
     where
         T: Param<OrigDstAddr>,
+        T: Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
-        N: svc::NewService<(Option<profiles::Receiver>, tcp::Accept), Service = NSvc>
-            + Clone
-            + Send
-            + Sync
-            + 'static,
-        NSvc: svc::Service<SensorIo<I>, Response = (), Error = Error> + Send + 'static,
+        N: svc::NewService<(Option<profiles::Receiver>, T), Service = NSvc>,
+        N: Clone + Send + Sync + 'static,
+        NSvc: svc::Service<I, Response = (), Error = Error> + Send + 'static,
         NSvc::Future: Send,
         P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + 'static,
         P::Future: Send,
         P::Error: Send,
     {
-        self.map_stack(|config, rt, accept| {
+        self.map_stack(|config, rt, inner| {
             let allow = config.allow_discovery.clone();
-            accept
-                .push(profiles::discover::layer(
-                    profiles,
-                    move |a: tcp::Accept| {
-                        let OrigDstAddr(addr) = a.orig_dst;
-                        if allow.matches_ip(addr.ip()) {
-                            debug!("Allowing profile lookup");
-                            Ok(profiles::LookupAddr(addr.into()))
-                        } else {
-                            tracing::debug!(
-                                %addr,
-                                networks = %allow.nets(),
-                                "Profile discovery not in configured search networks",
-                            );
-                            Err(profiles::DiscoveryRejected::new(
-                                "not in configured search networks",
-                            ))
-                        }
-                    },
-                ))
-                .instrument(|_: &_| debug_span!("profile"))
+            inner
+                .push(profiles::discover::layer(profiles, move |t: T| {
+                    let OrigDstAddr(addr) = t.param();
+                    if allow.matches_ip(addr.ip()) {
+                        debug!("Allowing profile lookup");
+                        return Ok(profiles::LookupAddr(addr.into()));
+                    }
+                    tracing::debug!(
+                        %addr,
+                        networks = %allow.nets(),
+                        "Profile discovery not in configured search networks",
+                    );
+                    Err(profiles::DiscoveryRejected::new(
+                        "not in configured search networks",
+                    ))
+                }))
                 .push_on_service(
                     svc::layers()
                         // If the traffic split is empty/unavailable, eagerly fail
@@ -77,13 +69,7 @@ impl<N> Outbound<N> {
                         ))
                         .push_spawn_buffer(config.proxy.buffer_capacity),
                 )
-                .push(transport::metrics::NewServer::layer(
-                    rt.metrics.proxy.transport.clone(),
-                ))
                 .push_cache(config.proxy.cache_max_idle_age)
-                .instrument(|a: &tcp::Accept| info_span!("server", orig_dst = %a.orig_dst))
-                .push_request_filter(|t: T| tcp::Accept::try_from(t.param()))
-                .push(rt.metrics.tcp_errors.to_layer())
                 .push(svc::ArcNewService::layer())
                 .check_new_service::<T, I>()
         })
@@ -93,7 +79,7 @@ impl<N> Outbound<N> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::*;
+    use crate::{tcp, test_util::*};
     use linkerd_app_core::{
         svc::{NewService, Service, ServiceExt},
         AddrMatch, IpNet,
@@ -122,7 +108,7 @@ mod tests {
             let new_count = new_count.clone();
             support::track::new_service(move |_| {
                 new_count.fetch_add(1, Ordering::SeqCst);
-                svc::mk(move |_: SensorIo<io::DuplexStream>| {
+                svc::mk(move |_: io::DuplexStream| {
                     future::err::<(), Error>(
                         io::Error::from(io::ErrorKind::ConnectionRefused).into(),
                     )
@@ -193,7 +179,7 @@ mod tests {
             let new_count = new_count.clone();
             support::track::new_service(move |_| {
                 new_count.fetch_add(1, Ordering::SeqCst);
-                svc::mk(move |_: SensorIo<io::DuplexStream>| future::pending::<Result<(), Error>>())
+                svc::mk(move |_: io::DuplexStream| future::pending::<Result<(), Error>>())
             })
         };
 
@@ -313,7 +299,7 @@ mod tests {
         // Mock an inner stack with a service that asserts that no profile is built.
         let stack = |(profile, _): (Option<profiles::Receiver>, _)| {
             assert!(profile.is_none(), "profile must not resolve");
-            svc::mk(move |_: SensorIo<io::DuplexStream>| future::ok::<(), Error>(()))
+            svc::mk(move |_: io::DuplexStream| future::ok::<(), Error>(()))
         };
 
         // Create a profile stack that uses the tracked inner stack, configured to never actually do

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -8,7 +8,7 @@ use linkerd_app_core::{
     },
     svc::{self, stack::Param},
     tls,
-    transport::{self, OrigDstAddr, Remote, ServerAddr},
+    transport::{OrigDstAddr, Remote, ServerAddr},
     AddrMatch, Error, Infallible, NameAddr,
 };
 use thiserror::Error;
@@ -34,14 +34,12 @@ enum Target {
 struct ProfileRequired;
 
 #[derive(Debug, Default, Error)]
-#[error("ingress-mode routing is HTTP-only")]
-struct IngressHttpOnly;
-
-#[derive(Debug, Default, Error)]
 #[error("l5d-dst-override is not a valid host:port")]
 struct InvalidOverrideHeader;
 
 const DST_OVERRIDE_HEADER: &str = "l5d-dst-override";
+
+type DetectIo<I> = io::PrefixedIo<I>;
 
 // === impl Outbound ===
 
@@ -49,8 +47,20 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
     /// Routes HTTP requests according to the l5d-dst-override header.
     ///
     /// This is only intended for Ingress configurations, where we assume all
-    /// outbound traffic is HTTP.
-    pub fn into_ingress<T, I, P, R>(self, profiles: P, resolve: R) -> svc::ArcNewTcp<T, I>
+    /// outbound traffic is HTTP and HTTP detection is **always** performed. If
+    /// HTTP detection fails, we revert to using the provided `fallback` stack.
+    //
+    // Profile-based stacks are cached so that they can be reused across
+    // multiple requests to the same logical destination (even if the
+    // connections target individual endpoints in a service). No other caching
+    // is employed here: per-endpoint stacks are uncached, and fallback stacks
+    // are expected to be cached elsewhere, if necessary.
+    pub fn push_ingress<T, I, P, R, F, FSvc>(
+        self,
+        profiles: P,
+        resolve: R,
+        fallback: F,
+    ) -> Outbound<svc::ArcNewTcp<T, I>>
     where
         T: Param<OrigDstAddr> + Clone + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
@@ -61,185 +71,202 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
         R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
         R::Resolution: Send,
         R::Future: Send + Unpin,
+        F: svc::NewService<tcp::Accept, Service = FSvc> + Clone + Send + Sync + 'static,
+        FSvc: svc::Service<DetectIo<I>, Response = (), Error = Error> + Send + 'static,
+        FSvc::Future: Send,
     {
-        let Outbound {
-            config,
-            runtime: rt,
-            stack: http_logical,
-        } = self.clone().push_http_logical(resolve);
+        let http_endpoint = self.clone().into_stack();
 
-        let http_endpoint = self.into_stack();
-
-        let detect_http = config.proxy.detect_http();
-        let Config {
-            allow_discovery,
-            proxy:
-                ProxyConfig {
-                    server: ServerConfig { h2_settings, .. },
-                    dispatch_timeout,
-                    max_in_flight_requests,
-                    buffer_capacity,
-                    cache_max_idle_age,
+        self.push_http_logical(resolve)
+            .map_stack(|config, rt, http_logical| {
+                let detect_http = config.proxy.detect_http();
+                let Config {
+                    allow_discovery,
+                    proxy:
+                        ProxyConfig {
+                            server: ServerConfig { h2_settings, .. },
+                            dispatch_timeout,
+                            max_in_flight_requests,
+                            buffer_capacity,
+                            cache_max_idle_age,
+                            ..
+                        },
                     ..
-                },
-            ..
-        } = config;
-        let profile_domains = allow_discovery.names().clone();
+                } = config;
+                let profile_domains = allow_discovery.names().clone();
 
-        http_logical
-            // If a profile was discovered, use it to build a logical stack. Otherwise, the override
-            // header was present but no profile information could be discovered, so fail the
-            // request.
-            .push_request_filter(
-                |(profile, http): (Option<profiles::Receiver>, Http<NameAddr>)| {
-                    if let Some(profile) = profile {
-                        if let Some(logical_addr) = profile.logical_addr() {
-                            return Ok(http::Logical {
-                                profile,
-                                logical_addr,
-                                protocol: http.version,
-                            });
-                        }
-                    }
+                let new_http = http_logical
+                    // If a profile was discovered, use it to build a logical stack.
+                    // Otherwise, the override header was present but no profile
+                    // information could be discovered, so fail the request.
+                    .push_request_filter(
+                        |(profile, http): (Option<profiles::Receiver>, Http<NameAddr>)| {
+                            if let Some(profile) = profile {
+                                if let Some(logical_addr) = profile.logical_addr() {
+                                    return Ok(http::Logical {
+                                        profile,
+                                        logical_addr,
+                                        protocol: http.version,
+                                    });
+                                }
+                            }
 
-                    Err(ProfileRequired)
-                },
-            )
-            .push(profiles::discover::layer(
-                profiles,
-                move |h: Http<NameAddr>| {
-                    // Lookup the profile if the override header was set and it is in the configured
-                    // profile domains. Otherwise, profile discovery is skipped.
-                    if profile_domains.matches(h.target.name()) {
-                        return Ok(profiles::LookupAddr(h.target.into()));
-                    }
-
-                    tracing::debug!(
-                        dst = %h.target,
-                        domains = %profile_domains,
-                        "Address not in a configured domain",
-                    );
-                    Err(profiles::DiscoveryRejected::new(
-                        "not in configured ingress search addresses",
-                    ))
-                },
-            ))
-            // This service is buffered because it needs to initialize the profile resolution and a
-            // fail-fast is instrumented in case it becomes unavailable. When this service is in
-            // fail-fast, ensure that we drive the inner service to readiness even if new requests
-            // aren't received.
-            .push_on_service(
-                svc::layers()
-                    .push(
-                        rt.metrics
-                            .proxy
-                            .stack
-                            .layer(stack_labels("http", "logical")),
+                            Err(ProfileRequired)
+                        },
                     )
-                    .push(svc::layer::mk(svc::SpawnReady::new))
-                    .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
-                    .push_spawn_buffer(buffer_capacity),
-            )
-            .push_cache(cache_max_idle_age)
-            .push_on_service(
-                svc::layers()
-                    .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER))
-                    .push(http::Retain::layer())
-                    .push(http::BoxResponse::layer()),
-            )
-            .instrument(|h: &Http<NameAddr>| info_span!("override", dst = %h.target))
-            // Route requests with destinations that can be discovered via the `l5d-dst-override`
-            // header through the (load balanced) logical stack. Route requests without the header
-            // through the endpoint stack.
-            .push_switch(
-                |Http { target, version }: Http<Target>| match target {
-                    Target::Override(target) => {
-                        Ok::<_, Infallible>(svc::Either::A(Http { target, version }))
-                    }
-                    Target::Forward(OrigDstAddr(addr)) => Ok(svc::Either::B(http::Endpoint {
-                        addr: Remote(ServerAddr(addr)),
-                        metadata: Metadata::default(),
-                        logical_addr: None,
-                        protocol: version,
-                        opaque_protocol: false,
-                        tls: tls::ConditionalClientTls::None(
-                            tls::NoClientTls::IngressWithoutOverride,
-                        ),
-                    })),
-                },
-                http_endpoint
+                    .push(profiles::discover::layer(
+                        profiles,
+                        move |h: Http<NameAddr>| {
+                            // Lookup the profile if the override header was set and it
+                            // is in the configured profile domains. Otherwise, profile
+                            // discovery is skipped.
+                            if profile_domains.matches(h.target.name()) {
+                                return Ok(profiles::LookupAddr(h.target.into()));
+                            }
+
+                            tracing::debug!(
+                                dst = %h.target,
+                                domains = %profile_domains,
+                                "Address not in a configured domain",
+                            );
+                            Err(profiles::DiscoveryRejected::new(
+                                "not in configured ingress search addresses",
+                            ))
+                        },
+                    ))
+                    // This service is buffered because it needs to initialize the
+                    // profile resolution and a fail-fast is instrumented in case it
+                    // becomes unavailable. When this service is in fail-fast, ensure
+                    // that we drive the inner service to readiness even if new requests
+                    // aren't received.
                     .push_on_service(
                         svc::layers()
+                            .push(
+                                rt.metrics
+                                    .proxy
+                                    .stack
+                                    .layer(stack_labels("http", "logical")),
+                            )
                             .push(svc::layer::mk(svc::SpawnReady::new))
-                            .push(svc::FailFast::layer("Ingress server", dispatch_timeout)),
+                            .push(svc::FailFast::layer("HTTP Logical", *dispatch_timeout))
+                            .push_spawn_buffer(*buffer_capacity),
                     )
-                    .instrument(|_: &_| info_span!("forward"))
-                    .into_inner(),
-            )
-            .push(svc::ArcNewService::layer())
-            // Obtain a new inner service for each request. Override stacks are cached, as they
-            // depend on discovery that should not be performed many times. Forwarding stacks are
-            // not cached explicitly, as there are no real resources we need to share across
-            // connections. This allows us to avoid buffering requests to these endpoints.
-            .push(svc::NewRouter::layer(
-                |http::Accept { orig_dst, protocol }| {
-                    move |req: &http::Request<_>| {
-                        // Use either the override header or the original destination address.
-                        let target = match http::authority_from_header(req, DST_OVERRIDE_HEADER) {
-                            None => Target::Forward(orig_dst),
-                            Some(a) => {
-                                let dst = NameAddr::from_authority_with_default_port(&a, 80)
-                                    .map_err(|_| InvalidOverrideHeader)?;
-                                Target::Override(dst)
+                    // Caches the profile-based stack so that it can be reused across
+                    // multiple requests to the same canonical destination.
+                    .push_cache(*cache_max_idle_age)
+                    .push_on_service(
+                        svc::layers()
+                            .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER))
+                            .push(http::Retain::layer())
+                            .push(http::BoxResponse::layer()),
+                    )
+                    .instrument(|h: &Http<NameAddr>| info_span!("override", dst = %h.target))
+                    // Route requests with destinations that can be discovered via the
+                    // `l5d-dst-override` header through the (load balanced) logical
+                    // stack. Route requests without the header through the endpoint
+                    // stack.
+                    //
+                    // Stacks with an override are cached and reused. Endpoint stacks
+                    // are not.
+                    .push_switch(
+                        |Http { target, version }: Http<Target>| match target {
+                            Target::Override(target) => {
+                                Ok::<_, Infallible>(svc::Either::A(Http { target, version }))
                             }
-                        };
-                        Ok(Http {
-                            target,
-                            version: protocol,
-                        })
-                    }
-                },
-            ))
-            .push(http::NewNormalizeUri::layer())
-            .push_on_service(
-                svc::layers()
-                    .push(http::MarkAbsoluteForm::layer())
-                    // The concurrency-limit can force the service into fail-fast, but it need not
-                    // be driven to readiness on a background task (i.e., by `SpawnReady`).
-                    // Otherwise, the inner service is always ready (because it's a router).
-                    .push(svc::ConcurrencyLimitLayer::new(max_in_flight_requests))
-                    .push(svc::FailFast::layer("Ingress server", dispatch_timeout))
-                    .push(rt.metrics.http_errors.to_layer()),
-            )
-            .push(http::ServerRescue::layer(config.emit_headers))
-            .push_on_service(
-                svc::layers()
-                    .push(http_tracing::server(rt.span_sink, trace_labels()))
-                    .push(http::BoxResponse::layer())
-                    .push(http::BoxRequest::layer()),
-            )
-            .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol))
-            .push(http::NewServeHttp::layer(h2_settings, rt.drain))
-            .push_request_filter(|(http, accept): (Option<http::Version>, _)| {
-                http.map(|h| http::Accept::from((h, accept)))
-                    .ok_or(IngressHttpOnly)
+                            Target::Forward(OrigDstAddr(addr)) => {
+                                Ok(svc::Either::B(http::Endpoint {
+                                    addr: Remote(ServerAddr(addr)),
+                                    metadata: Metadata::default(),
+                                    logical_addr: None,
+                                    protocol: version,
+                                    opaque_protocol: false,
+                                    tls: tls::ConditionalClientTls::None(
+                                        tls::NoClientTls::IngressWithoutOverride,
+                                    ),
+                                }))
+                            }
+                        },
+                        http_endpoint
+                            .push_on_service(
+                                svc::layers()
+                                    .push(svc::layer::mk(svc::SpawnReady::new))
+                                    .push(svc::FailFast::layer(
+                                        "Ingress server",
+                                        *dispatch_timeout,
+                                    )),
+                            )
+                            .instrument(|_: &_| info_span!("forward"))
+                            .into_inner(),
+                    )
+                    .push(svc::ArcNewService::layer())
+                    // Obtain a new inner service for each request. Override stacks are
+                    // cached, as they depend on discovery that should not be performed
+                    // many times. Forwarding stacks are not cached explicitly, as there
+                    // are no real resources we need to share across connections. This
+                    // allows us to avoid buffering requests to these endpoints.
+                    .push(svc::NewRouter::layer(
+                        |http::Accept { orig_dst, protocol }| {
+                            move |req: &http::Request<_>| {
+                                // Use either the override header or the original destination address.
+                                let target =
+                                    match http::authority_from_header(req, DST_OVERRIDE_HEADER) {
+                                        None => Target::Forward(orig_dst),
+                                        Some(a) => {
+                                            let dst =
+                                                NameAddr::from_authority_with_default_port(&a, 80)
+                                                    .map_err(|_| InvalidOverrideHeader)?;
+                                            Target::Override(dst)
+                                        }
+                                    };
+                                Ok(Http {
+                                    target,
+                                    version: protocol,
+                                })
+                            }
+                        },
+                    ))
+                    .push(http::NewNormalizeUri::layer())
+                    .push_on_service(
+                        svc::layers()
+                            .push(http::MarkAbsoluteForm::layer())
+                            // The concurrency-limit can force the service into
+                            // fail-fast, but it need not be driven to readiness on a
+                            // background task (i.e., by `SpawnReady`).  Otherwise, the
+                            // inner service is always ready (because it's a router).
+                            .push(svc::ConcurrencyLimitLayer::new(*max_in_flight_requests))
+                            .push(svc::FailFast::layer("Ingress server", *dispatch_timeout))
+                            .push(rt.metrics.http_errors.to_layer()),
+                    )
+                    .push(http::ServerRescue::layer(config.emit_headers))
+                    .push_on_service(
+                        svc::layers()
+                            .push(http_tracing::server(rt.span_sink.clone(), trace_labels()))
+                            .push(http::BoxResponse::layer())
+                            .push(http::BoxRequest::layer()),
+                    )
+                    .instrument(|a: &http::Accept| debug_span!("http", v = %a.protocol));
+
+                // HTTP detection is **always** performed. If detection fails, then we
+                // use the `fallback` stack to process the connection by its original
+                // destination address.
+                new_http
+                    .push(http::NewServeHttp::layer(*h2_settings, rt.drain.clone()))
+                    .push_switch(
+                        |(http, t): (Option<http::Version>, T)| -> Result<_, Infallible> {
+                            let accept = tcp::Accept::from(t.param());
+                            if let Some(version) = http {
+                                Ok(svc::Either::A(http::Accept::from((version, accept))))
+                            } else {
+                                Ok(svc::Either::B(accept))
+                            }
+                        },
+                        fallback,
+                    )
+                    .push_map_target(detect::allow_timeout)
+                    .push(detect::NewDetectService::layer(detect_http))
+                    .push_on_service(svc::BoxService::layer())
+                    .push(svc::ArcNewService::layer())
+                    .check_new_service::<T, I>()
             })
-            .push_cache(cache_max_idle_age)
-            .push_map_target(detect::allow_timeout)
-            .push(svc::ArcNewService::layer())
-            .push(detect::NewDetectService::layer(detect_http))
-            .push(transport::metrics::NewServer::layer(
-                rt.metrics.proxy.transport.clone(),
-            ))
-            .instrument(|a: &tcp::Accept| info_span!("ingress", orig_dst = %a.orig_dst))
-            .push_map_target(|a: T| {
-                let orig_dst = Param::<OrigDstAddr>::param(&a);
-                tcp::Accept::from(orig_dst)
-            })
-            .push(rt.metrics.tcp_errors.to_layer())
-            .push_on_service(svc::BoxService::layer())
-            .push(svc::ArcNewService::layer())
-            .check_new_service::<T, I>()
-            .into_inner()
     }
 }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -173,23 +173,74 @@ impl Outbound<()> {
     {
         if self.config.ingress_mode {
             info!("Outbound routing in ingress-mode");
-            let stack = self
-                .to_tcp_connect()
-                .push_tcp_endpoint()
-                .push_http_endpoint()
-                .into_ingress(profiles, resolve);
-            let shutdown = self.runtime.drain.signaled();
-            serve::serve(listen, stack, shutdown).await;
-        } else {
-            let logical = self.to_tcp_connect().push_logical(resolve);
-            let endpoint = self.to_tcp_connect().push_endpoint();
-            let server = endpoint
-                .push_switch_logical(logical.into_inner())
-                .push_discover(profiles)
-                .into_inner();
+            let server = self.mk_ingress(profiles, resolve);
             let shutdown = self.runtime.drain.signaled();
             serve::serve(listen, server, shutdown).await;
+        } else {
+            let proxy = self.mk_proxy(profiles, resolve);
+            let shutdown = self.runtime.drain.signaled();
+            serve::serve(listen, proxy, shutdown).await;
         }
+    }
+
+    fn mk_proxy<T, I, P, R>(&self, profiles: P, resolve: R) -> svc::ArcNewTcp<T, I>
+    where
+        T: Param<OrigDstAddr> + Clone + Send + Sync + 'static,
+        I: io::AsyncRead + io::AsyncWrite + io::Peek + io::PeerAddr,
+        I: Debug + Unpin + Send + Sync + 'static,
+        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
+        R: Clone + Send + Sync + Unpin + 'static,
+        R::Resolution: Send,
+        R::Future: Send + Unpin,
+        P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + Unpin + 'static,
+        P::Future: Send,
+        P::Error: Send,
+    {
+        let logical = self.to_tcp_connect().push_logical(resolve);
+        let endpoint = self.to_tcp_connect().push_endpoint();
+        endpoint
+            .push_switch_logical(logical.into_inner())
+            .push_discover(profiles)
+            .push_tcp_instrument(|t: &T| tracing::info_span!("proxy", addr = %t.param()))
+            .into_inner()
+    }
+
+    /// Builds a an "ingress mode" proxy.
+    ///
+    /// Ingress-mode proxies route based on request headers instead of using the
+    /// original destination. Protocol detection is **always** performed. If it
+    /// fails, we revert to using the normal IP-based discovery
+    fn mk_ingress<T, I, P, R>(&self, profiles: P, resolve: R) -> svc::ArcNewTcp<T, I>
+    where
+        T: Param<OrigDstAddr> + Clone + Send + Sync + 'static,
+        I: io::AsyncRead + io::AsyncWrite + io::Peek + io::PeerAddr,
+        I: Debug + Unpin + Send + Sync + 'static,
+        R: Clone + Send + Sync + Unpin + 'static,
+        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
+        R::Resolution: Send,
+        R::Future: Send + Unpin,
+        P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + Unpin + 'static,
+        P::Future: Send,
+        P::Error: Send,
+    {
+        // The fallback stack is the same thing as the normal proxy stack, but
+        // it doesn't include TCP metrics, since they are already instrumented
+        // on this ingress stack.
+        let fallback = {
+            let logical = self.to_tcp_connect().push_logical(resolve.clone());
+            let endpoint = self.to_tcp_connect().push_endpoint();
+            endpoint
+                .push_switch_logical(logical.into_inner())
+                .push_discover(profiles.clone())
+                .into_inner()
+        };
+
+        self.to_tcp_connect()
+            .push_tcp_endpoint()
+            .push_http_endpoint()
+            .push_ingress(profiles, resolve, fallback)
+            .push_tcp_instrument(|t: &T| tracing::info_span!("ingress", addr = %t.param()))
+            .into_inner()
     }
 }
 

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -47,7 +47,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tracing::info;
+use tracing::{info, info_span};
 
 const EWMA_DEFAULT_RTT: Duration = Duration::from_millis(30);
 const EWMA_DECAY: Duration = Duration::from_secs(10);
@@ -201,7 +201,7 @@ impl Outbound<()> {
         endpoint
             .push_switch_logical(logical.into_inner())
             .push_discover(profiles)
-            .push_tcp_instrument(|t: &T| tracing::info_span!("proxy", addr = %t.param()))
+            .push_tcp_instrument(|t: &T| info_span!("proxy", addr = %t.param()))
             .into_inner()
     }
 
@@ -239,7 +239,7 @@ impl Outbound<()> {
             .push_tcp_endpoint()
             .push_http_endpoint()
             .push_ingress(profiles, resolve, fallback)
-            .push_tcp_instrument(|t: &T| tracing::info_span!("ingress", addr = %t.param()))
+            .push_tcp_instrument(|t: &T| info_span!("ingress", addr = %t.param()))
             .into_inner()
     }
 }

--- a/linkerd/app/outbound/src/switch_logical.rs
+++ b/linkerd/app/outbound/src/switch_logical.rs
@@ -196,7 +196,6 @@ mod tests {
 
         let endpoint_addr = SocketAddr::new([192, 0, 2, 20].into(), 2020);
         let endpoint = {
-            let endpoint_addr = endpoint_addr.clone();
             move |ep: tcp::Endpoint| {
                 assert_eq!(ep.addr.as_ref(), &endpoint_addr);
                 assert!(ep.opaque_protocol, "protocol must be marked opaque");

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -40,6 +40,7 @@ impl svc::Param<Option<SessionProtocol>> for Endpoint {
 }
 
 impl<N> Outbound<N> {
+    /// Wraps a TCP accept stack with tracing and metrics instrumentation.
     pub fn push_tcp_instrument<T, I, G, NSvc>(self, mk_span: G) -> Outbound<svc::ArcNewTcp<T, I>>
     where
         T: svc::Param<OrigDstAddr> + Clone + Send + 'static,

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -1,10 +1,17 @@
+use crate::Outbound;
+use linkerd_app_core::{
+    io, svc,
+    transport::{metrics, OrigDstAddr},
+    transport_header::SessionProtocol,
+    Error,
+};
+
 pub mod connect;
 pub mod logical;
 pub mod opaque_transport;
 
 pub use self::connect::Connect;
 pub use linkerd_app_core::proxy::tcp::Forward;
-use linkerd_app_core::{svc::Param, transport::OrigDstAddr, transport_header::SessionProtocol};
 
 pub type Accept = crate::Accept<()>;
 pub type Logical = crate::logical::Logical<()>;
@@ -26,8 +33,34 @@ impl<P> From<(P, Accept)> for crate::Accept<P> {
     }
 }
 
-impl Param<Option<SessionProtocol>> for Endpoint {
+impl svc::Param<Option<SessionProtocol>> for Endpoint {
     fn param(&self) -> Option<SessionProtocol> {
         None
+    }
+}
+
+impl<N> Outbound<N> {
+    pub fn push_tcp_instrument<T, I, G, NSvc>(self, mk_span: G) -> Outbound<svc::ArcNewTcp<T, I>>
+    where
+        T: svc::Param<OrigDstAddr> + Clone + Send + 'static,
+        G: svc::GetSpan<T> + Clone + Send + Sync + 'static,
+        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+        N: svc::NewService<Accept, Service = NSvc> + Clone + Send + Sync + 'static,
+        NSvc: svc::Service<metrics::SensorIo<I>, Response = (), Error = Error> + Send + 'static,
+        NSvc::Future: Send,
+    {
+        self.map_stack(|_, rt, inner| {
+            inner
+                .push(metrics::NewServer::layer(
+                    rt.metrics.proxy.transport.clone(),
+                ))
+                .push_request_filter(|t: T| Accept::try_from(t.param()))
+                .push(rt.metrics.tcp_errors.to_layer())
+                .instrument(mk_span)
+                .check_new_service::<T, I>()
+                .push_on_service(svc::BoxService::layer())
+                .push(svc::ArcNewService::layer())
+                .check_new_service::<T, I>()
+        })
     }
 }


### PR DESCRIPTION
Currently, ingress-mode proxies ONLY support HTTP traffic. This is an
unfortunate tradeoff, as ingress may make arbitrary outbound connections
(e.g., TLS calls to external services). To avoid requiring that these
connections be completely skipped from the proxy, we can fallback to
transporting these connections after HTTP detection fails.

Ingress-mode proxies DO NOT fully honor port opacity configurations:
HTTP detection is always performed before discovery is attempted.

Fixes linkerd/linkerd2#7238

Signed-off-by: Oliver Gould <ver@buoyant.io>