### PR TITLE
[WIP] reimplement service profile matching with HTTPRoute types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
  "linkerd-dns-name",
  "linkerd-error",
  "linkerd-http-box",
+ "linkerd-http-route",
  "linkerd-proxy-api-resolve",
  "linkerd-stack",
  "linkerd-tonic-watch",

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -243,7 +243,7 @@ impl FmtLabels for ControlLabels {
 // === impl ProfileRouteLabels ===
 
 impl ProfileRouteLabels {
-    pub fn inbound(addr: profiles::LogicalAddr, route: &profiles::http::Route) -> Self {
+    pub fn inbound(addr: profiles::LogicalAddr, route: &profiles::http::RoutePolicy) -> Self {
         let labels = prefix_labels("rt", route.labels().iter());
         Self {
             addr,
@@ -252,7 +252,7 @@ impl ProfileRouteLabels {
         }
     }
 
-    pub fn outbound(addr: profiles::LogicalAddr, route: &profiles::http::Route) -> Self {
+    pub fn outbound(addr: profiles::LogicalAddr, route: &profiles::http::RoutePolicy) -> Self {
         let labels = prefix_labels("rt", route.labels().iter());
         Self {
             addr,

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -51,7 +51,7 @@ struct Profile {
 #[derive(Clone, Debug)]
 struct ProfileRoute {
     profile: Profile,
-    route: profiles::http::Route,
+    route: profiles::http::RoutePolicy,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -158,7 +158,7 @@ impl<C> Inbound<C> {
                         )
                         .push_on_service(http::BoxResponse::layer())
                         .push(classify::NewClassify::layer())
-                        .push_http_insert_target::<profiles::http::Route>()
+                        .push_http_insert_target::<profiles::http::RoutePolicy>()
                         .push_map_target(|(route, profile)| ProfileRoute { route, profile })
                         .into_inner(),
                 ))
@@ -318,8 +318,8 @@ impl<A> svc::stack::RecognizeRoute<http::Request<A>> for LogicalPerRequest {
 
 // === impl Route ===
 
-impl Param<profiles::http::Route> for ProfileRoute {
-    fn param(&self) -> profiles::http::Route {
+impl Param<profiles::http::RoutePolicy> for ProfileRoute {
+    fn param(&self) -> profiles::http::RoutePolicy {
         self.route.clone()
     }
 }
@@ -418,7 +418,7 @@ impl tap::Inspect for Logical {
 
     fn route_labels<B>(&self, req: &http::Request<B>) -> Option<tap::Labels> {
         req.extensions()
-            .get::<profiles::http::Route>()
+            .get::<profiles::http::RoutePolicy>()
             .map(|r| r.labels().clone())
     }
 

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -33,7 +33,7 @@ pub type Connect = self::endpoint::Connect<Endpoint>;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct ProfileRoute {
     logical: Logical,
-    route: profiles::http::Route,
+    route: profiles::http::RoutePolicy,
 }
 
 #[derive(Clone, Debug)]
@@ -173,7 +173,7 @@ impl tap::Inspect for Endpoint {
 
     fn route_labels<B>(&self, req: &Request<B>) -> Option<tap::Labels> {
         req.extensions()
-            .get::<profiles::http::Route>()
+            .get::<profiles::http::RoutePolicy>()
             .map(|r| r.labels().clone())
     }
 
@@ -184,8 +184,8 @@ impl tap::Inspect for Endpoint {
 
 // === impl ProfileRoute ===
 
-impl Param<profiles::http::Route> for ProfileRoute {
-    fn param(&self) -> profiles::http::Route {
+impl Param<profiles::http::RoutePolicy> for ProfileRoute {
+    fn param(&self) -> profiles::http::RoutePolicy {
         self.route.clone()
     }
 }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -131,7 +131,7 @@ impl<E> Outbound<E> {
             logical
                 .clone()
                 .push_switch(
-                    |(route, logical): (Option<profiles::http::Route>, Logical)| -> Result<_, Infallible> {
+                    |(route, logical): (Option<profiles::http::RoutePolicy>, Logical)| -> Result<_, Infallible> {
                         match route {
                             None => Ok(svc::Either::A(logical)),
                             Some(route) => Ok(svc::Either::B(ProfileRoute { route, logical })),
@@ -150,7 +150,7 @@ impl<E> Outbound<E> {
                         // retried, it may have one of two `Body` types. This
                         // layer unifies any `Body` type into `BoxBody`.
                         .push_on_service(http::BoxRequest::erased())
-                        .push_http_insert_target::<profiles::http::Route>()
+                        .push_http_insert_target::<profiles::http::RoutePolicy>()
                         // Sets an optional retry policy.
                         .push(retry::layer(rt.metrics.proxy.http_profile_route_retry.clone()))
                         // Sets an optional request timeout.

--- a/linkerd/http-route/src/http.rs
+++ b/linkerd/http-route/src/http.rs
@@ -3,7 +3,7 @@ pub mod r#match;
 #[cfg(test)]
 mod tests;
 
-pub use self::r#match::{HostMatch, MatchHeader, MatchHost, MatchRequest};
+pub use self::r#match::{HostMatch, MatchHeader, MatchHost, MatchPath, MatchRequest};
 
 pub type RouteMatch = crate::RouteMatch<r#match::RequestMatch>;
 

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -19,6 +19,7 @@ linkerd-addr = { path = "../addr" }
 linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }
 linkerd-http-box = { path = "../http-box" }
+linkerd-http-route = { path = "../http-route" }
 linkerd-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd-stack = { path = "../stack" }
 linkerd-tonic-watch = { path = "../tonic-watch" }

--- a/linkerd/service-profiles/src/http.rs
+++ b/linkerd/service-profiles/src/http.rs
@@ -1,7 +1,7 @@
 mod proxy;
 mod service;
 
-use linkerd_http_route as http_route;
+pub use linkerd_http_route::http as route;
 use regex::Regex;
 use std::{
     fmt,
@@ -14,7 +14,7 @@ use tower::retry::budget::Budget;
 
 pub use self::{proxy::NewProxyRouter, service::NewServiceRouter};
 
-pub type Route = http_route::http::Route<RoutePolicy>;
+pub type Route = route::Route<RoutePolicy>;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct RoutePolicy {

--- a/linkerd/service-profiles/src/http/service.rs
+++ b/linkerd/service-profiles/src/http/service.rs
@@ -1,4 +1,4 @@
-use super::{http_route, Route, RoutePolicy};
+use super::{Route, RoutePolicy};
 use crate::{Profile, Receiver, ReceiverStream};
 use futures::prelude::*;
 use linkerd_stack::{layer, NewService, Oneshot, Param, Service, ServiceExt};

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -4,6 +4,7 @@
 use futures::Stream;
 use linkerd_addr::{Addr, NameAddr};
 use linkerd_error::Error;
+use linkerd_http_route as http_route;
 use linkerd_proxy_api_resolve::Metadata;
 use std::{
     fmt,
@@ -36,10 +37,10 @@ struct ReceiverStream {
     inner: tokio_stream::wrappers::WatchStream<Profile>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct Profile {
     pub addr: Option<LogicalAddr>,
-    pub http_routes: Vec<(self::http::RequestMatch, self::http::Route)>,
+    pub http_routes: Option<http::Route>,
     pub targets: Vec<Target>,
     pub opaque_protocol: bool,
     pub endpoint: Option<(SocketAddr, Metadata)>,
@@ -118,6 +119,20 @@ where
     #[inline]
     fn call(&mut self, target: T) -> Self::Future {
         self.0.get_profile(target)
+    }
+}
+
+// === impl Profile ===
+
+impl Default for Profile {
+    fn default() -> Self {
+        Self {
+            addr: None,
+            http_routes: None,
+            targets: Vec::default(),
+            opaque_protocol: false,
+            endpoint: None,
+        }
     }
 }
 


### PR DESCRIPTION
This is a proof of concept of rewriting the internal proxy types used for matching Service Profile routes to use the same route-matching code that's used to match HTTPRoutes.

So far, it seems like this should be *possible*, but the logic for converting from the recursively-nested Service Profile route-matching types to the "flat" HTTPRoute route matching types is likely going to be _quite_ complex: https://github.com/linkerd/linkerd2-proxy/blob/c505931b22d31df158bd542d2fa5b82b011d5f66/linkerd/service-profiles/src/proto.rs#L78-L132