### PR TITLE
move client policy discovery out of HTTP logical stack

### DIFF
--- a/linkerd/app/gateway/src/gateway.rs
+++ b/linkerd/app/gateway/src/gateway.rs
@@ -99,7 +99,6 @@ where
                 profile,
                 protocol: http.version,
                 logical_addr,
-                orig_dst: todo!("eliza: fix this"),
             }));
 
         Gateway::new(svc, http.target, local_id)

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -1,19 +1,37 @@
-use crate::Outbound;
+use crate::{policy, Outbound};
 use linkerd_app_core::{
     io, profiles,
     svc::{self, stack::Param},
     transport::OrigDstAddr,
-    Error,
+    Error, Infallible,
 };
 use tracing::debug;
+
+#[derive(Debug, Clone)]
+pub struct Discovered<T> {
+    pub profile: Option<profiles::Receiver>,
+    pub policy: Option<policy::Policy>,
+    pub target: T,
+}
+
+impl<T> svc::Param<OrigDstAddr> for Discovered<T>
+where
+    T: svc::Param<OrigDstAddr>,
+{
+    #[inline]
+    fn param(&self) -> OrigDstAddr {
+        self.target.param()
+    }
+}
 
 impl<N> Outbound<N> {
     /// Discovers the profile for a TCP endpoint.
     ///
     /// Resolved services are cached and buffered.
-    pub fn push_discover<T, I, NSvc, P>(
+    pub fn push_discover<T, I, NSvc, P, C>(
         self,
         profiles: P,
+        policies: C,
     ) -> Outbound<
         svc::ArcNewService<
             T,
@@ -24,17 +42,57 @@ impl<N> Outbound<N> {
         T: Param<OrigDstAddr>,
         T: Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
-        N: svc::NewService<(Option<profiles::Receiver>, T), Service = NSvc>,
+        N: svc::NewService<Discovered<T>, Service = NSvc>,
         N: Clone + Send + Sync + 'static,
         NSvc: svc::Service<I, Response = (), Error = Error> + Send + 'static,
         NSvc::Future: Send,
         P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + 'static,
         P::Future: Send,
         P::Error: Send,
+        C: svc::Service<OrigDstAddr, Response = policy::Receiver>,
+        C: Clone + Send + Sync + 'static,
+        C::Future: Send,
+        Error: From<C::Error>,
     {
         self.map_stack(|config, rt, inner| {
             let allow = config.allow_discovery.clone();
+            let cache_max_idle_age = config.proxy.cache_max_idle_age;
+
+            // discovers client policies for targets.
+            let policy = inner
+                .clone()
+                .push_map_target(|(policy, discovered)| Discovered {
+                    policy: Some(policy),
+                    ..discovered
+                })
+                .push(policy::Discover::layer(policies, cache_max_idle_age))
+                // policies must be resolved before the logical stack can be
+                // built, so the policy layer is a `MakeService`. drive the
+                // initial resolution via the service's readiness here.
+                .into_new_service()
+                .check_new_service::<Discovered<T>, _>();
+
             inner
+                .push_switch(
+                    |(profile, target): (Option<profiles::Receiver>, T)| -> Result<_, Infallible> {
+                        // if a profile was discovered, also attempt client
+                        // policy discovery.
+                        if profile.is_some() {
+                            Ok(svc::Either::B(Discovered {
+                                target,
+                                profile,
+                                policy: None,
+                            }))
+                        } else {
+                            Ok(svc::Either::A(Discovered {
+                                target,
+                                profile: None,
+                                policy: None,
+                            }))
+                        }
+                    },
+                    policy,
+                )
                 .push(profiles::discover::layer(profiles, move |t: T| {
                     let OrigDstAddr(addr) = t.param();
                     if allow.matches_ip(addr.ip()) {
@@ -117,12 +175,17 @@ mod tests {
         };
 
         let profiles = support::profile::resolver().profile(addr, profiles::Profile::default());
+        let client_policy = svc::mk(|_| {
+            let (_, rx) =
+                tokio::sync::watch::channel(linkerd_client_policy::ClientPolicy::default());
+            future::ok::<_, Error>(rx)
+        });
 
         // Create a profile stack that uses the tracked inner stack.
         let (rt, _shutdown) = runtime();
         let stack = Outbound::new(default_config(), rt)
             .with_stack(stack)
-            .push_discover(profiles)
+            .push_discover(profiles, client_policy)
             .into_inner();
 
         assert_eq!(
@@ -184,6 +247,11 @@ mod tests {
         };
 
         let profiles = support::profile::resolver().profile(addr, profiles::Profile::default());
+        let client_policy = svc::mk(|_| {
+            let (_, rx) =
+                tokio::sync::watch::channel(linkerd_client_policy::ClientPolicy::default());
+            future::ok::<_, Error>(rx)
+        });
 
         // Create a profile stack that uses the tracked inner stack, configured to drop cached
         // service after `idle_timeout`.
@@ -195,7 +263,7 @@ mod tests {
         let (rt, _shutdown) = runtime();
         let stack = Outbound::new(cfg, rt)
             .with_stack(stack)
-            .push_discover(profiles)
+            .push_discover(profiles, client_policy)
             .into_inner();
 
         assert_eq!(
@@ -295,10 +363,21 @@ mod tests {
         // doesn't support that right now. So, instead, we return a profile for resolutions to
         // and assert (below) that no profile is provided.
         let profiles = support::profile::resolver().profile(addr, profiles::Profile::default());
+        let client_policy = svc::mk(|_| -> future::Ready<Result<policy::Receiver, Error>> {
+            panic!("if no profile is resolved, a client policy should also not be resolved");
+        });
 
         // Mock an inner stack with a service that asserts that no profile is built.
-        let stack = |(profile, _): (Option<profiles::Receiver>, _)| {
+        let stack = |Discovered {
+                         target: _,
+                         profile,
+                         policy,
+                     }| {
             assert!(profile.is_none(), "profile must not resolve");
+            assert!(
+                policy.is_none(),
+                "if no profile is resolved, client policy should not be resolved"
+            );
             svc::mk(move |_: io::DuplexStream| future::ok::<(), Error>(()))
         };
 
@@ -315,7 +394,7 @@ mod tests {
         let (rt, _shutdown) = runtime();
         let stack = Outbound::new(cfg, rt)
             .with_stack(stack)
-            .push_discover(profiles)
+            .push_discover(profiles, client_policy)
             .into_inner();
 
         // Instantiate a service from the stack so that it instantiates the tracked inner service.

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -80,7 +80,6 @@ impl From<(Version, tcp::Logical)> for Logical {
             policy: logical.policy,
             profile: logical.profile,
             logical_addr: logical.logical_addr,
-            orig_dst: logical.orig_dst,
         }
     }
 }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -1,9 +1,5 @@
 use super::{retry, CanonicalDstHeader, Concrete, Endpoint, Logical, PolicyRoute, ProfileRoute};
-use crate::{
-    endpoint,
-    policy::{self, Policy},
-    resolve, stack_labels, Outbound,
-};
+use crate::{endpoint, policy, resolve, stack_labels, Outbound};
 use linkerd_app_core::{
     classify, config, profiles,
     proxy::{
@@ -12,18 +8,12 @@ use linkerd_app_core::{
         http,
         resolve::map_endpoint,
     },
-    svc,
-    transport::OrigDstAddr,
-    Error, Infallible,
+    svc, Error, Infallible,
 };
 use tracing::debug_span;
 
 impl<E> Outbound<E> {
-    pub fn push_http_logical<ESvc, R, P>(
-        self,
-        resolve: R,
-        policies: P,
-    ) -> Outbound<svc::ArcNewHttp<Logical>>
+    pub fn push_http_logical<ESvc, R>(self, resolve: R) -> Outbound<svc::ArcNewHttp<Logical>>
     where
         E: svc::NewService<Endpoint, Service = ESvc> + Clone + Send + Sync + 'static,
         ESvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
@@ -35,10 +25,6 @@ impl<E> Outbound<E> {
         R: Clone + Send + Sync + 'static,
         R::Resolution: Send,
         R::Future: Send + Unpin,
-        P: svc::Service<OrigDstAddr, Response = policy::Receiver>,
-        P: Clone + Send + Sync + 'static,
-        P::Future: Send,
-        Error: From<P::Error>,
     {
         self.map_stack(|config, rt, endpoint| {
             let config::ProxyConfig {
@@ -222,46 +208,29 @@ impl<E> Outbound<E> {
                     )
                     .check_new_service::<(Option<policy::RoutePolicy>, Logical), http::Request<_>>()
                     .push(policy::http::NewServiceRouter::layer())
-                    .push_map_target(|(policy, logical): (Policy, Logical)| {
+                    .push_map_target(|logical: Logical| {
                         // for now, just log the client policy rather than actually
                         // doing anything...
-                        tracing::info!(?logical, ?policy);
-                        // Add the discovered policy to the logical target
-                        Logical {
-                            policy: Some(policy),
-                            ..logical
-                        }
+                        tracing::info!(dst = ?logical.logical_addr, policy = ?logical.policy);
+                        logical
+
                     })
-                    .instrument(|(policy, _): &(Policy, Logical)| debug_span!("policy", addr = %policy.dst))
-                    .check_new_service::<(Policy, Logical), http::Request<_>>();
+                    .instrument(|_: &Logical| debug_span!("policy"))
+                    .check_new_service::<Logical, http::Request<_>>();
 
                 let logical = policy.push_switch(
-                    |(policy, logical): (Policy, Logical)| -> Result<_, Infallible> {
-                        let is_empty = {
-                            let policy = policy.policy.borrow();
-                            policy.http_routes.is_empty() && policy.backends.is_empty()
-                        };
-                        if is_empty {
-                            // No client policy is defined for this destination,
-                            // so continue with the service profile stack.
-                            return Ok(svc::Either::B(logical));
+                    |logical: Logical| -> Result<_, Infallible> {
+                        if logical.policy.is_some() {
+                            Ok(svc::Either::A(logical))
+                        } else {
+                            Ok(svc::Either::B(logical))
                         }
-
-                        Ok(svc::Either::A((policy, logical)))
                     },
                     profile_route,
                 )
-                .check_new_service::<(Policy, Logical), http::Request<_>>();
+                .check_new_service::<Logical, http::Request<_>>();
 
                 logical
-                    // discover client policies for the original destination address
-                    .push(policy::Discover::layer(policies, cache_max_idle_age))
-                    .check_make_service::<Logical, http::Request<_>>()
-                    // policies must be resolved before the logical stack can be
-                    // built, so the policy layer is a `MakeService`. drive the
-                    // initial resolution via the service's readiness here.
-                    .into_new_service()
-                    .check_new_service::<Logical, _>()
                     // Strips headers that may be set by this proxy and add an
                     // outbound canonical-dst-header. The response body is boxed
                     // unify the profile stack's response type with that of to

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -202,10 +202,10 @@ impl Outbound<()> {
         O::Future: Send,
         Error: From<O::Error>,
     {
-        let logical = self.to_tcp_connect().push_logical(resolve, policies);
+        let logical = self.to_tcp_connect().push_logical(resolve);
         let endpoint = self.to_tcp_connect().push_endpoint();
         endpoint
-            .push_switch_logical(logical.into_inner())
+            .push_switch_logical(logical.into_inner(), policies)
             .push_discover(profiles)
             .push_tcp_instrument(|t: &T| info_span!("proxy", addr = %t.param()))
             .into_inner()
@@ -246,10 +246,10 @@ impl Outbound<()> {
                 .to_tcp_connect()
                 // TODO(eliza): this should share the same policy cache...figure
                 // that out...
-                .push_logical(resolve.clone(), policies.clone());
+                .push_logical(resolve.clone());
             let endpoint = self.to_tcp_connect().push_endpoint();
             endpoint
-                .push_switch_logical(logical.into_inner())
+                .push_switch_logical(logical.into_inner(), policies)
                 .push_discover(profiles.clone())
                 .into_inner()
         };
@@ -257,7 +257,7 @@ impl Outbound<()> {
         self.to_tcp_connect()
             .push_tcp_endpoint()
             .push_http_endpoint()
-            .push_ingress(profiles, resolve, fallback, policies)
+            .push_ingress(profiles, resolve, fallback)
             .push_tcp_instrument(|t: &T| info_span!("ingress", addr = %t.param()))
             .into_inner()
     }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -205,8 +205,8 @@ impl Outbound<()> {
         let logical = self.to_tcp_connect().push_logical(resolve);
         let endpoint = self.to_tcp_connect().push_endpoint();
         endpoint
-            .push_switch_logical(logical.into_inner(), policies)
-            .push_discover(profiles)
+            .push_switch_logical(logical.into_inner())
+            .push_discover(profiles, policies)
             .push_tcp_instrument(|t: &T| info_span!("proxy", addr = %t.param()))
             .into_inner()
     }
@@ -249,8 +249,8 @@ impl Outbound<()> {
                 .push_logical(resolve.clone());
             let endpoint = self.to_tcp_connect().push_endpoint();
             endpoint
-                .push_switch_logical(logical.into_inner(), policies)
-                .push_discover(profiles.clone())
+                .push_switch_logical(logical.into_inner())
+                .push_discover(profiles.clone(), policies)
                 .into_inner()
         };
 

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -1,8 +1,4 @@
-use crate::{
-    http,
-    policy::{self, Policy},
-    tcp, Outbound,
-};
+use crate::{http, policy, tcp, Outbound};
 pub use linkerd_app_core::proxy::api_resolve::ConcreteAddr;
 use linkerd_app_core::{
     io, profiles,
@@ -17,7 +13,7 @@ use std::fmt;
 #[derive(Clone)]
 pub struct Logical<P> {
     pub profile: profiles::Receiver,
-    pub policy: Option<Policy>,
+    pub policy: Option<policy::Receiver>,
     pub logical_addr: LogicalAddr,
     pub protocol: P,
 }
@@ -36,7 +32,7 @@ impl Logical<()> {
     pub(crate) fn new(
         logical_addr: LogicalAddr,
         profile: profiles::Receiver,
-        policy: Option<Policy>,
+        policy: Option<policy::Receiver>,
     ) -> Self {
         Self {
             profile,
@@ -103,8 +99,8 @@ impl svc::Param<Option<http::detect::Skip>> for Logical<()> {
 }
 
 /// Used for client policy
-impl<P> svc::Param<Option<Policy>> for Logical<P> {
-    fn param(&self) -> Option<Policy> {
+impl<P> svc::Param<Option<policy::Receiver>> for Logical<P> {
+    fn param(&self) -> Option<policy::Receiver> {
         self.policy.clone()
     }
 }

--- a/linkerd/app/outbound/src/policy.rs
+++ b/linkerd/app/outbound/src/policy.rs
@@ -1,37 +1,16 @@
 pub use self::{config::Config, discover::Discover};
 use crate::Outbound;
-use linkerd_app_core::{cache, dns, metrics, svc, transport::OrigDstAddr, Error};
+use linkerd_app_core::{
+    dns, metrics,
+    svc::{self, ServiceExt},
+    transport::OrigDstAddr,
+    Error,
+};
 pub use linkerd_client_policy::*;
 pub mod api;
 mod config;
 mod discover;
 pub mod http;
-
-pub type Receiver = tokio::sync::watch::Receiver<ClientPolicy>;
-
-#[derive(Clone, Debug)]
-pub struct Policy {
-    pub policy: cache::Cached<Receiver>,
-}
-
-// === impl Policy ===
-
-impl Policy {
-    pub fn backends(&self) -> Vec<split::Backend> {
-        self.policy.borrow().backends.clone()
-    }
-
-    pub fn backend_stream(&self) -> split::BackendStream {
-        let mut rx = self.policy.clone();
-        let stream = async_stream::stream! {
-            while rx.changed().await.is_ok() {
-                let backends = rx.borrow_and_update().backends.clone();
-                yield backends;
-            }
-        };
-        split::BackendStream(Box::pin(stream))
-    }
-}
 
 impl Outbound<()> {
     pub fn build_policies(
@@ -47,5 +26,6 @@ impl Outbound<()> {
             .policy
             .clone()
             .build(dns, metrics, self.runtime.identity.clone())
+            .map_response(Into::into)
     }
 }

--- a/linkerd/app/outbound/src/policy.rs
+++ b/linkerd/app/outbound/src/policy.rs
@@ -10,7 +10,6 @@ pub use linkerd_client_policy::*;
 pub mod api;
 mod config;
 mod discover;
-pub mod http;
 
 impl Outbound<()> {
     pub fn build_policies(

--- a/linkerd/app/outbound/src/policy.rs
+++ b/linkerd/app/outbound/src/policy.rs
@@ -11,7 +11,6 @@ pub type Receiver = tokio::sync::watch::Receiver<ClientPolicy>;
 
 #[derive(Clone, Debug)]
 pub struct Policy {
-    pub dst: OrigDstAddr,
     pub policy: cache::Cached<Receiver>,
 }
 

--- a/linkerd/app/outbound/src/policy/config.rs
+++ b/linkerd/app/outbound/src/policy/config.rs
@@ -1,4 +1,4 @@
-use super::{api::Api, Receiver};
+use super::{api::Api, ClientPolicy};
 
 use linkerd_app_core::{
     control, dns, identity, metrics,
@@ -7,6 +7,7 @@ use linkerd_app_core::{
     Error,
 };
 use std::sync::Arc;
+use tokio::sync::watch;
 use tower::ServiceExt;
 
 #[derive(Clone, Debug)]
@@ -21,8 +22,12 @@ impl Config {
         dns: dns::Resolver,
         metrics: metrics::ControlHttp,
         identity: identity::NewClient,
-    ) -> impl svc::Service<OrigDstAddr, Response = Receiver, Future = impl Send, Error = Error>
-           + Clone
+    ) -> impl svc::Service<
+        OrigDstAddr,
+        Response = watch::Receiver<ClientPolicy>,
+        Future = impl Send,
+        Error = Error,
+    > + Clone
            + Send
            + Sync
            + 'static {

--- a/linkerd/app/outbound/src/policy/discover.rs
+++ b/linkerd/app/outbound/src/policy/discover.rs
@@ -1,27 +1,19 @@
-use super::{Policy, Receiver};
+use super::Receiver;
 use linkerd_app_core::{
-    cache::Cache,
     svc::{self, stack::Param, NewService},
     transport::OrigDstAddr,
     Error,
 };
 use std::task::{Context, Poll};
-use tokio::time::Duration;
-
 #[derive(Clone)]
 pub struct Discover<S, N> {
-    cache: Cache<OrigDstAddr, Receiver>,
     inner: S,
     new_svc: N,
 }
 
 impl<S: Clone, N> Discover<S, N> {
-    pub(crate) fn layer(
-        inner: S,
-        max_idle_age: Duration,
-    ) -> impl svc::Layer<N, Service = Self> + Clone {
+    pub(crate) fn layer(inner: S) -> impl svc::Layer<N, Service = Self> + Clone {
         svc::layer::mk(move |new_svc| Self {
-            cache: Cache::new(max_idle_age),
             inner: inner.clone(),
             new_svc,
         })
@@ -31,9 +23,9 @@ impl<S: Clone, N> Discover<S, N> {
 impl<S, N, T> svc::Service<T> for Discover<S, N>
 where
     T: Param<OrigDstAddr> + Send + 'static,
-    S: svc::Service<OrigDstAddr, Response = Receiver> + Clone + Send + 'static,
+    S: svc::Service<OrigDstAddr, Response = Receiver> + Send + 'static,
     S::Future: Send,
-    N: NewService<(Policy, T)> + Clone + Send + 'static,
+    N: NewService<(Receiver, T)> + Clone + Send + 'static,
     Error: From<S::Error>,
 {
     type Response = N::Service;
@@ -46,22 +38,10 @@ where
 
     fn call(&mut self, target: T) -> Self::Future {
         let dst = target.param();
-        let cache = self.cache.clone();
-        let mut inner = self.inner.clone();
+        let lookup = self.inner.call(dst);
         let new_svc = self.new_svc.clone();
         Box::pin(async move {
-            // TODO(eliza): we can't just call
-            // `cache.get_or_insert_with(inner.call(dst).await)` because
-            // `Cache::get_or_insert_with` is synchronous, so we have to
-            // await the future separately...it would be nicer to add a
-            // `get_or_insert_async` type method...
-            let policy = if let Some(policy) = cache.get(&dst) {
-                policy
-            } else {
-                let policy = inner.call(dst).await?;
-                cache.get_or_insert_with(dst, |_| policy)
-            };
-            let policy = Policy { policy };
+            let policy = lookup.await?;
             Ok(new_svc.new_service((policy, target)))
         })
     }

--- a/linkerd/app/outbound/src/policy/discover.rs
+++ b/linkerd/app/outbound/src/policy/discover.rs
@@ -61,7 +61,7 @@ where
                 let policy = inner.call(dst).await?;
                 cache.get_or_insert_with(dst, |_| policy)
             };
-            let policy = Policy { dst, policy };
+            let policy = Policy { policy };
             Ok(new_svc.new_service((policy, target)))
         })
     }

--- a/linkerd/app/outbound/src/policy/http/router.rs
+++ b/linkerd/app/outbound/src/policy/http/router.rs
@@ -1,4 +1,4 @@
-use crate::policy::Policy;
+use crate::policy::Receiver;
 use futures::{future::MapErr, FutureExt, TryFutureExt};
 use linkerd_client_policy::{http::Route, RoutePolicy};
 use linkerd_error::Error;
@@ -26,7 +26,7 @@ pub struct NewServiceRouter<N>(N);
 pub struct ServiceRouter<T, N, S> {
     new_route: N,
     target: T,
-    changed: ReusableBoxFuture<'static, Result<Policy, Error>>,
+    changed: ReusableBoxFuture<'static, Result<Receiver, Error>>,
     http_routes: Arc<[Route]>,
     services: HashMap<RoutePolicy, S>,
     default: S,
@@ -42,7 +42,7 @@ impl<N> NewServiceRouter<N> {
 
 impl<T, N> NewService<T> for NewServiceRouter<N>
 where
-    T: Param<Option<Policy>> + Clone,
+    T: Param<Option<Receiver>> + Clone,
     N: NewService<(Option<RoutePolicy>, T)> + Clone,
 {
     type Service = ServiceRouter<T, N, N::Service>;
@@ -54,7 +54,7 @@ where
             // know the policy is there...
             .expect("new service router should only be built when a policy has been discovered");
         let default = self.0.new_service((None, target.clone()));
-        let http_routes = rx.policy.borrow().http_routes.clone();
+        let http_routes = rx.borrow().http_routes.clone();
         let mut router = ServiceRouter {
             default,
             target,
@@ -105,7 +105,7 @@ where
             Poll::Ready(update) => update?,
         };
 
-        let http_routes = policy.policy.borrow_and_update().http_routes.clone();
+        let http_routes = policy.borrow_and_update().http_routes.clone();
 
         // If the routes have been updated, update the cache.
         tracing::debug!(routes = %http_routes.len(), "Updating client policy HTTP routes");
@@ -150,9 +150,8 @@ where
     }
 }
 
-async fn changed(mut policy: Policy) -> Result<Policy, Error> {
+async fn changed(mut policy: Receiver) -> Result<Receiver, Error> {
     policy
-        .policy
         .changed()
         .await
         .map_err(|_| anyhow::anyhow!("client policy watch has closed"))?;

--- a/linkerd/app/outbound/src/switch_logical.rs
+++ b/linkerd/app/outbound/src/switch_logical.rs
@@ -63,8 +63,9 @@ impl<S> Outbound<S> {
                                 let has_client_policy = policy
                                     .as_ref()
                                     .map(|policy| {
-                                        let policy = policy.policy.borrow();
-                                        policy.http_routes.is_empty() && policy.backends.is_empty()
+                                        let policy = policy.borrow();
+                                        !(policy.http_routes.is_empty()
+                                            || policy.backends.is_empty())
                                     })
                                     .unwrap_or(false);
                                 // if the client policy discovered for this

--- a/linkerd/app/outbound/src/switch_logical.rs
+++ b/linkerd/app/outbound/src/switch_logical.rs
@@ -1,19 +1,9 @@
 use crate::{
-    endpoint::Endpoint,
-    logical::Logical,
-    policy::{self, LogicalAddr},
-    tcp,
-    transport::OrigDstAddr,
+    discover::Discovered, endpoint::Endpoint, logical::Logical, tcp, transport::OrigDstAddr,
     Outbound,
 };
-use linkerd_app_core::{io, profiles, svc, Error, Infallible};
+use linkerd_app_core::{io, svc, Error, Infallible};
 use std::fmt;
-
-struct ProfileDiscovered {
-    orig_dst: OrigDstAddr,
-    profile: profiles::Receiver,
-    logical_addr: LogicalAddr,
-}
 
 impl<S> Outbound<S> {
     /// Wraps an endpoint stack to switch to an alternate logical stack when an appropriate profile
@@ -24,11 +14,10 @@ impl<S> Outbound<S> {
     ///   stack is built, including client policy discovery;
     /// - Otherwise, we assume the target is not part of the mesh and we should connect to the
     ///   original destination.
-    pub fn push_switch_logical<T, I, N, P, NSvc, SSvc>(
+    pub fn push_switch_logical<T, I, N, NSvc, SSvc>(
         self,
         logical: N,
-        policies: P,
-    ) -> Outbound<svc::ArcNewTcp<(Option<profiles::Receiver>, T), I>>
+    ) -> Outbound<svc::ArcNewTcp<Discovered<T>, I>>
     where
         Self: Clone + 'static,
         T: svc::Param<OrigDstAddr> + Clone + Send + Sync + 'static,
@@ -39,40 +28,19 @@ impl<S> Outbound<S> {
         S: svc::NewService<tcp::Endpoint, Service = SSvc> + Clone + Send + Sync + 'static,
         SSvc: svc::Service<I, Response = (), Error = Error> + Send + 'static,
         SSvc::Future: Send,
-        P: svc::Service<OrigDstAddr, Response = policy::Receiver>,
-        P: Clone + Send + Sync + 'static,
-        P::Future: Send,
-        Error: From<P::Error>,
     {
         let no_tls_reason = self.no_tls_reason();
         self.map_stack(|config, _, endpoint| {
-            let cache_max_idle_age = config.proxy.cache_max_idle_age;
             let inbound_ips = config.inbound_ips.clone();
-
-            let logical = svc::stack(logical).push_map_target(|(policy, ProfileDiscovered { logical_addr, profile, ..}): (policy::Policy, ProfileDiscovered)| {
-                let is_empty = {
-                    let policy = policy.policy.borrow();
-                    policy.http_routes.is_empty() && policy.backends.is_empty()
-                };
-                if is_empty {
-                    // No client policy is defined for this destination,
-                    // so continue with the service profile stack.
-                    Logical::new(logical_addr, profile, None)
-                } else {
-                    Logical::new(logical_addr, profile, Some(policy))
-                }
-            })
-                // discover client policies for the original destination address
-                .push(policy::Discover::layer(policies, cache_max_idle_age))
-                // policies must be resolved before the logical stack can be
-                // built, so the policy layer is a `MakeService`. drive the
-                // initial resolution via the service's readiness here.
-                .into_new_service()
-                .check_new_service::<ProfileDiscovered, _>();
 
             endpoint
                 .push_switch(
-                    move |(profile, target): (Option<profiles::Receiver>, T)| -> Result<_, Infallible> {
+                    move |Discovered {
+                              target,
+                              profile,
+                              policy,
+                          }: Discovered<T>|
+                          -> Result<_, Infallible> {
                         if let Some(rx) = profile {
                             let is_opaque = rx.is_opaque_protocol();
 
@@ -92,8 +60,21 @@ impl<S> Outbound<S> {
                             // If the profile provides a (named) logical address, then we build a
                             // logical stack so we apply routes, traffic splits, and load balancing.
                             if let Some(logical_addr) = rx.logical_addr() {
-                                tracing::debug!("Profile describes a logical service");
-                                return Ok(svc::Either::B(ProfileDiscovered { orig_dst: target.param(), logical_addr, profile: rx }));
+                                let has_client_policy = policy
+                                    .as_ref()
+                                    .map(|policy| {
+                                        let policy = policy.policy.borrow();
+                                        policy.http_routes.is_empty() && policy.backends.is_empty()
+                                    })
+                                    .unwrap_or(false);
+                                // if the client policy discovered for this
+                                // service is empty, don't populate the policy field.
+                                let policy = if has_client_policy { policy } else { None };
+                                tracing::debug!(
+                                    has_client_policy,
+                                    "Profile describes a logical service"
+                                );
+                                return Ok(svc::Either::B(Logical::new(logical_addr, rx, policy)));
                             }
 
                             // Otherwise, if there was a profile but it didn't include an endpoint or logical
@@ -126,16 +107,10 @@ impl<S> Outbound<S> {
     }
 }
 
-impl svc::Param<OrigDstAddr> for ProfileDiscovered {
-    fn param(&self) -> OrigDstAddr {
-        self.orig_dst
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_util::*;
+    use crate::{profiles, test_util::*};
     use linkerd_app_core::{
         proxy::api_resolve::Metadata,
         svc::{NewService, Param, ServiceExt},
@@ -147,6 +122,25 @@ mod tests {
     #[derive(Debug, Error, Default)]
     #[error("wrong stack built")]
     struct WrongStack;
+
+    fn discovered_no_profile(orig_dst: OrigDstAddr) -> Discovered<OrigDstAddr> {
+        Discovered {
+            profile: None,
+            policy: None,
+            target: orig_dst,
+        }
+    }
+
+    fn discovered_profile(
+        profile: impl Into<profiles::Receiver>,
+        orig_dst: OrigDstAddr,
+    ) -> Discovered<OrigDstAddr> {
+        Discovered {
+            profile: Some(profile.into()),
+            policy: None,
+            target: orig_dst,
+        }
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn no_profile() {
@@ -162,14 +156,11 @@ mod tests {
         let (rt, _shutdown) = runtime();
         let stack = Outbound::new(default_config(), rt)
             .with_stack(endpoint)
-            .push_switch_logical(
-                svc::Fail::<_, WrongStack>::default(),
-                svc::Fail::<_, WrongStack>::default(),
-            )
+            .push_switch_logical(svc::Fail::<_, WrongStack>::default())
             .into_inner();
 
         let orig_dst = OrigDstAddr(SocketAddr::new([192, 0, 2, 20].into(), 2020));
-        let svc = stack.new_service((None, orig_dst));
+        let svc = stack.new_service(discovered_no_profile(orig_dst));
         let (server_io, _client_io) = io::duplex(1);
         svc.oneshot(server_io).await.expect("service must succeed");
     }
@@ -188,10 +179,7 @@ mod tests {
         let (rt, _shutdown) = runtime();
         let stack = Outbound::new(default_config(), rt)
             .with_stack(endpoint)
-            .push_switch_logical(
-                svc::Fail::<_, WrongStack>::default(),
-                svc::Fail::<_, WrongStack>::default(),
-            )
+            .push_switch_logical(svc::Fail::<_, WrongStack>::default())
             .into_inner();
 
         let (_tx, profile) = tokio::sync::watch::channel(profiles::Profile {
@@ -208,7 +196,7 @@ mod tests {
         });
 
         let orig_dst = OrigDstAddr(SocketAddr::new([192, 0, 2, 20].into(), 2020));
-        let svc = stack.new_service((Some(profile.into()), orig_dst));
+        let svc = stack.new_service(discovered_profile(profile, orig_dst));
         let (server_io, _client_io) = io::duplex(1);
         svc.oneshot(server_io).await.expect("service must succeed");
     }
@@ -223,16 +211,11 @@ mod tests {
             assert!(skip.is_some());
             svc::mk(|_: io::DuplexStream| future::ok::<(), Error>(()))
         };
-        let client_policy = svc::mk(|_| {
-            let (_, rx) =
-                tokio::sync::watch::channel(linkerd_client_policy::ClientPolicy::default());
-            future::ok::<_, Error>(rx)
-        });
 
         let (rt, _shutdown) = runtime();
         let stack = Outbound::new(default_config(), rt)
             .with_stack(svc::Fail::<_, WrongStack>::default())
-            .push_switch_logical(logical, client_policy)
+            .push_switch_logical(logical)
             .into_inner();
 
         let (_tx, profile) = tokio::sync::watch::channel(profiles::Profile {
@@ -244,7 +227,7 @@ mod tests {
         });
 
         let orig_dst = OrigDstAddr(SocketAddr::new([192, 0, 2, 20].into(), 2020));
-        let svc = stack.new_service((Some(profile.into()), orig_dst));
+        let svc = stack.new_service(discovered_profile(profile, orig_dst));
         let (server_io, _client_io) = io::duplex(1);
         svc.oneshot(server_io).await.expect("service must succeed");
     }
@@ -265,10 +248,7 @@ mod tests {
         let (rt, _shutdown) = runtime();
         let stack = Outbound::new(default_config(), rt)
             .with_stack(endpoint)
-            .push_switch_logical(
-                svc::Fail::<_, WrongStack>::default(),
-                svc::Fail::<_, WrongStack>::default(),
-            )
+            .push_switch_logical(svc::Fail::<_, WrongStack>::default())
             .into_inner();
 
         let (_tx, profile) = tokio::sync::watch::channel(profiles::Profile {
@@ -279,7 +259,7 @@ mod tests {
         });
 
         let orig_dst = OrigDstAddr(endpoint_addr);
-        let svc = stack.new_service((Some(profile.into()), orig_dst));
+        let svc = stack.new_service(discovered_profile(profile, orig_dst));
         let (server_io, _client_io) = io::duplex(1);
         svc.oneshot(server_io).await.expect("service must succeed");
     }

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -145,7 +145,6 @@ mod tests {
             policy: None,
             logical_addr: logical_addr.clone(),
             protocol: (),
-            orig_dst: OrigDstAddr(ep_addr),
         };
 
         // The resolution resolves a single endpoint.
@@ -210,7 +209,6 @@ mod tests {
             profile: rx.into(),
             logical_addr: logical_addr.clone(),
             protocol: (),
-            orig_dst: OrigDstAddr(SocketAddr::new([192, 0, 2, 29].into(), 3333)),
         };
 
         let ep0_addr = SocketAddr::new([192, 0, 2, 30].into(), 3333);

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -202,7 +202,6 @@ impl Config {
             outbound.to_tcp_connect(),
             dst.profiles.clone(),
             dst.resolve.clone(),
-            outbound_policies.clone(),
         );
 
         // Bind the proxy sockets eagerly (so they're reserved and known) but defer building the

--- a/linkerd/client-policy/src/http.rs
+++ b/linkerd/client-policy/src/http.rs
@@ -1,6 +1,8 @@
 use crate::RoutePolicy;
 use linkerd_http_route::http;
 pub use linkerd_http_route::http::{filter, r#match, RouteMatch};
+mod router;
+pub use self::router::*;
 
 pub type Route = http::Route<RoutePolicy>;
 pub type Rule = http::Rule<RoutePolicy>;

--- a/linkerd/client-policy/src/http/router.rs
+++ b/linkerd/client-policy/src/http/router.rs
@@ -1,6 +1,6 @@
-use crate::policy::Receiver;
+use super::Route;
+use crate::{Receiver, RoutePolicy};
 use futures::{future::MapErr, FutureExt, TryFutureExt};
-use linkerd_client_policy::{http::Route, RoutePolicy};
 use linkerd_error::Error;
 use linkerd_stack::{layer, NewService, Oneshot, Param, Service, ServiceExt};
 use std::{

--- a/linkerd/client-policy/src/lib.rs
+++ b/linkerd/client-policy/src/lib.rs
@@ -69,6 +69,10 @@ impl From<LogicalAddr> for NameAddr {
 // === impl ClientPolicy ===
 
 impl ClientPolicy {
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.backends.is_empty() && self.http_routes.is_empty()
+    }
     pub fn invalid() -> Self {
         static META: Lazy<Arc<Meta>> = Lazy::new(|| {
             Arc::new(Meta::Default {

--- a/linkerd/client-policy/src/lib.rs
+++ b/linkerd/client-policy/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
-pub mod discover;
 pub mod http;
 pub mod split;
 


### PR DESCRIPTION
This branch refactors the prototype client policy code to move the
discovery of client policies to still occur after profile discovery, but
before the HTTP logical stack. This means that SO_ORIGINAL_DST addresses
need not be stored in the `Logical` target type any longer, which I
think is significantly nicer, as we no longer have a `Logical` field
that's ignored by hashing and equality.

Instead, the client policy discovery now occurs in the stack produced by
`push_discover`. This is conceptually much more correct. In addition, it
allows us to remove the separate caching logic for client policy
lookups, and just use the same per-original-destination-address cache
that's used for service profile lookups. This simplifies the policy code
significantly, and allows moving stuff back out of
`linkerd-app-outbound` and into `linkerd-client-policy`, since the
policy receiver need no longer be wrapped in a `Cached` handle.

Depends on #2034