### PR TITLE
config: Decouple HTTP and TCP buffering config

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -15,7 +15,12 @@ pub struct ServerConfig {
 
 #[derive(Clone, Debug)]
 pub struct BufferConfig {
+    /// The number of requests (or connections, depending on the context) that
+    /// may be buffered
     pub capacity: usize,
+
+    /// The maximum amount of time a request may be buffered before failfast
+    /// errors are emitted.
     pub failfast_timeout: Duration,
 }
 

--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -14,6 +14,12 @@ pub struct ServerConfig {
 }
 
 #[derive(Clone, Debug)]
+pub struct BufferConfig {
+    pub capacity: usize,
+    pub failfast_timeout: Duration,
+}
+
+#[derive(Clone, Debug)]
 pub struct ConnectConfig {
     pub backoff: ExponentialBackoff,
     pub timeout: Duration,
@@ -26,9 +32,6 @@ pub struct ConnectConfig {
 pub struct ProxyConfig {
     pub server: ServerConfig,
     pub connect: ConnectConfig,
-    pub buffer_capacity: usize,
-    pub cache_max_idle_age: Duration,
-    pub dispatch_timeout: Duration,
     pub max_in_flight_requests: usize,
     pub detect_protocol_timeout: Duration,
 }

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -12,7 +12,7 @@ use tracing::warn;
 pub struct Config {
     pub addr: ControlAddr,
     pub connect: config::ConnectConfig,
-    pub buffer_capacity: usize,
+    pub buffer: config::BufferConfig,
 }
 
 #[derive(Clone, Debug)]
@@ -95,11 +95,7 @@ impl Config {
             .into_new_service()
             .push(metrics.to_layer::<classify::Response, _, _>())
             .push(self::add_origin::layer())
-            .push_buffer_on_service(
-                "Controller client",
-                self.buffer_capacity,
-                time::Duration::from_secs(60),
-            )
+            .push_buffer_on_service("Controller client", &self.buffer)
             .instrument(|c: &ControlAddr| tracing::info_span!("controller", addr = %c.addr))
             .push_map_target(move |()| addr.clone())
             .push(svc::ArcNewService::layer())

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -95,7 +95,11 @@ impl Config {
             .into_new_service()
             .push(metrics.to_layer::<classify::Response, _, _>())
             .push(self::add_origin::layer())
-            .push_on_service(svc::layers().push_spawn_buffer(self.buffer_capacity))
+            .push_buffer_on_service(
+                "Controller client",
+                self.buffer_capacity,
+                time::Duration::from_secs(60),
+            )
             .instrument(|c: &ControlAddr| tracing::info_span!("controller", addr = %c.addr))
             .push_map_target(move |()| addr.clone())
             .push(svc::ArcNewService::layer())

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -195,6 +195,7 @@ impl<S> Stack<S> {
         self.push(http::insert::NewResponseInsert::layer())
     }
 
+    /// Buffers requests in an mpsc, spawning the inner service onto a dedicated task.
     pub fn push_buffer_on_service<Req>(
         self,
         name: &'static str,

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -1,7 +1,7 @@
 // Possibly unused, but useful during development.
 
 pub use crate::proxy::http;
-use crate::{cache, Error};
+use crate::{cache, config::BufferConfig, Error};
 use linkerd_error::Recover;
 use linkerd_exp_backoff::{ExponentialBackoff, ExponentialBackoffStream};
 pub use linkerd_reconnect::NewReconnect;
@@ -92,13 +92,12 @@ impl<L> Layers<L> {
     pub fn push_buffer<Req>(
         self,
         name: &'static str,
-        capacity: usize,
-        failfast_timeout: Duration,
+        config: &BufferConfig,
     ) -> Layers<Pair<L, BufferLayer<Req>>>
     where
         Req: Send + 'static,
     {
-        self.push(buffer(name, capacity, failfast_timeout))
+        self.push(buffer(name, config))
     }
 
     pub fn push_on_service<U>(self, layer: U) -> Layers<Pair<L, stack::OnServiceLayer<U>>> {
@@ -199,13 +198,12 @@ impl<S> Stack<S> {
     pub fn push_buffer_on_service<Req>(
         self,
         name: &'static str,
-        capacity: usize,
-        failfast_timeout: Duration,
+        config: &BufferConfig,
     ) -> Stack<OnService<BufferLayer<Req>, S>>
     where
         Req: Send + 'static,
     {
-        self.push_on_service(buffer(name, capacity, failfast_timeout))
+        self.push_on_service(buffer(name, config))
     }
 
     pub fn push_cache<T>(self, idle: Duration) -> Stack<cache::NewCachedService<T, S>>
@@ -390,15 +388,11 @@ impl<E: Into<Error>> Recover<E> for AlwaysReconnect {
 
 // === impl BufferLayer ===
 
-fn buffer<Req>(
-    name: &'static str,
-    capacity: usize,
-    failfast_timeout: Duration,
-) -> BufferLayer<Req> {
+fn buffer<Req>(name: &'static str, config: &BufferConfig) -> BufferLayer<Req> {
     BufferLayer {
         name,
-        capacity,
-        failfast_timeout,
+        capacity: config.capacity,
+        failfast_timeout: config.failfast_timeout,
         _marker: PhantomData,
     }
 }
@@ -412,12 +406,9 @@ where
     type Service = Buffer<Req, S::Response, Error>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        Buffer::new(
-            BoxService::new(
-                FailFast::layer(self.name, self.failfast_timeout).layer(SpawnReady::new(inner)),
-            ),
-            self.capacity,
-        )
+        let spawn_ready = SpawnReady::new(inner);
+        let fail_fast = FailFast::layer(self.name, self.failfast_timeout).layer(spawn_ready);
+        Buffer::new(BoxService::new(fail_fast), self.capacity)
     }
 }
 

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -152,7 +152,7 @@ where
                         .stack
                         .layer(metrics::StackLabels::inbound("tcp", "gateway")),
                 )
-                .push_buffer("TCP Gatweay", &inbound_config.tcp_server_buffer),
+                .push_buffer("TCP Gatweay", &inbound_config.tcp_connection_buffer),
         )
         .push_cache(inbound_config.profile_idle_timeout)
         .check_new_service::<NameAddr, I>();
@@ -186,7 +186,7 @@ where
                         .stack
                         .layer(metrics::StackLabels::inbound("http", "gateway")),
                 )
-                .push_buffer("Gateway", &inbound_config.http_logical_buffer),
+                .push_buffer("Gateway", &inbound_config.http_request_buffer),
         )
         .push_cache(inbound_config.profile_idle_timeout)
         .push_on_service(

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -158,9 +158,7 @@ where
                         .stack
                         .layer(metrics::StackLabels::inbound("tcp", "gateway")),
                 )
-                .push(svc::layer::mk(svc::SpawnReady::new))
-                .push(svc::FailFast::layer("TCP Gateway", dispatch_timeout))
-                .push_spawn_buffer(buffer_capacity),
+                .push_buffer("TCP Gatweay", buffer_capacity, dispatch_timeout),
         )
         .push_cache(cache_max_idle_age)
         .check_new_service::<NameAddr, I>();
@@ -193,9 +191,7 @@ where
                         .stack
                         .layer(metrics::StackLabels::inbound("http", "gateway")),
                 )
-                .push(svc::layer::mk(svc::SpawnReady::new))
-                .push(svc::FailFast::layer("Gateway", dispatch_timeout))
-                .push_spawn_buffer(buffer_capacity),
+                .push_buffer("Gateway", buffer_capacity, dispatch_timeout),
         )
         .push_cache(cache_max_idle_age)
         .push_on_service(

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -152,7 +152,7 @@ where
                         .stack
                         .layer(metrics::StackLabels::inbound("tcp", "gateway")),
                 )
-                .push_buffer("TCP Gatweay", &inbound_config.tcp_connection_buffer),
+                .push_buffer("TCP Gateway", &inbound_config.tcp_connection_buffer),
         )
         .push_cache(inbound_config.profile_idle_timeout)
         .check_new_service::<NameAddr, I>();

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -152,9 +152,9 @@ where
                         .stack
                         .layer(metrics::StackLabels::inbound("tcp", "gateway")),
                 )
-                .push_buffer("TCP Gateway", &inbound_config.tcp_connection_buffer),
+                .push_buffer("TCP Gateway", &outbound.config().tcp_connection_buffer),
         )
-        .push_cache(inbound_config.profile_idle_timeout)
+        .push_cache(outbound.config().discovery_idle_timeout)
         .check_new_service::<NameAddr, I>();
 
     // Cache an HTTP gateway service for each destination and HTTP version.
@@ -188,7 +188,7 @@ where
                 )
                 .push_buffer("Gateway", &inbound_config.http_request_buffer),
         )
-        .push_cache(inbound_config.profile_idle_timeout)
+        .push_cache(inbound_config.discovery_idle_timeout)
         .push_on_service(
             svc::layers()
                 .push(http::Retain::layer())

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -152,11 +152,7 @@ where
                         .stack
                         .layer(metrics::StackLabels::inbound("tcp", "gateway")),
                 )
-                .push_buffer(
-                    "TCP Gatweay",
-                    inbound_config.tcp_server_buffer.capacity,
-                    inbound_config.tcp_server_buffer.failfast_timeout,
-                ),
+                .push_buffer("TCP Gatweay", &inbound_config.tcp_server_buffer),
         )
         .push_cache(inbound_config.profile_idle_timeout)
         .check_new_service::<NameAddr, I>();
@@ -190,11 +186,7 @@ where
                         .stack
                         .layer(metrics::StackLabels::inbound("http", "gateway")),
                 )
