### PR TITLE
justfile: allow passing extra args to docker build

### DIFF
--- a/justfile
+++ b/justfile
@@ -151,10 +151,11 @@ fuzzers:
     done
 
 # Build a docker image (FOR TESTING ONLY)
-docker tag='' mode='load':
+docker tag='' mode='load' *docker-args='':
     docker buildx build . \
         {{ if build_type != 'release' { "--build-arg PROXY_UNOPTIMIZED=1" } else { "" } }} \
-        {{ if tag != "" { "--tag=" + tag + " " + (if mode == "push" { "--push" } else { "--load" }) } else { "" } }}
+        {{ if tag != "" { "--tag=" + tag + " " + (if mode == "push" { "--push" } else { "--load" }) } else { "" } }} \
+        {{ docker-args }}
 
 # Display the git history minus dependabot updates
 history *paths='.':


### PR DESCRIPTION
Currently, when running `just docker`, it is not possible to pass
additional arguments to the `docker buildx build` command. This commit
adds the ability to pass through trailing arguments.

For example, if I want to pass additional build args, I can now do so
from `just`:

```shell
:; just docker 'ghcr.io/linkerd-io/proxy:eliza-log-stream.1' 'load' --build-arg PROXY_FEATURES="multicore,meshtls-rustls,log-streaming"
docker buildx build . --build-arg PROXY_UNOPTIMIZED=1 --tag=ghcr.io/linkerd-io/proxy:eliza-log-stream.1 --load --build-arg PROXY_FEATURES=multicore,meshtls-rustls,log-streaming
[+] Building 3.4s (14/17)
# ...
```