### PR TITLE
Shellscript housekeeping

### DIFF
--- a/.github/actions/list-changed-crates/entrypoint.sh
+++ b/.github/actions/list-changed-crates/entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 # Find the nearest Cargo.toml (except the root).
 find_manifest() {
-    p=$(dirname "$1")
+    p=${1%/*}
     if [ -f "$p/Cargo.toml" ]; then
         realpath "$p/Cargo.toml"
     else
@@ -19,7 +19,7 @@ find_manifest() {
 
 # Build an expression to match all changed manifests.
 manifest_expr() {
-    expr="false"
+    expr=false
 
     for file in "$@" ; do
         # If the workflow changes or root Cargo.toml changes, run checks for all crates in the repo.
@@ -38,9 +38,9 @@ manifest_expr() {
     echo "$expr"
 }
 
-files="$1"
+files=$1
 if [ -z "$files" ]; then
-    echo "No files specified" >&2
+    echo 'No files specified' >&2
     exit 1
 fi
 

--- a/checksec.sh
+++ b/checksec.sh
@@ -18,7 +18,7 @@ if [ $# -ne 1 ]; then
     exit 64
 fi
 
-path="$1"
+path=$1
 if [ ! -x "$path" ]; then
     echo "Executable not found: $path" >&2
     exit 1

--- a/linkerd/app/integration/src/data/gen-certs.sh
+++ b/linkerd/app/integration/src/data/gen-certs.sh
@@ -46,8 +46,8 @@ ee() {
     # "${ee_name}.csr"
 }
 
-ca "Cluster-local CA 1" ca1
-# ca "Cluster-local CA 1" ca2 # Same name, different key pair.
+ca 'Cluster-local CA 1' ca1
+# ca 'Cluster-local CA 1' ca2 # Same name, different key pair.
 
 # The controller itself.
 # ee ca1 controller linkerd linkerd

--- a/linkerd/tls/test-util/src/testdata/gen-certs.sh
+++ b/linkerd/tls/test-util/src/testdata/gen-certs.sh
@@ -48,8 +48,8 @@ ee() {
   mv "${ee}.csr" "${ee}/csr.pem"
 }
 
-ca "Cluster-local CA 1" ca1
-ca "Cluster-local CA 1" ca2 # Same name, different key pair.
+ca 'Cluster-local CA 1' ca1
+ca 'Cluster-local CA 1' ca2 # Same name, different key pair.
 
 # The controller itself.
 ee ca1 controller linkerd linkerd


### PR DESCRIPTION
- Single quotes instead of double quotes for static strings
- No quotes are needed for variable assignments
- Use shellscript built-in functionality instead of dirname

Signed-off-by: Joakim Roubert <joakim.roubert@axis.com>