### PR TITLE
ci: change how warnings are denied on CI

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -15,6 +15,7 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
+  RUSTFLAGS: "-D warnings"
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,7 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
+  RUSTFLAGS: "-D warnings -A deprecated"
 
 jobs:
   release:

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -20,6 +20,7 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
+  RUSTFLAGS: "-D warnings -A deprecated"
 
 jobs:
   check-all:

--- a/.github/workflows/check-each.yml
+++ b/.github/workflows/check-each.yml
@@ -23,6 +23,7 @@ env:
   DEBIAN_FRONTEND: noninteractive
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
+  RUSTFLAGS: "-D warnings -A deprecated"
 
 jobs:
   list-changed-crates:

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -11,6 +11,7 @@ on:
       - .github/workflows/deps.yml
 
 env:
+  CARGO_ACTION_FMT_VERSION: v0.1.3
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -39,3 +39,27 @@ jobs:
     - uses: EmbarkStudios/cargo-deny-action@3481b77dfd7b1d3c62bebdbfb57695131cd59c8f
       with:
         command: check bans licenses sources
+
+  # Check for upstream deprecations
+  deprecated:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    container:
+      image: docker://rust:1.60.0-bullseye
+    steps:
+      - run: |
+          curl --proto =https --tlsv1.3 -vsSfLo /usr/local/bin/cargo-action-fmt "https://github.com/olix0r/cargo-action-fmt/releases/download/release%2F${CARGO_ACTION_FMT_VERSION}/cargo-action-fmt-x86_64-unknown-linux-gnu"
+          chmod 755 /usr/local/bin/cargo-action-fmt
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: ./.github/actions/install-protoc
+      - run: cargo fetch
+      - name: cargo check (deny deprecations)
+        env:
+          RUSTFLAGS: "-D deprecated"
+        run: |
+          cargo check --frozen \
+            --workspace \
+            --all-targets \
+            --exclude=linkerd-meshtls-boring \
+            --message-format=json | cargo-action-fmt
+

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,7 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
+  RUSTFLAGS: "-D warnings -A deprecated"
 
 # Run only the app-level tests. These may take longer to compile (usually due to very large stack
 # types) and have the potential to be flakey as they depend on opening sockets and may have timing

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,7 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
+  RUSTFLAGS: "-D warnings"
 
 permissions:
   contents: read

--- a/hyper-balance/src/lib.rs
+++ b/hyper-balance/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use hyper::body::HttpBody;

