### PR TITLE
Dynamically discover policies for undocumented ports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "libfuzzer-sys",
  "linkerd-app-core",
  "linkerd-app-test",
+ "linkerd-cache",
  "linkerd-http-access-log",
  "linkerd-io",
  "linkerd-meshtls",

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -73,7 +73,7 @@ impl Config {
     pub fn build<B, R>(
         self,
         bind: B,
-        policy: impl inbound::policy::CheckPolicy,
+        policy: impl inbound::policy::GetPolicy,
         identity: identity::Server,
         report: R,
         metrics: inbound::Metrics,
@@ -89,7 +89,7 @@ impl Config {
         let (listen_addr, listen) = bind.bind(&self.server)?;
 
         // Get the policy for the admin server.
-        let policy = policy.check_policy(OrigDstAddr(listen_addr.into()))?;
+        let policy = policy.get_policy(OrigDstAddr(listen_addr.into()));
 
         let (ready, latch) = crate::server::Readiness::new();
         let admin = crate::server::Admin::new(report, ready, shutdown, trace);

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -35,6 +35,7 @@ libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 [dev-dependencies]
 hyper = { version = "0.14", features = ["http1", "http2"] }
 linkerd-app-test = { path = "../test" }
+linkerd-cache = { path = "../../cache", features = ["test-util"] }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 linkerd-meshtls = { path = "../../meshtls", features = ["rustls"] }
 linkerd-meshtls-rustls = { path = "../../meshtls/rustls", features = [

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -14,6 +14,7 @@ bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }
 linkerd-app-core = { path = "../core" }
+linkerd-cache = { path = "../../cache" }
 linkerd-http-access-log = { path = "../../http-access-log" }
 linkerd-server-policy = { path = "../../server-policy" }
 linkerd-tonic-watch = { path = "../../tonic-watch" }

--- a/linkerd/app/inbound/fuzz/Cargo.toml
+++ b/linkerd/app/inbound/fuzz/Cargo.toml
@@ -17,6 +17,7 @@ libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 linkerd-app-core = { path = "../../core" }
 linkerd-app-inbound = { path = ".." }
 linkerd-app-test = { path = "../../test" }
+linkerd-cache = { path = "../../../cache", features = ["test-util"] }
 linkerd-meshtls = { path = "../../../meshtls", features = ["rustls"] }
 linkerd-meshtls-rustls = { path = "../../../meshtls/rustls", features = ["test-util"] }
 linkerd-tracing = { path = "../../../tracing", features = ["ansi"] }

--- a/linkerd/app/inbound/src/accept.rs
+++ b/linkerd/app/inbound/src/accept.rs
@@ -110,7 +110,7 @@ impl svc::Param<AllowPolicy> for Accept {
 mod tests {
     use super::*;
     use crate::{
-        policy::{DefaultPolicy, Store},
+        policy::{store, DefaultPolicy},
         test_util,
     };
     use futures::future;
@@ -123,7 +123,7 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn default_allow() {
         let (io, _) = io::duplex(1);
-        let (policies, _tx) = Store::fixed(
+        let (policies, _tx) = store::Fixed::new(
             ServerPolicy {
                 protocol: linkerd_server_policy::Protocol::Opaque,
                 authorizations: vec![Authorization {
@@ -149,7 +149,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn default_deny() {
-        let (policies, _tx) = Store::fixed(DefaultPolicy::Deny, None);
+        let (policies, _tx) = store::Fixed::new(DefaultPolicy::Deny, None);
         let (io, _) = io::duplex(1);
         inbound()
             .with_stack(new_ok())
@@ -163,7 +163,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn direct() {
-        let (policies, _tx) = Store::fixed(DefaultPolicy::Deny, None);
+        let (policies, _tx) = store::Fixed::new(DefaultPolicy::Deny, None);
         let (io, _) = io::duplex(1);
         inbound()
             .with_stack(new_panic("detect stack must not be built"))

--- a/linkerd/app/inbound/src/metrics/error.rs
+++ b/linkerd/app/inbound/src/metrics/error.rs
@@ -3,8 +3,7 @@ mod tcp;
 
 pub(crate) use self::{http::HttpErrorMetrics, tcp::TcpErrorMetrics};
 use crate::{
-    policy::{DeniedUnauthorized, DeniedUnknownPort},
-    GatewayDomainInvalid, GatewayIdentityRequired, GatewayLoop,
+    policy::DeniedUnauthorized, GatewayDomainInvalid, GatewayIdentityRequired, GatewayLoop,
 };
 use linkerd_app_core::{errors::FailFastError, metrics::FmtLabels, tls};
 use std::fmt;
@@ -12,7 +11,6 @@ use std::fmt;
 /// Inbound proxy error types.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 enum ErrorKind {
-    DeniedUnknown,
     FailFast,
     GatewayDomainInvalid,
     GatewayIdentityRequired,
@@ -29,8 +27,6 @@ impl ErrorKind {
         if err.is::<DeniedUnauthorized>() {
             // Unauthorized metrics are tracked separately.and are not considered to be errors.
             None
-        } else if err.is::<DeniedUnknownPort>() {
-            Some(ErrorKind::DeniedUnknown)
         } else if err.is::<FailFastError>() {
             Some(ErrorKind::FailFast)
         } else if err.is::<std::io::Error>() {
@@ -57,7 +53,6 @@ impl FmtLabels for ErrorKind {
             f,
             "error=\"{}\"",
             match self {
-                ErrorKind::DeniedUnknown => "unknown port denied",
                 ErrorKind::FailFast => "failfast",
                 ErrorKind::TlsDetectTimeout => "tls detection timeout",
                 ErrorKind::GatewayIdentityRequired => "gateway identity required",

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -2,7 +2,7 @@ mod api;
 mod authorize;
 mod config;
 pub mod defaults;
-mod store;
+pub(crate) mod store;
 #[cfg(test)]
 mod tests;
 

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -29,7 +29,7 @@ pub struct DeniedUnauthorized {
 }
 
 pub trait GetPolicy {
-    /// Checks that the destination address is configured to allow traffic.
+    // Returns the traffic policy configured for the destination address.
     fn get_policy(&self, dst: OrigDstAddr) -> AllowPolicy;
 }
 

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -115,18 +115,23 @@ impl AllowPolicy {
         }
     }
 
+    /// Checks whether the server has any authorizations at all. If it does not,
+    /// a denial error is returned.
     pub(crate) fn check_port_allowed(&self) -> Result<(), DeniedUnauthorized> {
         let server = self.server.borrow();
+
         if server.authorizations.is_empty() {
             return Err(DeniedUnauthorized {
                 kind: server.kind.clone(),
                 name: server.name.clone(),
             });
         }
+
         Ok(())
     }
-    /// Checks whether the destination port's `AllowPolicy` is authorized to accept connections
-    /// given the provided TLS state.
+
+    /// Checks whether the destination port's `AllowPolicy` is authorized to
+    /// accept connections given the provided TLS state.
     pub(crate) fn check_authorized(
         &self,
         client_addr: Remote<ClientAddr>,

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -1,7 +1,7 @@
+mod api;
 mod authorize;
 mod config;
 pub mod defaults;
-mod discover;
 mod store;
 #[cfg(test)]
 mod tests;

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -1,4 +1,4 @@
-use super::{api::Api, DefaultPolicy, ServerPolicy, Store};
+use super::{api::Api, CheckPolicy, DefaultPolicy, ServerPolicy, Store};
 use linkerd_app_core::{control, dns, identity, metrics, svc::NewService};
 use std::collections::{HashMap, HashSet};
 
@@ -29,7 +29,7 @@ impl Config {
         dns: dns::Resolver,
         metrics: metrics::ControlHttp,
         identity: identity::NewClient,
-    ) -> Store {
+    ) -> impl CheckPolicy + Clone + Send + Sync + 'static {
         match self {
             Self::Fixed { default, ports } => {
                 let (store, tx) = Store::fixed(default, ports);
@@ -40,6 +40,7 @@ impl Config {
                 }
                 store
             }
+
             Self::Discover {
                 control,
                 ports,

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -1,4 +1,4 @@
-use super::{discover::Discover, DefaultPolicy, ServerPolicy, Store};
+use super::{api::Api, DefaultPolicy, ServerPolicy, Store};
 use linkerd_app_core::{control, dns, identity, metrics, svc::NewService};
 use std::collections::{HashMap, HashSet};
 
@@ -49,7 +49,7 @@ impl Config {
                 let watch = {
                     let backoff = control.connect.backoff;
                     let c = control.build(dns, metrics, identity).new_service(());
-                    Discover::new(workload, c).into_watch(backoff)
+                    Api::new(workload, c).into_watch(backoff)
                 };
                 Store::spawn_discover(default, ports, watch)
             }

--- a/linkerd/app/inbound/src/policy/store.rs
+++ b/linkerd/app/inbound/src/policy/store.rs
@@ -1,4 +1,4 @@
-use super::{discover, AllowPolicy, CheckPolicy, DefaultPolicy, DeniedUnknownPort};
+use super::{api, AllowPolicy, CheckPolicy, DefaultPolicy, DeniedUnknownPort};
 use linkerd_app_core::{proxy::http, transport::OrigDstAddr, Error, Result};
 pub use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy, Suffix};
 use std::{
@@ -75,7 +75,7 @@ impl Store {
     pub(super) fn spawn_discover<S>(
         default: DefaultPolicy,
         ports: HashSet<u16>,
-        discover: discover::Watch<S>,
+        watch: api::Watch<S>,
     ) -> Self
     where
         S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
@@ -87,10 +87,10 @@ impl Store {
         let rxs = ports
             .into_iter()
             .map(|port| {
-                let discover = discover.clone();
+                let watch = watch.clone();
                 let default = default.clone();
                 let rx = info_span!("watch", %port)
-                    .in_scope(|| discover.spawn_with_init(port, default.into()));
+                    .in_scope(|| watch.spawn_with_init(port, default.into()));
                 (port, rx)
             })
             .collect::<PortMap<_>>();

--- a/linkerd/app/inbound/src/policy/tests.rs
+++ b/linkerd/app/inbound/src/policy/tests.rs
@@ -244,6 +244,6 @@ impl Store<MockSvc> {
         default: impl Into<DefaultPolicy>,
         ports: impl IntoIterator<Item = (u16, ServerPolicy)>,
     ) -> Self {
-        Self::spawn_fixed(default.into(), ports)
+        Self::spawn_fixed(default.into(), std::time::Duration::MAX, ports)
     }
 }

--- a/linkerd/app/inbound/src/policy/tests.rs
+++ b/linkerd/app/inbound/src/policy/tests.rs
@@ -6,8 +6,8 @@ use std::collections::HashSet;
 #[derive(Clone)]
 pub(crate) struct MockSvc;
 
-#[test]
-fn unauthenticated_allowed() {
+#[tokio::test(flavor = "current_thread")]
+async fn unauthenticated_allowed() {
     let policy = ServerPolicy {
         protocol: Protocol::Opaque,
         authorizations: vec![Authorization {
@@ -45,8 +45,8 @@ fn unauthenticated_allowed() {
     );
 }
 
-#[test]
-fn authenticated_identity() {
+#[tokio::test(flavor = "current_thread")]
+async fn authenticated_identity() {
     let policy = ServerPolicy {
         protocol: Protocol::Opaque,
         authorizations: vec![Authorization {
@@ -102,8 +102,8 @@ fn authenticated_identity() {
         .expect_err("policy must require a client identity");
 }
 
-#[test]
-fn authenticated_suffix() {
+#[tokio::test(flavor = "current_thread")]
+async fn authenticated_suffix() {
     let policy = ServerPolicy {
         protocol: Protocol::Opaque,
         authorizations: vec![Authorization {
@@ -158,8 +158,8 @@ fn authenticated_suffix() {
         .expect_err("policy must require a client identity");
 }
 
-#[test]
-fn tls_unauthenticated() {
+#[tokio::test(flavor = "current_thread")]
+async fn tls_unauthenticated() {
     let policy = ServerPolicy {
         protocol: Protocol::Opaque,
         authorizations: vec![Authorization {

--- a/linkerd/app/inbound/src/policy/tests.rs
+++ b/linkerd/app/inbound/src/policy/tests.rs
@@ -1,6 +1,10 @@
 use super::*;
+use linkerd_app_core::{proxy::http, Error};
 use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy, Suffix};
 use std::collections::HashSet;
+
+#[derive(Clone)]
+pub(crate) struct MockSvc;
 
 #[test]
 fn unauthenticated_allowed() {
@@ -16,10 +20,8 @@ fn unauthenticated_allowed() {
         name: "test".into(),
     };
 
-    let (policies, _tx) = store::Fixed::new(policy.clone(), None);
-    let allowed = policies
-        .check_policy(orig_dst_addr())
-        .expect("port must be known");
+    let policies = Store::for_test(policy.clone(), None);
+    let allowed = policies.get_policy(orig_dst_addr());
     assert_eq!(*allowed.server.borrow(), policy);
 
     let tls = tls::ConditionalServerTls::None(tls::NoServerTls::NoClientHello);
@@ -60,10 +62,8 @@ fn authenticated_identity() {
         name: "test".into(),
     };
 
-    let (policies, _tx) = store::Fixed::new(policy.clone(), None);
-    let allowed = policies
-        .check_policy(orig_dst_addr())
-        .expect("port must be known");
+    let policies = Store::for_test(policy.clone(), None);
+    let allowed = policies.get_policy(orig_dst_addr());
     assert_eq!(*allowed.server.borrow(), policy);
 
     let tls = tls::ConditionalServerTls::Some(tls::ServerTls::Established {
@@ -119,10 +119,8 @@ fn authenticated_suffix() {
         name: "test".into(),
     };
 
-    let (policies, _tx) = store::Fixed::new(policy.clone(), None);
-    let allowed = policies
-        .check_policy(orig_dst_addr())
-        .expect("port must be known");
+    let policies = Store::for_test(policy.clone(), None);
+    let allowed = policies.get_policy(orig_dst_addr());
     assert_eq!(*allowed.server.borrow(), policy);
 
     let tls = tls::ConditionalServerTls::Some(tls::ServerTls::Established {
@@ -174,10 +172,8 @@ fn tls_unauthenticated() {
         name: "test".into(),
     };
 
-    let (policies, _tx) = store::Fixed::new(policy.clone(), None);
-    let allowed = policies
-        .check_policy(orig_dst_addr())
-        .expect("port must be known");
+    let policies = Store::for_test(policy.clone(), None);
+    let allowed = policies.get_policy(orig_dst_addr());
     assert_eq!(*allowed.server.borrow(), policy);
 
     let tls = tls::ConditionalServerTls::Some(tls::ServerTls::Established {
@@ -224,4 +220,30 @@ fn client_addr() -> Remote<ClientAddr> {
 
 fn orig_dst_addr() -> OrigDstAddr {
     OrigDstAddr(([192, 0, 2, 2], 1000).into())
+}
+
+impl tonic::client::GrpcService<tonic::body::BoxBody> for MockSvc {
+    type ResponseBody = linkerd_app_core::control::RspBody;
+    type Error = Error;
+    type Future = futures::future::Pending<Result<http::Response<Self::ResponseBody>, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Error>> {
+        unreachable!()
+    }
+
+    fn call(&mut self, _req: http::Request<tonic::body::BoxBody>) -> Self::Future {
+        unreachable!()
+    }
+}
+
+impl Store<MockSvc> {
+    pub(crate) fn for_test(
+        default: impl Into<DefaultPolicy>,
+        ports: impl IntoIterator<Item = (u16, ServerPolicy)>,
+    ) -> Self {
+        Self::spawn_fixed(default.into(), ports)
+    }
 }

--- a/linkerd/app/inbound/src/policy/tests.rs
+++ b/linkerd/app/inbound/src/policy/tests.rs
@@ -16,7 +16,7 @@ fn unauthenticated_allowed() {
         name: "test".into(),
     };
 
-    let (policies, _tx) = Store::fixed(policy.clone(), None);
+    let (policies, _tx) = store::Fixed::new(policy.clone(), None);
     let allowed = policies
         .check_policy(orig_dst_addr())
         .expect("port must be known");
@@ -60,7 +60,7 @@ fn authenticated_identity() {
         name: "test".into(),
     };
 
-    let (policies, _tx) = Store::fixed(policy.clone(), None);
+    let (policies, _tx) = store::Fixed::new(policy.clone(), None);
     let allowed = policies
         .check_policy(orig_dst_addr())
         .expect("port must be known");
@@ -119,7 +119,7 @@ fn authenticated_suffix() {
         name: "test".into(),
     };
 
-    let (policies, _tx) = Store::fixed(policy.clone(), None);
+    let (policies, _tx) = store::Fixed::new(policy.clone(), None);
     let allowed = policies
         .check_policy(orig_dst_addr())
         .expect("port must be known");
@@ -174,7 +174,7 @@ fn tls_unauthenticated() {
         name: "test".into(),
     };
 
-    let (policies, _tx) = Store::fixed(policy.clone(), None);
+    let (policies, _tx) = store::Fixed::new(policy.clone(), None);
     let allowed = policies
         .check_policy(orig_dst_addr())
         .expect("port must be known");

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -20,7 +20,7 @@ impl Inbound<()> {
         &self,
         dns: dns::Resolver,
         control_metrics: metrics::ControlHttp,
-    ) -> policy::Store {
+    ) -> impl policy::CheckPolicy + Clone + Send + Sync + 'static {
         self.config
             .policy
             .clone()

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -20,7 +20,7 @@ impl Inbound<()> {
         &self,
         dns: dns::Resolver,
         control_metrics: metrics::ControlHttp,
-    ) -> impl policy::CheckPolicy + Clone + Send + Sync + 'static {
+    ) -> impl policy::GetPolicy + Clone + Send + Sync + 'static {
         self.config
             .policy
             .clone()
@@ -31,7 +31,7 @@ impl Inbound<()> {
         self,
         addr: Local<ServerAddr>,
         listen: impl Stream<Item = Result<(A, I)>> + Send + Sync + 'static,
-        policies: impl policy::CheckPolicy + Clone + Send + Sync + 'static,
+        policies: impl policy::GetPolicy + Clone + Send + Sync + 'static,
         profiles: P,
         gateway: G,
     ) where

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -51,6 +51,7 @@ pub fn default_config() -> Config {
             detect_protocol_timeout: Duration::from_secs(10),
         },
         policy: policy::Config::Fixed {
+            cache_max_idle_age: Duration::from_secs(20),
             default: ServerPolicy {
                 protocol: Protocol::Detect {
                     timeout: std::time::Duration::from_secs(10),

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -665,6 +665,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
                     inbound::policy::Config::Fixed {
                         default,
+                        cache_max_idle_age,
                         ports: require_identity_ports
                             .into_iter()
                             .chain(require_tls_ports)

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -587,6 +587,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                         ports,
                         workload,
                         control,
+                        cache_max_idle_age,
                     }
                 }
 

--- a/linkerd/cache/Cargo.toml
+++ b/linkerd/cache/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0"
 edition = "2021"
 publish = false
 
+[features]
+test-util = []
+
 [dependencies]
 futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -310,6 +310,7 @@ impl<V> CacheEntry<V> {
 
 // === impl Cached ===
 
+#[cfg(feature = "test-util")]
 impl<V> Cached<V> {
     /// Returns a new `Cached` handle wrapping the provided value, but *not*
     /// associated with a cache.

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -310,6 +310,24 @@ impl<V> CacheEntry<V> {
 
 // === impl Cached ===
 
+impl<V> Cached<V> {
+    /// Returns a new `Cached` handle wrapping the provided value, but *not*
+    /// associated with a cache.
+    ///
+    /// This is intended for use in cases where most values returned by a
+    /// function are stored in a cache, but some may instead be fixed, uncached
+    /// values.
+    ///
+    /// The uncached `Cached` instance will never be evicted, since it didn't
+    /// come from a cache.
+    pub fn uncached(inner: V) -> Self {
+        Self {
+            inner,
+            handle: None,
+        }
+    }
+}
+
 impl<Req, S> tower::Service<Req> for Cached<S>
 where
     S: tower::Service<Req> + Send + Sync + 'static,

--- a/linkerd/stack/src/filter.rs
+++ b/linkerd/stack/src/filter.rs
@@ -1,7 +1,7 @@
 //! A `Service` middleware that applies arbitrary-user provided logic to each
 //! target before it is issued to an inner service.
 
-pub use tower::filter::{AsyncFilter, AsyncPredicate, Filter, FilterLayer, Predicate};
+pub use tower::filter::{Filter, FilterLayer, Predicate};
 
 impl<T, P, S> super::NewService<T> for Filter<S, P>
 where

--- a/linkerd/stack/src/filter.rs
+++ b/linkerd/stack/src/filter.rs
@@ -1,7 +1,7 @@
 //! A `Service` middleware that applies arbitrary-user provided logic to each
 //! target before it is issued to an inner service.
 
-pub use tower::filter::{Filter, FilterLayer, Predicate};
+pub use tower::filter::{AsyncFilter, AsyncPredicate, Filter, FilterLayer, Predicate};
 
 impl<T, P, S> super::NewService<T> for Filter<S, P>
 where


### PR DESCRIPTION
During process startup, proxies discover policies for all documented
inbound ports. Undocumented ports use the default policy and cannot be
configured by the policy controller.

This is an annoying limitation, as Kubernetes does not otherwise require
a pod's ports to be explicitly documented.

This change lifts this limitation. We continue to eagerly
discover policies for documented ports during startup, but we now fall
back to dynamically discovering policies for undocumented ports. This
discovery does not block processing a connection. The default policy is
honored until a policy is provided by the control plane.

Fixes https://github.com/linkerd/linkerd2/issues/7640