### PR TITLE
annotate proxy errors with target metadata

### DIFF
--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -493,11 +493,11 @@ impl ExtractParam<errors::respond::EmitHeaders, Logical> for ClientRescue {
 
 impl errors::HttpRescue<Error> for ClientRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        if let Some(cause) = errors::cause_ref::<std::io::Error>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
+        if errors::is_caused_by::<std::io::Error>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::bad_gateway(error));
         }
-        if let Some(cause) = errors::cause_ref::<errors::ConnectTimeout>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
+        if errors::is_caused_by::<errors::ConnectTimeout>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::gateway_timeout(error));
         }
 
         Err(error)

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -227,9 +227,7 @@ impl<C> Inbound<C> {
                 // dispatches the request.
                 .check_new_service::<Logical, http::Request<http::BoxBody>>()
                 .push_on_service(svc::LoadShed::layer())
-                    // TODO(eliza): what additional error context do we want here?
-                // just the port?
-                .push(svc::NewAnnotateError::<_, u16>::layer_named("HTTP logical"))
+                .push(svc::NewAnnotateError::layer_with(|t: &Logical| svc::annotate_error::named("HTTP logical", t.addr)))
                 .push_new_clone()
                 .check_new_new::<(policy::HttpRoutePermit, T), Logical>()
                 .push(svc::NewOneshotRoute::layer_via(|(permit, t): &(policy::HttpRoutePermit, T)| {

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -130,15 +130,15 @@ impl<T: Param<tls::ConditionalServerTls>> ExtractParam<errors::respond::EmitHead
 
 impl errors::HttpRescue<Error> for ServerRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        if let Some(cause) = errors::cause_ref::<policy::HttpRouteNotFound>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::not_found(cause));
+        if errors::is_caused_by::<policy::HttpRouteNotFound>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::not_found(error));
         }
 
-        if let Some(cause) = errors::cause_ref::<policy::HttpRouteUnauthorized>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::permission_denied(cause));
+        if errors::is_caused_by::<policy::HttpRouteUnauthorized>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::permission_denied(error));
         }
 
-        if let Some(error) = errors::cause_ref::<policy::HttpRouteInvalidRedirect>(&*error) {
+        if errors::is_caused_by::<policy::HttpRouteInvalidRedirect>(&*error) {
             tracing::warn!(%error);
             return Ok(errors::SyntheticHttpResponse::unexpected_error());
         }
@@ -147,26 +147,26 @@ impl errors::HttpRescue<Error> for ServerRescue {
         {
             return Ok(errors::SyntheticHttpResponse::redirect(*status, location));
         }
-        if let Some(cause) = errors::cause_ref::<policy::HttpInvalidPolicy>(&*error) {
+        if errors::is_caused_by::<policy::HttpInvalidPolicy>(&*error) {
             return Ok(errors::SyntheticHttpResponse::internal_error(
-                cause.to_string(),
+                error.to_string(),
             ));
         }
 
-        if let Some(cause) = errors::cause_ref::<crate::GatewayDomainInvalid>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::not_found(cause));
+        if errors::is_caused_by::<crate::GatewayDomainInvalid>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::not_found(error));
         }
-        if let Some(cause) = errors::cause_ref::<crate::GatewayIdentityRequired>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::unauthenticated(cause));
+        if errors::is_caused_by::<crate::GatewayIdentityRequired>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::unauthenticated(error));
         }
-        if let Some(cause) = errors::cause_ref::<crate::GatewayLoop>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::loop_detected(cause));
+        if errors::is_caused_by::<crate::GatewayLoop>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::loop_detected(error));
         }
-        if let Some(cause) = errors::cause_ref::<errors::FailFastError>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
+        if errors::is_caused_by::<errors::FailFastError>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::gateway_timeout(error));
         }
