### PR TITLE
ci: Split fuzzer logic into a script

### DIFF
--- a/.github/fuzzers-list.sh
+++ b/.github/fuzzers-list.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+## Lists the fuzzers that should be run given a set of changed files.
+
+# Find the nearest fuzzer crate, or nothing.
+find_fuzz_dir() {
+    d=${1%/*}
+    if [ "$d" = . ]; then
+        return
+    elif [ -d "$d" ] && [[ "$d" = */fuzz ]]; then
+        echo "$d"
+    elif [ -f "$d/fuzz/Cargo.toml" ]; then
+        echo "$d/fuzz"
+    else
+        find_fuzz_dir "$d"
+    fi
+}
+
+for file in "$@" ; do
+    if [ "$file" = .github/workflows/fuzzers.yml ] || [ "$file" = .github/fuzzers-list.sh ]; then
+        find * -type d -name fuzz
+        break
+    fi
+    find_fuzz_dir "$file"
+done | sort -u

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -11,6 +11,7 @@ on:
       - 'linkerd/tls/**'
       - 'linkerd/transport-header/**'
       - .github/workflows/fuzzers.yml
+      - .github/fuzzers-list.sh
 
 env:
   CARGO_INCREMENTAL: 0
@@ -37,41 +38,8 @@ jobs:
         id: list-changed
         shell: bash
         run: |
-          files="${{ steps.changed-files.outputs.all_changed_files }}"
-          # Find the nearest fuzzer crate, or nothing.
-          find_fuzz_dir() {
-            d=$(dirname "$1")
-            if [ "$d" = . ]; then
-              return
-            elif [ -d "$d" ] && [[ "$d" = */fuzz ]]; then
-              echo "$d"
-            elif [ -f "$d/fuzz/Cargo.toml" ]; then
-              echo "$d/fuzz"
-            else
-              find_fuzz_dir "$d"
-            fi
-          }
-          list_dirs() {
-            dirs=""
-            for file in $(echo $*) ; do
-              if [ "$file" = .github/workflows/fuzzers.yml ]; then
-                dirs=$(find . -type d -name fuzz)
-                break
-              fi
-              d=$(find_fuzz_dir "$file")
-              if [ -n "$d" ]; then
-                if [ -z "$dirs" ]; then
-                  dirs="$d"
-                else
-                  dirs="$dirs $d"
-                fi
-              fi
-            done
-            echo "${dirs}" | tr ' ' "\n" | sort -u
-          }
-          dirs=$(list_dirs $files)
-          echo "$dirs"
-          echo "::set-output name=dirs::$(echo "$dirs" | jo -a)"
+          dirs=$(.github/fuzzers-list.sh ${{ steps.changed-files.outputs.all_changed_files }} | jo -a)
+          echo "::set-output name=dirs::$dirs"
     outputs:
       dirs: ${{ steps.list-changed.outputs.dirs }}
 


### PR DESCRIPTION
The fuzzer CI embeds a somewhat complicated script. This change splits
it into a distinct file so that it can be shellchecked, etc.

Signed-off-by: Oliver Gould <ver@buoyant.io>