### PR TITLE
fill in the blanks for `ver/client-policy-sketch`

### DIFF
--- a/linkerd/app/inbound/src/accept.rs
+++ b/linkerd/app/inbound/src/accept.rs
@@ -118,14 +118,14 @@ mod tests {
         svc::{NewService, ServiceExt},
         Error,
     };
-    use linkerd_proxy_policy::{Authentication, Authorization, Meta, ServerPolicy};
+    use linkerd_proxy_policy::{server, Authentication, Authorization, Meta};
     use std::sync::Arc;
 
     #[tokio::test(flavor = "current_thread")]
     async fn default_allow() {
         let (io, _) = io::duplex(1);
         let policies = Store::for_test(
-            ServerPolicy {
+            server::Policy {
                 protocol: linkerd_proxy_policy::Protocol::Opaque(Arc::new([Authorization {
                     authentication: Authentication::Unauthenticated,
                     networks: vec![Default::default()],

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -614,7 +614,7 @@ impl svc::Param<policy::AllowPolicy> for Target {
         }]);
         let (policy, _) = policy::AllowPolicy::for_test(
             self.param(),
-            policy::ServerPolicy {
+            policy::server::Policy {
                 protocol: policy::Protocol::Http1(Arc::new([linkerd_proxy_policy::http::default(
                     authorizations,
                 )])),

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -1,4 +1,4 @@
-use super::{api::Api, DefaultPolicy, GetPolicy, Protocol, ServerPolicy, Store};
+use super::{api::Api, server, DefaultPolicy, GetPolicy, Store};
 use linkerd_app_core::{control, dns, identity, metrics, svc::NewService};
 use std::collections::{HashMap, HashSet};
 use tokio::time::Duration;
@@ -20,7 +20,7 @@ pub enum Config {
     Fixed {
         default: DefaultPolicy,
         cache_max_idle_age: Duration,
-        ports: HashMap<u16, ServerPolicy>,
+        ports: HashMap<u16, server::Policy>,
     },
 }
 
@@ -51,8 +51,8 @@ impl Config {
                     let backoff = control.connect.backoff;
                     let client = control.build(dns, metrics, identity).new_service(());
                     let detect_timeout = match default {
-                        DefaultPolicy::Allow(ServerPolicy {
-                            protocol: Protocol::Detect { timeout, .. },
+                        DefaultPolicy::Allow(server::Policy {
+                            protocol: server::Protocol::Detect { timeout, .. },
                             ..
                         }) => timeout,
                         _ => Duration::from_secs(10),

--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -1,14 +1,14 @@
 use linkerd_app_core::{IpNet, Ipv4Net, Ipv6Net};
 use linkerd_proxy_policy::{
-    authz::Suffix, http, Authentication, Authorization, Meta, Protocol, ServerPolicy,
+    authz::Suffix, http, opaque, server, Authentication, Authorization, Meta,
 };
 use std::{sync::Arc, time::Duration};
 
-pub fn all_authenticated(timeout: Duration) -> ServerPolicy {
+pub fn all_authenticated(timeout: Duration) -> server::Policy {
     mk("all-authenticated", all_nets(), authenticated(), timeout)
 }
 
-pub fn all_unauthenticated(timeout: Duration) -> ServerPolicy {
+pub fn all_unauthenticated(timeout: Duration) -> server::Policy {
     mk(
         "all-unauthenticated",
         all_nets(),
@@ -20,14 +20,14 @@ pub fn all_unauthenticated(timeout: Duration) -> ServerPolicy {
 pub fn cluster_authenticated(
     nets: impl IntoIterator<Item = IpNet>,
     timeout: Duration,
-) -> ServerPolicy {
+) -> server::Policy {
     mk("cluster-authenticated", nets, authenticated(), timeout)
 }
 
 pub fn cluster_unauthenticated(
     nets: impl IntoIterator<Item = IpNet>,
     timeout: Duration,
-) -> ServerPolicy {
+) -> server::Policy {
     mk(
         "cluster-unauthenticated",
         nets,
@@ -36,7 +36,7 @@ pub fn cluster_unauthenticated(
     )
 }
 
-pub fn all_mtls_unauthenticated(timeout: Duration) -> ServerPolicy {
+pub fn all_mtls_unauthenticated(timeout: Duration) -> server::Policy {
     mk(
         "all-tls-unauthenticated",
         all_nets(),
@@ -61,7 +61,7 @@ fn mk(
     nets: impl IntoIterator<Item = IpNet>,
     authentication: Authentication,
     timeout: Duration,
-) -> ServerPolicy {
+) -> server::Policy {
     let authorizations = Arc::new([Authorization {
         meta: Meta::new_default(name),
         networks: nets.into_iter().map(Into::into).collect(),
@@ -70,13 +70,13 @@ fn mk(
 
     // The default policy supports protocol detection and uses the default
     // authorization policy on a default route that matches all requests.
-    let protocol = Protocol::Detect {
+    let protocol = server::Protocol::Detect {
         timeout,
         http: Arc::new([http::default(authorizations.clone())]),
-        tcp_authorizations: authorizations,
+        opaque: Arc::new([opaque::default(authorizations)]),
     };
 
-    ServerPolicy {
+    server::Policy {
         meta: Meta::new_default(name),
         protocol,
     }

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -186,9 +186,13 @@ impl<T, N> HttpPolicyService<T, N> {
     /// authorization.
     fn authorize<'m, M: super::route::Match + 'm, P, B>(
         &self,
-        routes: &'m [super::route::Route<M, RoutePolicy<P>>],
+        routes: &'m [super::route::Route<M, RoutePolicy<P, ()>>],
         req: &::http::Request<B>,
-    ) -> Result<(HttpRoutePermit, RouteMatch<M::Summary>, &'m RoutePolicy<P>)> {
+    ) -> Result<(
+        HttpRoutePermit,
+        RouteMatch<M::Summary>,
+        &'m RoutePolicy<P, ()>,
+    )> {
         let (r#match, route) =
             super::route::find(routes, req).ok_or_else(|| self.mk_route_not_found())?;
 
@@ -260,7 +264,7 @@ impl<T, N> HttpPolicyService<T, N> {
 
 fn apply_http_filters<B>(
     r#match: http::RouteMatch,
-    route: &http::Policy,
+    route: &http::Policy<()>,
     req: &mut ::http::Request<B>,
 ) -> Result<()> {
     // TODO Do any metrics apply here?
@@ -299,7 +303,7 @@ fn apply_http_filters<B>(
     Ok(())
 }
 
-fn apply_grpc_filters<B>(route: &grpc::Policy, req: &mut ::http::Request<B>) -> Result<()> {
+fn apply_grpc_filters<B>(route: &grpc::Policy<()>, req: &mut ::http::Request<B>) -> Result<()> {
     for filter in &route.filters {
         match filter {
             grpc::Filter::InjectFailure(fail) => {

--- a/linkerd/app/inbound/src/policy/http/tests.rs
+++ b/linkerd/app/inbound/src/policy/http/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::policy::{Authentication, Authorization, Meta, Protocol, ServerPolicy};
+use crate::policy::{server, Authentication, Authorization, Meta, Protocol};
 use linkerd_app_core::{svc::Service, Infallible};
 use std::sync::Arc;
 
@@ -23,7 +23,7 @@ macro_rules! new_svc {
     ($proto:expr, $conn:expr, $rsp:expr) => {{
         let (policy, tx) = AllowPolicy::for_test(
             $conn.dst,
-            ServerPolicy {
+            server::Policy {
                 protocol: $proto,
                 meta: Arc::new(Meta::Resource {
                     group: "policy.linkerd.io".into(),
@@ -90,6 +90,7 @@ async fn http_route() {
                     }]),
                     filters: vec![],
                     meta: rmeta.clone(),
+                    distribution: (),
                 },
             },
             Rule {
@@ -101,6 +102,7 @@ async fn http_route() {
                     authorizations: Arc::new([]),
                     filters: vec![],
                     meta: rmeta.clone(),
+                    distribution: (),
                 },
             }
         ],
@@ -148,7 +150,7 @@ async fn http_route() {
     // Update all of the policies and then test the same requests to ensure that
     // the requests are handled differently after an update.
 
-    tx.send(ServerPolicy {
+    tx.send(server::Policy {
         meta: Arc::new(Meta::Resource {
             group: "policy.linkerd.io".into(),
             kind: "Server".into(),
@@ -174,6 +176,7 @@ async fn http_route() {
                         }]),
                         filters: vec![],
                         meta: rmeta.clone(),
+                        distribution: (),
                     },
                 },
                 Rule {
@@ -193,6 +196,7 @@ async fn http_route() {
                         }]),
                         filters: vec![],
                         meta: rmeta.clone(),
+                        distribution: (),
                     },
                 },
             ],
@@ -268,6 +272,7 @@ async fn http_filter_header() {
                     ..filter::ModifyHeader::default()
                 })],
                 meta: rmeta.clone(),
+                distribution: (),
             },
         }],
     }]));
@@ -334,6 +339,7 @@ async fn http_filter_inject_failure() {
                     },
                 })],
                 meta: rmeta.clone(),
+                distribution: (),
             },
         }],
     }]));
@@ -394,6 +400,7 @@ async fn grpc_route() {
                     }]),
                     filters: vec![],
                     meta: rmeta.clone(),
+                    distribution: (),
                 },
             },
             Rule {
@@ -408,6 +415,7 @@ async fn grpc_route() {
                     authorizations: Arc::new([]),
                     filters: vec![],
                     meta: rmeta.clone(),
+                    distribution: (),
                 },
             }
         ],
@@ -495,6 +503,7 @@ async fn grpc_filter_header() {
                     ..http::filter::ModifyHeader::default()
                 })],
                 meta: rmeta.clone(),
+                distribution: (),
             },
         }],
     }]));
@@ -571,6 +580,7 @@ async fn grpc_filter_inject_failure() {
                     },
                 })],
                 meta: rmeta.clone(),
+                distribution: (),
             },
         }],
     }]));

