### PR TITLE
justfile: generate a default docker tag name

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ features := ""
 package_version := `git rev-parse --short HEAD`
 
 # Docker image name & tag.
-docker_repo := "localhost/linked/proxy"
+docker_repo := "localhost/linkerd/proxy"
 docker_tag := `git rev-parse --abbrev-ref HEAD | sed 's|/|.|'` + "." + `git rev-parse --short HEAD`
 docker_image := docker_repo + ":" + docker_tag
 

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ cargo := "cargo" + if toolchain != "" { " +" + toolchain } else { "" }
 package_version := `git rev-parse --short HEAD`
 
 # Default docker tag name
-default_docker_tag := "gchr.io/linkerd-io/proxy:" + env_var_or_default("USER", "dev") + "-" + package_version
+default_docker_tag := env_var_or_default("USER", "dev") + "/l2-proxy:" + package_version
 
 # The architecture name to use for packages. Either 'amd64', 'arm64', or 'arm'.
 package_arch := "amd64"

--- a/justfile
+++ b/justfile
@@ -19,6 +19,9 @@ cargo := "cargo" + if toolchain != "" { " +" + toolchain } else { "" }
 # The version name to use for packages.
 package_version := `git rev-parse --short HEAD`
 
+# Default docker tag name
+default_docker_tag := "gchr.io/linkerd-io/proxy:" + env_var_or_default("USER", "dev") + "-" + package_version
+
 # The architecture name to use for packages. Either 'amd64', 'arm64', or 'arm'.
 package_arch := "amd64"
 

