### PR TITLE
metrics: add `process_uptime_seconds_total` metric

### DIFF
--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -12,7 +12,7 @@ use std::{
     fmt::{self, Write},
     net::SocketAddr,
     sync::Arc,
-    time::{Duration, SystemTime},
+    time::Duration,
 };
 
 pub type ControlHttp = http_metrics::Requests<ControlLabels, Class>;
@@ -124,8 +124,11 @@ where
 // === impl Metrics ===
 
 impl Metrics {
-    pub fn new(retain_idle: Duration) -> (Self, impl FmtMetrics + Clone + Send + 'static) {
-        let process = telemetry::process::Report::new(SystemTime::now());
+    pub fn new(
+        retain_idle: Duration,
+        start_time: telemetry::StartTime,
+    ) -> (Self, impl FmtMetrics + Clone + Send + 'static) {
+        let process = telemetry::process::Report::new(start_time);
 
         let build_info = telemetry::build_info::Report::new();
 

--- a/linkerd/app/core/src/telemetry.rs
+++ b/linkerd/app/core/src/telemetry.rs
@@ -1,2 +1,3 @@
 pub mod build_info;
 pub mod process;
+pub use self::process::StartTime;

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -75,7 +75,8 @@ pub fn default_config() -> Config {
 pub fn runtime() -> (ProxyRuntime, drain::Signal) {
     let (drain_tx, drain) = drain::channel();
     let (tap, _) = tap::new();
-    let (metrics, _) = metrics::Metrics::new(std::time::Duration::from_secs(10));
+    let (metrics, _) =
+        metrics::Metrics::new(std::time::Duration::from_secs(10), Default::default());
     let runtime = ProxyRuntime {
         identity: rustls::creds::default_for_test().1.into(),
         metrics: metrics.proxy,

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -367,7 +367,14 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
                         let bind_adm = listen::BindTcp::default();
                         let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::unbounded_channel();
                         let main = config
-                            .build(bind_in, bind_out, bind_adm, shutdown_tx, trace_handle)
+                            .build(
+                                bind_in,
+                                bind_out,
+                                bind_adm,
+                                shutdown_tx,
+                                trace_handle,
+                                Default::default(),
+                            )
                             .await
                             .expect("config");
 

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -51,7 +51,8 @@ pub(crate) fn default_config() -> Config {
 pub(crate) fn runtime() -> (ProxyRuntime, drain::Signal) {
     let (drain_tx, drain) = drain::channel();
     let (tap, _) = tap::new();
-    let (metrics, _) = metrics::Metrics::new(std::time::Duration::from_secs(10));
+    let (metrics, _) =
+        metrics::Metrics::new(std::time::Duration::from_secs(10), Default::default());
     let runtime = ProxyRuntime {
         identity: linkerd_meshtls_rustls::creds::default_for_test().1.into(),
         metrics: metrics.proxy,

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -24,6 +24,7 @@ use linkerd_app_core::{
     dns, drain,
     metrics::FmtMetrics,
     svc::Param,
+    telemetry,
     transport::{listen::Bind, ClientAddr, Local, OrigDstAddr, Remote, ServerAddr},
     Error, ProxyRuntime,
 };
@@ -93,6 +94,7 @@ impl Config {
         bind_admin: BAdmin,
         shutdown_tx: mpsc::UnboundedSender<()>,
         log_level: trace::Handle,
+        start_time: telemetry::StartTime,
     ) -> Result<App, Error>
     where
         BIn: Bind<ServerConfig> + 'static,
@@ -114,7 +116,7 @@ impl Config {
             tap,
         } = self;
         debug!("building app");
-        let (metrics, report) = Metrics::new(admin.metrics_retain_idle);
+        let (metrics, report) = Metrics::new(admin.metrics_retain_idle, start_time);
 
         let dns = dns.build();
 

--- a/linkerd/tracing/src/lib.rs
+++ b/linkerd/tracing/src/lib.rs
@@ -14,6 +14,7 @@ mod uptime;
 use self::uptime::Uptime;
 use linkerd_error::Error;
 use std::str;
+use tokio::time::Instant;
 use tracing::{Dispatch, Subscriber};
 use tracing_subscriber::{
     filter::{FilterFn, LevelFilter},
@@ -31,32 +32,17 @@ const DEFAULT_LOG_LEVEL: &str = "warn,linkerd=info";
 const DEFAULT_LOG_FORMAT: &str = "PLAIN";
 
 #[derive(Debug, Default)]
+#[must_use]
 pub struct Settings {
     filter: Option<String>,
     format: Option<String>,
+    start_time: Option<Instant>,
     access_log: Option<access_log::Format>,
     is_test: bool,
 }
 
 #[derive(Clone)]
 pub struct Handle(Option<level::Handle>);
-
-/// Initialize tracing and logging with the value of the `ENV_LOG`
-/// environment variable as the verbosity-level filter.
-pub fn init() -> Result<Handle, Error> {
-    let (dispatch, handle) = match Settings::from_env() {
-        Some(s) => s.build(),
-        None => return Ok(Handle(None)),
-    };
-
-    // Set the default subscriber.
-    tracing::dispatcher::set_global_default(dispatch)?;
-
-    // Set up log compatibility.
-    init_log_compat()?;
-
-    Ok(handle)
-}
 
 #[inline]
 pub(crate) fn update_max_level() {
@@ -74,26 +60,28 @@ pub fn init_log_compat() -> Result<(), Error> {
 // === impl Settings ===
 
 impl Settings {
-    pub fn from_env() -> Option<Self> {
-        let filter = std::env::var(ENV_LOG_LEVEL).ok();
-        if let Some(level) = filter.as_ref() {
-            if level.to_uppercase().trim() == "OFF" {
-                return None;
-            }
-        }
-
-        Some(Self {
-            filter,
+    pub fn from_env() -> Self {
+        Self {
+            filter: std::env::var(ENV_LOG_LEVEL).ok(),
             format: std::env::var(ENV_LOG_FORMAT).ok(),
             access_log: Self::access_log_format(),
+            start_time: None,
             is_test: false,
-        })
+        }
+    }
+
+    pub fn with_start_time(self, start: Instant) -> Self {
+        Self {
+            start_time: Some(start),
+            ..self
+        }
     }
 
     fn for_test(filter: String, format: String) -> Self {
         Self {
             filter: Some(filter),
             format: Some(format),
+            start_time: None,
             access_log: Self::access_log_format(),
             is_test: true,
         }
@@ -117,13 +105,19 @@ impl Settings {
         }
     }
 
+    fn timer(&self) -> Uptime {
+        self.start_time
+            .map(Uptime::starting_at)
+            .unwrap_or_else(Uptime::starting_now)
+    }
+
     fn mk_json<S>(&self) -> Box<dyn Layer<S> + Send + Sync + 'static>
     where
         S: Subscriber + for<'span> LookupSpan<'span>,
         S: Send + Sync,
     {
         let fmt = tracing_subscriber::fmt::format()
-            .with_timer(Uptime::starting_now())
+            .with_timer(self.timer())
             .with_thread_ids(!self.is_test)
             // Configure the formatter to output JSON logs.
             .json()
@@ -153,7 +147,7 @@ impl Settings {
         S: Send + Sync,
     {
         let fmt = tracing_subscriber::fmt::format()
-            .with_timer(Uptime::starting_now())
+            .with_timer(self.timer())
             .with_thread_ids(!self.is_test);
         let fmt = tracing_subscriber::fmt::layer().event_format(fmt);
         if self.is_test {
@@ -161,6 +155,23 @@ impl Settings {
         } else {
             Box::new(fmt)
         }
+    }
+
+    /// Initialize tracing and logging with the value of the `ENV_LOG`
+    /// environment variable as the verbosity-level filter.
+    pub fn init(self) -> Result<Handle, Error> {
+        let (dispatch, handle) = match self.filter.as_deref() {
+            Some(filter) if filter.trim().eq_ignore_ascii_case("off") => return Ok(Handle(None)),
+            _ => self.build(),
+        };
+
+        // Set the default subscriber.
+        tracing::dispatcher::set_global_default(dispatch)?;
+
+        // Set up log compatibility.
+        init_log_compat()?;
+
+        Ok(handle)
     }
 
     pub fn build(self) -> (Dispatch, Handle) {

--- a/linkerd/tracing/src/lib.rs
+++ b/linkerd/tracing/src/lib.rs
@@ -60,20 +60,13 @@ pub fn init_log_compat() -> Result<(), Error> {
 // === impl Settings ===
 
 impl Settings {
-    pub fn from_env() -> Self {
+    pub fn from_env(start_time: Instant) -> Self {
         Self {
             filter: std::env::var(ENV_LOG_LEVEL).ok(),
             format: std::env::var(ENV_LOG_FORMAT).ok(),
             access_log: Self::access_log_format(),
-            start_time: None,
+            start_time: Some(start_time),
             is_test: false,
-        }
-    }
-
-    pub fn with_start_time(self, start: Instant) -> Self {
-        Self {
-            start_time: Some(start),
-            ..self
         }
     }
 

--- a/linkerd/tracing/src/uptime.rs
+++ b/linkerd/tracing/src/uptime.rs
@@ -13,6 +13,10 @@ impl Uptime {
         }
     }
 
+    pub(crate) fn starting_at(start_time: Instant) -> Self {
+        Self { start_time }
+    }
+
     fn format(d: Duration, w: &mut impl fmt::Write) -> fmt::Result {
         let micros = d.subsec_micros();
         write!(w, "[{:>6}.{:06}s]", d.as_secs(), micros)

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -33,10 +33,7 @@ const EX_USAGE: i32 = 64;
 
 fn main() {
     let start_time = StartTime::now();
-    let trace = match trace::Settings::from_env()
-        .with_start_time(start_time.into())
-        .init()
-    {
+    let trace = match trace::Settings::from_env(start_time.into()).init() {
         Ok(t) => t,
         Err(e) => {
             eprintln!("Invalid logging configuration: {}", e);


### PR DESCRIPTION
The proxy exposes a `process_cpu_seconds_total` metric. It also exposes
a `process_start_time_seconds` metric. But given a random metrics
snapshot, we have no way of knowing the proxy's uptime unless we know
the current time at the time of the snapshot. linkerd/linkerd2#8443
proposed adding a `process_uptime_seconds_total` metric tracking the
(fractional) number of seconds since the process started, to make these
other process metrics easier to interpret.

This branch implements the `process_uptime_seconds_total` metric.
Actually adding the metric is rather simple.

However, it occurred to me that uptimes are also used as timestamps in
the proxy's `tracing` logs. Currently, the start time used to calculate
log timestamps is just recorded when constructing the logger. If
separate `Instant`s are used as the start time for log uptime timestamps
and for the `process_uptime_seconds_total` metric, this means the
process' uptime as reported by the metrics endpoint and the process'
uptime according to log messages may not quite agree. Therefore, I
thought it would be good if a single `Instant` was used for both logging
and metrics, and I made some additional changes so that we can record a
single timestamp when the proxy starts, and pass it into both the
metrics endpoint and the logger. This does make this branch a slightly
larger change, though.

Closes linkerd/linkerd2#8443