--- a/linkerd/addr/src/lib.rs
+++ b/linkerd/addr/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 use linkerd_dns_name::Name;
 use std::{

--- a/linkerd/app/admin/src/lib.rs
+++ b/linkerd/app/admin/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod server;

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -7,12 +7,7 @@
 //! - Tap
 //! - Metric labeling
 
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub use drain;

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod gateway;

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -23,7 +23,9 @@ use linkerd_app_core::{
     http_tracing::OpenCensusSink,
     identity, io,
     proxy::{tap, tcp},
-    svc, Error, NameMatch, ProxyRuntime,
+    svc,
+    transport::{self, Remote, ServerAddr},
+    Error, NameMatch, ProxyRuntime,
 };
 use std::{fmt::Debug, time::Duration};
 use thiserror::Error;

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -3,12 +3,7 @@
 //! The inbound proxy is responsible for terminating traffic from other network
 //! endpoints inbound to the local application.
 
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod accept;
@@ -28,9 +23,7 @@ use linkerd_app_core::{
     http_tracing::OpenCensusSink,
     identity, io,
     proxy::{tap, tcp},
-    svc,
-    transport::{self, Remote, ServerAddr},
-    Error, NameMatch, ProxyRuntime,
+    svc, Error, NameMatch, ProxyRuntime,
 };
 use std::{fmt::Debug, time::Duration};
 use thiserror::Error;

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -1,11 +1,6 @@
 //! Shared infrastructure for integration tests
 
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![warn(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod test_env;

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -2,11 +2,7 @@
 //!
 //! The outbound proxy is responsible for routing traffic from the local application to other hosts.
 
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod discover;

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -3,7 +3,6 @@
 //! The outbound proxy is responsible for routing traffic from the local application to other hosts.
 
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -1,10 +1,6 @@
 //! Configures and executes the proxy
 
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub mod dst;

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -1,7 +1,6 @@
 //! Configures and executes the proxy
 
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/app/test/src/lib.rs
+++ b/linkerd/app/test/src/lib.rs
@@ -1,7 +1,6 @@
 //! Shared infrastructure for integration tests
 
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/app/test/src/lib.rs
+++ b/linkerd/app/test/src/lib.rs
@@ -1,10 +1,6 @@
 //! Shared infrastructure for integration tests
 
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub use futures::{future, FutureExt, TryFuture, TryFutureExt};

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use linkerd_stack::{layer, NewService};

--- a/linkerd/conditional/src/lib.rs
+++ b/linkerd/conditional/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 /// Like `std::option::Option<C>` but `None` carries a reason why the value

--- a/linkerd/detect/src/lib.rs
+++ b/linkerd/detect/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use bytes::BytesMut;

--- a/linkerd/detect/src/lib.rs
+++ b/linkerd/detect/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/dns/name/src/lib.rs
+++ b/linkerd/dns/name/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/dns/name/src/lib.rs
+++ b/linkerd/dns/name/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod name;

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use linkerd_dns_name::NameRef;

--- a/linkerd/duplex/src/lib.rs
+++ b/linkerd/duplex/src/lib.rs
@@ -3,7 +3,6 @@
 //! This module uses unsafe code to implement [`BufMut`].
 
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types,

--- a/linkerd/errno/src/lib.rs
+++ b/linkerd/errno/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/errno/src/lib.rs
+++ b/linkerd/errno/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use std::fmt;

--- a/linkerd/error-respond/src/lib.rs
+++ b/linkerd/error-respond/src/lib.rs
@@ -1,7 +1,6 @@
 //! Layer to map service errors into responses.
 
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/error-respond/src/lib.rs
+++ b/linkerd/error-respond/src/lib.rs
@@ -1,10 +1,6 @@
 //! Layer to map service errors into responses.
 
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use futures::{ready, TryFuture};

--- a/linkerd/error/src/lib.rs
+++ b/linkerd/error/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub mod recover;

--- a/linkerd/exp-backoff/src/lib.rs
+++ b/linkerd/exp-backoff/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/exp-backoff/src/lib.rs
+++ b/linkerd/exp-backoff/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use futures::Stream;

--- a/linkerd/http-access-log/src/lib.rs
+++ b/linkerd/http-access-log/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use futures_core::TryFuture;

--- a/linkerd/http-access-log/src/lib.rs
+++ b/linkerd/http-access-log/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/http-box/src/lib.rs
+++ b/linkerd/http-box/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/http-box/src/lib.rs
+++ b/linkerd/http-box/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod body;

--- a/linkerd/http-classify/src/lib.rs
+++ b/linkerd/http-classify/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod service;

--- a/linkerd/http-metrics/src/lib.rs
+++ b/linkerd/http-metrics/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/http-metrics/src/lib.rs
+++ b/linkerd/http-metrics/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub use self::{requests::Requests, retries::Retries};

--- a/linkerd/http-retry/src/lib.rs
+++ b/linkerd/http-retry/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/http-retry/src/lib.rs
+++ b/linkerd/http-retry/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};

--- a/linkerd/identity/src/lib.rs
+++ b/linkerd/identity/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/identity/src/lib.rs
+++ b/linkerd/identity/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod credentials;

--- a/linkerd/io/src/lib.rs
+++ b/linkerd/io/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/io/src/lib.rs
+++ b/linkerd/io/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod boxed;

--- a/linkerd/meshtls/boring/src/lib.rs
+++ b/linkerd/meshtls/boring/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 //! This crate provides an implementation of _meshtls_ backed by `boringssl` (as

--- a/linkerd/meshtls/boring/src/lib.rs
+++ b/linkerd/meshtls/boring/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/meshtls/rustls/src/lib.rs
+++ b/linkerd/meshtls/rustls/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/meshtls/rustls/src/lib.rs
+++ b/linkerd/meshtls/rustls/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod client;

--- a/linkerd/meshtls/src/lib.rs
+++ b/linkerd/meshtls/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/meshtls/src/lib.rs
+++ b/linkerd/meshtls/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 //! This crate provides a static interface for the proxy's x509 certificate

--- a/linkerd/meshtls/tests/boring.rs
+++ b/linkerd/meshtls/tests/boring.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "boring")]
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/meshtls/tests/boring.rs
+++ b/linkerd/meshtls/tests/boring.rs
@@ -1,9 +1,5 @@
 #![cfg(feature = "boring")]
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod util;

