### PR TITLE
outbound: Split the concrete and logical stack builders

### DIFF
--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -173,7 +173,8 @@ where
     let endpoint = outbound.push_tcp_endpoint().push_http_endpoint();
     let http = endpoint
         .clone()
-        .push_http_logical(resolve)
+        .push_http_concrete(resolve)
+        .push_http_logical()
         .into_stack()
         .push_switch(Ok::<_, Infallible>, endpoint.into_stack())
         .push(NewGateway::layer(local_id))

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -1,3 +1,4 @@
+mod concrete;
 pub mod detect;
 mod endpoint;
 pub mod logical;

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -1,0 +1,115 @@
+use super::{Concrete, Endpoint};
+use crate::{endpoint, resolve, stack_labels, Outbound};
+use linkerd_app_core::{
+    config::ProxyConfig,
+    proxy::{
+        api_resolve::{ConcreteAddr, Metadata},
+        core::Resolve,
+        http,
+        resolve::map_endpoint,
+    },
+    svc, Error, Infallible,
+};
+use tracing::debug_span;
+
+impl<N> Outbound<N> {
+    pub fn push_http_concrete<NSvc, R>(
+        self,
+        resolve: R,
+    ) -> Outbound<
+        svc::ArcNewService<
+            Concrete,
+            impl svc::Service<
+                http::Request<http::BoxBody>,
+                Response = http::Response<http::BoxBody>,
+                Error = Error,
+                Future = impl Send,
+            >,
+        >,
+    >
+    where
+        N: svc::NewService<Endpoint, Service = NSvc> + Clone + Send + Sync + 'static,
+        NSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+            + Send
+            + 'static,
+        NSvc::Error: Into<Error>,
+        NSvc::Future: Send,
+        R: Resolve<ConcreteAddr, Error = Error, Endpoint = Metadata>,
+        R: Clone + Send + Sync + 'static,
+        R::Resolution: Send,
+        R::Future: Send + Unpin,
+    {
+        self.map_stack(|config, rt, endpoint| {
+            let ProxyConfig {
+                cache_max_idle_age,
+                dispatch_timeout,
+                ..
+            } = config.proxy;
+            let watchdog = cache_max_idle_age * 2;
+
+            let resolve = svc::stack(resolve.into_service())
+                .check_service::<ConcreteAddr>()
+                .push_request_filter(|c: Concrete| Ok::<_, Infallible>(c.resolve))
+                .push(svc::layer::mk(move |inner| {
+                    map_endpoint::Resolve::new(
+                        endpoint::FromMetadata {
+                            inbound_ips: config.inbound_ips.clone(),
+                        },
+                        inner,
+                    )
+                }))
+                .check_service::<Concrete>()
+                .into_inner();
+
+            endpoint
+                .instrument(|e: &Endpoint| debug_span!("endpoint", server.addr = %e.addr))
+                .check_new_service::<Endpoint, http::Request<http::BoxBody>>()
+                .push_on_service(
+                    svc::layers().push(http::BoxRequest::layer()).push(
+                        rt.metrics
+                            .proxy
+                            .stack
+                            .layer(stack_labels("http", "balance.endpoint")),
+                    ),
+                )
+                .check_new_service::<Endpoint, http::Request<_>>()
+                // Resolve the service to its endpoints and balance requests over them.
+                //
+                // If the balancer has been empty/unavailable, eagerly fail requests.
+                // When the balancer is in failfast, spawn the service in a background
+                // task so it becomes ready without new requests.
+                //
+                // We *don't* ensure that the endpoint is driven to readiness here, because this
+                // might cause us to continually attempt to reestablish connections without
+                // consulting discovery to see whether the endpoint has been removed. Instead, the
+                // endpoint layer spawns each _connection_ attempt on a background task, but the
+                // decision to attempt the connection must be driven by the balancer.
+                .push(resolve::layer(resolve, watchdog))
+                .push_on_service(
+                    svc::layers()
+                        .push(http::balance::layer(
+                            crate::EWMA_DEFAULT_RTT,
+                            crate::EWMA_DECAY,
+                        ))
+                        .push(
+                            rt.metrics
+                                .proxy
+                                .stack
+                                .layer(stack_labels("http", "balancer")),
+                        )
+                        .push(svc::layer::mk(svc::SpawnReady::new))
+                        .push(svc::FailFast::layer("HTTP Balancer", dispatch_timeout))
+                        .push(http::BoxResponse::layer()),
+                )
+                .check_make_service::<Concrete, http::Request<_>>()
+                .push(svc::MapErr::layer(Into::into))
+                // Drives the initial resolution via the service's readiness.
+                .into_new_service()
+                // The concrete address is only set when the profile could be
+                // resolved. Endpoint resolution is skipped when there is no
+                // concrete address.
+                .instrument(|c: &Concrete| debug_span!("concrete", addr = %c.resolve))
+                .push(svc::ArcNewService::layer())
+        })
+    }
+}

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -77,7 +77,8 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
     {
         let http_endpoint = self.clone().into_stack();
 
-        self.push_http_logical(resolve)
+        self.push_http_concrete(resolve)
+            .push_http_logical()
             .map_stack(|config, rt, http_logical| {
                 let detect_http = config.proxy.detect_http();
                 let Config {

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -134,7 +134,8 @@ impl<C> Outbound<C> {
             .clone()
             .push_tcp_endpoint()
             .push_http_endpoint()
-            .push_http_logical(resolve.clone())
+            .push_http_concrete(resolve.clone())
+            .push_http_logical()
             .push_http_server()
             .into_inner();
 


### PR DESCRIPTION
Currently the `push_http_logical` commingles the concrete stack (load balancers, etc) and the logical stack (routing). This change splits these builders into separate functions.