-        if let Some(cause) = errors::cause_ref::<errors::LoadShedError>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::unavailable(cause));
+        if errors::is_caused_by::<errors::LoadShedError>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::unavailable(error));
         }
 
         if errors::is_caused_by::<errors::H2Error>(&*error) {

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -341,7 +341,7 @@ async fn h2_response_meshed_error_header() {
         .headers()
         .get(L5D_PROXY_ERROR)
         .expect("response did not contain L5D_PROXY_ERROR header");
-    assert_eq!(message, "service in fail-fast");
+    assert_eq!(message, "HTTP logical (127.0.0.1:80): service in fail-fast");
 
     // Drop the client and discard the result of awaiting the proxy background
     // task. The result is discarded because it hits an error that is related
@@ -423,7 +423,7 @@ async fn grpc_meshed_response_error_header() {
         .headers()
         .get(L5D_PROXY_ERROR)
         .expect("response did not contain L5D_PROXY_ERROR header");
-    assert_eq!(message, "service in fail-fast");
+    assert_eq!(message, "HTTP logical (127.0.0.1:80): service in fail-fast");
 
     // Drop the client and discard the result of awaiting the proxy background
     // task. The result is discarded because it hits an error that is related

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -185,7 +185,7 @@ async fn http1_bad_gateway_meshed_response_error_header() {
         .headers()
         .get(L5D_PROXY_ERROR)
         .expect("response did not contain L5D_PROXY_ERROR header");
-    assert_eq!(message, "server is not listening");
+    assert_eq!(message, "error trying to connect: server is not listening");
 
     drop(client);
     bg.await.expect("background task failed");
@@ -263,7 +263,10 @@ async fn http1_connect_timeout_meshed_response_error_header() {
         .headers()
         .get(L5D_PROXY_ERROR)
         .expect("response did not contain L5D_PROXY_ERROR header");
-    assert_eq!(message, "connect timed out after 1s");
+    assert_eq!(
+        message,
+        "error trying to connect: connect timed out after 1s"
+    );
 
     drop(client);
     bg.await.expect("background task failed");

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -1,5 +1,8 @@
 use super::{api::Api, DefaultPolicy, GetPolicy, Protocol, ServerPolicy, Store};
-use linkerd_app_core::{control, dns, identity, metrics, svc::NewService};
+use linkerd_app_core::{
+    control, dns, identity, metrics,
+    svc::{NewService, ServiceExt},
+};
 use std::collections::{HashMap, HashSet};
 use tokio::time::Duration;
 
@@ -49,7 +52,10 @@ impl Config {
             } => {
                 let watch = {
                     let backoff = control.connect.backoff;
-                    let client = control.build(dns, metrics, identity).new_service(());
+                    let client = control
+                        .build(dns, metrics, identity)
+                        .new_service(())
+                        .map_err(Into::into);
                     let detect_timeout = match default {
                         DefaultPolicy::Allow(ServerPolicy {
                             protocol: Protocol::Detect { timeout, .. },

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -60,9 +60,6 @@ impl<N> Outbound<N> {
                         )
                         .push_buffer(&config.tcp_connection_buffer),
                 )
-                .push(svc::NewAnnotateError::<_, OrigDstAddr>::layer_named(
-                    "TCP server",
-                ))
                 .push_idle_cache(config.discovery_idle_timeout)
                 .push(svc::ArcNewService::layer())
                 .check_new_service::<T, I>()

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -58,8 +58,11 @@ impl<N> Outbound<N> {
                                 .stack
                                 .layer(crate::stack_labels("tcp", "server")),
                         )
-                        .push_buffer("TCP Server", &config.tcp_connection_buffer),
+                        .push_buffer(&config.tcp_connection_buffer),
                 )
+                .push(svc::NewAnnotateError::<_, OrigDstAddr>::layer_named(
+                    "TCP server",
+                ))
                 .push_idle_cache(config.discovery_idle_timeout)
                 .push(svc::ArcNewService::layer())
                 .check_new_service::<T, I>()

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -270,8 +270,11 @@ impl<S> Outbound<S> {
                         // that in the concrete stack. It should probably be
                         // derived from the target so that we can configure it
                         // via the API.
-                        .push_buffer("HTTP Forward", &config.http_request_buffer),
+                        .push_buffer(&config.http_request_buffer),
                 )
+                .push(svc::NewAnnotateError::<_, Remote<ServerAddr>>::layer_named(
+                    "HTTP forward",
+                ))
             })
             .push_http_server()
             .into_inner();

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -19,7 +19,7 @@ use linkerd_app_core::{
     profiles::{self, LogicalAddr},
     proxy::{api_resolve::ProtocolHint, tap},
     svc::Param,
-    tls, Addr, Conditional, CANONICAL_DST_HEADER,
+    tls, Addr, Conditional, Error, CANONICAL_DST_HEADER,
 };
 use std::{net::SocketAddr, str::FromStr};
 
@@ -173,5 +173,31 @@ impl tap::Inspect for Endpoint {
 
     fn is_outbound<B>(&self, _: &Request<B>) -> bool {
         true
+    }
+}
+
+impl<E> From<(&Concrete, E)> for crate::logical::ConcreteError
+where
+    E: Into<Error>,
+{
+    fn from((concrete, source): (&Concrete, E)) -> Self {
+        Self {
+            addr: concrete.resolve.clone(),
+            source: source.into(),
+            protocol: "HTTP",
+        }
+    }
+}
+
+impl<E> From<(&Logical, E)> for crate::logical::LogicalError
+where
+    E: Into<Error>,
+{
+    fn from((logical, source): (&Logical, E)) -> Self {
+        Self {
+            addr: logical.logical_addr.clone(),
+            source: source.into(),
+            protocol: "HTTP",
+        }
     }
 }

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -128,14 +128,14 @@ impl<T> ExtractParam<errors::respond::EmitHeaders, T> for ClientRescue {
 
 impl errors::HttpRescue<Error> for ClientRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        if let Some(cause) = errors::cause_ref::<http::orig_proto::DowngradedH2Error>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
+        if errors::is_caused_by::<http::orig_proto::DowngradedH2Error>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::bad_gateway(error));
         }
-        if let Some(cause) = errors::cause_ref::<std::io::Error>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
+        if errors::is_caused_by::<std::io::Error>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::bad_gateway(error));
         }
-        if let Some(cause) = errors::cause_ref::<errors::ConnectTimeout>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
+        if errors::is_caused_by::<errors::ConnectTimeout>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::gateway_timeout(error));
         }
 
         Err(error)

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -136,8 +136,8 @@ impl<N> Outbound<N> {
                 // TODO(ver) do we need to strip headers here?
                 .push(http::NewHeaderFromTarget::<CanonicalDstHeader, _>::layer())
                 // Annotate errors with the logical address.
-                .push(svc::NewAnnotateError::<_, LogicalAddr>::layer_with(
-                    svc::annotate_error::named("HTTP logical"),
+                .push(svc::NewAnnotateError::<_, LogicalAddr>::layer_named(
+                    "HTTP logical",
                 ))
                 .push(svc::ArcNewService::layer())
         })
@@ -271,19 +271,5 @@ impl classify::CanClassify for RouteParams {
 
     fn classify(&self) -> classify::Request {
         self.profile.response_classes().clone().into()
-    }
-}
-
-struct ErrorContext(LogicalAddr);
-
-impl fmt::Display for ErrorContext {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "HTTP logical ({})", self.0)
-    }
-}
-
-impl svc::Param<ErrorContext> for Logical {
-    fn param(&self) -> ErrorContext {
-        ErrorContext(self.logical_addr.clone())
     }
 }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -9,7 +9,7 @@ use linkerd_app_core::{
     svc, Error,
 };
 use linkerd_distribute as distribute;
