### PR TITLE
Rename `Route*` to `ProfileRoute*`

### DIFF
--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -28,9 +28,9 @@ pub type ControlHttp = http_metrics::Requests<ControlLabels, Class>;
 
 pub type HttpEndpoint = http_metrics::Requests<EndpointLabels, Class>;
 
-pub type HttpRoute = http_metrics::Requests<RouteLabels, Class>;
+pub type HttpProfileRoute = http_metrics::Requests<ProfileRouteLabels, Class>;
 
-pub type HttpRouteRetry = http_metrics::Retries<RouteLabels>;
+pub type HttpProfileRouteRetry = http_metrics::Retries<ProfileRouteLabels>;
 
 pub type Stack = stack_metrics::Registry<StackLabels>;
 
@@ -43,9 +43,9 @@ pub struct Metrics {
 
 #[derive(Clone, Debug)]
 pub struct Proxy {
-    pub http_route: HttpRoute,
-    pub http_route_actual: HttpRoute,
-    pub http_route_retry: HttpRouteRetry,
+    pub http_profile_route: HttpProfileRoute,
+    pub http_profile_route_actual: HttpProfileRoute,
+    pub http_profile_route_retry: HttpProfileRouteRetry,
     pub http_endpoint: HttpEndpoint,
     pub transport: transport::Metrics,
     pub stack: Stack,
@@ -98,7 +98,7 @@ pub struct StackLabels {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct RouteLabels {
+pub struct ProfileRouteLabels {
     direction: Direction,
     addr: profiles::LogicalAddr,
     labels: Option<String>,
@@ -149,20 +149,20 @@ impl Metrics {
             (m, r)
         };
 
-        let (http_route, route_report) = {
-            let m = metrics::Requests::<RouteLabels, Class>::default();
+        let (http_profile_route, profile_route_report) = {
+            let m = metrics::Requests::<ProfileRouteLabels, Class>::default();
             let r = m.clone().into_report(retain_idle).with_prefix("route");
             (m, r)
         };
 
-        let (http_route_retry, retry_report) = {
-            let m = metrics::Retries::<RouteLabels>::default();
+        let (http_profile_route_retry, retry_report) = {
+            let m = metrics::Retries::<ProfileRouteLabels>::default();
             let r = m.clone().into_report(retain_idle).with_prefix("route");
             (m, r)
         };
 
-        let (http_route_actual, actual_report) = {
-            let m = metrics::Requests::<RouteLabels, Class>::default();
+        let (http_profile_route_actual, actual_report) = {
+            let m = metrics::Requests::<ProfileRouteLabels, Class>::default();
             let r = m
                 .clone()
                 .into_report(retain_idle)
@@ -176,9 +176,9 @@ impl Metrics {
 
         let proxy = Proxy {
             http_endpoint,
-            http_route,
-            http_route_retry,
-            http_route_actual,
+            http_profile_route,
+            http_profile_route_retry,
+            http_profile_route_actual,
             stack: stack.clone(),
             transport,
         };
@@ -192,7 +192,7 @@ impl Metrics {
         };
 
         let report = endpoint_report
-            .and_report(route_report)
+            .and_report(profile_route_report)
             .and_report(retry_report)
             .and_report(actual_report)
             .and_report(control_report)
@@ -226,9 +226,9 @@ impl FmtLabels for ControlLabels {
     }
 }
 
-// === impl RouteLabels ===
+// === impl ProfileRouteLabels ===
 
-impl RouteLabels {
+impl ProfileRouteLabels {
     pub fn inbound(addr: profiles::LogicalAddr, route: &profiles::http::Route) -> Self {
         let labels = prefix_labels("rt", route.labels().iter());
         Self {
@@ -248,7 +248,7 @@ impl RouteLabels {
     }
 }
 
-impl FmtLabels for RouteLabels {
+impl FmtLabels for ProfileRouteLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.direction.fmt_labels(f)?;
         write!(f, ",dst=\"{}\"", self.addr)?;

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -153,7 +153,7 @@ impl<C> Inbound<C> {
                         .push(
                             rt.metrics
                                 .proxy
-                                .http_route
+                                .http_profile_route
                                 .to_layer::<classify::Response, _, _>(),
                         )
                         .push_on_service(http::BoxResponse::layer())
@@ -339,9 +339,9 @@ impl Param<profiles::http::Route> for Route {
     }
 }
 
-impl Param<metrics::RouteLabels> for Route {
-    fn param(&self) -> metrics::RouteLabels {
-        metrics::RouteLabels::inbound(self.profile.addr.clone(), &self.route)
+impl Param<metrics::ProfileRouteLabels> for Route {
+    fn param(&self) -> metrics::ProfileRouteLabels {
+        metrics::ProfileRouteLabels::inbound(self.profile.addr.clone(), &self.route)
     }
 }
 

--- a/linkerd/app/inbound/src/policy/authorize/http.rs
+++ b/linkerd/app/inbound/src/policy/authorize/http.rs
@@ -1,6 +1,5 @@
-use crate::metrics::authz::HttpAuthzMetrics;
-
 use super::super::{AllowPolicy, ServerPermit};
+use crate::metrics::authz::HttpAuthzMetrics;
 use futures::{future, TryFutureExt};
 use linkerd_app_core::{
     svc::{self, ServiceExt},

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -190,9 +190,9 @@ impl Param<profiles::http::Route> for Route {
     }
 }
 
-impl Param<metrics::RouteLabels> for Route {
-    fn param(&self) -> metrics::RouteLabels {
-        metrics::RouteLabels::outbound(self.logical.logical_addr.clone(), &self.route)
+impl Param<metrics::ProfileRouteLabels> for Route {
+    fn param(&self) -> metrics::ProfileRouteLabels {
+        metrics::ProfileRouteLabels::outbound(self.logical.logical_addr.clone(), &self.route)
     }
 }
 

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -143,7 +143,7 @@ impl<E> Outbound<E> {
                         .push(
                             rt.metrics
                                 .proxy
-                                .http_route_actual
+                                .http_profile_route_actual
                                 .to_layer::<classify::Response, _, Route>(),
                         )
                         // Depending on whether or not the request can be
@@ -152,14 +152,14 @@ impl<E> Outbound<E> {
                         .push_on_service(http::BoxRequest::erased())
                         .push_http_insert_target::<profiles::http::Route>()
                         // Sets an optional retry policy.
-                        .push(retry::layer(rt.metrics.proxy.http_route_retry.clone()))
+                        .push(retry::layer(rt.metrics.proxy.http_profile_route_retry.clone()))
                         // Sets an optional request timeout.
                         .push(http::NewTimeout::layer())
                         // Records per-route metrics.
                         .push(
                             rt.metrics
                                 .proxy
-                                .http_route
+                                .http_profile_route
                                 .to_layer::<classify::Response, _, _>(),
                         )
                         // Sets the per-route response classifier as a request

--- a/linkerd/app/outbound/src/http/retry.rs
+++ b/linkerd/app/outbound/src/http/retry.rs
@@ -14,14 +14,14 @@ use linkerd_retry as retry;
 use std::sync::Arc;
 
 pub fn layer<N>(
-    metrics: metrics::HttpRouteRetry,
+    metrics: metrics::HttpProfileRouteRetry,
 ) -> impl layer::Layer<N, Service = retry::NewRetry<NewRetryPolicy, N>> + Clone {
     retry::NewRetry::<_, N>::layer(NewRetryPolicy::new(metrics))
 }
 
 #[derive(Clone, Debug)]
 pub struct NewRetryPolicy {
-    metrics: metrics::HttpRouteRetry,
+    metrics: metrics::HttpProfileRouteRetry,
 }
 
 #[derive(Clone, Debug)]
@@ -37,7 +37,7 @@ const MAX_BUFFERED_BYTES: usize = 64 * 1024;
 // === impl NewRetryPolicy ===
 
 impl NewRetryPolicy {
-    pub fn new(metrics: metrics::HttpRouteRetry) -> Self {
+    pub fn new(metrics: metrics::HttpProfileRouteRetry) -> Self {
         Self { metrics }
     }
 }


### PR DESCRIPTION
In preparation for introducing additional route types to the proxy
(i.e., for the gateway API), this change renames existing route types to
more clearly be scoped to service profiles.

No functional changes.

Signed-off-by: Oliver Gould <ver@buoyant.io>