### PR TITLE
test: replace `profile_test!` macro with builder

### DIFF
--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use linkerd2_proxy_api::destination as pb;
+pub use linkerd2_proxy_api::destination as pb;
 use linkerd2_proxy_api::net;
 use linkerd_app_core::proxy::http::trace;
 use parking_lot::Mutex;

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -190,6 +190,30 @@ impl Proxy {
 }
 
 impl Listening {
+    pub fn outbound_http_client(&self, auth: impl Into<String>) -> client::Client {
+        let version = self
+            .outbound_server
+            .as_ref()
+            .and_then(|outbound| outbound.http_version)
+            .expect("proxy does not have an outbound server, or the outbound server is not HTTP");
+        match version {
+            server::Run::Http1 => client::http1(self.outbound, auth),
+            server::Run::Http2 => client::http2(self.outbound, auth),
+        }
+    }
+
+    pub fn inbound_http_client(&self, auth: impl Into<String>) -> client::Client {
+        let version = self
+            .inbound_server
+            .as_ref()
+            .and_then(|inbound| inbound.http_version)
+            .expect("proxy does not have an inbound server, or the inbound server is not HTTP");
+        match version {
+            server::Run::Http1 => client::http1(self.inbound, auth),
+            server::Run::Http2 => client::http2(self.inbound, auth),
+        }
+    }
+
     pub async fn join_servers(self) {
         let Self {
             inbound_server,

--- a/linkerd/app/integration/src/tcp.rs
+++ b/linkerd/app/integration/src/tcp.rs
@@ -243,5 +243,6 @@ async fn run_server(tcp: TcpServer) -> server::Listening {
         drain: drain_tx,
         conn_count,
         task: Some(task),
+        http_version: None,
     }
 }

--- a/linkerd/app/integration/src/tests/profiles.rs
+++ b/linkerd/app/integration/src/tests/profiles.rs
@@ -168,9 +168,8 @@ impl TestBuilder {
     }
 }
 
-#[tokio::test]
-async fn retry_if_profile_allows() {
-    let test = TestBuilder::new(server::http1())
+async fn test_retry_if_profile_allows(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -183,9 +182,8 @@ async fn retry_if_profile_allows() {
     assert_eq!(test.client.get("/0.5").await, "retried");
 }
 
-#[tokio::test]
-async fn retry_uses_budget() {
-    let test = TestBuilder::new(server::http1())
+async fn test_retry_uses_budget(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -216,9 +214,8 @@ async fn retry_uses_budget() {
         .await;
 }
 
-#[tokio::test]
-async fn retry_with_small_post_body() {
-    let test = TestBuilder::new(server::http1())
+async fn test_retry_with_small_post_body(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -238,9 +235,8 @@ async fn retry_with_small_post_body() {
     assert_eq!(res.status(), 200);
 }
 
-#[tokio::test]
-async fn retry_with_small_put_body() {
-    let test = TestBuilder::new(server::http1())
+async fn test_retry_with_small_put_body(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -260,9 +256,8 @@ async fn retry_with_small_put_body() {
     assert_eq!(res.status(), 200);
 }
 
-#[tokio::test]
-async fn retry_without_content_length() {
-    let test = TestBuilder::new(server::http1())
+async fn test_retry_without_content_length(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -291,9 +286,8 @@ async fn retry_without_content_length() {
     assert_eq!(res.status(), 200);
 }
 
-#[tokio::test]
-async fn does_not_retry_if_request_does_not_match() {
-    let test = TestBuilder::new(server::http1())
+async fn test_does_not_retry_if_request_does_not_match(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_path("/wont/match/anything")
@@ -311,9 +305,8 @@ async fn does_not_retry_if_request_does_not_match() {
     assert_eq!(res.status(), 533);
 }
 
-#[tokio::test]
-async fn does_not_retry_if_earlier_response_class_is_success() {
-    let test = TestBuilder::new(server::http1())
+async fn test_does_not_retry_if_earlier_response_class_is_success(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -333,9 +326,8 @@ async fn does_not_retry_if_earlier_response_class_is_success() {
     assert_eq!(res.status(), 533);
 }
 
-#[tokio::test]
-async fn does_not_retry_if_body_is_too_long() {
-    let test = TestBuilder::new(server::http1())
+async fn test_does_not_retry_if_body_is_too_long(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -357,11 +349,10 @@ async fn does_not_retry_if_body_is_too_long() {
     assert_eq!(res.status(), 533);
 }
 
-#[tokio::test]
-async fn does_not_retry_if_streaming_body_exceeds_max_length() {
+async fn test_does_not_retry_if_streaming_body_exceeds_max_length(version: server::Server) {
     // TODO(eliza): if we make the max length limit configurable, update this
     // test to test the configurable max length limit...
-    let test = TestBuilder::new(server::http1())
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -397,9 +388,8 @@ async fn does_not_retry_if_streaming_body_exceeds_max_length() {
     assert_eq!(res.status(), 533);
 }
 
-#[tokio::test]
-async fn does_not_retry_if_missing_retry_budget() {
-    let test = TestBuilder::new(server::http1())
+async fn test_does_not_retry_if_missing_retry_budget(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -418,9 +408,8 @@ async fn does_not_retry_if_missing_retry_budget() {
     assert_eq!(res.status(), 533);
 }
 
-#[tokio::test]
-async fn ignores_invalid_retry_budget_ttl() {
-    let test = TestBuilder::new(server::http1())
+async fn test_ignores_invalid_retry_budget_ttl(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -439,9 +428,8 @@ async fn ignores_invalid_retry_budget_ttl() {
     assert_eq!(res.status(), 533);
 }
 
-#[tokio::test]
-async fn ignores_invalid_retry_budget_ratio() {
-    let test = TestBuilder::new(server::http1())
+async fn test_ignores_invalid_retry_budget_ratio(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -464,9 +452,8 @@ async fn ignores_invalid_retry_budget_ratio() {
     assert_eq!(res.status(), 533);
 }
 
-#[tokio::test]
-async fn ignores_invalid_retry_budget_negative_ratio() {
-    let test = TestBuilder::new(server::http1())
+async fn ignores_invalid_retry_budget_negative_ratio(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -485,27 +472,8 @@ async fn ignores_invalid_retry_budget_negative_ratio() {
     assert_eq!(res.status(), 533);
 }
 
-#[tokio::test]
-async fn http2_failures_dont_leak_connection_window() {
-    let test = TestBuilder::new(server::http2())
-        .with_profile_route(
-            controller::route()
-                .request_any()
-                .response_failure(500..600)
-                .retryable(true),
-        )
-        .run()
-        .await;
-
-    // Before https://github.com/carllerche/h2/pull/334, this would
-    // hang since the retried failure would have leaked the 100k window
-    // capacity, preventing the successful response from being read.
-    assert_eq!(test.client.get("/0.5/100KB").await, "retried")
-}
-
-#[tokio::test]
-async fn timeout() {
-    let test = TestBuilder::new(server::http1())
+async fn test_timeout(version: server::Server) {
+    let test = TestBuilder::new(version)
         .with_profile_route(
             controller::route()
                 .request_any()
@@ -532,4 +500,161 @@ async fn timeout() {
         .label("error", "timeout")
         .value(1u64)
         .assert_in(&test.metrics)
+        .await;
+}
+
+mod http1 {
+    use super::*;
+
+    #[tokio::test]
+    async fn retry_if_profile_allows() {
+        test_retry_if_profile_allows(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn retry_uses_budget() {
+        test_retry_uses_budget(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn retry_with_small_post_body() {
+        test_retry_with_small_post_body(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn retry_with_small_put_body() {
+        test_retry_with_small_put_body(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn retry_without_content_length() {
+        test_retry_without_content_length(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_if_request_does_not_match() {
+        test_does_not_retry_if_request_does_not_match(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_if_earlier_response_class_is_success() {
+        test_does_not_retry_if_earlier_response_class_is_success(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_if_body_is_too_long() {
+        test_does_not_retry_if_body_is_too_long(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_if_streaming_body_exceeds_max_length() {
+        test_does_not_retry_if_streaming_body_exceeds_max_length(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_if_missing_retry_budget() {
+        test_does_not_retry_if_missing_retry_budget(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn ignores_invalid_retry_budget_ttl() {
+        test_ignores_invalid_retry_budget_ttl(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn ignores_invalid_retry_budget_ratio() {
+        test_ignores_invalid_retry_budget_ratio(server::http1()).await
+    }
+
+    #[tokio::test]
+    async fn timeout() {
+        test_timeout(server::http1()).await
+    }
+}
+
+mod http2 {
+    use super::*;
+
+    #[tokio::test]
+    async fn retry_if_profile_allows() {
+        test_retry_if_profile_allows(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn retry_uses_budget() {
+        test_retry_uses_budget(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn retry_with_small_post_body() {
+        test_retry_with_small_post_body(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn retry_with_small_put_body() {
+        test_retry_with_small_put_body(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn retry_without_content_length() {
+        test_retry_without_content_length(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_if_request_does_not_match() {
+        test_does_not_retry_if_request_does_not_match(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_if_earlier_response_class_is_success() {
+        test_does_not_retry_if_earlier_response_class_is_success(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_if_body_is_too_long() {
+        test_does_not_retry_if_body_is_too_long(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_if_streaming_body_exceeds_max_length() {
+        test_does_not_retry_if_streaming_body_exceeds_max_length(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_if_missing_retry_budget() {
+        test_does_not_retry_if_missing_retry_budget(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn ignores_invalid_retry_budget_ttl() {
+        test_ignores_invalid_retry_budget_ttl(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn ignores_invalid_retry_budget_ratio() {
+        test_ignores_invalid_retry_budget_ratio(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn timeout() {
+        test_timeout(server::http2()).await
+    }
+
+    #[tokio::test]
+    async fn http2_failures_dont_leak_connection_window() {
+        let test = TestBuilder::new(server::http2())
+            .with_profile_route(
+                controller::route()
+                    .request_any()
+                    .response_failure(500..600)
+                    .retryable(true),
+            )
+            .run()
+            .await;
+
+        // Before https://github.com/carllerche/h2/pull/334, this would
+        // hang since the retried failure would have leaked the 100k window
+        // capacity, preventing the successful response from being read.
+        assert_eq!(test.client.get("/0.5/100KB").await, "retried")
+    }
 }

--- a/linkerd/app/integration/src/tests/profiles.rs
+++ b/linkerd/app/integration/src/tests/profiles.rs
@@ -504,7 +504,7 @@ mod cross_version {
     }
 }
 
-macro_rules! cross_version {
+macro_rules! version_tests {
     ($version:expr => $($test:ident),+ $(,)?) => {
         $(
             #[tokio::test]
@@ -517,7 +517,7 @@ macro_rules! cross_version {
 mod http1 {
     use super::*;
 
-    cross_version! {
+    version_tests! {
         server::http1() =>
         retry_if_profile_allows,
         retry_uses_budget,
@@ -539,8 +539,8 @@ mod http1 {
 mod http2 {
     use super::*;
 
-    cross_version! {
-        server::http1() =>
+    version_tests! {
+        server::http2() =>
         retry_if_profile_allows,
         retry_uses_budget,
         retry_with_small_post_body,

--- a/linkerd/app/integration/src/tests/profiles.rs
+++ b/linkerd/app/integration/src/tests/profiles.rs
@@ -1,123 +1,149 @@
 use crate::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-macro_rules! profile_test {
-    (routes: [$($route:expr),+], budget: $budget:expr, with_client: $with_client:expr) => {
-        profile_test! {
-            routes: [$($route),+],
-            budget: $budget,
-            with_client: $with_client,
-            with_metrics: |_m, _| async {}
-        }
-    };
-    (routes: [$($route:expr),+], budget: $budget:expr, with_client: $with_client:expr, with_metrics: $with_metrics:expr) => {
-        profile_test! {
-            http: http1,
-            routes: [$($route),+],
-            budget: $budget,
-            with_client: $with_client,
-            with_metrics: $with_metrics
-        }
-    };
-    (http: $http:ident, routes: [$($route:expr),+], budget: $budget:expr, with_client: $with_client:expr, with_metrics: $with_metrics:expr) => {
-        let _trace = trace_init();
+struct TestBuilder {
+    server: server::Server,
+    routes: Vec<controller::RouteBuilder>,
+    budget: Option<controller::pb::RetryBudget>,
+    default_routes: bool,
+}
 
-        let counter = AtomicUsize::new(0);
-        let counter2 = AtomicUsize::new(0);
-        let counter3 = AtomicUsize::new(0);
+struct Test {
+    metrics: client::Client,
+    client: client::Client,
+    proxy: proxy::Listening,
+    port: u16,
+    // stuff that tests currently never use, but we can't drop while the test is running
+    _guards: (
+        controller::DstSender,
+        controller::ProfileSender,
+        tracing::dispatcher::DefaultGuard,
+    ),
+}
+
+impl TestBuilder {
+    fn new(server: server::Server) -> Self {
+        Self {
+            server,
+            routes: vec![
+                // This route is used to get the proxy to start fetching the`
+                // ServiceProfile. We'll keep GETting this route and checking
+                // the metrics for the labels, to know that the other route
+                // rules are now in place and the test can proceed.
+                controller::route()
+                    .request_path("/load-profile")
+                    .label("load_profile", "test"),
+            ],
+            budget: Some(controller::retry_budget(Duration::from_secs(1), 0.1, 1)),
+            default_routes: true,
+        }
+    }
+
+    fn with_budget(self, budget: impl Into<Option<controller::pb::RetryBudget>>) -> Self {
+        Self {
+            budget: budget.into(),
+            ..self
+        }
+    }
+
+    fn with_profile_route(self, route: controller::RouteBuilder) -> Self {
+        let mut routes = self.routes;
+        routes.push(route);
+        Self { routes, ..self }
+    }
+
+    fn no_default_routes(self) -> Self {
+        Self {
+            default_routes: false,
+            ..self
+        }
+    }
+
+    async fn run(self) -> Test {
+        let (trace, _) = trace_init();
         let host = "profiles.test.svc.cluster.local";
-
-        let srv = server::$http()
+        let mut srv = self
+            .server
             // This route is just called by the test setup, to trigger the proxy
             // to start fetching the ServiceProfile.
             .route_fn("/load-profile", |_| {
-                Response::builder()
-                    .status(201)
-                    .body("".into())
-                    .unwrap()
-            })
-            .route_fn("/1.0/sleep",  move |_req| {
-                ::std::thread::sleep(Duration::from_secs(1));
-                Response::builder()
-                    .status(200)
-                    .body("slept".into())
-                    .unwrap()
-            })
-            .route_async("/0.5",  move |req| {
-                let fail = counter.fetch_add(1, Ordering::Relaxed) % 2 == 0;
-                async move {
-                    // Read the entire body before responding, so that the
-                    // client doesn't fail when writing it out.
-                    let _body = hyper::body::to_bytes(req.into_body()).await;
-                    tracing::debug!(body = ?_body.as_ref().map(|body| body.len()), "recieved body");
-                    Ok::<_, Error>(if fail {
+                Response::builder().status(201).body("".into()).unwrap()
+            });
+        if self.default_routes {
+            let counter = AtomicUsize::new(0);
+            let counter2 = AtomicUsize::new(0);
+            let counter3 = AtomicUsize::new(0);
+            srv = srv
+                .route_fn("/1.0/sleep", move |_req| {
+                    ::std::thread::sleep(Duration::from_secs(1));
+                    Response::builder()
+                        .status(200)
+                        .body("slept".into())
+                        .unwrap()
+                })
+                .route_async("/0.5", move |req| {
+                    let fail = counter.fetch_add(1, Ordering::Relaxed) % 2 == 0;
+                    async move {
+                        // Read the entire body before responding, so that the
+                        // client doesn't fail when writing it out.
+                        let _body = hyper::body::to_bytes(req.into_body()).await;
+                        tracing::debug!(body = ?_body.as_ref().map(|body| body.len()), "recieved body");
+                        Ok::<_, Error>(if fail {
+                            Response::builder().status(533).body("nope".into()).unwrap()
+                        } else {
+                            Response::builder()
+                                .status(200)
+                                .body("retried".into())
+                                .unwrap()
+                        })
+                    }
+                })
+                .route_fn("/0.5/sleep", move |_req| {
+                    ::std::thread::sleep(Duration::from_secs(1));
+                    if counter2.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
+                        Response::builder().status(533).body("nope".into()).unwrap()
+                    } else {
+                        Response::builder()
+                            .status(200)
+                            .body("retried".into())
+                            .unwrap()
+                    }
+                })
+                .route_fn("/0.5/100KB", move |_req| {
+                    if counter3.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
                         Response::builder()
                             .status(533)
-                            .body("nope".into())
+                            .body(vec![b'x'; 1024 * 100].into())
                             .unwrap()
                     } else {
                         Response::builder()
                             .status(200)
                             .body("retried".into())
                             .unwrap()
-                    })
-                }
-            })
-            .route_fn("/0.5/sleep",  move |_req| {
-                ::std::thread::sleep(Duration::from_secs(1));
-                if counter2.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
-                    Response::builder()
-                        .status(533)
-                        .body("nope".into())
-                        .unwrap()
-                } else {
-                    Response::builder()
-                        .status(200)
-                        .body("retried".into())
-                        .unwrap()
-                }
-            })
-            .route_fn("/0.5/100KB",  move |_req| {
-                if counter3.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
-                    Response::builder()
-                        .status(533)
-                        .body(vec![b'x'; 1024 * 100].into())
-                        .unwrap()
-                } else {
-                    Response::builder()
-                        .status(200)
-                        .body("retried".into())
-                        .unwrap()
-                }
-            })
-            .run().await;
+                    }
+                });
+        };
+
+        let srv = srv.run().await;
+
         let port = srv.addr.port();
         let ctrl = controller::new();
 
         let dst_tx = ctrl.destination_tx(&format!("{}:{}", host, port));
         dst_tx.send_addr(srv.addr);
 
+        let ctrl = controller::new();
+
+        let dst_tx = ctrl.destination_tx(&format!("{}:{}", host, port));
+        dst_tx.send_addr(srv.addr);
+
         let profile_tx = ctrl.profile_tx(srv.addr.to_string());
-        let routes = vec![
-            // This route is used to get the proxy to start fetching the`
-            // ServiceProfile. We'll keep GETting this route and checking
-            // the metrics for the labels, to know that the other route
-            // rules are now in place and the test can proceed.
-            controller::route()
-                .request_path("/load-profile")
-                .label("load_profile", "test"),
-            $($route,),+
-        ];
-        profile_tx.send(controller::profile(routes, $budget, vec![], host));
+        profile_tx.send(controller::profile(self.routes, self.budget, vec![], host));
 
         let ctrl = ctrl.run().await;
-        let proxy = proxy::new()
-            .controller(ctrl)
-            .outbound(srv)
-            .run()
-            .await;
+        let proxy = proxy::new().controller(ctrl).outbound(srv).run().await;
 
-        let client = client::$http(proxy.outbound, host);
+        let client = proxy.outbound_http_client(host);
 
         let metrics = client::http1(proxy.admin, "localhost");
 
@@ -132,334 +158,378 @@ macro_rules! profile_test {
             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
         }
 
-        $with_client(client).await;
-
-        $with_metrics(metrics, port).await;
+        Test {
+            metrics,
+            client,
+            proxy,
+            port,
+            _guards: (dst_tx, profile_tx, trace),
+        }
     }
 }
 
 #[tokio::test]
 async fn retry_if_profile_allows() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 // use default classifier
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
-        with_client: |client: client::Client| async move {
-            assert_eq!(client.get("/0.5").await, "retried");
-        }
-    }
+                .retryable(true),
+        )
+        .run()
+        .await;
+
+    assert_eq!(test.client.get("/0.5").await, "retried");
 }
 
 #[tokio::test]
 async fn retry_uses_budget() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(1), 0.1, 1)),
-        with_client: |client: client::Client| async move {
-            assert_eq!(client.get("/0.5").await, "retried");
-            let res = client.request(client.request_builder("/0.5")).await.unwrap();
-            assert_eq!(res.status(), 533);
-        },
-        with_metrics: |metrics: client::Client, port| async move {
-            metrics::metric("route_retryable_total")
-                .label("direction", "outbound")
-                .label("dst", format_args!("profiles.test.svc.cluster.local:{}", port))
-                .label("skipped", "no_budget")
-                .value(1u64)
-                .assert_in(&metrics)
-                .await;
-        }
-    }
+                .retryable(true),
+        )
+        .run()
+        .await;
+    let client = &test.client;
+
+    assert_eq!(client.get("/0.5").await, "retried");
+    let res = client
+        .request(client.request_builder("/0.5"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 533);
+    assert_eq!(client.get("/0.5").await, "retried");
+
+    metrics::metric("route_retryable_total")
+        .label("direction", "outbound")
+        .label(
+            "dst",
+            format_args!("profiles.test.svc.cluster.local:{}", test.port),
+        )
+        .label("skipped", "no_budget")
+        .value(1u64)
+        .assert_in(&test.metrics)
+        .await;
 }
 
 #[tokio::test]
 async fn retry_with_small_post_body() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
-        with_client: |client: client::Client| async move {
-            let req = client.request_builder("/0.5")
-                .method("POST")
-                .body("req has a body".into())
-                .unwrap();
-            let res = client.request_body(req).await;
-            assert_eq!(res.status(), 200);
-        }
-    }
+                .retryable(true),
+        )
+        .run()
+        .await;
+
+    let client = &test.client;
+    let req = client
+        .request_builder("/0.5")
+        .method(http::Method::POST)
+        .body("req has a body".into())
+        .unwrap();
+    let res = client.request_body(req).await;
+    assert_eq!(res.status(), 200);
 }
 
 #[tokio::test]
 async fn retry_with_small_put_body() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
-        with_client: |client: client::Client| async move {
-            let req = client.request_builder("/0.5")
-                .method("PUT")
-                .body("req has a body".into())
-                .unwrap();
-            let res = client.request_body(req).await;
-            assert_eq!(res.status(), 200);
-        }
-    }
+                .retryable(true),
+        )
+        .run()
+        .await;
+
+    let client = &test.client;
+    let req = client
+        .request_builder("/0.5")
+        .method(http::Method::PUT)
+        .body("req has a body".into())
+        .unwrap();
+    let res = client.request_body(req).await;
+    assert_eq!(res.status(), 200);
 }
 
 #[tokio::test]
 async fn retry_without_content_length() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
-        with_client: |client: client::Client| async move {
-            let (mut tx, body) = hyper::body::Body::channel();
-            let req = client.request_builder("/0.5")
-                .method("POST")
-                .body(body)
-                .unwrap();
-            let res = tokio::spawn(async move { client.request_body(req).await });
-            tx.send_data(Bytes::from_static(b"hello"))
-                .await
-                .expect("the whole body should be read");
-            tx.send_data(Bytes::from_static(b"world"))
-                .await
-                .expect("the whole body should be read");
-            drop(tx);
-            let res = res.await.unwrap();
-            assert_eq!(res.status(), 200);
-        }
-    }
+                .retryable(true),
+        )
+        .run()
+        .await;
+
+    let client = test.client;
+    let (mut tx, body) = hyper::body::Body::channel();
+    let req = client
+        .request_builder("/0.5")
+        .method("POST")
+        .body(body)
+        .unwrap();
+    let res = tokio::spawn(async move { client.request_body(req).await });
+    tx.send_data(Bytes::from_static(b"hello"))
+        .await
+        .expect("the whole body should be read");
+    tx.send_data(Bytes::from_static(b"world"))
+        .await
+        .expect("the whole body should be read");
+    drop(tx);
+    let res = res.await.unwrap();
+    assert_eq!(res.status(), 200);
 }
 
 #[tokio::test]
 async fn does_not_retry_if_request_does_not_match() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_path("/wont/match/anything")
                 .response_failure(..)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
-        with_client: |client: client::Client| async move {
-            let res = client.request(client.request_builder("/0.5")).await.unwrap();
-            assert_eq!(res.status(), 533);
-        }
-    }
+                .retryable(true),
+        )
+        .run()
+        .await;
+
+    let client = &test.client;
+    let res = client
+        .request(client.request_builder("/0.5"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 533);
 }
 
 #[tokio::test]
 async fn does_not_retry_if_earlier_response_class_is_success() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 // prevent 533s from being retried
                 .response_success(533..534)
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
-        with_client: |client: client::Client| async move {
-            let res = client.request(client.request_builder("/0.5")).await.unwrap();
-            assert_eq!(res.status(), 533);
-        }
-    }
+                .retryable(true),
+        )
+        .run()
+        .await;
+
+    let client = &test.client;
+    let res = client
+        .request(client.request_builder("/0.5"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 533);
 }
 
 #[tokio::test]
 async fn does_not_retry_if_body_is_too_long() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
+                // prevent 533s from being retried
+                .response_success(533..534)
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
-        with_client: |client: client::Client| async move {
-            let req = client.request_builder("/0.5")
-                .method("POST")
-                .body(hyper::Body::from(&[1u8; 64 * 1024 + 1][..]))
-                .unwrap();
-            let res = client.request_body(req).await;
-            assert_eq!(res.status(), 533);
-        }
-    }
+                .retryable(true),
+        )
+        .run()
+        .await;
+
+    let client = &test.client;
+    let req = client
+        .request_builder("/0.5")
+        .method("POST")
+        .body(hyper::Body::from(&[1u8; 64 * 1024 + 1][..]))
+        .unwrap();
+    let res = client.request_body(req).await;
+    assert_eq!(res.status(), 533);
 }
 
 #[tokio::test]
 async fn does_not_retry_if_streaming_body_exceeds_max_length() {
     // TODO(eliza): if we make the max length limit configurable, update this
     // test to test the configurable max length limit...
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), 0.1, 1)),
-        with_client: |client: client::Client| async move {
-            let (mut tx, body) = hyper::body::Body::channel();
-            let req = client.request_builder("/0.5")
-                .method("POST")
-                .body(body)
-                .unwrap();
-            let res = tokio::spawn(async move { client.request_body(req).await });
-            // send a 32k chunk
-            tx.send_data(Bytes::from(&[1u8; 32 * 1024][..]))
-                .await
-                .expect("the whole body should be read");
-            // ...and another one...
-            tx.send_data(Bytes::from(&[1u8; 32 * 1024][..]))
-                .await
-                .expect("the whole body should be read");
-            // ...and a third one (exceeding the max length limit)
-            tx.send_data(Bytes::from(&[1u8; 32 * 1024][..]))
-                .await
-                .expect("the whole body should be read");
-            drop(tx);
-            let res = res.await.unwrap();
+                .retryable(true),
+        )
+        .run()
+        .await;
 
-            assert_eq!(res.status(), 533);
-        }
-    }
+    let client = test.client;
+    let (mut tx, body) = hyper::body::Body::channel();
+    let req = client
+        .request_builder("/0.5")
+        .method("POST")
+        .body(body)
+        .unwrap();
+    let res = tokio::spawn(async move { client.request_body(req).await });
+    // send a 32k chunk
+    tx.send_data(Bytes::from(&[1u8; 32 * 1024][..]))
+        .await
+        .expect("the whole body should be read");
+    // ...and another one...
+    tx.send_data(Bytes::from(&[1u8; 32 * 1024][..]))
+        .await
+        .expect("the whole body should be read");
+    // ...and a third one (exceeding the max length limit)
+    tx.send_data(Bytes::from(&[1u8; 32 * 1024][..]))
+        .await
+        .expect("the whole body should be read");
+    drop(tx);
+    let res = res.await.unwrap();
+
+    assert_eq!(res.status(), 533);
 }
 
 #[tokio::test]
 async fn does_not_retry_if_missing_retry_budget() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: None,
-        with_client: |client: client::Client|async move {
-            let res = client.request(client.request_builder("/0.5")).await.unwrap();
-            assert_eq!(res.status(), 533);
-        }
-    }
+                .retryable(true),
+        )
+        .with_budget(None)
+        .run()
+        .await;
+
+    let client = &test.client;
+    let res = client
+        .request(client.request_builder("/0.5"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 533);
 }
 
 #[tokio::test]
 async fn ignores_invalid_retry_budget_ttl() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(1000), 0.1, 1)),
-        with_client: |client: client::Client| async move {
-            let res = client.request(client.request_builder("/0.5")).await.unwrap();
-            assert_eq!(res.status(), 533);
-        }
-    }
+                .retryable(true),
+        )
+        .with_budget(controller::retry_budget(Duration::from_secs(1000), 0.1, 1))
+        .run()
+        .await;
+
+    let client = &test.client;
+    let res = client
+        .request(client.request_builder("/0.5"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 533);
 }
 
 #[tokio::test]
 async fn ignores_invalid_retry_budget_ratio() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), 10_000.0, 1)),
-        with_client: |client: client::Client| async move {
-            let res = client.request(client.request_builder("/0.5")).await.unwrap();
-            assert_eq!(res.status(), 533);
-        }
-    }
+                .retryable(true),
+        )
+        .with_budget(controller::retry_budget(
+            Duration::from_secs(10),
+            10_000.0,
+            1,
+        ))
+        .run()
+        .await;
+
+    let client = &test.client;
+    let res = client
+        .request(client.request_builder("/0.5"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 533);
 }
 
 #[tokio::test]
 async fn ignores_invalid_retry_budget_negative_ratio() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), -1.0, 1)),
-        with_client: |client: client::Client| async move {
-            let res = client.request(client.request_builder("/0.5")).await.unwrap();
-            assert_eq!(res.status(), 533);
-        }
-    }
+                .retryable(true),
+        )
+        .with_budget(controller::retry_budget(Duration::from_secs(10), -1.0, 1))
+        .run()
+        .await;
+
+    let client = &test.client;
+    let res = client
+        .request(client.request_builder("/0.5"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 533);
 }
 
 #[tokio::test]
 async fn http2_failures_dont_leak_connection_window() {
-    profile_test! {
-        http: http2,
-        routes: [
+    let test = TestBuilder::new(server::http2())
+        .with_profile_route(
             controller::route()
                 .request_any()
                 .response_failure(500..600)
-                .retryable(true)
-        ],
-        budget: Some(controller::retry_budget(Duration::from_secs(10), 1.0, 10)),
-        with_client: |client: client::Client| async move {
-            // Before https://github.com/carllerche/h2/pull/334, this would
-            // hang since the retried failure would have leaked the 100k window
-            // capacity, preventing the successful response from being read.
-            assert_eq!(client.get("/0.5/100KB").await, "retried");
-        },
-        with_metrics: |_m, _| async {}
-    }
+                .retryable(true),
+        )
+        .run()
+        .await;
+
+    // Before https://github.com/carllerche/h2/pull/334, this would
+    // hang since the retried failure would have leaked the 100k window
+    // capacity, preventing the successful response from being read.
+    assert_eq!(test.client.get("/0.5/100KB").await, "retried")
 }
 
 #[tokio::test]
 async fn timeout() {
-    profile_test! {
-        routes: [
+    let test = TestBuilder::new(server::http1())
+        .with_profile_route(
             controller::route()
                 .request_any()
-                .timeout(Duration::from_millis(100))
-        ],
-        budget: None,
-        with_client: |client: client::Client| async move {
-            let res = client.request(client.request_builder("/1.0/sleep")).await.unwrap();
-            assert_eq!(res.status(), 504);
-        },
-        with_metrics: |metrics: client::Client, port| async move {
-            metrics::metric("route_response_total")
-                .label("direction", "outbound")
-                .label("dst", format_args!("profiles.test.svc.cluster.local:{}", port))
-                .label("classification", "failure")
-                .label("error", "timeout")
-                .value(1u64)
-                .assert_in(&metrics)
-                .await;
-        }
-    }
+                .timeout(Duration::from_millis(100)),
+        )
+        .with_budget(None)
+        .run()
+        .await;
+
+    let client = &test.client;
+    let res = client
+        .request(client.request_builder("/1.0/sleep"))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 504);
+
+    metrics::metric("route_response_total")
+        .label("direction", "outbound")
+        .label(
+            "dst",
+            format_args!("profiles.test.svc.cluster.local:{}", test.port),
+        )
+        .label("classification", "failure")
+        .label("error", "timeout")
+        .value(1u64)
+        .assert_in(&test.metrics)
 }


### PR DESCRIPTION
Currently, the service profiles integration test uses a very complex
declarative macro to generate test bodies. This approach has some
downsides:

1. All of the test code is contained inside a macro. This means that
   `rustfmt` will not reformat it, and (in some cases) compilation
   errors can be unclear.
2. The macro-generated code is relatively inflexible. This makes it
   difficult to add new tests that need to do slightly different things.
3. Adding new configurations to the macro is complex. If we want to add
   some new thing that can also be passed in to change the generated
   code, we have to modify a bunch of macro match arms, which is
   annoying and time-consuming.

This branch rewrites the profiles integration tests to use a
builder-style design instead of a macro. This way, the repetitive
boilerplate necessary to set up the tests is still factored out, and can
still be overridden by passing in different parameters to the builder,
but instead of having a giant macro generate the test, the test itself
is just normal Rust code.

The builder spins up the test proxy and servers, and returns the test
client and metrics client to the test itself, and the test can now do
whatever it wants with them, rather than having to pass bits of test
code into a macro. This is much nicer, because the ests are just normal
tests now. Additionally, the builder can accept an arbitrary server
configuration, which will be necessary for some new tests I'm working on
in a separate branch.

I've also changed the profiles integration test so that most of the
tests are run with both HTTP/1 *and* HTTP/2 clients and servers. This is
still accomplished using macros, but now, the macro is much simpler. The
tests themselves are factored out into functions that take either an
HTTP/1 or HTTP/2 server, and all the macro does is generate wrapper
functions that call the actual test function with the appropriate server
version. This way, the actual test code is never inside of a macro
expansion.

I'd like to change more of the integration tests to work similarly to
these, removing other cases where a macro is used to generate test
boilerplate, and replacing it with a builder.  Also, and more importantly,
this change is necessary for some additional tests I'll be adding in a 
separate PR.