### PR TITLE
Don't allow a policy to be used if `check_port_allowed` fails

### DIFF
--- a/linkerd/app/inbound/src/accept.rs
+++ b/linkerd/app/inbound/src/accept.rs
@@ -56,8 +56,7 @@ impl<N> Inbound<N> {
                             return Ok(svc::Either::B(t));
                         }
 
-                        let policy = policies.get_policy(addr);
-                        policy.check_port_allowed()?;
+                        let policy = policies.get_policy(addr).check_port_allowed()?;
 
                         tracing::debug!(?policy, "Accepted");
                         Ok(svc::Either::A(Accept {

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -182,8 +182,9 @@ impl<N> Inbound<N> {
                                     // connection is a gateway connection. We check the _gateway
                                     // address's_ policy to determine whether the client is
                                     // authorized to use this gateway.
-                                    let policy = policies.get_policy(client.local_addr);
-                                    policy.check_port_allowed()?;
+                                    let policy = policies
+                                        .get_policy(client.local_addr)
+                                        .check_port_allowed()?;
                                     Ok(svc::Either::B(GatewayTransportHeader {
                                         target: NameAddr::from((name, port)),
                                         protocol,

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -117,7 +117,7 @@ impl AllowPolicy {
 
     /// Checks whether the server has any authorizations at all. If it does not,
     /// a denial error is returned.
-    pub(crate) fn check_port_allowed(&self) -> Result<(), DeniedUnauthorized> {
+    pub(crate) fn check_port_allowed(self) -> Result<Self, DeniedUnauthorized> {
         let server = self.server.borrow();
 
         if server.authorizations.is_empty() {
@@ -126,8 +126,9 @@ impl AllowPolicy {
                 name: server.name.clone(),
             });
         }
+        drop(server);
 
-        Ok(())
+        Ok(self)
     }
 
     /// Checks whether the destination port's `AllowPolicy` is authorized to


### PR DESCRIPTION
Signed-off-by: Oliver Gould <ver@buoyant.io>