-                .push_buffer(
-                    "Gateway",
-                    inbound_config.http_logical_buffer.capacity,
-                    inbound_config.http_logical_buffer.failfast_timeout,
-                ),
+                .push_buffer("Gateway", &inbound_config.http_logical_buffer),
         )
         .push_cache(inbound_config.profile_idle_timeout)
         .push_on_service(

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -210,7 +210,7 @@ impl<C> Inbound<C> {
                 .push_on_service(
                     svc::layers()
                         .push(rt.metrics.proxy.stack.layer(stack_labels("http", "logical")))
-                        .push_buffer("HTTP Logical", config.http_logical_buffer.capacity, config.http_logical_buffer.failfast_timeout),
+                        .push_buffer("HTTP Logical", &config.http_logical_buffer),
                 )
                 .push_cache(config.profile_idle_timeout)
                 .push_on_service(

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -210,11 +210,7 @@ impl<C> Inbound<C> {
                 .push_on_service(
                     svc::layers()
                         .push(rt.metrics.proxy.stack.layer(stack_labels("http", "logical")))
-                        .push(svc::FailFast::layer(
-                            "HTTP Logical",
-                            config.proxy.dispatch_timeout,
-                        ))
-                        .push_spawn_buffer(config.proxy.buffer_capacity),
+                        .push_buffer("HTTP Logical", config.proxy.buffer_capacity, config.proxy.dispatch_timeout),
                 )
                 .push_cache(config.proxy.cache_max_idle_age)
                 .push_on_service(

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -210,7 +210,7 @@ impl<C> Inbound<C> {
                 .push_on_service(
                     svc::layers()
                         .push(rt.metrics.proxy.stack.layer(stack_labels("http", "logical")))
-                        .push_buffer("HTTP Logical", &config.http_logical_buffer),
+                        .push_buffer("HTTP Logical", &config.http_request_buffer),
                 )
                 .push_cache(config.profile_idle_timeout)
                 .push_on_service(

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -203,16 +203,16 @@ impl<C> Inbound<C> {
                 .push_on_service(svc::layer::mk(svc::SpawnReady::new))
                 // Skip the profile stack if it takes too long to become ready.
                 .push_when_unready(
-                    config.profile_idle_timeout,
+                    config.profile_skip_timeout,
                     http.push_on_service(svc::layer::mk(svc::SpawnReady::new))
                         .into_inner(),
                 )
                 .push_on_service(
                     svc::layers()
                         .push(rt.metrics.proxy.stack.layer(stack_labels("http", "logical")))
-                        .push_buffer("HTTP Logical", config.proxy.buffer_capacity, config.proxy.dispatch_timeout),
+                        .push_buffer("HTTP Logical", config.http_logical_buffer.capacity, config.http_logical_buffer.failfast_timeout),
                 )
-                .push_cache(config.proxy.cache_max_idle_age)
+                .push_cache(config.profile_idle_timeout)
                 .push_on_service(
                     svc::layers()
                         .push(http::Retain::layer())

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -43,6 +43,7 @@ impl<H> Inbound<H> {
         self.map_stack(|config, rt, http| {
             let ProxyConfig {
                 server: ServerConfig { h2_settings, .. },
+                max_in_flight_requests,
                 ..
             } = config.proxy;
 
@@ -56,15 +57,19 @@ impl<H> Inbound<H> {
                     svc::layers()
                         .push(http::BoxRequest::layer())
                         // Downgrades the protocol if upgraded by an outbound proxy.
-                        .push(http::orig_proto::Downgrade::layer()),
-                    // Limit the number of in-flight requests. When the proxy is
-                    // at capacity, go into failfast after a dispatch timeout.
-                    // Note that the inner service _always_ returns ready (due
-                    // to `NewRouter`) and the concurrency limit need not be
-                    // driven outside of the request path, so there's no need
-                    // for SpawnReady
-                    //.push(svc::ConcurrencyLimitLayer::new(max_in_flight_requests))
-                    //.push(svc::FailFast::layer("HTTP Server", dispatch_timeout)),
+                        .push(http::orig_proto::Downgrade::layer())
+                        // Limit the number of in-flight inbound requests.
+                        //
+                        // TODO(ver) This concurrency limit applies only to
+                        // requests that do not yet have responses, but ignores
+                        // streaming bodies. We should change this to an
+                        // HTTP-specific imlementation that tracks request and
+                        // response bodies.
+                        //
+                        // TODO(ver) Shed load by failing requests when the
+                        // concurrency limit is reached. We don't want to bother
+                        // with failfast.
+                        .push(svc::ConcurrencyLimitLayer::new(max_in_flight_requests)),
                 )
                 .push(rt.metrics.http_errors.to_layer())
                 .push(ServerRescue::layer())

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -43,8 +43,6 @@ impl<H> Inbound<H> {
         self.map_stack(|config, rt, http| {
             let ProxyConfig {
                 server: ServerConfig { h2_settings, .. },
-                dispatch_timeout,
-                max_in_flight_requests,
                 ..
             } = config.proxy;
 
@@ -58,15 +56,15 @@ impl<H> Inbound<H> {
                     svc::layers()
                         .push(http::BoxRequest::layer())
                         // Downgrades the protocol if upgraded by an outbound proxy.
-                        .push(http::orig_proto::Downgrade::layer())
-                        // Limit the number of in-flight requests. When the proxy is
-                        // at capacity, go into failfast after a dispatch timeout.
-                        // Note that the inner service _always_ returns ready (due
-                        // to `NewRouter`) and the concurrency limit need not be
-                        // driven outside of the request path, so there's no need
-                        // for SpawnReady
-                        .push(svc::ConcurrencyLimitLayer::new(max_in_flight_requests))
-                        .push(svc::FailFast::layer("HTTP Server", dispatch_timeout)),
+                        .push(http::orig_proto::Downgrade::layer()),
+                    // Limit the number of in-flight requests. When the proxy is
+                    // at capacity, go into failfast after a dispatch timeout.
+                    // Note that the inner service _always_ returns ready (due
+                    // to `NewRouter`) and the concurrency limit need not be
+                    // driven outside of the request path, so there's no need
+                    // for SpawnReady
+                    //.push(svc::ConcurrencyLimitLayer::new(max_in_flight_requests))
+                    //.push(svc::FailFast::layer("HTTP Server", dispatch_timeout)),
                 )
                 .push(rt.metrics.http_errors.to_layer())
                 .push(ServerRescue::layer())

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -45,12 +45,9 @@ pub struct Config {
     /// skipping route information.
     pub profile_skip_timeout: Duration,
 
-    /// Configures how long the proxy will retain profile resolutions for
-    /// idle/unused services.
-    pub profile_idle_timeout: Duration,
-
-    /// Configures how connections are buffered *for each inbound port*.
-    pub tcp_connection_buffer: BufferConfig,
+    /// Configures how long the proxy will retain policy & profile resolutions
+    /// for idle/unused ports and services.
+    pub discovery_idle_timeout: Duration,
 
     /// Configures how HTTP requests are buffered *for each inbound port*.
     pub http_request_buffer: BufferConfig,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -41,8 +41,8 @@ pub struct Config {
     pub policy: policy::Config,
     pub allowed_ips: transport::AllowIps,
 
-    /// Configures how long the proxy will wait for a profile response for
-    /// skipping route information.
+    /// Configures the timeout after which the proxy will revert to skipping
+    /// service profile routing instrumentation.
     pub profile_skip_timeout: Duration,
 
     /// Configures how long the proxy will retain policy & profile resolutions

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -41,10 +41,19 @@ pub struct Config {
     pub policy: policy::Config,
     pub allowed_ips: transport::AllowIps,
 
+    /// Configures how long the proxy will wait for a profile response for
+    /// skipping route information.
     pub profile_skip_timeout: Duration,
+
+    /// Configures how long the proxy will retain profile resolutions for
+    /// idle/unused services.
     pub profile_idle_timeout: Duration,
-    pub tcp_server_buffer: BufferConfig,
-    pub http_logical_buffer: BufferConfig,
+
+    /// Configures how connections are buffered *for each inbound port*.
+    pub tcp_connection_buffer: BufferConfig,
+
+    /// Configures how HTTP requests are buffered *for each inbound port*.
+    pub http_request_buffer: BufferConfig,
 }
 
 #[derive(Clone)]

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -18,7 +18,7 @@ pub(crate) mod test_util;
 
 pub use self::{metrics::Metrics, policy::DefaultPolicy};
 use linkerd_app_core::{
-    config::{ConnectConfig, ProxyConfig},
+    config::{BufferConfig, ConnectConfig, ProxyConfig},
     drain,
     http_tracing::OpenCensusSink,
     identity, io,
@@ -39,8 +39,12 @@ pub struct Config {
     pub allow_discovery: NameMatch,
     pub proxy: ProxyConfig,
     pub policy: policy::Config,
-    pub profile_idle_timeout: Duration,
     pub allowed_ips: transport::AllowIps,
+
+    pub profile_skip_timeout: Duration,
+    pub profile_idle_timeout: Duration,
+    pub tcp_server_buffer: BufferConfig,
+    pub http_logical_buffer: BufferConfig,
 }
 
 #[derive(Clone)]

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -77,15 +77,11 @@ pub fn default_config() -> Config {
             detect_protocol_timeout: Duration::from_secs(10),
         },
         allowed_ips: Default::default(),
-        tcp_connection_buffer: config::BufferConfig {
-            capacity: 10_000,
-            failfast_timeout: Duration::from_secs(1),
-        },
         http_request_buffer: config::BufferConfig {
             capacity: 10_000,
             failfast_timeout: Duration::from_secs(1),
         },
-        profile_idle_timeout: Duration::from_secs(20),
+        discovery_idle_timeout: Duration::from_secs(20),
         profile_skip_timeout: Duration::from_secs(1),
     }
 }

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -50,6 +50,7 @@ pub fn default_config() -> Config {
     };
 
     Config {
+        policy,
         allow_discovery: Some(cluster_local).into_iter().collect(),
         proxy: config::ProxyConfig {
             server: config::ServerConfig {
@@ -72,15 +73,20 @@ pub fn default_config() -> Config {
                 },
                 h2_settings: h2::Settings::default(),
             },
-            buffer_capacity: 10_000,
-            cache_max_idle_age: Duration::from_secs(20),
-            dispatch_timeout: Duration::from_secs(1),
             max_in_flight_requests: 10_000,
             detect_protocol_timeout: Duration::from_secs(10),
         },
-        policy,
-        profile_idle_timeout: Duration::from_millis(500),
         allowed_ips: Default::default(),
+        tcp_server_buffer: config::BufferConfig {
+            capacity: 10_000,
+            failfast_timeout: Duration::from_secs(1),
+        },
+        http_logical_buffer: config::BufferConfig {
+            capacity: 10_000,
+            failfast_timeout: Duration::from_secs(1),
+        },
+        profile_idle_timeout: Duration::from_secs(20),
+        profile_skip_timeout: Duration::from_secs(1),
     }
 }
 

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -77,11 +77,11 @@ pub fn default_config() -> Config {
             detect_protocol_timeout: Duration::from_secs(10),
         },
         allowed_ips: Default::default(),
-        tcp_server_buffer: config::BufferConfig {
+        tcp_connection_buffer: config::BufferConfig {
             capacity: 10_000,
             failfast_timeout: Duration::from_secs(1),
         },
-        http_logical_buffer: config::BufferConfig {
+        http_request_buffer: config::BufferConfig {
             capacity: 10_000,
             failfast_timeout: Duration::from_secs(1),
         },

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -60,11 +60,11 @@ impl<N> Outbound<N> {
                         )
                         .push_buffer(
                             "TCP Server",
-                            config.proxy.buffer_capacity,
-                            config.proxy.dispatch_timeout,
+                            config.tcp_connection_buffer.capacity,
+                            config.tcp_connection_buffer.failfast_timeout,
                         ),
                 )
-                .push_cache(config.proxy.cache_max_idle_age)
+                .push_cache(config.orig_dst_idle_timeout)
                 .push(svc::ArcNewService::layer())
                 .check_new_service::<T, I>()
         })
@@ -184,7 +184,7 @@ mod tests {
         // service after `idle_timeout`.
         let cfg = {
             let mut cfg = default_config();
-            cfg.proxy.cache_max_idle_age = idle_timeout;
+            cfg.orig_dst_idle_timeout = idle_timeout;
             cfg
         };
         let (rt, _shutdown) = runtime();

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -58,11 +58,7 @@ impl<N> Outbound<N> {
                                 .stack
                                 .layer(crate::stack_labels("tcp", "server")),
                         )
-                        .push_buffer(
-                            "TCP Server",
-                            config.tcp_connection_buffer.capacity,
-                            config.tcp_connection_buffer.failfast_timeout,
-                        ),
+                        .push_buffer("TCP Server", &config.tcp_connection_buffer),
                 )
                 .push_cache(config.orig_dst_idle_timeout)
                 .push(svc::ArcNewService::layer())

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -60,7 +60,7 @@ impl<N> Outbound<N> {
                         )
                         .push_buffer("TCP Server", &config.tcp_connection_buffer),
                 )
-                .push_cache(config.orig_dst_idle_timeout)
+                .push_cache(config.discovery_idle_timeout)
                 .push(svc::ArcNewService::layer())
                 .check_new_service::<T, I>()
         })
@@ -180,7 +180,7 @@ mod tests {
         // service after `idle_timeout`.
         let cfg = {
             let mut cfg = default_config();
-            cfg.orig_dst_idle_timeout = idle_timeout;
+            cfg.discovery_idle_timeout = idle_timeout;
             cfg
         };
         let (rt, _shutdown) = runtime();

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -216,7 +216,7 @@ impl<S> Outbound<S> {
             .push_tcp_endpoint::<http::Connect>()
             .push_http_endpoint()
             .map_stack(|config, _, stk| {
-                stk.push_buffer_on_service("HTTP Server", &config.http_server_buffer)
+                stk.push_buffer_on_service("HTTP Server", &config.http_request_buffer)
             })
             .push_http_server()
             .into_inner();

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -215,7 +215,13 @@ impl<S> Outbound<S> {
             .clone()
             .push_tcp_endpoint::<http::Connect>()
             .push_http_endpoint()
-            .push_buffer_on_service("HTTP Server")
+            .map_stack(|config, _, stk| {
+                stk.push_buffer_on_service(
+                    "HTTP Server",
+                    config.http_server_buffer.capacity,
+                    config.http_server_buffer.failfast_timeout,
+                )
+            })
             .push_http_server()
             .into_inner();
 

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -216,11 +216,7 @@ impl<S> Outbound<S> {
             .push_tcp_endpoint::<http::Connect>()
             .push_http_endpoint()
             .map_stack(|config, _, stk| {
-                stk.push_buffer_on_service(
-                    "HTTP Server",
-                    config.http_server_buffer.capacity,
-                    config.http_server_buffer.failfast_timeout,
-                )
+                stk.push_buffer_on_service("HTTP Server", &config.http_server_buffer)
             })
             .push_http_server()
             .into_inner();

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -215,6 +215,7 @@ impl<S> Outbound<S> {
             .clone()
             .push_tcp_endpoint::<http::Connect>()
             .push_http_endpoint()
+            .push_buffer_on_service("HTTP Server")
             .push_http_server()
             .into_inner();
 

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -16,7 +16,6 @@ pub(crate) use self::{require_id_header::IdentityRequired, server::ServerRescue}
 use crate::tcp;
 pub use linkerd_app_core::proxy::http::*;
 use linkerd_app_core::{
-    classify, metrics,
     profiles::{self, LogicalAddr},
     proxy::{api_resolve::ProtocolHint, tap},
     svc::Param,
@@ -30,12 +29,6 @@ pub type Concrete = crate::logical::Concrete<Version>;
 pub type Endpoint = crate::endpoint::Endpoint<Version>;
 
 pub type Connect = self::endpoint::Connect<Endpoint>;
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct ProfileRoute {
-    logical: Logical,
-    route: profiles::http::Route,
-}
 
 #[derive(Clone, Debug)]
 pub struct CanonicalDstHeader(pub Addr);
@@ -180,33 +173,5 @@ impl tap::Inspect for Endpoint {
 
     fn is_outbound<B>(&self, _: &Request<B>) -> bool {
         true
-    }
-}
-
-// === impl ProfileRoute ===
-
-impl Param<profiles::http::Route> for ProfileRoute {
-    fn param(&self) -> profiles::http::Route {
-        self.route.clone()
-    }
-}
-
-impl Param<metrics::ProfileRouteLabels> for ProfileRoute {
-    fn param(&self) -> metrics::ProfileRouteLabels {
-        metrics::ProfileRouteLabels::outbound(self.logical.logical_addr.clone(), &self.route)
-    }
-}
-
-impl Param<ResponseTimeout> for ProfileRoute {
-    fn param(&self) -> ResponseTimeout {
-        ResponseTimeout(self.route.timeout())
-    }
-}
-
-impl classify::CanClassify for ProfileRoute {
-    type Classify = classify::Request;
-
-    fn classify(&self) -> classify::Request {
-        self.route.response_classes().clone().into()
     }
 }

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -1,3 +1,4 @@
+mod concrete;
 pub mod detect;
 mod endpoint;
 pub mod logical;

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -1,0 +1,111 @@
+use super::{Concrete, Endpoint};
+use crate::{endpoint, resolve, stack_labels, Outbound};
+use linkerd_app_core::{
+    proxy::{
+        api_resolve::{ConcreteAddr, Metadata},
+        core::Resolve,
+        http,
+        resolve::map_endpoint,
+    },
+    svc, Error, Infallible,
+};
+use tracing::debug_span;
+
+impl<N> Outbound<N> {
+    pub fn push_http_concrete<NSvc, R>(
+        self,
+        resolve: R,
+    ) -> Outbound<
+        svc::ArcNewService<
+            Concrete,
+            impl svc::Service<
+                http::Request<http::BoxBody>,
+                Response = http::Response<http::BoxBody>,
+                Error = Error,
+                Future = impl Send,
+            >,
+        >,
+    >
+    where
+        N: svc::NewService<Endpoint, Service = NSvc> + Clone + Send + Sync + 'static,
+        NSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+            + Send
+            + 'static,
+        NSvc::Error: Into<Error>,
+        NSvc::Future: Send,
+        R: Resolve<ConcreteAddr, Error = Error, Endpoint = Metadata>,
+        R: Clone + Send + Sync + 'static,
+        R::Resolution: Send,
+        R::Future: Send + Unpin,
+    {
+        self.map_stack(|config, rt, endpoint| {
+            let crate::Config {
+                orig_dst_idle_timeout,
+                ..
+            } = config;
+            let watchdog = *orig_dst_idle_timeout * 2;
+
+            let resolve = svc::stack(resolve.into_service())
+                .check_service::<ConcreteAddr>()
+                .push_request_filter(|c: Concrete| Ok::<_, Infallible>(c.resolve))
+                .push(svc::layer::mk(move |inner| {
+                    map_endpoint::Resolve::new(
+                        endpoint::FromMetadata {
+                            inbound_ips: config.inbound_ips.clone(),
+                        },
+                        inner,
+                    )
+                }))
+                .check_service::<Concrete>()
+                .into_inner();
+
+            endpoint
+                .instrument(|e: &Endpoint| debug_span!("endpoint", server.addr = %e.addr))
+                .check_new_service::<Endpoint, http::Request<http::BoxBody>>()
+                .push_on_service(
+                    svc::layers().push(http::BoxRequest::layer()).push(
+                        rt.metrics
+                            .proxy
+                            .stack
+                            .layer(stack_labels("http", "balance.endpoint")),
+                    ),
+                )
+                .check_new_service::<Endpoint, http::Request<_>>()
+                // Resolve the service to its endpoints and balance requests over them.
+                //
+                // If the balancer has been empty/unavailable, eagerly fail requests.
+                // When the balancer is in failfast, spawn the service in a background
+                // task so it becomes ready without new requests.
+                //
+                // We *don't* ensure that the endpoint is driven to readiness here, because this
+                // might cause us to continually attempt to reestablish connections without
+                // consulting discovery to see whether the endpoint has been removed. Instead, the
+                // endpoint layer spawns each _connection_ attempt on a background task, but the
+                // decision to attempt the connection must be driven by the balancer.
+                .push(resolve::layer(resolve, watchdog))
+                .push_on_service(
+                    svc::layers()
+                        .push(http::balance::layer(
+                            crate::EWMA_DEFAULT_RTT,
+                            crate::EWMA_DECAY,
+                        ))
+                        .push(
+                            rt.metrics
+                                .proxy
+                                .stack
+                                .layer(stack_labels("http", "balancer")),
+                        )
+                        .push(http::BoxResponse::layer()),
+                )
+                .check_make_service::<Concrete, http::Request<_>>()
+                .push(svc::MapErr::layer(Into::into))
+                // Drives the initial resolution via the service's readiness.
+                .into_new_service()
+                // The concrete address is only set when the profile could be
+                // resolved. Endpoint resolution is skipped when there is no
+                // concrete address.
+                .instrument(|c: &Concrete| debug_span!("concrete", addr = %c.resolve))
+                .push(svc::ArcNewService::layer())
+        })
+    }
+}

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -39,10 +39,10 @@ impl<N> Outbound<N> {
     {
         self.map_stack(|config, rt, endpoint| {
             let crate::Config {
-                orig_dst_idle_timeout,
+                discovery_idle_timeout,
                 ..
             } = config;
-            let watchdog = *orig_dst_idle_timeout * 2;
+            let watchdog = *discovery_idle_timeout * 2;
 
             let resolve = svc::stack(resolve.into_service())
                 .check_service::<ConcreteAddr>()

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -9,7 +9,6 @@ use linkerd_app_core::{
     },
     svc, Error, Infallible,
 };
-use tracing::debug_span;
 
 impl<N> Outbound<N> {
     pub fn push_http_concrete<NSvc, R>(
@@ -60,7 +59,6 @@ impl<N> Outbound<N> {
                 .into_inner();
 
             endpoint
-                .instrument(|e: &Endpoint| debug_span!("endpoint", server.addr = %e.addr))
                 .check_new_service::<Endpoint, http::Request<http::BoxBody>>()
                 .push_on_service(
                     svc::layers().push(http::BoxRequest::layer()).push(
@@ -104,7 +102,7 @@ impl<N> Outbound<N> {
                 // The concrete address is only set when the profile could be
                 // resolved. Endpoint resolution is skipped when there is no
                 // concrete address.
-                .instrument(|c: &Concrete| debug_span!("concrete", addr = %c.resolve))
+                .instrument(|c: &Concrete| tracing::debug_span!("concrete", service = %c.resolve))
                 .push(svc::ArcNewService::layer())
         })
     }

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -68,6 +68,7 @@ impl<N> Outbound<N> {
                             .layer(stack_labels("http", "balance.endpoint")),
                     ),
                 )
+                .instrument(|t: &Endpoint| tracing::debug_span!("endpoint", addr = %t.addr))
                 .check_new_service::<Endpoint, http::Request<_>>()
                 // Resolve the service to its endpoints and balance requests over them.
                 //

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -25,8 +25,7 @@ impl<C> Outbound<C> {
     pub fn push_http_endpoint<T, B>(self) -> Outbound<svc::ArcNewHttp<T, B>>
     where
         T: Clone + Send + Sync + 'static,
-        T: svc::Param<Remote<ServerAddr>>
-            + svc::Param<http::client::Settings>
+        T: svc::Param<http::client::Settings>
             + svc::Param<Option<http::AuthorityOverride>>
             + svc::Param<metrics::EndpointLabels>
             + svc::Param<tls::ConditionalClientTls>
@@ -91,10 +90,6 @@ impl<C> Outbound<C> {
                     "host",
                     CANONICAL_DST_HEADER,
                 ]))
-                .instrument(|t: &T| {
-                    let Remote(ServerAddr(addr)) = t.param();
-                    tracing::debug_span!("endpoint", %addr)
-                })
                 .push_on_service(
                     svc::layers()
                         .push(http::BoxResponse::layer())

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -25,7 +25,7 @@ impl<N> Outbound<N> {
     {
         self.map_stack(|config, rt, concrete| {
             let crate::Config {
-                orig_dst_idle_timeout,
+                discovery_idle_timeout,
                 http_request_buffer,
                 ..
             } = config;
@@ -60,7 +60,7 @@ impl<N> Outbound<N> {
                         .push_buffer("HTTP Logical", http_request_buffer),
                 )
                 // TODO(ver) this should not be a generalized time-based evicting cache.
-                .push_cache(*orig_dst_idle_timeout);
+                .push_cache(*discovery_idle_timeout);
 
             // If there's no route, use the logical service directly; otherwise
             // use the per-route stack.

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -114,15 +114,13 @@ impl<E> Outbound<E> {
                 .push(profiles::split::layer())
                 .push_on_service(
                     svc::layers()
-                        .push(svc::layer::mk(svc::SpawnReady::new))
                         .push(
                             rt.metrics
                                 .proxy
                                 .stack
                                 .layer(stack_labels("http", "logical")),
                         )
-                        .push(svc::FailFast::layer("HTTP Logical", dispatch_timeout))
-                        .push_spawn_buffer(buffer_capacity),
+                        .push_buffer("HTTP Logical", buffer_capacity, dispatch_timeout),
                 )
                 .push_cache(cache_max_idle_age);
 

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -42,7 +42,7 @@ impl<N> Outbound<N> {
                                 .stack
                                 .layer(stack_labels("http", "logical")),
                         )
-                        .push_buffer("HTTP Logical", http_logical_buffer.capacity, http_logical_buffer.failfast_timeout),
+                        .push_buffer("HTTP Logical", http_logical_buffer),
                 )
                 .push_cache(*orig_dst_idle_timeout);
 

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -34,6 +34,9 @@ impl<N> Outbound<N> {
                 .push_map_target(Concrete::from)
                 // This failfast is needed to ensure that a single unavailable
                 // balancer doesn't block the entire split.
+                //
+                // TODO(ver) remove this when we replace `split` with
+                // `distribute`.
                 .push_on_service(
                     svc::layers()
                         .push(svc::layer::mk(svc::SpawnReady::new))
@@ -56,6 +59,7 @@ impl<N> Outbound<N> {
                         )
                         .push_buffer("HTTP Logical", http_request_buffer),
                 )
+                // TODO(ver) this should not be a generalized time-based evicting cache.
                 .push_cache(*orig_dst_idle_timeout);
 
             // If there's no route, use the logical service directly; otherwise

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -1,115 +1,13 @@
-use super::{retry, CanonicalDstHeader, Concrete, Endpoint, Logical, ProfileRoute};
-use crate::{endpoint, resolve, stack_labels, Outbound};
+use super::{retry, CanonicalDstHeader, Concrete, Logical, ProfileRoute};
+use crate::{stack_labels, Outbound};
 use linkerd_app_core::{
     classify, profiles,
-    proxy::{
-        api_resolve::{ConcreteAddr, Metadata},
-        core::Resolve,
-        http,
-        resolve::map_endpoint,
-    },
+    proxy::{api_resolve::ConcreteAddr, http},
     svc, Error, Infallible,
 };
 use tracing::debug_span;
 
 impl<N> Outbound<N> {
-    pub fn push_http_concrete<NSvc, R>(
-        self,
-        resolve: R,
-    ) -> Outbound<
-        svc::ArcNewService<
-            Concrete,
-            impl svc::Service<
-                http::Request<http::BoxBody>,
-                Response = http::Response<http::BoxBody>,
-                Error = Error,
-                Future = impl Send,
-            >,
-        >,
-    >
-    where
-        N: svc::NewService<Endpoint, Service = NSvc> + Clone + Send + Sync + 'static,
-        NSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
-            + Send
-            + 'static,
-        NSvc::Error: Into<Error>,
-        NSvc::Future: Send,
-        R: Resolve<ConcreteAddr, Error = Error, Endpoint = Metadata>,
-        R: Clone + Send + Sync + 'static,
-        R::Resolution: Send,
-        R::Future: Send + Unpin,
-    {
-        self.map_stack(|config, rt, endpoint| {
-            let crate::Config {
-                orig_dst_idle_timeout,
-                ..
-            } = config;
-            let watchdog = *orig_dst_idle_timeout * 2;
-
-            let resolve = svc::stack(resolve.into_service())
-                .check_service::<ConcreteAddr>()
-                .push_request_filter(|c: Concrete| Ok::<_, Infallible>(c.resolve))
-                .push(svc::layer::mk(move |inner| {
-                    map_endpoint::Resolve::new(
-                        endpoint::FromMetadata {
-                            inbound_ips: config.inbound_ips.clone(),
-                        },
-                        inner,
-                    )
-                }))
-                .check_service::<Concrete>()
-                .into_inner();
-
-            endpoint
-                // .instrument(|e: &Endpoint| debug_span!("endpoint", server.addr = %e.addr))
-                .check_new_service::<Endpoint, http::Request<http::BoxBody>>()
-                .push_on_service(
-                    svc::layers().push(http::BoxRequest::layer()).push(
-                        rt.metrics
-                            .proxy
-                            .stack
-                            .layer(stack_labels("http", "balance.endpoint")),
-                    ),
-                )
-                .check_new_service::<Endpoint, http::Request<_>>()
-                // Resolve the service to its endpoints and balance requests over them.
-                //
-                // If the balancer has been empty/unavailable, eagerly fail requests.
-                // When the balancer is in failfast, spawn the service in a background
-                // task so it becomes ready without new requests.
-                //
-                // We *don't* ensure that the endpoint is driven to readiness here, because this
-                // might cause us to continually attempt to reestablish connections without
-                // consulting discovery to see whether the endpoint has been removed. Instead, the
-                // endpoint layer spawns each _connection_ attempt on a background task, but the
-                // decision to attempt the connection must be driven by the balancer.
-                .push(resolve::layer(resolve, watchdog))
-                .push_on_service(
-                    svc::layers()
-                        .push(http::balance::layer(
-                            crate::EWMA_DEFAULT_RTT,
-                            crate::EWMA_DECAY,
-                        ))
-                        .push(
-                            rt.metrics
-                                .proxy
-                                .stack
-                                .layer(stack_labels("http", "balancer")),
-                        )
-                        .push(http::BoxResponse::layer()),
-                )
-                .check_make_service::<Concrete, http::Request<_>>()
-                .push(svc::MapErr::layer(Into::into))
-                // Drives the initial resolution via the service's readiness.
-                .into_new_service()
-                // The concrete address is only set when the profile could be
-                // resolved. Endpoint resolution is skipped when there is no
-                // concrete address.
-                .instrument(|c: &Concrete| debug_span!("concrete", addr = %c.resolve))
-                .push(svc::ArcNewService::layer())
-        })
-    }
-
     pub fn push_http_logical<NSvc>(self) -> Outbound<svc::ArcNewHttp<Logical>>
     where
         N: svc::NewService<Concrete, Service = NSvc> + Clone + Send + Sync + 'static,

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -64,7 +64,7 @@ impl<N> Outbound<N> {
 
             // If there's no route, use the logical service directly; otherwise
             // use the per-route stack.
-            let route = (split.clone())
+            let route = split.clone()
                 .check_new_service::<Logical, http::Request<http::BoxBody>>()
                 .push_map_target(|r: ProfileRoute| r.logical)
                 .push_on_service(http::BoxRequest::layer())

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -43,6 +43,21 @@ impl<N> Outbound<N> {
                 .push_on_service(
                     svc::layers()
                         .push(http::BoxRequest::layer())
+                        // Limit the number of in-flight outbound requests
+                        // (across all targets).
+                        //
+                        // TODO(ver) This concurrency limit applies only to
+                        // requests that do not yet have responses, but ignores
+                        // streaming bodies. We should change this to an
+                        // HTTP-specific imlementation that tracks request and
+                        // response bodies.
+                        .push(svc::ConcurrencyLimitLayer::new(
+                            config.proxy.max_in_flight_requests,
+                        ))
+                        // Shed load by failing requests when the concurrency
+                        // limit is reached. No delay is used before failfast
+                        // goes into effect so it is expected that the inner.
+                        .push(svc::FailFast::layer("HTTP Server", Default::default()))
                         .push(rt.metrics.http_errors.to_layer())
                         // Tear down server connections when a peer proxy generates an error.
                         .push(ProxyConnectionClose::layer()),

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -83,7 +83,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                 let detect_http = config.proxy.detect_http();
                 let Config {
                     allow_discovery,
-                    http_logical_buffer,
+                    http_request_buffer,
                     orig_dst_idle_timeout,
                     proxy:
                         ProxyConfig {
@@ -147,7 +147,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                                     .stack
                                     .layer(stack_labels("http", "logical")),
                             )
-                            .push_buffer("HTTP Logical", http_logical_buffer),
+                            .push_buffer("HTTP Logical", http_request_buffer),
                     )
                     // Caches the profile-based stack so that it can be reused across
                     // multiple requests to the same canonical destination.

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -147,9 +147,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                                     .stack
                                     .layer(stack_labels("http", "logical")),
                             )
-                            .push(svc::layer::mk(svc::SpawnReady::new))
-                            .push(svc::FailFast::layer("HTTP Logical", *dispatch_timeout))
-                            .push_spawn_buffer(*buffer_capacity),
+                            .push_buffer("HTTP Logical", *buffer_capacity, *dispatch_timeout),
                     )
                     // Caches the profile-based stack so that it can be reused across
                     // multiple requests to the same canonical destination.

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -147,11 +147,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                                     .stack
                                     .layer(stack_labels("http", "logical")),
                             )
-                            .push_buffer(
-                                "HTTP Logical",
-                                http_logical_buffer.capacity,
-                                http_logical_buffer.failfast_timeout,
-                            ),
+                            .push_buffer("HTTP Logical", http_logical_buffer),
                     )
                     // Caches the profile-based stack so that it can be reused across
                     // multiple requests to the same canonical destination.

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -84,7 +84,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                 let Config {
                     allow_discovery,
                     http_request_buffer,
-                    orig_dst_idle_timeout,
+                    discovery_idle_timeout,
                     proxy:
                         ProxyConfig {
                             server: ServerConfig { h2_settings, .. },
@@ -151,7 +151,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                     )
                     // Caches the profile-based stack so that it can be reused across
                     // multiple requests to the same canonical destination.
-                    .push_cache(*orig_dst_idle_timeout)
+                    .push_cache(*discovery_idle_timeout)
                     .push_on_service(
                         svc::layers()
                             .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER))

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -56,7 +56,7 @@ pub struct Config {
     /// Configures the duration the proxy will retain idle stacks (with no
     /// active connections) for an outbound address. When an idle stack is
     /// dropped, all cached service discovery information is dropped.
-    pub orig_dst_idle_timeout: Duration,
+    pub discovery_idle_timeout: Duration,
 
     /// Configures how connections are buffered *for each outbound address*.
     ///

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -60,14 +60,14 @@ pub struct Config {
 
     /// Configures how connections are buffered *for each outbound address*.
     ///
-    /// A buffer capacity of 100 eans that 100 connections may be buffered for
+    /// A buffer capacity of 100 means that 100 connections may be buffered for
     /// each IP:port to which an application attempts to connect.
     pub tcp_connection_buffer: BufferConfig,
 
     /// Configures how HTTP requests are buffered *for each outbound address*.
     ///
-    /// A buffer capacity of 100 eans that 100 connections may be buffered for
-    /// each IP:port to which an application attempts to connect.
+    /// A buffer capacity of 100 means that 100 requests may be buffered for
+    /// each IP:port to which an application has opened an outbound TCP connection.
     pub http_request_buffer: BufferConfig,
 
     // In "ingress mode", we assume we are always routing HTTP requests and do

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -53,13 +53,22 @@ pub struct Config {
 
     pub proxy: ProxyConfig,
 
+    /// Configures the duration the proxy will retain idle stacks (with no
+    /// active connections) for an outbound address. When an idle stack is
+    /// dropped, all cached service discovery information is dropped.
     pub orig_dst_idle_timeout: Duration,
 
+    /// Configures how connections are buffered *for each outbound address*.
+    ///
+    /// A buffer capacity of 100 eans that 100 connections may be buffered for
+    /// each IP:port to which an application attempts to connect.
     pub tcp_connection_buffer: BufferConfig,
-    pub tcp_logical_buffer: BufferConfig,
 
-    pub http_server_buffer: BufferConfig,
-    pub http_logical_buffer: BufferConfig,
+    /// Configures how HTTP requests are buffered *for each outbound address*.
+    ///
+    /// A buffer capacity of 100 eans that 100 connections may be buffered for
+    /// each IP:port to which an application attempts to connect.
+    pub http_request_buffer: BufferConfig,
 
     // In "ingress mode", we assume we are always routing HTTP requests and do
     // not perform per-target-address discovery. Non-HTTP connections are

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -134,6 +134,19 @@ impl<S> Outbound<S> {
         self.map_stack(move |_, _, stack| stack.push(layer))
     }
 
+    pub fn push_buffer_on_service<Req: Send + 'static>(
+        self,
+        name: &'static str,
+    ) -> Outbound<svc::stack::OnService<svc::BufferLayer<Req>, S>> {
+        self.map_stack(|config, _, stack| {
+            stack.push_buffer_on_service(
+                name,
+                config.proxy.buffer_capacity,
+                config.proxy.dispatch_timeout,
+            )
+        })
+    }
+
     /// Creates a new `Outbound` by replacing the inner stack, as modified by `f`.
     fn map_stack<T>(
         self,

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -135,6 +135,7 @@ impl<C> Outbound<C> {
             .push_tcp_endpoint()
             .push_http_endpoint()
             .push_http_logical(resolve.clone())
+            .push_buffer_on_service("HTTP Server")
             .push_http_server()
             .into_inner();
 

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -137,11 +137,7 @@ impl<C> Outbound<C> {
             .push_http_concrete(resolve.clone())
             .push_http_logical()
             .map_stack(|config, _, stk| {
-                stk.push_buffer_on_service(
-                    "HTTP Server",
-                    config.http_server_buffer.capacity,
-                    config.http_server_buffer.failfast_timeout,
-                )
+                stk.push_buffer_on_service("HTTP Server", &config.http_server_buffer)
             })
             .push_http_server()
             .into_inner();

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -134,8 +134,15 @@ impl<C> Outbound<C> {
             .clone()
             .push_tcp_endpoint()
             .push_http_endpoint()
-            .push_http_logical(resolve.clone())
-            .push_buffer_on_service("HTTP Server")
+            .push_http_concrete(resolve.clone())
+            .push_http_logical()
+            .map_stack(|config, _, stk| {
+                stk.push_buffer_on_service(
+                    "HTTP Server",
+                    config.http_server_buffer.capacity,
+                    config.http_server_buffer.failfast_timeout,
+                )
+            })
             .push_http_server()
             .into_inner();
 

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -137,7 +137,7 @@ impl<C> Outbound<C> {
             .push_http_concrete(resolve.clone())
             .push_http_logical()
             .map_stack(|config, _, stk| {
-                stk.push_buffer_on_service("HTTP Server", &config.http_server_buffer)
+                stk.push_buffer_on_service("HTTP Server", &config.http_request_buffer)
             })
             .push_http_server()
             .into_inner();

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -40,7 +40,7 @@ impl<C> Outbound<C> {
     {
         self.map_stack(|config, rt, connect| {
             let crate::Config {
-                orig_dst_idle_timeout,
+                discovery_idle_timeout,
                 tcp_connection_buffer,
                 ..
             } = config;
@@ -63,7 +63,7 @@ impl<C> Outbound<C> {
                 .push(svc::stack::WithoutConnectionMetadata::layer())
                 .push_make_thunk()
                 .instrument(|t: &Endpoint| debug_span!("endpoint", addr = %t.addr))
-                .push(resolve::layer(resolve, *orig_dst_idle_timeout * 2))
+                .push(resolve::layer(resolve, *discovery_idle_timeout * 2))
                 .push_on_service(
                     svc::layers()
                         .push(tcp::balance::layer(
@@ -100,7 +100,7 @@ impl<C> Outbound<C> {
                 )
                 // TODO(ver) Can we replace this evicting cache? The detect
                 // stack would have to hold/reuse inner stacks.
-                .push_cache(*orig_dst_idle_timeout)
+                .push_cache(*discovery_idle_timeout)
                 .check_new_service::<Logical, I>()
                 .instrument(|_: &Logical| debug_span!("tcp"))
                 .check_new_service::<Logical, I>()

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -62,13 +62,7 @@ impl<C> Outbound<C> {
             let concrete = connect
                 .push(svc::stack::WithoutConnectionMetadata::layer())
                 .push_make_thunk()
-                .instrument(|t: &Endpoint| {
-                    debug_span!(
-                        "endpoint",
-                        server.addr = %t.addr,
-                        server.id = t.tls.value().map(|tls| tracing::field::display(&tls.server_id)),
-                    )
-                })
+                .instrument(|t: &Endpoint| debug_span!("endpoint", addr = %t.addr))
                 .push(resolve::layer(resolve, *orig_dst_idle_timeout * 2))
                 .push_on_service(
                     svc::layers()

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -100,7 +100,7 @@ impl<C> Outbound<C> {
                                 .stack
                                 .layer(crate::stack_labels("tcp", "logical")),
                         )
-                        .push_buffer("TCP Logical", tcp_logical_buffer.capacity, tcp_logical_buffer.failfast_timeout),
+                        .push_buffer("TCP Logical", tcp_logical_buffer),
                 )
                 .push_cache(*orig_dst_idle_timeout)
                 .check_new_service::<Logical, I>()

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -41,7 +41,7 @@ impl<C> Outbound<C> {
         self.map_stack(|config, rt, connect| {
             let crate::Config {
                 orig_dst_idle_timeout,
-                tcp_logical_buffer,
+                tcp_connection_buffer,
                 ..
             } = config;
 
@@ -100,8 +100,12 @@ impl<C> Outbound<C> {
                                 .stack
                                 .layer(crate::stack_labels("tcp", "logical")),
                         )
-                        .push_buffer("TCP Logical", tcp_logical_buffer),
+                        // TODO(ver) We should instead buffer per concrete
+                        // target.
+                        .push_buffer("TCP Logical", tcp_connection_buffer),
                 )
+                // TODO(ver) Can we replace this evicting cache? The detect
+                // stack would have to hold/reuse inner stacks.
                 .push_cache(*orig_dst_idle_timeout)
                 .check_new_service::<Logical, I>()
                 .instrument(|_: &Logical| debug_span!("tcp"))

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -99,9 +99,7 @@ impl<C> Outbound<C> {
                                 .stack
                                 .layer(crate::stack_labels("tcp", "logical")),
                         )
-                        .push(svc::layer::mk(svc::SpawnReady::new))
-                        .push(svc::FailFast::layer("TCP Logical", dispatch_timeout))
-                        .push_spawn_buffer(buffer_capacity),
+                        .push_buffer("TCP Logical", buffer_capacity, dispatch_timeout),
                 )
                 .push_cache(cache_max_idle_age)
                 .check_new_service::<Logical, I>()

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -49,9 +49,7 @@ pub(crate) fn default_config() -> Config {
         inbound_ips: Default::default(),
         orig_dst_idle_timeout: Duration::from_secs(60),
         tcp_connection_buffer: buffer.clone(),
-        tcp_logical_buffer: buffer.clone(),
-        http_logical_buffer: buffer.clone(),
-        http_server_buffer: buffer,
+        http_request_buffer: buffer,
     }
 }
 

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -47,7 +47,7 @@ pub(crate) fn default_config() -> Config {
             detect_protocol_timeout: Duration::from_secs(3),
         },
         inbound_ips: Default::default(),
-        orig_dst_idle_timeout: Duration::from_secs(60),
+        discovery_idle_timeout: Duration::from_secs(60),
         tcp_connection_buffer: buffer.clone(),
         http_request_buffer: buffer,
     }

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -96,12 +96,12 @@ pub const ENV_METRICS_RETAIN_IDLE: &str = "LINKERD2_PROXY_METRICS_RETAIN_IDLE";
 
 const ENV_INGRESS_MODE: &str = "LINKERD2_PROXY_INGRESS_MODE";
 
-const ENV_INBOUND_HTTP_BUFFER_CAPACITY: &str = "LINKERD2_PROXY_INBOUND_HTTP_BUFFER_CAPACITY";
+const ENV_INBOUND_HTTP_QUEUE_CAPACITY: &str = "LINKERD2_PROXY_INBOUND_HTTP_QUEUE_CAPACITY";
 const ENV_INBOUND_HTTP_FAILFAST_TIMEOUT: &str = "LINKERD2_PROXY_INBOUND_HTTP_FAILFAST_TIMEOUT";
 
-const ENV_OUTBOUND_TCP_BUFFER_CAPACITY: &str = "LINKERD2_PROXY_OUTBOUND_TCP_BUFFER_CAPACITY";
+const ENV_OUTBOUND_TCP_QUEUE_CAPACITY: &str = "LINKERD2_PROXY_OUTBOUND_TCP_QUEUE_CAPACITY";
 const ENV_OUTBOUND_TCP_FAILFAST_TIMEOUT: &str = "LINKERD2_PROXY_OUTBOUND_TCP_FAILFAST_TIMEOUT";
-const ENV_OUTBOUND_HTTP_BUFFER_CAPACITY: &str = "LINKERD2_PROXY_OUTBOUND_HTTP_BUFFER_CAPACITY";
+const ENV_OUTBOUND_HTTP_QUEUE_CAPACITY: &str = "LINKERD2_PROXY_OUTBOUND_HTTP_QUEUE_CAPACITY";
 const ENV_OUTBOUND_HTTP_FAILFAST_TIMEOUT: &str = "LINKERD2_PROXY_OUTBOUND_HTTP_FAILFAST_TIMEOUT";
 
 pub const ENV_INBOUND_DETECT_TIMEOUT: &str = "LINKERD2_PROXY_INBOUND_DETECT_TIMEOUT";
@@ -233,23 +233,23 @@ pub const DEFAULT_CONTROL_LISTEN_ADDR: &str = "0.0.0.0:4190";
 const DEFAULT_ADMIN_LISTEN_ADDR: &str = "127.0.0.1:4191";
 const DEFAULT_METRICS_RETAIN_IDLE: Duration = Duration::from_secs(10 * 60);
 
-const DEFAULT_INBOUND_HTTP_BUFFER_CAPACITY: usize = 100;
+const DEFAULT_INBOUND_HTTP_QUEUE_CAPACITY: usize = 100;
 const DEFAULT_INBOUND_HTTP_FAILFAST_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_INBOUND_DETECT_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_INBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
 const DEFAULT_INBOUND_CONNECT_BACKOFF: ExponentialBackoff =
     ExponentialBackoff::new_unchecked(Duration::from_millis(100), Duration::from_millis(500), 0.1);
 
-const DEFAULT_OUTBOUND_TCP_BUFFER_CAPACITY: usize = 10;
+const DEFAULT_OUTBOUND_TCP_QUEUE_CAPACITY: usize = 10;
 const DEFAULT_OUTBOUND_TCP_FAILFAST_TIMEOUT: Duration = Duration::from_secs(3);
-const DEFAULT_OUTBOUND_HTTP_BUFFER_CAPACITY: usize = 100;
+const DEFAULT_OUTBOUND_HTTP_QUEUE_CAPACITY: usize = 100;
 const DEFAULT_OUTBOUND_HTTP_FAILFAST_TIMEOUT: Duration = Duration::from_secs(3);
 const DEFAULT_OUTBOUND_DETECT_TIMEOUT: Duration = Duration::from_secs(10);
 const DEFAULT_OUTBOUND_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
 const DEFAULT_OUTBOUND_CONNECT_BACKOFF: ExponentialBackoff =
     ExponentialBackoff::new_unchecked(Duration::from_millis(100), Duration::from_millis(500), 0.1);
 
-const DEFAULT_CONTROL_BUFFER_CAPACITY: usize = 100;
+const DEFAULT_CONTROL_QUEUE_CAPACITY: usize = 100;
 const DEFAULT_CONTROL_FAILFAST_TIMEOUT: Duration = Duration::from_secs(10);
 
 const DEFAULT_RESOLV_CONF: &str = "/etc/resolv.conf";
@@ -322,17 +322,17 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let inbound_detect_timeout = parse(strings, ENV_INBOUND_DETECT_TIMEOUT, parse_duration);
     let inbound_connect_timeout = parse(strings, ENV_INBOUND_CONNECT_TIMEOUT, parse_duration);
     let inbound_http_buffer_capacity =
-        parse(strings, ENV_INBOUND_HTTP_BUFFER_CAPACITY, parse_number);
+        parse(strings, ENV_INBOUND_HTTP_QUEUE_CAPACITY, parse_number);
     let inbound_http_failfast_timeout =
         parse(strings, ENV_INBOUND_HTTP_FAILFAST_TIMEOUT, parse_duration);
 
     let outbound_detect_timeout = parse(strings, ENV_OUTBOUND_DETECT_TIMEOUT, parse_duration);
     let outbound_tcp_buffer_capacity =
-        parse(strings, ENV_OUTBOUND_TCP_BUFFER_CAPACITY, parse_number);
+        parse(strings, ENV_OUTBOUND_TCP_QUEUE_CAPACITY, parse_number);
     let outbound_tcp_failfast_timeout =
         parse(strings, ENV_OUTBOUND_TCP_FAILFAST_TIMEOUT, parse_duration);
     let outbound_http_buffer_capacity =
-        parse(strings, ENV_OUTBOUND_HTTP_BUFFER_CAPACITY, parse_number);
+        parse(strings, ENV_OUTBOUND_HTTP_QUEUE_CAPACITY, parse_number);
     let outbound_http_failfast_timeout =
         parse(strings, ENV_OUTBOUND_HTTP_FAILFAST_TIMEOUT, parse_duration);
     let outbound_connect_timeout = parse(strings, ENV_OUTBOUND_CONNECT_TIMEOUT, parse_duration);
@@ -489,11 +489,11 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             outbound_detect_timeout?.unwrap_or(DEFAULT_OUTBOUND_DETECT_TIMEOUT);
 
         let tcp_buffer_capacity =
-            outbound_tcp_buffer_capacity?.unwrap_or(DEFAULT_OUTBOUND_TCP_BUFFER_CAPACITY);
+            outbound_tcp_buffer_capacity?.unwrap_or(DEFAULT_OUTBOUND_TCP_QUEUE_CAPACITY);
         let tcp_failfast_timeout =
             outbound_tcp_failfast_timeout?.unwrap_or(DEFAULT_OUTBOUND_TCP_FAILFAST_TIMEOUT);
         let http_buffer_capacity =
-            outbound_http_buffer_capacity?.unwrap_or(DEFAULT_OUTBOUND_HTTP_BUFFER_CAPACITY);
+            outbound_http_buffer_capacity?.unwrap_or(DEFAULT_OUTBOUND_HTTP_QUEUE_CAPACITY);
         let http_failfast_timeout =
             outbound_http_failfast_timeout?.unwrap_or(DEFAULT_OUTBOUND_HTTP_FAILFAST_TIMEOUT);
 
@@ -637,7 +637,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                             addr,
                             connect,
                             buffer: BufferConfig {
-                                capacity: DEFAULT_CONTROL_BUFFER_CAPACITY,
+                                capacity: DEFAULT_CONTROL_QUEUE_CAPACITY,
                                 failfast_timeout: DEFAULT_CONTROL_FAILFAST_TIMEOUT,
                             },
                         }
@@ -759,7 +759,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             discovery_idle_timeout,
             http_request_buffer: BufferConfig {
                 capacity: inbound_http_buffer_capacity?
-                    .unwrap_or(DEFAULT_INBOUND_HTTP_BUFFER_CAPACITY),
+                    .unwrap_or(DEFAULT_INBOUND_HTTP_QUEUE_CAPACITY),
                 failfast_timeout: inbound_http_failfast_timeout?
                     .unwrap_or(DEFAULT_INBOUND_HTTP_FAILFAST_TIMEOUT),
             },
@@ -784,7 +784,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 addr,
                 connect,
                 buffer: BufferConfig {
-                    capacity: DEFAULT_CONTROL_BUFFER_CAPACITY,
+                    capacity: DEFAULT_CONTROL_QUEUE_CAPACITY,
                     failfast_timeout,
                 },
             },
@@ -835,7 +835,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                     addr,
                     connect,
                     buffer: BufferConfig {
-                        capacity: DEFAULT_CONTROL_BUFFER_CAPACITY,
+                        capacity: DEFAULT_CONTROL_QUEUE_CAPACITY,
                         failfast_timeout,
                     },
                 },
@@ -873,7 +873,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 addr,
                 connect,
                 buffer: BufferConfig {
-                    capacity: DEFAULT_CONTROL_BUFFER_CAPACITY,
+                    capacity: DEFAULT_CONTROL_QUEUE_CAPACITY,
                     failfast_timeout,
                 },
             },

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -372,7 +372,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
     let dst_addr = parse_control_addr(strings, ENV_DESTINATION_SVC_BASE);
     let dst_token = strings.get(ENV_DESTINATION_CONTEXT);
-    let dst_profile_idle_timeout = parse(
+    let dst_profile_skip_timeout = parse(
         strings,
         ENV_DESTINATION_PROFILE_INITIAL_TIMEOUT,
         parse_duration,
@@ -473,14 +473,28 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             proxy: ProxyConfig {
                 server,
                 connect,
-                cache_max_idle_age,
-                buffer_capacity,
-                dispatch_timeout,
                 max_in_flight_requests: outbound_max_in_flight?
                     .unwrap_or(DEFAULT_OUTBOUND_MAX_IN_FLIGHT),
                 detect_protocol_timeout,
             },
             inbound_ips: inbound_ips.clone(),
+            orig_dst_idle_timeout: cache_max_idle_age,
+            tcp_connection_buffer: BufferConfig {
+                capacity: buffer_capacity,
+                failfast_timeout: dispatch_timeout,
+            },
+            tcp_logical_buffer: BufferConfig {
+                capacity: buffer_capacity,
+                failfast_timeout: dispatch_timeout,
+            },
+            http_server_buffer: BufferConfig {
+                capacity: buffer_capacity,
+                failfast_timeout: dispatch_timeout,
+            },
+            http_logical_buffer: BufferConfig {
+                capacity: buffer_capacity,
+                failfast_timeout: dispatch_timeout,
+            },
         }
     };
 
@@ -709,17 +723,24 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             proxy: ProxyConfig {
                 server,
                 connect,
-                cache_max_idle_age,
-                buffer_capacity,
-                dispatch_timeout,
                 max_in_flight_requests: inbound_max_in_flight?
                     .unwrap_or(DEFAULT_INBOUND_MAX_IN_FLIGHT),
                 detect_protocol_timeout,
             },
             policy,
-            profile_idle_timeout: dst_profile_idle_timeout?
+            profile_skip_timeout: dst_profile_skip_timeout?
                 .unwrap_or(DEFAULT_DESTINATION_PROFILE_IDLE_TIMEOUT),
             allowed_ips: inbound_ips.into(),
+
+            profile_idle_timeout: cache_max_idle_age,
+            tcp_server_buffer: BufferConfig {
+                capacity: buffer_capacity,
+                failfast_timeout: dispatch_timeout,
+            },
+            http_logical_buffer: BufferConfig {
+                capacity: buffer_capacity,
+                failfast_timeout: dispatch_timeout,
+            },
         }
     };
 

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -615,7 +615,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                         ControlConfig {
                             addr,
                             connect,
-                            buffer_capacity,
+                            buffer: BufferConfig {
+                                capacity: buffer_capacity,
+                                failfast_timeout: dispatch_timeout,
+                            },
                         }
                     };
 
@@ -751,12 +754,20 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         } else {
             outbound.proxy.connect.clone()
         };
+        let failfast_timeout = if addr.addr.is_loopback() {
+            inbound.http_logical_buffer.failfast_timeout
+        } else {
+            outbound.http_logical_buffer.failfast_timeout
+        };
         super::dst::Config {
             context: dst_token?.unwrap_or_default(),
             control: ControlConfig {
                 addr,
                 connect,
-                buffer_capacity,
+                buffer: BufferConfig {
+                    capacity: buffer_capacity,
+                    failfast_timeout,
+                },
             },
         }
     };
@@ -786,7 +797,11 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             } else {
                 outbound.proxy.connect.clone()
             };
-
+            let failfast_timeout = if addr.addr.is_loopback() {
+                inbound.http_logical_buffer.failfast_timeout
+            } else {
+                outbound.http_logical_buffer.failfast_timeout
+            };
             let attributes = oc_attributes_file_path
                 .map(|path| match path {
                     Some(path) => oc_trace_attributes(path),
@@ -800,7 +815,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 control: ControlConfig {
                     addr,
                     connect,
-                    buffer_capacity: 10,
+                    buffer: BufferConfig {
+                        capacity: buffer_capacity,
+                        failfast_timeout,
+                    },
                 },
             }))
         }
@@ -825,12 +843,20 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         } else {
             outbound.proxy.connect.clone()
         };
+        let failfast_timeout = if addr.addr.is_loopback() {
+            inbound.http_logical_buffer.failfast_timeout
+        } else {
+            outbound.http_logical_buffer.failfast_timeout
+        };
         identity::Config {
             certify,
             control: ControlConfig {
                 addr,
                 connect,
-                buffer_capacity: 1,
+                buffer: BufferConfig {
+                    capacity: buffer_capacity,
+                    failfast_timeout,
+                },
             },
             documents,
         }

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -483,15 +483,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 capacity: buffer_capacity,
                 failfast_timeout: dispatch_timeout,
             },
-            tcp_logical_buffer: BufferConfig {
-                capacity: buffer_capacity,
-                failfast_timeout: dispatch_timeout,
-            },
-            http_server_buffer: BufferConfig {
-                capacity: buffer_capacity,
-                failfast_timeout: dispatch_timeout,
-            },
-            http_logical_buffer: BufferConfig {
+            http_request_buffer: BufferConfig {
                 capacity: buffer_capacity,
                 failfast_timeout: dispatch_timeout,
             },
@@ -736,11 +728,11 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             allowed_ips: inbound_ips.into(),
 
             profile_idle_timeout: cache_max_idle_age,
-            tcp_server_buffer: BufferConfig {
+            tcp_connection_buffer: BufferConfig {
                 capacity: buffer_capacity,
                 failfast_timeout: dispatch_timeout,
             },
-            http_logical_buffer: BufferConfig {
+            http_request_buffer: BufferConfig {
                 capacity: buffer_capacity,
                 failfast_timeout: dispatch_timeout,
             },
@@ -755,9 +747,9 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             outbound.proxy.connect.clone()
         };
         let failfast_timeout = if addr.addr.is_loopback() {
-            inbound.http_logical_buffer.failfast_timeout
+            inbound.http_request_buffer.failfast_timeout
         } else {
-            outbound.http_logical_buffer.failfast_timeout
+            outbound.http_request_buffer.failfast_timeout
         };
         super::dst::Config {
             context: dst_token?.unwrap_or_default(),
@@ -798,9 +790,9 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 outbound.proxy.connect.clone()
             };
             let failfast_timeout = if addr.addr.is_loopback() {
-                inbound.http_logical_buffer.failfast_timeout
+                inbound.http_request_buffer.failfast_timeout
             } else {
-                outbound.http_logical_buffer.failfast_timeout
+                outbound.http_request_buffer.failfast_timeout
             };
             let attributes = oc_attributes_file_path
                 .map(|path| match path {
@@ -844,9 +836,9 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             outbound.proxy.connect.clone()
         };
         let failfast_timeout = if addr.addr.is_loopback() {
-            inbound.http_logical_buffer.failfast_timeout
+            inbound.http_request_buffer.failfast_timeout
         } else {
-            outbound.http_logical_buffer.failfast_timeout
+            outbound.http_request_buffer.failfast_timeout
         };
         identity::Config {
             certify,

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -118,7 +118,7 @@ where
         debug!(?version, "Handling as HTTP");
 
         Box::pin(async move {
-            let (svc, closed) = SetClientHandle::new(io.peer_addr()?, inner.clone());
+            let (svc, closed) = SetClientHandle::new(io.peer_addr()?, inner);
 
             match version {
                 Version::Http1 => {

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -16,7 +16,7 @@ parking_lot = "0.12"
 pin-project = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["time"] }
-tower = { version = "0.4", features = ["filter", "util"] }
+tower = { version = "0.4", features = ["filter", "spawn-ready", "util"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/linkerd/stack/src/switch_ready.rs
+++ b/linkerd/stack/src/switch_ready.rs
@@ -6,14 +6,14 @@ use std::{
     task::{Context, Poll},
 };
 use tokio::time;
-use tower::util::Either;
+use tower::{spawn_ready::SpawnReady, util::Either};
 use tracing::{debug, trace};
 
 /// A service which falls back to a secondary service if the primary service
 /// takes too long to become ready.
 #[derive(Debug)]
 pub struct SwitchReady<A, B> {
-    primary: A,
+    primary: SpawnReady<A>,
     secondary: B,
     switch_after: time::Duration,
     sleep: Pin<Box<time::Sleep>>,
@@ -78,7 +78,12 @@ impl<A, B> SwitchReady<A, B> {
     /// the `secondary` service is used until the primary service becomes ready again.
     pub fn new(primary: A, secondary: B, switch_after: time::Duration) -> Self {
         Self {
-            primary,
+            // The primary service is wrapped in a `SpawnReady` so that it can
+            // still become ready even when we've reverted to using the
+            // secondary service.
+            primary: SpawnReady::new(primary),
+            // The secondary service is not wrapped because we don't really care
+            // about driving it to readiness unless the primary has timed out.
             secondary,
             switch_after,
             // The sleep is reset whenever the service becomes unready; this
@@ -90,16 +95,17 @@ impl<A, B> SwitchReady<A, B> {
     }
 }
 
-impl<A, B, R> tower::Service<R> for SwitchReady<A, B>
+impl<A, B, Req> tower::Service<Req> for SwitchReady<A, B>
 where
-    A: tower::Service<R>,
+    Req: 'static,
+    A: tower::Service<Req> + Send + 'static,
     A::Error: Into<Error>,
-    B: tower::Service<R, Response = A::Response>,
+    B: tower::Service<Req, Response = A::Response>,
     B::Error: Into<Error>,
 {
     type Response = A::Response;
     type Error = Error;
-    type Future = Either<A::Future, B::Future>;
+    type Future = Either<<SpawnReady<A> as tower::Service<Req>>::Future, B::Future>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         loop {
@@ -156,26 +162,12 @@ where
         }
     }
 
-    fn call(&mut self, req: R) -> Self::Future {
+    fn call(&mut self, req: Req) -> Self::Future {
         trace!(state = ?self.state, "SwitchReady::call");
         match self.state {
             State::Primary => Either::A(self.primary.call(req)),
             State::Secondary => Either::B(self.secondary.call(req)),
             State::Waiting => panic!("called before ready!"),
-        }
-    }
-}
-
-impl<A: Clone, B: Clone> Clone for SwitchReady<A, B> {
-    fn clone(&self) -> Self {
-        Self {
-            primary: self.primary.clone(),
-            secondary: self.secondary.clone(),
-            switch_after: self.switch_after,
-            // Reset the state and the sleep; each clone of the underlying services
-            // may become ready independently (e.g. semaphore).
-            sleep: Box::pin(time::sleep(time::Duration::default())),
-            state: State::Primary,
         }
     }
 }

--- a/linkerd/stack/src/switch_ready.rs
+++ b/linkerd/stack/src/switch_ready.rs
@@ -218,6 +218,7 @@ mod tests {
 
         // The primary service becomes ready.
         a_handle.allow(1);
+        tokio::task::yield_now().await;
         assert_ready_ok!(switch.poll_ready());
 
         let call = switch.call(());
@@ -249,6 +250,7 @@ mod tests {
 
         // The secondary service becomes ready.
         b_handle.allow(1);
+        tokio::task::yield_now().await;
         assert_ready_ok!(switch.poll_ready());
 
         let call = switch.call(());
@@ -279,6 +281,7 @@ mod tests {
 
         // The secondary service becomes ready.
         b_handle.allow(1);
+        tokio::task::yield_now().await;
         assert_ready_ok!(switch.poll_ready());
 
         let call = switch.call(());
@@ -289,6 +292,7 @@ mod tests {
 
         // The primary service becomes ready.
         a_handle.allow(1);
+        tokio::task::yield_now().await;
         assert_ready_ok!(switch.poll_ready());
 
         let call = switch.call(());
@@ -304,6 +308,7 @@ mod tests {
 
         // The primary service becomes ready again.
         a_handle.allow(1);
+        tokio::task::yield_now().await;
         assert_ready_ok!(switch.poll_ready());
 
         let call = switch.call(());
@@ -335,6 +340,7 @@ mod tests {
 
         // The primary service becomes ready.
         a_handle.allow(1);
+        tokio::task::yield_now().await;
         assert_ready_ok!(switch.poll_ready());
 
         let call = switch.call(());
@@ -350,6 +356,7 @@ mod tests {
 
         // The primary service becomes ready.
         a_handle.allow(1);
+        tokio::task::yield_now().await;
         assert_ready_ok!(switch.poll_ready());
 
         let call = switch.call(());
@@ -367,6 +374,7 @@ mod tests {
 
         // The primary service becomes ready.
         a_handle.allow(1);
+        tokio::task::yield_now().await;
         assert_ready_ok!(switch.poll_ready());
 
         let call = switch.call(());
@@ -394,6 +402,7 @@ mod tests {
 
         // Error the primary
         a_handle.send_error("lol");
+        tokio::task::yield_now().await;
         assert_ready_err!(switch.poll_ready());
     }
 


### PR DESCRIPTION
Proxies may buffer TCP connections while waiting for policy discovery
and may buffer HTTP requests while waiting for a shared resource (like a
load balancer).

Previously, a single configuration was used to configure both TCP and
HTTP buffers. This change decouples these configurations in preparation
for allowing balancer configuration to be configured by the control
plane.

Furthermore, this change updates the stack builder to always construct
buffers with failfast and spawnready to (1) ensure that all buffers
enforce the proper backpressure and load shedding semantics and (2) to
reduce boilerplate.

This change updates the proxy's environment configuration as follows:

* Removed `LINKERD2_PROXY_INBOUND_DISPATCH_TIMEOUT`
* Removed `LINKERD2_PROXY_OUTBOUND_DISPATCH_TIMEOUT`
* Added `LINKERD2_PROXY_INBOUND_DISCOVERY_IDLE_TIMEOUT`
* Added `LINKERD2_PROXY_OUTBOUND_DISCOVERY_IDLE_TIMEOUT`
* Removed `LINKERD2_PROXY_BUFFER_CAPACITY`
* Removed `LINKERD2_PROXY_INBOUND_ROUTER_MAX_IDLE_AGE`
* Removed `LINKERD2_PROXY_OUTBOUND_ROUTER_MAX_IDLE_AGE`
* Added `LINKERD2_PROXY_INBOUND_HTTP_QUEUE_CAPACITY`
* Added `LINKERD2_PROXY_INBOUND_HTTP_FAILFAST_TIMEOUT`
* Added `LINKERD2_PROXY_OUTBOUND_TCP_QUEUE_CAPACITY`
* Added `LINKERD2_PROXY_OUTBOUND_TCP_FAILFAST_TIMEOUT`
* Added `LINKERD2_PROXY_OUTBOUND_HTTP_QUEUE_CAPACITY`
* Added `LINKERD2_PROXY_OUTBOUND_HTTP_FAILFAST_TIMEOUT`
* Added `LINKERD2_PROXY_OUTBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT`