### PR TITLE
inbound: Cleanup in preparation for route policies #1781

### DIFF
--- a/linkerd/app/inbound/src/detect/tests.rs
+++ b/linkerd/app/inbound/src/detect/tests.rs
@@ -1,0 +1,239 @@
+use super::*;
+use crate::test_util;
+use futures::future;
+use linkerd_app_core::{
+    io::AsyncWriteExt,
+    svc::{NewService, ServiceExt},
+    trace, Error,
+};
+use linkerd_server_policy::{Authentication, Authorization, Meta, Protocol, ServerPolicy};
+use std::sync::Arc;
+
+const HTTP1: &[u8] = b"GET / HTTP/1.1\r\nhost: example.com\r\n\r\n";
+const HTTP2: &[u8] = b"PRI * HTTP/2.0\r\n";
+const NOT_HTTP: &[u8] = b"foo\r\nbar\r\nblah\r\n";
+
+fn authzs() -> Arc<[Authorization]> {
+    Arc::new([Authorization {
+        authentication: Authentication::Unauthenticated,
+        networks: vec![client_addr().ip().into()],
+        meta: Arc::new(Meta::Resource {
+            group: "policy.linkerd.io".into(),
+            kind: "authorizationpolicy".into(),
+            name: "testsaz".into(),
+        }),
+    }])
+}
+
+fn allow(protocol: Protocol) -> AllowPolicy {
+    let (allow, _tx) = AllowPolicy::for_test(
+        orig_dst_addr(),
+        ServerPolicy {
+            protocol,
+            authorizations: authzs(),
+            meta: Arc::new(Meta::Resource {
+                group: "policy.linkerd.io".into(),
+                kind: "server".into(),
+                name: "testsrv".into(),
+            }),
+        },
+    );
+    allow
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn detect_tls_opaque() {
+    let _trace = trace::test::trace_init();
+
+    let (io, _) = io::duplex(1);
+    inbound()
+        .with_stack(new_panic("detect stack must not be used"))
+        .push_detect_tls(new_ok())
+        .into_inner()
+        .new_service(Target(allow(Protocol::Opaque)))
+        .oneshot(io)
+        .await
+        .expect("should succeed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn detect_http_non_http() {
+    let _trace = trace::test::trace_init();
+
+    let target = Tls {
+        client_addr: client_addr(),
+        orig_dst_addr: orig_dst_addr(),
+        status: tls::ConditionalServerTls::Some(tls::ServerTls::Established {
+            client_id: Some(client_id()),
+            negotiated_protocol: None,
+        }),
+        policy: allow(Protocol::Detect {
+            timeout: std::time::Duration::from_secs(10),
+        }),
+    };
+
+    let (ior, mut iow) = io::duplex(100);
+    iow.write_all(NOT_HTTP).await.unwrap();
+
+    inbound()
+        .with_stack(new_panic("http stack must not be used"))
+        .push_detect_http(new_ok())
+        .into_inner()
+        .new_service(target)
+        .oneshot(ior)
+        .await
+        .expect("should succeed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn detect_http() {
+    let _trace = trace::test::trace_init();
+
+    let target = Tls {
+        client_addr: client_addr(),
+        orig_dst_addr: orig_dst_addr(),
+        status: tls::ConditionalServerTls::Some(tls::ServerTls::Established {
+            client_id: Some(client_id()),
+            negotiated_protocol: None,
+        }),
+        policy: allow(Protocol::Detect {
+            timeout: std::time::Duration::from_secs(10),
+        }),
+    };
+
+    let (ior, mut iow) = io::duplex(100);
+    iow.write_all(HTTP1).await.unwrap();
+
+    inbound()
+        .with_stack(new_ok())
+        .push_detect_http(new_panic("tcp stack must not be used"))
+        .into_inner()
+        .new_service(target)
+        .oneshot(ior)
+        .await
+        .expect("should succeed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn hinted_http1() {
+    let _trace = trace::test::trace_init();
+    let target = Tls {
+        client_addr: client_addr(),
+        orig_dst_addr: orig_dst_addr(),
+        status: tls::ConditionalServerTls::Some(tls::ServerTls::Established {
+            client_id: Some(client_id()),
+            negotiated_protocol: None,
+        }),
+        policy: allow(Protocol::Http1),
+    };
+
+    let (ior, mut iow) = io::duplex(100);
+    iow.write_all(HTTP1).await.unwrap();
+
+    inbound()
+        .with_stack(new_ok())
+        .push_detect_http(new_panic("tcp stack must not be used"))
+        .into_inner()
+        .new_service(target)
+        .oneshot(ior)
+        .await
+        .expect("should succeed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn hinted_http1_supports_http2() {
+    let _trace = trace::test::trace_init();
+    let target = Tls {
+        client_addr: client_addr(),
+        orig_dst_addr: orig_dst_addr(),
+        status: tls::ConditionalServerTls::Some(tls::ServerTls::Established {
+            client_id: Some(client_id()),
+            negotiated_protocol: None,
+        }),
+        policy: allow(Protocol::Http1),
+    };
+
+    let (ior, mut iow) = io::duplex(100);
+    iow.write_all(HTTP2).await.unwrap();
+
+    inbound()
+        .with_stack(new_ok())
+        .push_detect_http(new_panic("tcp stack must not be used"))
+        .into_inner()
+        .new_service(target)
+        .oneshot(ior)
+        .await
+        .expect("should succeed");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn hinted_http2() {
+    let _trace = trace::test::trace_init();
+    let target = Tls {
+        client_addr: client_addr(),
+        orig_dst_addr: orig_dst_addr(),
+        status: tls::ConditionalServerTls::Some(tls::ServerTls::Established {
+            client_id: Some(client_id()),
+            negotiated_protocol: None,
+        }),
+        policy: allow(Protocol::Http2),
+    };
+
+    let (ior, _) = io::duplex(100);
+
+    inbound()
+        .with_stack(new_ok())
+        .push_detect_http(new_panic("tcp stack must not be used"))
+        .into_inner()
+        .new_service(target)
+        .oneshot(ior)
+        .await
+        .expect("should succeed");
+}
+
+fn client_id() -> tls::ClientId {
+    "testsa.testns.serviceaccount.identity.linkerd.cluster.local"
+        .parse()
+        .unwrap()
+}
+
+fn client_addr() -> Remote<ClientAddr> {
+    Remote(ClientAddr(([192, 0, 2, 3], 54321).into()))
+}
+
+fn orig_dst_addr() -> OrigDstAddr {
+    OrigDstAddr(([192, 0, 2, 2], 1000).into())
+}
+
+fn inbound() -> Inbound<()> {
+    Inbound::new(test_util::default_config(), test_util::runtime().0)
+}
+
+fn new_panic<T, I: 'static>(msg: &'static str) -> svc::ArcNewTcp<T, I> {
+    svc::ArcNewService::new(move |_| -> svc::BoxTcp<I> { panic!("{}", msg) })
+}
+
+fn new_ok<T>() -> svc::ArcNewTcp<T, io::BoxedIo> {
+    svc::ArcNewService::new(|_| svc::BoxService::new(svc::mk(|_| future::ok::<(), Error>(()))))
+}
+
+#[derive(Clone, Debug)]
+struct Target(AllowPolicy);
+
+impl svc::Param<AllowPolicy> for Target {
+    fn param(&self) -> AllowPolicy {
+        self.0.clone()
+    }
+}
+
+impl svc::Param<OrigDstAddr> for Target {
+    fn param(&self) -> OrigDstAddr {
+        orig_dst_addr()
+    }
+}
+
+impl svc::Param<Remote<ClientAddr>> for Target {
+    fn param(&self) -> Remote<ClientAddr> {
+        client_addr()
+    }
+}

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -13,8 +13,8 @@ pub use self::{
 };
 
 pub use linkerd_app_core::metrics::ServerLabel;
-use linkerd_app_core::metrics::{RouteAuthzLabels, ServerAuthzLabels};
 use linkerd_app_core::{
+    metrics::{RouteAuthzLabels, ServerAuthzLabels},
     tls,
     transport::{ClientAddr, OrigDstAddr, Remote},
 };
@@ -78,7 +78,7 @@ impl From<DefaultPolicy> for ServerPolicy {
             DefaultPolicy::Allow(p) => p,
             DefaultPolicy::Deny => ServerPolicy {
                 protocol: Protocol::Opaque,
-                authorizations: vec![].into(),
+                authorizations: Arc::new([]),
                 meta: Meta::new_default("deny"),
             },
         }
@@ -97,6 +97,11 @@ impl AllowPolicy {
         let server = Cached::uncached(server);
         let p = Self { dst, server };
         (p, tx)
+    }
+
+    #[inline]
+    pub(crate) fn borrow(&self) -> tokio::sync::watch::Ref<'_, ServerPolicy> {
+        self.server.borrow()
     }
 
     #[inline]

--- a/linkerd/app/inbound/src/policy/store.rs
+++ b/linkerd/app/inbound/src/policy/store.rs
@@ -120,6 +120,7 @@ where
             self.cache
                 .get_or_insert_with(dst.port(), |port| match self.discover.clone() {
                     Some(disco) => info_span!("watch", port).in_scope(|| {
+                        tracing::trace!(%port, "spawning policy discovery");
                         disco.spawn_with_init(*port, self.default_rx.borrow().clone())
                     }),
 
@@ -127,7 +128,10 @@ where
                     // default policy. Whlie it's a little wasteful to cache
                     // these results separately, this case isn't expected to be
                     // used outside of testing.
-                    None => self.default_rx.clone(),
+                    None => {
+                        tracing::trace!(%port, "using the default policy");
+                        self.default_rx.clone()
+                    }
                 });
 
         AllowPolicy { dst, server }


### PR DESCRIPTION
Before making changes that support inbound HTTP route authorization
policies, this change makes some cosmetic changes that will help
minimize the changes needed for new funcationality.

No funtional changes.

Signed-off-by: Oliver Gould <ver@buoyant.io>