### PR TITLE
Add an HTTP route redirect filter

### DIFF
--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -36,7 +36,7 @@ pub struct SyntheticHttpResponse {
     http_status: http::StatusCode,
     close_connection: bool,
     message: Cow<'static, str>,
-    location: Option<http::header::HeaderValue>,
+    location: Option<HeaderValue>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -167,7 +167,7 @@ impl SyntheticHttpResponse {
             close_connection: false,
             message: Cow::Borrowed("redirected"),
             location: Some(
-                http::header::HeaderValue::from_str(&*location.to_string())
+                HeaderValue::from_str(&*location.to_string())
                     .expect("location must be a valid header value"),
             ),
         }

--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -1,5 +1,5 @@
 use crate::svc;
-use http::header::HeaderValue;
+use http::header::{HeaderValue, LOCATION};
 use linkerd_error::{Error, Result};
 use linkerd_error_respond as respond;
 pub use linkerd_proxy_http::{ClientHandle, HasH2Reason};
@@ -32,10 +32,11 @@ pub trait HttpRescue<E> {
 
 #[derive(Clone, Debug)]
 pub struct SyntheticHttpResponse {
-    pub grpc_status: tonic::Code,
-    pub http_status: http::StatusCode,
-    pub close_connection: bool,
-    pub message: Cow<'static, str>,
+    grpc_status: tonic::Code,
+    http_status: http::StatusCode,
+    close_connection: bool,
+    message: Cow<'static, str>,
+    location: Option<http::header::HeaderValue>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -95,6 +96,7 @@ impl SyntheticHttpResponse {
             http_status: http::StatusCode::INTERNAL_SERVER_ERROR,
             grpc_status: tonic::Code::Internal,
             message: Cow::Borrowed("unexpected error"),
+            location: None,
         }
     }
 
@@ -104,6 +106,7 @@ impl SyntheticHttpResponse {
             http_status: http::StatusCode::BAD_GATEWAY,
             grpc_status: tonic::Code::Unavailable,
             message: Cow::Owned(msg.to_string()),
+            location: None,
         }
     }
 
@@ -113,6 +116,7 @@ impl SyntheticHttpResponse {
             http_status: http::StatusCode::GATEWAY_TIMEOUT,
             grpc_status: tonic::Code::Unavailable,
             message: Cow::Owned(msg.to_string()),
+            location: None,
         }
     }
 
@@ -122,6 +126,7 @@ impl SyntheticHttpResponse {
             grpc_status: tonic::Code::Unauthenticated,
             close_connection: false,
             message: Cow::Owned(msg.to_string()),
+            location: None,
         }
     }
 
@@ -131,6 +136,7 @@ impl SyntheticHttpResponse {
             grpc_status: tonic::Code::PermissionDenied,
             close_connection: false,
             message: Cow::Owned(msg.to_string()),
+            location: None,
         }
     }
 
@@ -140,6 +146,7 @@ impl SyntheticHttpResponse {
             grpc_status: tonic::Code::Aborted,
             close_connection: true,
             message: Cow::Owned(msg.to_string()),
+            location: None,
         }
     }
 
@@ -149,6 +156,30 @@ impl SyntheticHttpResponse {
             grpc_status: tonic::Code::NotFound,
             close_connection: false,
             message: Cow::Owned(msg.to_string()),
+            location: None,
+        }
+    }
+
+    pub fn redirect(http_status: http::StatusCode, location: &http::Uri) -> Self {
+        Self {
+            http_status,
+            grpc_status: tonic::Code::NotFound,
+            close_connection: false,
+            message: Cow::Borrowed("redirected"),
+            location: Some(
+                http::header::HeaderValue::from_str(&*location.to_string())
+                    .expect("location must be a valid header value"),
+            ),
+        }
+    }
+
+    pub fn response(http_status: http::StatusCode, message: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            http_status,
+            location: None,
+            grpc_status: tonic::Code::FailedPrecondition,
+            close_connection: false,
+            message: message.into(),
         }
     }
 
@@ -193,7 +224,12 @@ impl SyntheticHttpResponse {
         version: http::Version,
         emit_headers: bool,
     ) -> http::Response<B> {
-        debug!(status = %self.http_status, ?version, close = %self.close_connection, "Handling error on HTTP connection");
+        debug!(
+            status = %self.http_status,
+            ?version,
+            close = %self.close_connection,
+            "Handling error on HTTP connection"
+        );
         let mut rsp = http::Response::builder()
             .status(self.http_status)
             .version(version)
@@ -215,6 +251,10 @@ impl SyntheticHttpResponse {
                 // TODO only set when meshed.
                 rsp = rsp.header(L5D_PROXY_CONNECTION, "close");
             }
+        }
+
+        if let Some(loc) = &self.location {
+            rsp = rsp.header(LOCATION, loc);
         }
 
         rsp.body(B::default())

--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -167,7 +167,7 @@ impl SyntheticHttpResponse {
             close_connection: false,
             message: Cow::Borrowed("redirected"),
             location: Some(
-                HeaderValue::from_str(&*location.to_string())
+                HeaderValue::try_from(location.to_string())
                     .expect("location must be a valid header value"),
             ),
         }

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -8,7 +8,10 @@ mod tcp;
 pub(crate) use self::store::Store;
 pub use self::{
     config::Config,
-    http::{HttpRouteNotFound, HttpRouteUnauthorized, NewHttpPolicy},
+    http::{
+        HttpRouteInvalidRedirect, HttpRouteNotFound, HttpRouteRedirect, HttpRouteUnauthorized,
+        NewHttpPolicy,
+    },
     tcp::NewTcpPolicy,
 };
 
@@ -20,8 +23,10 @@ use linkerd_app_core::{
 };
 use linkerd_cache::Cached;
 pub use linkerd_server_policy::{
-    authz::Suffix, grpc::Route as GrpcRoute, http::Route as HttpRoute, route, Authentication,
-    Authorization, Meta, Protocol, RoutePolicy, ServerPolicy,
+    authz::Suffix,
+    grpc::Route as GrpcRoute,
+    http::{filter::Redirection, Route as HttpRoute},
+    route, Authentication, Authorization, Meta, Protocol, RoutePolicy, ServerPolicy,
 };
 use std::sync::Arc;
 use thiserror::Error;

--- a/linkerd/http-route/src/http/filter.rs
+++ b/linkerd/http-route/src/http/filter.rs
@@ -1,3 +1,13 @@
 pub mod modify_header;
+pub mod redirect;
 
-pub use self::modify_header::ModifyHeader;
+pub use self::{
+    modify_header::ModifyHeader,
+    redirect::{InvalidRedirect, RedirectRequest, Redirection},
+};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum ModifyPath {
+    ReplaceFullPath(String),
+    ReplacePrefixMatch(String),
+}

--- a/linkerd/http-route/src/http/filter/redirect.rs
+++ b/linkerd/http-route/src/http/filter/redirect.rs
@@ -87,10 +87,12 @@ impl RedirectRequest {
                 .cloned()
                 .ok_or(InvalidRedirect::MissingAuthority),
 
-            // A full override is specified,
+            // A full override is specified, so use it without considering the
+            // original URI.
             Some(AuthorityOverride::Exact(hp)) => Ok(hp.clone()),
 
-            // If only the host is specified, use the
+            // If only the host is specified, try to use the original request's
+            // port, (if it's not the scheme's default).
             Some(AuthorityOverride::Host(h)) => {
                 match orig_uri
                     .port_u16()

--- a/linkerd/http-route/src/http/filter/redirect.rs
+++ b/linkerd/http-route/src/http/filter/redirect.rs
@@ -1,0 +1,416 @@
+use std::num::NonZeroU16;
+
+use super::ModifyPath;
+use crate::http::RouteMatch;
+use http::{
+    uri::{Authority, InvalidUri, PathAndQuery, Scheme, Uri},
+    StatusCode,
+};
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct RedirectRequest {
+    pub scheme: Option<Scheme>,
+    pub host: Option<String>,
+    pub port: Option<NonZeroU16>,
+    pub path: Option<ModifyPath>,
+    pub status: Option<StatusCode>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum InvalidRedirect {
+    #[error("redirects may only replace the path prefix when a path prefix match applied")]
+    InvalidReplacePrefix,
+
+    #[error("redirect produced an invalid location: {0}")]
+    InvalidLocation(#[from] http::Error),
+
+    #[error("redirect produced an invalid authority: {0}")]
+    InvalidAuthority(#[from] InvalidUri),
+
+    #[error("no authority to redirect to")]
+    MissingAuthority,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Redirection {
+    pub status: http::StatusCode,
+    pub location: Uri,
+}
+
+// === impl RedirectRequest ===
+
+impl RedirectRequest {
+    pub fn apply(
+        &self,
+        orig_uri: &http::Uri,
+        rm: &RouteMatch,
+    ) -> Result<Option<Redirection>, InvalidRedirect> {
+        let location = {
+            let scheme = self
+                .scheme
+                .as_ref()
+                .or_else(|| orig_uri.scheme())
+                .cloned()
+                .unwrap_or(Scheme::HTTP);
+
+            Uri::builder()
+                .scheme(scheme)
+                .authority(self.authority(orig_uri)?)
+                .path_and_query(self.path_and_query(orig_uri, rm)?)
+                .build()
+                .map_err(InvalidRedirect::InvalidLocation)?
+        };
+        if &location == orig_uri {
+            return Ok(None);
+        }
+
+        let status = self.status.unwrap_or(http::StatusCode::MOVED_PERMANENTLY);
+
+        Ok(Some(Redirection { status, location }))
+    }
+
+    fn authority(&self, orig_uri: &http::Uri) -> Result<Authority, InvalidRedirect> {
+        match (self.host.as_deref(), self.port) {
+            // If a host is configured, use it and whatever port is configured.
+            (Some(h), Some(p)) => format!("{}:{}", h, p).parse().map_err(Into::into),
+            (Some(h), None) => h.parse().map_err(Into::into),
+
+            // If a host is NOT configured, use the request's original host
+            // and either an overridden port or the original port.
+            (None, p) => {
+                let h = orig_uri.host().ok_or(InvalidRedirect::MissingAuthority)?;
+                match p.or_else(|| orig_uri.port_u16().and_then(|p| p.try_into().ok())) {
+                    Some(p) => format!("{}:{}", h, p).parse().map_err(Into::into),
+                    None => h.parse().map_err(Into::into),
+                }
+            }
+        }
+    }
+
+    // XXX This function probably does more allocation that is strictly needed.
+    // We may want to optimize it as it settles.
+    fn path_and_query(
+        &self,
+        orig_uri: &http::Uri,
+        rm: &RouteMatch,
+    ) -> Result<PathAndQuery, InvalidRedirect> {
+        use crate::http::r#match::PathMatch;
+
+        match &self.path {
+            // If the redirect does not specify a path, use the original path/query.
+            None => Ok(orig_uri
+                .path_and_query()
+                .expect("URI must have a path")
+                .clone()),
+
+            // If the redirect specifies a full path (potentially including a
+            // query), use it.
+            Some(ModifyPath::ReplaceFullPath(p)) => p.clone().try_into().map_err(Into::into),
+
+            // If the redirect specifies a prefix rewrite, using the original
+            // query parameters.
+            //
+            // XXX #fragments are not included in the rewritten location; but
+            // fragments are generally not transmitted to servers.
+            Some(ModifyPath::ReplacePrefixMatch(new_pfx)) => match rm.route.path() {
+                PathMatch::Prefix(pfx_len) if *pfx_len <= orig_uri.path().len() => {
+                    let mut new_path = new_pfx.to_string();
+                    let (_, rest) = orig_uri.path().split_at(*pfx_len);
+                    if !rest.is_empty() && !rest.starts_with('/') {
+                        new_path.push('/');
+                    }
+                    new_path.push_str(rest);
+                    if let Some(q) = orig_uri.query() {
+                        new_path.push('?');
+                        new_path.push_str(q);
+                    }
+                    new_path.try_into().map_err(Into::into)
+                }
+
+                // If the matched rule was not a prefix match, the redirect
+                // filter is invalid. This should cause us to fail requests with
+                // a 5XX.
+                _ => Err(InvalidRedirect::InvalidReplacePrefix),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::http::{find, r#match::MatchPath, MatchRequest, Route, Rule};
+
+    use super::*;
+
+    macro_rules! apply {
+        ($uri:expr, $rule:expr) => {{
+            let req = http::Request::builder().uri($uri).body(()).unwrap();
+            let routes = vec![Route {
+                hosts: vec![],
+                rules: vec![$rule],
+            }];
+            let (rm, redir) = find(&*routes, &req).expect("request must match");
+            redir.apply(req.uri(), &rm)
+        }};
+    }
+
+    #[test]
+    fn default_noop() {
+        let rule = Rule {
+            matches: vec![MatchRequest::default()],
+            policy: RedirectRequest::default(),
+        };
+        assert_eq!(
+            apply!("http://example.com/foo", rule).expect("must apply"),
+            None,
+            "default redirect should be noop"
+        );
+    }
+
+    #[test]
+    fn host() {
+        let rule = Rule {
+            matches: vec![MatchRequest::default()],
+            policy: RedirectRequest {
+                host: Some("example.org".to_string()),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo?a=b&c", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "http://example.org/foo?a=b&c".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn port() {
+        let rule = Rule {
+            matches: vec![MatchRequest::default()],
+            policy: RedirectRequest {
+                port: Some(8080.try_into().unwrap()),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo?a=b&c", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "http://example.com:8080/foo?a=b&c".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn replace_path_full() {
+        let rule = Rule {
+            matches: vec![MatchRequest::default()],
+            policy: RedirectRequest {
+                path: Some(ModifyPath::ReplaceFullPath("/bar".to_string())),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "http://example.com/bar".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn replace_path_full_overwrites_query_params() {
+        let rule = Rule {
+            matches: vec![MatchRequest::default()],
+            policy: RedirectRequest {
+                path: Some(ModifyPath::ReplaceFullPath("/bar".to_string())),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo?a=b&c=d", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "http://example.com/bar".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn replace_path_full_with_query_params() {
+        let rule = Rule {
+            matches: vec![MatchRequest::default()],
+            policy: RedirectRequest {
+                path: Some(ModifyPath::ReplaceFullPath("/bar?a=b&c".to_string())),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "http://example.com/bar?a=b&c".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn replace_path_prefix() {
+        let rule = Rule {
+            matches: vec![MatchRequest {
+                path: Some(MatchPath::Prefix("/foo".to_string())),
+                ..MatchRequest::default()
+            }],
+            policy: RedirectRequest {
+                path: Some(ModifyPath::ReplacePrefixMatch("/qux".to_string())),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo/bar", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "http://example.com/qux/bar".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn replace_path_prefix_with_query_params() {
+        let rule = Rule {
+            matches: vec![MatchRequest {
+                path: Some(MatchPath::Prefix("/foo".to_string())),
+                ..MatchRequest::default()
+            }],
+            policy: RedirectRequest {
+                path: Some(ModifyPath::ReplacePrefixMatch("/qux".to_string())),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo/bar?a=b&c", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "http://example.com/qux/bar?a=b&c".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn replace_path_prefix_default_match() {
+        let rule = Rule {
+            matches: vec![MatchRequest::default()],
+            policy: RedirectRequest {
+                path: Some(ModifyPath::ReplacePrefixMatch("/qux".to_string())),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo/bar", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "http://example.com/qux/foo/bar".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn replace_path_prefix_root_match() {
+        let rule = Rule {
+            matches: vec![MatchRequest {
+                path: Some(MatchPath::Prefix("/".to_string())),
+                ..MatchRequest::default()
+            }],
+            policy: RedirectRequest {
+                path: Some(ModifyPath::ReplacePrefixMatch("/qux".to_string())),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo/bar", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "http://example.com/qux/foo/bar".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn replace_path_prefix_trailing_slash() {
+        let rule = Rule {
+            matches: vec![MatchRequest {
+                path: Some(MatchPath::Prefix("/foo/".to_string())),
+                ..MatchRequest::default()
+            }],
+            policy: RedirectRequest {
+                path: Some(ModifyPath::ReplacePrefixMatch("/qux".to_string())),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo/bar", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "http://example.com/qux/bar".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn replace_path_prefix_exact_match() {
+        let rule = Rule {
+            matches: vec![MatchRequest {
+                path: Some(MatchPath::Exact("/foo/bar".to_string())),
+                ..MatchRequest::default()
+            }],
+            policy: RedirectRequest {
+                path: Some(ModifyPath::ReplacePrefixMatch("/qux".to_string())),
+                ..RedirectRequest::default()
+            },
+        };
+        assert!(matches!(
+            apply!("http://example.com/foo/bar", rule).expect_err("must not apply"),
+            InvalidRedirect::InvalidReplacePrefix
+        ));
+    }
+
+    #[test]
+    fn scheme() {
+        let rule = Rule {
+            matches: vec![MatchRequest::default()],
+            policy: RedirectRequest {
+                scheme: Some(http::uri::Scheme::HTTPS),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo?a=b&c", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::MOVED_PERMANENTLY,
+                location: "https://example.com/foo?a=b&c".parse().unwrap()
+            }),
+        );
+    }
+
+    #[test]
+    fn status() {
+        let rule = Rule {
+            matches: vec![MatchRequest::default()],
+            policy: RedirectRequest {
+                status: Some(http::StatusCode::TEMPORARY_REDIRECT),
+                scheme: Some(http::uri::Scheme::HTTPS),
+                ..RedirectRequest::default()
+            },
+        };
+        assert_eq!(
+            apply!("http://example.com/foo?a=b&c", rule).expect("must apply"),
+            Some(Redirection {
+                status: http::StatusCode::TEMPORARY_REDIRECT,
+                location: "https://example.com/foo?a=b&c".parse().unwrap()
+            }),
+        );
+    }
+}

--- a/linkerd/http-route/src/http/filter/redirect.rs
+++ b/linkerd/http-route/src/http/filter/redirect.rs
@@ -72,7 +72,7 @@ impl RedirectRequest {
     fn authority(&self, orig_uri: &http::Uri) -> Result<Authority, InvalidRedirect> {
         match (self.host.as_deref(), self.port) {
             // If a host is configured, use it and whatever port is configured.
-            (Some(h), Some(p)) => format!("{}:{}", h, p).parse().map_err(Into::into),
+            (Some(h), Some(p)) => format!("{}:{}", h, p).try_into().map_err(Into::into),
             (Some(h), None) => h.parse().map_err(Into::into),
 
             // If a host is NOT configured, use the request's original host
@@ -80,7 +80,7 @@ impl RedirectRequest {
             (None, p) => {
                 let h = orig_uri.host().ok_or(InvalidRedirect::MissingAuthority)?;
                 match p.or_else(|| orig_uri.port_u16().and_then(|p| p.try_into().ok())) {
-                    Some(p) => format!("{}:{}", h, p).parse().map_err(Into::into),
+                    Some(p) => format!("{}:{}", h, p).try_into().map_err(Into::into),
                     None => h.parse().map_err(Into::into),
                 }
             }

--- a/linkerd/http-route/src/http/match.rs
+++ b/linkerd/http-route/src/http/match.rs
@@ -77,7 +77,7 @@ impl Default for RequestMatch {
         // > If no matches are specified, the default is a prefix path match on
         // > "/", which has the effect of matching every HTTP request.
         Self {
-            path_match: PathMatch::Prefix(0),
+            path_match: PathMatch::Prefix("/".len()),
             headers: 0,
             query_params: 0,
             method: false,

--- a/linkerd/http-route/src/http/match.rs
+++ b/linkerd/http-route/src/http/match.rs
@@ -33,6 +33,12 @@ pub struct RequestMatch {
 
 // === impl MatchRequest ===
 
+impl RequestMatch {
+    pub(crate) fn path(&self) -> &PathMatch {
+        &self.path_match
+    }
+}
+
 impl crate::Match for MatchRequest {
     type Summary = RequestMatch;
 
@@ -71,7 +77,7 @@ impl Default for RequestMatch {
         // > If no matches are specified, the default is a prefix path match on
         // > "/", which has the effect of matching every HTTP request.
         Self {
-            path_match: PathMatch::Prefix("/".len()),
+            path_match: PathMatch::Prefix(0),
             headers: 0,
             query_params: 0,
             method: false,

--- a/linkerd/server-policy/src/http.rs
+++ b/linkerd/server-policy/src/http.rs
@@ -7,7 +7,8 @@ pub type Rule = http::Rule<Policy>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Filter {
-    RequestHeaders(http::filter::ModifyHeader),
+    Redirect(filter::RedirectRequest),
+    RequestHeaders(filter::ModifyHeader),
 }
 
 #[inline]


### PR DESCRIPTION
The Gateway API requires that `HTTPRoute` implementations support a
[redirection filter][gwapi].

This change adds a filter implementation to the `http-route` crate.
Inbound server policies are updated to apply this filter on HTTP routes.
When a request is redirected, the policy layer returns an error and the
error crate is responsible for turning that error into an HTTP response.

This change fixes path matching so that trailing slashes do not impact
prefix matching.

[gwapi]: https://github.com/kubernetes-sigs/gateway-api/blob/541e9fc2b3c2f62915cb58dc0ee5e43e4096b3e2/apis/v1beta1/httproute_types.go#L772-L821

Signed-off-by: Oliver Gould <ver@buoyant.io>