### PR TITLE
[WIP] allow routes to modify request targets

### DIFF
--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -99,6 +99,13 @@ impl<P: std::fmt::Debug> std::fmt::Debug for Logical<P> {
     }
 }
 
+impl<P: Clone> profiles::http::RequestTarget for Logical<P> {
+    fn request_target<B>(&self, route: &profiles::http::Route, req: &http::Request<B>) -> Self {
+        // for now, this always does nothing...
+        self.clone()
+    }
+}
+
 // === impl Concrete ===
 
 impl<P> From<(ConcreteAddr, Logical<P>)> for Concrete<P> {

--- a/linkerd/service-profiles/src/http.rs
+++ b/linkerd/service-profiles/src/http.rs
@@ -55,6 +55,13 @@ pub struct Retries {
     budget: Arc<Budget>,
 }
 
+/// Modifies a target based on an HTTP route and a request.
+///
+/// If the route does not modify the target, this can simply clone `Self`.
+pub trait RequestTarget {
+    fn request_target<B>(&self, route: &Route, request: &http::Request<B>) -> Self;
+}
+
 #[derive(Clone, Default)]
 struct Labels(Arc<std::collections::BTreeMap<String, String>>);
 


### PR DESCRIPTION
This is an exploratory change to allow the profile router to modify the target based on a request.

The router is changed so that it no longer keeps a map of routes to services, and instead uses the route to determine a target that's passed to the `NewService`, oneshotting the resulting `Service`. In order to retain the current behavior where services built for routes are reused, we would layer a `Cache` layer on the `NewService` that's passed in, similarly to what we do for the `Router` service. Alternatively, we could hard-code the cache into the profile router, if we always want the caching behavior.

A new `RequestTarget` trait is added to allow constructing a target based on a route and a request, and the initial target. This may not be the nicest abstraction, and we can change this in the future, but this is a sketch.

This doesn't quite compile yet, but I'm opening a draft PR for now to show the approach.