### PR TITLE
ci: Validate that rust-toolchain matches devcontainer

### DIFF
--- a/.github/actions/list-changed-crates/Dockerfile
+++ b/.github/actions/list-changed-crates/Dockerfile
@@ -1,8 +1,3 @@
-ARG RUST_VERSION=1.62.1
-FROM docker.io/library/rust:${RUST_VERSION}-bullseye
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt update && \
-    apt install -y jq && \
-    rm -rf /var/lib/apt/lists/*
+FROM ghcr.io/linkerd/dev:v26-rust
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/list-changed-crates/action.yml
+++ b/.github/actions/list-changed-crates/action.yml
@@ -9,7 +9,6 @@ inputs:
 outputs:
   crates:
     description: "A JSON list of crates that have changed"
-    value: ${{ steps.list-changed.outputs.crates }}
 
 runs:
   using: docker

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,29 +16,11 @@ jobs:
     container: ghcr.io/linkerd/dev:v26-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - name: Run actionlint
-        run: |
-          # shellcheck disable=SC2016
-          actionlint \
-            -format '{{range $err := .}}::error file={{$err.Filepath}},line={{$err.Line}},col={{$err.Column}}::{{$err.Message}}%0A```%0A{{replace $err.Snippet "\\n" "%0A"}}%0A```\n{{end}}' \
-            .github/workflows/*
+      - run: just actions-lint
 
   devcontainer-versions:
     runs-on: ubuntu-latest
     container: ghcr.io/linkerd/dev:v26-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - name: Scan workflows for other Devcontainer image versions
-        shell: bash
-        run: |
-          set -euo pipefail
-          # Strip jsonc comments because `jq` doesn't support them.
-          image=$(json5-to-json <.devcontainer/devcontainer.json |jq -r '.image')
-          for f in .github/workflows/* ; do
-            for i in $(yq '.jobs.* | .container.image // .container // "" | match("ghcr.io/linkerd/dev:v[0-9]+").string' < "$f") ; do
-              if [ "$i" != "$image" ]; then
-                echo "::error file=$f::Workflow '$f' uses incorrect Devcontainer image '$i'"
-                exit 1
-              fi
-            done
-          done
+      - run: just actions-dev-versions

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -12,6 +12,18 @@ permissions:
   contents: read
 
 jobs:
+  devcontainer:
+    runs-on: ubuntu-latest
+    container: ghcr.io/linkerd/dev:v26-rust
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - run: |
+          VERSION="$(cat rust-toolchain)"
+          if [ "$(cargo --version | cut -d' ' -f2)" != "$VERSION" ]; then
+            echo "::error file=rust-toolchain::rust-toolchain $VERSION does not match devcontainer $(cargo --version)"
+            exit 1
+          fi
+
   dockerfiles:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add a job to the `rust-toolchain` workflow that compares the
`rust-toolchain` file to the output of `cargo --version` in the
devcontainer.

Signed-off-by: Oliver Gould <ver@buoyant.io>