### PR TITLE
outbound: separate TCP logical and concrete stacks

### DIFF
--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -96,7 +96,8 @@ where
     let logical = outbound
         .clone()
         .push_tcp_endpoint()
-        .push_tcp_logical(resolve.clone());
+        .push_tcp_concrete(resolve.clone())
+        .push_tcp_logical();
     let endpoint = outbound
         .clone()
         .push_tcp_endpoint()

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -124,7 +124,11 @@ impl<C> Outbound<C> {
         C::Connection: Send + Unpin,
         C::Future: Send + Unpin,
         R: Clone + Send + 'static,
-        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error> + Sync,
+        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>
+            + Clone
+            + Send
+            + Sync
+            + 'static,
         R::Resolution: Send,
         R::Future: Send + Unpin,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr,
@@ -143,7 +147,8 @@ impl<C> Outbound<C> {
             .into_inner();
 
         self.push_tcp_endpoint()
-            .push_tcp_logical(resolve)
+            .push_tcp_concrete(resolve)
+            .push_tcp_logical()
             .push_detect_http(http)
     }
 }

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -6,6 +6,7 @@ use linkerd_app_core::{
     Error,
 };
 
+pub mod concrete;
 pub mod connect;
 pub mod logical;
 pub mod opaque_transport;

--- a/linkerd/app/outbound/src/tcp/concrete.rs
+++ b/linkerd/app/outbound/src/tcp/concrete.rs
@@ -1,0 +1,84 @@
+use super::{Concrete, Endpoint};
+use crate::{endpoint, resolve, Outbound};
+use linkerd_app_core::{
+    drain, io,
+    proxy::{
+        api_resolve::{ConcreteAddr, Metadata},
+        core::Resolve,
+        resolve::map_endpoint,
+        tcp,
+    },
+    svc, Error, Infallible,
+};
+use tracing::debug_span;
+
+// === impl Outbound ===
+
+impl<C> Outbound<C> {
+    /// Constructs a TCP load balancer.
+    pub fn push_tcp_concrete<I, R>(
+        self,
+        resolve: R,
+    ) -> Outbound<
+        svc::ArcNewService<
+            Concrete,
+            impl svc::Service<I, Response = (), Error = Error, Future = impl Send>,
+        >,
+    >
+    where
+        C: svc::MakeConnection<Endpoint> + Clone + Send + 'static,
+        C::Connection: Send + Unpin,
+        C::Metadata: Send + Unpin,
+        C::Future: Send,
+        C: Send + Sync + 'static,
+        I: io::AsyncRead + io::AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
+        R: Clone + Send + 'static,
+        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error> + Sync,
+        R::Resolution: Send,
+        R::Future: Send + Unpin,
+    {
+        self.map_stack(|config, rt, connect| {
+            let crate::Config {
+                discovery_idle_timeout,
+                ..
+            } = config;
+
+            let resolve = svc::stack(resolve.into_service())
+                .check_service::<ConcreteAddr>()
+                .push_request_filter(|c: Concrete| Ok::<_, Infallible>(c.resolve))
+                .push(svc::layer::mk(move |inner| {
+                    map_endpoint::Resolve::new(
+                        endpoint::FromMetadata {
+                            inbound_ips: config.inbound_ips.clone(),
+                        },
+                        inner,
+                    )
+                }))
+                .check_service::<Concrete>()
+                .into_inner();
+
+            connect
+                .push(svc::stack::WithoutConnectionMetadata::layer())
+                .push_make_thunk()
+                .instrument(|t: &Endpoint| debug_span!("endpoint", addr = %t.addr))
+                .push(resolve::layer(resolve, *discovery_idle_timeout * 2))
+                .push_on_service(
+                    svc::layers()
+                        .push(tcp::balance::layer(
+                            crate::EWMA_DEFAULT_RTT,
+                            crate::EWMA_DECAY,
+                        ))
+                        .push(
+                            rt.metrics
+                                .proxy
+                                .stack
+                                .layer(crate::stack_labels("tcp", "balancer")),
+                        )
+                        .push(tcp::Forward::layer())
+                        .push(drain::Retain::layer(rt.drain.clone())),
+                )
+                .into_new_service()
+                .push(svc::ArcNewService::layer())
+        })
+    }
+}

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -1,25 +1,14 @@
-use super::{Concrete, Endpoint, Logical};
-use crate::{endpoint, resolve, Outbound};
-use linkerd_app_core::{
-    drain, io, profiles,
-    proxy::{
-        api_resolve::{ConcreteAddr, Metadata},
-        core::Resolve,
-        resolve::map_endpoint,
-        tcp,
-    },
-    svc, Error, Infallible,
-};
+use super::{Concrete, Logical};
+use crate::Outbound;
+use linkerd_app_core::{io, profiles, proxy::api_resolve::ConcreteAddr, svc, Error};
 use tracing::debug_span;
 
 #[cfg(test)]
 mod tests;
 
