### PR TITLE
remove fixed inbound policy mode

### DIFF
--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -1,5 +1,5 @@
 mod api;
-mod config;
+pub mod config;
 pub mod defaults;
 mod http;
 mod store;

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -5,7 +5,10 @@ use tokio::time::Duration;
 
 /// Configures inbound policies.
 ///
-/// The proxy usually watches dynamic policies from the control plane.
+/// Most policies are watched dynamically from the control plane. A default
+/// policy is used when the controller does not provide a policy for a given
+/// port. In addition, a pre-configured list of opaque ports can be provided
+/// to avoid unnecessary policy lookups for ports which will always be opaque.
 #[derive(Clone, Debug)]
 pub struct Config {
     pub control: control::Config,

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -1,27 +1,25 @@
 use super::{api::Api, DefaultPolicy, GetPolicy, Protocol, ServerPolicy, Store};
 use linkerd_app_core::{control, dns, identity, metrics, svc::NewService};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use tokio::time::Duration;
 
 /// Configures inbound policies.
 ///
-/// The proxy usually watches dynamic policies from the control plane, though it can also use
-/// 'fixed' policies configured at startup.
+/// The proxy usually watches dynamic policies from the control plane.
 #[derive(Clone, Debug)]
-#[allow(clippy::large_enum_variant)]
-pub enum Config {
-    Discover {
-        control: control::Config,
-        workload: String,
-        default: DefaultPolicy,
-        cache_max_idle_age: Duration,
-        ports: HashSet<u16>,
-    },
-    Fixed {
-        default: DefaultPolicy,
-        cache_max_idle_age: Duration,
-        ports: HashMap<u16, ServerPolicy>,
-    },
+pub struct Config {
+    pub control: control::Config,
+    pub workload: String,
+    pub default: DefaultPolicy,
+    pub opaque_ports: Option<OpaquePorts>,
+    pub cache_max_idle_age: Duration,
+    pub ports: HashSet<u16>,
+}
+
+#[derive(Clone, Debug)]
+pub struct OpaquePorts {
+    pub ports: HashSet<u16>,
+    pub policy: ServerPolicy,
 }
 
 // === impl Config ===
@@ -33,34 +31,26 @@ impl Config {
         metrics: metrics::ControlHttp,
         identity: identity::NewClient,
     ) -> impl GetPolicy + Clone + Send + Sync + 'static {
-        match self {
-            Self::Fixed {
-                default,
-                ports,
-                cache_max_idle_age,
-            } => Store::spawn_fixed(default, cache_max_idle_age, ports),
-
-            Self::Discover {
-                control,
-                ports,
-                workload,
-                default,
-                cache_max_idle_age,
-            } => {
-                let watch = {
-                    let backoff = control.connect.backoff;
-                    let client = control.build(dns, metrics, identity).new_service(());
-                    let detect_timeout = match default {
-                        DefaultPolicy::Allow(ServerPolicy {
-                            protocol: Protocol::Detect { timeout, .. },
-                            ..
-                        }) => timeout,
-                        _ => Duration::from_secs(10),
-                    };
-                    Api::new(workload, detect_timeout, client).into_watch(backoff)
-                };
-                Store::spawn_discover(default, cache_max_idle_age, watch, ports)
-            }
-        }
+        let Self {
+            control,
+            workload,
+            default,
+            opaque_ports,
+            cache_max_idle_age,
+            ports,
+        } = self;
+        let watch = {
+            let backoff = control.connect.backoff;
+            let client = control.build(dns, metrics, identity).new_service(());
+            let detect_timeout = match default {
+                DefaultPolicy::Allow(ServerPolicy {
+                    protocol: Protocol::Detect { timeout, .. },
+                    ..
+                }) => timeout,
+                _ => Duration::from_secs(10),
+            };
+            Api::new(workload, detect_timeout, client).into_watch(backoff)
+        };
+        Store::spawn_discover(default, cache_max_idle_age, watch, ports, opaque_ports)
     }
 }

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -14,11 +14,19 @@ pub struct Config {
     pub control: control::Config,
     pub workload: String,
     pub default: DefaultPolicy,
+    /// A pre-configured list of ports which are assumed to always be opaque,
+    /// and for which no control plane lookup is performed.
+    ///
+    /// This is set to `None` when the default policy is `Deny`, as using the
+    /// default policy for pre-configured opaque ports will simply result in
+    /// them being denied. If this is `None`, policies will be looked up for all
+    /// ports.
     pub opaque_ports: Option<OpaquePorts>,
     pub cache_max_idle_age: Duration,
     pub ports: HashSet<u16>,
 }
 
