### PR TITLE
Consolidate error chain inspection with `cause_ref`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ name = "linkerd-error"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "thiserror",
 ]
 
 [[package]]

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -291,9 +291,8 @@ impl<T: Param<tls::ConditionalServerTls>> ExtractParam<errors::respond::EmitHead
 
 impl errors::HttpRescue<Error> for Rescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        let cause = errors::root_cause(&*error);
-        if cause.is::<inbound::policy::DeniedUnauthorized>() {
-            return Ok(errors::SyntheticHttpResponse::permission_denied(error));
+        if let Some(cause) = errors::cause_ref::<inbound::policy::DeniedUnauthorized>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::permission_denied(cause));
         }
 
         tracing::warn!(error, "Unexpected error");

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -61,7 +61,7 @@ impl Config {
             let backoff = self.connect.backoff;
             move |error: Error| {
                 warn!(error, "Failed to resolve control-plane component");
-                if let Some(e) = crate::errors::caused_by::<dns::ResolveError>(&*error) {
+                if let Some(e) = crate::errors::cause_ref::<dns::ResolveError>(&*error) {
                     if let Some(ttl) = e.negative_ttl() {
                         return Ok(Either::Left(
                             IntervalStream::new(time::interval(ttl)).map(|_| ()),

--- a/linkerd/app/core/src/errors.rs
+++ b/linkerd/app/core/src/errors.rs
@@ -1,34 +1,11 @@
 pub mod respond;
 
 pub use self::respond::{HttpRescue, NewRespond, NewRespondService, SyntheticHttpResponse};
+pub use linkerd_error::{cause_ref, is_caused_by};
 pub use linkerd_proxy_http::h2::H2Error;
 pub use linkerd_stack::FailFastError;
-use thiserror::Error;
 pub use tonic::Code as Grpc;
 
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 #[error("connect timed out after {0:?}")]
 pub struct ConnectTimeout(pub(crate) std::time::Duration);
-
-/// Obtain the source error at the end of a chain of `Error`s.
-pub fn root_cause<'e>(
-    mut error: &'e (dyn std::error::Error + 'static),
-) -> &'e (dyn std::error::Error + 'static) {
-    while let Some(e) = error.source() {
-        error = e;
-    }
-    error
-}
-
-/// Determines if the provided error was caused by an `E` typed error.
-pub fn caused_by<'e, E: std::error::Error + 'static>(
-    mut error: &'e (dyn std::error::Error + 'static),
-) -> Option<&'e E> {
-    while let Some(src) = error.source() {
-        if let Some(e) = src.downcast_ref::<E>() {
-            return Some(e);
-        }
-        error = src;
-    }
-    None
-}

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -22,7 +22,7 @@ pub use linkerd_cache as cache;
 pub use linkerd_conditional::Conditional;
 pub use linkerd_detect as detect;
 pub use linkerd_dns;
-pub use linkerd_error::{is_error, Error, Infallible, Recover, Result};
+pub use linkerd_error::{cause_ref, is_caused_by, Error, Infallible, Recover, Result};
 pub use linkerd_exp_backoff as exp_backoff;
 pub use linkerd_http_metrics as http_metrics;
 pub use linkerd_io as io;

--- a/linkerd/app/core/src/serve.rs
+++ b/linkerd/app/core/src/serve.rs
@@ -1,5 +1,5 @@
 use crate::{
-    io,
+    io, is_caused_by,
     svc::{self, Param},
     transport::{ClientAddr, Remote},
     Result,
@@ -56,7 +56,7 @@ pub async fn serve<M, S, I, A>(
                                         .await
                                     {
                                         Ok(()) => debug!("Connection closed"),
-                                        Err(reason) if is_io(&*reason) => {
+                                        Err(reason) if is_caused_by::<std::io::Error>(&*reason) => {
                                             debug!(%reason, "Connection closed")
                                         }
                                         Err(error) => {
@@ -88,8 +88,4 @@ pub async fn serve<M, S, I, A>(
         res = accept => { res }
         _ = shutdown => {}
     }
-}
-
-fn is_io(e: &(dyn std::error::Error + 'static)) -> bool {
-    e.is::<io::Error>() || e.source().map(is_io).unwrap_or(false)
 }

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -494,11 +494,10 @@ impl ExtractParam<errors::respond::EmitHeaders, Logical> for ClientRescue {
 
 impl errors::HttpRescue<Error> for ClientRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        let cause = errors::root_cause(&*error);
-        if cause.is::<std::io::Error>() {
+        if let Some(cause) = errors::cause_ref::<std::io::Error>(&*error) {
             return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
         }
-        if cause.is::<errors::ConnectTimeout>() {
+        if let Some(cause) = errors::cause_ref::<errors::ConnectTimeout>(&*error) {
             return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
         }
 

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -127,23 +127,23 @@ impl<T: Param<tls::ConditionalServerTls>> ExtractParam<errors::respond::EmitHead
 
 impl errors::HttpRescue<Error> for ServerRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        let cause = errors::root_cause(&*error);
-        if cause.is::<crate::policy::DeniedUnauthorized>() {
+        if let Some(cause) = errors::cause_ref::<crate::policy::DeniedUnauthorized>(&*error) {
             return Ok(errors::SyntheticHttpResponse::permission_denied(cause));
         }
-        if cause.is::<crate::GatewayDomainInvalid>() {
+        if let Some(cause) = errors::cause_ref::<crate::GatewayDomainInvalid>(&*error) {
             return Ok(errors::SyntheticHttpResponse::not_found(cause));
         }
-        if cause.is::<crate::GatewayIdentityRequired>() {
+        if let Some(cause) = errors::cause_ref::<crate::GatewayIdentityRequired>(&*error) {
             return Ok(errors::SyntheticHttpResponse::unauthenticated(cause));
         }
-        if cause.is::<crate::GatewayLoop>() {
+        if let Some(cause) = errors::cause_ref::<crate::GatewayLoop>(&*error) {
             return Ok(errors::SyntheticHttpResponse::loop_detected(cause));
         }
-        if cause.is::<errors::FailFastError>() {
+        if let Some(cause) = errors::cause_ref::<errors::FailFastError>(&*error) {
             return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
         }
-        if cause.is::<errors::H2Error>() {
+
+        if errors::is_caused_by::<errors::H2Error>(&*error) {
             return Err(error);
         }
 

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -128,14 +128,13 @@ impl<T> ExtractParam<errors::respond::EmitHeaders, T> for ClientRescue {
 
 impl errors::HttpRescue<Error> for ClientRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        let cause = errors::root_cause(&*error);
-        if cause.is::<http::orig_proto::DowngradedH2Error>() {
+        if let Some(cause) = errors::cause_ref::<http::orig_proto::DowngradedH2Error>(&*error) {
             return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
         }
-        if cause.is::<std::io::Error>() {
+        if let Some(cause) = errors::cause_ref::<std::io::Error>(&*error) {
             return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
         }
-        if cause.is::<errors::ConnectTimeout>() {
+        if let Some(cause) = errors::cause_ref::<errors::ConnectTimeout>(&*error) {
             return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
         }
 

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -104,18 +104,17 @@ impl<T> ExtractParam<errors::respond::EmitHeaders, T> for ServerRescue {
 
 impl errors::HttpRescue<Error> for ServerRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        let cause = errors::root_cause(&*error);
-        if cause.is::<http::ResponseTimeoutError>() {
+        if let Some(cause) = errors::cause_ref::<http::ResponseTimeoutError>(&*error) {
             return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
         }
-        if cause.is::<IdentityRequired>() {
+        if let Some(cause) = errors::cause_ref::<IdentityRequired>(&*error) {
             return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
         }
-        if cause.is::<errors::FailFastError>() {
+        if let Some(cause) = errors::cause_ref::<errors::FailFastError>(&*error) {
             return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
         }
 
-        if cause.is::<errors::H2Error>() {
+        if errors::is_caused_by::<errors::H2Error>(&*error) {
             return Err(error);
         }
 

--- a/linkerd/error/Cargo.toml
+++ b/linkerd/error/Cargo.toml
@@ -8,3 +8,6 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
+
+[dev-dependencies]
+thiserror = "1"

--- a/linkerd/error/src/lib.rs
+++ b/linkerd/error/src/lib.rs
@@ -15,6 +15,64 @@ pub type Error = Box<dyn std::error::Error + Send + Sync>;
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
-pub fn is_error<E: std::error::Error + 'static>(e: &(dyn std::error::Error + 'static)) -> bool {
-    e.is::<E>() || e.source().map(is_error::<E>).unwrap_or(false)
+/// Determines whether the provided error was caused by an `E` typed error.
+pub fn is_caused_by<E: std::error::Error + 'static>(
+    mut error: &(dyn std::error::Error + 'static),
+) -> bool {
+    loop {
+        if error.is::<E>() {
+            return true;
+        }
+        error = match error.source() {
+            Some(e) => e,
+            None => return false,
+        };
+    }
+}
+
+/// Finds an `E` typed error in the provided error's sources.
+pub fn cause_ref<'e, E: std::error::Error + 'static>(
+    mut error: &'e (dyn std::error::Error + 'static),
+) -> Option<&'e E> {
+    loop {
+        if let Some(e) = error.downcast_ref::<E>() {
+            return Some(e);
+        }
+        error = error.source()?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[derive(Debug, thiserror::Error)]
+    enum Outer {
+        #[error("nada")]
+        Nada,
+        #[error("{0}")]
+        Inner(#[source] Inner),
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("inner")]
+    struct Inner;
+
+    #[test]
+    fn is_caused_by() {
+        assert!(!super::is_caused_by::<Inner>(&Outer::Nada));
+        assert!(super::is_caused_by::<Outer>(&Outer::Nada));
+        assert!(super::is_caused_by::<Inner>(&Outer::Inner(Inner)));
+        assert!(super::is_caused_by::<Outer>(&Outer::Inner(Inner)));
+        assert!(super::is_caused_by::<Inner>(&Inner));
+        assert!(!super::is_caused_by::<Outer>(&Inner));
+    }
+
+    #[test]
+    fn cause_ref() {
+        assert!(super::cause_ref::<Inner>(&Outer::Nada).is_none());
+        assert!(super::cause_ref::<Outer>(&Outer::Nada).is_some());
+        assert!(super::cause_ref::<Inner>(&Outer::Inner(Inner)).is_some());
+        assert!(super::cause_ref::<Outer>(&Outer::Inner(Inner)).is_some());
+        assert!(super::cause_ref::<Inner>(&Inner).is_some());
+        assert!(super::cause_ref::<Outer>(&Inner).is_none());
+    }
 }

--- a/linkerd/stack/src/fail_on_error.rs
+++ b/linkerd/stack/src/fail_on_error.rs
@@ -1,4 +1,4 @@
-use linkerd_error::{is_error, Error};
+use linkerd_error::{is_caused_by, Error};
 use parking_lot::RwLock;
 use std::{
     future::Future,
@@ -55,7 +55,7 @@ where
                 Ok(rsp) => Ok(rsp),
                 Err(e) => {
                     let e = e.into();
-                    if is_error::<E>(&*e) {
+                    if is_caused_by::<E>(&*e) {
                         let e = SharedError(Arc::new(e));
                         *error.write() = Some(e.clone());
                         Err(e.into())


### PR DESCRIPTION
We have similar/redundant code that handles inspecting (boxed) errors to
determine whether they are caused by a given error type. This change
replaces the other methods for expecting with utility functions
`is_caused_by` and `cause_ref`.

These helpers are now tested.

Signed-off-by: Oliver Gould <ver@buoyant.io>