### PR TITLE
rough draft of client policy traffic splitting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,6 +941,7 @@ dependencies = [
 name = "linkerd-app-outbound"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "bytes",
  "futures",
  "http",
@@ -1563,6 +1564,7 @@ dependencies = [
 name = "linkerd-service-profiles"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "bytes",
  "futures",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,6 +418,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -998,18 +1010,25 @@ dependencies = [
 name = "linkerd-client-policy"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
+ "futures",
  "http",
+ "indexmap",
  "linkerd-addr",
+ "linkerd-error",
  "linkerd-http-route",
  "linkerd-policy-core",
+ "linkerd-proxy-api-resolve",
+ "linkerd-stack",
  "linkerd2-proxy-api",
  "once_cell",
  "prost-types",
+ "rand",
  "thiserror",
  "tokio",
- "tokio-stream",
  "tonic",
  "tower",
+ "tracing",
 ]
 
 [[package]]
@@ -1550,6 +1569,7 @@ dependencies = [
  "http-body",
  "indexmap",
  "linkerd-addr",
+ "linkerd-client-policy",
  "linkerd-dns-name",
  "linkerd-error",
  "linkerd-http-box",
@@ -2608,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -2621,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2632,9 +2652,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",

--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -95,6 +95,7 @@ where
         let svc = self
             .outbound
             .new_service(svc::Either::A(outbound::http::Logical {
+                policy: None,
                 profile,
                 protocol: http.version,
                 logical_addr,

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -139,6 +139,7 @@ where
 
                 Ok(svc::Either::B(outbound::tcp::Logical {
                     profile,
+                    policy: None,
                     protocol: (),
                     logical_addr,
                     orig_dst: todo!("eliza: fix this"),

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -15,6 +15,7 @@ allow-loopback = []
 test-subscriber = []
 
 [dependencies]
+async-stream = "0.3.1"
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -73,6 +73,7 @@ impl From<(Version, tcp::Logical)> for Logical {
     fn from((protocol, logical): (Version, tcp::Logical)) -> Self {
         Self {
             protocol,
+            policy: logical.policy,
             profile: logical.profile,
             logical_addr: logical.logical_addr,
             orig_dst: logical.orig_dst,

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -125,7 +125,7 @@ impl<E> Outbound<E> {
             // task so it becomes ready without new requests.
             let logical = concrete
                 .check_new_service::<(ConcreteAddr, Logical), _>()
-                .push(profiles::split::layer())
+                .push(policy::split::layer())
                 .push_on_service(
                     svc::layers()
                         .push(svc::layer::mk(svc::SpawnReady::new))

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -188,19 +188,26 @@ impl<E> Outbound<E> {
                 )
                 .push(profiles::http::NewServiceRouter::layer());
 
-                let policy = logical.push_map_target(|(policy, logical): (Policy, Logical)| {
+                let policy = logical
+                .check_new_service::<Logical, http::Request<_>>()
+                .push_map_target(|(policy, logical): (Policy, Logical)| {
                     // for now, just log the client policy rather than actually
                     // doing anything...
-                    tracing::info!("resolved client policy for {}", policy.dst);
-                    let policy = policy.policy.borrow();
-                    tracing::info!(?policy.meta);
-                    tracing::info!(?policy.http_routes);
-                    tracing::info!(?policy.backends);
-                    
-                    // TODO(eliza): this is where the stack used when a client
-                    // policy is resolved will go...
-                    logical
+                    {
+                        tracing::info!("resolved client policy for {}", policy.dst);
+                        let policy = policy.policy.borrow();
+                        tracing::info!(?policy.meta);
+                        tracing::info!(?policy.http_routes);
+                        tracing::info!(?policy.backends);
+                    }
+                    // Add the discovered policy to the logical target
+                    Logical {
+                        policy: Some(policy),
+                        ..logical
+                    }
                 })
+                // TODO(eliza): this is where the client-policy-specific
+                // middleware would go...
                 .instrument(|(policy, _): &(Policy, Logical)| debug_span!("policy", addr = %policy.dst))
                 .check_new_service::<(Policy, Logical), http::Request<_>>();
 

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -110,6 +110,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                                 if let Some(logical_addr) = profile.logical_addr() {
                                     return Ok(http::Logical {
                                         profile,
+                                        policy: None,
                                         logical_addr,
                                         protocol: http.version,
                                         orig_dst: todo!("eliza: ugh"),

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -9,6 +9,7 @@ use linkerd_app_core::{
 };
 pub use profiles::LogicalAddr;
 use std::fmt;
+use tokio::sync::watch;
 
 #[derive(Clone)]
 pub struct Logical<P> {
@@ -47,6 +48,12 @@ impl Logical<()> {
 impl<P> svc::Param<profiles::Receiver> for Logical<P> {
     fn param(&self) -> profiles::Receiver {
         self.profile.clone()
+    }
+}
+
+impl<P> svc::Param<watch::Receiver<profiles::Profile>> for Logical<P> {
+    fn param(&self) -> watch::Receiver<profiles::Profile> {
+        self.profile.clone().into_inner()
     }
 }
 

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -46,8 +46,8 @@ impl Logical<()> {
 }
 
 /// Used for traffic split.
-impl<P> svc::Param<Vec<policy::Backend>> for Logical<P> {
-    fn param(&self) -> Vec<policy::Backend> {
+impl<P> svc::Param<Vec<policy::split::Backend>> for Logical<P> {
+    fn param(&self) -> Vec<policy::split::Backend> {
         // if a client policy was discovered, use its backends
         if let Some(ref policy) = self.policy {
             return policy.backends();

--- a/linkerd/app/outbound/src/policy.rs
+++ b/linkerd/app/outbound/src/policy.rs
@@ -14,6 +14,25 @@ pub struct Policy {
     pub policy: cache::Cached<Receiver>,
 }
 
+// === impl Policy ===
+
+impl Policy {
+    pub fn backends(&self) -> Vec<Backend> {
+        self.policy.borrow().backends.clone()
+    }
+
+    pub fn backend_stream(&self) -> split::BackendStream {
+        let mut rx = self.policy.clone();
+        let stream = async_stream::stream! {
+            while rx.changed().await.is_ok() {
+                let backends = rx.borrow_and_update().backends.clone();
+                yield backends;
+            }
+        };
+        split::BackendStream(Box::pin(stream))
+    }
+}
+
 impl Outbound<()> {
     pub fn build_policies(
         &self,

--- a/linkerd/app/outbound/src/policy.rs
+++ b/linkerd/app/outbound/src/policy.rs
@@ -17,7 +17,7 @@ pub struct Policy {
 // === impl Policy ===
 
 impl Policy {
-    pub fn backends(&self) -> Vec<Backend> {
+    pub fn backends(&self) -> Vec<split::Backend> {
         self.policy.borrow().backends.clone()
     }
 

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -142,6 +142,7 @@ mod tests {
         });
         let logical = Logical {
             profile: rx.into(),
+            policy: None,
             logical_addr: logical_addr.clone(),
             protocol: (),
             orig_dst: OrigDstAddr(ep_addr),
@@ -205,6 +206,7 @@ mod tests {
             ..Default::default()
         });
         let logical = Logical {
+            policy: None,
             profile: rx.into(),
             logical_addr: logical_addr.clone(),
             protocol: (),

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -1,7 +1,7 @@
 use super::{Concrete, Endpoint, Logical};
-use crate::{endpoint, resolve, Outbound};
+use crate::{endpoint, policy, resolve, Outbound};
 use linkerd_app_core::{
-    config, drain, io, profiles,
+    config, drain, io,
     proxy::{
         api_resolve::{ConcreteAddr, Metadata},
         core::Resolve,
@@ -90,7 +90,7 @@ impl<C> Outbound<C> {
                 .push_map_target(Concrete::from)
                 .push(svc::ArcNewService::layer())
                 .check_new_service::<(ConcreteAddr, Logical), I>()
-                .push(profiles::split::layer())
+                .push(policy::split::layer())
                 .push_on_service(
                     svc::layers()
                         .push(

--- a/linkerd/client-policy/Cargo.toml
+++ b/linkerd/client-policy/Cargo.toml
@@ -15,17 +15,25 @@ proto = [
 ]
 
 [dependencies]
+async-stream = "0.3.1"
+futures = "0.3"
 http = "0.2"
+indexmap = "1"
 linkerd-addr = { path = "../addr" }
+linkerd-error = { path = "../error" }
 linkerd-http-route = { path = "../http-route" }
+linkerd-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd-policy-core = { path = "../policy-core" }
+linkerd-stack = { path = "../stack" }
 once_cell = "1"
 prost-types = { version = "0.11", optional = true }
+rand = { version = "0.8", features = ["small_rng"] }
+thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
-tokio-stream = { version = "0.1", features = ["sync"] }
+# tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = { version = "0.8", default-features = false }
 tower = { version = "0.4.13", features = ["ready-cache", "retry", "util"] }
-thiserror = "1"
+tracing = "0.1.37"
 
 [dependencies.linkerd2-proxy-api]
 version = "0.7"

--- a/linkerd/client-policy/src/http.rs
+++ b/linkerd/client-policy/src/http.rs
@@ -29,7 +29,7 @@ pub fn default() -> Route {
 #[cfg(feature = "proto")]
 pub mod proto {
     use super::*;
-    use crate::{meta::proto::InvalidMeta, proto::InvalidBackend, Backend, Meta};
+    use crate::{meta::proto::InvalidMeta, proto::InvalidBackend, split::Backend, Meta};
     use linkerd2_proxy_api::outbound as api;
     use linkerd_http_route::http::r#match::{
         host::proto::InvalidHostMatch, proto::InvalidRouteMatch,

--- a/linkerd/client-policy/src/split.rs
+++ b/linkerd/client-policy/src/split.rs
@@ -1,4 +1,4 @@
-use crate::{Backend, LogicalAddr};
+use crate::LogicalAddr;
 use futures::{prelude::*, ready};
 use indexmap::IndexSet;
 use linkerd_addr::{Addr, NameAddr};
@@ -39,6 +39,13 @@ pub struct Split<T, N, S, Req> {
     addrs: IndexSet<NameAddr>,
     services: ReadyCache<NameAddr, S, Req>,
 }
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Backend {
+    pub weight: u32,
+    pub addr: Addr,
+}
+
 pub struct BackendStream(pub Pin<Box<dyn Stream<Item = Vec<Backend>> + Send + Sync + 'static>>);
 
 // === impl NewSplit ===

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -16,6 +16,7 @@ http = "0.2"
 http-body = "0.4"
 indexmap = "1"
 linkerd-addr = { path = "../addr" }
+linkerd-client-policy = { path = "../client-policy" }
 linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }
 linkerd-http-box = { path = "../http-box" }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -10,6 +10,7 @@ Implements client layers for Linkerd ServiceProfiles.
 """
 
 [dependencies]
+async-stream = "0.3.1"
 bytes = "1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -3,8 +3,8 @@
 
 use futures::Stream;
 use linkerd_addr::Addr;
+use linkerd_client_policy::split;
 pub use linkerd_client_policy::LogicalAddr;
-use linkerd_client_policy::{split, Backend};
 use linkerd_error::Error;
 use linkerd_proxy_api_resolve::Metadata;
 use linkerd_stack::Param;
@@ -42,7 +42,7 @@ struct ReceiverStream {
 pub struct Profile {
     pub addr: Option<LogicalAddr>,
     pub http_routes: Vec<(self::http::RequestMatch, self::http::Route)>,
-    pub targets: Vec<Backend>,
+    pub targets: Vec<split::Backend>,
     pub opaque_protocol: bool,
     pub endpoint: Option<(SocketAddr, Metadata)>,
 }
@@ -115,8 +115,8 @@ where
 
 // === impl Profile ===
 
-impl Param<Vec<Backend>> for Profile {
-    fn param(&self) -> Vec<Backend> {
+impl Param<Vec<split::Backend>> for Profile {
+    fn param(&self) -> Vec<split::Backend> {
         self.targets.clone()
     }
 }
@@ -141,7 +141,7 @@ impl Receiver {
     pub fn endpoint(&self) -> Option<(SocketAddr, Metadata)> {
         self.inner.borrow().endpoint.clone()
     }
-    pub fn backends(&self) -> Vec<Backend> {
+    pub fn backends(&self) -> Vec<split::Backend> {
         self.inner.borrow().targets.clone()
     }
 

--- a/linkerd/service-profiles/src/proto.rs
+++ b/linkerd/service-profiles/src/proto.rs
@@ -1,4 +1,4 @@
-use crate::{http, Backend, LogicalAddr, Profile};
+use crate::{http, split::Backend, LogicalAddr, Profile};
 use linkerd2_proxy_api::destination as api;
 use linkerd_addr::NameAddr;
 use linkerd_dns_name::Name;

--- a/linkerd/service-profiles/src/proto.rs
+++ b/linkerd/service-profiles/src/proto.rs
@@ -1,4 +1,4 @@
-use crate::{http, LogicalAddr, Profile, Target};
+use crate::{http, Backend, LogicalAddr, Profile};
 use linkerd2_proxy_api::destination as api;
 use linkerd_addr::NameAddr;
 use linkerd_dns_name::Name;
@@ -54,12 +54,12 @@ fn convert_route(
     Some((req_match, route))
 }
 
-fn convert_dst_override(orig: api::WeightedDst) -> Option<Target> {
+fn convert_dst_override(orig: api::WeightedDst) -> Option<Backend> {
     if orig.weight == 0 {
         return None;
     }
-    let addr = NameAddr::from_str(orig.authority.as_str()).ok()?;
-    Some(Target {
+    let addr = NameAddr::from_str(orig.authority.as_str()).ok()?.into();
+    Some(Backend {
         addr,
         weight: orig.weight,
     })


### PR DESCRIPTION
Depends on #1992

This branch adds a very rough implementation of traffic splitting based
on client policy backends.

Client policy traffic splitting is implemented by moving the existing
traffic split implementation into the `linkerd-client-policy` crate, and
changing it to operate on the `Backend` type. The `Target` struct stored
in a ServiceProfile are replaced with the `Backend` type, so that the
same traffic split layer can work with a list of backends provided by
either a client policy or a ServiceProfile. The `Logical` target type
has a new impl of `Param<Vec<Backend>>` and `Param<BackendStream>` that
chooses whether to return backends from the client policy discovery or
the ServiceProfile based on whether or not a client policy was
discovered for that logical destination.

This could use some polish, and some cases aren't yet implemented
(client policy backends may be either a named address _or_ a direct
endpoint address, which is not supported by ServiceProfiles, so we'll
need to add additional switching code to handle that case). However,
this should be a decent working steelthread.