### PR TITLE
dev: Update memory contraints

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,8 +16,8 @@
 	"runArgs": [
 		"--init",
 		// Limit container memory usage.
-		"--memory=8g",
-		"--memory-swap=8g",
+		"--memory=12g",
+		"--memory-swap=12g",
 		// Use the host network so we can access k3d, etc.
 		"--net=host",
 		// For lldb


### PR DESCRIPTION
I see OOM kills when trying to build/test the proxy (my guess is
rust-analyzer has gotten more memory-hungry). This change updates the
devcontainer memory constraint to 12GB, which seems to work.

Signed-off-by: Oliver Gould <ver@buoyant.io>