### PR TITLE
http: Strip illegal headers from CONNECT responses

### DIFF
--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -709,6 +709,98 @@ macro_rules! http1_tests {
             proxy.join_servers().await;
         }
 
+        /// Tests that the proxy drops headers that can't be used in CONNECT responses.
+        ///
+        /// Exercises https://tools.ietf.org/html/rfc7231#section-4.3.6:
+        ///
+        ///     A client MUST ignore any Content-Length or Transfer-Encoding
+        ///     header fields received in a successful response to CONNECT.
+        ///
+        /// Reproduces https://github.com/linkerd/linkerd2/issues/8539
+        #[tokio::test]
+        async fn http11_connect_headers_stripped() {
+            let _trace = trace_init();
+
+            // To simplify things for this test, we just use the test TCP
+            // client and server to do an HTTP CONNECT.
+            //
+            // We don't *actually* perfom a new connect to requested host,
+            // but client doesn't need to know that for our tests.
+
+            let connect_req = b"\
+                               CONNECT transparency.test.svc.cluster.local HTTP/1.1\r\n\
+                               Host: transparency.test.svc.cluster.local\r\n\
+                               \r\n\
+                               ";
+            let connect_res = b"\
+                               HTTP/1.1 200 OK\r\n\
+                               content-length: 0\r\n\
+                               \r\n\
+                               ";
+
+            let tunneled_req = b"{send}: hi all\n";
+            let tunneled_res = b"{recv}: welcome!\n";
+
+            let srv = server::tcp()
+                .accept_fut(move |mut sock| {
+                    async move {
+                        // Read connect_req...
+                        let mut vec = vec![0; 512];
+                        let n = sock.read(&mut vec).await?;
+                        let head = s(&vec[..n]);
+                        assert_contains!(
+                            head,
+                            "CONNECT transparency.test.svc.cluster.local HTTP/1.1\r\n"
+                        );
+
+                        // Write connect_res back...
+                        sock.write_all(&connect_res[..]).await?;
+
+                        // Read the message after tunneling...
+                        let mut vec = vec![0; 512];
+                        let n = sock.read(&mut vec).await?;
+                        assert_eq!(s(&vec[..n]), s(&tunneled_req[..]));
+
+                        // Some processing... and then write back tunneled res...
+                        sock.write_all(&tunneled_res[..]).await
+                    }
+                    .map(|res: std::io::Result<()>| match res {
+                        Ok(()) => {}
+                        Err(e) => panic!("tcp server error: {}", e),
+                    })
+                })
+                .run()
+                .await;
+            let mk = $proxy;
+            let proxy = mk(srv).await;
+
+            let client = client::tcp(proxy.inbound);
+
+            let tcp_client = client.connect().await;
+
+            tcp_client.write(&connect_req[..]).await;
+
+            let resp = tcp_client.read().await;
+            let resp_str = s(&resp);
+            assert!(
+                resp_str.starts_with("HTTP/1.1 200 OK\r\n"),
+                "response not an upgrade: {:?}",
+                resp_str
+            );
+
+            // We've CONNECTed from HTTP to foo.bar! Say hi!
+            tcp_client.write(&tunneled_req[..]).await;
+            // Did anyone respond?
+            let resp2 = tcp_client.read().await;
+            assert_eq!(s(&resp2), s(&tunneled_res[..]));
+
+            // TCP client must close first
+            tcp_client.shutdown().await;
+
+            // ensure panics from the server are propagated
+            proxy.join_servers().await;
+        }
+
         #[tokio::test]
         async fn http11_connect_bad_requests() {
             let _trace = trace_init();


### PR DESCRIPTION
When the proxy transports `CONNECT` requests, the client silently
ignores `content-length` and `transport-encoding` response headers, as
it should. When the proxy passees these headers to the hyper server, it
errors (as is dictated by the RFC).

This change updates the HTTP client to remove these headers from
responses so that the proxy no longer propagates these illegal headers.

Fixes linkerd/linkerd2#8539

Signed-off-by: Oliver Gould <ver@buoyant.io>