### PR TITLE
cache: generalize `Cache` into a key-value cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,6 @@ dependencies = [
  "libfuzzer-sys",
  "linkerd-app-core",
  "linkerd-app-test",
- "linkerd-cache",
  "linkerd-http-access-log",
  "linkerd-io",
  "linkerd-meshtls",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "libfuzzer-sys",
  "linkerd-app-core",
  "linkerd-app-test",
+ "linkerd-cache",
  "linkerd-http-access-log",
  "linkerd-io",
  "linkerd-meshtls",

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -202,13 +202,13 @@ impl<S> Stack<S> {
         self.push(http::insert::NewResponseInsert::layer())
     }
 
-    pub fn push_cache<T>(self, idle: Duration) -> Stack<cache::Cache<T, S>>
+    pub fn push_cache<T>(self, idle: Duration) -> Stack<cache::NewCachedService<T, S>>
     where
         T: Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
         S: NewService<T> + 'static,
         S::Service: Send + Sync + 'static,
     {
-        self.push(cache::Cache::layer(idle))
+        self.push(cache::NewCachedService::layer(idle))
     }
 
     /// Push a service that either calls the inner service if it is ready, or

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -15,6 +15,7 @@ use std::{
 };
 use tokio::{sync::Notify, time};
 use tracing::{debug, instrument, trace};
+
 mod new_service;
 
 pub use new_service::NewCachedService;

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -26,24 +26,38 @@ pub struct Cache<K, V, S = RandomState>
 where
     K: Eq + Hash,
 {
-    inner: Arc<Inner<K, V, S>>,
+    /// The amount of time after which an entry is considered idle and may be
+    /// evicted.
     idle: time::Duration,
+
+    inner: Arc<InnerMap<K, V, S>>,
 }
 
+/// A handle that that holds the referenced value in the cache. When dropped,
+/// the cache may drop the value from the cache after an idle timeout.
 #[derive(Clone, Debug)]
 pub struct Cached<V> {
     inner: V,
-    // Notifies entry's eviction task that a drop has occurred.
+
+    // Notifies entry's eviction task that a drop has occurred. If no handle is
+    // set, then the entry is permanent and will not be evicted.
     handle: Option<Arc<Notify>>,
 }
-
-type Inner<K, V, S> = RwLock<HashMap<K, CacheEntry<V>, S>>;
 
 #[derive(Debug)]
 struct CacheEntry<V> {
     value: V,
+    /// A handle to wake the expiration task.
+    ///
+    /// If this is unset, the entry is permanent and will not be evicted.
     handle: Option<Weak<Notify>>,
 }
+
+/// A locked cache map holding values and an optional handle. When the handle is
+/// unset, the entry is 'permanent' and will never be evicted from the map. When
+/// a handle is set, it is used to notify the eviction task that an entry has
+/// been dropped.
+type InnerMap<K, V, S> = RwLock<HashMap<K, CacheEntry<V>, S>>;
 
 // === impl Cache ===
 
@@ -63,18 +77,29 @@ where
     V: Send + Sync + 'static,
     BuildHasherDefault<S>: BuildHasher + Send + Sync + 'static,
 {
-    /// Constructs a `Cache` from an iterator of fixed cache entries.
-    ///
-    /// These entries will never be expired from the cache. Any entries inserted
-    /// later will still expire when they become idle.
-    pub fn from_iter_fixed(idle: time::Duration, iter: impl IntoIterator<Item = (K, V)>) -> Self
+    /// Creates a new cache with an initial capacity.
+    pub fn with_capacity(idle: time::Duration, capacity: usize) -> Self {
+        Self {
+            idle,
+            inner: Arc::new(RwLock::new(HashMap::with_capacity_and_hasher(
+                capacity,
+                BuildHasherDefault::default(),
+            ))),
+        }
+    }
+
+    /// Creates a new cache with a set of permanent entries.
+    pub fn with_permanent_from_iter(
+        idle: time::Duration,
+        iter: impl IntoIterator<Item = (K, V)>,
+    ) -> Self
     where
         S: Default,
         V: Clone,
     {
         let entries = iter
             .into_iter()
-            .map(|(k, v)| (k, CacheEntry::fixed(v)))
+            .map(|(k, v)| (k, CacheEntry::permanent(v)))
             .collect();
         let inner = Arc::new(RwLock::new(entries));
         Self { inner, idle }
@@ -98,19 +123,19 @@ where
         Q: Hash + Eq + fmt::Debug,
         V: Clone,
     {
-        let lock = self.inner.read();
-        let cache_entry = lock.get(&key)?;
-        let cached = cache_entry.cached()?;
+        let cache = self.inner.read();
+        let cache_entry = cache.get(key)?;
+        let cached = cache_entry.cached();
 
         trace!(
             ?key,
-            entry.is_expiring = cache_entry.is_expiring(),
+            entry.is_permanent = cache_entry.is_permanent(),
             "Using cached value"
         );
         Some(cached)
     }
 
-    pub fn get_or_insert_with(&self, key: K, f: impl FnOnce(K) -> V) -> Cached<V>
+    pub fn get_or_insert_with(&self, key: K, f: impl FnOnce(&K) -> V) -> Cached<V>
     where
         V: Clone,
     {
@@ -121,67 +146,45 @@ where
         }
 
         // Otherwise, obtain a write lock to insert a new value.
-        match self.inner.write().entry(key.clone()) {
-            Entry::Occupied(ref mut entry) => {
-                let cache_entry = entry.get();
-                // Another thread raced us to create a value for this target.
-                // Try to use it.
-                match cache_entry.cached() {
-                    Some(cached) => {
-                        trace!(
-                            ?key,
-                            entry.is_expiring = cache_entry.is_expiring(),
-                            "Using cached value"
-                        );
-                        cached
-                    }
-                    None => {
-                        debug!(?key, "Replacing defunct value");
-                        let inner = f(key.clone());
-                        let (handle, element) = self.expiring_entry(key, inner.clone());
-                        entry.insert(element);
-                        Cached {
-                            inner,
-                            handle: Some(handle),
-                        }
-                    }
-                }
-            }
+        let mut cache = self.inner.write();
+        match cache.entry(key) {
             Entry::Vacant(entry) => {
-                debug!(?key, "Caching new value");
-                let inner = f(key.clone());
-                let (handle, element) = self.expiring_entry(key, inner.clone());
-                entry.insert(element);
+                debug!(key = ?entry.key(), "Caching new value");
+                let inner = f(entry.key());
+                let handle = self.spawn_idle(entry.key().clone());
+                entry.insert(CacheEntry {
+                    value: inner.clone(),
+                    handle: Some(Arc::downgrade(&handle)),
+                });
                 Cached {
                     inner,
                     handle: Some(handle),
                 }
             }
+
+            Entry::Occupied(entry) => {
+                // Another thread raced us to create a value for this target.
+                trace!(key = ?entry.key(), "Using cached value");
+                entry.get().cached()
+            }
         }
     }
 
-    /// Inserts a fixed (non-expiring) entry into the cache.
-    ///
-    /// This entry will never be removed, and will not spawn a background
-    /// expiration task.
-    ///
-    /// # Returns
-    ///
-    /// The previous value for that key, if there was one.
-    pub fn insert_fixed(&self, key: K, value: V) -> Option<V> {
-        self.inner
-            .write()
-            .insert(key, CacheEntry::fixed(value))
-            .map(|CacheEntry { value, .. }| value)
-    }
-
-    fn expiring_entry(&self, key: K, value: V) -> (Arc<Notify>, CacheEntry<V>) {
-        let handle = self.spawn_idle(key);
-        let entry = CacheEntry {
-            value,
-            handle: Some(Arc::downgrade(&handle)),
-        };
-        (handle, entry)
+    /// Adds or overwrites a value in the cache that will never be evicted from
+    /// the cache.
+    pub fn insert_permanent(&self, key: K, val: V) -> Option<V> {
+        match self.inner.write().entry(key) {
+            Entry::Vacant(entry) => {
+                debug!(key = ?entry.key(), "Permanently caching new value");
+                entry.insert(CacheEntry::permanent(val));
+                None
+            }
+            Entry::Occupied(ref mut entry) => {
+                debug!(key = ?entry.key(), "Updating permanently cached value");
+                let prior_entry = entry.insert(CacheEntry::permanent(val));
+                Some(prior_entry.value)
+            }
+        }
     }
 
     fn spawn_idle(&self, key: K) -> Arc<Notify> {
@@ -204,103 +207,108 @@ where
         key: K,
         idle: time::Duration,
         mut reset: Arc<Notify>,
-        cache: Weak<Inner<K, V, S>>,
+        cache: Weak<InnerMap<K, V, S>>,
     ) {
         // Wait for the handle to be notified before starting to track idleness.
         reset.notified().await;
         debug!("Awaiting idleness");
 
-        // Wait for either the reset to be notified or the idle timeout to
-        // elapse.
         loop {
-            tokio::select! {
+            // Wait until the idle timeout expires to check to see if the entry
+            // should be evicted from the cache.
+            let cache = tokio::select! {
                 biased;
 
-                // If the reset was notified, restart the timer.
+                // If the reset was notified, restart the timer (and skip
+                // checking the cache).
                 _ = reset.notified() => {
                     trace!("Reset");
+                    continue;
                 }
+
+                // If the timeout expires, try to clear the key from the cache...
                 _ = time::sleep(idle) => match cache.upgrade() {
-                    Some(cache) => match Arc::try_unwrap(reset) {
-                        // If this is the last reference to the handle after the
-                        // idle timeout, remove the cache entry.
-                        Ok(_) => {
-                            let removed = cache.write().remove(&key).is_some();
-                            debug_assert!(removed, "Cache item must exist: {:?}", key);
-                            debug!("Cache entry dropped");
-                            return;
-                        }
-                        // Otherwise, another handle has been acquired, so
-                        // restore our reset reference for the next iteration.
-                        Err(r) => {
-                            trace!("The handle is still active");
-                            reset = r;
-                        }
-                    },
+                    Some(c) => c,
                     None => {
                         trace!("Cache already dropped");
                         return;
                     }
                 },
+            };
+
+            // Lock the cache before checking the handle.
+            //
+            // Otherwise, if we consume the reset handle first, it's possible
+            // for another task to update the cache entry before we lock the
+            // cache.
+            let mut cache = cache.write();
+
+            // Try to consume the reset handle to ensure no other tasks are
+            // holding a clone
+            if let Err(r) = Arc::try_unwrap(reset) {
+                // The handle is still being held elsewhere, So wait for another
+                // idle timeout to check again.
+                reset = r;
+                continue;
             }
+
+            // If this was the last handle, attempt to clear the key from the
+            // cache (unless it was replaced by a permanent value). There should
+            // be at most one task per key, so we expect the key to be in the
+            // cached.
+            let entry = cache.entry(key);
+            debug_assert!(
+                matches!(entry, Entry::Occupied(_)),
+                "Cache item must exist: {:?}",
+                entry.key()
+            );
+            if let Entry::Occupied(entry) = entry {
+                if entry.get().is_permanent() {
+                    // The key was updated with a permanent value that cannot be
+                    // evicted.
+                    debug!(key = ?entry.key(), "Cache entry was replaced by permanent value");
+                    return;
+                }
+
+                debug!(key = ?entry.key(), "Dropping cache entry");
+                entry.remove();
+            }
+
+            // The entry no longer exists in the cache.
+            return;
         }
     }
 }
 
 impl<V> CacheEntry<V> {
-    fn fixed(value: V) -> Self {
+    fn permanent(value: V) -> Self {
         Self {
             value,
             handle: None,
         }
     }
 
-    fn cached(&self) -> Option<Cached<V>>
+    fn cached(&self) -> Cached<V>
     where
         V: Clone,
     {
-        match self.handle {
-            // This is an expiring entry. See if its expiry task is still
-            // running.
-            Some(ref handle) => {
-                let handle = handle.upgrade()?;
-                Some(Cached {
-                    inner: self.value.clone(),
-                    handle: Some(handle),
-                })
-            }
-            // This is a fixed (non-expiring) entry
-            None => Some(Cached {
-                inner: self.value.clone(),
-                handle: None,
-            }),
+        let handle = self.handle.as_ref().map(|handle| {
+            handle
+                .upgrade()
+                .expect("handles must be held as long as the entry is in the cache")
+        });
+        Cached {
+            inner: self.value.clone(),
+            handle,
         }
     }
 
-    fn is_expiring(&self) -> bool {
-        self.handle.is_some()
+    fn is_permanent(&self) -> bool {
+        self.handle.is_none()
     }
 }
 
 // === impl Cached ===
-
-impl<V> Cached<V> {
-    /// Returns a new `Cached` handle wrapping the provided value, but *not*
-    /// associated with a cache.
-    ///
-    /// This is intended for use in cases where most values returned by a
-    /// function are stored in a cache, but some may instead be fixed, uncached
-    /// values.
-    ///
-    /// The uncached `Cached` instance will never be evicted, since it didn't
-    /// come from a cache.
-    pub fn uncached(inner: V) -> Self {
-        Self {
-            inner,
-            handle: None,
-        }
-    }
-}
 
 impl<Req, S> tower::Service<Req> for Cached<S>
 where
@@ -352,7 +360,13 @@ async fn test_idle_retain() {
 
     let handle = cache.spawn_idle(());
     let weak = Arc::downgrade(&handle);
-    cache.inner.write().insert((), ((), weak.clone()));
+    cache.inner.write().insert(
+        (),
+        CacheEntry {
+            value: (),
+            handle: Some(weak.clone()),
+        },
+    );
     let c0 = Cached {
         inner: (),
         handle: Some(handle),

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -88,14 +88,14 @@ where
         Self { inner, idle }
     }
 
-    pub fn get<'a, Q: ?Sized>(&self, key: &Q) -> Option<Cached<V>>
+    pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<Cached<V>>
     where
         K: Borrow<Q>,
         Q: Hash + Eq,
         V: Clone,
     {
         let lock = self.inner.read();
-        let (value, weak) = lock.get(&key)?;
+        let (value, weak) = lock.get(key)?;
         let handle = weak.upgrade()?;
 
         trace!("Using cached value");

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
     borrow::Borrow,
     collections::{hash_map::{Entry, RandomState}, HashMap},
     hash::{BuildHasher, Hash, BuildHasherDefault},
-    ops::Deref,
+    ops::{Deref, DerefMut},
     sync::{Arc, Weak},
     task::{Context, Poll},
 };
@@ -257,6 +257,12 @@ impl<V> Deref for Cached<V> {
     type Target = V;
     fn deref(&self) -> &Self::Target {
         &self.inner
+    }
+}
+
+impl<V> DerefMut for Cached<V> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
     }
 }
 

--- a/linkerd/cache/src/new_service.rs
+++ b/linkerd/cache/src/new_service.rs
@@ -37,6 +37,6 @@ where
 
     fn new_service(&self, target: T) -> Cached<N::Service> {
         self.cache
-            .get_or_insert_with(target, |target| self.new_svc.new_service(target))
+            .get_or_insert_with(target, |target| self.new_svc.new_service(target.clone()))
     }
 }

--- a/linkerd/cache/src/new_service.rs
+++ b/linkerd/cache/src/new_service.rs
@@ -1,5 +1,5 @@
-use linkerd_stack::{layer, NewService};
 use super::*;
+use linkerd_stack::{layer, NewService};
 
 #[derive(Clone)]
 pub struct NewCachedService<T, N>
@@ -22,7 +22,7 @@ where
     pub fn layer(idle: time::Duration) -> impl layer::Layer<N, Service = Self> + Clone {
         layer::mk(move |new_svc| Self {
             new_svc,
-            cache: Cache::new(idle)
+            cache: Cache::new(idle),
         })
     }
 }
@@ -36,6 +36,7 @@ where
     type Service = Cached<N::Service>;
 
     fn new_service(&self, target: T) -> Cached<N::Service> {
-        self.cache.get_or_insert_with(target, |target| self.new_svc.new_service(target)).into_owned()
+        self.cache
+            .get_or_insert_with(target, |target| self.new_svc.new_service(target))
     }
 }

--- a/linkerd/cache/src/new_service.rs
+++ b/linkerd/cache/src/new_service.rs
@@ -1,0 +1,41 @@
+use linkerd_stack::{layer, NewService};
+use super::*;
+
+#[derive(Clone)]
+pub struct NewCachedService<T, N>
+where
+    T: Eq + Hash,
+    N: NewService<T>,
+{
+    cache: Cache<T, N::Service>,
+    new_svc: N,
+}
+
+// === impl NewCachedService ===
+
+impl<T, N> NewCachedService<T, N>
+where
+    T: Clone + std::fmt::Debug + Eq + Hash + Send + Sync + 'static,
+    N: NewService<T> + 'static,
+    N::Service: Send + Sync + 'static,
+{
+    pub fn layer(idle: time::Duration) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |new_svc| Self {
+            new_svc,
+            cache: Cache::new(idle)
+        })
+    }
+}
+
+impl<T, N> NewService<T> for NewCachedService<T, N>
+where
+    T: Clone + std::fmt::Debug + Eq + Hash + Send + Sync + 'static,
+    N: NewService<T> + 'static,
+    N::Service: Clone + Send + Sync + 'static,
+{
+    type Service = Cached<N::Service>;
+
+    fn new_service(&self, target: T) -> Cached<N::Service> {
+        self.cache.get_or_insert_with(target, |target| self.new_svc.new_service(target)).into_owned()
+    }
+}


### PR DESCRIPTION
Currently, the `linkerd-cache` crate contains an implementation of a
cache where entries are evicted if they have not been accessed for a
timeout duration. This type currently implements the `NewService` trait
and requires that cached values are `Service`s. It does not provide a
more general purpose key-value cache interface.

PR #1677 introduces dynamic discovery for inbound port policies. We
would like to implement a similar eviction strategy for these policy
watches. However, the policy watches are *not* used in a `NewService`
implementation, but in a `CheckPolicy` implementation.

Therefore, this branch rewrites the `Cache` type to serve as a
general-purpose key-value cache, and adds a new `NewCachedService` type
that implements `NewService` on top of `Cache`.