### PR TITLE
Dedupe discovery updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,6 +1287,7 @@ name = "linkerd-proxy-discover"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "indexmap",
  "linkerd-error",
  "linkerd-proxy-core",
  "linkerd-stack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,13 +1286,13 @@ dependencies = [
 name = "linkerd-proxy-discover"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "futures",
  "linkerd-error",
  "linkerd-proxy-core",
  "linkerd-stack",
  "pin-project",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tower",
  "tracing",

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -14,7 +14,7 @@ use std::{
     sync::Arc,
 };
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Endpoint<P> {
     pub addr: Remote<ServerAddr>,
     pub tls: tls::ConditionalClientTls,
@@ -137,15 +137,6 @@ impl<P> svc::Param<metrics::OutboundEndpointLabels> for Endpoint<P> {
 impl<P> svc::Param<metrics::EndpointLabels> for Endpoint<P> {
     fn param(&self) -> metrics::EndpointLabels {
         svc::Param::<metrics::OutboundEndpointLabels>::param(self).into()
-    }
-}
-
-impl<P: std::hash::Hash> std::hash::Hash for Endpoint<P> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.addr.hash(state);
-        self.tls.hash(state);
-        self.logical_addr.hash(state);
-        self.protocol.hash(state);
     }
 }
 

--- a/linkerd/proxy/api-resolve/src/metadata.rs
+++ b/linkerd/proxy/api-resolve/src/metadata.rs
@@ -2,7 +2,7 @@ use http::uri::Authority;
 use linkerd_tls::client::ServerId;
 use std::collections::BTreeMap;
 
-/// Endpoint labels are lexographically ordered by key.
+/// Endpoint labels are lexigraphically ordered by key.
 pub type Labels = std::sync::Arc<BTreeMap<String, String>>;
 
 /// Metadata describing an endpoint.

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -22,6 +22,6 @@ tracing = "0.1"
 pin-project = "1"
 
 [dev-dependencies]
-async-stream = "0.3"
-tokio = { version = "1", features = ["macros"] }
-tower = { version = "0.4", default-features = false, features = ["discover", "util"] }
+tokio = { version = "1", features = ["macros", "test-util"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
+tower = { version = "0.4", default-features = false, features = ["util"] }

--- a/linkerd/proxy/discover/Cargo.toml
+++ b/linkerd/proxy/discover/Cargo.toml
@@ -12,6 +12,7 @@ Utilities to implement a Discover with the core Resolve type
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
+indexmap = "1"
 linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/proxy/discover/src/from_resolve.rs
+++ b/linkerd/proxy/discover/src/from_resolve.rs
@@ -14,7 +14,7 @@ use tracing::{debug, trace};
 #[derive(Clone, Debug)]
 pub struct FromResolve<R, E> {
     resolve: R,
-    _marker: std::marker::PhantomData<fn() -> E>,
+    _marker: std::marker::PhantomData<fn(E)>,
 }
 
 #[pin_project]
@@ -22,7 +22,7 @@ pub struct FromResolve<R, E> {
 pub struct DiscoverFuture<F, E> {
     #[pin]
     future: F,
-    _marker: std::marker::PhantomData<fn() -> E>,
+    _marker: std::marker::PhantomData<fn(E)>,
 }
 
 /// Observes an `R`-typed resolution stream, using an `M`-typed endpoint stack to

--- a/linkerd/proxy/discover/src/from_resolve.rs
+++ b/linkerd/proxy/discover/src/from_resolve.rs
@@ -281,11 +281,11 @@ mod tests {
         ));
 
         // Re-adding the address is observed.
-        tx.try_send(Ok(Update::Add(vec![(addr(1), "c")])))
+        tx.try_send(Ok(Update::Add(vec![(addr(1), "b")])))
             .expect("must send");
         assert!(matches!(
             disco.try_next().await,
-            Ok(Some(Change::Insert(sa, "c"))) if sa == addr(1)
+            Ok(Some(Change::Insert(sa, "b"))) if sa == addr(1)
         ));
 
         // No more updates.

--- a/linkerd/proxy/discover/src/from_resolve.rs
+++ b/linkerd/proxy/discover/src/from_resolve.rs
@@ -215,7 +215,7 @@ mod tests {
 
         // Reset to a new state with 3 addresses, one of which is unchanged, one of which is
         // changed, and one of which is added.
-        tx.try_send(Ok::<_, Infallible>(Update::Reset(
+        tx.try_send(Ok(Update::Reset(
             // Restore the original `2` value. We shouldn't see an update for it.
             Some((addr(2), 2))
                 .into_iter()
@@ -256,7 +256,7 @@ mod tests {
         ));
 
         // A redundant update is not.
-        tx.try_send(Ok::<_, Infallible>(Update::Add(vec![(addr(1), "a")])))
+        tx.try_send(Ok(Update::Add(vec![(addr(1), "a")])))
             .expect("must send");
         tokio::select! {
             biased;
@@ -265,7 +265,7 @@ mod tests {
         }
 
         // A new value for an existing address is observed.
-        tx.try_send(Ok::<_, Infallible>(Update::Add(vec![(addr(1), "b")])))
+        tx.try_send(Ok(Update::Add(vec![(addr(1), "b")])))
             .expect("must send");
         assert!(matches!(
             disco.try_next().await,
@@ -273,7 +273,7 @@ mod tests {
         ));
 
         // Remove the address.
-        tx.try_send(Ok::<_, Infallible>(Update::Remove(vec![addr(1)])))
+        tx.try_send(Ok(Update::Remove(vec![addr(1)])))
             .expect("must send");
         assert!(matches!(
             disco.try_next().await,
@@ -281,7 +281,7 @@ mod tests {
         ));
 
         // Re-adding the address is observed.
-        tx.try_send(Ok::<_, Infallible>(Update::Add(vec![(addr(1), "c")])))
+        tx.try_send(Ok(Update::Add(vec![(addr(1), "c")])))
             .expect("must send");
         assert!(matches!(
             disco.try_next().await,


### PR DESCRIPTION
The proxy can receive redundant discovery updates. When this occurs, it
causes the balancer to churn, replacing an endpoint stack (and
therefore needlessly dropping a connection).

This change updates the discovery module to keep clones of the
discovered endpoint metadata, so that updated values can be compared to
eliminate duplicate updates.

Relates to linkerd/linkerd2#8677

Signed-off-by: Oliver Gould <ver@buoyant.io>