### PR TITLE
Add 'group' labels to describe policy resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,7 @@ dependencies = [
  "linkerd-proxy-tcp",
  "linkerd-proxy-transport",
  "linkerd-reconnect",
+ "linkerd-server-policy",
  "linkerd-service-profiles",
  "linkerd-stack",
  "linkerd-stack-metrics",

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -52,7 +52,7 @@ struct Http {
 
 #[derive(Clone, Debug)]
 struct Permitted {
-    permit: inbound::policy::Permit,
+    permit: inbound::policy::ServerPermit,
     http: Http,
 }
 

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -48,6 +48,7 @@ linkerd-proxy-tap = { path = "../../proxy/tap" }
 linkerd-proxy-tcp = { path = "../../proxy/tcp" }
 linkerd-proxy-transport = { path = "../../proxy/transport" }
 linkerd-reconnect = { path = "../../reconnect" }
+linkerd-server-policy = { path = "../../server-policy" }
 linkerd-service-profiles = { path = "../../service-profiles" }
 linkerd-stack = { path = "../../stack" }
 linkerd-stack-metrics = { path = "../../stack/metrics" }

--- a/linkerd/app/inbound/src/accept.rs
+++ b/linkerd/app/inbound/src/accept.rs
@@ -119,7 +119,8 @@ mod tests {
         svc::{NewService, ServiceExt},
         Error,
     };
-    use linkerd_server_policy::{Authentication, Authorization, ServerPolicy};
+    use linkerd_server_policy::{Authentication, Authorization, Meta, ServerPolicy};
+    use std::sync::Arc;
 
     #[tokio::test(flavor = "current_thread")]
     async fn default_allow() {
@@ -130,11 +131,17 @@ mod tests {
                 authorizations: vec![Authorization {
                     authentication: Authentication::Unauthenticated,
                     networks: vec![Default::default()],
-                    kind: "serverauthorization".into(),
-                    name: "testsaz".into(),
+                    meta: Arc::new(Meta {
+                        group: "policy.linkerd.io".into(),
+                        kind: "serverauthorization".into(),
+                        name: "testsaz".into(),
+                    }),
                 }],
-                kind: "server".into(),
-                name: "testsrv".into(),
+                meta: Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
+                    kind: "server".into(),
+                    name: "testsrv".into(),
+                }),
             },
             None,
         );

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -1,9 +1,10 @@
 use crate::{
-    policy::{self, AllowPolicy, Permit, Protocol, ServerLabel},
+    policy::{self, AllowPolicy, Protocol, ServerPermit},
     Inbound,
 };
 use linkerd_app_core::{
     detect, identity, io,
+    metrics::ServerLabel,
     proxy::http,
     svc, tls,
     transport::{
@@ -21,7 +22,7 @@ pub(crate) struct Forward {
     client_addr: Remote<ClientAddr>,
     orig_dst_addr: OrigDstAddr,
     tls: tls::ConditionalServerTls,
-    permit: Permit,
+    permit: ServerPermit,
 }
 
 #[derive(Clone, Debug)]
@@ -281,8 +282,8 @@ impl<N> Inbound<N> {
 
 // === impl Forward ===
 
-impl From<(Permit, Tls)> for Forward {
-    fn from((permit, tls): (Permit, Tls)) -> Self {
+impl From<(ServerPermit, Tls)> for Forward {
+    fn from((permit, tls): (ServerPermit, Tls)) -> Self {
         Self {
             client_addr: tls.client_addr,
             orig_dst_addr: tls.orig_dst_addr,
@@ -450,12 +451,13 @@ mod tests {
     use super::*;
     use crate::test_util;
     use futures::future;
-    use io::AsyncWriteExt;
     use linkerd_app_core::{
+        io::AsyncWriteExt,
         svc::{NewService, ServiceExt},
         trace, Error,
     };
-    use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy};
+    use linkerd_server_policy::{Authentication, Authorization, Meta, Protocol, ServerPolicy};
+    use std::sync::Arc;
 
     const HTTP1: &[u8] = b"GET / HTTP/1.1\r\nhost: example.com\r\n\r\n";
     const HTTP2: &[u8] = b"PRI * HTTP/2.0\r\n";
@@ -469,11 +471,17 @@ mod tests {
                 authorizations: vec![Authorization {
                     authentication: Authentication::Unauthenticated,
                     networks: vec![client_addr().ip().into()],
-                    kind: "serverathorizationu".into(),
-                    name: "testsaz".into(),
+                    meta: Arc::new(Meta {
+                        group: "policy.linkerd.io".into(),
+                        kind: "serverathorization".into(),
+                        name: "testsaz".into(),
+                    }),
                 }],
-                kind: "server".into(),
-                name: "testsrv".into(),
+                meta: Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
+                    kind: "server".into(),
+                    name: "testsrv".into(),
+                }),
             },
         );
         allow

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -29,7 +29,7 @@ struct RefusedNoTarget;
 pub(crate) struct LocalTcp {
     addr: Remote<ServerAddr>,
     client_id: tls::ClientId,
-    permit: policy::Permit,
+    permit: policy::ServerPermit,
 }
 
 #[derive(Debug, Clone)]

--- a/linkerd/app/inbound/src/http.rs
+++ b/linkerd/app/inbound/src/http.rs
@@ -33,7 +33,7 @@ pub mod fuzz {
     };
     pub use linkerd_app_test as support;
     use linkerd_app_test::*;
-    use std::{fmt, str};
+    use std::{fmt, str, sync::Arc};
 
     #[derive(Arbitrary)]
     pub struct HttpRequestSpec {
@@ -216,11 +216,17 @@ pub mod fuzz {
                     authorizations: vec![policy::Authorization {
                         authentication: policy::Authentication::Unauthenticated,
                         networks: vec![std::net::IpAddr::from([192, 0, 2, 3]).into()],
-                        kind: "server".into(),
-                        name: "testsaz".into(),
+                        meta: Arc::new(policy::Meta {
+                            group: "policy.linkerd.io".into(),
+                            kind: "server".into(),
+                            name: "testsaz".into(),
+                        }),
                     }],
-                    kind: "server".into(),
-                    name: "testsrv".into(),
+                    meta: Arc::new(policy::Meta {
+                        group: "policy.linkerd.io".into(),
+                        kind: "server".into(),
+                        name: "testsrv".into(),
+                    }),
                 },
             );
             policy
@@ -229,10 +235,11 @@ pub mod fuzz {
 
     impl svc::Param<policy::ServerLabel> for Target {
         fn param(&self) -> policy::ServerLabel {
-            policy::ServerLabel {
+            policy::ServerLabel(Arc::new(policy::Meta {
+                group: "policy.linkerd.io".into(),
                 kind: "server".into(),
                 name: "testsrv".into(),
-            }
+            }))
         }
     }
 

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -18,7 +18,7 @@ use linkerd_app_core::{
 };
 use linkerd_app_test::connect::ConnectFuture;
 use linkerd_tracing::test::trace_init;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
 use tracing::Instrument;
 
 fn build_server<I>(
@@ -610,11 +610,17 @@ impl svc::Param<policy::AllowPolicy> for Target {
                 authorizations: vec![policy::Authorization {
                     authentication: policy::Authentication::Unauthenticated,
                     networks: vec![std::net::IpAddr::from([192, 0, 2, 3]).into()],
-                    kind: "serverauthorization".into(),
-                    name: "testsaz".into(),
+                    meta: Arc::new(policy::Meta {
+                        group: "policy.linkerd.io".into(),
+                        kind: "serverauthorization".into(),
+                        name: "testsaz".into(),
+                    }),
                 }],
-                kind: "server".into(),
-                name: "testsrv".into(),
+                meta: Arc::new(policy::Meta {
+                    group: "policy.linkerd.io".into(),
+                    kind: "server".into(),
+                    name: "testsrv".into(),
+                }),
             },
         );
         policy
@@ -623,10 +629,11 @@ impl svc::Param<policy::AllowPolicy> for Target {
 
 impl svc::Param<policy::ServerLabel> for Target {
     fn param(&self) -> policy::ServerLabel {
-        policy::ServerLabel {
+        policy::ServerLabel(Arc::new(policy::Meta {
+            group: "policy.linkerd.io".into(),
             kind: "server".into(),
             name: "testsrv".into(),
-        }
+        }))
     }
 }
 

--- a/linkerd/app/inbound/src/metrics/authz.rs
+++ b/linkerd/app/inbound/src/metrics/authz.rs
@@ -1,6 +1,8 @@
-use crate::policy::{AllowPolicy, Permit};
+use crate::policy::{AllowPolicy, ServerPermit};
 use linkerd_app_core::{
-    metrics::{metrics, AuthzLabels, Counter, FmtMetrics, ServerLabel, TargetAddr, TlsAccept},
+    metrics::{
+        metrics, Counter, FmtMetrics, ServerAuthzLabels, ServerLabel, TargetAddr, TlsAccept,
+    },
     tls,
 };
 use parking_lot::Mutex;
@@ -54,14 +56,14 @@ struct SrvKey {
 #[derive(Debug, Hash, PartialEq, Eq)]
 struct AuthzKey {
     target: TargetAddr,
-    authz: AuthzLabels,
+    authz: ServerAuthzLabels,
     tls: tls::ConditionalServerTls,
 }
 
 // === impl HttpAuthzMetrics ===
 
 impl HttpAuthzMetrics {
-    pub fn allow(&self, permit: &Permit, tls: tls::ConditionalServerTls) {
+    pub fn allow(&self, permit: &ServerPermit, tls: tls::ConditionalServerTls) {
         self.0
             .allow
             .lock()
@@ -114,7 +116,7 @@ impl FmtMetrics for HttpAuthzMetrics {
 // === impl TcpAuthzMetrics ===
 
 impl TcpAuthzMetrics {
-    pub fn allow(&self, permit: &Permit, tls: tls::ConditionalServerTls) {
+    pub fn allow(&self, permit: &ServerPermit, tls: tls::ConditionalServerTls) {
         self.0
             .allow
             .lock()
@@ -201,11 +203,11 @@ impl SrvKey {
 // === impl AuthzKey ===
 
 impl AuthzKey {
-    fn new(permit: &Permit, tls: tls::ConditionalServerTls) -> Self {
+    fn new(permit: &ServerPermit, tls: tls::ConditionalServerTls) -> Self {
         Self {
+            tls,
             target: TargetAddr(permit.dst.into()),
             authz: permit.labels.clone(),
-            tls,
         }
     }
 }

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -10,22 +10,25 @@ pub use self::authorize::{NewAuthorizeHttp, NewAuthorizeTcp};
 pub use self::config::Config;
 pub(crate) use self::store::Store;
 
-pub use linkerd_app_core::metrics::{AuthzLabels, ServerLabel};
+use linkerd_app_core::metrics::ServerAuthzLabels;
+pub use linkerd_app_core::metrics::ServerLabel;
 use linkerd_app_core::{
     tls,
     transport::{ClientAddr, OrigDstAddr, Remote},
     Result,
 };
 use linkerd_cache::Cached;
-pub use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy, Suffix};
+pub use linkerd_server_policy::{
+    Authentication, Authorization, Meta, Protocol, ServerPolicy, Suffix,
+};
+use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::watch;
 
 #[derive(Clone, Debug, Error)]
-#[error("unauthorized connection on {kind}/{name}")]
+#[error("unauthorized connection on {}/{}", server.kind, server.name)]
 pub struct DeniedUnauthorized {
-    kind: std::sync::Arc<str>,
-    name: std::sync::Arc<str>,
+    server: Arc<Meta>,
 }
 
 pub trait GetPolicy {
@@ -46,11 +49,11 @@ pub struct AllowPolicy {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Permit {
+pub struct ServerPermit {
     pub dst: OrigDstAddr,
     pub protocol: Protocol,
 
-    pub labels: AuthzLabels,
+    pub labels: ServerAuthzLabels,
 }
 
 // === impl DefaultPolicy ===
@@ -68,8 +71,11 @@ impl From<DefaultPolicy> for ServerPolicy {
             DefaultPolicy::Deny => ServerPolicy {
                 protocol: Protocol::Opaque,
                 authorizations: vec![],
-                kind: "default".into(),
-                name: "deny".into(),
+                meta: Arc::new(Meta {
+                    group: "default".into(),
+                    kind: "default".into(),
+                    name: "deny".into(),
+                }),
             },
         }
     }
@@ -100,12 +106,23 @@ impl AllowPolicy {
     }
 
     #[inline]
+    pub fn group(&self) -> String {
+        self.server.borrow().meta.group.to_string()
+    }
+
+    #[inline]
+    pub fn kind(&self) -> String {
+        self.server.borrow().meta.kind.to_string()
+    }
+
+    #[inline]
+    pub fn name(&self) -> String {
+        self.server.borrow().meta.name.to_string()
+    }
+
+    #[inline]
     pub fn server_label(&self) -> ServerLabel {
-        let s = self.server.borrow();
-        ServerLabel {
-            kind: s.kind.clone(),
-            name: s.name.clone(),
-        }
+        ServerLabel(self.server.borrow().meta.clone())
     }
 
     async fn changed(&mut self) {
@@ -122,8 +139,7 @@ impl AllowPolicy {
 
         if server.authorizations.is_empty() {
             return Err(DeniedUnauthorized {
-                kind: server.kind.clone(),
-                name: server.name.clone(),
+                server: server.meta.clone(),
             });
         }
         drop(server);
@@ -137,13 +153,13 @@ impl AllowPolicy {
         &self,
         client_addr: Remote<ClientAddr>,
         tls: &tls::ConditionalServerTls,
-    ) -> Result<Permit, DeniedUnauthorized> {
+    ) -> Result<ServerPermit, DeniedUnauthorized> {
         let server = self.server.borrow();
         for authz in server.authorizations.iter() {
             if authz.networks.iter().any(|n| n.contains(&client_addr.ip())) {
                 match authz.authentication {
                     Authentication::Unauthenticated => {
-                        return Ok(Permit::new(self.dst, &*server, authz));
+                        return Ok(ServerPermit::new(self.dst, &*server, authz));
                     }
 
                     Authentication::TlsUnauthenticated => {
@@ -151,7 +167,7 @@ impl AllowPolicy {
                             ..
                         }) = tls
                         {
-                            return Ok(Permit::new(self.dst, &*server, authz));
+                            return Ok(ServerPermit::new(self.dst, &*server, authz));
                         }
                     }
 
@@ -167,7 +183,7 @@ impl AllowPolicy {
                             if identities.contains(id.as_str())
                                 || suffixes.iter().any(|s| s.contains(id.as_str()))
                             {
-                                return Ok(Permit::new(self.dst, &*server, authz));
+                                return Ok(ServerPermit::new(self.dst, &*server, authz));
                             }
                         }
                     }
@@ -176,26 +192,21 @@ impl AllowPolicy {
         }
 
         Err(DeniedUnauthorized {
-            kind: server.kind.clone(),
-            name: server.name.clone(),
+            server: server.meta.clone(),
         })
     }
 }
 
-// === impl Permit ===
+// === impl ServerPermit ===
 
-impl Permit {
+impl ServerPermit {
     fn new(dst: OrigDstAddr, server: &ServerPolicy, authz: &Authorization) -> Self {
         Self {
             dst,
             protocol: server.protocol,
-            labels: AuthzLabels {
-                kind: authz.kind.clone(),
-                name: authz.name.clone(),
-                server: ServerLabel {
-                    kind: server.kind.clone(),
-                    name: server.name.clone(),
-                },
+            labels: ServerAuthzLabels {
+                authz: authz.meta.clone(),
+                server: ServerLabel(server.meta.clone()),
             },
         }
     }

--- a/linkerd/app/inbound/src/policy/authorize/http.rs
+++ b/linkerd/app/inbound/src/policy/authorize/http.rs
@@ -1,6 +1,6 @@
 use crate::metrics::authz::HttpAuthzMetrics;
 
-use super::super::{AllowPolicy, Permit};
+use super::super::{AllowPolicy, ServerPermit};
 use futures::{future, TryFutureExt};
 use linkerd_app_core::{
     svc::{self, ServiceExt},
@@ -73,7 +73,7 @@ where
 impl<Req, T, N, S> svc::Service<Req> for AuthorizeHttp<T, N>
 where
     T: Clone,
-    N: svc::NewService<(Permit, T), Service = S>,
+    N: svc::NewService<(ServerPermit, T), Service = S>,
     S: svc::Service<Req>,
     S::Error: Into<Error>,
 {
@@ -105,7 +105,9 @@ where
             }
             Err(e) => {
                 tracing::info!(
-                    server = %format_args!("{}:{}", self.policy.server_label().kind, self.policy.server_label().name),
+                    server.group = %self.policy.group(),
+                    server.kind = %self.policy.kind(),
+                    server.name = %self.policy.name(),
                     tls = ?self.tls,
                     client = %self.client_addr,
                     "Request denied",

--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -1,6 +1,6 @@
 use linkerd_app_core::{IpNet, Ipv4Net, Ipv6Net};
-use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy, Suffix};
-use std::time::Duration;
+use linkerd_server_policy::{Authentication, Authorization, Meta, Protocol, ServerPolicy, Suffix};
+use std::{sync::Arc, time::Duration};
 
 pub fn all_authenticated(timeout: Duration) -> ServerPolicy {
     mk("all-authenticated", all_nets(), authenticated(), timeout)
@@ -55,7 +55,7 @@ fn authenticated() -> Authentication {
 }
 
 fn mk(
-    name: &str,
+    name: &'static str,
     nets: impl IntoIterator<Item = IpNet>,
     authentication: Authentication,
     timeout: Duration,
@@ -65,10 +65,16 @@ fn mk(
         authorizations: vec![Authorization {
             networks: nets.into_iter().map(Into::into).collect(),
             authentication,
+            meta: Arc::new(Meta {
+                group: "default".into(),
+                kind: "default".into(),
+                name: name.into(),
+            }),
+        }],
+        meta: Arc::new(Meta {
+            group: "default".into(),
             kind: "default".into(),
             name: name.into(),
-        }],
-        kind: "default".into(),
-        name: name.into(),
+        }),
     }
 }

--- a/linkerd/app/inbound/src/policy/tests.rs
+++ b/linkerd/app/inbound/src/policy/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use linkerd_app_core::{proxy::http, Error};
 use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy, Suffix};
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 #[derive(Clone)]
 pub(crate) struct MockSvc;
@@ -13,11 +13,17 @@ async fn unauthenticated_allowed() {
         authorizations: vec![Authorization {
             authentication: Authentication::Unauthenticated,
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            kind: "serverauthorization".into(),
-            name: "unauth".into(),
+            meta: Arc::new(Meta {
+                group: "policy.linkerd.io".into(),
+                kind: "serverauthorization".into(),
+                name: "unauth".into(),
+            }),
         }],
-        kind: "server".into(),
-        name: "test".into(),
+        meta: Arc::new(Meta {
+            group: "policy.linkerd.io".into(),
+            kind: "server".into(),
+            name: "test".into(),
+        }),
     };
 
     let policies = Store::for_test(policy.clone(), None);
@@ -30,17 +36,21 @@ async fn unauthenticated_allowed() {
         .expect("unauthenticated connection must be permitted");
     assert_eq!(
         permitted,
-        Permit {
+        ServerPermit {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
-            labels: AuthzLabels {
-                kind: "serverauthorization".into(),
-                name: "unauth".into(),
-                server: ServerLabel {
+            labels: ServerAuthzLabels {
+                authz: Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
+                    kind: "serverauthorization".into(),
+                    name: "unauth".into()
+                }),
+                server: ServerLabel(Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
                     kind: "server".into(),
-                    name: "test".into(),
-                }
-            }
+                    name: "test".into()
+                }))
+            },
         }
     );
 }
@@ -55,11 +65,17 @@ async fn authenticated_identity() {
                 identities: vec![client_id().to_string()].into_iter().collect(),
             },
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            kind: "serverauthorization".into(),
-            name: "tls-auth".into(),
+            meta: Arc::new(Meta {
+                group: "policy.linkerd.io".into(),
+                kind: "serverauthorization".into(),
+                name: "tls-auth".into(),
+            }),
         }],
-        kind: "server".into(),
-        name: "test".into(),
+        meta: Arc::new(Meta {
+            group: "policy.linkerd.io".into(),
+            kind: "server".into(),
+            name: "test".into(),
+        }),
     };
 
     let policies = Store::for_test(policy.clone(), None);
@@ -75,16 +91,20 @@ async fn authenticated_identity() {
         .expect("unauthenticated connection must be permitted");
     assert_eq!(
         permitted,
-        Permit {
+        ServerPermit {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
-            labels: AuthzLabels {
-                kind: "serverauthorization".into(),
-                name: "tls-auth".into(),
-                server: ServerLabel {
+            labels: ServerAuthzLabels {
+                authz: Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
+                    kind: "serverauthorization".into(),
+                    name: "tls-auth".into()
+                }),
+                server: ServerLabel(Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
                     kind: "server".into(),
                     name: "test".into()
-                },
+                }))
             }
         }
     );
@@ -112,11 +132,17 @@ async fn authenticated_suffix() {
                 suffixes: vec![Suffix::from(vec!["cluster".into(), "local".into()])],
             },
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            kind: "serverauthorization".into(),
-            name: "tls-auth".into(),
+            meta: Arc::new(Meta {
+                group: "policy.linkerd.io".into(),
+                kind: "serverauthorization".into(),
+                name: "tls-auth".into(),
+            }),
         }],
-        kind: "server".into(),
-        name: "test".into(),
+        meta: Arc::new(Meta {
+            group: "policy.linkerd.io".into(),
+            kind: "server".into(),
+            name: "test".into(),
+        }),
     };
 
     let policies = Store::for_test(policy.clone(), None);
@@ -131,16 +157,20 @@ async fn authenticated_suffix() {
         allowed
             .check_authorized(client_addr(), &tls)
             .expect("unauthenticated connection must be permitted"),
-        Permit {
+        ServerPermit {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
-            labels: AuthzLabels {
-                kind: "serverauthorization".into(),
-                name: "tls-auth".into(),
-                server: ServerLabel {
+            labels: ServerAuthzLabels {
+                authz: Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
+                    kind: "serverauthorization".into(),
+                    name: "tls-auth".into()
+                }),
+                server: ServerLabel(Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
                     kind: "server".into(),
                     name: "test".into()
-                }
+                })),
             }
         }
     );
@@ -165,11 +195,17 @@ async fn tls_unauthenticated() {
         authorizations: vec![Authorization {
             authentication: Authentication::TlsUnauthenticated,
             networks: vec!["192.0.2.0/24".parse().unwrap()],
-            kind: "serverauthorization".into(),
-            name: "tls-unauth".into(),
+            meta: Arc::new(Meta {
+                group: "policy.linkerd.io".into(),
+                kind: "serverauthorization".into(),
+                name: "tls-unauth".into(),
+            }),
         }],
-        kind: "server".into(),
-        name: "test".into(),
+        meta: Arc::new(Meta {
+            group: "policy.linkerd.io".into(),
+            kind: "server".into(),
+            name: "test".into(),
+        }),
     };
 
     let policies = Store::for_test(policy.clone(), None);
@@ -184,16 +220,20 @@ async fn tls_unauthenticated() {
         allowed
             .check_authorized(client_addr(), &tls)
             .expect("unauthenticated connection must be permitted"),
-        Permit {
+        ServerPermit {
             dst: orig_dst_addr(),
             protocol: policy.protocol,
-            labels: AuthzLabels {
-                kind: "serverauthorization".into(),
-                name: "tls-unauth".into(),
-                server: ServerLabel {
+            labels: ServerAuthzLabels {
+                authz: Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
+                    kind: "serverauthorization".into(),
+                    name: "tls-unauth".into()
+                }),
+                server: ServerLabel(Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
                     kind: "server".into(),
-                    name: "test".into(),
-                },
+                    name: "test".into()
+                })),
             }
         }
     );

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -14,8 +14,8 @@ use linkerd_app_core::{
     ProxyRuntime,
 };
 pub use linkerd_app_test as support;
-use linkerd_server_policy::{Authentication, Authorization, Protocol, ServerPolicy};
-use std::time::Duration;
+use linkerd_server_policy::{Authentication, Authorization, Meta, Protocol, ServerPolicy};
+use std::{sync::Arc, time::Duration};
 
 pub fn default_config() -> Config {
     let cluster_local = "svc.cluster.local."
@@ -59,11 +59,17 @@ pub fn default_config() -> Config {
                 authorizations: vec![Authorization {
                     authentication: Authentication::Unauthenticated,
                     networks: vec![Default::default()],
-                    kind: "serverauthorization".into(),
-                    name: "testsaz".into(),
+                    meta: Arc::new(Meta {
+                        group: "policy.linkerd.io".into(),
+                        kind: "serverauthorization".into(),
+                        name: "testsaz".into(),
+                    }),
                 }],
-                kind: "server".into(),
-                name: "testsrv".into(),
+                meta: Arc::new(Meta {
+                    group: "policy.linkerd.io".into(),
+                    kind: "server".into(),
+                    name: "testsrv".into(),
+                }),
             }
             .into(),
             ports: Default::default(),

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -4,14 +4,13 @@
 mod network;
 
 pub use self::network::Network;
-use std::{collections::HashSet, hash::Hash, sync::Arc, time};
+use std::{borrow::Cow, collections::HashSet, hash::Hash, sync::Arc, time};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ServerPolicy {
     pub protocol: Protocol,
     pub authorizations: Vec<Authorization>,
-    pub kind: Arc<str>,
-    pub name: Arc<str>,
+    pub meta: Arc<Meta>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -28,8 +27,14 @@ pub enum Protocol {
 pub struct Authorization {
     pub networks: Vec<Network>,
     pub authentication: Authentication,
-    pub kind: Arc<str>,
-    pub name: Arc<str>,
+    pub meta: Arc<Meta>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Meta {
+    pub group: Cow<'static, str>,
+    pub kind: Cow<'static, str>,
+    pub name: Cow<'static, str>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
In preparation to introduce new route types to the policy API, this
change introduces a new `server_policy::Meta` type that includes a
`group` field so that we can explicitly differentiate between multiple
types of resources).

This change renames some types in anticipation of new types being
introduced:

* `Permit` is now `ServerPermit`
* `AuthzLabels` is now `ServerAuthzLabels`

Signed-off-by: Oliver Gould <ver@buoyant.io>