### PR TITLE
Fall back to A record when SRV resolution fails

### DIFF
--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -70,7 +70,7 @@ impl Resolver {
     ) -> Result<(Vec<net::SocketAddr>, time::Sleep), Error> {
         match self.resolve_srv(name).await {
             Ok(res) => Ok(res),
-            Err(e) if e.is::<InvalidSrv>() => {
+            Err(e) if e.is::<ResolveError>() || e.is::<InvalidSrv>() => {
                 let (ips, delay) = self.resolve_a(name).await?;
                 let addrs = ips
                     .into_iter()


### PR DESCRIPTION
Fixes #8296

Adapted from: https://github.com/linkerd/linkerd2/issues/8296#issuecomment-1104093285 by @magec

When we do a DNS SRV lookup, if that lookup succeeds but the response has no labels, we fall back and issue a DNS A lookup instead.  However, if the initial SRV lookup fails to resolve at all, we do not fallback to an A lookup.

We change this logic to fallback to A lookups in either case.  It's not clear under what conditions a SRV lookup will fail vs returning an entry with no labels, but falling back to an A lookup seems like reasonable behavior and there is anecdotal evidence from #8296 that this resolves certain issues.

Signed-off-by:_ Alex Leong <alex@buoyant.io>