### PR TITLE
remove stray `dbg!` in `watch`

### DIFF
--- a/linkerd/stack/src/watch.rs
+++ b/linkerd/stack/src/watch.rs
@@ -108,7 +108,7 @@ where
     type Future = S::Future;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if dbg!(matches!(self.rx.has_changed(), Ok(true))) {
+        if matches!(self.rx.has_changed(), Ok(true)) {
             self.inner = self.rx.borrow_and_update().clone();
         }
 


### PR DESCRIPTION
I added this while trying to debug the tests, and forgot to remove it. We should get rid of it before merging #2095.