### PR TITLE
dev: Use the kokakiwi.vscode-just

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,10 @@
 	"image": "ghcr.io/linkerd/dev:v24",
 	"extensions": [
 		"DavidAnson.vscode-markdownlint",
+		"kokakiwi.vscode-just",
 		"NathanRidley.autotrim",
 		"rust-lang.rust-analyzer",
 		"samverschueren.final-newline",
-		"skellock.just",
 		"tamasfe.even-better-toml",
 		"zxh404.vscode-proto3"
 	],


### PR DESCRIPTION
`skellock.just` is unmaintained and has syntax highlighting bugs.
`kokakiwi.vscode-just` fixes those bugs!

Signed-off-by: Oliver Gould <ver@buoyant.io>