-use std::{fmt, sync::Arc};
+use std::sync::Arc;
 
 #[derive(Debug, thiserror::Error)]
 #[error("no route")]

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -35,11 +35,8 @@ impl<N> Outbound<N> {
     where
         T: svc::Param<http::normalize_uri::DefaultAuthority>,
         N: svc::NewService<T, Service = NSvc> + Clone + Send + Sync + 'static,
-        NSvc: svc::Service<
-                http::Request<http::BoxBody>,
-                Response = http::Response<http::BoxBody>,
-                Error = Error,
-            > + Clone
+        NSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
+            + Clone
             + Send
             + 'static,
         NSvc::Error: Into<Error>,

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -115,21 +115,21 @@ impl<T> ExtractParam<errors::respond::EmitHeaders, T> for ServerRescue {
 
 impl errors::HttpRescue<Error> for ServerRescue {
     fn rescue(&self, error: Error) -> Result<errors::SyntheticHttpResponse> {
-        if let Some(cause) = errors::cause_ref::<http::ResponseTimeoutError>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
+        if errors::is_caused_by::<http::ResponseTimeoutError>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::gateway_timeout(error));
         }
-        if let Some(cause) = errors::cause_ref::<IdentityRequired>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::bad_gateway(cause));
+        if errors::is_caused_by::<IdentityRequired>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::bad_gateway(error));
         }
