### PR TITLE
metrics: add response classification to latency metrics

### DIFF
--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -440,7 +440,9 @@ where
 
     // assert the >=1000ms bucket is incremented by our request with 500ms
     // extra latency.
-    let labels = labels.label("status_code", 200);
+    let labels = labels
+        .label("status_code", 200)
+        .label("classification", "success");
     let mut bucket_1000 = labels
         .clone()
         .metric("response_latency_ms_bucket")

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -361,6 +361,7 @@ macro_rules! http1_tests {
             let srv = server::http1()
                 .route_fn("/", |req| {
                     assert!(!req.headers().contains_key("x-foo-bar"));
+                    tracing::info!("request headers: {:?}", req.headers());
                     Response::builder()
                         .header("x-server-quux", "lorem ipsum")
                         .header("connection", "close, x-server-quux")

--- a/linkerd/http-metrics/src/requests.rs
+++ b/linkerd/http-metrics/src/requests.rs
@@ -32,13 +32,13 @@ struct StatusMetrics<C>
 where
     C: Hash + Eq,
 {
-    latency: Histogram<latency::Ms>,
     by_class: HashMap<C, ClassMetrics>,
 }
 
 #[derive(Debug, Default)]
 pub struct ClassMetrics {
     total: Counter,
+    latency: Histogram<latency::Ms>,
 }
 
 // === impl Requests ===
@@ -99,7 +99,6 @@ where
 {
     fn default() -> Self {
         Self {
-            latency: Histogram::default(),
             by_class: HashMap::default(),
         }
     }

--- a/linkerd/http-metrics/src/requests.rs
+++ b/linkerd/http-metrics/src/requests.rs
@@ -24,15 +24,7 @@ where
 {
     last_update: Instant,
     total: Counter,
-    by_status: HashMap<Option<http::StatusCode>, StatusMetrics<C>>,
-}
-
-#[derive(Debug)]
-struct StatusMetrics<C>
-where
-    C: Hash + Eq,
-{
-    by_class: HashMap<C, ClassMetrics>,
+    by_class: HashMap<(Option<http::StatusCode>, C), ClassMetrics>,
 }
 
 #[derive(Debug, Default)]
@@ -82,7 +74,7 @@ impl<C: Hash + Eq> Default for Metrics<C> {
         Self {
             last_update: Instant::now(),
             total: Counter::default(),
-            by_status: HashMap::default(),
+            by_class: HashMap::default(),
         }
     }
 }
@@ -92,18 +84,6 @@ impl<C: Hash + Eq> LastUpdate for Metrics<C> {
         self.last_update
     }
 }
-
-impl<C> Default for StatusMetrics<C>
-where
-    C: Hash + Eq,
-{
-    fn default() -> Self {
-        Self {
-            by_class: HashMap::default(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     #[test]

--- a/linkerd/http-metrics/src/requests/report.rs
+++ b/linkerd/http-metrics/src/requests/report.rs
@@ -71,12 +71,10 @@ where
     {
         for (tgt, tm) in registry.iter() {
             let tm = tm.lock();
-            for (status, sm) in &tm.by_status {
-                for (cls, m) in &sm.by_class {
-                    let status = status.as_ref().map(|s| Status(*s));
-                    let labels = (tgt, (status, cls));
-                    get_metric(m).fmt_metric_labeled(f, &metric.name, labels)?;
-                }
+            for ((status, cls), m) in &tm.by_class {
+                let status = status.as_ref().map(|s| Status(*s));
+                let labels = (tgt, (status, cls));
+                get_metric(m).fmt_metric_labeled(f, &metric.name, labels)?;
             }
         }
 

--- a/linkerd/http-metrics/src/requests/service.rs
+++ b/linkerd/http-metrics/src/requests/service.rs
@@ -1,4 +1,4 @@
-use super::{ClassMetrics, Metrics, StatusMetrics};
+use super::{ClassMetrics, Metrics};
 use futures::{ready, TryFuture};
 use http_body::Body;
 use linkerd_error::Error;
@@ -372,14 +372,9 @@ fn measure_class<C: Hash + Eq>(
 
     (*metrics).last_update = now;
 
-    let status_metrics = metrics
-        .by_status
-        .entry(status)
-        .or_insert_with(StatusMetrics::default);
-
-    let class_metrics = status_metrics
+    let class_metrics = metrics
         .by_class
-        .entry(class)
+        .entry((status, class))
         .or_insert_with(ClassMetrics::default);
 
     class_metrics.total.incr();

--- a/linkerd/tracing/src/test.rs
+++ b/linkerd/tracing/src/test.rs
@@ -4,7 +4,7 @@ use std::env;
 /// By default, disable logging in modules that are expected to error in tests.
 pub const DEFAULT_LOG: &str = "warn,\
                            linkerd=debug,\
-                           linkerd_proxy_http=error,\
+                           linkerd_proxy_http=debug,\
                            linkerd_proxy_transport=error";
 
 pub fn trace_subscriber(default: impl ToString) -> (Dispatch, Handle) {


### PR DESCRIPTION
Currently, the documentation for proxy metrics [states][1] that all
`response_`-prefixed metrics are labeled with response classifications.
However, the `response_latency_ms` histograms lack this label --- they
are labeled with status codes, but not with response classifications or
gRPC status labels.

This is because response latencies are calculated when the last `DATA`
frame of a response body is received, rather than when a `TRAILERS`
frame is received or the body stream ends (depending on whether the
response includes trailers). Response classifications, however, cannot
be determined until a `TRAILERS` frame is received or the body stream
terminates, as a `TRAILERS` frame may contain a `grpc-status` trailer
that influences response classification.

This branch adds response classification labels to the
`response_latency_ms` histogram metrics. In order to do so, it was
necessary to change how response latencies are recorded slightly. Now,
the `ResponseBody` type still _calculates_ the latency when the last
`DATA` frame of a response is received, but the latency is not actually
recorded in the histogram until a response classification is recorded.
This way, the response latency histogram can be part of the
`ClassMetrics` structure rather than the `StatusMetrics` structure.

Now that response latency metrics are labeled with a classification as
well as a status code, it is no longer necessary to maintain a hashmap
of metrics by status code which contains hashmaps of metrics by
classification, since all response metrics are now labeled with both a
status and a classification. Therefore, we can combine these two nested
hashmaps into a single map keyed by `(Option<Status>, Classification)`.
This makes the code a bit simpler and may be slightly more efficient due
to fewer pointer dereferences to traverse nested maps.

Fixes linkerd/linkerd2#9737

[1]: https://linkerd.io/2.12/reference/proxy-metrics/#response-labels