### PR TITLE
build: add shell.nix and minimal flake.nix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@ Dockerfile*
 **/target
 target
 .cargo
+.direnv
+.envrc

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,17 @@
+name: nix
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
+    - name: Build in shell
+      run: nix-shell --pure --run "just fetch build"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,6 +1,12 @@
 name: nix
 
-on: push
+on:
+  pull_request:
+    paths:
+      - Cargo.lock
+      - "*.nix"
+      - justfile
+      - .github/workflows/nix.yml
 
 jobs:
   build:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v12
+      uses: cachix/install-nix-action@d64e0553100205688c0fb2fa16edb0fc8663c590
       with:
         nix_path: nixpkgs=channel:nixos-unstable
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 **/corpus
 **/artifacts
 **/fuzz/Cargo.lock
+.direnv
+.envrc

--- a/README.md
+++ b/README.md
@@ -32,10 +32,15 @@ The Linkerd project is hosted by the Cloud Native Computing Foundation
 
 ## Building the project
 
+A [`shell.nix`](./shell.nix) (and generic [`flake.nix`](./flake.nix)) is
+provided with the build dependencies. Use this with `nix-shell` (or with
+`nix develop`, respectively) to get a reproducible development environment.
+
 A [`justfile`](./justfile) is provided to automate most build tasks. It provides
 the following recipes:
 
-* `just build` -- Compiles the proxy on your local system using `cargo`
+* `just fetch` -- Fetches the dependencies on your local system using `cargo fetch`
+* `just build` -- Compiles the proxy on your local system using `cargo build`
 * `just test` -- Runs unit and integration tests on your local system using `cargo`
 * `just docker` -- Builds a Docker container image that can be used for testing.
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ the tooling needed to build and test the proxy.
 A [`shell.nix`](./shell.nix) (and generic [`flake.nix`](./flake.nix)) is
 provided with the build dependencies. Use this with `nix-shell` (or with
 `nix develop`, respectively) to get a reproducible development environment.
-This is particularly useful in conjuction with [Direnv](https://direnv.net)'s
+This is particularly useful in conjunction with [Direnv](https://direnv.net)'s
 [`use flake`](https://direnv.net/man/direnv-stdlib.1.html#codeuse-flake-ltinstallablegtcode).
 
 ### Repository Structure

--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ The Linkerd project is hosted by the Cloud Native Computing Foundation
 
 ## Building the project
 
-A [`shell.nix`](./shell.nix) (and generic [`flake.nix`](./flake.nix)) is
-provided with the build dependencies. Use this with `nix-shell` (or with
-`nix develop`, respectively) to get a reproducible development environment.
-This is particularly useful in conjuction with (Direnv)[https://direnv.net]'s
-[`use flake`](https://direnv.net/man/direnv-stdlib.1.html#codeuse-flake-ltinstallablegtcode).
-
 A [`justfile`](./justfile) is provided to automate most build tasks. It provides
 the following recipes:
 
@@ -45,6 +39,14 @@ the following recipes:
 * `just build` -- Compiles the proxy on your local system using `cargo build`
 * `just test` -- Runs unit and integration tests on your local system using `cargo`
 * `just docker` -- Builds a Docker container image that can be used for testing.
+
+### Nix
+
+A [`shell.nix`](./shell.nix) (and generic [`flake.nix`](./flake.nix)) is
+provided with the build dependencies. Use this with `nix-shell` (or with
+`nix develop`, respectively) to get a reproducible development environment.
+This is particularly useful in conjuction with [Direnv](https://direnv.net)'s
+[`use flake`](https://direnv.net/man/direnv-stdlib.1.html#codeuse-flake-ltinstallablegtcode).
 
 ### Cargo
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ The Linkerd project is hosted by the Cloud Native Computing Foundation
 A [`shell.nix`](./shell.nix) (and generic [`flake.nix`](./flake.nix)) is
 provided with the build dependencies. Use this with `nix-shell` (or with
 `nix develop`, respectively) to get a reproducible development environment.
+This is particularly useful in conjuction with (Direnv)[https://direnv.net]'s
+[`use flake`](https://direnv.net/man/direnv-stdlib.1.html#codeuse-flake-ltinstallablegtcode).
 
 A [`justfile`](./justfile) is provided to automate most build tasks. It provides
 the following recipes:

--- a/README.md
+++ b/README.md
@@ -40,14 +40,6 @@ the following recipes:
 * `just test` -- Runs unit and integration tests on your local system using `cargo`
 * `just docker` -- Builds a Docker container image that can be used for testing.
 
-### Nix
-
-A [`shell.nix`](./shell.nix) (and generic [`flake.nix`](./flake.nix)) is
-provided with the build dependencies. Use this with `nix-shell` (or with
-`nix develop`, respectively) to get a reproducible development environment.
-This is particularly useful in conjuction with [Direnv](https://direnv.net)'s
-[`use flake`](https://direnv.net/man/direnv-stdlib.1.html#codeuse-flake-ltinstallablegtcode).
-
 ### Cargo
 
 Usually, [Cargo][cargo], Rust's package manager, is used to build and test this
@@ -58,6 +50,14 @@ project. If you don't have Cargo installed, we suggest getting it via
 
 A Devcontainer is provided for use with Visual Studio Code. It includes all of
 the tooling needed to build and test the proxy.
+
+### Nix
+
+A [`shell.nix`](./shell.nix) (and generic [`flake.nix`](./flake.nix)) is
+provided with the build dependencies. Use this with `nix-shell` (or with
+`nix develop`, respectively) to get a reproducible development environment.
+This is particularly useful in conjuction with [Direnv](https://direnv.net)'s
+[`use flake`](https://direnv.net/man/direnv-stdlib.1.html#codeuse-flake-ltinstallablegtcode).
 
 ### Repository Structure
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1661353537,
+        "narHash": "sha256-1E2IGPajOsrkR49mM5h55OtYnU0dGyre6gl60NXKITE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0e304ff0d9db453a4b230e9386418fd974d5804a",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,10 @@
+{
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; in
+        {
+          devShells.default = import ./shell.nix { inherit pkgs; };
+        }
+      );
+}

--- a/justfile
+++ b/justfile
@@ -192,7 +192,7 @@ sh-lint:
     shellcheck $files
 
 md-lint:
-    markdownlint-cli2 '**/*.md' '!target'
+    markdownlint-cli2 '**/*.md' '!target' '!.direnv'
 
 # Format actionlint output for Github Actions if running in CI.
 _actionlint-fmt := if env_var_or_default("GITHUB_ACTIONS", "") != "true" { "" } else {

--- a/shell.nix
+++ b/shell.nix
@@ -3,6 +3,7 @@ with pkgs;
 mkShell {
   buildInputs = [
     cacert
+    cmake # for rust-analyzer
     docker
     git
     just

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
 with pkgs;
 mkShell {
   buildInputs = [
+    cacert
     docker
     git
     just

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+mkShell {
+  buildInputs = [
+    docker
+    git
+    just
+    libiconv
+    nodePackages.markdownlint-cli2
+    rustup
+    shellcheck
+  ] ++ lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.Security
+  ];
+}


### PR DESCRIPTION
with build dependencies.

* Tested with `--pure`;
* Fixes running `just build` and `just docker` on clean MacOS with Nix (and Docker desktop.)
* Updated the readme (also mentioning `fetch`, without which `just build` fails.)
* Added a Github action