-        if let Some(cause) = errors::cause_ref::<errors::FailFastError>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::gateway_timeout(cause));
+        if errors::is_caused_by::<errors::FailFastError>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::gateway_timeout(error));
         }
-        if let Some(cause) = errors::cause_ref::<errors::LoadShedError>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::unavailable(cause));
+        if errors::is_caused_by::<errors::LoadShedError>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::unavailable(error));
         }
 
-        if let Some(cause) = errors::cause_ref::<super::logical::NoRoute>(&*error) {
-            return Ok(errors::SyntheticHttpResponse::not_found(cause));
+        if errors::is_caused_by::<super::logical::NoRoute>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::not_found(error));
         }
 
         if errors::is_caused_by::<errors::H2Error>(&*error) {

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -9,6 +9,7 @@ use linkerd_app_core::{
 };
 pub use profiles::LogicalAddr;
 use std::fmt;
+use thiserror::Error;
 use tracing::info_span;
 
 #[derive(Clone)]
@@ -25,6 +26,24 @@ pub struct Concrete<P> {
 }
 
 pub type UnwrapLogical<L, E> = svc::stack::ResultService<svc::Either<L, E>>;
+
+#[derive(Debug, Error)]
+#[error("{} logical ({}): {}", .protocol, .addr, .source)]
+pub struct LogicalError {
+    pub(crate) addr: LogicalAddr,
+    #[source]
+    pub(crate) source: Error,
+    pub(crate) protocol: &'static str,
+}
+
+#[derive(Debug, Error)]
+#[error("{} concrete ({}): {}", .protocol, .addr, .source)]
+pub struct ConcreteError {
+    pub(crate) addr: ConcreteAddr,
+    #[source]
+    pub(crate) source: Error,
+    pub(crate) protocol: &'static str,
+}
 
 // === impl Logical ===
 

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -66,3 +66,29 @@ impl<N> Outbound<N> {
         })
     }
 }
+
+impl<E> From<(&Concrete, E)> for crate::logical::ConcreteError
+where
+    E: Into<Error>,
+{
+    fn from((concrete, source): (&Concrete, E)) -> Self {
+        Self {
+            addr: concrete.resolve.clone(),
+            source: source.into(),
+            protocol: "TCP",
+        }
+    }
+}
+
+impl<E> From<(&Logical, E)> for crate::logical::LogicalError
+where
+    E: Into<Error>,
+{
+    fn from((logical, source): (&Logical, E)) -> Self {
+        Self {
+            addr: logical.logical_addr.clone(),
+            source: source.into(),
+            protocol: "TCP",
+        }
+    }
+}

--- a/linkerd/app/src/dst.rs
+++ b/linkerd/app/src/dst.rs
@@ -1,5 +1,6 @@
 use linkerd_app_core::{
-    control, dns,
+    control::{self, ControlError},
+    dns,
     exp_backoff::{ExponentialBackoff, ExponentialBackoffStream},
     identity, metrics,
     profiles::{self, DiscoveryRejected},
@@ -42,7 +43,7 @@ impl Config {
             impl svc::Service<
                     http::Request<tonic::body::BoxBody>,
                     Response = http::Response<control::RspBody>,
-                    Error = Error,
+                    Error = ControlError,
                     Future = impl Send,
                 > + Clone,
         >,

--- a/linkerd/stack/src/annotate_error.rs
+++ b/linkerd/stack/src/annotate_error.rs
@@ -1,0 +1,172 @@
+use crate::{layer, ExtractParam, NewService, Service};
+use std::{
+    error::Error,
+    fmt,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+pub struct NewAnnotateError<N, C, X = ()> {
+    inner: N,
+    extract: X,
+    _cx: PhantomData<fn(C)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct AnnotateError<S> {
+    inner: S,
+    context: Arc<str>,
+}
+
+#[derive(Debug)]
+pub struct AnnotatedError {
+    context: Arc<str>,
+    // TODO(eliza): avoid double boxing these
+    source: linkerd_error::Error,
+}
+
+#[derive(Debug)]
+#[pin_project::pin_project]
+pub struct ResponseFuture<F> {
+    #[pin]
+    f: F,
+    context: Option<Arc<str>>,
+}
+
+// === impl NewAnnotateError ===
+
+impl<N, C: fmt::Display> NewAnnotateError<N, C> {
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(|inner| Self::new(inner, ()))
+    }
+}
+
+impl<N, C, X> NewAnnotateError<N, C, X>
+where
+    C: fmt::Display,
+    X: Clone,
+{
+    pub fn layer_with(extract: X) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self::new(inner, extract.clone()))
+    }
+}
+
+impl<N, C, X> NewAnnotateError<N, C, X> {
+    fn new(inner: N, extract: X) -> Self {
+        Self {
+            inner,
+            extract,
+            _cx: PhantomData,
+        }
+    }
+}
+
+impl<N, C, X> Clone for NewAnnotateError<N, C, X>
+where
+    N: Clone,
+    X: Clone,
+{
+    fn clone(&self) -> Self {
+        Self::new(self.inner.clone(), self.extract.clone())
+    }
+}
+
+impl<N, C, X> fmt::Debug for NewAnnotateError<N, C, X>
+where
+    N: fmt::Debug,
+    X: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            inner,
+            extract,
+            _cx,
+        } = self;
+        f.debug_struct("NewAnnotateError")
+            .field("inner", inner)
+            .field("extract", extract)
+            .finish()
+    }
+}
+
+impl<T, N, C, X> NewService<T> for NewAnnotateError<N, C, X>
+where
+    N: NewService<T>,
+    X: ExtractParam<C, T>,
+    C: fmt::Display,
+{
+    type Service = AnnotateError<N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let param = self.extract.extract_param(&target);
+        let context = param.to_string().into();
+        let inner = self.inner.new_service(target);
+
+        AnnotateError { inner, context }
+    }
+}
+
+// === impl AnnotateError ===
+
+impl<S, Req> Service<Req> for AnnotateError<S>
+where
+    S: Service<Req>,
+    S::Error: Into<linkerd_error::Error>,
+{
+    type Response = S::Response;
+    type Error = linkerd_error::Error;
+    type Future = ResponseFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(|source| {
+            AnnotatedError {
+                context: self.context.clone(),
+                source: source.into(),
+            }
+            .into()
+        })
+    }
+
+    fn call(&mut self, request: Req) -> Self::Future {
+        ResponseFuture {
+            f: self.inner.call(request),
+            context: Some(self.context.clone()),
+        }
+    }
+}
+
+// === impl AnnotatedError ===
+
+impl fmt::Display for AnnotatedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self { context, source } = self;
+        write!(f, "{context}: {source}")
+    }
+}
+
+impl Error for AnnotatedError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+impl<F, T, E> Future for ResponseFuture<F>
+where
+    F: Future<Output = Result<T, E>>,
+    E: Into<linkerd_error::Error>,
+{
+    type Output = Result<T, linkerd_error::Error>;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        this.f.poll(cx).map_err(|source| {
+            AnnotatedError {
+                context: this.context.take().expect("polled after ready"),
+                source: source.into(),
+            }
+            .into()
+        })
+    }
+}

