### PR TITLE
Make `Profile::clone` cheaper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,6 @@ dependencies = [
  "linkerd-tonic-watch",
  "linkerd2-proxy-api",
  "once_cell",
- "parking_lot",
  "pin-project",
  "prost-types",
  "quickcheck",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1541,6 +1541,8 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tonic-watch",
  "linkerd2-proxy-api",
+ "once_cell",
+ "parking_lot",
  "pin-project",
  "prost-types",
  "quickcheck",

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -23,6 +23,7 @@ linkerd-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd-stack = { path = "../stack" }
 linkerd-tonic-watch = { path = "../tonic-watch" }
 linkerd2-proxy-api = { version = "0.7", features = ["destination"] }
+once_cell = "1.17"
 rand = { version = "0.8", features = ["small_rng"] }
 regex = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
@@ -31,6 +32,7 @@ tonic = { version = "0.8", default-features = false }
 tower = { version = "0.4.13", features = ["ready-cache", "retry", "util"] }
 thiserror = "1"
 tracing = "0.1"
+parking_lot = "0.12"
 pin-project = "1"
 prost-types = "0.11"
 

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -24,6 +24,8 @@ linkerd-stack = { path = "../stack" }
 linkerd-tonic-watch = { path = "../tonic-watch" }
 linkerd2-proxy-api = { version = "0.7", features = ["destination"] }
 once_cell = "1.17"
+pin-project = "1"
+prost-types = "0.11"
 rand = { version = "0.8", features = ["small_rng"] }
 regex = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
@@ -32,9 +34,6 @@ tonic = { version = "0.8", default-features = false }
 tower = { version = "0.4.13", features = ["ready-cache", "retry", "util"] }
 thiserror = "1"
 tracing = "0.1"
-parking_lot = "0.12"
-pin-project = "1"
-prost-types = "0.11"
 
 [dev-dependencies]
 linkerd2-proxy-api = { version = "0.7", features = ["arbitrary"] }

--- a/linkerd/service-profiles/src/http/proxy.rs
+++ b/linkerd/service-profiles/src/http/proxy.rs
@@ -5,6 +5,7 @@ use linkerd_error::{Error, Result};
 use linkerd_stack::{layer, NewService, Param, Proxy, Service};
 use std::{
     collections::{hash_map, HashMap, HashSet},
+    sync::Arc,
     task::{Context, Poll},
 };
 use tracing::{debug, trace};
@@ -31,7 +32,7 @@ pub struct ProxyRouter<T, N, P, S> {
     inner: S,
     target: T,
     rx: ReceiverStream,
-    http_routes: Vec<(RequestMatch, Route)>,
+    http_routes: Arc<[(RequestMatch, Route)]>,
     proxies: HashMap<Route, P>,
 }
 
@@ -61,7 +62,7 @@ where
             inner,
             target,
             rx: rx.into(),
-            http_routes: Vec::new(),
+            http_routes: std::iter::empty().collect(),
             proxies: HashMap::new(),
             new_proxy: self.new_proxy.clone(),
         }

--- a/linkerd/service-profiles/src/http/service.rs
+++ b/linkerd/service-profiles/src/http/service.rs
@@ -4,6 +4,7 @@ use futures::prelude::*;
 use linkerd_stack::{layer, NewService, Oneshot, Param, Service, ServiceExt};
 use std::{
     collections::{hash_map, HashMap, HashSet},
+    sync::Arc,
     task::{Context, Poll},
 };
 use tracing::{debug, trace};
@@ -32,14 +33,14 @@ pub struct ServiceRouter<T, N, S> {
 
 #[derive(Clone, Debug)]
 struct Routes<S> {
-    matches: Vec<(RequestMatch, Route)>,
+    matches: Arc<[(RequestMatch, Route)]>,
     services: HashMap<Route, S>,
 }
 
 impl<S> Default for Routes<S> {
     fn default() -> Self {
         Self {
-            matches: Vec::new(),
+            matches: Profile::default().http_routes,
             services: HashMap::new(),
         }
     }


### PR DESCRIPTION
We may clone `Profile` structures when processing a watch. Currently, the profile includes vectors that we need not copy every time we clone a profile.

This change replaces these heap-allocated vectors (`Vec`) instances with reference-counted slices (`Arc<[_]>`) so that `Profile::clone` calls need not allocate.