### PR TITLE
deny: Remove tokio-util from exceptions

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - justfile
       - Cargo.lock
+      - deny.toml
       - .github/workflows/deps.yml
 
 env:

--- a/deny.toml
+++ b/deny.toml
@@ -47,10 +47,7 @@ highlight = "all"
 deny = [
     { name = "rustls", wrappers = ["tokio-rustls"] },
 ]
-skip = [
-    # waiting on `h2` and `tower` releases that update h2 to v0.7
-    { name = "tokio-util", version = "0.6" },
-]
+skip = []
 skip-tree = [
     # Hasn't seen a new release since 2017. Pulls in an older version of nom.
     { name = "procinfo" },


### PR DESCRIPTION
The tokio-util exception is no longer needed, as all dependencies have
been updated to use v0.7.

Signed-off-by: Oliver Gould <ver@buoyant.io>