### PR TITLE
dev: Update markdowlint-cli2 to 5.0.1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "linkerd2-proxy",
-	"image": "ghcr.io/linkerd/dev:v24",
+	"image": "ghcr.io/linkerd/dev:v26",
 	"extensions": [
 		"DavidAnson.vscode-markdownlint",
 		"kokakiwi.vscode-just",

--- a/.devcontainer/on-create.sh
+++ b/.devcontainer/on-create.sh
@@ -7,4 +7,4 @@ cargo +nightly install cargo-fuzz
 
 scurl https://run.linkerd.io/install-edge | sh
 mkdir -p "$HOME/bin"
-(cd "$HOME/bin" && ln -s "$HOME/.linkerd2/bin/linkerd")
+(cd "$HOME/bin" && ln -s "$HOME/.linkerd2/bin/linkerd" .)

--- a/.github/fuzzers-list.sh
+++ b/.github/fuzzers-list.sh
@@ -18,7 +18,7 @@ find_fuzz_dir() {
 
 for file in "$@" ; do
     if [ "$file" = .github/workflows/fuzzers.yml ] || [ "$file" = .github/fuzzers-list.sh ]; then
-        find * -type d -name fuzz
+        find linkerd -type d -name fuzz
         break
     fi
     find_fuzz_dir "$file"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,7 +13,7 @@ jobs:
   actionlint:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
-    container: ghcr.io/linkerd/dev:v24-tools
+    container: ghcr.io/linkerd/dev:v26-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Run actionlint
@@ -25,7 +25,7 @@ jobs:
 
   devcontainer-versions:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-tools
+    container: ghcr.io/linkerd/dev:v26-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Scan workflows for other Devcontainer image versions

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -25,7 +25,7 @@ jobs:
   check-all:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch

--- a/.github/workflows/check-each.yml
+++ b/.github/workflows/check-each.yml
@@ -49,7 +49,7 @@ jobs:
     needs: list-changed-crates
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     strategy:
       matrix:
         crate: ${{ fromJson(needs.list-changed-crates.outputs.crates) }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
-      image: docker://ghcr.io/linkerd/dev:v24-rust
+      image: docker://ghcr.io/linkerd/dev:v26-rust
       options: --security-opt seccomp=unconfined # 🤷
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -46,7 +46,7 @@ jobs:
   deprecated:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
   clippy:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch
@@ -30,7 +30,7 @@ jobs:
   fmt:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just check-fmt
@@ -38,7 +38,7 @@ jobs:
   docs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,15 +6,14 @@ permissions:
 on:
   pull_request:
     paths:
-      - '**/*.md'
-      - .github/workflows/markdown.yml
+      - '**/*.sh'
+      - .github/workflows/shellcheck.yml
 
 jobs:
   markdownlint:
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    container: ghcr.io/linkerd/dev:v26-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - uses: DavidAnson/markdownlint-cli2-action@e3969ef4ed874458f4b66d4631f78fff7717012c
-        with:
-            globs: "**/*.md"
+      - run: just shellcheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
   meshtls:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch
@@ -42,7 +42,7 @@ jobs:
   unit:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-rust
+    container: ghcr.io/linkerd/dev:v26-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -30,7 +30,7 @@ jobs:
 
   workflows:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v24-tools
+    container: ghcr.io/linkerd/dev:v26-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 ## Getting Help
 
 If you have a question about Linkerd2 or have encountered problems using it,
-start by [asking a question in the forums][discourse] or join us in the
+start by [asking a question in the forums][discussions] or join us in the
 [#linkerd2 Slack channel][slack].
 
 ## Certificate of Origin
@@ -99,9 +99,6 @@ Describe the modifications you've made.
 Describe the testing you've done to validate your change.  Performance-related
 changes should include before- and after- benchmark results.
 
-[discourse]: https://discourse.linkerd.io/c/conduit
-[governance]: GOVERNANCE.md
+[discussions]: https://github.com/linkerd/linkerd2/discussions/new
 [issue]: https://github.com/linkerd/linkerd2/issues/new
-[maintainers]: MAINTAINERS.md
-[members]: https://github.com/orgs/linkerd/people
 [slack]: http://slack.linkerd.io/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ![linkerd2][logo]
 
-<!-- TODO [![Build Status][ci-badge]][ci] -->
-[![GitHub license][license-badge]](LICENSE)
+[![GitHub license](https://img.shields.io/github/license/linkerd/linkerd2-proxy.svg)](LICENSE)
 [![Slack Status][slack-badge]][slack]
 
 This repo contains the transparent proxy component of [Linkerd2][linkerd2].
@@ -99,19 +98,15 @@ specific language governing permissions and limitations under the License.
 
 <!-- refs -->
 [cargo]: https://github.com/rust-lang/cargo/
-[ci]: https://travis-ci.org/linkerd/linkerd2-proxy
-<!-- TODO [ci-badge]: https://travis-ci.org/linkerd/linkerd2-proxy.svg?branch=master -->
 [cncf]: https://cncf.io/
 [coc]: https://github.com/linkerd/linkerd/wiki/Linkerd-code-of-conduct
 [k8s]: https://kubernetes.io/
-[license-badge]: https://img.shields.io/github/license/linkerd/linkerd2.svg
-[linkerd1]: https://github.com/linkerd/linkerd
-[linkerd2]: https://github.com/linkerd/linkerd2
-[linkerd2-proxy-api]: https://github.com/linkerd/linkerd2-proxy-api
-[loadbalancing]: https://linkerd.io/features/load-balancing/
-[logo]: https://user-images.githubusercontent.com/9226/33582867-3e646e02-d90c-11e7-85a2-2e238737e859.png
-[prom]: https://prometheus.io/
-[rust]: https://www.rust-lang.org/
-[slack-badge]: https://slack.linkerd.io/badge.svg
-[slack]: https://slack.linkerd.io
-[twitter]: https://twitter.com/linkerd/
+[linkerd1]: <https://github.com/linkerd/linkerd>
+[linkerd2]: <https://github.com/linkerd/linkerd2>
+[linkerd2-proxy-api]: <https://github.com/linkerd/linkerd2-proxy-api>
+[loadbalancing]: <https://linkerd.io/2.11/features/load-balancing/>
+[logo]: <https://user-images.githubusercontent.com/9226/33582867-3e646e02-d90c-11e7-85a2-2e238737e859.png>
+[prom]: <https://prometheus.io/>
+[rust]: <https://www.rust-lang.org/>
+[slack-badge]: <https://slack.linkerd.io/badge.svg>
+[slack]: <https://slack.linkerd.io>

--- a/justfile
+++ b/justfile
@@ -97,7 +97,7 @@ check-fmt:
     {{ cargo }} fmt -- --check
 
 # Run all lints
-lint: shellcheck clippy doc
+lint: shellcheck markdownlint clippy doc
 
 # Lints all shell scripts in the repo.
 shellcheck:
@@ -110,6 +110,9 @@ shellcheck:
     done)
     echo shellcheck $files
     shellcheck $files
+
+markdownlint:
+    markdownlint-cli2 '**/*.md' '!target'
 
 check *flags:
     {{ cargo }} check --workspace --all-targets --frozen {{ flags }} {{ _fmt }}


### PR DESCRIPTION
* Update devcontainer to v26
* Add a `just markdownlint` recipe
* Add a `shellcheck` workflow
* Address lints

Signed-off-by: Oliver Gould <ver@buoyant.io>