### PR TITLE
Allow Unicode-dfs-2016 for unicode-ident

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,10 @@ confidence-threshold = 0.8
 exceptions = [
     { allow = ["Zlib"], name = "adler32", version = "*" },
     { allow = ["ISC", "MIT", "OpenSSL"], name = "ring", version = "*" },
+    # The Unicode-DFS-2016 license is necessary for unicode-ident because they
+    # use data from the unicode tables to generate the tables which are
+    # included in the application. We do not distribute those data files so
+    # this is not a problem for us. See https://github.com/dtolnay/unicode-ident/pull/9/files
     { allow = ["Unicode-DFS-2016"], name = "unicode-ident", version = "*"},
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,7 @@ confidence-threshold = 0.8
 exceptions = [
     { allow = ["Zlib"], name = "adler32", version = "*" },
     { allow = ["ISC", "MIT", "OpenSSL"], name = "ring", version = "*" },
+    { allow = ["Unicode-DFS-2016"], name = "unicode-ident", version = "*"},
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
The other unicode packages don't use this license, so an exception should be
okay. This could also just be moved to licenses.allow.

Fixes #1964 checks.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>