### PR TITLE
inbound: Rename policy-enforcement layers

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -96,7 +96,7 @@ impl Config {
         let admin = svc::stack(move |_| admin.clone())
             .push(metrics.proxy.http_endpoint.to_layer::<classify::Response, _, Permitted>())
             .push_map_target(|(permit, http)| Permitted { permit, http })
-            .push(inbound::policy::NewAuthorizeHttp::layer(metrics.http_authz.clone()))
+            .push(inbound::policy::NewHttpPolicy::layer(metrics.http_authz.clone()))
             .push(Rescue::layer())
             .push_on_service(http::BoxResponse::layer())
             .push(http::NewServeHttp::layer(Default::default(), drain.clone()))

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -106,7 +106,7 @@ impl<N> Inbound<N> {
         self.map_stack(|cfg, rt, detect| {
             let forward = svc::stack(forward)
                 .push_map_target(Forward::from)
-                .push(policy::NewAuthorizeTcp::layer(rt.metrics.tcp_authz.clone()));
+                .push(policy::NewTcpPolicy::layer(rt.metrics.tcp_authz.clone()));
 
             let detect_timeout = cfg.proxy.detect_protocol_timeout;
             detect
@@ -236,7 +236,7 @@ impl<N> Inbound<N> {
                             rt.metrics.proxy.transport.clone(),
                         ))
                         .push_map_target(Forward::from)
-                        .push(policy::NewAuthorizeTcp::layer(rt.metrics.tcp_authz.clone()))
+                        .push(policy::NewTcpPolicy::layer(rt.metrics.tcp_authz.clone()))
                         .into_inner(),
                 )
                 .push(detect::NewDetectService::layer(ConfigureHttpDetect));

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -235,7 +235,7 @@ impl<C> Inbound<C> {
                 // minimize it's type footprint with a Box.
                 .push(svc::ArcNewService::layer())
                 .push(svc::NewRouter::layer(LogicalPerRequest::from))
-                .push(policy::NewAuthorizeHttp::layer(rt.metrics.http_authz.clone()))
+                .push(policy::NewHttpPolicy::layer(rt.metrics.http_authz.clone()))
                 // Used by tap.
                 .push_http_insert_target::<tls::ConditionalServerTls>()
                 .push_http_insert_target::<Remote<ClientAddr>>()

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -92,15 +92,15 @@ impl<S> Inbound<S> {
     /// A helper for gateways to instrument policy checks.
     pub fn authorize_http<N>(
         &self,
-    ) -> impl svc::layer::Layer<N, Service = policy::NewAuthorizeHttp<N>> + Clone {
-        policy::NewAuthorizeHttp::layer(self.runtime.metrics.http_authz.clone())
+    ) -> impl svc::layer::Layer<N, Service = policy::NewHttpPolicy<N>> + Clone {
+        policy::NewHttpPolicy::layer(self.runtime.metrics.http_authz.clone())
     }
 
     /// A helper for gateways to instrument policy checks.
     pub fn authorize_tcp<N>(
         &self,
-    ) -> impl svc::layer::Layer<N, Service = policy::NewAuthorizeTcp<N>> + Clone {
-        policy::NewAuthorizeTcp::layer(self.runtime.metrics.tcp_authz.clone())
+    ) -> impl svc::layer::Layer<N, Service = policy::NewTcpPolicy<N>> + Clone {
+        policy::NewTcpPolicy::layer(self.runtime.metrics.tcp_authz.clone())
     }
 
     pub fn into_stack(self) -> svc::Stack<S> {

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -1,14 +1,14 @@
 mod api;
-mod authorize;
 mod config;
 pub mod defaults;
+mod http;
 mod store;
+mod tcp;
 #[cfg(test)]
 mod tests;
 
-pub use self::authorize::{NewAuthorizeHttp, NewAuthorizeTcp};
-pub use self::config::Config;
 pub(crate) use self::store::Store;
+pub use self::{config::Config, http::NewHttpPolicy, tcp::NewTcpPolicy};
 
 use linkerd_app_core::metrics::ServerAuthzLabels;
 pub use linkerd_app_core::metrics::ServerLabel;

--- a/linkerd/app/inbound/src/policy/authorize.rs
+++ b/linkerd/app/inbound/src/policy/authorize.rs
@@ -1,4 +1,0 @@
-mod http;
-mod tcp;
-
-pub use self::{http::NewAuthorizeHttp, tcp::NewAuthorizeTcp};


### PR DESCRIPTION
The `AuthorizeHttp` and `AuthorizeTcp` layers don't necessarily only
enforce authorization. This change renames to, for instance,
`HttpPolicy` and `TcpPolicy` and eliminates the `authorize` submodule
structure.

No functional changes.

Signed-off-by: Oliver Gould <ver@buoyant.io>