### PR TITLE
stack: add `Proxy::proxy_oneshot`

### DIFF
--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -19,7 +19,7 @@ mod map_target;
 pub mod monitor;
 pub mod new_service;
 mod on_service;
-mod proxy;
+pub mod proxy;
 mod result;
 mod router;
 mod switch_ready;

--- a/linkerd/stack/src/proxy.rs
+++ b/linkerd/stack/src/proxy.rs
@@ -19,6 +19,18 @@ pub trait Proxy<Req, S: tower::Service<Self::Request>> {
 
     /// Usually invokes `S::call`, potentially modifying requests or responses.
     fn proxy(&self, inner: &mut S, req: Req) -> Self::Future;
+
+    /// Like [`ServiceExt::oneshot`](tower::util::ServiceExt::oneshot), but with
+    /// a `Proxy` too.
+    fn proxy_oneshot(self, svc: S, req: Req) -> Oneshot<Self, S, Req>
+    where
+        Self: Sized,
+    {
+        Oneshot {
+            req: Some(req),
+            state: State::PollReady { proxy: self, svc },
+        }
+    }
 }
 
 // === impl Proxy ===
@@ -37,5 +49,47 @@ where
     #[inline]
     fn proxy(&self, inner: &mut S, req: Req) -> Self::Future {
         inner.call(req)
+    }
+}
+
+#[pin_project::pin_project]
+pub struct Oneshot<P, S, R>
+where
+    P: Proxy<R, S>,
+    S: tower::Service<P::Request>,
+{
+    req: Option<R>,
+    #[pin]
+    state: State<P, S, P::Future>,
+}
+
+#[pin_project::pin_project(project = StateProj)]
+enum State<P, S, F> {
+    PollReady { proxy: P, svc: S },
+    Future(#[pin] F),
+}
+
+impl<P, S, R> Future for Oneshot<P, S, R>
+where
+    P: Proxy<R, S>,
+    S: tower::Service<P::Request>,
+    P::Error: From<S::Error>,
+{
+    type Output = Result<P::Response, P::Error>;
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let mut this = self.project();
+        loop {
+            match this.state.as_mut().project() {
+                StateProj::PollReady { proxy, svc } => {
+                    futures::ready!(svc.poll_ready(cx))?;
+                    let f = proxy.proxy(svc, this.req.take().expect("already called"));
+                    this.state.as_mut().set(State::Future(f));
+                }
+                StateProj::Future(f) => return f.poll(cx),
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently, `ServiceExt::oneshot` is used to take a `Service` by value,
poll it until it's ready, and then call that service. This composes well
with `Service` middleware, but it does not compose with our `Proxy`
trait. If a `Service` must be wrapped in a `Proxy` call, it is
impossible to oneshot it.

This branch adds a new `Proxy::proxy_oneshot` method to `Proxy` that
takes a `Proxy` and a `Service` by value, and returns a `Future` that
drives the `Service` to readiness and then calls it through that
`Proxy`.

Currently, this is unused, but it will be used in PR #1706 (from which
this change was factored out).