### PR TITLE
stack: Fix `NewSpawnWatch::layer` type signature

### DIFF
--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -15,7 +15,7 @@ linkerd-error = { path = "../error" }
 parking_lot = "0.12"
 pin-project = "1"
 thiserror = "1"
-tokio = { version = "1", features = ["time", "sync"] }
+tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-util = { version = "0.7" }
 tower = { version = "0.4", features = ["filter", "spawn-ready", "util"] }
 tracing = "0.1"

--- a/linkerd/stack/src/watch.rs
+++ b/linkerd/stack/src/watch.rs
@@ -47,7 +47,7 @@ pub struct NewFromTuple<T, P, N> {
     _marker: PhantomData<fn() -> P>,
 }
 
-type SpawnFromTuple<P, T, N> = NewSpawnWatch<P, NewWatchedFromTuple<T, N>>;
+type SpawnFromTuple<T, P, N> = NewSpawnWatch<P, NewWatchedFromTuple<T, N>>;
 
 // === impl NewSpawnWatch ===
 
@@ -167,13 +167,12 @@ impl<T, N> NewWatchedFromTuple<T, N> {
     }
 }
 
-impl<T, P, N, M> NewService<T> for NewWatchedFromTuple<P, N>
+impl<T, P, N> NewService<T> for NewWatchedFromTuple<P, N>
 where
     T: Clone,
-    N: NewService<T, Service = M>,
-    M: NewService<P> + Send + 'static,
+    N: NewService<T>,
 {
-    type Service = NewFromTuple<T, P, M>;
+    type Service = NewFromTuple<T, P, N::Service>;
 
     fn new_service(&self, target: T) -> Self::Service {
         // Create a `NewService` that is used to process updates to the watched


### PR DESCRIPTION
The spawn watch layer helper wasn't actually usable. This has been fixed.

This change also fixes stack's tokio feature flags (needed for watch).