### PR TITLE
dev: Use a common action-dev-check

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "linkerd2-proxy",
-	"image": "ghcr.io/linkerd/dev:v26",
+	"image": "ghcr.io/linkerd/dev:v28",
 	"extensions": [
 		"DavidAnson.vscode-markdownlint",
 		"kokakiwi.vscode-just",

--- a/.github/actions/list-changed-crates/Dockerfile
+++ b/.github/actions/list-changed-crates/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/linkerd/dev:v26-rust
+FROM ghcr.io/linkerd/dev:v28-rust
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,14 +13,14 @@ jobs:
   actionlint:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
-    container: ghcr.io/linkerd/dev:v26-tools
+    container: ghcr.io/linkerd/dev:v28-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - run: just actions-lint
+      - run: just action-lint
 
   devcontainer-versions:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-tools
+    container: ghcr.io/linkerd/dev:v28-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - run: just actions-dev-versions
+      - run: just action-dev-check

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -25,7 +25,7 @@ jobs:
   check-all:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch

--- a/.github/workflows/check-each.yml
+++ b/.github/workflows/check-each.yml
@@ -49,7 +49,7 @@ jobs:
     needs: list-changed-crates
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     strategy:
       matrix:
         crate: ${{ fromJson(needs.list-changed-crates.outputs.crates) }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
-      image: docker://ghcr.io/linkerd/dev:v26-rust
+      image: docker://ghcr.io/linkerd/dev:v28-rust
       options: --security-opt seccomp=unconfined # 🤷
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -46,7 +46,7 @@ jobs:
   deprecated:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
   clippy:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch
@@ -30,7 +30,7 @@ jobs:
   fmt:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just check-fmt
@@ -38,7 +38,7 @@ jobs:
   docs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,14 +6,15 @@ permissions:
 on:
   pull_request:
     paths:
-      - '**/*.sh'
       - .github/workflows/shellcheck.yml
+      - '**/*.sh'
+      - justfile
 
 jobs:
-  markdownlint:
+  sh-lint:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-tools
+    container: ghcr.io/linkerd/dev:v28-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - run: just shellcheck
+      - run: just sh-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
   meshtls:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch
@@ -42,7 +42,7 @@ jobs:
   unit:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: just fetch

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   devcontainer:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-rust
+    container: ghcr.io/linkerd/dev:v28-rust
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - run: |
@@ -42,7 +42,7 @@ jobs:
 
   workflows:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v26-tools
+    container: ghcr.io/linkerd/dev:v28-tools
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - shell: bash


### PR DESCRIPTION
This change updates to the v28 devcontainer, which includes an extracted
`action-dev-check` script that replaces the inlined just recipe. This
change also renames some recipes (like action-lint, md-lint, and
sh-lint) to be uniform with the recipes in other repos.

Signed-off-by: Oliver Gould <ver@buoyant.io>