### PR TITLE
Store permanent values in the cache (for #1683)

### DIFF
--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -360,7 +360,7 @@ async fn test_idle_retain() {
 
     let handle = cache.spawn_idle(());
     let weak = Arc::downgrade(&handle);
-    cache.inner.write().insert((), ((), Some(weak.clone())));
+    cache.inner.write().insert((), CacheEntry { value: (), handle: Some(weak.clone()) });
     let c0 = Cached {
         inner: (),
         handle: Some(handle),

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -124,7 +124,7 @@ where
         V: Clone,
     {
         let cache = self.inner.read();
-        let cache_entry = cache.get(&key)?;
+        let cache_entry = cache.get(key)?;
         let cached = cache_entry.cached();
 
         trace!(
@@ -165,7 +165,7 @@ where
             Entry::Occupied(entry) => {
                 // Another thread raced us to create a value for this target.
                 trace!(key = ?entry.key(), "Using cached value");
-                entry.get().clone().cached()
+                entry.get().cached()
             }
         }
     }

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -360,7 +360,13 @@ async fn test_idle_retain() {
 
     let handle = cache.spawn_idle(());
     let weak = Arc::downgrade(&handle);
-    cache.inner.write().insert((), CacheEntry { value: (), handle: Some(weak.clone()) });
+    cache.inner.write().insert(
+        (),
+        CacheEntry {
+            value: (),
+            handle: Some(weak.clone()),
+        },
+    );
     let c0 = Cached {
         inner: (),
         handle: Some(handle),

--- a/linkerd/cache/src/new_service.rs
+++ b/linkerd/cache/src/new_service.rs
@@ -37,6 +37,6 @@ where
 
     fn new_service(&self, target: T) -> Cached<N::Service> {
         self.cache
-            .get_or_insert_with(target, |target| self.new_svc.new_service(target))
+            .get_or_insert_with(target, |target| self.new_svc.new_service(target.clone()))
     }
 }


### PR DESCRIPTION
In some cases--like inbound policy discovery--we have a set of permanent
values that should never be removed from the cache. This change updates
the cache to only hold a handle when eviction is scheduled. No handle is
held when the cache entry is permanent.

This change also fixes a possible race condition. Previously, the
eviction task could consume an entry's handle without locking the cache.
This made it possible for a `get_or_insert_with` call to race against
the eviction task, adding an entry that would be immediately evicted by
the eviction task.

Signed-off-by: Oliver Gould <ver@buoyant.io>