### PR TITLE
Disable musl in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64, arm64, arm]
-        libc: [gnu, musl]
+        libc: [gnu] # musl
 
     # If we're not actually building on a release tag, don't short-circuit on
     # errors. This helps us know whether a failure is platform-specific.

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -2,6 +2,7 @@
 
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
+#![recursion_limit = "256"]
 
 // Emit a compile-time error if no TLS implementations are enabled. When adding
 // new implementations, add their feature flags here!


### PR DESCRIPTION
Our cross-compiled musl builds do not currently compile (OOM). To unblock releases, this change disables these builds for now.