### PR TITLE
implement traffic splitting on client policy HTTPRoutes

### DIFF
--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -226,6 +226,6 @@ impl Param<Vec<policy::split::Backend>> for PolicyRoute {
 
 impl Param<LogicalAddr> for PolicyRoute {
     fn param(&self) -> LogicalAddr {
-        self.logical.logical_addr
+        self.logical.logical_addr.clone()
     }
 }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -1,4 +1,4 @@
-use super::{retry, CanonicalDstHeader, Concrete, Endpoint, Logical, ProfileRoute};
+use super::{retry, CanonicalDstHeader, Concrete, Endpoint, Logical, PolicyRoute, ProfileRoute};
 use crate::{
     endpoint,
     policy::{self, Policy},
@@ -124,6 +124,7 @@ impl<E> Outbound<E> {
             // When the split is in failfast, spawn the service in a background
             // task so it becomes ready without new requests.
             let logical = concrete
+                .clone()
                 .check_new_service::<(ConcreteAddr, Logical), _>()
                 .push(policy::split::NewDynamicSplit::layer())
                 .push_on_service(
@@ -188,14 +189,37 @@ impl<E> Outbound<E> {
                 )
                 .push(profiles::http::NewServiceRouter::layer());
 
+            // for now, the client-policy route stack is just a fixed traffic split
+            let policy_route = concrete
+                .check_new_service::<(ConcreteAddr, Logical), _>()
+                .push_map_target(|(concrete, PolicyRoute { route: _, logical }): (ConcreteAddr, PolicyRoute)| {
+                    (concrete, logical)
+                })
+                .push(policy::split::layer())
+                .push_on_service(
+                    svc::layers()
+                        .push(svc::layer::mk(svc::SpawnReady::new))
+                        .push(
+                            rt.metrics
+                                .proxy
+                                .stack
+                                .layer(stack_labels("http", "HTTPRoute")),
+                        )
+                        .push(svc::FailFast::layer("HTTPRoute", dispatch_timeout))
+                        .push_spawn_buffer(buffer_capacity),
+                )
+                .check_new_service::<PolicyRoute, http::Request<_>>();
+
                 let policy = logical
-                    .check_new_service::<Logical, http::Request<_>>()
-                    .push_map_target(|(route, logical): (Option<policy::RoutePolicy>, Logical)| {
-                        // for now, just log the route policy
-                        tracing::info!(?route);
-                        // TODO(eliza): actually apply route policies
-                        logical
-                    })
+                    .push_switch(
+                        |(route, logical): (Option<policy::RoutePolicy>, Logical)| -> Result<_, Infallible> {
+                            match route {
+                                None => Ok(svc::Either::A(logical)),
+                                Some(route) => Ok(svc::Either::B(PolicyRoute { route, logical })),
+                            }
+                        },
+                        policy_route,
+                    )
                     .check_new_service::<(Option<policy::RoutePolicy>, Logical), http::Request<_>>()
                     .push(policy::http::NewServiceRouter::layer())
                     .push_map_target(|(policy, logical): (Policy, Logical)| {

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -208,7 +208,7 @@ impl<E> Outbound<E> {
                         .push(svc::FailFast::layer("HTTPRoute", dispatch_timeout))
                         .push_spawn_buffer(buffer_capacity),
                 )
-                .check_new_service::<PolicyRoute, http::Request<_>>();
+                .check_new_clone::<PolicyRoute>();
 
                 let policy = logical
                     .push_switch(

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -125,7 +125,7 @@ impl<E> Outbound<E> {
             // task so it becomes ready without new requests.
             let logical = concrete
                 .check_new_service::<(ConcreteAddr, Logical), _>()
-                .push(policy::split::layer())
+                .push(policy::split::NewDynamicSplit::layer())
                 .push_on_service(
                     svc::layers()
                         .push(svc::layer::mk(svc::SpawnReady::new))

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -90,7 +90,7 @@ impl<C> Outbound<C> {
                 .push_map_target(Concrete::from)
                 .push(svc::ArcNewService::layer())
                 .check_new_service::<(ConcreteAddr, Logical), I>()
-                .push(policy::split::layer())
+                .push(policy::split::NewDynamicSplit::layer())
                 .push_on_service(
                     svc::layers()
                         .push(

--- a/linkerd/client-policy/src/split.rs
+++ b/linkerd/client-policy/src/split.rs
@@ -62,6 +62,15 @@ where
     }
 }
 
+impl<N: Clone, S, Req> Clone for NewSplit<N, S, Req> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _service: PhantomData,
+        }
+    }
+}
+
 // === impl Split ===
 
 impl<S, Req> Split<S, Req> {

--- a/linkerd/client-policy/src/split.rs
+++ b/linkerd/client-policy/src/split.rs
@@ -13,7 +13,8 @@ use std::{
     task::{Context, Poll},
 };
 use tower::ready_cache::ReadyCache;
-use tracing::{debug, trace};
+mod dynamic;
+pub use self::dynamic::*;
 
 pub fn layer<N, S, Req>() -> impl layer::Layer<N, Service = NewSplit<N, S, Req>> + Clone {
     // This RNG doesn't need to be cryptographically secure. Small and fast is
@@ -24,17 +25,15 @@ pub fn layer<N, S, Req>() -> impl layer::Layer<N, Service = NewSplit<N, S, Req>>
     })
 }
 
+/// A fixed (non-updating) traffic split.
 #[derive(Debug)]
 pub struct NewSplit<N, S, Req> {
     inner: N,
     _service: PhantomData<fn(Req) -> S>,
 }
 
-pub struct Split<T, N, S, Req> {
+pub struct Split<S, Req> {
     rng: SmallRng,
-    stream: Pin<Box<dyn Stream<Item = Vec<Backend>> + Send + Sync + 'static>>,
-    target: T,
-    new_service: N,
     distribution: WeightedIndex<u32>,
     addrs: IndexSet<NameAddr>,
     services: ReadyCache<NameAddr, S, Req>,
@@ -46,30 +45,36 @@ pub struct Backend {
     pub addr: Addr,
 }
 
-pub struct BackendStream(pub Pin<Box<dyn Stream<Item = Vec<Backend>> + Send + Sync + 'static>>);
-
 // === impl NewSplit ===
-
-impl<N: Clone, S, Req> Clone for NewSplit<N, S, Req> {
-    fn clone(&self) -> Self {
-        Self {
-            inner: self.inner.clone(),
-            _service: self._service,
-        }
-    }
-}
 
 impl<T, N, S, Req> NewService<T> for NewSplit<N, S, Req>
 where
-    T: Clone + Param<LogicalAddr> + Param<Vec<Backend>> + Param<BackendStream>,
+    T: Clone + Param<LogicalAddr> + Param<Vec<Backend>>,
     N: NewService<(ConcreteAddr, T), Service = S> + Clone,
     S: tower::Service<Req>,
     S::Error: Into<Error>,
 {
-    type Service = Split<T, N, S, Req>;
+    type Service = Split<S, Req>;
 
     fn new_service(&self, target: T) -> Self::Service {
-        let mut backends: Vec<Backend> = target.param();
+        let backends: Vec<Backend> = target.param();
+        Split::new(backends, &self.inner, target)
+    }
+}
+
+// === impl Split ===
+
+impl<S, Req> Split<S, Req> {
+    fn new<T>(
+        mut backends: Vec<Backend>,
+        new_service: &impl NewService<(ConcreteAddr, T), Service = S>,
+        target: T,
+    ) -> Self
+    where
+        S: tower::Service<Req>,
+        S::Error: Into<Error>,
+        T: Param<LogicalAddr> + Clone,
+    {
         if backends.is_empty() {
             let LogicalAddr(addr) = target.param();
             backends.push(Backend {
@@ -77,12 +82,11 @@ where
                 weight: 1,
             })
         }
-        trace!(?backends, "Building split service");
+        tracing::trace!(?backends, "Building split service");
 
         let mut addrs = IndexSet::with_capacity(backends.len());
         let mut weights = Vec::with_capacity(backends.len());
         let mut services = ReadyCache::default();
-        let new_service = self.inner.clone();
         for Backend { weight, addr } in backends.into_iter() {
             match addr {
                 Addr::Name(addr) => {
@@ -97,12 +101,7 @@ where
             }
         }
 
-        let BackendStream(stream) = target.param();
-
-        Split {
-            stream,
-            target,
-            new_service,
+        Self {
             services,
             addrs,
             distribution: WeightedIndex::new(weights).unwrap(),
@@ -111,13 +110,9 @@ where
     }
 }
 
-// === impl Split ===
-
-impl<T, N, S, Req> tower::Service<Req> for Split<T, N, S, Req>
+impl<S, Req> tower::Service<Req> for Split<S, Req>
 where
     Req: Send + 'static,
-    T: Clone + Param<LogicalAddr>,
-    N: NewService<(ConcreteAddr, T), Service = S> + Clone,
     S: tower::Service<Req> + Send + 'static,
     S::Response: Send + 'static,
     S::Error: Into<Error>,
@@ -128,60 +123,6 @@ where
     type Future = Pin<Box<dyn Future<Output = Result<S::Response, Error>> + Send + 'static>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        let mut update = None;
-        while let Poll::Ready(Some(up)) = self.stream.poll_next_unpin(cx) {
-            update = Some(up);
-        }
-
-        // Every time the profile updates, rebuild the distribution, reusing
-        // services that existed in the prior state.
-        if let Some(mut backends) = update {
-            if backends.is_empty() {
-                let LogicalAddr(addr) = self.target.param();
-                backends.push(Backend {
-                    addr: addr.into(),
-                    weight: 1,
-                })
-            }
-            debug!(?backends, "Updating");
-
-            // Replace the old set of addresses with an empty set. The
-            // prior set is used to determine whether a new service
-            // needs to be created and what stale services should be
-            // removed.
-            let mut prior_addrs =
-                std::mem::replace(&mut self.addrs, IndexSet::with_capacity(backends.len()));
-            let mut weights = Vec::with_capacity(backends.len());
-
-            // Create an updated distribution and set of services.
-            for Backend { weight, addr } in backends.into_iter() {
-                let addr = match addr {
-                    Addr::Name(addr) => addr,
-                    Addr::Socket(_) => todo!("eliza: update splits to handle WeightedEndpoints"),
-                };
-                // Reuse the prior services whenever possible.
-                if !prior_addrs.remove(&addr) {
-                    debug!(%addr, "Creating backend");
-                    let svc = self
-                        .new_service
-                        .new_service((ConcreteAddr(addr.clone()), self.target.clone()));
-                    self.services.push(addr.clone(), svc);
-                } else {
-                    trace!(%addr, "Backend already exists");
-                }
-                self.addrs.insert(addr);
-                weights.push(weight);
-            }
-
-            self.distribution = WeightedIndex::new(weights).unwrap();
-
-            // Remove all prior services that did not exist in the new
-            // set of targets.
-            for addr in prior_addrs.into_iter() {
-                self.services.evict(&addr);
-            }
-        }
-
         // Wait for all target services to be ready. If any services fail, then
         // the whole service fails.
         Poll::Ready(ready!(self.services.poll_pending(cx)).map_err(Into::into))
@@ -194,7 +135,7 @@ where
             self.distribution.sample(&mut self.rng)
         };
         let addr = self.addrs.get_index(idx).expect("invalid index");
-        trace!(?addr, "Dispatching");
+        tracing::trace!(?addr, "Dispatching");
         Box::pin(self.services.call_ready(addr, req).err_into::<Error>())
     }
 }

--- a/linkerd/client-policy/src/split/dynamic.rs
+++ b/linkerd/client-policy/src/split/dynamic.rs
@@ -1,0 +1,156 @@
+use super::{Backend, Split};
+use crate::LogicalAddr;
+use futures::prelude::*;
+use indexmap::IndexSet;
+use linkerd_addr::Addr;
+use linkerd_error::Error;
+use linkerd_proxy_api_resolve::ConcreteAddr;
+use linkerd_stack::{layer, NewService, Param};
+use rand::distributions::WeightedIndex;
+use std::{
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tracing::{debug, trace};
+
+pub struct BackendStream(pub Pin<Box<dyn Stream<Item = Vec<Backend>> + Send + Sync + 'static>>);
+
+/// Builds dynamically updated traffic splits.
+#[derive(Debug)]
+pub struct NewDynamicSplit<N, S, Req> {
+    inner: N,
+    _service: PhantomData<fn(Req) -> S>,
+}
+
+pub struct DynamicSplit<T, N, S, Req> {
+    stream: Pin<Box<dyn Stream<Item = Vec<Backend>> + Send + Sync + 'static>>,
+    target: T,
+    new_service: N,
+    split: Split<S, Req>,
+}
+
+// === impl NewDynamicSplit ===
+
+impl<N: Clone, S, Req> Clone for NewDynamicSplit<N, S, Req> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _service: self._service,
+        }
+    }
+}
+
+impl<N, S, Req> NewDynamicSplit<N, S, Req> {
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Clone {
+        // This RNG doesn't need to be cryptographically secure. Small and fast is
+        // preferable.
+        layer::mk(move |inner| NewDynamicSplit {
+            inner,
+            _service: PhantomData,
+        })
+    }
+}
+
+impl<T, N, S, Req> NewService<T> for NewDynamicSplit<N, S, Req>
+where
+    T: Clone + Param<LogicalAddr> + Param<Vec<Backend>> + Param<BackendStream>,
+    N: NewService<(ConcreteAddr, T), Service = S> + Clone,
+    S: tower::Service<Req>,
+    S::Error: Into<Error>,
+{
+    type Service = DynamicSplit<T, N, S, Req>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let backends: Vec<Backend> = target.param();
+        let split = Split::new(backends, &self.inner, target.clone());
+        let BackendStream(stream) = target.param();
+        DynamicSplit {
+            stream,
+            target,
+            new_service: self.inner.clone(),
+            split,
+        }
+    }
+}
+
+// === impl DynamicSplit ===
+
+impl<T, N, S, Req> tower::Service<Req> for DynamicSplit<T, N, S, Req>
+where
+    Req: Send + 'static,
+    T: Clone + Param<LogicalAddr>,
+    N: NewService<(ConcreteAddr, T), Service = S> + Clone,
+    S: tower::Service<Req> + Send + 'static,
+    S::Response: Send + 'static,
+    S::Error: Into<Error>,
+    S::Future: Send,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<S::Response, Error>> + Send + 'static>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let mut update = None;
+        while let Poll::Ready(Some(up)) = self.stream.poll_next_unpin(cx) {
+            update = Some(up);
+        }
+
+        // Every time the profile updates, rebuild the distribution, reusing
+        // services that existed in the prior state.
+        if let Some(mut backends) = update {
+            if backends.is_empty() {
+                let LogicalAddr(addr) = self.target.param();
+                backends.push(Backend {
+                    addr: addr.into(),
+                    weight: 1,
+                })
+            }
+            debug!(?backends, "Updating");
+
+            // Replace the old set of addresses with an empty set. The
+            // prior set is used to determine whether a new service
+            // needs to be created and what stale services should be
+            // removed.
+            let mut prior_addrs = std::mem::replace(
+                &mut self.split.addrs,
+                IndexSet::with_capacity(backends.len()),
+            );
+            let mut weights = Vec::with_capacity(backends.len());
+
+            // Create an updated distribution and set of services.
+            for Backend { weight, addr } in backends.into_iter() {
+                let addr = match addr {
+                    Addr::Name(addr) => addr,
+                    Addr::Socket(_) => todo!("eliza: update splits to handle WeightedEndpoints"),
+                };
+                // Reuse the prior services whenever possible.
+                if !prior_addrs.remove(&addr) {
+                    debug!(%addr, "Creating backend");
+                    let svc = self
+                        .new_service
+                        .new_service((ConcreteAddr(addr.clone()), self.target.clone()));
+                    self.split.services.push(addr.clone(), svc);
+                } else {
+                    trace!(%addr, "Backend already exists");
+                }
+                self.split.addrs.insert(addr);
+                weights.push(weight);
+            }
+
+            self.split.distribution = WeightedIndex::new(weights).unwrap();
+
+            // Remove all prior services that did not exist in the new
+            // set of targets.
+            for addr in prior_addrs.into_iter() {
+                self.split.services.evict(&addr);
+            }
+        }
+
+        self.split.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        self.split.call(req)
+    }
+}


### PR DESCRIPTION
Depends on #2029

This branch builds on #2021 and #2029 to implement traffic splitting
based on client policy HTTPRoute backends. This is everything necessary
to implement header-based routing using HTTPRoutes, by creating a route
that matches a header and routes to a different `backendRef`. In
addition, this means that we can also now do other forms of traffic
splitting (such as weights) with a HTTPRoute, as well.

The implementation here is pretty straightforward. Currently, the
traffic split middleware that's used for ServiceProfile traffic splits
(and for the top-level list of backends in a client policy lookup, which
are currently not used by the control plane) requires dynamically
updating the split service when the set of backends in the traffic split
changes. In the per-HTTPRoute case, however, this is not necessary, as
the set of HTTPRoutes is being watched by the client policy router, and
the whole stack for a route will be torn down and rebuilt if that
route's definition changes. Therefore, I've factored out the fixed
component of the traffic split (just shifting traffic across a weighted
distribution of services) from the dynamically updating component, so
that the client policy HTTPRoute traffic split can just build and
destroy fixed split middlewares. The dynamically changing traffic split
middleware is now implemented by mutating an inner fixed split
middleware.