### PR TITLE
inbound: Add route authorization labels

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -52,7 +52,7 @@ struct Http {
 
 #[derive(Clone, Debug)]
 struct Permitted {
-    permit: inbound::policy::ServerPermit,
+    permit: inbound::policy::RoutePermit,
     http: Http,
 }
 
@@ -115,7 +115,7 @@ impl Config {
                         // - If we received some unexpected SNI, the client is mostly likely
                         //   confused/stale.
                         Err(_timeout) => {
-                            let version = match tcp.tls.clone() {
+                            let version = match tcp.tls {
                                 tls::ConditionalServerTls::None(_) => http::Version::Http1,
                                 tls::ConditionalServerTls::Some(tls::ServerTls::Established {
                                     ..
@@ -291,7 +291,7 @@ impl<T: Param<tls::ConditionalServerTls>> ExtractParam<errors::respond::EmitHead
 
 impl errors::HttpRescue<Error> for Rescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        if let Some(cause) = errors::cause_ref::<inbound::policy::DeniedUnauthorized>(&*error) {
+        if let Some(cause) = errors::cause_ref::<inbound::policy::HttpRouteUnauthorized>(&*error) {
             return Ok(errors::SyntheticHttpResponse::permission_denied(cause));
         }
 

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -52,7 +52,7 @@ struct Http {
 
 #[derive(Clone, Debug)]
 struct Permitted {
-    permit: inbound::policy::RoutePermit,
+    permit: inbound::policy::HTTPRoutePermit,
     http: Http,
 }
 

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -68,7 +68,7 @@ pub struct InboundEndpointLabels {
     pub tls: tls::ConditionalServerTls,
     pub authority: Option<http::uri::Authority>,
     pub target_addr: SocketAddr,
-    pub policy: ServerAuthzLabels,
+    pub policy: RouteAuthzLabels,
 }
 
 /// A label referencing an inbound `Server` (i.e. for policy).
@@ -79,6 +79,20 @@ pub struct ServerLabel(pub Arc<policy::Meta>);
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ServerAuthzLabels {
     pub server: ServerLabel,
+    pub authz: Arc<policy::Meta>,
+}
+
+/// Labels referencing an inbound route.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct RouteLabels {
+    pub server: ServerLabel,
+    pub route: Arc<policy::Meta>,
+}
+
+/// Labels referencing an inbound route and authorization.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct RouteAuthzLabels {
+    pub route: RouteLabels,
     pub authz: Arc<policy::Meta>,
 }
 
@@ -322,6 +336,32 @@ impl FmtLabels for ServerAuthzLabels {
             self.authz.group(),
             self.authz.kind(),
             self.authz.name()
+        )
+    }
+}
+
+impl FmtLabels for RouteLabels {
+    fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.server.fmt_labels(f)?;
+        write!(
+            f,
+            ",route_group=\"{}\",route_kind=\"{}\",route_name=\"{}\"",
+            self.route.group(),
+            self.route.kind(),
+            self.route.name(),
+        )
+    }
+}
+
+impl FmtLabels for RouteAuthzLabels {
+    fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.route.fmt_labels(f)?;
+        write!(
+            f,
+            ",authz_group=\"{}\",authz_kind=\"{}\",authz_name=\"{}\"",
+            self.authz.group(),
+            self.authz.kind(),
+            self.authz.name(),
         )
     }
 }

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -16,7 +16,7 @@ use tracing::{debug, debug_span};
 pub struct Http {
     addr: Remote<ServerAddr>,
     settings: http::client::Settings,
-    permit: policy::RoutePermit,
+    permit: policy::HTTPRoutePermit,
 }
 
 /// Builds `Logical` targets for each HTTP request.
@@ -24,7 +24,7 @@ pub struct Http {
 struct LogicalPerRequest {
     server: Remote<ServerAddr>,
     tls: tls::ConditionalServerTls,
-    permit: policy::RoutePermit,
+    permit: policy::HTTPRoutePermit,
     labels: tap::Labels,
 }
 
@@ -36,7 +36,7 @@ struct Logical {
     addr: Remote<ServerAddr>,
     http: http::Version,
     tls: tls::ConditionalServerTls,
-    permit: policy::RoutePermit,
+    permit: policy::HTTPRoutePermit,
     labels: tap::Labels,
 }
 
@@ -246,12 +246,12 @@ impl<C> Inbound<C> {
 
 // === impl LogicalPerRequest ===
 
-impl<T> From<(policy::RoutePermit, T)> for LogicalPerRequest
+impl<T> From<(policy::HTTPRoutePermit, T)> for LogicalPerRequest
 where
     T: Param<Remote<ServerAddr>>,
     T: Param<tls::ConditionalServerTls>,
 {
-    fn from((permit, t): (policy::RoutePermit, T)) -> Self {
+    fn from((permit, t): (policy::HTTPRoutePermit, T)) -> Self {
         let labels = [
             ("srv", &permit.labels.route.server.0),
             ("route", &permit.labels.route.route),

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -16,7 +16,7 @@ use tracing::{debug, debug_span};
 pub struct Http {
     addr: Remote<ServerAddr>,
     settings: http::client::Settings,
-    permit: policy::ServerPermit,
+    permit: policy::RoutePermit,
 }
 
 /// Builds `Logical` targets for each HTTP request.
@@ -24,7 +24,7 @@ pub struct Http {
 struct LogicalPerRequest {
     server: Remote<ServerAddr>,
     tls: tls::ConditionalServerTls,
-    permit: policy::ServerPermit,
+    permit: policy::RoutePermit,
     labels: tap::Labels,
 }
 
@@ -36,7 +36,7 @@ struct Logical {
     addr: Remote<ServerAddr>,
     http: http::Version,
     tls: tls::ConditionalServerTls,
-    permit: policy::ServerPermit,
+    permit: policy::RoutePermit,
     labels: tap::Labels,
 }
 
@@ -246,47 +246,32 @@ impl<C> Inbound<C> {
 
 // === impl LogicalPerRequest ===
 
-impl<T> From<(policy::ServerPermit, T)> for LogicalPerRequest
+impl<T> From<(policy::RoutePermit, T)> for LogicalPerRequest
 where
     T: Param<Remote<ServerAddr>>,
     T: Param<tls::ConditionalServerTls>,
 {
-    fn from((permit, t): (policy::ServerPermit, T)) -> Self {
-        let labels = vec![
-            (
-                "srv_group".to_string(),
-                permit.labels.server.0.group().to_string(),
-            ),
-            (
-                "srv_kind".to_string(),
-                permit.labels.server.0.kind().to_string(),
-            ),
-            (
-                "srv_name".to_string(),
-                permit.labels.server.0.name().to_string(),
-            ),
-            (
-                "authz_group".to_string(),
-                permit.labels.authz.group().to_string(),
-            ),
-            (
-                "authz_kind".to_string(),
-                permit.labels.authz.kind().to_string(),
-            ),
-            (
-                "authz_name".to_string(),
-                permit.labels.authz.name().to_string(),
-            ),
-        ];
+    fn from((permit, t): (policy::RoutePermit, T)) -> Self {
+        let labels = [
+            ("srv", &permit.labels.route.server.0),
+            ("route", &permit.labels.route.route),
+            ("authz", &permit.labels.authz),
+        ]
+        .into_iter()
+        .flat_map(|(k, v)| {
+            [
+                (format!("{k}_group"), v.group().to_string()),
+                (format!("{k}_kind"), v.kind().to_string()),
+                (format!("{k}_name"), v.name().to_string()),
+            ]
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
 
         Self {
             server: t.param(),
             tls: t.param(),
             permit,
-            labels: labels
-                .into_iter()
-                .collect::<std::collections::BTreeMap<_, _>>()
-                .into(),
+            labels: labels.into(),
         }
     }
 }

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -1,5 +1,5 @@
 use super::set_identity_header::NewSetIdentityHeader;
-use crate::Inbound;
+use crate::{policy, Inbound};
 pub use linkerd_app_core::proxy::http::{
     normalize_uri, strip_header, uri, BoxBody, BoxResponse, DetectHttp, Request, Response, Retain,
     Version,
@@ -127,9 +127,10 @@ impl<T: Param<tls::ConditionalServerTls>> ExtractParam<errors::respond::EmitHead
 
 impl errors::HttpRescue<Error> for ServerRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        if let Some(cause) = errors::cause_ref::<crate::policy::DeniedUnauthorized>(&*error) {
+        if let Some(cause) = errors::cause_ref::<policy::HttpRouteUnauthorized>(&*error) {
             return Ok(errors::SyntheticHttpResponse::permission_denied(cause));
         }
+
         if let Some(cause) = errors::cause_ref::<crate::GatewayDomainInvalid>(&*error) {
             return Ok(errors::SyntheticHttpResponse::not_found(cause));
         }

--- a/linkerd/app/inbound/src/metrics/error.rs
+++ b/linkerd/app/inbound/src/metrics/error.rs
@@ -3,7 +3,8 @@ mod tcp;
 
 pub(crate) use self::{http::HttpErrorMetrics, tcp::TcpErrorMetrics};
 use crate::{
-    policy::DeniedUnauthorized, GatewayDomainInvalid, GatewayIdentityRequired, GatewayLoop,
+    policy::{HttpRouteUnauthorized, ServerUnauthorized},
+    GatewayDomainInvalid, GatewayIdentityRequired, GatewayLoop,
 };
 use linkerd_app_core::{errors::FailFastError, metrics::FmtLabels, tls};
 use std::fmt;
@@ -24,7 +25,7 @@ enum ErrorKind {
 
 impl ErrorKind {
     fn mk(err: &(dyn std::error::Error + 'static)) -> Option<Self> {
-        if err.is::<DeniedUnauthorized>() {
+        if err.is::<ServerUnauthorized>() || err.is::<HttpRouteUnauthorized>() {
             // Unauthorized metrics are tracked separately.and are not considered to be errors.
             None
         } else if err.is::<FailFastError>() {

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -52,6 +52,7 @@ pub struct AllowPolicy {
     server: Cached<watch::Receiver<ServerPolicy>>,
 }
 
+// Describes an authorized non-HTTP connection.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ServerPermit {
     pub dst: OrigDstAddr,
@@ -59,8 +60,9 @@ pub struct ServerPermit {
     pub labels: ServerAuthzLabels,
 }
 
+// Describes an authorized HTTP request.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct RoutePermit {
+pub struct HTTPRoutePermit {
     pub dst: OrigDstAddr,
     pub labels: RouteAuthzLabels,
 }

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -45,7 +45,7 @@ struct ConnectionMeta {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("unauthorized request on route kind={:?} name={:?}", .0.kind(), .0.name())]
+#[error("unauthorized request on route {}/{}", .0.kind(), .0.name())]
 pub struct HttpRouteUnauthorized(Arc<Meta>);
 
 // === impl NewHttpPolicy ===

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -1,17 +1,19 @@
 use crate::{
     metrics::authz::HttpAuthzMetrics,
-    policy::{AllowPolicy, ServerPermit},
+    policy::{AllowPolicy, RoutePermit},
 };
 use futures::{future, TryFutureExt};
 use linkerd_app_core::{
+    metrics::{RouteAuthzLabels, RouteLabels, ServerLabel},
     svc::{self, ServiceExt},
     tls,
-    transport::{ClientAddr, Remote},
+    transport::{ClientAddr, OrigDstAddr, Remote},
     Error,
 };
-use std::task;
+use linkerd_server_policy::{Authorization, Meta};
+use std::{sync::Arc, task};
 
-/// A middleware that attaches & enforces policy on each HTTP request.
+/// A middleware that enforces policy on each HTTP request.
 ///
 /// This enforcement is done lazily on each request so that policy updates are
 /// honored as the connection progresses.
@@ -22,24 +24,41 @@ use std::task;
 pub struct NewHttpPolicy<N> {
     metrics: HttpAuthzMetrics,
     inner: N,
+    default_route_meta: Arc<Meta>,
 }
 
 #[derive(Clone, Debug)]
-pub struct HttpPolicy<T, N> {
+pub struct HttpPolicyService<T, N> {
     target: T,
-    client_addr: Remote<ClientAddr>,
-    tls: tls::ConditionalServerTls,
+    meta: ConnectionMeta,
     policy: AllowPolicy,
     metrics: HttpAuthzMetrics,
     inner: N,
+    default_route_meta: Arc<Meta>,
 }
+
+#[derive(Clone, Debug)]
+struct ConnectionMeta {
+    dst: OrigDstAddr,
+    client: Remote<ClientAddr>,
+    tls: tls::ConditionalServerTls,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("unauthorized request on route kind={:?} name={:?}", .0.kind(), .0.name())]
+pub struct HttpRouteUnauthorized(Arc<Meta>);
 
 // === impl NewHttpPolicy ===
 
 impl<N> NewHttpPolicy<N> {
     pub fn layer(metrics: HttpAuthzMetrics) -> impl svc::layer::Layer<N, Service = Self> + Clone {
+        // XXX for now we use a single, synthetic route for all requests. This
+        // will change in the near future.
+        let default_route_meta = Meta::new_default("default");
+
         svc::layer::mk(move |inner| Self {
             metrics: metrics.clone(),
+            default_route_meta: default_route_meta.clone(),
             inner,
         })
     }
@@ -52,36 +71,37 @@ where
         + svc::Param<tls::ConditionalServerTls>,
     N: Clone,
 {
-    type Service = HttpPolicy<T, N>;
+    type Service = HttpPolicyService<T, N>;
 
     fn new_service(&self, target: T) -> Self::Service {
-        let client_addr = target.param();
+        let client = target.param();
         let tls = target.param();
-        let policy = target.param();
-        HttpPolicy {
+        let policy: AllowPolicy = target.param();
+        let dst = policy.dst_addr();
+        HttpPolicyService {
             target,
-            client_addr,
-            tls,
             policy,
+            meta: ConnectionMeta { client, dst, tls },
             metrics: self.metrics.clone(),
             inner: self.inner.clone(),
+            default_route_meta: self.default_route_meta.clone(),
         }
     }
 }
 
-// === impl HttpPolicy ===
+// === impl HttpPolicyService ===
 
-impl<Req, T, N, S> svc::Service<Req> for HttpPolicy<T, N>
+impl<B, T, N, S> svc::Service<::http::Request<B>> for HttpPolicyService<T, N>
 where
     T: Clone,
-    N: svc::NewService<(ServerPermit, T), Service = S>,
-    S: svc::Service<Req>,
+    N: svc::NewService<(RoutePermit, T), Service = S>,
+    S: svc::Service<::http::Request<B>>,
     S::Error: Into<Error>,
 {
     type Response = S::Response;
     type Error = Error;
     type Future = future::Either<
-        future::ErrInto<svc::stack::Oneshot<S, Req>, Error>,
+        future::ErrInto<svc::stack::Oneshot<S, ::http::Request<B>>, Error>,
         future::Ready<Result<Self::Response, Error>>,
     >;
 
@@ -90,32 +110,90 @@ where
         task::Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, req: Req) -> Self::Future {
-        tracing::trace!(policy = ?self.policy, "Authorizing request");
-        match self.policy.check_authorized(self.client_addr, &self.tls) {
-            Ok(permit) => {
-                tracing::debug!(
-                    ?permit,
-                    tls = ?self.tls,
-                    client = %self.client_addr,
-                    "Request authorized",
-                );
-                self.metrics.allow(&permit, self.tls.clone());
-                let svc = self.inner.new_service((permit, self.target.clone()));
-                future::Either::Left(svc.oneshot(req).err_into::<Error>())
-            }
-            Err(e) => {
+    fn call(&mut self, req: ::http::Request<B>) -> Self::Future {
+        let server = self.policy.server.borrow();
+        let labels = ServerLabel(server.meta.clone());
+
+        let labels = RouteLabels {
+            route: self.default_route_meta.clone(),
+            server: labels,
+        };
+
+        let permit = match Self::check_authorized(
+            &*server.authorizations,
+            &self.meta,
+            labels,
+            &self.metrics,
+        ) {
+            Ok(p) => p,
+            Err(deny) => return future::Either::Right(future::err(deny.into())),
+        };
+
+        future::Either::Left(
+            self.inner
+                .new_service((permit, self.target.clone()))
+                .oneshot(req)
+                .err_into::<Error>(),
+        )
+    }
+}
+
+impl<T, N> HttpPolicyService<T, N> {
+    fn check_authorized<'a>(
+        authzs: impl IntoIterator<Item = &'a Authorization>,
+        conn: &ConnectionMeta,
+        labels: RouteLabels,
+        metrics: &HttpAuthzMetrics,
+    ) -> Result<RoutePermit, HttpRouteUnauthorized> {
+        let authz = match authzs
+            .into_iter()
+            .find(|a| super::is_authorized(a, conn.client, &conn.tls))
+        {
+            Some(authz) => authz,
+            None => {
                 tracing::info!(
-                    server.group = %self.policy.group(),
-                    server.kind = %self.policy.kind(),
-                    server.name = %self.policy.name(),
-                    tls = ?self.tls,
-                    client = %self.client_addr,
+                    server.group = %labels.server.0.group(),
+                    server.kind = %labels.server.0.kind(),
+                    server.name = %labels.server.0.name(),
+                    route.group = %labels.route.group(),
+                    route.kind = %labels.route.kind(),
+                    route.name = %labels.route.name(),
+                    client.tls = ?conn.tls,
+                    client.ip = %conn.client.ip(),
                     "Request denied",
                 );
-                self.metrics.deny(&self.policy, self.tls.clone());
-                future::Either::Right(future::err(e.into()))
+                let route = labels.route.clone();
+                metrics.deny(labels, conn.dst, conn.tls.clone());
+                return Err(HttpRouteUnauthorized(route));
             }
-        }
+        };
+
+        let permit = {
+            let labels = RouteAuthzLabels {
+                route: labels,
+                authz: authz.meta.clone(),
+            };
+            tracing::debug!(
+                server.group = %labels.route.server.0.group(),
+                server.kind = %labels.route.server.0.kind(),
+                server.name = %labels.route.server.0.name(),
+                route.group = %labels.route.route.group(),
+                route.kind = %labels.route.route.kind(),
+                route.name = %labels.route.route.name(),
+                authz.group = %labels.authz.group(),
+                authz.kind = %labels.authz.kind(),
+                authz.name = %labels.authz.name(),
+                client.tls = ?conn.tls,
+                client.ip = %conn.client.ip(),
+                "Request authorized",
+            );
+            RoutePermit {
+                dst: conn.dst,
+                labels,
+            }
+        };
+
+        metrics.allow(&permit, conn.tls.clone());
+        Ok(permit)
     }
 }

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -1,6 +1,6 @@
 use crate::{
     metrics::authz::HttpAuthzMetrics,
-    policy::{AllowPolicy, RoutePermit},
+    policy::{AllowPolicy, HTTPRoutePermit},
 };
 use futures::{future, TryFutureExt};
 use linkerd_app_core::{
@@ -94,7 +94,7 @@ where
 impl<B, T, N, S> svc::Service<::http::Request<B>> for HttpPolicyService<T, N>
 where
     T: Clone,
-    N: svc::NewService<(RoutePermit, T), Service = S>,
+    N: svc::NewService<(HTTPRoutePermit, T), Service = S>,
     S: svc::Service<::http::Request<B>>,
     S::Error: Into<Error>,
 {
@@ -144,7 +144,7 @@ impl<T, N> HttpPolicyService<T, N> {
         conn: &ConnectionMeta,
         labels: RouteLabels,
         metrics: &HttpAuthzMetrics,
-    ) -> Result<RoutePermit, HttpRouteUnauthorized> {
+    ) -> Result<HTTPRoutePermit, HttpRouteUnauthorized> {
         let authz = match authzs
             .into_iter()
             .find(|a| super::is_authorized(a, conn.client, &conn.tls))
@@ -187,7 +187,7 @@ impl<T, N> HttpPolicyService<T, N> {
                 client.ip = %conn.client.ip(),
                 "Request authorized",
             );
-            RoutePermit {
+            HTTPRoutePermit {
                 dst: conn.dst,
                 labels,
             }


### PR DESCRIPTION
This change adds `route_{kind,group,name}` labels for inbound HTTP
authorization metrics. In this first implementation, a default route is
used for all metrics. In followup changes these labels will vary based
on control plane responses; and they will be wired into additional
inbound HTTP metrics.

Distinct error and permit types are introduced so that TCP-only
types are differentiated.

Signed-off-by: Oliver Gould <ver@buoyant.io>