+/// Pre-configured opaque ports.
 #[derive(Clone, Debug)]
 pub struct OpaquePorts {
     pub ports: HashSet<u16>,

--- a/linkerd/app/inbound/src/policy/tcp/tests.rs
+++ b/linkerd/app/inbound/src/policy/tcp/tests.rs
@@ -270,6 +270,6 @@ impl Store<MockSvc> {
         default: impl Into<DefaultPolicy>,
         ports: impl IntoIterator<Item = (u16, ServerPolicy)>,
     ) -> Self {
-        Self::spawn_fixed(default.into(), std::time::Duration::MAX, ports)
+        Self::spawn_fixed(default.into(), std::time::Duration::MAX, ports, None)
     }
 }

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -25,6 +25,10 @@ pub fn identity() -> identity::Controller {
     identity::Controller::default()
 }
 
+pub fn policy() -> policy::Controller {
+    policy::Controller::default()
+}
+
 pub type Labels = HashMap<String, String>;
 
 pub type DstReceiver = UnboundedReceiverStream<Result<pb::Update, grpc::Status>>;

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -163,6 +163,7 @@ pub mod client;
 pub mod controller;
 pub mod identity;
 pub mod metrics;
+pub mod policy;
 pub mod proxy;
 pub mod server;
 pub mod tap;

