### PR TITLE
Split out failfast into smaller modules

### DIFF
--- a/linkerd/stack/src/failfast.rs
+++ b/linkerd/stack/src/failfast.rs
@@ -292,11 +292,7 @@ impl Shared {
     fn exit_failfast(&self) {
         // The load part of this operation can be `Relaxed` because this task
         // is the only place where the the value is ever set.
-        if self
-            .in_failfast
-            .compare_exchange(true, false, Ordering::Release, Ordering::Relaxed)
-            .is_ok()
-        {
+        if self.in_failfast.swap(true, Ordering::Release) {
             self.notify.notify_waiters();
         }
     }

--- a/linkerd/stack/src/failfast.rs
+++ b/linkerd/stack/src/failfast.rs
@@ -292,7 +292,7 @@ impl Shared {
     fn exit_failfast(&self) {
         // The load part of this operation can be `Relaxed` because this task
         // is the only place where the the value is ever set.
-        if self.in_failfast.swap(true, Ordering::Release) {
+        if self.in_failfast.swap(false, Ordering::Release) {
             self.notify.notify_waiters();
         }
     }

--- a/linkerd/stack/src/failfast/gate.rs
+++ b/linkerd/stack/src/failfast/gate.rs
@@ -24,7 +24,10 @@ use tracing::trace;
 ///
 /// A `Layer`, such as a `Buffer` layer, may be wrapped in a new `Layer` which
 /// produces a [`FailFast`]/[`Gate`] pair around the inner `Layer`'s
-/// service using the [`FailFast::wrap_layer`] function.
+/// service using the [`FailFast::layer_gated`] function.
+///
+/// [`FailFast`]: super::FailFast
+/// [`FailFast::layer_gated`]: super::FailFast::layer_gated
 #[derive(Debug)]
 pub struct Gate<S> {
     inner: S,

--- a/linkerd/stack/src/failfast/gate.rs
+++ b/linkerd/stack/src/failfast/gate.rs
@@ -88,11 +88,10 @@ where
                     trace!("service has become ready");
                 });
                 self.is_waiting = true;
-                continue;
+            } else {
+                // Otherwise, we are not in failfast. Poll the inner service.
+                return self.inner.poll_ready(cx);
             }
-
-            // Otherwise, we are not in failfast. Poll the inner service.
-            return self.inner.poll_ready(cx);
         }
     }
 

--- a/linkerd/stack/src/failfast/gate.rs
+++ b/linkerd/stack/src/failfast/gate.rs
@@ -1,0 +1,103 @@
+use super::Shared;
+use futures::{ready, FutureExt};
+use std::{
+    sync::{atomic::Ordering, Arc},
+    task::{Context, Poll},
+};
+use tokio_util::sync::ReusableBoxFuture;
+use tracing::trace;
+
+/// A middleware which, when paired with a [`FailFast`] middleware, advertises
+/// the *actual* readiness state of the [`FailFast`]'s inner service up the
+/// stack.
+///
+/// A [`FailFast`]/[`Gate`] pair is primarily intended to be used in
+/// conjunction with a `tower::Buffer`. By placing the [`FailFast`] middleware
+/// inside of the `Buffer` and the `Gate` middleware outside of the buffer,
+/// the buffer's queue can be proactively drained when the inner service enters
+/// failfast, while the outer `Gate` middleware will continue to return
+/// [`Poll::Pending`] from its `poll_ready` method. This can be used to fail any
+/// requests that have already been dispatched to the inner service while it is in
+/// failfast, while allowing a load balancer or other traffic distributor to
+/// send any new requests to a different backend until this backend actually
+/// becomes available.
+///
+/// A `Layer`, such as a `Buffer` layer, may be wrapped in a new `Layer` which
+/// produces a [`FailFast`]/[`Gate`] pair around the inner `Layer`'s
+/// service using the [`FailFast::wrap_layer`] function.
+#[derive(Debug)]
+pub struct Gate<S> {
+    inner: S,
+    shared: Arc<Shared>,
+
+    /// Are we currently waiting on a notification that the inner service has
+    /// exited failfast?
+    is_waiting: bool,
+
+    /// Future awaiting a notification from the inner `FailFast` service.
+    waiting: ReusableBoxFuture<'static, ()>,
+}
+
+// === impl Gate ===
+
+impl<S> Gate<S> {
+    pub(super) fn new(inner: S, shared: Arc<Shared>) -> Self {
+        Self {
+            inner,
+            shared,
+            is_waiting: false,
+            waiting: ReusableBoxFuture::new(async move { unreachable!() }),
+        }
+    }
+}
+
+impl<S> Clone for Gate<S>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self::new(self.inner.clone(), self.shared.clone())
+    }
+}
+
+impl<S, T> tower::Service<T> for Gate<S>
+where
+    S: tower::Service<T>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        loop {
+            if self.is_waiting {
+                // We are currently waiting for the inner service to exit failfast.
+                trace!("waiting for service to become ready",);
+                ready!(self.waiting.poll_unpin(cx));
+                trace!("service became ready");
+                self.is_waiting = false;
+            }
+
+            // Check if the inner service is in failfast. If it is, start
+            // waiting to be notified of a change.
+            if self.shared.in_failfast.load(Ordering::Acquire) {
+                trace!("service in failfast, waiting for readiness",);
+                let shared = self.shared.clone();
+                self.waiting.set(async move {
+                    shared.notify.notified().await;
+                    trace!("service has become ready");
+                });
+                self.is_waiting = true;
+                continue;
+            }
+
+            // Otherwise, we are not in failfast. Poll the inner service.
+            return self.inner.poll_ready(cx);
+        }
+    }
+
+    #[inline]
+    fn call(&mut self, req: T) -> Self::Future {
+        self.inner.call(req)
+    }
+}

