### PR TITLE
Revert "build(deps): bump tracing-subscriber from 0.3.11 to 0.3.14 (#1806)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2567,9 +2567,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2598,13 +2598,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.14"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
+ "lazy_static",
  "matchers",
- "once_cell",
  "parking_lot",
  "regex",
  "serde",

--- a/linkerd/tracing/Cargo.toml
+++ b/linkerd/tracing/Cargo.toml
@@ -20,6 +20,6 @@ tracing = "0.1"
 tracing-log = "0.1"
 
 [dependencies.tracing-subscriber]
-version = "0.3.14"
+version = "0.3.11"
 default-features = false
 features = ["env-filter", "fmt", "smallvec", "tracing-log", "json", "parking_lot", "registry"]


### PR DESCRIPTION
This reverts commit 7ecdd7840fb2a4b2a26f8195585a54621d4b1f07.

Upgrading tracing-subscriber breaks logging in the proxy.

`cargo run` on main:

```
    Finished dev [unoptimized] target(s) in 43.90s
     Running `target/debug/linkerd2-proxy`
Invalid configuration: no destination service configured
```

Versus `cargo run` with this change reverted:

```
    Finished dev [unoptimized] target(s) in 52.61s
     Running `target/debug/linkerd2-proxy`
[     0.007639s] ERROR ThreadId(01) linkerd_app::env: LINKERD2_PROXY_IDENTITY_SVC_ADDR and LINKERD2_PROXY_IDENTITY_SVC_NAME must be set.
[     0.007680s] ERROR ThreadId(01) linkerd_app::env: LINKERD2_PROXY_IDENTITY_TRUST_ANCHORS must be set.
[     0.007687s] ERROR ThreadId(01) linkerd_app::env: LINKERD2_PROXY_IDENTITY_DIR must be set.
[     0.007692s] ERROR ThreadId(01) linkerd_app::env: LINKERD2_PROXY_IDENTITY_LOCAL_NAME must be set.
[     0.007697s] ERROR ThreadId(01) linkerd_app::env: LINKERD2_PROXY_IDENTITY_TOKEN_FILE must be set.
[     0.007787s]  INFO ThreadId(01) linkerd_app::env: `LINKERD2_PROXY_INBOUND_IPS` allowlist not configured, allowing all target addresses
[     0.007850s]  INFO ThreadId(01) linkerd_app::env: LINKERD2_PROXY_POLICY_CLUSTER_NETWORKS not set; cluster-scoped modes are unsupported
[     0.007868s]  WARN ThreadId(01) linkerd_app::env: LINKERD2_PROXY_INBOUND_DEFAULT_POLICY was not set; using `all-unauthenticated`
Invalid configuration: no destination service configured
```

Signed-off-by: Oliver Gould <ver@buoyant.io>