### PR TITLE
inbound: Add a header-modification route filter

### DIFF
--- a/linkerd/http-route/src/http.rs
+++ b/linkerd/http-route/src/http.rs
@@ -1,3 +1,4 @@
+pub mod filter;
 pub mod r#match;
 #[cfg(test)]
 mod tests;

--- a/linkerd/http-route/src/http/filter.rs
+++ b/linkerd/http-route/src/http/filter.rs
@@ -1,0 +1,3 @@
+pub mod modify_request_header;
+
+pub use self::modify_request_header::ModifyRequestHeader;

--- a/linkerd/http-route/src/http/filter/modify_request_header.rs
+++ b/linkerd/http-route/src/http/filter/modify_request_header.rs
@@ -1,0 +1,24 @@
+use http::header::{HeaderMap, HeaderName, HeaderValue};
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct ModifyRequestHeader {
+    pub add: Vec<(HeaderName, HeaderValue)>,
+    pub set: Vec<(HeaderName, HeaderValue)>,
+    pub remove: Vec<HeaderName>,
+}
+
+// === impl ModifyRequestHeader ===
+
+impl ModifyRequestHeader {
+    pub fn apply(&self, headers: &mut HeaderMap) {
+        for (hdr, val) in &self.add {
+            headers.append(hdr, val.clone());
+        }
+        for (hdr, val) in &self.set {
+            headers.insert(hdr, val.clone());
+        }
+        for hdr in &self.remove {
+            headers.remove(hdr);
+        }
+    }
+}

--- a/linkerd/server-policy/src/grpc.rs
+++ b/linkerd/server-policy/src/grpc.rs
@@ -1,15 +1,20 @@
-use linkerd_http_route::grpc;
-pub use linkerd_http_route::grpc::r#match;
+pub use linkerd_http_route::grpc::{r#match, RouteMatch};
+use linkerd_http_route::{grpc, http};
 
-pub type Policy = crate::RoutePolicy;
+pub type Policy = crate::RoutePolicy<Filter>;
 pub type Route = grpc::Route<Policy>;
 pub type Rule = grpc::Rule<Policy>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Filter {
+    RequestHeaders(http::filter::ModifyRequestHeader),
+}
 
 #[inline]
 pub fn find<'r, B>(
     routes: &'r [Route],
     req: &::http::Request<B>,
-) -> Option<(grpc::RouteMatch, &'r Policy)> {
+) -> Option<(RouteMatch, &'r Policy)> {
     grpc::find(routes, req)
 }
 
@@ -21,6 +26,7 @@ pub fn default(authorizations: std::sync::Arc<[crate::Authorization]>) -> Route 
             policy: Policy {
                 meta: crate::Meta::new_default("default"),
                 authorizations,
+                filters: vec![],
             },
         }],
     }

--- a/linkerd/server-policy/src/http.rs
+++ b/linkerd/server-policy/src/http.rs
@@ -1,9 +1,14 @@
 use linkerd_http_route::http;
-pub use linkerd_http_route::http::r#match;
+pub use linkerd_http_route::http::{filter, r#match, RouteMatch};
 
-pub type Policy = crate::RoutePolicy;
+pub type Policy = crate::RoutePolicy<Filter>;
 pub type Route = http::Route<Policy>;
 pub type Rule = http::Rule<Policy>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Filter {
+    RequestHeaders(http::filter::ModifyRequestHeader),
+}
 
 #[inline]
 pub fn find<'r, B>(
@@ -21,6 +26,7 @@ pub fn default(authorizations: std::sync::Arc<[crate::Authorization]>) -> Route 
             policy: Policy {
                 meta: crate::Meta::new_default("default"),
                 authorizations,
+                filters: vec![],
             },
         }],
     }

--- a/linkerd/server-policy/src/lib.rs
+++ b/linkerd/server-policy/src/lib.rs
@@ -31,10 +31,10 @@ pub enum Protocol {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct RoutePolicy {
+pub struct RoutePolicy<T> {
     pub meta: Arc<Meta>,
     pub authorizations: Arc<[Authorization]>,
-    // TODO pub filters: Vec<T>,
+    pub filters: Vec<T>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
The Gateway API defines a [header-rewriting filter](gwapi) that may be
attached to HTTP routes. This change updates the HTTP route types to
support a list of filters. The inbound proxy supports only the
header modifier filter. Additional filters will be added in follow-up
changes (see #1788 for an example of these additional filters).

[gwapi]: https://gateway-api.sigs.k8s.io/v1alpha2/references/spec/#gateway.networking.k8s.io/v1alpha2.HTTPRequestHeaderFilter

Signed-off-by: Oliver Gould <ver@buoyant.io>