### PR TITLE
Rename HTTPRoutePermit to HttpRoutePermit

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -52,7 +52,7 @@ struct Http {
 
 #[derive(Clone, Debug)]
 struct Permitted {
-    permit: inbound::policy::HTTPRoutePermit,
+    permit: inbound::policy::HttpRoutePermit,
     http: Http,
 }
 

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -16,7 +16,7 @@ use tracing::{debug, debug_span};
 pub struct Http {
     addr: Remote<ServerAddr>,
     settings: http::client::Settings,
-    permit: policy::HTTPRoutePermit,
+    permit: policy::HttpRoutePermit,
 }
 
 /// Builds `Logical` targets for each HTTP request.
@@ -24,7 +24,7 @@ pub struct Http {
 struct LogicalPerRequest {
     server: Remote<ServerAddr>,
     tls: tls::ConditionalServerTls,
-    permit: policy::HTTPRoutePermit,
+    permit: policy::HttpRoutePermit,
     labels: tap::Labels,
 }
 
@@ -36,7 +36,7 @@ struct Logical {
     addr: Remote<ServerAddr>,
     http: http::Version,
     tls: tls::ConditionalServerTls,
-    permit: policy::HTTPRoutePermit,
+    permit: policy::HttpRoutePermit,
     labels: tap::Labels,
 }
 
@@ -246,12 +246,12 @@ impl<C> Inbound<C> {
 
 // === impl LogicalPerRequest ===
 
-impl<T> From<(policy::HTTPRoutePermit, T)> for LogicalPerRequest
+impl<T> From<(policy::HttpRoutePermit, T)> for LogicalPerRequest
 where
     T: Param<Remote<ServerAddr>>,
     T: Param<tls::ConditionalServerTls>,
 {
-    fn from((permit, t): (policy::HTTPRoutePermit, T)) -> Self {
+    fn from((permit, t): (policy::HttpRoutePermit, T)) -> Self {
         let labels = [
             ("srv", &permit.labels.route.server.0),
             ("route", &permit.labels.route.route),

--- a/linkerd/app/inbound/src/metrics/authz.rs
+++ b/linkerd/app/inbound/src/metrics/authz.rs
@@ -1,4 +1,4 @@
-use crate::policy::{AllowPolicy, HTTPRoutePermit, ServerPermit};
+use crate::policy::{AllowPolicy, HttpRoutePermit, ServerPermit};
 use linkerd_app_core::{
     metrics::{
         metrics, Counter, FmtLabels, FmtMetrics, RouteAuthzLabels, RouteLabels, ServerAuthzLabels,
@@ -63,7 +63,7 @@ type RouteAuthzKey = Key<RouteAuthzLabels>;
 // === impl HttpAuthzMetrics ===
 
 impl HttpAuthzMetrics {
-    pub fn allow(&self, permit: &HTTPRoutePermit, tls: tls::ConditionalServerTls) {
+    pub fn allow(&self, permit: &HttpRoutePermit, tls: tls::ConditionalServerTls) {
         self.0
             .allow
             .lock()
@@ -196,7 +196,7 @@ impl ServerKey {
 }
 
 impl RouteAuthzKey {
-    fn from_permit(permit: &HTTPRoutePermit, tls: tls::ConditionalServerTls) -> Self {
+    fn from_permit(permit: &HttpRoutePermit, tls: tls::ConditionalServerTls) -> Self {
         Self::new(permit.labels.clone(), permit.dst, tls)
     }
 }

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -62,7 +62,7 @@ pub struct ServerPermit {
 
 // Describes an authorized HTTP request.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct HTTPRoutePermit {
+pub struct HttpRoutePermit {
     pub dst: OrigDstAddr,
     pub labels: RouteAuthzLabels,
 }

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -1,6 +1,6 @@
 use crate::{
     metrics::authz::HttpAuthzMetrics,
-    policy::{AllowPolicy, HTTPRoutePermit},
+    policy::{AllowPolicy, HttpRoutePermit},
 };
 use futures::{future, TryFutureExt};
 use linkerd_app_core::{
@@ -94,7 +94,7 @@ where
 impl<B, T, N, S> svc::Service<::http::Request<B>> for HttpPolicyService<T, N>
 where
     T: Clone,
-    N: svc::NewService<(HTTPRoutePermit, T), Service = S>,
+    N: svc::NewService<(HttpRoutePermit, T), Service = S>,
     S: svc::Service<::http::Request<B>>,
     S::Error: Into<Error>,
 {
@@ -144,7 +144,7 @@ impl<T, N> HttpPolicyService<T, N> {
         conn: &ConnectionMeta,
         labels: RouteLabels,
         metrics: &HttpAuthzMetrics,
-    ) -> Result<HTTPRoutePermit, HttpRouteUnauthorized> {
+    ) -> Result<HttpRoutePermit, HttpRouteUnauthorized> {
         let authz = match authzs
             .into_iter()
             .find(|a| super::is_authorized(a, conn.client, &conn.tls))
@@ -187,7 +187,7 @@ impl<T, N> HttpPolicyService<T, N> {
                 client.ip = %conn.client.ip(),
                 "Request authorized",
             );
-            HTTPRoutePermit {
+            HttpRoutePermit {
                 dst: conn.dst,
                 labels,
             }


### PR DESCRIPTION
a32f1b02 introduced a type with inconsitent capitalization. This change
renames the offending type to match the rest of our codebase.

Signed-off-by: Oliver Gould <ver@buoyant.io>