--- a/linkerd/app/inbound/src/policy/tcp/tests.rs
+++ b/linkerd/app/inbound/src/policy/tcp/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::policy::*;
 use linkerd_app_core::{proxy::http, Error};
-use linkerd_proxy_policy::{authz::Suffix, Authentication, Authorization, Protocol, ServerPolicy};
+use linkerd_proxy_policy::{authz::Suffix, server, Authentication, Authorization, Protocol};
 use std::{collections::BTreeSet, sync::Arc};
 
 #[derive(Clone)]
@@ -9,7 +9,7 @@ pub(crate) struct MockSvc;
 
 #[tokio::test(flavor = "current_thread")]
 async fn unauthenticated_allowed() {
-    let policy = ServerPolicy {
+    let policy = server::Policy {
         protocol: Protocol::Opaque(
             vec![Authorization {
                 authentication: Authentication::Unauthenticated,
@@ -55,7 +55,7 @@ async fn unauthenticated_allowed() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn authenticated_identity() {
-    let policy = ServerPolicy {
+    let policy = server::Policy {
         protocol: Protocol::Opaque(
             vec![Authorization {
                 authentication: Authentication::TlsAuthenticated {
@@ -118,7 +118,7 @@ async fn authenticated_identity() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn authenticated_suffix() {
-    let policy = ServerPolicy {
+    let policy = server::Policy {
         protocol: Protocol::Opaque(
             vec![Authorization {
                 authentication: Authentication::TlsAuthenticated {
@@ -180,7 +180,7 @@ async fn authenticated_suffix() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn tls_unauthenticated() {
-    let policy = ServerPolicy {
+    let policy = server::Policy {
         protocol: Protocol::Opaque(
             vec![Authorization {
                 authentication: Authentication::TlsUnauthenticated,
@@ -268,7 +268,7 @@ impl tonic::client::GrpcService<tonic::body::BoxBody> for MockSvc {
 impl Store<MockSvc> {
     pub(crate) fn for_test(
         default: impl Into<DefaultPolicy>,
-        ports: impl IntoIterator<Item = (u16, ServerPolicy)>,
+        ports: impl IntoIterator<Item = (u16, server::Policy)>,
     ) -> Self {
         Self::spawn_fixed(default.into(), std::time::Duration::MAX, ports)
     }

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -14,7 +14,7 @@ use linkerd_app_core::{
     ProxyRuntime,
 };
 pub use linkerd_app_test as support;
-use linkerd_proxy_policy::{Authentication, Authorization, Meta, Protocol, ServerPolicy};
+use linkerd_proxy_policy::{server, Authentication, Authorization, Meta, Protocol};
 use std::{sync::Arc, time::Duration};
 
 pub fn default_config() -> Config {
@@ -33,11 +33,11 @@ pub fn default_config() -> Config {
     }]);
     let policy = policy::Config::Fixed {
         cache_max_idle_age: Duration::from_secs(20),
-        default: ServerPolicy {
+        default: server::Policy {
             protocol: Protocol::Detect {
                 timeout: std::time::Duration::from_secs(10),
                 http: Arc::new([linkerd_proxy_policy::http::default(authorizations.clone())]),
-                tcp_authorizations: authorizations,
+                opaque: Arc::new([linkerd_proxy_policy::opaque::default(authorizations)]),
             },
             meta: Arc::new(Meta::Resource {
                 group: "policy.linkerd.io".into(),

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -708,14 +708,14 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                                     .cloned()
                                     .unwrap_or_else(|| default_allow.clone());
                                 sp.protocol = match sp.protocol {
-                                    inbound::policy::Protocol::Detect { tcp_authorizations, .. } => {
-                                        inbound::policy::Protocol::Opaque(tcp_authorizations)
+                                    inbound::policy::Protocol::Detect { opaque, .. } => {
+                                        inbound::policy::Protocol::Opaque(opaque[0].rules[0].policy.authorizations.clone())
                                     }
                                     _ => unreachable!("port must have been configured to detect prior to marking it opaque"),
                                 };
                                 (p, sp)
                             })
-                            .collect::<HashMap<_, inbound::policy::ServerPolicy>>();
+                            .collect::<HashMap<_, inbound::policy::server::Policy>>();
                         // Ensure that the inbound port does not disable protocol detection, as
                         if ports.contains_key(&inbound_port) {
                             error!(

--- a/linkerd/proxy/policy/src/grpc.rs
+++ b/linkerd/proxy/policy/src/grpc.rs
@@ -20,7 +20,7 @@ pub fn find<'r, B, D>(
     grpc::find(routes, req)
 }
 
-pub fn default(authorizations: std::sync::Arc<[crate::Authorization]>) -> Route {
+pub fn default<D: Default>(authorizations: std::sync::Arc<[crate::Authorization]>) -> Route<D> {
     Route {
         hosts: vec![],
         rules: vec![Rule {
@@ -29,6 +29,7 @@ pub fn default(authorizations: std::sync::Arc<[crate::Authorization]>) -> Route 
                 meta: crate::Meta::new_default("default"),
                 authorizations,
                 filters: vec![],
+                distribution: D::default(),
             },
         }],
     }
@@ -79,7 +80,7 @@ pub mod proto {
     pub fn try_route(
         proto: api::GrpcRoute,
         server_authorizations: &[Authorization],
-    ) -> Result<Route, InvalidGrpcRoute> {
+    ) -> Result<Route<()>, InvalidGrpcRoute> {
         let api::GrpcRoute {
             hosts,
             authorizations,
@@ -106,7 +107,7 @@ pub mod proto {
         authorizations: Arc<[authz::Authorization]>,
         meta: Arc<Meta>,
         proto: api::grpc_route::Rule,
-    ) -> Result<Rule, InvalidGrpcRoute> {
+    ) -> Result<Rule<()>, InvalidGrpcRoute> {
         let matches = proto
             .matches
             .into_iter()
@@ -136,6 +137,8 @@ pub mod proto {
                 authorizations,
                 filters,
                 meta,
+                // server policy, no distribution
+                distribution: (),
             }
         };
 

--- a/linkerd/proxy/policy/src/http.rs
+++ b/linkerd/proxy/policy/src/http.rs
@@ -21,7 +21,7 @@ pub fn find<'r, B, D>(
     http::find(routes, req)
 }
 
-pub fn default(authorizations: std::sync::Arc<[crate::Authorization]>) -> Route {
+pub fn default<D: Default>(authorizations: std::sync::Arc<[crate::Authorization]>) -> Route<D> {
     Route {
         hosts: vec![],
         rules: vec![Rule {
@@ -30,6 +30,7 @@ pub fn default(authorizations: std::sync::Arc<[crate::Authorization]>) -> Route 
                 meta: crate::Meta::new_default("default"),
                 authorizations,
                 filters: vec![],
+                distribution: D::default(),
             },
         }],
     }
@@ -80,7 +81,7 @@ pub mod proto {
     pub fn try_route(
         proto: api::HttpRoute,
         server_authorizations: &[Authorization],
-    ) -> Result<Route, InvalidHttpRoute> {
+    ) -> Result<Route<()>, InvalidHttpRoute> {
         let api::HttpRoute {
             hosts,
             authorizations,
@@ -107,7 +108,7 @@ pub mod proto {
         authorizations: Arc<[authz::Authorization]>,
         meta: Arc<Meta>,
         proto: api::http_route::Rule,
-    ) -> Result<Rule, InvalidHttpRoute> {
+    ) -> Result<Rule<()>, InvalidHttpRoute> {
         let matches = proto
             .matches
             .into_iter()
@@ -138,6 +139,8 @@ pub mod proto {
                 authorizations,
                 filters,
                 meta,
+                // server policy, no distribution
+                distribution: (),
             }
         };
 

--- a/linkerd/proxy/policy/src/lib.rs
+++ b/linkerd/proxy/policy/src/lib.rs
@@ -31,7 +31,7 @@ pub enum Protocol<D> {
         timeout: time::Duration,
         /// HTTP routes to use when protocol detection identifies an HTTP
         http: Arc<[http::Route<D>]>,
-        opaque: Arc<[OpaqueRoute<D>]>,
+        opaque: Arc<[opaque::Route<D>]>,
     },
     Http1(Arc<[http::Route<D>]>),
     Http2(Arc<[http::Route<D>]>),
@@ -139,6 +139,7 @@ pub mod proto {
                         .ok_or(InvalidServer::MissingDetectTimeout)?
                         .try_into()?,
                     tcp_authorizations: authorizations,
+                    opaque: todo!("eliza"),
                 },
 
                 api::proxy_protocol::Kind::Http1(api::proxy_protocol::Http1 { routes }) => {

--- a/linkerd/proxy/policy/src/lib.rs
+++ b/linkerd/proxy/policy/src/lib.rs
@@ -137,19 +137,7 @@ pub mod proto {
                     timeout: timeout
                         .ok_or(InvalidServer::MissingDetectTimeout)?
                         .try_into()?,
-                    // TODO(eliza): since there's currently only one opaque
-                    // route, it ought to live in a static that gets cloned...
-                    opaque: Arc::from(vec![opaque::Route {
-                        rules: vec![route::Rule {
-                            matches: vec![()],
-                            policy: RoutePolicy {
-                                meta: Meta::new_default("opaque"),
-                                authorizations,
-                                filters: Vec::default(),
-                                distribution: (),
-                            },
-                        }],
-                    }]),
+                    opaque: Arc::new([opaque::default(authorizations)]),
                 },
 
                 api::proxy_protocol::Kind::Http1(api::proxy_protocol::Http1 { routes }) => {

--- a/linkerd/proxy/policy/src/opaque.rs
+++ b/linkerd/proxy/policy/src/opaque.rs
@@ -1,4 +1,15 @@
+use linkerd_http_route::Rule;
 pub type Policy<D> = crate::RoutePolicy<Filter, D>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Filter {}
+
+// TODO(eliza): how would we match opaque routes?
+pub type RouteMatch = ();
+
+/// Groups routing rules under a common set of hostnames.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct Route<D> {
+    /// Must not be empty.
+    pub rules: Vec<Rule<RouteMatch, Policy<D>>>,
+}

--- a/linkerd/proxy/policy/src/opaque.rs
+++ b/linkerd/proxy/policy/src/opaque.rs
@@ -13,3 +13,17 @@ pub struct Route<D> {
     /// Must not be empty.
     pub rules: Vec<Rule<RouteMatch, Policy<D>>>,
 }
+
+pub fn default<D: Default>(authorizations: std::sync::Arc<[crate::Authorization]>) -> Route<D> {
+    Route {
+        rules: vec![Rule {
+            matches: vec![],
+            policy: Policy {
+                meta: crate::Meta::new_default("default"),
+                authorizations,
+                filters: vec![],
+                distribution: D::default(),
+            },
+        }],
+    }
+}


### PR DESCRIPTION
This branch just does most of the remaining busywork to update existing code with the changes from `ver/client-policy-sketch`, and fix the remaining compiler errors.