### PR TITLE
inbound: Add HTTP route filters

### DIFF
--- a/linkerd/http-route/src/grpc.rs
+++ b/linkerd/http-route/src/grpc.rs
@@ -1,3 +1,4 @@
+pub mod filter;
 pub mod r#match;
 
 pub use self::r#match::MatchRoute;

--- a/linkerd/http-route/src/grpc/filter.rs
+++ b/linkerd/http-route/src/grpc/filter.rs
@@ -1,0 +1,3 @@
+pub mod error_respond;
+
+pub use self::error_respond::RespondWithError;

--- a/linkerd/http-route/src/grpc/filter/error_respond.rs
+++ b/linkerd/http-route/src/grpc/filter/error_respond.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct RespondWithError {
+    pub code: u16,
+    pub message: std::sync::Arc<str>,
+}

--- a/linkerd/http-route/src/http.rs
+++ b/linkerd/http-route/src/http.rs
@@ -1,3 +1,4 @@
+pub mod filter;
 pub mod r#match;
 #[cfg(test)]
 mod tests;

--- a/linkerd/http-route/src/http/filter.rs
+++ b/linkerd/http-route/src/http/filter.rs
@@ -1,0 +1,15 @@
+pub mod error_respond;
+pub mod modify_request_header;
+pub mod redirect;
+
+pub use self::{
+    error_respond::RespondWithError,
+    modify_request_header::ModifyRequestHeader,
+    redirect::{InvalidRedirect, RedirectRequest, Redirection},
+};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ModifyPath {
+    ReplaceFullPath(String),
+    ReplacePrefixMatch(String),
+}

--- a/linkerd/http-route/src/http/filter/error_respond.rs
+++ b/linkerd/http-route/src/http/filter/error_respond.rs
@@ -1,0 +1,5 @@
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct RespondWithError {
+    pub status: http::StatusCode,
+    pub message: std::sync::Arc<str>,
+}

--- a/linkerd/http-route/src/http/filter/modify_request_header.rs
+++ b/linkerd/http-route/src/http/filter/modify_request_header.rs
@@ -1,0 +1,24 @@
+use http::header::{HeaderMap, HeaderName, HeaderValue};
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct ModifyRequestHeader {
+    pub add: Vec<(HeaderName, HeaderValue)>,
+    pub set: Vec<(HeaderName, HeaderValue)>,
+    pub remove: Vec<HeaderName>,
+}
+
+// === impl ModifyRequestHeader ===
+
+impl ModifyRequestHeader {
+    pub fn apply(&self, headers: &mut HeaderMap) {
+        for (hdr, val) in &self.add {
+            headers.append(hdr, val.clone());
+        }
+        for (hdr, val) in &self.set {
+            headers.insert(hdr, val.clone());
+        }
+        for hdr in &self.remove {
+            headers.remove(hdr);
+        }
+    }
+}

