### PR TITLE
release: Produce static binaries

### DIFF
--- a/.checksec/amd64-gnu.json
+++ b/.checksec/amd64-gnu.json
@@ -1,10 +1,8 @@
 {
   "canary": "yes",
-  "fortify_source": "no",
   "nx": "yes",
   "pie": "yes",
   "relro": "full",
   "rpath": "no",
-  "runpath": "no",
-  "symbols": "yes"
+  "runpath": "no"
 }

--- a/.checksec/amd64-gnu.json
+++ b/.checksec/amd64-gnu.json
@@ -6,5 +6,5 @@
   "relro": "full",
   "rpath": "no",
   "runpath": "no",
-  "symbols": "no"
+  "symbols": "yes"
 }

--- a/.checksec/amd64-musl.json
+++ b/.checksec/amd64-musl.json
@@ -1,0 +1,10 @@
+{
+  "canary": "yes",
+  "fortify_source": "no",
+  "nx": "yes",
+  "pie": "yes",
+  "relro": "full",
+  "rpath": "no",
+  "runpath": "no",
+  "symbols": "yes"
+}

--- a/.checksec/amd64-musl.json
+++ b/.checksec/amd64-musl.json
@@ -1,10 +1,8 @@
 {
   "canary": "yes",
-  "fortify_source": "no",
   "nx": "yes",
   "pie": "yes",
   "relro": "full",
   "rpath": "no",
-  "runpath": "no",
-  "symbols": "yes"
+  "runpath": "no"
 }

--- a/.checksec/arm-gnu.json
+++ b/.checksec/arm-gnu.json
@@ -1,0 +1,10 @@
+{
+  "canary": "yes",
+  "fortify_source": "no",
+  "nx": "yes",
+  "pie": "yes",
+  "relro": "full",
+  "rpath": "no",
+  "runpath": "no",
+  "symbols": "yes"
+}

--- a/.checksec/arm-gnu.json
+++ b/.checksec/arm-gnu.json
@@ -1,10 +1,8 @@
 {
   "canary": "yes",
-  "fortify_source": "no",
   "nx": "yes",
   "pie": "yes",
   "relro": "full",
   "rpath": "no",
-  "runpath": "no",
-  "symbols": "yes"
+  "runpath": "no"
 }

--- a/.checksec/arm-musl.json
+++ b/.checksec/arm-musl.json
@@ -1,0 +1,10 @@
+{
+  "canary": "yes",
+  "fortify_source": "no",
+  "nx": "yes",
+  "pie": "no",
+  "relro": "partial",
+  "rpath": "no",
+  "runpath": "no",
+  "symbols": "yes"
+}

--- a/.checksec/arm-musl.json
+++ b/.checksec/arm-musl.json
@@ -1,10 +1,8 @@
 {
   "canary": "yes",
-  "fortify_source": "no",
   "nx": "yes",
   "pie": "no",
   "relro": "partial",
   "rpath": "no",
-  "runpath": "no",
-  "symbols": "yes"
+  "runpath": "no"
 }

--- a/.checksec/arm64-gnu.json
+++ b/.checksec/arm64-gnu.json
@@ -1,0 +1,10 @@
+{
+  "canary": "yes",
+  "fortify_source": "no",
+  "nx": "yes",
+  "pie": "yes",
+  "relro": "full",
+  "rpath": "no",
+  "runpath": "no",
+  "symbols": "yes"
+}

--- a/.checksec/arm64-gnu.json
+++ b/.checksec/arm64-gnu.json
@@ -1,10 +1,8 @@
 {
   "canary": "yes",
-  "fortify_source": "no",
   "nx": "yes",
   "pie": "yes",
   "relro": "full",
   "rpath": "no",
-  "runpath": "no",
-  "symbols": "yes"
+  "runpath": "no"
 }

