### PR TITLE
just: Fix justfile command silencing

### DIFF
--- a/.github/actions/list-changed-crates/entrypoint.sh
+++ b/.github/actions/list-changed-crates/entrypoint.sh
@@ -40,13 +40,13 @@ manifest_expr() {
 
 files=$1
 if [ -z "$files" ]; then
-    echo 'No files specified' >&2
-    exit 1
+    echo '[]'
+    exit 0
 fi
 
 # Get the crate names for all changed manifest directories.
 crates=$(cargo metadata --locked --format-version=1 \
     | jq -cr "[.packages[] | select(.manifest_path | $(manifest_expr "$files")) | .name]")
 
-echo "::set-output name=crates::$crates"
+echo "crates=$crates" >> "$GITHUB_OUTPUT"
 echo "$crates" | jq .

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -38,7 +38,7 @@ jobs:
         shell: bash
         run: |
           dirs=$(.github/fuzzers-list.sh ${{ steps.changed-files.outputs.all_changed_files }} | jo -a)
-          echo "::set-output name=dirs::$dirs"
+          echo "dirs=$dirs" >> "$GITHUB_OUTPUT"
     outputs:
       dirs: ${{ steps.list-changed.outputs.dirs }}
 

--- a/justfile
+++ b/justfile
@@ -211,6 +211,6 @@ action-dev-check:
 
 # Display the git history minus dependabot updates
 history *paths='.':
-    @-git log --oneline --graph --invert-grep --author="dependabot" -- {{ paths }}
+    @git log --oneline --graph --invert-grep --author="dependabot" -- {{ paths }}
 
 # vim: set ft=make :


### PR DESCRIPTION
`@-` suppresses logging and ignores the command's exit code. We only want to
use `@` so that logging is suppressed but exit codes are fatal.