--- a/linkerd/http-route/src/http/filter/redirect.rs
+++ b/linkerd/http-route/src/http/filter/redirect.rs
@@ -1,0 +1,100 @@
+use super::ModifyPath;
+use crate::http::RouteMatch;
+use http::{
+    uri::{Authority, InvalidUri, Scheme, Uri},
+    StatusCode,
+};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct RedirectRequest {
+    pub scheme: Option<Scheme>,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub path: Option<ModifyPath>,
+    pub status: Option<StatusCode>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidRedirect {
+    #[error("redirects may only replace the path prefix when a path prefix match applied")]
+    InvalidReplacePrefix,
+
+    #[error("redirect produced an invalid location: {0}")]
+    InvalidLocation(#[from] http::Error),
+
+    #[error("redirect produced an invalid authority: {0}")]
+    InvalidAuthority(#[from] InvalidUri),
+
+    #[error("no authority to redirect to")]
+    MissingAuthority,
+}
+
+#[derive(Clone, Debug)]
+pub struct Redirection {
+    pub status: http::StatusCode,
+    pub location: Uri,
+}
+
+// === impl RedirectRequest ===
+
+impl RedirectRequest {
+    pub fn apply(
+        &self,
+        orig_uri: &http::Uri,
+        rm: &RouteMatch,
+    ) -> Result<Option<Redirection>, InvalidRedirect> {
+        let location = {
+            let scheme = self
+                .scheme
+                .clone()
+                .or_else(|| orig_uri.scheme().cloned())
+                .unwrap_or(Scheme::HTTP);
+
+            let authority: Authority = match (self.host.as_deref(), self.port) {
+                // If a host is configured, use it and whatever port is configured.
+                (Some(h), p) => p
+                    .map(|p| format!("{}:{}", h, p).parse())
+                    .unwrap_or_else(|| h.parse())?,
+                // If a host is NOT configured, use the request's original host and either an
+                // overridden port or the original port.
+                (None, p) => {
+                    let h = orig_uri.host().ok_or(InvalidRedirect::MissingAuthority)?;
+                    p.or_else(|| orig_uri.port_u16())
+                        .map(|p| format!("{}:{}", h, p).parse())
+                        .unwrap_or_else(|| h.parse())?
+                }
+            };
+
+            let path = {
+                use crate::http::r#match::PathMatch;
+
+                let orig_path = orig_uri.path();
+                match &self.path {
+                    None => orig_path.to_string(),
+                    Some(ModifyPath::ReplaceFullPath(p)) => p.clone(),
+                    Some(ModifyPath::ReplacePrefixMatch(new_pfx)) => match rm.route.path() {
+                        PathMatch::Prefix(pfx_len) if *pfx_len <= orig_path.len() => {
+                            let (_, rest) = orig_path.split_at(*pfx_len);
+                            format!("{}{}", new_pfx, rest)
+                        }
+                        _ => return Err(InvalidRedirect::InvalidReplacePrefix),
+                    },
+                }
+            };
+
+            Uri::builder()
+                .scheme(scheme)
+                .authority(authority)
+                .path_and_query(path)
+                .build()
+                .map_err(InvalidRedirect::InvalidLocation)?
+        };
+        if &location == orig_uri {
+            return Ok(None);
+        }
+
+        let status = self.status.unwrap_or(http::StatusCode::MOVED_PERMANENTLY);
+
+        Ok(Some(Redirection { status, location }))
+    }
+}

--- a/linkerd/http-route/src/http/match.rs
+++ b/linkerd/http-route/src/http/match.rs
@@ -81,6 +81,12 @@ impl Default for RequestMatch {
 
 // === impl RequestMatch ===
 
+impl RequestMatch {
+    pub(crate) fn path(&self) -> &PathMatch {
+        &self.path_match
+    }
+}
+
 impl std::cmp::PartialOrd for RequestMatch {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))

--- a/linkerd/server-policy/src/http.rs
+++ b/linkerd/server-policy/src/http.rs
@@ -1,9 +1,25 @@
 use linkerd_http_route::http;
-pub use linkerd_http_route::http::r#match;
+pub use linkerd_http_route::http::{filter, r#match, RouteMatch};
 
-pub type Policy = crate::RoutePolicy;
+pub type Policy = crate::RoutePolicy<Filter>;
 pub type Route = http::Route<Policy>;
 pub type Rule = http::Rule<Policy>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Filter {
+    Error(http::filter::RespondWithError),
+
+    RequestHeaders(http::filter::ModifyRequestHeader),
+
+    Redirect(http::filter::RedirectRequest),
+
+    /// Indicates that the filter kind is unknown to the proxy (e.g., because
+    /// the controller is on a new version of the protobuf).
+    ///
+    /// Route handlers must be careful about this situation, as it may not be
+    /// appropriate for a proxy to skip filtering logic.
+    Unknown,
+}
 
 #[inline]
 pub fn find<'r, B>(
@@ -21,6 +37,7 @@ pub fn default(authorizations: std::sync::Arc<[crate::Authorization]>) -> Route 
             policy: Policy {
                 meta: crate::Meta::new_default("default"),
                 authorizations,
+                filters: vec![],
             },
         }],
     }

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -31,10 +31,10 @@ pub enum Protocol {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct RoutePolicy {
+pub struct RoutePolicy<T> {
     pub meta: Arc<Meta>,
     pub authorizations: Arc<[Authorization]>,
-    // TODO pub filters: Vec<T>,
+    pub filters: Vec<T>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This change adds several route filters:

* An HTTP header rewriting;
* An HTTP redirection filter;
* An HTTP error filter; and
* A gRPC error filter.

The header-rewriting and HTTP redirection filters are implemented as
specified by the Kubernetes Gateway API HTTPRoute spec.

These filters apply only on inbound policies are not yet configurable
via the control plane. A followup change will be made to support
configuring these filters. Depends on #1781.

Signed-off-by: Oliver Gould <ver@buoyant.io>