--- a/linkerd/stack/src/failfast/test.rs
+++ b/linkerd/stack/src/failfast/test.rs
@@ -1,0 +1,106 @@
+use super::*;
+use std::time::Duration;
+use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok, task};
+use tower_test::mock::{self, Spawn};
+
+#[tokio::test]
+async fn fails_fast() {
+    let _trace = linkerd_tracing::test::trace_init();
+    tokio::time::pause();
+
+    let max_unavailable = Duration::from_millis(100);
+    let (service, mut handle) = mock::pair::<(), ()>();
+    let shared = Arc::new(Shared {
+        notify: tokio::sync::Notify::new(),
+        in_failfast: AtomicBool::new(false),
+    });
+    let mut service = Spawn::new(FailFast::new(max_unavailable, shared, service));
+
+    // The inner starts unavailable.
+    handle.allow(0);
+    assert_pending!(service.poll_ready());
+
+    // Then we wait for the idle timeout, at which point the service
+    // should start failing fast.
+    tokio::time::sleep(max_unavailable + Duration::from_millis(1)).await;
+    assert_ready_ok!(service.poll_ready());
+
+    let err = service.call(()).await.expect_err("should failfast");
+    assert!(err.is::<super::FailFastError>());
+
+    // Then the inner service becomes available.
+    handle.allow(1);
+
+    // Yield to allow the background task to drive the inner service to readiness.
+    tokio::task::yield_now().await;
+
+    assert_ready_ok!(service.poll_ready());
+    let fut = service.call(());
+
+    let ((), rsp) = handle.next_request().await.expect("must get a request");
+    rsp.send_response(());
+
+    let ret = fut.await;
+    assert!(ret.is_ok());
+}
+
+#[tokio::test]
+async fn drains_buffer() {
+    use tower::{buffer::Buffer, Layer};
+
+    let _trace = linkerd_tracing::test::with_default_filter("trace");
+    tokio::time::pause();
+
+    let max_unavailable = Duration::from_millis(100);
+    let (service, mut handle) = mock::pair::<(), ()>();
+
+    let layer = FailFast::layer_gated(max_unavailable, layer::mk(|inner| Buffer::new(inner, 3)));
+    let mut service = Spawn::new(layer.layer(service));
+
+    // The inner starts unavailable...
+    handle.allow(0);
+    // ...but the buffer will accept requests while it has capacity.
+    assert_ready_ok!(service.poll_ready());
+    let mut buffer1 = task::spawn(service.call(()));
+
+    assert_ready_ok!(service.poll_ready());
+    let mut buffer2 = task::spawn(service.call(()));
+
+    assert_ready_ok!(service.poll_ready());
+    let mut buffer3 = task::spawn(service.call(()));
+
+    // The buffer is now full
+    assert_pending!(service.poll_ready());
+
+    // Then we wait for the idle timeout, at which point failfast should
+    // trigger and the buffer requests should be failed.
+    tokio::time::sleep(max_unavailable + Duration::from_millis(1)).await;
+    // However, the *outer* service should remain unready.
+    assert_pending!(service.poll_ready());
+
+    // Buffered requests should now fail.
+    assert_ready_err!(buffer1.poll());
+    assert_ready_err!(buffer2.poll());
+    assert_ready_err!(buffer3.poll());
+    drop((buffer1, buffer2, buffer3));
+
+    // The buffer has been drained, but the outer service should still be
+    // pending.
+    assert_pending!(service.poll_ready());
+
+    // Then the inner service becomes available.
+    handle.allow(1);
+    tracing::info!("handle.allow(1)");
+
+    // Yield to allow the background task to drive the inner service to readiness.
+    tokio::task::yield_now().await;
+
+    assert_ready_ok!(service.poll_ready());
+    let fut = service.call(());
+
+    let ((), rsp) = handle.next_request().await.expect("must get a request");
+    rsp.send_response(());
+
+    let ret = fut.await;
+    assert!(ret.is_ok());
+}


### PR DESCRIPTION
* Moved `Gate` into its own module.
* Moved `test` into their own file.
* Reorganized `Gate:poll_ready` slightly for clarity.
* Added comments to `FailFast::poll_ready` state changes.
* Renamed `max_unavailable` to `timeout`.