### PR TITLE
populate policy cache with defaults configured by env vars

### DIFF
--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -14,6 +14,7 @@ pub enum Config {
         control: control::Config,
         workload: String,
         default: DefaultPolicy,
+        default_ports: HashMap<u16, DefaultPolicy>,
         cache_max_idle_age: Duration,
         ports: HashSet<u16>,
     },
@@ -45,6 +46,7 @@ impl Config {
                 ports,
                 workload,
                 default,
+                default_ports,
                 cache_max_idle_age,
             } => {
                 let watch = {
@@ -59,7 +61,7 @@ impl Config {
                     };
                     Api::new(workload, detect_timeout, client).into_watch(backoff)
                 };
-                Store::spawn_discover(default, cache_max_idle_age, watch, ports)
+                Store::spawn_discover(default, cache_max_idle_age, watch, ports, default_ports)
             }
         }
     }


### PR DESCRIPTION
Currently, the proxy-injector may set the following environment variables to configure the policies that the proxy should use for specific inbound ports:

- `LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION`
- `LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_IDENTITY`
- `LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS`

However, when the proxy is configured with a policy service address, these environment variables are never used, even when they are set. Instead, the proxy will always look up those ports with the policy controller, which will then tell it to do...what the environment variable would have already told it to do (because the env vars are generated based on the same annotations that would tell the policy controller what policy to send). This means we do unnecessary policy resolutions for those ports.

This branch updates the proxy so that these environment variables are always honored, even when a policy controller is configured. This way, the unnecessary lookups are avoided. Critically, we should note that we will never do a policy lookup for a port that is configured by one of these environment variables.

If a port is present in both `LINKERD2_PROXY_INBOUND_PORTS` (the list of ports for which we proactively start policy controller watches), as well as configured by one of the policy env vars, we will still look that port up with the policy controller, rather than using the env var configuration. A warning is logged in this case.