### PR TITLE
Add HTTP and gRPC route failure-injection filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ name = "linkerd-http-route"
 version = "0.1.0"
 dependencies = [
  "http",
+ "rand",
  "regex",
  "thiserror",
  "tracing",

--- a/linkerd/http-route/Cargo.toml
+++ b/linkerd/http-route/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 http = "0.2"
 regex = "1"
+rand = "0.8"
 thiserror = "1"
 tracing = "0.1"
 url = "2"

--- a/linkerd/http-route/src/grpc.rs
+++ b/linkerd/http-route/src/grpc.rs
@@ -1,8 +1,9 @@
+pub mod filter;
 pub mod r#match;
-
-pub use self::r#match::MatchRoute;
 #[cfg(test)]
 mod tests;
+
+pub use self::r#match::MatchRoute;
 
 pub type RouteMatch = crate::RouteMatch<r#match::RouteMatch>;
 

--- a/linkerd/http-route/src/grpc/filter.rs
+++ b/linkerd/http-route/src/grpc/filter.rs
@@ -1,0 +1,3 @@
+mod inject_failure;
+
+pub use self::inject_failure::{Distribution, FailureResponse, InjectFailure};

--- a/linkerd/http-route/src/grpc/filter/inject_failure.rs
+++ b/linkerd/http-route/src/grpc/filter/inject_failure.rs
@@ -1,0 +1,12 @@
+use std::hash::Hash;
+
+pub use crate::http::filter::Distribution;
+
+pub type InjectFailure = crate::http::filter::InjectFailure<FailureResponse>;
+
+/// A gRPC error code and status message.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct FailureResponse {
+    pub code: u16,
+    pub message: std::sync::Arc<str>,
+}

--- a/linkerd/http-route/src/http/filter.rs
+++ b/linkerd/http-route/src/http/filter.rs
@@ -1,7 +1,9 @@
+pub mod inject_failure;
 pub mod modify_header;
 pub mod redirect;
 
 pub use self::{
+    inject_failure::{Distribution, FailureResponse, InjectFailure},
     modify_header::ModifyHeader,
     redirect::{InvalidRedirect, RedirectRequest, Redirection},
 };

--- a/linkerd/http-route/src/http/filter/inject_failure.rs
+++ b/linkerd/http-route/src/http/filter/inject_failure.rs
@@ -1,0 +1,75 @@
+use std::hash::Hash;
+
+/// A filter that responds with an error at a predictable rate.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct InjectFailure<T = FailureResponse> {
+    pub response: T,
+    pub distribution: Distribution,
+}
+
+/// An HTTP error response.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct FailureResponse {
+    pub status: http::StatusCode,
+    pub message: std::sync::Arc<str>,
+}
+
+/// A Bernoulli distribution that implements `Hash`, `PartialEq`, and `Eq`.
+#[derive(Clone, Debug)]
+pub struct Distribution {
+    numerator: u32,
+    denominator: u32,
+    inner: rand::distributions::Bernoulli,
+}
+
+// === impl InjectFailure ===
+
+impl<T: Clone> InjectFailure<T> {
+    pub fn apply(&self) -> Option<T> {
+        use rand::distributions::Distribution;
+
+        if self.distribution.sample(&mut rand::thread_rng()) {
+            return Some(self.response.clone());
+        }
+
+        None
+    }
+}
+
+// === impl InjectFailure ===
+
+impl Distribution {
+    pub fn from_ratio(
+        numerator: u32,
+        denominator: u32,
+    ) -> Result<Self, rand::distributions::BernoulliError> {
+        let inner = rand::distributions::Bernoulli::from_ratio(numerator, denominator)?;
+        Ok(Self {
+            numerator,
+            denominator,
+            inner,
+        })
+    }
+}
+
+impl rand::distributions::Distribution<bool> for Distribution {
+    #[inline]
+    fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> bool {
+        self.inner.sample(rng)
+    }
+}
+
+impl PartialEq for Distribution {
+    fn eq(&self, other: &Self) -> bool {
+        self.numerator == other.numerator && self.denominator == other.denominator
+    }
+}
+
+impl Eq for Distribution {}
+
+impl Hash for Distribution {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.numerator.hash(state);
+        self.denominator.hash(state);
+    }
+}

--- a/linkerd/server-policy/src/grpc.rs
+++ b/linkerd/server-policy/src/grpc.rs
@@ -1,4 +1,4 @@
-pub use linkerd_http_route::grpc::{r#match, RouteMatch};
+pub use linkerd_http_route::grpc::{filter, r#match, RouteMatch};
 use linkerd_http_route::{grpc, http};
 
 pub type Policy = crate::RoutePolicy<Filter>;
@@ -7,6 +7,7 @@ pub type Rule = grpc::Rule<Policy>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Filter {
+    InjectFailure(filter::InjectFailure),
     RequestHeaders(http::filter::ModifyHeader),
 }
 

--- a/linkerd/server-policy/src/http.rs
+++ b/linkerd/server-policy/src/http.rs
@@ -7,6 +7,7 @@ pub type Rule = http::Rule<Policy>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Filter {
+    InjectFailure(filter::InjectFailure),
     Redirect(filter::RedirectRequest),
     RequestHeaders(filter::ModifyHeader),
 }


### PR DESCRIPTION
The control plane may choose to inject failures for a route. It may
cause all requests to fail, or only a random subset of requests to fail.

This change adds HTTP and gRPC route filters that can cause error
responses for inbound requests.

Signed-off-by: Oliver Gould <ver@buoyant.io>