--- a/.checksec/arm64-musl.json
+++ b/.checksec/arm64-musl.json
@@ -1,0 +1,10 @@
+{
+  "canary": "yes",
+  "fortify_source": "no",
+  "nx": "yes",
+  "pie": "no",
+  "relro": "partial",
+  "rpath": "no",
+  "runpath": "no",
+  "symbols": "yes"
+}

--- a/.checksec/arm64-musl.json
+++ b/.checksec/arm64-musl.json
@@ -1,10 +1,8 @@
 {
   "canary": "yes",
-  "fortify_source": "no",
   "nx": "yes",
   "pie": "no",
   "relro": "partial",
   "rpath": "no",
-  "runpath": "no",
-  "symbols": "yes"
+  "runpath": "no"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "linkerd2-proxy",
-	"image": "ghcr.io/linkerd/dev:v37",
+	"image": "ghcr.io/linkerd/dev:v38",
 	"extensions": [
 		"DavidAnson.vscode-markdownlint",
 		"kokakiwi.vscode-just",

--- a/.github/actions/list-changed-crates/Dockerfile
+++ b/.github/actions/list-changed-crates/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linkerd/dev:v37-rust
+FROM ghcr.io/linkerd/dev:v38-rust
 RUN apt-get update && apt-get install -y --no-install-recommends jq \
     && rm -rf /var/lib/apt/lists/*
 COPY entrypoint.sh /

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-20.04
     timeout-minutes: 10
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v37
+      - uses: linkerd/dev/actions/setup-tools@v38
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just action-lint
 
   devcontainer-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v37
+      - uses: linkerd/dev/actions/setup-tools@v38
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just action-dev-check

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -22,7 +22,7 @@ jobs:
   check-all:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just fetch

--- a/.github/workflows/check-each.yml
+++ b/.github/workflows/check-each.yml
@@ -49,7 +49,7 @@ jobs:
     needs: list-changed-crates
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     strategy:
       matrix:
         crate: ${{ fromJson(needs.list-changed-crates.outputs.crates) }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
-      image: docker://ghcr.io/linkerd/dev:v37-rust
+      image: docker://ghcr.io/linkerd/dev:v38-rust
       options: --security-opt seccomp=unconfined # 🤷
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -46,7 +46,7 @@ jobs:
   deprecated:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just fetch

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,9 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      DOCKER_BUILDKIT: "1"
     steps:
-      - uses: extractions/setup-just@95b912dc5d3ed106a72907f2f9b91e76d60bdb76
+      - uses: linkerd/dev/actions/setup-tools@v38
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just docker

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just fetch

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
   clippy:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just fetch
@@ -30,7 +30,7 @@ jobs:
   fmt:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just check-fmt
@@ -38,7 +38,7 @@ jobs:
   docs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just fetch

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,40 +52,20 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64, arm]
+        libc: [gnu, musl]
+
     # If we're not actually building on a release tag, don't short-circuit on
     # errors. This helps us know whether a failure is platform-specific.
     continue-on-error: ${{ !needs.meta.outputs.publish }}
-    name: Package (${{ matrix.arch }})
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    container: docker://ghcr.io/linkerd/dev:v37-rust
+    container: docker://ghcr.io/linkerd/dev:v38-rust-musl
     steps:
-      - if: matrix.arch == 'arm64'
-        run: |
-          rustup target add aarch64-unknown-linux-gnu
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            binutils-aarch64-linux-gnu \
-            g++-aarch64-linux-gnu \
-            gcc-aarch64-linux-gnu \
-            libc6-dev-arm64-cross
-          echo CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc >> "$GITHUB_ENV"
-
-      - if: matrix.arch == 'arm'
-        run: |
-          rustup target add armv7-unknown-linux-gnueabihf
-          apt-get update
-          apt-get install -y --no-install-recommends \
-            binutils-arm-linux-gnueabihf \
-            g++-arm-linux-gnueabihf \
-            gcc-arm-linux-gnueabihf \
-            libc6-dev-armhf-cross
-          echo CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc >> "$GITHUB_ENV"
-
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just fetch
-      - name: Run just package
-        run: just profile=release package_arch=${{ matrix.arch }} package_version=${{ needs.meta.outputs.version }} package
+      - run: just arch=${{ matrix.arch }} libc=${{ matrix.libc }} rustup
+      - run: just arch=${{ matrix.arch }} libc=${{ matrix.libc }} profile=release build
+      - run: just arch=${{ matrix.arch }} libc=${{ matrix.libc }} profile=release package_version=${{ needs.meta.outputs.version }} package
       - uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb
         with:
           name: ${{ matrix.arch }}-artifacts

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,6 +15,6 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v37
+      - uses: linkerd/dev/actions/setup-tools@v38
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just sh-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
   meshtls:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just fetch
@@ -42,7 +42,7 @@ jobs:
   unit:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: just fetch

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   devcontainer:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v37-rust
+    container: ghcr.io/linkerd/dev:v38-rust
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - run: |
@@ -24,26 +24,10 @@ jobs:
             exit 1
           fi
 
-  dockerfiles:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-      - run: |
-          VERSION="$(cat rust-toolchain)"
-          ex=0
-          while IFS= read -r file ; do
-            versions=$(sed -nE 's/^ARG RUST_VERSION=([^ ]+)/\1/p' "$file")
-            for mismatch in $(echo "$versions" | grep -vF "$VERSION" || true) ; do
-              echo "::error file=$file::$file uses incorrect rust version(s): $mismatch"
-              ex=$((ex + 1))
-            done
-          done < <(find . -name Dockerfile)
-          exit $ex
-
   workflows:
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v37
+      - uses: linkerd/dev/actions/setup-tools@v38
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
       - shell: bash
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ members = [
     "linkerd/transport-metrics",
     "linkerd2-proxy",
     "opencensus-proto",
-    "tools"
+    "tools",
 ]
 
 # Debug symbols end up chewing up several GB of disk space, so better to just

--- a/justfile
+++ b/justfile
@@ -122,7 +122,8 @@ _strip:
 
 _package_bin := _package_dir / "bin" / "linkerd2-proxy"
 
-# XXX {aarch64,arm}-musl builds do not enable PIE, so we can't use
+# XXX {aarch64,arm}-musl builds do not enable PIE, so we use target-specific
+# files to document those differences.
 _expected_checksec := '.checksec' / arch + '-' + libc + '.json'
 
 # Check the security properties of the proxy binary.

--- a/justfile
+++ b/justfile
@@ -129,18 +129,16 @@ _expected_checksec := '.checksec' / arch + '-' + libc + '.json'
 checksec:
     checksec --output=json --file='{{ _target_bin }}' \
         | jq '.' | tee /dev/stderr \
-        | jq -S '.[] | del(."fortify-able") | del(.fortified)' \
+        | jq -S '.[] | del(."fortify_source") | del(."fortify-able") | del(.fortified) | del(.symbols)' \
         | diff -u {{ _expected_checksec }} - >&2
 
 _objcopy := 'llvm-objcopy-' + `just-cargo --evaluate _llvm-version`
 
 # Build a package (i.e. for a release)
 package: build
-    @rm -f  {{ _package_dir }}/bin
     @mkdir -p {{ _package_dir }}/bin
     cp LICENSE {{ _package_dir }}/
-    cp {{ _target_bin }} {{ _package_bin }}
-    cp {{ _target_bin }}.dbg {{ _package_bin }}.dbg
+    cp {{ _target_bin }} {{ _target_bin }}.dbg {{ _package_dir }}/
     tar -czvf target/package/{{ _package_name }}.tar.gz  -C target/package {{ _package_name }} >/dev/null
     cd target/package && ({{ shasum }} {{ _package_name }}.tar.gz | tee {{ _package_name }}.txt)
     @rm -rf {{ _package_dir }}


### PR DESCRIPTION
This change adds release targets for static binaries (using musl).

With this change, we retain debug symbols in an alternate file.

This change bumps the devcontainer to v38 to include just-cargo fixes.