### PR TITLE
generate distributions per-route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1528,6 +1528,7 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tonic-watch",
  "linkerd2-proxy-api",
+ "once_cell",
  "parking_lot",
  "pin-project",
  "prost-types",
@@ -1877,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opencensus-proto"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
+name = "ahash"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf6ccdb167abbf410dcb915cabd428929d7f6a04980b54a11f26a39f1c7f7107"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +932,7 @@ dependencies = [
 name = "linkerd-app-outbound"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bytes",
  "futures",
  "http",
@@ -1514,6 +1527,7 @@ dependencies = [
 name = "linkerd-service-profiles"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bytes",
  "futures",
  "http",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -15,6 +15,7 @@ allow-loopback = []
 test-subscriber = []
 
 [dependencies]
+ahash = "0.8"
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -128,16 +128,9 @@ impl classify::CanClassify for ProfileRoute {
 
 impl svc::Param<router::Distribution> for ProfileRoute {
     fn param(&self) -> router::Distribution {
-        let targets = self.route.targets().as_ref();
-        // If the route has no backend overrides, distribute all traffic to the
-        // logical address.
-        if targets.is_empty() {
-            let profiles::LogicalAddr(addr) = self.logical.param();
-            return router::Distribution::from(addr);
-        }
-
         router::Distribution::random_available(
-            targets
+            self.route
+                .targets()
                 .iter()
                 .map(|profiles::Target { addr, weight }| (addr.clone(), *weight)),
         )

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -10,6 +10,7 @@ Implements client layers for Linkerd ServiceProfiles.
 """
 
 [dependencies]
+ahash = "0.8"
 bytes = "1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -24,6 +24,7 @@ linkerd-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd-stack = { path = "../stack" }
 linkerd-tonic-watch = { path = "../tonic-watch" }
 linkerd2-proxy-api = { version = "0.7", features = ["destination"] }
+once_cell = "1.17"
 rand = { version = "0.8", features = ["small_rng"] }
 regex = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }

--- a/linkerd/service-profiles/src/http.rs
+++ b/linkerd/service-profiles/src/http.rs
@@ -108,10 +108,10 @@ impl Route {
     pub fn timeout(&self) -> Option<Duration> {
         self.timeout
     }
-
     pub fn targets(&self) -> &Targets {
         &self.targets
     }
+
     pub fn set_retries(&mut self, budget: Arc<Budget>) {
         self.retries = Some(Retries { budget });
     }

--- a/linkerd/service-profiles/src/http.rs
+++ b/linkerd/service-profiles/src/http.rs
@@ -10,6 +10,7 @@ use std::{
 use tower::retry::budget::Budget;
 
 pub use self::proxy::NewProxyRouter;
+use crate::Targets;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Route {
@@ -17,6 +18,8 @@ pub struct Route {
     response_classes: ResponseClasses,
     retries: Option<Retries>,
     timeout: Option<Duration>,
+    // TODO(eliza): I would prefer to rename this to `backends`...
+    targets: Targets,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -75,13 +78,14 @@ pub fn route_for_request<'r, B>(
 // === impl Route ===
 
 impl Route {
-    pub fn new<I>(label_iter: I, response_classes: Vec<ResponseClass>) -> Self
+    pub fn new<I>(label_iter: I, response_classes: Vec<ResponseClass>, targets: Targets) -> Self
     where
         I: Iterator<Item = (String, String)>,
     {
         let labels = Labels(Arc::new(label_iter.collect()));
 
         Self {
+            targets,
             labels,
             response_classes: ResponseClasses(response_classes.into()),
             retries: None,
@@ -105,6 +109,9 @@ impl Route {
         self.timeout
     }
 
+    pub fn targets(&self) -> &Targets {
+        &self.targets
+    }
     pub fn set_retries(&mut self, budget: Arc<Budget>) {
         self.retries = Some(Retries { budget });
     }

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -173,6 +173,23 @@ impl Stream for ReceiverStream {
     }
 }
 
+// === impl Profile ===
+
+impl Profile {
+    /// Returns an iterator over all targets in this profile.
+    ///
+    /// Note that targets are *not* de-duplicated here. The same target may
+    /// occur multiple times in this iterator, with different or the same weights.
+    // XXX(eliza): this is kinda gross...
+    pub fn all_targets(&self) -> impl Iterator<Item = &Target> + '_ {
+        self.targets.0.iter().chain(
+            self.http_routes
+                .iter()
+                .flat_map(|(_, r)| r.targets().iter()),
+        )
+    }
+}
+
 // === impl LookupAddr ===
 
 impl fmt::Display for LookupAddr {

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -63,8 +63,10 @@ pub struct Target {
     pub addr: NameAddr,
     pub weight: u32,
 }
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Targets(Arc<[Target]>);
+
 #[derive(Clone, Debug)]
 pub struct GetProfileService<P>(P);
 
@@ -266,6 +268,11 @@ impl Targets {
     #[inline]
     pub fn iter(&self) -> std::slice::Iter<'_, Target> {
         self.0.iter()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 }
 

--- a/linkerd/service-profiles/src/proto.rs
+++ b/linkerd/service-profiles/src/proto.rs
@@ -10,29 +10,40 @@ use tracing::warn;
 
 pub(super) fn convert_profile(proto: api::DestinationProfile, port: u16) -> Profile {
     let name = Name::from_str(&proto.fully_qualified_name).ok();
-    let retry_budget = proto.retry_budget.and_then(convert_retry_budget);
-    let targets = proto
+    let addr = name.map(|n| NameAddr::from((n, port)));
+
+    let mut targets = proto
         .dst_overrides
         .into_iter()
         .filter_map(convert_dst_override)
         .collect::<Targets>();
-    let target_addrs = targets.iter().map(|t| t.addr.clone()).collect();
-    // This has to be borrowed here so that it's not moved into the `filter_map` closure.
-    let targets_ref = &targets;
-    let http_routes = proto
-        .routes
-        .into_iter()
-        .filter_map(move |orig| convert_route(orig, retry_budget.as_ref(), targets_ref))
-        .collect();
+    if targets.is_empty() {
+        if let Some(addr) = addr.clone() {
+            targets = std::iter::once(Target { addr, weight: 1 }).collect();
+        }
+    }
+
+    let http_routes = {
+        let retry_budget = proto.retry_budget.and_then(convert_retry_budget);
+
+        let ts = &targets;
+        proto
+            .routes
+            .into_iter()
+            .filter_map(move |orig| convert_route(orig, retry_budget.as_ref(), ts))
+            .collect()
+    };
+
     let endpoint = proto.endpoint.and_then(|e| {
         let labels = std::collections::HashMap::new();
         resolve::to_addr_meta(e, &labels)
     });
+
     Profile {
-        addr: name.map(move |n| LogicalAddr(NameAddr::from((n, port)))),
+        addr: addr.map(LogicalAddr),
         http_routes,
         opaque_protocol: proto.opaque_protocol,
-        target_addrs,
+        target_addrs: targets.iter().map(|t| t.addr.clone()).collect(),
         tcp_targets: targets,
         endpoint,
     }

--- a/linkerd/service-profiles/src/proto.rs
+++ b/linkerd/service-profiles/src/proto.rs
@@ -15,7 +15,8 @@ pub(super) fn convert_profile(proto: api::DestinationProfile, port: u16) -> Prof
         .dst_overrides
         .into_iter()
         .filter_map(convert_dst_override)
-        .collect();
+        .collect::<Targets>();
+    let target_addrs = targets.iter().map(|t| t.addr.clone()).collect();
     // This has to be borrowed here so that it's not moved into the `filter_map` closure.
     let targets_ref = &targets;
     let http_routes = proto
@@ -31,8 +32,9 @@ pub(super) fn convert_profile(proto: api::DestinationProfile, port: u16) -> Prof
         addr: name.map(move |n| LogicalAddr(NameAddr::from((n, port)))),
         http_routes,
         opaque_protocol: proto.opaque_protocol,
+        target_addrs,
+        tcp_targets: targets,
         endpoint,
-        targets,
     }
 }
 


### PR DESCRIPTION
Currently, the logical router will generate a single traffic
distribution that's used for every HTTP route. This is fine when working
with ServiceProfiles, where a single traffic split applies to the entire
profile, but won't work with the new client policy implementation based
on HTTPRoutes, where each route may have its own separate list of
backends.

This branch changes the profile router so that a separate distribution
is built per route. The `Profile` and `profiles::http::Route` types are
changed so that each route has its own list of targets. In the case of
`Profile`s constructed from a ServiceProfile, these lists are all the
same. However, when adding support for the new client policy API, the
same structures can be generated with separate lists of backends per
route.

In a follow-up PR, I'll attempt to unify the TCP and HTTP logical
routers.