### PR TITLE
Rename target types from Route to ProfileRoute

### DIFF
--- a/linkerd/app/integration/src/server.rs
+++ b/linkerd/app/integration/src/server.rs
@@ -2,18 +2,17 @@ use super::*;
 use futures::TryFuture;
 use http::Response;
 use linkerd_app_core::proxy::http::trace;
-use std::collections::HashMap;
-use std::future::Future;
-use std::io;
-use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use tokio::net::TcpStream;
-use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
-use tokio_rustls::rustls::ServerConfig;
-use tokio_rustls::TlsAcceptor;
+use std::{
+    collections::HashMap,
+    future::Future,
+    io,
+    pin::Pin,
+    sync::atomic::{AtomicUsize, Ordering},
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::{net::TcpStream, sync::oneshot, task::JoinHandle};
+use tokio_rustls::{rustls::ServerConfig, TlsAcceptor};
 use tracing::instrument::Instrument;
 
 pub fn new() -> Server {

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -31,7 +31,7 @@ pub type Endpoint = crate::endpoint::Endpoint<Version>;
 pub type Connect = self::endpoint::Connect<Endpoint>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct Route {
+struct ProfileRoute {
     logical: Logical,
     route: profiles::http::Route,
 }
@@ -182,27 +182,27 @@ impl tap::Inspect for Endpoint {
     }
 }
 
-// === impl Route ===
+// === impl ProfileRoute ===
 
-impl Param<profiles::http::Route> for Route {
+impl Param<profiles::http::Route> for ProfileRoute {
     fn param(&self) -> profiles::http::Route {
         self.route.clone()
     }
 }
 
-impl Param<metrics::ProfileRouteLabels> for Route {
+impl Param<metrics::ProfileRouteLabels> for ProfileRoute {
     fn param(&self) -> metrics::ProfileRouteLabels {
         metrics::ProfileRouteLabels::outbound(self.logical.logical_addr.clone(), &self.route)
     }
 }
 
-impl Param<ResponseTimeout> for Route {
+impl Param<ResponseTimeout> for ProfileRoute {
     fn param(&self) -> ResponseTimeout {
         ResponseTimeout(self.route.timeout())
     }
 }
 
-impl classify::CanClassify for Route {
+impl classify::CanClassify for ProfileRoute {
     type Classify = classify::Request;
 
     fn classify(&self) -> classify::Request {

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -1,4 +1,4 @@
-use super::{retry, CanonicalDstHeader, Concrete, Endpoint, Logical, Route};
+use super::{retry, CanonicalDstHeader, Concrete, Endpoint, Logical, ProfileRoute};
 use crate::{endpoint, resolve, stack_labels, Outbound};
 use linkerd_app_core::{
     classify, config, profiles,
@@ -134,17 +134,17 @@ impl<E> Outbound<E> {
                     |(route, logical): (Option<profiles::http::Route>, Logical)| -> Result<_, Infallible> {
                         match route {
                             None => Ok(svc::Either::A(logical)),
-                            Some(route) => Ok(svc::Either::B(Route { route, logical })),
+                            Some(route) => Ok(svc::Either::B(ProfileRoute { route, logical })),
                         }
                     },
                     logical
-                        .push_map_target(|r: Route| r.logical)
+                        .push_map_target(|r: ProfileRoute| r.logical)
                         .push_on_service(http::BoxRequest::layer())
                         .push(
                             rt.metrics
                                 .proxy
                                 .http_profile_route_actual
-                                .to_layer::<classify::Response, _, Route>(),
+                                .to_layer::<classify::Response, _, ProfileRoute>(),
                         )
                         // Depending on whether or not the request can be
                         // retried, it may have one of two `Body` types. This

--- a/linkerd/app/outbound/src/http/retry.rs
+++ b/linkerd/app/outbound/src/http/retry.rs
@@ -1,4 +1,4 @@
-use super::Route;
+use super::ProfileRoute;
 use futures::future;
 use linkerd_app_core::{
     classify,
@@ -42,10 +42,10 @@ impl NewRetryPolicy {
     }
 }
 
-impl retry::NewPolicy<Route> for NewRetryPolicy {
+impl retry::NewPolicy<ProfileRoute> for NewRetryPolicy {
     type Policy = RetryPolicy;
 
-    fn new_policy(&self, route: &Route) -> Option<Self::Policy> {
+    fn new_policy(&self, route: &ProfileRoute) -> Option<Self::Policy> {
         let retries = route.route.retries().cloned()?;
 
         let metrics = self.metrics.get_handle(route.param());


### PR DESCRIPTION
In anticipation of introducing new route types, this change renames
inbound and outbound `Route` target types to `ProfileRoute`.

No functional changes.

Signed-off-by: Oliver Gould <ver@buoyant.io>