--- a/linkerd/meshtls/tests/rustls.rs
+++ b/linkerd/meshtls/tests/rustls.rs
@@ -1,9 +1,5 @@
 #![cfg(feature = "rustls")]
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod util;

--- a/linkerd/meshtls/tests/rustls.rs
+++ b/linkerd/meshtls/tests/rustls.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "rustls")]
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 //! Utilities for exposing metrics to Prometheus.

--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub mod metrics;

--- a/linkerd/proxy/api-resolve/src/lib.rs
+++ b/linkerd/proxy/api-resolve/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use linkerd2_proxy_api as api;

--- a/linkerd/proxy/core/src/lib.rs
+++ b/linkerd/proxy/core/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub mod resolve;

--- a/linkerd/proxy/discover/src/lib.rs
+++ b/linkerd/proxy/discover/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use linkerd_proxy_core::Resolve;

--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use futures::{future, prelude::*, stream};

--- a/linkerd/proxy/dns-resolve/src/lib.rs
+++ b/linkerd/proxy/dns-resolve/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 use http::header::AsHeaderName;
 use http::uri::Authority;

--- a/linkerd/proxy/identity-client/src/lib.rs
+++ b/linkerd/proxy/identity-client/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub mod certify;

--- a/linkerd/proxy/resolve/src/lib.rs
+++ b/linkerd/proxy/resolve/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub mod map_endpoint;

--- a/linkerd/proxy/tap/src/lib.rs
+++ b/linkerd/proxy/tap/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/proxy/tap/src/lib.rs
+++ b/linkerd/proxy/tap/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use linkerd_tls as tls;

--- a/linkerd/proxy/tcp/src/lib.rs
+++ b/linkerd/proxy/tcp/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub mod balance;

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -3,7 +3,6 @@
 //! Uses unsafe code to interact with socket options for SO_ORIGINAL_DST.
 
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types,

--- a/linkerd/reconnect/src/lib.rs
+++ b/linkerd/reconnect/src/lib.rs
@@ -1,10 +1,5 @@
 //! Conditionally reconnects with a pluggable recovery/backoff strategy.
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 #[cfg(test)]

--- a/linkerd/retry/src/lib.rs
+++ b/linkerd/retry/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/retry/src/lib.rs
+++ b/linkerd/retry/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use futures::future;

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod network;

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use futures::Stream;

--- a/linkerd/signal/src/lib.rs
+++ b/linkerd/signal/src/lib.rs
@@ -1,11 +1,6 @@
 //! Unix signal handling for the proxy binary.
 
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 /// Returns a `Future` that completes when the proxy should start to shutdown.

--- a/linkerd/stack/metrics/src/lib.rs
+++ b/linkerd/stack/metrics/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod layer;

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -1,11 +1,6 @@
 //! Utilities for composing Tower Services.
 
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod arc_new_service;

--- a/linkerd/stack/tracing/src/lib.rs
+++ b/linkerd/stack/tracing/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use linkerd_stack::{layer, NewService, Proxy};

--- a/linkerd/system/src/lib.rs
+++ b/linkerd/system/src/lib.rs
@@ -1,7 +1,6 @@
 //! Unsafe code for accessing system-level counters for memory & CPU usage.
 
 #![deny(
-    warnings,
     rust_2018_idioms,
     rust_2018_idioms,
     clippy::disallowed_methods,