-impl<C> Outbound<C> {
-    /// Constructs a TCP load balancer.
-    pub fn push_tcp_logical<I, R>(
+impl<N> Outbound<N> {
+    pub fn push_tcp_logical<I, NSvc>(
         self,
-        resolve: R,
     ) -> Outbound<
         svc::ArcNewService<
             Logical,
@@ -27,63 +16,17 @@ impl<C> Outbound<C> {
         >,
     >
     where
-        C: svc::MakeConnection<Endpoint> + Clone + Send + 'static,
-        C::Connection: Send + Unpin,
-        C::Metadata: Send + Unpin,
-        C::Future: Send,
-        C: Send + Sync + 'static,
+        N: svc::NewService<Concrete, Service = NSvc> + Clone + Send + Sync + 'static,
+        NSvc: svc::Service<I, Response = (), Error = Error> + Send + 'static,
+        NSvc::Future: Send,
         I: io::AsyncRead + io::AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
-        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>
-            + Clone
-            + Send
-            + Sync
-            + 'static,
-        R::Resolution: Send,
-        R::Future: Send + Unpin,
     {
-        self.map_stack(|config, rt, connect| {
+        self.map_stack(|config, rt, concrete| {
             let crate::Config {
                 discovery_idle_timeout,
                 tcp_connection_buffer,
                 ..
             } = config;
-
-            let resolve = svc::stack(resolve.into_service())
-                .check_service::<ConcreteAddr>()
-                .push_request_filter(|c: Concrete| Ok::<_, Infallible>(c.resolve))
-                .push(svc::layer::mk(move |inner| {
-                    map_endpoint::Resolve::new(
-                        endpoint::FromMetadata {
-                            inbound_ips: config.inbound_ips.clone(),
-                        },
-                        inner,
-                    )
-                }))
-                .check_service::<Concrete>()
-                .into_inner();
-
-            let concrete = connect
-                .push(svc::stack::WithoutConnectionMetadata::layer())
-                .push_make_thunk()
-                .instrument(|t: &Endpoint| debug_span!("endpoint", addr = %t.addr))
-                .push(resolve::layer(resolve, *discovery_idle_timeout * 2))
-                .push_on_service(
-                    svc::layers()
-                        .push(tcp::balance::layer(
-                            crate::EWMA_DEFAULT_RTT,
-                            crate::EWMA_DECAY,
-                        ))
-                        .push(
-                            rt.metrics
-                                .proxy
-                                .stack
-                                .layer(crate::stack_labels("tcp", "balancer")),
-                        )
-                        .push(tcp::Forward::layer())
-                        .push(drain::Retain::layer(rt.drain.clone())),
-                )
-                .into_new_service()
-                .push(svc::ArcNewService::layer());
 
             concrete
                 .push_map_target(Concrete::from)

--- a/linkerd/app/outbound/src/tcp/logical/tests.rs
+++ b/linkerd/app/outbound/src/tcp/logical/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::tcp::Endpoint;
 use crate::test_util::*;
 use io::AsyncWriteExt;
 use linkerd_app_core::{
@@ -45,7 +46,8 @@ async fn forward() {
             let local = Local(ClientAddr(([0, 0, 0, 0], 4444).into()));
             future::ok::<_, support::io::Error>((io.build(), local))
         }))
-        .push_tcp_logical(resolve)
+        .push_tcp_concrete(resolve)
+        .push_tcp_logical()
         .into_inner();
 
     // Build a client to the endpoint and proxy a connection.
@@ -121,7 +123,8 @@ async fn balances() {
             }
             addr => unreachable!("unexpected endpoint: {}", addr),
         }))
-        .push_tcp_logical(resolve)
+        .push_tcp_concrete(resolve)
+        .push_tcp_logical()
         .into_inner()
         .new_service(logical);
 


### PR DESCRIPTION
This branch refactors the outbound proxy to have separate `push_tcp_logical` and `push_tcp_concrete` methods, rather than building both stacks in `push_tcp_logical`. This makes the TCP outbound proxy more consistent with how the HTTP outbound proxy is built (as it has separate methods for building the logical and concrete stacks).

No functional changes, just moving code around.