### PR TITLE
allow port ranges in opaque ports environment variable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,6 +744,7 @@ dependencies = [
  "linkerd-app-outbound",
  "linkerd-error",
  "linkerd-opencensus",
+ "rangemap",
  "regex",
  "thiserror",
  "tokio",
@@ -2104,6 +2105,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed5f515fe4093fa60900ac1918c9ea73f18189114588ec9b99941e22cc2aedd"
 
 [[package]]
 name = "redox_syscall"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "linkerd2-proxy-api",
  "once_cell",
  "parking_lot",
+ "rangemap",
  "thiserror",
  "tokio",
  "tokio-test",

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -24,6 +24,7 @@ linkerd-app-inbound = { path = "./inbound" }
 linkerd-app-outbound = { path = "./outbound" }
 linkerd-error = { path = "../error" }
 linkerd-opencensus = { path = "../opencensus" }
+rangemap = "1.1"
 regex = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["rt"] }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -21,6 +21,7 @@ linkerd-tonic-watch = { path = "../../tonic-watch" }
 linkerd2-proxy-api = { version = "0.7", features = ["inbound"] }
 once_cell = "1"
 parking_lot = "0.12"
+rangemap = "1.1"
 thiserror = "1"
 tokio = { version = "1", features = ["sync"] }
 tonic = { version = "0.8", default-features = false }

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -1,5 +1,6 @@
 use super::{api::Api, DefaultPolicy, GetPolicy, Protocol, ServerPolicy, Store};
 use linkerd_app_core::{control, dns, identity, metrics, svc::NewService};
+use rangemap::RangeInclusiveSet;
 use std::collections::HashSet;
 use tokio::time::Duration;
 
@@ -18,7 +19,7 @@ pub struct Config {
 
 #[derive(Clone, Debug)]
 pub struct OpaquePorts {
-    pub ports: HashSet<u16>,
+    pub ranges: RangeInclusiveSet<u16>,
     pub policy: ServerPolicy,
 }
 

--- a/linkerd/cache/src/lib.rs
+++ b/linkerd/cache/src/lib.rs
@@ -310,7 +310,6 @@ impl<V> CacheEntry<V> {
 
 // === impl Cached ===
 
-#[cfg(feature = "test-util")]
 impl<V> Cached<V> {
     /// Returns a new `Cached` handle wrapping the provided value, but *not*
     /// associated with a cache.


### PR DESCRIPTION
Depends on #2079

Currently, the `LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION`
environment variable accepts a comma-delimited list of individual port
numbers. Each of these ports is then stored as a separate cache entry in
the port policy cache to indicate that the port is opaque.

Unfortunately, this does not work well when a very large number of ports
are marked as opaque, because the proxy-injector will generate a massive
value for that environment variable, listing every individual port. This
can cause issues when this manifest becomes larger than the Kubernetes
API can reasonably handle. In addition, huge numbers of ports will all
be kept in memory as a separate cache entry by the proxy, increasing
proxy memory usage. See linkerd/linkerd2#9803 for details.

This branch changes the proxy so that the
`LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` environment
variable may contain a list of individual port numbers *and* port
ranges, which are specified as `<low>-<high>`.

Opaque ports are now stored using a `RangeInclusiveSet` from the
`rangemap` crate, rather than by creating individual cache entries for
each port. This means we are no longer storing a separate entry in the
cache for every port in a range, reducing memory consumption when there
are very large ranges of opaque ports.

This is the proxy half of the work towards resolving
linkerd/linkerd2#9803. Once this branch lands, we'll also have to change
the proxy-injector so that it no longer handles opaque port ranges by
generating a list of all the individual ports in the range, and simply
forwards those ranges as they were specified when generating the
environment variable.