--- a/linkerd/stack/src/annotate_error.rs
+++ b/linkerd/stack/src/annotate_error.rs
@@ -47,6 +47,10 @@ pub struct ExtractNamed {
     name: &'static str,
 }
 
+pub fn named<P>(name: &'static str, param: P) -> Named<P> {
+    Named { name, param }
+}
+
 // === impl NewAnnotateError ===
 
 impl<N, C: fmt::Display> NewAnnotateError<N, C> {

--- a/linkerd/stack/src/annotate_error.rs
+++ b/linkerd/stack/src/annotate_error.rs
@@ -198,7 +198,7 @@ where
 
 impl<P: fmt::Display> fmt::Display for Named<P> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} {}", self.name, self.param)
+        write!(f, "{} ({})", self.name, self.param)
     }
 }
 

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
-mod annotate_error;
+pub mod annotate_error;
 mod arc_new_service;
 mod box_future;
 mod box_service;

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -3,6 +3,7 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
+mod annotate_error;
 mod arc_new_service;
 mod box_future;
 mod box_service;
@@ -29,6 +30,7 @@ mod unwrap_or;
 mod watch;
 
 pub use self::{
+    annotate_error::{AnnotateError, NewAnnotateError},
     arc_new_service::ArcNewService,
     box_future::BoxFuture,
     box_service::{BoxService, BoxServiceLayer},

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -30,7 +30,7 @@ mod unwrap_or;
 mod watch;
 
 pub use self::{
-    annotate_error::{AnnotateError, NewAnnotateError},
+    annotate_error::{AnnotateErrorService, NewAnnotateError},
     arc_new_service::ArcNewService,
     box_future::BoxFuture,
     box_service::{BoxService, BoxServiceLayer},


### PR DESCRIPTION
In order to improve the proxy's debuggability, it's desirable that the
errors logged by the proxy and/or returned to HTTP clients include
relevant information about where in the proxy that error occurred. 
Currently, buffer layers are constructed with a string "name" parameter
that describes which part of the stack is behind that buffer, so that
the fail-fast errors returned by those buffers can contain the stack
layer's name. While this provides some useful context, it isn't a
complete solution, as this context is only added to fail-fast errors,
and not other errors such as I/O errors, Additionally, these names only
indicate where in the stack the error occurred, and don't provide
metadata describing *which instance* of that stack layer produced the
error --- e.g., there is no context describing the client address,
logical address, concrete address, or endpoint (as appropriate) that
produced the error.

Instead, we should annotate *all* errors with the following information:

- The name of the stack layer where the error occurred
- Target metadata including the logical, concrete, and endpoint
  addresses (as appropriate)

This branch introduces a new `AnnotateError` middleware in
`linkerd-stack`. This middleware consists of a `NewService` which
extracts a `Param` from the target and formats it into a
reference-counted `Arc<str>`, and the `Service` produced by that
`NewService`, which wraps any errors returned by the inner `Service`
with that context. An `ExtractParam` implementation can also be provided
to configure how the context is extracted from the target. In addition,
the `annotate_error` modules contains helpers for formatting a `Param`
provided by the target plus a string name describing a stack layer.

Furthermore, this branch removes the existing name parameter from buffer
layers, and replaces them with the `AnnotateError` middleware, which is
used to add target metadata *and* a string name describing the stack
layer to all errors. Additionally, the various `HttpRescue`
implementations have been changed slightly, so that when a specific
cause is found for an error, the entire error chain is still formatted
in the HTTP response `l5d-error` header, rather than _just_ the cause.
This ensures that all context added to an error is included in the
formatted message, rather than just the root cause (which lacks target
metadata). 