--- a/linkerd/app/integration/src/policy.rs
+++ b/linkerd/app/integration/src/policy.rs
@@ -1,0 +1,148 @@
+use super::*;
+use futures::stream;
+use parking_lot::Mutex;
+use std::{collections::VecDeque, sync::Arc};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tonic as grpc;
+
+pub use linkerd2_proxy_api::inbound;
+
+#[derive(Clone, Debug, Default)]
+pub struct Controller {
+    inbound_calls: Arc<Mutex<VecDeque<(inbound::PortSpec, InboundReceiver)>>>,
+    inbound_default: Option<inbound::Server>,
+    expected_workload: Option<Arc<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InboundSender(mpsc::UnboundedSender<Result<inbound::Server, grpc::Status>>);
+
+type InboundReceiver = UnboundedReceiverStream<Result<inbound::Server, grpc::Status>>;
+
+impl Controller {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn expect_workload(self, workload: String) -> Self {
+        Self {
+            expected_workload: Some(workload.into()),
+            ..self
+        }
+    }
+
+    pub fn inbound_tx(&self, port: u16) -> InboundSender {
+        let spec = inbound::PortSpec {
+            workload: String::new(),
+            port: port as u32,
+        };
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rx = UnboundedReceiverStream::new(rx);
+        self.inbound_calls.lock().push_back((spec, rx));
+        InboundSender(tx)
+    }
+
+    pub fn with_inbound_default(mut self, default: inbound::Server) -> Self {
+        self.inbound_default = Some(default);
+        self
+    }
+
+    pub async fn run(self) -> controller::Listening {
+        controller::run(
+            inbound::inbound_server_policies_server::InboundServerPoliciesServer::new(self),
+            "support policy controller",
+            None,
+        )
+        .await
+    }
+}
+
+impl InboundSender {
+    pub fn send(&self, up: inbound::Server) {
+        self.0.send(Ok(up)).expect("send inbound Server update")
+    }
+
+    pub fn send_err(&self, err: grpc::Status) {
+        self.0.send(Err(err)).expect("send inbound error")
+    }
+}
+
+#[tonic::async_trait]
+impl inbound::inbound_server_policies_server::InboundServerPolicies for Controller {
+    type WatchPortStream =
+        Pin<Box<dyn Stream<Item = Result<inbound::Server, grpc::Status>> + Send + Sync + 'static>>;
+
+    async fn get_port(
+        &self,
+        _req: grpc::Request<inbound::PortSpec>,
+    ) -> Result<grpc::Response<inbound::Server>, grpc::Status> {
+        Err(grpc::Status::new(
+            grpc::Code::Unimplemented,
+            "the proxy should only make `WatchPort` RPCs to the inbound policy \
+                service, so `GetPort` is not implemented by the test controller",
+        ))
+    }
+    async fn watch_port(
+        &self,
+        req: grpc::Request<inbound::PortSpec>,
+    ) -> Result<grpc::Response<Self::WatchPortStream>, grpc::Status> {
+        let req = req.into_inner();
+        let _span = tracing::info_span!(
+            "InboundPolicies::watch_port",
+            req.port,
+            %req.workload,
+        )
+        .entered();
+        tracing::debug!("received request");
+
+        if let Some(ref expected_workload) = self.expected_workload {
+            if req.workload != **expected_workload {
+                tracing::warn!(
+                    actual = ?req.workload,
+                    expected = ?expected_workload,
+                    "request workload does not match"
+                );
+                return Err(grpc_unexpected_request());
+            }
+        }
+
+        let mut calls = self.inbound_calls.lock();
+        if let Some((spec, policy)) = calls.pop_front() {
+            tracing::debug!(?spec, "checking next call");
+            if spec.port == req.port {
+                tracing::info!(?spec, ?policy, "found request");
+                return Ok(grpc::Response::new(Box::pin(policy)));
+            }
+
+            tracing::warn!(?spec, ?policy, "request does not match");
+            calls.push_front((spec, policy));
+
+            if let Some(default) = self.inbound_default.clone() {
+                tracing::info!("using default inbound policy");
+                let stream =
+                    Box::pin(stream::once(async move { Ok(default) }).chain(stream::pending()));
+                return Ok(grpc::Response::new(stream));
+            }
+
+            return Err(grpc_unexpected_request());
+        }
+
+        Err(grpc_no_results())
+    }
+}
+
+fn grpc_no_results() -> grpc::Status {
+    grpc::Status::new(
+        grpc::Code::Unavailable,
+        "unit test policy controller has no results",
+    )
+}
+
+fn grpc_unexpected_request() -> grpc::Status {
+    grpc::Status::new(
+        grpc::Code::Unavailable,
+        "unit test policy controller expected different request",
+    )
+}

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -17,6 +17,7 @@ pub fn new() -> Proxy {
 pub struct Proxy {
     controller: Option<controller::Listening>,
     identity: Option<controller::Listening>,
+    policy: Option<controller::Listening>,
 
     /// Inbound/outbound addresses helpful for mocking connections that do not
     /// implement `server::Listener`.
@@ -44,6 +45,7 @@ pub struct Listening {
 
     controller: controller::Listening,
     identity: controller::Listening,
+    policy: controller::Listening,
 
     shutdown: Shutdown,
     terminated: oneshot::Receiver<()>,
@@ -119,6 +121,15 @@ impl Proxy {
 
     pub fn identity(mut self, i: controller::Listening) -> Self {
         self.identity = Some(i);
+        self
+    }
+
+    /// Pass a customized support policy controller for this proxy to use.
+    ///
+    /// If not called, this proxy will be configured with a default policy
+    /// controller.
+    pub fn policy(mut self, p: controller::Listening) -> Self {
+        self.policy = Some(p);
         self
     }
 
@@ -223,6 +234,7 @@ impl Listening {
             thread,
             shutdown,
             terminated,
+            policy,
             ..
         } = self;
 
@@ -249,9 +261,14 @@ impl Listening {
         }
         .instrument(tracing::info_span!("inbound"));
 
+        let policy_controller = policy
+            .join()
+            .instrument(tracing::info_span!("policy_controller"));
+
         tokio::join! {
             inbound,
             outbound,
+            policy_controller,
             identity.join(),
             controller.join(),
         };
@@ -265,6 +282,16 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
         controller
     } else {
         controller::new().run().await
+    };
+
+    let policy = match proxy.policy {
+        Some(policy) => policy,
+        None => {
+            controller::policy()
+                .with_inbound_default(Default::default())
+                .run()
+                .await
+        }
     };
 
     let identity = if let Some(identity) = proxy.identity {
@@ -295,6 +322,13 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
         "LINKERD2_PROXY_DESTINATION_SVC_ADDR",
         controller.addr.to_string(),
     );
+
+    env.put("LINKERD2_PROXY_POLICY_SVC_ADDR", policy.addr.to_string());
+    env.put(
+        "LINKERD2_PROXY_POLICY_SVC_NAME",
+        "policy.linkerd.serviceaccount.identity.linkerd.cluster.local".to_string(),
+    );
+
     if random_ports {
         env.put(app::env::ENV_OUTBOUND_LISTEN_ADDR, "127.0.0.1:0".to_owned());
     }
@@ -344,6 +378,10 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
             app::env::ENV_DESTINATION_PROFILE_NETWORKS,
             "127.0.0.0/24".to_owned(),
         );
+    }
+
+    if !env.contains_key(app::env::ENV_POLICY_WORKLOAD) {
+        env.put(app::env::ENV_POLICY_WORKLOAD, "test:test".into());
     }
 
     let config = app::env::parse_config(&env).unwrap();
@@ -466,6 +504,7 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
 
         controller,
         identity,
+        policy,
 
         shutdown: tx,
         terminated: term_rx,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -38,6 +38,8 @@ pub enum EnvError {
     InvalidEnvVar,
     #[error("no destination service configured")]
     NoDestinationAddress,
+    #[error("no policy service configured")]
+    NoPolicyAddress,
 }
 
 #[derive(Debug, Error, Eq, PartialEq)]
@@ -538,6 +540,21 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         let policy = {
             let inbound_port = server.addr.port();
 
+            let control = {
+                let addr = parse_control_addr(strings, ENV_POLICY_SVC_BASE)?
+                    .ok_or(EnvError::NoPolicyAddress)?;
+                let connect = if addr.addr.is_loopback() {
+                    connect.clone()
+                } else {
+                    outbound.proxy.connect.clone()
+                };
+                ControlConfig {
+                    addr,
+                    connect,
+                    buffer_capacity,
+                }
+            };
+
             let cluster_nets = parse(strings, ENV_POLICY_CLUSTER_NETWORKS, parse_networks)?
                 .unwrap_or_else(|| {
                     info!(
@@ -560,147 +577,102 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 policy::defaults::all_unauthenticated(detect_protocol_timeout).into()
             });
 
-            match parse_control_addr(strings, ENV_POLICY_SVC_BASE)? {
-                Some(addr) => {
-                    // If the inbound is proxy is configured to discover policies, then load the set
-                    // of all known inbound ports to be discovered during initialization.
-                    let mut ports = match parse(strings, ENV_INBOUND_PORTS, parse_port_set)? {
-                        Some(ports) => ports,
-                        None => {
-                            error!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
-                            Default::default()
-                        }
-                    };
-                    if !gateway.allow_discovery.is_empty() {
-                        // Add the inbound port to the set of ports to be discovered if the proxy is
-                        // configured as a gateway. If there are no suffixes configured in the
-                        // gateway, it's not worth maintaining the extra policy watch (which will be
-                        // the more common case).
-                        ports.insert(inbound_port);
-                    }
+            // Warn if legacy environment variables are set.
+            if strings.get(ENV_INBOUND_PORTS_REQUIRE_IDENTITY)?.is_some() {
+                warn!(
+                    "The {ENV_INBOUND_PORTS_REQUIRE_IDENTITY} configuration \
+                    is no longer supported and will be ignored. Use a \
+                    MeshTlsAuthentication resource instead."
+                );
+            }
 
-                    // Ensure that the admin server port is included in policy discovery.
-                    ports.insert(admin_listener_addr.port());
+            if strings.get(ENV_INBOUND_PORTS_REQUIRE_TLS)?.is_some() {
+                warn!(
+                    "The {ENV_INBOUND_PORTS_REQUIRE_TLS} configuration \
+                    is no longer supported and will be ignored. Use a \
+                    MeshTlsAuthentication resource instead."
+                );
+            }
 
-                    // The workload, which is opaque from the proxy's point-of-view, is sent to the
-                    // policy controller to support policy discovery.
-                    let workload = strings.get(ENV_POLICY_WORKLOAD)?.ok_or_else(|| {
-                        error!(
-                            "{} must be set with {}_ADDR",
-                            ENV_POLICY_WORKLOAD, ENV_POLICY_SVC_BASE
-                        );
-                        EnvError::InvalidEnvVar
-                    })?;
+            // Load opaque ports from the environment.
+            let opaque_ports = {
+                let ports = inbound_disable_ports?.unwrap_or_default();
+                // Ensure that the inbound port does not disable protocol detection
+                if ports.contains(&inbound_port) {
+                    error!(
+                        "{} must not contain {} ({})",
+                        ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION,
+                        ENV_INBOUND_LISTEN_ADDR,
+                        inbound_port
+                    );
+                    return Err(EnvError::InvalidEnvVar);
+                }
 
-                    let control = {
-                        let connect = if addr.addr.is_loopback() {
-                            connect.clone()
-                        } else {
-                            outbound.proxy.connect.clone()
+                match default.clone() {
+                    inbound::policy::DefaultPolicy::Allow(mut policy) => {
+                        policy.protocol = match policy.protocol {
+                            inbound::policy::Protocol::Detect { tcp_authorizations, .. } => {
+                                inbound::policy::Protocol::Opaque(tcp_authorizations)
+                            }
+                            _ => unreachable!("port must have been configured to detect prior to marking it opaque"),
                         };
-                        ControlConfig {
-                            addr,
-                            connect,
-                            buffer_capacity,
-                        }
-                    };
-
-                    inbound::policy::Config::Discover {
-                        default,
-                        ports,
-                        workload,
-                        control,
-                        cache_max_idle_age,
+                        Some(inbound::policy::config::OpaquePorts { ports, policy })
                     }
+                    // If the default policy is deny, then we should still
+                    // perform policy lookups for all ports, even if they are
+                    // marked as opaque.
+                    inbound::policy::DefaultPolicy::Deny => None,
                 }
+            };
 
+            // Load the set of all known inbound ports to be discovered during initialization.
+            let mut ports = match parse(strings, ENV_INBOUND_PORTS, parse_port_set)? {
+                Some(ports) => ports,
                 None => {
-                    let default_allow = match default.clone() {
-                        policy::DefaultPolicy::Allow(a) => a,
-                        policy::DefaultPolicy::Deny => {
-                            warn!("The default policy `deny` may not be used with a static policy configuration");
-                            return Err(EnvError::InvalidEnvVar);
-                        }
-                    };
+                    error!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
+                    Default::default()
+                }
+            };
+            if !gateway.allow_discovery.is_empty() {
+                // Add the inbound port to the set of ports to be discovered if the proxy is
+                // configured as a gateway. If there are no suffixes configured in the
+                // gateway, it's not worth maintaining the extra policy watch (which will be
+                // the more common case).
+                ports.insert(inbound_port);
+            }
 
-                    // If the inbound is not configured to discover policies, then load basic policies from the environment:
-                    // - ports that require authentication
-                    // - ports that require some form of proxy-terminated TLS, though not
-                    //   necessarily with a client identity.
-                    // - opaque ports
-                    let require_identity_ports =
-                        parse(strings, ENV_INBOUND_PORTS_REQUIRE_IDENTITY, parse_port_set)?
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(|p| {
-                                let allow =
-                                    policy::defaults::all_authenticated(detect_protocol_timeout);
-                                (p, allow)
-                            })
-                            .collect::<HashMap<_, _>>();
+            // Ensure that the admin server port is included in policy discovery.
+            ports.insert(admin_listener_addr.port());
 
-                    let require_tls_ports = {
-                        let mut ports =
-                            parse(strings, ENV_INBOUND_PORTS_REQUIRE_TLS, parse_port_set)?
-                                .unwrap_or_default()
-                                .into_iter()
-                                .map(|p| {
-                                    let allow = policy::defaults::all_mtls_unauthenticated(
-                                        detect_protocol_timeout,
-                                    );
-                                    (p, allow)
-                                })
-                                .collect::<HashMap<_, _>>();
-                        // `require_identity` is more restrictive than `require_tls`, so prefer it if
-                        // there are duplicates.
-                        for p in require_identity_ports.keys() {
-                            ports.remove(p);
-                        }
-                        ports
-                    };
+            // The workload, which is opaque from the proxy's point-of-view, is sent to the
+            // policy controller to support policy discovery.
+            let workload = strings.get(ENV_POLICY_WORKLOAD)?.ok_or_else(|| {
+                error!(
+                    "{} must be set with {}_ADDR",
+                    ENV_POLICY_WORKLOAD, ENV_POLICY_SVC_BASE
+                );
+                EnvError::InvalidEnvVar
+            })?;
 
-                    let opaque_ports = {
-                        let ports = inbound_disable_ports?
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(|p| {
-                                let mut sp = require_identity_ports
-                                    .get(&p)
-                                    .or_else(|| require_tls_ports.get(&p))
-                                    .cloned()
-                                    .unwrap_or_else(|| default_allow.clone());
-                                sp.protocol = match sp.protocol {
-                                    inbound::policy::Protocol::Detect { tcp_authorizations, .. } => {
-                                        inbound::policy::Protocol::Opaque(tcp_authorizations)
-                                    }
-                                    _ => unreachable!("port must have been configured to detect prior to marking it opaque"),
-                                };
-                                (p, sp)
-                            })
-                            .collect::<HashMap<_, inbound::policy::ServerPolicy>>();
-                        // Ensure that the inbound port does not disable protocol detection, as
-                        if ports.contains_key(&inbound_port) {
-                            error!(
-                                "{} must not contain {} ({})",
-                                ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION,
-                                ENV_INBOUND_LISTEN_ADDR,
-                                inbound_port
-                            );
-                            return Err(EnvError::InvalidEnvVar);
-                        }
-                        ports
-                    };
-
-                    inbound::policy::Config::Fixed {
-                        default,
-                        cache_max_idle_age,
-                        ports: require_identity_ports
-                            .into_iter()
-                            .chain(require_tls_ports)
-                            .chain(opaque_ports)
-                            .collect(),
+            if let Some(ref opaque) = opaque_ports {
+                for port in &ports {
+                    if opaque.ports.contains(port) {
+                        error!(
+                            "{} must not contain ports in {} ({})",
+                            ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION, ENV_INBOUND_PORTS, port
+                        );
+                        return Err(EnvError::InvalidEnvVar);
                     }
                 }
+            }
+
+            inbound::policy::Config {
+                default,
+                opaque_ports,
+                ports,
+                workload,
+                control,
+                cache_max_idle_age,
             }
         };
 

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -310,7 +310,6 @@ impl<V> CacheEntry<V> {
 
 // === impl Cached ===
 
-#[cfg(feature = "test-util")]
 impl<V> Cached<V> {
     /// Returns a new `Cached` handle wrapping the provided value, but *not*
     /// associated with a cache.

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -310,6 +310,7 @@ impl<V> CacheEntry<V> {
 
 // === impl Cached ===
 
+#[cfg(feature = "test-util")]
 impl<V> Cached<V> {
     /// Returns a new `Cached` handle wrapping the provided value, but *not*
     /// associated with a cache.


### PR DESCRIPTION
Currently, the inbound proxy is capable of operating in two modes: a
fixed mode, where no policy controller address is provided, and inbound
port policies are configured by the environment variables
`LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION`,
`LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_IDENTITY`, and
`LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS`; and a discovery-based mode,
where port policies are discovered from the policy controller. In
practice, the fixed mode is never actually used, so we probably ought to
remove it entirely in 2.13.

This branch removes the fixed mode for inbound port policy. Starting the
proxy without the `LINKERD2_PROXY_POLICY_SVC_ADDR` and
`LINKERD2_PROXY_POLICY_SVC_IDENTITY` environment variables set is now an
error. If the `LINKERD2_INBOUND_PORTS_REQUIRE_IDENTITY` or
`LINKERD2_PROXY_INBOUND_PORTS_REQUIRE_TLS` environment variables are
present, the proxy will now log a warning and ignore their values. The
`LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` environment
variable is still supported, however, in order to allow the proxy to
avoid performing policy controller lookups when configured with a large
list of opaque ports.

The `Store::spawn_fixed` method on `linkerd_app_inbound::policy::Store`
is no longer used when running the proxy normally, but it is retained
for testing purposes, and has been made test-only.

Finally, it was necessary to add a mock implementation of the policy
controller for integration tests to pass, since a policy controller is
now required. This is based on the implementation of a mock policy
controller added in #1992, but without the outbound policy API. PR #1992
should be able to rebase cleanly once this branch merges.

Closes #2076