### PR TITLE
2.161.3: cherry-pick #1758

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2246,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a89fd63ad6adf737582df5db40d286574513c69a11dac5214dc3b5603d6713e"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -31,7 +31,7 @@ linkerd-stack = { path = "../../stack" }
 rand = "0.8"
 thiserror = "1"
 tokio = { version = "1", features = ["time", "rt"] }
-tower = { version = "0.4", default-features = false, features = ["balance", "load", "discover"] }
+tower = { version = "0.4.13", default-features = false, features = ["balance", "load", "discover"] }
 tracing = "0.1"
 try-lock = "0.2"
 pin-project = "1"

--- a/linkerd/proxy/tcp/Cargo.toml
+++ b/linkerd/proxy/tcp/Cargo.toml
@@ -14,5 +14,5 @@ linkerd-error = { path = "../../error" }
 linkerd-stack = { path = "../../stack" }
 rand = "0.8"
 tokio = { version = "1" }
-tower = { version = "0.4", default-features = false, features = ["balance", "load", "discover"] }
+tower = { version = "0.4.13", default-features = false, features = ["balance", "load", "discover"] }
 pin-project = "1"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -28,7 +28,7 @@ regex = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = { version = "0.7", default-features = false }
-tower = { version = "0.4", features = ["ready-cache", "retry", "util"] }
+tower = { version = "0.4.13", features = ["ready-cache", "retry", "util"] }
 thiserror = "1"
 tracing = "0.1"
 pin-project = "1"


### PR DESCRIPTION
Tower [v0.4.13] includes a fix for a bug in the `tower::ready_cache`
module, tower-rs/tower#415. The `ready_cache` module is used internally
in Tower's load balancer. This bug resulted in panics in the proxy
(linkerd/linkerd2#8666, linkerd/linkerd2#6086) in cases where the
Destination service sends a very large number of service discovery
updates (see linkerd/linkerd2#8677).

This commit updates the proxy's dependency on `tower` to 0.4.13, to
ensure that this bugfix is picked up.

Fixes linkerd/linkerd2#8666
Fixes linkerd/linkerd2#6086

[v0.4.13]: https://github.com/tower-rs/tower/releases/tag/tower-0.4.13