### PR TITLE
Add HTTP route matchers to support the Gateway API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,6 +1141,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkerd-http-route"
+version = "0.1.0"
+dependencies = [
+ "http",
+ "maplit",
+ "regex",
+ "thiserror",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "linkerd-identity"
 version = "0.1.0"
 dependencies = [
@@ -1724,6 +1736,12 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "match_cfg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,6 @@ name = "linkerd-http-route"
 version = "0.1.0"
 dependencies = [
  "http",
- "maplit",
  "regex",
  "thiserror",
  "tracing",
@@ -1736,12 +1735,6 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[package]]
-name = "maplit"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "match_cfg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "linkerd/http-classify",
     "linkerd/http-metrics",
     "linkerd/http-retry",
+    "linkerd/http-route",
     "linkerd/identity",
     "linkerd/io",
     "linkerd/meshtls",

--- a/linkerd/http-route/Cargo.toml
+++ b/linkerd/http-route/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "linkerd-http-route"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+http = "0.2"
+regex = "1"
+thiserror = "1"
+tracing = "0.1"
+url = "2"
+
+[dev-dependencies]
+maplit = "1"

--- a/linkerd/http-route/Cargo.toml
+++ b/linkerd/http-route/Cargo.toml
@@ -11,6 +11,3 @@ regex = "1"
 thiserror = "1"
 tracing = "0.1"
 url = "2"
-
-[dev-dependencies]
-maplit = "1"

--- a/linkerd/http-route/src/grpc.rs
+++ b/linkerd/http-route/src/grpc.rs
@@ -1,0 +1,19 @@
+pub mod r#match;
+
+pub use self::r#match::MatchRoute;
+#[cfg(test)]
+mod tests;
+
+pub type RouteMatch = crate::RouteMatch<r#match::RouteMatch>;
+
+pub type Route<P> = crate::Route<MatchRoute, P>;
+
+pub type Rule<P> = crate::Rule<MatchRoute, P>;
+
+#[inline]
+pub fn find<'r, P, B>(
+    routes: &'r [Route<P>],
+    req: &::http::Request<B>,
+) -> Option<(RouteMatch, &'r P)> {
+    super::find(routes, req)
+}

--- a/linkerd/http-route/src/grpc/match.rs
+++ b/linkerd/http-route/src/grpc/match.rs
@@ -27,7 +27,9 @@ pub(crate) struct MatchRpc {
 /// Summarizes a matched gRPC endpoints.
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct RpcMatch {
+    /// The number of characters matched in the service name.
     service: usize,
+    /// The number of characters matched in the method name.
     method: usize,
 }
 

--- a/linkerd/http-route/src/grpc/match.rs
+++ b/linkerd/http-route/src/grpc/match.rs
@@ -36,7 +36,7 @@ pub(crate) struct RpcMatch {
 impl crate::Match for MatchRoute {
     type Summary = RouteMatch;
 
-    fn r#match<B>(&self, req: &http::Request<B>) -> Option<RouteMatch> {
+    fn match_request<B>(&self, req: &http::Request<B>) -> Option<RouteMatch> {
         if req.method() != http::Method::POST {
             return None;
         }
@@ -64,11 +64,9 @@ impl std::cmp::PartialOrd for RouteMatch {
 
 impl std::cmp::Ord for RouteMatch {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        use std::cmp::Ordering;
-        match self.rpc.cmp(&other.rpc) {
-            Ordering::Equal => self.headers.cmp(&other.headers),
-            ord => ord,
-        }
+        self.rpc
+            .cmp(&other.rpc)
+            .then_with(|| self.headers.cmp(&other.headers))
     }
 }
 

--- a/linkerd/http-route/src/grpc/match.rs
+++ b/linkerd/http-route/src/grpc/match.rs
@@ -1,0 +1,104 @@
+#[cfg(test)]
+mod tests;
+
+use crate::http::MatchHeader;
+
+/// Matches gRPC routes.
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct MatchRoute {
+    pub(crate) rpc: MatchRpc,
+    pub(crate) headers: Vec<MatchHeader>,
+}
+
+/// Summarizes a matched gRPC route.
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct RouteMatch {
+    rpc: RpcMatch,
+    headers: usize,
+}
+
+/// Matches gRPC endpoints.
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct MatchRpc {
+    pub(crate) service: Option<String>,
+    pub(crate) method: Option<String>,
+}
+
+/// Summarizes a matched gRPC endpoints.
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct RpcMatch {
+    service: usize,
+    method: usize,
+}
+
+// === impl MatchRoute ===
+
+impl crate::Match for MatchRoute {
+    type Summary = RouteMatch;
+
+    fn r#match<B>(&self, req: &http::Request<B>) -> Option<RouteMatch> {
+        if req.method() != http::Method::POST {
+            return None;
+        }
+
+        let rpc = self.rpc.match_length(req.uri().path())?;
+
+        let headers = {
+            if !self.headers.iter().all(|h| h.is_match(req.headers())) {
+                return None;
+            }
+            self.headers.len()
+        };
+
+        Some(RouteMatch { rpc, headers })
+    }
+}
+
+// === impl RouteMatch ===
+
+impl std::cmp::PartialOrd for RouteMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for RouteMatch {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match self.rpc.cmp(&other.rpc) {
+            Ordering::Equal => self.headers.cmp(&other.headers),
+            ord => ord,
+        }
+    }
+}
+
+// === impl MatchRpc ===
+
+impl MatchRpc {
+    fn match_length(&self, path: &str) -> Option<RpcMatch> {
+        let mut summary = RpcMatch::default();
+
+        let mut parts = path.split('/');
+        if !parts.next()?.is_empty() {
+            return None;
+        }
+
+        let service = parts.next()?;
+        if let Some(s) = &self.service {
+            if s != service {
+                return None;
+            }
+            summary.service = s.len();
+        }
+
+        let method = parts.next()?;
+        if let Some(m) = &self.method {
+            if m != method {
+                return None;
+            }
+            summary.method = m.len();
+        }
+
+        Some(summary)
+    }
+}

--- a/linkerd/http-route/src/grpc/match/tests.rs
+++ b/linkerd/http-route/src/grpc/match/tests.rs
@@ -1,0 +1,187 @@
+use super::*;
+use crate::Match;
+use http::header::{HeaderName, HeaderValue};
+
+// Empty matches apply to all requests.
+#[test]
+fn empty_match() {
+    let m = MatchRoute::default();
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://example.com/foo/bar")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), Some(RouteMatch::default()));
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://example.com/foo")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+}
+
+#[test]
+fn method() {
+    let m = MatchRoute {
+        rpc: MatchRpc {
+            service: None,
+            method: Some("bar".to_string()),
+        },
+        ..MatchRoute::default()
+    };
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://example.com/foo/bar")
+        .body(())
+        .unwrap();
+    assert_eq!(
+        m.r#match(&req),
+        Some(RouteMatch {
+            rpc: RpcMatch {
+                service: 0,
+                method: 3
+            },
+            ..Default::default()
+        })
+    );
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("https://example.org/foo/bah")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+}
+
+#[test]
+fn headers() {
+    let m = MatchRoute {
+        headers: vec![
+            MatchHeader::Exact(
+                HeaderName::from_static("x-foo"),
+                HeaderValue::from_static("bar"),
+            ),
+            MatchHeader::Regex(HeaderName::from_static("x-baz"), "qu+x".parse().unwrap()),
+        ],
+        ..MatchRoute::default()
+    };
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://example.com/foo")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("https://example.org/")
+        .header("x-foo", "bar")
+        .header("x-baz", "zab") // invalid header value
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+
+    // Regex matches apply
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("https://example.org/foo/bar")
+        .header("x-foo", "bar")
+        .header("x-baz", "quuuux")
+        .body(())
+        .unwrap();
+    assert_eq!(
+        m.r#match(&req),
+        Some(RouteMatch {
+            headers: 2,
+            ..RouteMatch::default()
+        })
+    );
+
+    // Regex must be anchored.
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("https://example.org/foo/bar")
+        .header("x-foo", "bar")
+        .header("x-baz", "quxa")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+}
+
+#[test]
+fn http_method() {
+    let m = MatchRoute {
+        rpc: MatchRpc {
+            service: Some("foo".to_string()),
+            method: Some("bar".to_string()),
+        },
+        headers: vec![],
+    };
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://example.com/foo/bar")
+        .body(())
+        .unwrap();
+    assert_eq!(
+        m.r#match(&req),
+        Some(RouteMatch {
+            rpc: RpcMatch {
+                service: 3,
+                method: 3,
+            },
+            headers: 0,
+        })
+    );
+
+    let req = http::Request::builder()
+        .method(http::Method::GET)
+        .uri("http://example.com/foo/bar")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+}
+
+#[test]
+fn multiple() {
+    let m = MatchRoute {
+        rpc: MatchRpc {
+            service: Some("foo".to_string()),
+            method: Some("bar".to_string()),
+        },
+        headers: vec![MatchHeader::Exact(
+            HeaderName::from_static("x-foo"),
+            HeaderValue::from_static("bar"),
+        )],
+    };
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("https://example.org/foo/bar")
+        .header("x-foo", "bar")
+        .body(())
+        .unwrap();
+    assert_eq!(
+        m.r#match(&req),
+        Some(RouteMatch {
+            rpc: RpcMatch {
+                service: 3,
+                method: 3
+            },
+            headers: 1
+        })
+    );
+
+    // One invalid field (header) invalidates the match.
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("https://example.org/foo/bar")
+        .header("x-foo", "bah")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+}

--- a/linkerd/http-route/src/grpc/match/tests.rs
+++ b/linkerd/http-route/src/grpc/match/tests.rs
@@ -12,14 +12,14 @@ fn empty_match() {
         .uri("http://example.com/foo/bar")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), Some(RouteMatch::default()));
+    assert_eq!(m.match_request(&req), Some(RouteMatch::default()));
 
     let req = http::Request::builder()
         .method(http::Method::POST)
         .uri("http://example.com/foo")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 }
 
 #[test]
@@ -38,7 +38,7 @@ fn method() {
         .body(())
         .unwrap();
     assert_eq!(
-        m.r#match(&req),
+        m.match_request(&req),
         Some(RouteMatch {
             rpc: RpcMatch {
                 service: 0,
@@ -53,7 +53,7 @@ fn method() {
         .uri("https://example.org/foo/bah")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 }
 
 #[test]
@@ -74,7 +74,7 @@ fn headers() {
         .uri("http://example.com/foo")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 
     let req = http::Request::builder()
         .method(http::Method::POST)
@@ -83,7 +83,7 @@ fn headers() {
         .header("x-baz", "zab") // invalid header value
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 
     // Regex matches apply
     let req = http::Request::builder()
@@ -94,7 +94,7 @@ fn headers() {
         .body(())
         .unwrap();
     assert_eq!(
-        m.r#match(&req),
+        m.match_request(&req),
         Some(RouteMatch {
             headers: 2,
             ..RouteMatch::default()
@@ -109,7 +109,7 @@ fn headers() {
         .header("x-baz", "quxa")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 }
 
 #[test]
@@ -128,7 +128,7 @@ fn http_method() {
         .body(())
         .unwrap();
     assert_eq!(
-        m.r#match(&req),
+        m.match_request(&req),
         Some(RouteMatch {
             rpc: RpcMatch {
                 service: 3,
@@ -143,7 +143,7 @@ fn http_method() {
         .uri("http://example.com/foo/bar")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 }
 
 #[test]
@@ -166,7 +166,7 @@ fn multiple() {
         .body(())
         .unwrap();
     assert_eq!(
-        m.r#match(&req),
+        m.match_request(&req),
         Some(RouteMatch {
             rpc: RpcMatch {
                 service: 3,
@@ -183,5 +183,5 @@ fn multiple() {
         .header("x-foo", "bah")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 }

--- a/linkerd/http-route/src/grpc/tests.rs
+++ b/linkerd/http-route/src/grpc/tests.rs
@@ -55,9 +55,9 @@ fn hostname_precedence() {
     assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
 }
 
+/// Given two equivalent routes, choose the longer path match.
 #[test]
 fn method_precedence() {
-    // Given two equivalent routes, choose the longer path match.
     let rts = vec![
         Route {
             rules: vec![Rule {

--- a/linkerd/http-route/src/grpc/tests.rs
+++ b/linkerd/http-route/src/grpc/tests.rs
@@ -1,0 +1,171 @@
+use super::{r#match::*, *};
+use crate::http::MatchHeader;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Policy {
+    Expected,
+    Unexpected,
+}
+
+impl Default for Policy {
+    fn default() -> Self {
+        Self::Unexpected
+    }
+}
+
+/// Given two equivalent routes, choose the explicit hostname match and not
+/// the wildcard.
+#[test]
+fn hostname_precedence() {
+    let rts = vec![
+        Route {
+            hosts: vec!["*.example.com".parse().unwrap()],
+            rules: vec![Rule {
+                matches: vec![MatchRoute {
+                    rpc: MatchRpc {
+                        service: Some("foo".to_string()),
+                        method: Some("bar".to_string()),
+                    },
+                    ..MatchRoute::default()
+                }],
+                ..Rule::default()
+            }],
+        },
+        Route {
+            hosts: vec!["foo.example.com".parse().unwrap()],
+            rules: vec![Rule {
+                matches: vec![MatchRoute {
+                    rpc: MatchRpc {
+                        service: Some("foo".to_string()),
+                        method: Some("bar".to_string()),
+                    },
+                    ..MatchRoute::default()
+                }],
+                policy: Policy::Expected,
+            }],
+        },
+    ];
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://foo.example.com/foo/bar")
+        .body(())
+        .unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}
+
+#[test]
+fn method_precedence() {
+    // Given two equivalent routes, choose the longer path match.
+    let rts = vec![
+        Route {
+            rules: vec![Rule {
+                matches: vec![MatchRoute {
+                    rpc: MatchRpc {
+                        service: Some("foo".to_string()),
+                        method: None,
+                    },
+                    ..MatchRoute::default()
+                }],
+                ..Rule::default()
+            }],
+            hosts: vec![],
+        },
+        Route {
+            rules: vec![Rule {
+                matches: vec![MatchRoute {
+                    rpc: MatchRpc {
+                        service: Some("foo".to_string()),
+                        method: Some("bar".to_string()),
+                    },
+                    ..MatchRoute::default()
+                }],
+                policy: Policy::Expected,
+            }],
+            hosts: vec![],
+        },
+    ];
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://foo.example.com/foo/bar")
+        .body(())
+        .unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}
+
+/// Given two routes with header matches, use the one that matches more
+/// headers.
+#[test]
+fn header_count_precedence() {
+    let rts = vec![
+        Route {
+            rules: vec![Rule {
+                matches: vec![MatchRoute {
+                    headers: vec![
+                        MatchHeader::Exact("x-foo".parse().unwrap(), "bar".parse().unwrap()),
+                        MatchHeader::Exact("x-baz".parse().unwrap(), "qux".parse().unwrap()),
+                    ],
+                    ..MatchRoute::default()
+                }],
+                ..Rule::default()
+            }],
+            hosts: vec![],
+        },
+        Route {
+            rules: vec![Rule {
+                matches: vec![MatchRoute {
+                    headers: vec![
+                        MatchHeader::Exact("x-foo".parse().unwrap(), "bar".parse().unwrap()),
+                        MatchHeader::Exact("x-baz".parse().unwrap(), "qux".parse().unwrap()),
+                        MatchHeader::Exact("x-biz".parse().unwrap(), "qyx".parse().unwrap()),
+                    ],
+                    ..MatchRoute::default()
+                }],
+                policy: Policy::Expected,
+            }],
+            hosts: vec![],
+        },
+    ];
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://www.example.com/foo/bar")
+        .header("x-foo", "bar")
+        .header("x-baz", "qux")
+        .header("x-biz", "qyx")
+        .body(())
+        .unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}
+
+/// Given two routes with header matches, use the one that matches more
+/// headers.
+#[test]
+fn first_identical_wins() {
+    let rts = vec![
+        Route {
+            rules: vec![
+                Rule {
+                    policy: Policy::Expected,
+                    ..Rule::default()
+                },
+                // Redundant rule.
+                Rule::default(),
+            ],
+            hosts: vec![],
+        },
+        // Redundant route.
+        Route {
+            rules: vec![Rule::default()],
+            hosts: vec![],
+        },
+    ];
+
+    let req = http::Request::builder().body(()).unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}

--- a/linkerd/http-route/src/http.rs
+++ b/linkerd/http-route/src/http.rs
@@ -1,0 +1,19 @@
+pub mod r#match;
+#[cfg(test)]
+mod tests;
+
+pub use self::r#match::{HostMatch, MatchHeader, MatchHost, MatchRequest};
+
+pub type RouteMatch = crate::RouteMatch<r#match::RequestMatch>;
+
+pub type Route<P> = crate::Route<MatchRequest, P>;
+
+pub type Rule<P> = crate::Rule<MatchRequest, P>;
+
+#[inline]
+pub fn find<'r, P, B>(
+    routes: &'r [Route<P>],
+    req: &::http::Request<B>,
+) -> Option<(RouteMatch, &'r P)> {
+    super::find(routes, req)
+}

--- a/linkerd/http-route/src/http/match.rs
+++ b/linkerd/http-route/src/http/match.rs
@@ -1,0 +1,104 @@
+pub mod header;
+pub mod host;
+pub mod path;
+pub mod query_param;
+#[cfg(test)]
+mod tests;
+
+pub(crate) use self::path::PathMatch;
+pub use self::{
+    header::MatchHeader,
+    host::{HostMatch, InvalidHost, MatchHost},
+    path::MatchPath,
+    query_param::MatchQueryParam,
+};
+
+/// Matches HTTP requests.
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct MatchRequest {
+    pub path: Option<MatchPath>,
+    pub headers: Vec<MatchHeader>,
+    pub query_params: Vec<MatchQueryParam>,
+    pub method: Option<http::Method>,
+}
+
+/// Summarizes a matched HTTP request.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct RequestMatch {
+    path_match: PathMatch,
+    headers: usize,
+    query_params: usize,
+    method: bool,
+}
+
+// === impl MatchRequest ===
+
+impl crate::Match for MatchRequest {
+    type Summary = RequestMatch;
+
+    fn r#match<B>(&self, req: &http::Request<B>) -> Option<RequestMatch> {
+        let mut summary = RequestMatch::default();
+
+        if let Some(method) = &self.method {
+            if req.method() != *method {
+                return None;
+            }
+            summary.method = true;
+        }
+
+        if let Some(path) = &self.path {
+            summary.path_match = path.match_length(req.uri())?;
+        }
+
+        if !self.headers.iter().all(|h| h.is_match(req.headers())) {
+            return None;
+        }
+        summary.headers = self.headers.len();
+
+        if !self.query_params.iter().all(|h| h.is_match(req.uri())) {
+            return None;
+        }
+        summary.query_params = self.query_params.len();
+
+        Some(summary)
+    }
+}
+
+impl Default for RequestMatch {
+    fn default() -> Self {
+        // Per the gateway spec:
+        //
+        // > If no matches are specified, the default is a prefix path match on
+        // > "/", which has the effect of matching every HTTP request.
+        Self {
+            path_match: PathMatch::Prefix("/".len()),
+            headers: 0,
+            query_params: 0,
+            method: false,
+        }
+    }
+}
+
+// === impl RequestMatch ===
+
+impl std::cmp::PartialOrd for RequestMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for RequestMatch {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match self.path_match.cmp(&other.path_match) {
+            Ordering::Equal => match self.headers.cmp(&other.headers) {
+                Ordering::Equal => match self.query_params.cmp(&other.query_params) {
+                    Ordering::Equal => self.method.cmp(&other.method),
+                    ord => ord,
+                },
+                ord => ord,
+            },
+            ord => ord,
+        }
+    }
+}

--- a/linkerd/http-route/src/http/match.rs
+++ b/linkerd/http-route/src/http/match.rs
@@ -36,7 +36,7 @@ pub struct RequestMatch {
 impl crate::Match for MatchRequest {
     type Summary = RequestMatch;
 
-    fn r#match<B>(&self, req: &http::Request<B>) -> Option<RequestMatch> {
+    fn match_request<B>(&self, req: &http::Request<B>) -> Option<RequestMatch> {
         let mut summary = RequestMatch::default();
 
         if let Some(method) = &self.method {
@@ -89,16 +89,10 @@ impl std::cmp::PartialOrd for RequestMatch {
 
 impl std::cmp::Ord for RequestMatch {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        use std::cmp::Ordering;
-        match self.path_match.cmp(&other.path_match) {
-            Ordering::Equal => match self.headers.cmp(&other.headers) {
-                Ordering::Equal => match self.query_params.cmp(&other.query_params) {
-                    Ordering::Equal => self.method.cmp(&other.method),
-                    ord => ord,
-                },
-                ord => ord,
-            },
-            ord => ord,
-        }
+        self.path_match
+            .cmp(&other.path_match)
+            .then_with(|| self.headers.cmp(&other.headers))
+            .then_with(|| self.query_params.cmp(&other.query_params))
+            .then_with(|| self.method.cmp(&other.method))
     }
 }

--- a/linkerd/http-route/src/http/match/header.rs
+++ b/linkerd/http-route/src/http/match/header.rs
@@ -1,0 +1,149 @@
+use http::header::{HeaderName, HeaderValue};
+use regex::Regex;
+
+/// Matches a single HTTP header value.
+#[derive(Clone, Debug)]
+pub enum MatchHeader {
+    Exact(HeaderName, HeaderValue),
+    Regex(HeaderName, Regex),
+}
+
+// === impl MatchHeader ===
+
+impl MatchHeader {
+    pub fn is_match(&self, headers: &http::HeaderMap) -> bool {
+        match self {
+            Self::Exact(n, v) => headers.get_all(n).iter().any(|h| h == v),
+            Self::Regex(n, re) => headers
+                .get_all(n)
+                .iter()
+                .filter_map(|h| h.to_str().ok())
+                .any(|h| {
+                    if let Some(m) = re.find(h) {
+                        // Check that the regex is anchored at the start and end
+                        // of the value.
+                        m.start() == 0 && m.end() == h.len()
+                    } else {
+                        false
+                    }
+                }),
+        }
+    }
+}
+
+impl std::hash::Hash for MatchHeader {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Exact(n, s) => {
+                n.hash(state);
+                s.hash(state)
+            }
+            Self::Regex(n, r) => {
+                n.hash(state);
+                r.as_str().hash(state);
+            }
+        }
+    }
+}
+
+impl std::cmp::Eq for MatchHeader {}
+
+impl std::cmp::PartialEq for MatchHeader {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Exact(n, s), Self::Exact(m, o)) => n == m && s == o,
+            (Self::Regex(n, s), Self::Regex(m, o)) => n == m && s.as_str() == o.as_str(),
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn headers_exact() {
+        let m = MatchHeader::Exact(
+            HeaderName::from_static("foo"),
+            HeaderValue::from_static("bar"),
+        );
+        assert!(m.is_match(&{
+            let mut h = http::HeaderMap::new();
+            h.insert(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("bar"),
+            );
+            h
+        }));
+        assert!(m.is_match(&{
+            let mut h = http::HeaderMap::new();
+            h.append(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("bah"),
+            );
+            h.append(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("bar"),
+            );
+            h.append(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("baz"),
+            );
+            h
+        }));
+        assert!(!m.is_match(&{
+            let mut h = http::HeaderMap::new();
+            h.append(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("bah"),
+            );
+            h
+        }));
+    }
+
+    #[test]
+    fn headers_regex() {
+        let m = MatchHeader::Regex(HeaderName::from_static("foo"), "bar*".parse().unwrap());
+        assert!(m.is_match(&{
+            let mut h = http::HeaderMap::new();
+            h.insert(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("bar"),
+            );
+            h
+        }));
+        assert!(m.is_match(&{
+            let mut h = http::HeaderMap::new();
+            h.append(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("bahh"),
+            );
+            h.append(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("barr"),
+            );
+            h.append(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("bazz"),
+            );
+            h
+        }));
+        assert!(!m.is_match(&{
+            let mut h = http::HeaderMap::new();
+            h.append(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("bah"),
+            );
+            h
+        }));
+        assert!(!m.is_match(&{
+            let mut h = http::HeaderMap::new();
+            h.append(
+                HeaderName::from_static("foo"),
+                HeaderValue::from_static("barro"),
+            );
+            h
+        }));
+    }
+}

--- a/linkerd/http-route/src/http/match/host.rs
+++ b/linkerd/http-route/src/http/match/host.rs
@@ -1,0 +1,205 @@
+use http::Uri;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum MatchHost {
+    Exact(String),
+
+    /// Tokenized reverse list of DNS name suffix labels.
+    ///
+    /// For example: the match `*.example.com` is stored as `["com",
+    /// "example"]`.
+    Suffix(Vec<String>),
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum HostMatch {
+    Exact(usize),
+    Suffix(usize),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidHost {
+    #[error("invalid host: {0}")]
+    Invalid(#[from] url::ParseError),
+
+    #[error("host must not be an IP address")]
+    NumericHost,
+}
+
+// === impl MatchHost ===
+
+impl std::str::FromStr for MatchHost {
+    type Err = InvalidHost;
+
+    fn from_str(host: &str) -> Result<Self, Self::Err> {
+        use url::Host;
+        if let Host::Ipv4(_) | Host::Ipv6(_) = Host::parse(host)? {
+            return Err(InvalidHost::NumericHost);
+        }
+
+        if let Some(host) = host.strip_prefix("*.") {
+            return Ok(Self::Suffix(
+                host.split('.').map(|s| s.to_string()).rev().collect(),
+            ));
+        }
+
+        Ok(Self::Exact(host.to_string()))
+    }
+}
+
+impl MatchHost {
+    pub fn summarize_match(&self, uri: &Uri) -> Option<HostMatch> {
+        let mut host = uri.authority()?.host();
+
+        match self {
+            Self::Exact(h) => {
+                if !h.ends_with('.') {
+                    host = host.strip_suffix('.').unwrap_or(host);
+                }
+                if h == host {
+                    Some(HostMatch::Exact(h.len()))
+                } else {
+                    None
+                }
+            }
+
+            Self::Suffix(suffix) => {
+                if suffix.first().map(|s| &**s) != Some("") {
+                    host = host.strip_suffix('.').unwrap_or(host);
+                }
+                let mut length = 0;
+                for sfx in suffix.iter() {
+                    if !host.ends_with(sfx) {
+                        return None;
+                    }
+                    host = &host[..host.len() - sfx.len()];
+                    if !host.ends_with('.') {
+                        return None;
+                    }
+                    host = &host[..host.len() - 1];
+                    length += sfx.len() + 1;
+                }
+
+                Some(HostMatch::Suffix(length))
+            }
+        }
+    }
+}
+
+// === impl HostMatch ===
+
+impl std::cmp::PartialOrd for HostMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for HostMatch {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match (self, other) {
+            (Self::Exact(l), Self::Exact(r)) => l.cmp(r),
+            (Self::Suffix(l), Self::Suffix(r)) => l.cmp(r),
+            (Self::Exact(_), Self::Suffix(_)) => Ordering::Greater,
+            (Self::Suffix(_), Self::Exact(_)) => Ordering::Less,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exact() {
+        let m = "example.com"
+            .parse::<MatchHost>()
+            .expect("example.com parses");
+        assert_eq!(m, MatchHost::Exact("example.com".to_string()));
+        assert_eq!(
+            m.summarize_match(&"https://example.com/foo/bar".parse().unwrap()),
+            Some(HostMatch::Exact("example.com".len()))
+        );
+        assert_eq!(
+            m.summarize_match(&"https://example.com./foo/bar".parse().unwrap()),
+            Some(HostMatch::Exact("example.com".len()))
+        );
+        assert_eq!(
+            m.summarize_match(&"https://foo.example.com/foo/bar".parse().unwrap()),
+            None
+        );
+
+        let m = "example.com."
+            .parse::<MatchHost>()
+            .expect("example.com parses");
+        assert_eq!(m, MatchHost::Exact("example.com.".to_string()));
+        assert_eq!(
+            m.summarize_match(&"https://example.com/foo/bar".parse().unwrap()),
+            None,
+        );
+        assert_eq!(
+            m.summarize_match(&"https://example.com./foo/bar".parse().unwrap()),
+            Some(HostMatch::Exact("example.com.".len()))
+        );
+    }
+
+    #[test]
+    fn suffix() {
+        let m = "*.example.com"
+            .parse::<MatchHost>()
+            .expect("*.example.com parses");
+        assert_eq!(
+            m,
+            MatchHost::Suffix(vec!["com".to_string(), "example".to_string()])
+        );
+        assert_eq!(
+            m.summarize_match(&"https://example.com/foo/bar".parse().unwrap()),
+            None
+        );
+        assert_eq!(
+            m.summarize_match(&"https://foo.example.com/foo/bar".parse().unwrap()),
+            Some(HostMatch::Suffix(".example.com".len()))
+        );
+        assert_eq!(
+            m.summarize_match(&"https://foo.example.com./foo/bar".parse().unwrap()),
+            Some(HostMatch::Suffix(".example.com".len()))
+        );
+        assert_eq!(
+            m.summarize_match(&"https://bar.foo.example.com/foo/bar".parse().unwrap()),
+            Some(HostMatch::Suffix(".example.com".len()))
+        );
+
+        let m = "*.example.com."
+            .parse::<MatchHost>()
+            .expect("*.example.com. parses");
+        assert_eq!(
+            m,
+            MatchHost::Suffix(vec![
+                "".to_string(),
+                "com".to_string(),
+                "example".to_string()
+            ])
+        );
+        assert_eq!(
+            m.summarize_match(&"https://bar.foo.example.com/foo/bar".parse().unwrap()),
+            None
+        );
+        assert_eq!(
+            m.summarize_match(&"https://bar.foo.example.com./foo/bar".parse().unwrap()),
+            Some(HostMatch::Suffix(".example.com.".len()))
+        );
+    }
+
+    #[test]
+    fn cmp() {
+        assert!(HostMatch::Exact("example.com".len()) > HostMatch::Suffix(".example.com".len()));
+        assert!(HostMatch::Exact("foo.example.com".len()) > HostMatch::Exact("example.com".len()));
+        assert!(
+            HostMatch::Suffix(".foo.example.com".len()) > HostMatch::Suffix(".example.com".len())
+        );
+        assert_eq!(
+            HostMatch::Suffix(".foo.example.com".len()),
+            HostMatch::Suffix(".bar.example.com".len())
+        );
+    }
+}

--- a/linkerd/http-route/src/http/match/host.rs
+++ b/linkerd/http-route/src/http/match/host.rs
@@ -69,14 +69,8 @@ impl MatchHost {
                 }
                 let mut length = 0;
                 for sfx in suffix.iter() {
-                    if !host.ends_with(sfx) {
-                        return None;
-                    }
-                    host = &host[..host.len() - sfx.len()];
-                    if !host.ends_with('.') {
-                        return None;
-                    }
-                    host = &host[..host.len() - 1];
+                    host = host.strip_suffix(sfx)?;
+                    host = host.strip_suffix('.')?;
                     length += sfx.len() + 1;
                 }
 

--- a/linkerd/http-route/src/http/match/path.rs
+++ b/linkerd/http-route/src/http/match/path.rs
@@ -8,6 +8,7 @@ pub enum MatchPath {
     Regex(Regex),
 }
 
+/// The number of characters matched in the path.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub(crate) enum PathMatch {
     Exact(usize),

--- a/linkerd/http-route/src/http/match/path.rs
+++ b/linkerd/http-route/src/http/match/path.rs
@@ -1,0 +1,153 @@
+use http::Uri;
+use regex::Regex;
+
+#[derive(Clone, Debug)]
+pub enum MatchPath {
+    Exact(String),
+    Prefix(String),
+    Regex(Regex),
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub(crate) enum PathMatch {
+    Exact(usize),
+    Regex(usize),
+    Prefix(usize),
+}
+
+// === impl MatchPath ===
+
+impl MatchPath {
+    pub(crate) fn match_length(&self, uri: &Uri) -> Option<PathMatch> {
+        match self {
+            Self::Exact(s) => {
+                if s == uri.path() {
+                    return Some(PathMatch::Exact(s.len()));
+                }
+            }
+
+            Self::Regex(re) => {
+                if let Some(m) = re.find(uri.path()) {
+                    let len = uri.path().len();
+                    // Check that the regex is anchored at the start and end of
+                    // the value.
+                    if m.start() == 0 && m.end() == len {
+                        return Some(PathMatch::Regex(len));
+                    }
+                }
+            }
+
+            Self::Prefix(prefix) => {
+                let path = uri.path();
+                if path.starts_with(prefix) {
+                    let rest = &path[prefix.len()..];
+                    // Check that the prefix matches an entire path segment.
+                    if rest.is_empty() || (!prefix.ends_with('/') && rest.starts_with('/')) {
+                        return Some(PathMatch::Prefix(prefix.len()));
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}
+
+impl std::hash::Hash for MatchPath {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Exact(s) => s.hash(state),
+            Self::Prefix(s) => s.hash(state),
+            Self::Regex(r) => r.as_str().hash(state),
+        };
+    }
+}
+
+impl std::cmp::Eq for MatchPath {}
+
+impl std::cmp::PartialEq for MatchPath {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Exact(s), Self::Exact(o)) => s == o,
+            (Self::Prefix(s), Self::Prefix(o)) => s == o,
+            (Self::Regex(s), Self::Regex(o)) => s.as_str() == o.as_str(),
+            _ => false,
+        }
+    }
+}
+
+// === impl PathMatch ===
+
+impl PathMatch {
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Exact(len) => *len,
+            Self::Regex(len) => *len,
+            Self::Prefix(len) => *len,
+        }
+    }
+}
+
+impl std::cmp::PartialOrd for PathMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for PathMatch {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.len().cmp(&other.len())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_exact() {
+        let m = MatchPath::Exact("/foo/bar".into());
+        assert_eq!(
+            m.match_length(&"/foo/bar".parse().unwrap()),
+            Some(PathMatch::Exact("/foo/bar".len()))
+        );
+        assert_eq!(m.match_length(&"/foo".parse().unwrap()), None);
+        assert_eq!(m.match_length(&"/foo/bah".parse().unwrap()), None);
+        assert_eq!(m.match_length(&"/foo/bar/qux".parse().unwrap()), None);
+    }
+
+    #[test]
+    fn path_prefix() {
+        let m = MatchPath::Prefix("/foo".to_string());
+        assert_eq!(
+            m.match_length(&"/foo".parse().unwrap()),
+            Some(PathMatch::Prefix("/foo".len()))
+        );
+        assert_eq!(
+            m.match_length(&"/foo/bar".parse().unwrap()),
+            Some(PathMatch::Prefix("/foo".len()))
+        );
+        assert_eq!(
+            m.match_length(&"/foo/bar/qux".parse().unwrap()),
+            Some(PathMatch::Prefix("/foo".len()))
+        );
+        assert_eq!(m.match_length(&"/foobar".parse().unwrap()), None);
+    }
+
+    #[test]
+    fn path_regex() {
+        let m = MatchPath::Regex(r#"/foo/\d+"#.parse().unwrap());
+        assert_eq!(
+            m.match_length(&"/foo/4".parse().unwrap()),
+            Some(PathMatch::Regex("/foo/4".len()))
+        );
+        assert_eq!(
+            m.match_length(&"/foo/4321".parse().unwrap()),
+            Some(PathMatch::Regex("/foo/4321".len()))
+        );
+        assert_eq!(m.match_length(&"/bar/foo/4".parse().unwrap()), None);
+        assert_eq!(m.match_length(&"/foo/4abc".parse().unwrap()), None);
+        assert_eq!(m.match_length(&"/foo/4/bar".parse().unwrap()), None);
+        assert_eq!(m.match_length(&"/foo/bar".parse().unwrap()), None);
+    }
+}

--- a/linkerd/http-route/src/http/match/query_param.rs
+++ b/linkerd/http-route/src/http/match/query_param.rs
@@ -1,0 +1,96 @@
+use http::uri::Uri;
+use regex::Regex;
+
+#[derive(Clone, Debug)]
+pub enum MatchQueryParam {
+    Exact(String, String),
+    Regex(String, Regex),
+}
+
+// === impl MatchQueryParam ===
+
+impl MatchQueryParam {
+    pub fn is_match(&self, uri: &Uri) -> bool {
+        uri.query().map_or(false, |qs| {
+            url::form_urlencoded::parse(qs.as_bytes()).any(|(q, p)| match self {
+                Self::Exact(n, v) => *n == *q && *v == *p,
+                Self::Regex(n, r) => {
+                    if *n == *q {
+                        if let Some(m) = r.find(&*p) {
+                            // Check that the regex is anchored at the start and
+                            // end of the value.
+                            return m.start() == 0 && m.end() == p.len();
+                        }
+                    }
+                    false
+                }
+            })
+        })
+    }
+}
+
+impl std::hash::Hash for MatchQueryParam {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Exact(n, s) => {
+                n.hash(state);
+                s.hash(state)
+            }
+            Self::Regex(n, r) => {
+                n.hash(state);
+                r.as_str().hash(state);
+            }
+        }
+    }
+}
+
+impl std::cmp::Eq for MatchQueryParam {}
+
+impl std::cmp::PartialEq for MatchQueryParam {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Exact(n, s), Self::Exact(m, o)) => n == m && s == o,
+            (Self::Regex(n, s), Self::Regex(m, o)) => n == m && s.as_str() == o.as_str(),
+            _ => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MatchQueryParam;
+
+    #[test]
+    fn query_param_exact() {
+        let m = MatchQueryParam::Exact("foo".to_string(), "bar".to_string());
+        assert!(m.is_match(&"/?foo=bar".parse().unwrap()));
+        assert!(m.is_match(&"/?foo=bar&fah=bah".parse().unwrap()));
+        assert!(m.is_match(&"/?fah=bah&foo=bar".parse().unwrap()));
+        assert!(!m.is_match(&"/?foo=bah".parse().unwrap()));
+
+        let m = MatchQueryParam::Exact("foo".to_string(), "".to_string());
+        assert!(m.is_match(&"/?foo".parse().unwrap()));
+        assert!(!m.is_match(&"/?foo=bah".parse().unwrap()));
+        assert!(!m.is_match(&"/?bar=foo".parse().unwrap()));
+    }
+
+    #[test]
+    fn query_param_regex() {
+        let m = MatchQueryParam::Regex("foo".to_string(), "bar*".parse().unwrap());
+        assert!(m.is_match(&"/?foo=bar".parse().unwrap()));
+        assert!(m.is_match(&"/?foo=ba&fah=bah".parse().unwrap()));
+        assert!(m.is_match(&"/?foo=barr&fah=bah".parse().unwrap()));
+        assert!(m.is_match(&"/?bar=foo&foo=bar".parse().unwrap()));
+        assert!(m.is_match(&"/?foo=bah&foo=bar".parse().unwrap()));
+        assert!(!m.is_match(&"/?foo=bah".parse().unwrap()));
+        assert!(!m.is_match(&"/?bar=foo".parse().unwrap()));
+        assert!(!m.is_match(&"/?foo=barro".parse().unwrap()));
+
+        let m = MatchQueryParam::Regex("foo".to_string(), "bar/.+".parse().unwrap());
+        assert!(m.is_match(&"/?foo=bar%2Fhi".parse().unwrap()));
+        assert!(!m.is_match(&"/?foo=bah%20hi".parse().unwrap()));
+
+        let m = MatchQueryParam::Regex("foo".to_string(), ".*".parse().unwrap());
+        assert!(m.is_match(&"/?foo".parse().unwrap()));
+    }
+}

--- a/linkerd/http-route/src/http/match/tests.rs
+++ b/linkerd/http-route/src/http/match/tests.rs
@@ -8,13 +8,13 @@ fn empty_match() {
     let m = MatchRequest::default();
 
     let req = http::Request::builder().body(()).unwrap();
-    assert_eq!(m.r#match(&req), Some(RequestMatch::default()));
+    assert_eq!(m.match_request(&req), Some(RequestMatch::default()));
 
     let req = http::Request::builder()
         .method(http::Method::HEAD)
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), Some(RequestMatch::default()));
+    assert_eq!(m.match_request(&req), Some(RequestMatch::default()));
 }
 
 #[test]
@@ -29,7 +29,7 @@ fn method() {
         .body(())
         .unwrap();
     assert_eq!(
-        m.r#match(&req),
+        m.match_request(&req),
         Some(RequestMatch {
             method: true,
             ..Default::default()
@@ -41,7 +41,7 @@ fn method() {
         .uri("https://example.org/")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn headers() {
         .uri("http://example.com/foo")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 
     let req = http::Request::builder()
         .uri("https://example.org/")
@@ -69,7 +69,7 @@ fn headers() {
         .header("x-baz", "zab") // invalid header value
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 
     // Regex matches apply
     let req = http::Request::builder()
@@ -79,7 +79,7 @@ fn headers() {
         .body(())
         .unwrap();
     assert_eq!(
-        m.r#match(&req),
+        m.match_request(&req),
         Some(RequestMatch {
             headers: 2,
             ..RequestMatch::default()
@@ -93,7 +93,7 @@ fn headers() {
         .header("x-baz", "quxa")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 }
 
 #[test]
@@ -107,14 +107,14 @@ fn path() {
         .uri("http://example.com/foo")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 
     let req = http::Request::builder()
         .uri("https://example.org/foo/bar")
         .body(())
         .unwrap();
     assert_eq!(
-        m.r#match(&req),
+        m.match_request(&req),
         Some(RequestMatch {
             path_match: PathMatch::Exact("/foo/bar".len()),
             ..Default::default()
@@ -140,7 +140,7 @@ fn multiple() {
         .body(())
         .unwrap();
     assert_eq!(
-        m.r#match(&req),
+        m.match_request(&req),
         Some(RequestMatch {
             path_match: PathMatch::Exact("/foo/bar".len()),
             headers: 1,
@@ -156,5 +156,5 @@ fn multiple() {
         .header("x-foo", "bar")
         .body(())
         .unwrap();
-    assert_eq!(m.r#match(&req), None);
+    assert_eq!(m.match_request(&req), None);
 }

--- a/linkerd/http-route/src/http/match/tests.rs
+++ b/linkerd/http-route/src/http/match/tests.rs
@@ -1,0 +1,160 @@
+use super::*;
+use crate::Match;
+use http::header::{HeaderName, HeaderValue};
+
+// Empty matches apply to all requests.
+#[test]
+fn empty_match() {
+    let m = MatchRequest::default();
+
+    let req = http::Request::builder().body(()).unwrap();
+    assert_eq!(m.r#match(&req), Some(RequestMatch::default()));
+
+    let req = http::Request::builder()
+        .method(http::Method::HEAD)
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), Some(RequestMatch::default()));
+}
+
+#[test]
+fn method() {
+    let m = MatchRequest {
+        method: Some(http::Method::GET),
+        ..MatchRequest::default()
+    };
+
+    let req = http::Request::builder()
+        .uri("http://example.com/foo")
+        .body(())
+        .unwrap();
+    assert_eq!(
+        m.r#match(&req),
+        Some(RequestMatch {
+            method: true,
+            ..Default::default()
+        })
+    );
+
+    let req = http::Request::builder()
+        .method(http::Method::HEAD)
+        .uri("https://example.org/")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+}
+
+#[test]
+fn headers() {
+    let m = MatchRequest {
+        headers: vec![
+            MatchHeader::Exact(
+                HeaderName::from_static("x-foo"),
+                HeaderValue::from_static("bar"),
+            ),
+            MatchHeader::Regex(HeaderName::from_static("x-baz"), "qu+x".parse().unwrap()),
+        ],
+        ..MatchRequest::default()
+    };
+
+    let req = http::Request::builder()
+        .uri("http://example.com/foo")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+
+    let req = http::Request::builder()
+        .uri("https://example.org/")
+        .header("x-foo", "bar")
+        .header("x-baz", "zab") // invalid header value
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+
+    // Regex matches apply
+    let req = http::Request::builder()
+        .uri("https://example.org/")
+        .header("x-foo", "bar")
+        .header("x-baz", "quuuux")
+        .body(())
+        .unwrap();
+    assert_eq!(
+        m.r#match(&req),
+        Some(RequestMatch {
+            headers: 2,
+            ..RequestMatch::default()
+        })
+    );
+
+    // Regex must be anchored.
+    let req = http::Request::builder()
+        .uri("https://example.org/")
+        .header("x-foo", "bar")
+        .header("x-baz", "quxa")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+}
+
+#[test]
+fn path() {
+    let m = MatchRequest {
+        path: Some(MatchPath::Exact("/foo/bar".to_string())),
+        ..MatchRequest::default()
+    };
+
+    let req = http::Request::builder()
+        .uri("http://example.com/foo")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+
+    let req = http::Request::builder()
+        .uri("https://example.org/foo/bar")
+        .body(())
+        .unwrap();
+    assert_eq!(
+        m.r#match(&req),
+        Some(RequestMatch {
+            path_match: PathMatch::Exact("/foo/bar".len()),
+            ..Default::default()
+        })
+    );
+}
+
+#[test]
+fn multiple() {
+    let m = MatchRequest {
+        path: Some(MatchPath::Exact("/foo/bar".to_string())),
+        headers: vec![MatchHeader::Exact(
+            HeaderName::from_static("x-foo"),
+            HeaderValue::from_static("bar"),
+        )],
+        query_params: vec![MatchQueryParam::Exact("foo".to_string(), "bar".to_string())],
+        method: Some(http::Method::GET),
+    };
+
+    let req = http::Request::builder()
+        .uri("https://example.org/foo/bar?foo=bar")
+        .header("x-foo", "bar")
+        .body(())
+        .unwrap();
+    assert_eq!(
+        m.r#match(&req),
+        Some(RequestMatch {
+            path_match: PathMatch::Exact("/foo/bar".len()),
+            headers: 1,
+            query_params: 1,
+            method: true,
+        })
+    );
+
+    // One invalid field (method) invalidates the match.
+    let req = http::Request::builder()
+        .method(http::Method::HEAD)
+        .uri("https://example.org/foo/bar?foo=bar")
+        .header("x-foo", "bar")
+        .body(())
+        .unwrap();
+    assert_eq!(m.r#match(&req), None);
+}

--- a/linkerd/http-route/src/http/tests.rs
+++ b/linkerd/http-route/src/http/tests.rs
@@ -1,0 +1,155 @@
+use super::{r#match::*, *};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Policy {
+    Expected,
+    Unexpected,
+}
+
+impl Default for Policy {
+    fn default() -> Self {
+        Self::Unexpected
+    }
+}
+
+/// Given two equivalent routes, choose the explicit hostname match and not
+/// the wildcard.
+#[test]
+fn hostname_precedence() {
+    let rts = vec![
+        Route {
+            hosts: vec!["*.example.com".parse().unwrap()],
+            rules: vec![Rule {
+                matches: vec![MatchRequest {
+                    path: Some(MatchPath::Exact("/foo".to_string())),
+                    ..MatchRequest::default()
+                }],
+                ..Rule::default()
+            }],
+        },
+        Route {
+            hosts: vec!["foo.example.com".parse().unwrap()],
+            rules: vec![Rule {
+                matches: vec![MatchRequest {
+                    path: Some(MatchPath::Exact("/foo".to_string())),
+                    ..MatchRequest::default()
+                }],
+                policy: Policy::Expected,
+            }],
+        },
+    ];
+
+    let req = http::Request::builder()
+        .uri("http://foo.example.com/foo")
+        .body(())
+        .unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}
+
+#[test]
+fn path_length_precedence() {
+    // Given two equivalent routes, choose the longer path match.
+    let rts = vec![
+        Route {
+            rules: vec![Rule {
+                matches: vec![MatchRequest {
+                    path: Some(MatchPath::Prefix("/foo".to_string())),
+                    ..MatchRequest::default()
+                }],
+                ..Rule::default()
+            }],
+            hosts: vec![],
+        },
+        Route {
+            rules: vec![Rule {
+                matches: vec![MatchRequest {
+                    path: Some(MatchPath::Exact("/foo/bar".to_string())),
+                    ..MatchRequest::default()
+                }],
+                policy: Policy::Expected,
+            }],
+            hosts: vec![],
+        },
+    ];
+
+    let req = http::Request::builder()
+        .uri("http://foo.example.com/foo/bar")
+        .body(())
+        .unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}
+
+/// Given two routes with header matches, use the one that matches more
+/// headers.
+#[test]
+fn header_count_precedence() {
+    let rts = vec![
+        Route {
+            rules: vec![Rule {
+                matches: vec![MatchRequest {
+                    headers: vec![
+                        MatchHeader::Exact("x-foo".parse().unwrap(), "bar".parse().unwrap()),
+                        MatchHeader::Exact("x-baz".parse().unwrap(), "qux".parse().unwrap()),
+                    ],
+                    ..MatchRequest::default()
+                }],
+                ..Rule::default()
+            }],
+            hosts: vec![],
+        },
+        Route {
+            rules: vec![Rule {
+                matches: vec![MatchRequest {
+                    headers: vec![
+                        MatchHeader::Exact("x-foo".parse().unwrap(), "bar".parse().unwrap()),
+                        MatchHeader::Exact("x-baz".parse().unwrap(), "qux".parse().unwrap()),
+                        MatchHeader::Exact("x-biz".parse().unwrap(), "qyx".parse().unwrap()),
+                    ],
+                    ..MatchRequest::default()
+                }],
+                policy: Policy::Expected,
+            }],
+            hosts: vec![],
+        },
+    ];
+
+    let req = http::Request::builder()
+        .uri("http://www.example.com")
+        .header("x-foo", "bar")
+        .header("x-baz", "qux")
+        .header("x-biz", "qyx")
+        .body(())
+        .unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}
+
+/// Given two routes with header matches, use the one that matches more
+/// headers.
+#[test]
+fn first_identical_wins() {
+    let rts = vec![
+        Route {
+            rules: vec![
+                Rule {
+                    policy: Policy::Expected,
+                    ..Rule::default()
+                },
+                // Redundant rule.
+                Rule::default(),
+            ],
+            hosts: vec![],
+        },
+        // Redundant route.
+        Route {
+            rules: vec![Rule::default()],
+            hosts: vec![],
+        },
+    ];
+
+    let req = http::Request::builder().body(()).unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}

--- a/linkerd/http-route/src/lib.rs
+++ b/linkerd/http-route/src/lib.rs
@@ -50,7 +50,7 @@ pub struct RouteMatch<T> {
 pub trait Match {
     type Summary: Default + Ord;
 
-    fn r#match<B>(&self, req: &::http::Request<B>) -> Option<Self::Summary>;
+    fn match_request<B>(&self, req: &::http::Request<B>) -> Option<Self::Summary>;
 }
 
 /// Finds the best matching route policy for a request.
@@ -86,7 +86,11 @@ pub fn find<'r, M: Match + 'r, P, B>(
             // Find the best match to compare against other rules/routes
             // (if any apply). The order/precedence of matches is not
             // relevant.
-            let summary = rule.matches.iter().filter_map(|m| m.r#match(req)).max()?;
+            let summary = rule
+                .matches
+                .iter()
+                .filter_map(|m| m.match_request(req))
+                .max()?;
             trace!("matches!");
             Some((summary, &rule.policy))
         }))?;

--- a/linkerd/http-route/src/lib.rs
+++ b/linkerd/http-route/src/lib.rs
@@ -99,5 +99,5 @@ pub fn find<'r, M: Match + 'r, P, B>(
 fn best<M: Ord, P>(matches: impl Iterator<Item = (M, P)>) -> Option<(M, P)> {
     // This is roughly equivalent to `max_by(...)` but we want to ensure
     // that the first match wins.
-    matches.reduce(|(m0, p0), (m1, p1)| if m0 < m1 { (m1, p1) } else { (m0, p0) })
+    matches.reduce(|(m0, p0), (m1, p1)| if m0 >= m1 { (m0, p0) } else { (m1, p1) })
 }

--- a/linkerd/http-route/src/lib.rs
+++ b/linkerd/http-route/src/lib.rs
@@ -1,0 +1,103 @@
+//! An HTTP route matching library for Linkerd to support the HTTPRoute (and
+//! GRPCRoute) Kubernetes Gateway API types.
+
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
+#![forbid(unsafe_code)]
+
+use tracing::trace;
+
+pub mod grpc;
+pub mod http;
+
+// Matchers used by both HTTP and gRPC routes.
+pub use self::http::{HostMatch, MatchHeader, MatchHost};
+
+/// Groups routing rules under a common set of hostnames.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct Route<M, P> {
+    /// A list of hostnames that this route applies to, to be matched against,
+    /// e.g., the HTTP `host`.
+    ///
+    /// If at least one match is specified, any match may apply to the request
+    /// for rules to applied. When no host matches are present, all hosts match.
+    pub hosts: Vec<http::MatchHost>,
+
+    /// Must not be empty.
+    pub rules: Vec<Rule<M, P>>,
+}
+
+/// Policies for a given set of route matches.
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct Rule<M, P> {
+    /// A list of request matchers, *any* of which may apply.
+    ///
+    /// The "best" match is used when comparing rules.
+    pub matches: Vec<M>,
+
+    /// The policy to apply to requests matched by this rule.
+    pub policy: P,
+}
+
+/// Summarizes a matched route so that route matches may be compared/ordered. A
+/// greater matches is preferred over a lesser match.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RouteMatch<T> {
+    host: Option<http::HostMatch>,
+    route: T,
+}
+
+/// A strategy for matching a request to a route.
+pub trait Match {
+    type Summary: Default + Ord;
+
+    fn r#match<B>(&self, req: &::http::Request<B>) -> Option<Self::Summary>;
+}
+
+/// Finds the best matching route policy for a request.
+pub fn find<'r, M: Match + 'r, P, B>(
+    routes: &'r [Route<M, P>],
+    req: &::http::Request<B>,
+) -> Option<(RouteMatch<M::Summary>, &'r P)> {
+    trace!(routes = ?routes.len(), "Finding matching route");
+
+    best(routes.iter().filter_map(|rt| {
+        trace!(hosts = ?rt.hosts);
+        let host = if rt.hosts.is_empty() {
+            None
+        } else {
+            let uri = req.uri();
+            trace!(%uri, "matching host");
+            let hm = rt
+                .hosts
+                .iter()
+                .filter_map(|a| a.summarize_match(uri))
+                .max()?;
+            Some(hm)
+        };
+
+        trace!(rules = %rt.rules.len());
+        let (route, policy) = best(rt.rules.iter().filter_map(|rule| {
+            // If there are no matches in the list, then the rule has an
+            // implicit default match.
+            if rule.matches.is_empty() {
+                trace!("implicit match");
+                return Some((M::Summary::default(), &rule.policy));
+            }
+            // Find the best match to compare against other rules/routes
+            // (if any apply). The order/precedence of matches is not
+            // relevant.
+            let summary = rule.matches.iter().filter_map(|m| m.r#match(req)).max()?;
+            trace!("matches!");
+            Some((summary, &rule.policy))
+        }))?;
+
+        Some((RouteMatch { host, route }, policy))
+    }))
+}
+
+#[inline]
+fn best<M: Ord, P>(matches: impl Iterator<Item = (M, P)>) -> Option<(M, P)> {
+    // This is roughly equivalent to `max_by(...)` but we want to ensure
+    // that the first match wins.
+    matches.reduce(|(m0, p0), (m1, p1)| if m0 < m1 { (m1, p1) } else { (m0, p0) })
+}


### PR DESCRIPTION
This change adds a standalone utility crate that will support matching
routes for the Gateway API's HTTP route types. This crate is not yet
used. In followup changes:

* filter types will be added to support header-rewriting, HTTP
  redirection, and error injection filters;
* the inbound proxy will be updated to supcort route-oriented
  authorization policies; and
* the inbound policy API client will be updated to configure inbound
  server routes.