--- a/justfile
+++ b/justfile
@@ -16,11 +16,15 @@ build_type := if env_var_or_default("RELEASE", "") == "" { "debug" } else { "rel
 toolchain := ""
 cargo := "cargo" + if toolchain != "" { " +" + toolchain } else { "" }
 
+features := ""
+
 # The version name to use for packages.
 package_version := `git rev-parse --short HEAD`
 
-# Docker tag
-docker_tag := env_var_or_default("USER", "dev") + "/l2-proxy:" + package_version
+# Docker image name & tag.
+docker_repo := "localhost/linked/proxy"
+docker_tag := `git rev-parse --abbrev-ref HEAD | sed 's|/|.|'` + "." + `git rev-parse --short HEAD`
+docker_image := docker_repo + ":" + docker_tag
 
 # The architecture name to use for packages. Either 'amd64', 'arm64', or 'arm'.
 package_arch := "amd64"
@@ -56,6 +60,8 @@ _fmt := if env_var_or_default("GITHUB_ACTIONS", "") != "true" { "" } else {
     ```
 }
 
+_features := if features != "" { "--no-default-features --features=" + features } else { "" }
+
 #
 # Recipes
 #
@@ -90,34 +96,34 @@ check *flags:
     {{ cargo }} check --workspace --all-targets --frozen {{ flags }} {{ _fmt }}
 
 check-crate crate *flags:
-    {{ cargo }} check --package={{ crate }} --all-targets --frozen {{ flags }} {{ _fmt }}
+    {{ cargo }} check --package={{ crate }} --all-targets --frozen {{ _features }} {{ flags }} {{ _fmt }}
 
 clippy *flags:
-    {{ cargo }} clippy --workspace --all-targets --frozen {{ flags }} {{ _fmt }}
+    {{ cargo }} clippy --workspace --all-targets --frozen {{ _features }} {{ flags }} {{ _fmt }}
 
 clippy-crate crate *flags:
-    {{ cargo }} clippy --package={{ crate }} --all-targets --frozen {{ flags }} {{ _fmt }}
+    {{ cargo }} clippy --package={{ crate }} --all-targets --frozen {{ _features }} {{ flags }} {{ _fmt }}
 
 doc *flags:
-    {{ cargo }} doc --no-deps --workspace --frozen {{ flags }} {{ _fmt }}
+    {{ cargo }} doc --no-deps --workspace --frozen {{ _features }} {{ flags }} {{ _fmt }}
 
 doc-crate crate *flags:
-    {{ cargo }} doc --package={{ crate }} --all-targets --frozen {{ flags }} {{ _fmt }}
+    {{ cargo }} doc --package={{ crate }} --all-targets --frozen {{ _features }} {{ flags }} {{ _fmt }}
 
 # Run all tests
 test *flags:
-    {{ cargo }} test --workspace --frozen \
+    {{ cargo }} test --workspace --frozen {{ _features }} \
         {{ if build_type == "release" { "--release" } else { "" } }} \
         {{ flags }}
 
 test-crate crate *flags:
-    {{ cargo }} test --package={{ crate }} --all-targets --frozen {{ flags }} {{ _fmt }}
+    {{ cargo }} test --package={{ crate }} --all-targets --frozen {{ _features }} {{ flags }} {{ _fmt }}
 
 # Build the proxy
 build:
     {{ cargo }} build --frozen --package=linkerd2-proxy --target={{ cargo_target }} \
         {{ if build_type == "release" { "--release" } else { "" } }} \
-        {{ _fmt }}
+        {{ _features }} {{ _fmt }}
 
 # Build a package (i.e. for a release)
 package: build
@@ -156,9 +162,10 @@ fuzzers:
 # Build a docker image (FOR TESTING ONLY)
 docker mode='load':
     docker buildx build . \
-        --tag={{ tag }} \
+        --tag={{ docker_image }} \
         {{ if build_type != 'release' { "--build-arg PROXY_UNOPTIMIZED=1" } else { "" } }} \
-        {{ if mode == "push" { "--push" } else { "--load" } }}
+        {{ if features != "" { "--build-arg PROXY_FEATURES=" + features } else { "" } }} \
+        {{ if mode == 'push' { "--push" } else { "--load" } }}
 
 # Display the git history minus dependabot updates
 history *paths='.':

--- a/justfile
+++ b/justfile
@@ -19,8 +19,8 @@ cargo := "cargo" + if toolchain != "" { " +" + toolchain } else { "" }
 # The version name to use for packages.
 package_version := `git rev-parse --short HEAD`
 
-# Default docker tag name
-default_docker_tag := env_var_or_default("USER", "dev") + "/l2-proxy:" + package_version
+# Docker tag
+docker_tag := env_var_or_default("USER", "dev") + "/l2-proxy:" + package_version
 
 # The architecture name to use for packages. Either 'amd64', 'arm64', or 'arm'.
 package_arch := "amd64"
@@ -154,10 +154,11 @@ fuzzers:
     done
 
 # Build a docker image (FOR TESTING ONLY)
-docker tag=default_docker_tag mode='load':
+docker mode='load':
     docker buildx build . \
+        --tag={{ tag }} \
         {{ if build_type != 'release' { "--build-arg PROXY_UNOPTIMIZED=1" } else { "" } }} \
-        {{ if tag != "" { "--tag=" + tag + " " + (if mode == "push" { "--push" } else { "--load" }) } else { "" } }}
+        {{ if mode == "push" { "--push" } else { "--load" } }}
 
 # Display the git history minus dependabot updates
 history *paths='.':

--- a/justfile
+++ b/justfile
@@ -154,7 +154,7 @@ fuzzers:
     done
 
 # Build a docker image (FOR TESTING ONLY)
-docker tag='' mode='load':
+docker tag=default_docker_tag mode='load':
     docker buildx build . \
         {{ if build_type != 'release' { "--build-arg PROXY_UNOPTIMIZED=1" } else { "" } }} \
         {{ if tag != "" { "--tag=" + tag + " " + (if mode == "push" { "--push" } else { "--load" }) } else { "" } }}


### PR DESCRIPTION
Currently, when running `just docker`, the image is not given a
meaningful tag name by default. This commit changes the `justfile` so
that the default tag is something useful, rather than `''`. If no tag
name is provided from the command line, the Docker image will be given
the tag `gchr.io/linkerd-io/proxy:$USER-$GIT_SHA`. The image name of the
actual Linkerd repository is used so that dev images can be selected
using only the `--proxy-version` flag of `linkerd inject`, and
`--proxy-image` is not needed.

If we'd prefer not to output the same image name as release images by
default, I could that part to something different.