--- a/linkerd/tls/src/lib.rs
+++ b/linkerd/tls/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/tls/src/lib.rs
+++ b/linkerd/tls/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub mod client;

--- a/linkerd/tls/test-util/src/lib.rs
+++ b/linkerd/tls/test-util/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub struct Entity {

--- a/linkerd/tls/test-util/src/lib.rs
+++ b/linkerd/tls/test-util/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/tonic-watch/src/lib.rs
+++ b/linkerd/tonic-watch/src/lib.rs
@@ -1,5 +1,4 @@
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types

--- a/linkerd/tonic-watch/src/lib.rs
+++ b/linkerd/tonic-watch/src/lib.rs
@@ -1,8 +1,4 @@
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 use futures::prelude::*;

--- a/linkerd/trace-context/src/lib.rs
+++ b/linkerd/trace-context/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod propagation;

--- a/linkerd/tracing/src/lib.rs
+++ b/linkerd/tracing/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub mod access_log;

--- a/linkerd/transport-header/src/lib.rs
+++ b/linkerd/transport-header/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod server;

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -1,9 +1,4 @@
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 mod client;

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -1,11 +1,6 @@
 //! The main entrypoint for the proxy.
 
-#![deny(
-    warnings,
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 // Emit a compile-time error if no TLS implementations are enabled. When adding

--- a/opencensus-proto/src/lib.rs
+++ b/opencensus-proto/src/lib.rs
@@ -2,11 +2,7 @@
 //!
 //! Vendored from <https://github.com/census-instrumentation/opencensus-proto/>.
 
-#![deny(
-    rust_2018_idioms,
-    clippy::disallowed_methods,
-    clippy::disallowed_types
-)]
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
 pub mod agent {

--- a/opencensus-proto/src/lib.rs
+++ b/opencensus-proto/src/lib.rs
@@ -3,7 +3,6 @@
 //! Vendored from <https://github.com/census-instrumentation/opencensus-proto/>.
 
 #![deny(
-    warnings,
     rust_2018_idioms,
     clippy::disallowed_methods,
     clippy::disallowed_types


### PR DESCRIPTION
Currently, all crates in the proxy have `#![deny(warnings)]` attributes.
These turn all rustc warnings into errors globally for these crates.

There are two primary issues with this approach:

1. `#![deny(warnings)]` will deny the "deprecated" warning, turning
   upstream deprecations into broken builds. However, APIs may be
   deprecated in semver-compatible releases, so this means a
   non-breaking dependency release can break our builds. See [here][1]
   for details.
2. Sometimes, while working on an in-development change, warnings may be
   temporarily introduced. For example, if a developer is working on
   some change and adds a function that will be used as part of that
   change but isn't called yet because the change is incomplete, this
   will emit a dead code warning and break the build. Because these
   warnings are turned into errors, this can prevent a developer from
   running tests while working on a change that's in an incomplete
   state.

   The typical solution to this is to temporarily remove the
   `#![deny(warnings)]` attributes while working on a change that
   temporarily introduces warnings. However, the downside of this is
   this can accidentally be committed, and then warnings will no longer
   be denied for a particular crate. This means we have another thing to
   look out for when reviewing PRs.

As an alternative, this branch changes the proxy's CI configuration so
that warnings are denied on CI builds using `RUSTFLAGS="-D warnings"`,
rather than using `#![deny(...)] attributes in the code itself. This has
the advantage that when building locally, warnings don't fail the build.

In addition, I've added a separate CI job in the `deps` workflow that's
specifically for checking for deprecation warnings using `RUSTFLAGS="-D
deprecated". All the other builds now pass `RUSTFLAGS="-D warnings -A
deprecated" to allow deprecations, so that they can't break other
builds. The deprecations CI job should be allowed to fail, as it's
informational --- it shouldn't block PRs from merging, but it provides
information about things that should be addressed when possible.

In the future, it would be nice to change this job so that it creates
new issues for deprecation warnings rather than failing, similarly to
what we currently do for security advisories. That way, new deprecations
no longer block PRs from merging, but instead create issues that can be
fixed separately.

[1]: https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html