### PR TITLE
Implement `Deref` for address newtypes

### DIFF
--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -377,7 +377,7 @@ impl From<Profile> for Logical {
 
 impl Param<u16> for Logical {
     fn param(&self) -> u16 {
-        self.addr.as_ref().port()
+        self.addr.port()
     }
 }
 
@@ -409,9 +409,7 @@ impl classify::CanClassify for Logical {
 
 impl tap::Inspect for Logical {
     fn src_addr<B>(&self, req: &http::Request<B>) -> Option<SocketAddr> {
-        req.extensions()
-            .get::<Remote<ClientAddr>>()
-            .map(|a| *a.as_ref())
+        req.extensions().get::<Remote<ClientAddr>>().map(|a| **a)
     }
 
     fn src_tls<B>(&self, req: &http::Request<B>) -> tls::ConditionalServerTls {

--- a/linkerd/app/outbound/src/switch_logical.rs
+++ b/linkerd/app/outbound/src/switch_logical.rs
@@ -105,8 +105,8 @@ mod tests {
         let _trace = linkerd_tracing::test::trace_init();
 
         let endpoint = |ep: tcp::Endpoint| {
-            assert_eq!(ep.addr.as_ref().ip(), IpAddr::from([192, 0, 2, 20]));
-            assert_eq!(ep.addr.as_ref().port(), 2020);
+            assert_eq!(ep.addr.ip(), IpAddr::from([192, 0, 2, 20]));
+            assert_eq!(ep.addr.port(), 2020);
             assert!(!ep.opaque_protocol);
             svc::mk(|_: io::DuplexStream| future::ok::<(), Error>(()))
         };
@@ -128,8 +128,8 @@ mod tests {
         let _trace = linkerd_tracing::test::trace_init();
 
         let endpoint = |ep: tcp::Endpoint| {
-            assert_eq!(ep.addr.as_ref().ip(), IpAddr::from([192, 0, 2, 10]));
-            assert_eq!(ep.addr.as_ref().port(), 1010);
+            assert_eq!(ep.addr.ip(), IpAddr::from([192, 0, 2, 10]));
+            assert_eq!(ep.addr.port(), 1010);
             assert!(ep.opaque_protocol);
             svc::mk(|_: io::DuplexStream| future::ok::<(), Error>(()))
         };
@@ -197,7 +197,7 @@ mod tests {
         let endpoint_addr = SocketAddr::new([192, 0, 2, 20].into(), 2020);
         let endpoint = {
             move |ep: tcp::Endpoint| {
-                assert_eq!(ep.addr.as_ref(), &endpoint_addr);
+                assert_eq!(*ep.addr, endpoint_addr);
                 assert!(ep.opaque_protocol, "protocol must be marked opaque");
                 svc::mk(|_: io::DuplexStream| future::ok::<(), Error>(()))
             }

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -155,7 +155,7 @@ mod tests {
         let (rt, _shutdown) = runtime();
         let stack = Outbound::new(default_config(), rt)
             .with_stack(svc::mk(move |ep: Endpoint| {
-                assert_eq!(*ep.addr.as_ref(), ep_addr);
+                assert_eq!(*ep.addr, ep_addr);
                 let mut io = support::io();
                 io.write(b"hola").read(b"mundo");
                 let local = Local(ClientAddr(([0, 0, 0, 0], 4444).into()));

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -513,7 +513,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         // Ensure that connections that directly target the inbound port are secured (unless
         // identity is disabled).
         let policy = {
-            let inbound_port = server.addr.as_ref().port();
+            let inbound_port = server.addr.port();
 
             let cluster_nets = parse(strings, ENV_POLICY_CLUSTER_NETWORKS, parse_networks)?
                 .unwrap_or_else(|| {

--- a/linkerd/proxy/transport/src/addrs.rs
+++ b/linkerd/proxy/transport/src/addrs.rs
@@ -3,7 +3,7 @@ use std::{
     net::{IpAddr, SocketAddr, ToSocketAddrs},
 };
 
-/// The address of a remote client.
+/// The address of a client.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ClientAddr(pub SocketAddr);
 
@@ -11,7 +11,7 @@ pub struct ClientAddr(pub SocketAddr);
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ListenAddr(pub SocketAddr);
 
-/// The address of a local server.
+/// The address of a server.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ServerAddr(pub SocketAddr);
 
@@ -30,8 +30,10 @@ pub struct Remote<T>(pub T);
 
 // === impl ClientAddr ===
 
-impl AsRef<SocketAddr> for ClientAddr {
-    fn as_ref(&self) -> &SocketAddr {
+impl std::ops::Deref for ClientAddr {
+    type Target = SocketAddr;
+
+    fn deref(&self) -> &SocketAddr {
         &self.0
     }
 }
@@ -60,8 +62,10 @@ impl ClientAddr {
 
 // === impl ListenAddr ===
 
-impl AsRef<SocketAddr> for ListenAddr {
-    fn as_ref(&self) -> &SocketAddr {
+impl std::ops::Deref for ListenAddr {
+    type Target = SocketAddr;
+
+    fn deref(&self) -> &SocketAddr {
         &self.0
     }
 }
@@ -98,8 +102,10 @@ impl ListenAddr {
 
 // === impl ServerAddr ===
 
-impl AsRef<SocketAddr> for ServerAddr {
-    fn as_ref(&self) -> &SocketAddr {
+impl std::ops::Deref for ServerAddr {
+    type Target = SocketAddr;
+
+    fn deref(&self) -> &SocketAddr {
         &self.0
     }
 }
@@ -128,8 +134,10 @@ impl ServerAddr {
 
 // === impl OrigDstAddr ===
 
-impl AsRef<SocketAddr> for OrigDstAddr {
-    fn as_ref(&self) -> &SocketAddr {
+impl std::ops::Deref for OrigDstAddr {
+    type Target = SocketAddr;
+
+    fn deref(&self) -> &SocketAddr {
         &self.0
     }
 }
@@ -146,21 +154,13 @@ impl fmt::Display for OrigDstAddr {
     }
 }
 
-impl OrigDstAddr {
-    pub fn ip(&self) -> IpAddr {
-        self.0.ip()
-    }
-
-    pub fn port(&self) -> u16 {
-        self.0.port()
-    }
-}
-
 // === impl Local ===
 
-impl<T: AsRef<SocketAddr>> AsRef<SocketAddr> for Local<T> {
-    fn as_ref(&self) -> &SocketAddr {
-        self.0.as_ref()
+impl<T: std::ops::Deref> std::ops::Deref for Local<T> {
+    type Target = T::Target;
+
+    fn deref(&self) -> &T::Target {
+        self.0.deref()
     }
 }
 
@@ -176,21 +176,13 @@ impl<T: fmt::Display> fmt::Display for Local<T> {
     }
 }
 
-impl<T: AsRef<SocketAddr>> Local<T> {
-    pub fn ip(&self) -> IpAddr {
-        self.0.as_ref().ip()
-    }
-
-    pub fn port(&self) -> u16 {
-        self.0.as_ref().port()
-    }
-}
-
 // === impl Remote ===
 
-impl<T: AsRef<SocketAddr>> AsRef<SocketAddr> for Remote<T> {
-    fn as_ref(&self) -> &SocketAddr {
-        self.0.as_ref()
+impl<T: std::ops::Deref> std::ops::Deref for Remote<T> {
+    type Target = T::Target;
+
+    fn deref(&self) -> &T::Target {
+        self.0.deref()
     }
 }
 
@@ -203,15 +195,5 @@ impl<T: Into<SocketAddr>> From<Remote<T>> for SocketAddr {
 impl<T: fmt::Display> fmt::Display for Remote<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
-    }
-}
-
-impl<T: AsRef<SocketAddr>> Remote<T> {
-    pub fn ip(&self) -> IpAddr {
-        self.0.as_ref().ip()
-    }
-
-    pub fn port(&self) -> u16 {
-        self.0.as_ref().port()
     }
 }


### PR DESCRIPTION
We have several address-related newtypes that wrap `SocketAddr` types.
They currently implement `AsRef<SocketAddr>`, but this is a little
cumbersome in practice. This change replaces these `AsRef`
implementations with `Deref` so that we can, for instance, call `.ip()`
and `.port()` on these types directly without special handling.

No functional changes.

Signed-off-by: Oliver Gould <ver@buoyant.io>