### PR TITLE
stack: add `ProxyService` for composing a `Proxy` with a `Service`

### DIFF
--- a/linkerd/stack/src/proxy.rs
+++ b/linkerd/stack/src/proxy.rs
@@ -25,7 +25,9 @@ pub trait Proxy<Req, S: tower::Service<Self::Request>> {
     fn proxy(&self, inner: &mut S, req: Req) -> Self::Future;
 
     /// Composes this `Proxy` with a [`Service`], returning a new [`Service`]
-    /// that calls the provided [`Service`] through this [`Proxy`].
+    /// that calls the provided [`Service`] through this `Proxy`.
+    ///
+    /// [`Service`]: tower::Service
     fn into_service(self, svc: S) -> ProxyService<Self, S>
     where
         Self: Sized,
@@ -35,6 +37,8 @@ pub trait Proxy<Req, S: tower::Service<Self::Request>> {
 }
 
 /// Composes a [`Proxy`] with a [`Service`] to create a new [`Service`].
+///
+/// [`Service`]: tower::Service
 #[derive(Clone, Debug)]
 pub struct ProxyService<P, S> {
     proxy: P,


### PR DESCRIPTION
This branch adds a `Proxy::into_service` method that composes a `Proxy`
with a `Service`, returning a new `Service` that calls the inner
`Service` through that `Proxy`.

This negates the need for `Proxy::proxy_oneshot`, so this also
closes #1725.

Currently, this is unused, but it will be used in PR #1706 (from which
this change was factored out).