### PR TITLE
Simplify profile discovery

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -100,7 +100,7 @@ impl Config {
             .push_on_service(svc::layer::mk(svc::SpawnReady::new))
             .push_new_reconnect(self.connect.backoff)
             .instrument(|t: &self::client::Target| info_span!("endpoint", addr = %t.addr))
-            .push_new_clone()
+            .lift_new()
             .push(self::balance::layer(dns, resolve_backoff))
             .push(metrics.to_layer::<classify::Response, _, _>())
             .push(self::add_origin::layer())

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -157,6 +157,16 @@ impl<S> Stack<S> {
     /// Lifts the inner stack via [`Self::lift_new`], but combines both target
     /// types into a new `P`-typed value via `From`.
     pub fn lift_new_with_target<P>(self) -> Stack<NewFromTargets<P, NewCloneService<S>>> {
+        // `lift_new` takes a NewService<P> and returns a NewService<T, Service =
+        // NewService<P>> -- turning it into a double-NewService that ignores
+        // the `T`-typed target.
+        //
+        // `NewFromTargets` wraps that and returns a NewService<T, Service =
+        // NewService<(U, T)> -- so that first target is cloned and
+        // combined with the second target via `P::from`.
+        //
+        // The result is that we expose NewService<T, Service = NewService<U>>
+        // over an inner NewService<P>
         self.lift_new().push(NewFromTargets::layer())
     }
 

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -166,7 +166,7 @@ impl<S> Stack<S> {
         // combined with the second target via `P::from`.
         //
         // The result is that we expose NewService<T, Service = NewService<U>>
-        // over an inner NewService<P>
+        // over an inner NewService<P>.
         self.lift_new().push(NewFromTargets::layer())
     }
 

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -183,8 +183,7 @@ impl<C> Inbound<C> {
                         .check_new_service::<Logical, http::Request<_>>()
                         .into_inner(),
                 )
-                .check_new_service::<(Option<profiles::Receiver>, Logical), http::Request<_>>()
-                ;
+                .check_new_service::<(Option<profiles::Receiver>, Logical), http::Request<_>>();
 
             let discover = router.clone()
                 .lift_new_with_target()

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -43,7 +43,7 @@ impl Inbound<()> {
         GSvc: svc::Service<direct::GatewayIo<io::ScopedIo<I>>, Response = ()> + Send + 'static,
         GSvc::Error: Into<Error>,
         GSvc::Future: Send,
-        P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + Unpin + 'static,
+        P: profiles::GetProfile + Clone + Send + Sync + Unpin + 'static,
         P::Error: Send,
         P::Future: Send,
     {

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -1,9 +1,8 @@
 use crate::Outbound;
 use linkerd_app_core::{
-    io, profiles,
+    profiles,
     svc::{self, stack::Param},
-    transport::OrigDstAddr,
-    Error,
+    Error, Infallible,
 };
 use tracing::debug;
 
@@ -11,58 +10,84 @@ impl<N> Outbound<N> {
     /// Discovers the profile for a TCP endpoint.
     ///
     /// Resolved services are cached and buffered.
-    pub fn push_discover<T, I, NSvc, P>(
+    pub fn push_discover<T, Req, NSvc, P>(
         self,
         profiles: P,
-    ) -> Outbound<
-        svc::ArcNewService<
-            T,
-            impl svc::Service<I, Response = (), Error = Error, Future = impl Send> + Clone,
-        >,
-    >
+    ) -> Outbound<svc::ArcNewService<T, svc::BoxService<Req, NSvc::Response, Error>>>
     where
-        T: Param<OrigDstAddr>,
-        T: Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
-        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+        T: Param<profiles::LookupAddr>,
+        T: Clone + Send + Sync + 'static,
         N: svc::NewService<(Option<profiles::Receiver>, T), Service = NSvc>,
         N: Clone + Send + Sync + 'static,
-        NSvc: svc::Service<I, Response = (), Error = Error> + Send + 'static,
+        Req: Send + 'static,
+        NSvc: svc::Service<Req, Response = (), Error = Error> + Send + 'static,
         NSvc::Future: Send,
-        P: profiles::GetProfile<profiles::LookupAddr> + Clone + Send + Sync + 'static,
+        P: profiles::GetProfile + Clone + Send + Sync + 'static,
         P::Future: Send,
         P::Error: Send,
     {
-        self.map_stack(|config, rt, inner| {
+        self.map_stack(|config, _, stk| {
             let allow = config.allow_discovery.clone();
-            inner
-                .push(profiles::discover::layer(profiles, move |t: T| {
-                    let OrigDstAddr(addr) = t.param();
-                    if allow.matches_ip(addr.ip()) {
-                        debug!("Allowing profile lookup");
-                        return Ok(profiles::LookupAddr(addr.into()));
-                    }
-                    debug!(
-                        %addr,
-                        networks = %allow.nets(),
-                        "Address is not in discoverable networks",
-                    );
-                    Err(profiles::DiscoveryRejected::new(
-                        "not in discoverable networks",
-                    ))
-                }))
-                .push_on_service(
-                    svc::layers()
-                        .push(
-                            rt.metrics
-                                .proxy
-                                .stack
-                                .layer(crate::stack_labels("tcp", "server")),
-                        )
-                        .push_buffer("TCP Server", &config.tcp_connection_buffer),
+            stk.clone()
+                .check_new_service::<(Option<profiles::Receiver>, T), Req>()
+                .lift_new_with_target()
+                .check_new_new_service::<T, Option<profiles::Receiver>, Req>()
+                .push(profiles::Discover::layer(profiles))
+                .check_new::<T>()
+                .check_new_service::<T, Req>()
+                .push_switch(
+                    move |t: T| -> Result<_, Infallible> {
+                        // TODO(ver) Should this allowance be parameterized by
+                        // the target type?
+                        let profiles::LookupAddr(addr) = t.param();
+                        if allow.matches(&addr) {
+                            debug!("Allowing profile lookup");
+                            return Ok(svc::Either::A(t));
+                        }
+                        debug!(
+                            %addr,
+                            networks = %allow.nets(),
+                            "Address is not in discoverable networks",
+                        );
+                        Ok(svc::Either::B((None, t)))
+                    },
+                    stk.into_inner(),
                 )
-                .push_idle_cache(config.discovery_idle_timeout)
+                .check_new_service::<T, Req>()
+                .push_on_service(svc::BoxService::layer())
                 .push(svc::ArcNewService::layer())
-                .check_new_service::<T, I>()
+        })
+    }
+
+    pub fn push_discover_cache<T, Req, NSvc>(
+        self,
+    ) -> Outbound<
+        svc::ArcNewService<
+            T,
+            impl svc::Service<Req, Response = NSvc::Response, Error = Error, Future = impl Send> + Clone,
+        >,
+    >
+    where
+        T: Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+        N: svc::NewService<T, Service = NSvc>,
+        N: Clone + Send + Sync + 'static,
+        Req: Send + 'static,
+        NSvc: svc::Service<Req, Response = (), Error = Error> + Send + 'static,
+        NSvc::Future: Send,
+    {
+        self.map_stack(|config, rt, stk| {
+            stk.push_on_service(
+                svc::layers()
+                    .push(
+                        rt.metrics
+                            .proxy
+                            .stack
+                            .layer(crate::stack_labels("tcp", "discover")),
+                    )
+                    .push_buffer("discover", &config.tcp_connection_buffer),
+            )
+            .push_idle_cache(config.discovery_idle_timeout)
+            .push(svc::ArcNewService::layer())
         })
     }
 }
@@ -72,7 +97,9 @@ mod tests {
     use super::*;
     use crate::{tcp, test_util::*};
     use linkerd_app_core::{
+        io,
         svc::{NewService, Service, ServiceExt},
+        transport::addrs::OrigDstAddr,
         AddrMatch, IpNet,
     };
     use std::{
@@ -114,6 +141,7 @@ mod tests {
         let stack = Outbound::new(default_config(), rt)
             .with_stack(stack)
             .push_discover(profiles)
+            .push_discover_cache()
             .into_inner();
 
         assert_eq!(
@@ -187,6 +215,7 @@ mod tests {
         let stack = Outbound::new(cfg, rt)
             .with_stack(stack)
             .push_discover(profiles)
+            .push_discover_cache()
             .into_inner();
 
         assert_eq!(
@@ -307,6 +336,7 @@ mod tests {
         let stack = Outbound::new(cfg, rt)
             .with_stack(stack)
             .push_discover(profiles)
+            .push_discover_cache()
             .into_inner();
 
         // Instantiate a service from the stack so that it instantiates the tracked inner service.

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -23,7 +23,6 @@ use linkerd_app_core::{
 };
 use std::{net::SocketAddr, str::FromStr};
 
-pub type Accept = crate::Accept<Version>;
 pub type Logical = crate::logical::Logical<Version>;
 pub type Concrete = crate::logical::Concrete<Version>;
 pub type Endpoint = crate::endpoint::Endpoint<Version>;
@@ -41,23 +40,6 @@ impl From<CanonicalDstHeader> for HeaderPair {
             HeaderName::from_static(CANONICAL_DST_HEADER),
             HeaderValue::from_str(&dst.to_string()).expect("addr must be a valid header"),
         )
-    }
-}
-
-// === impl Accept ===
-
-impl Param<Version> for Accept {
-    fn param(&self) -> Version {
-        self.protocol
-    }
-}
-
-impl Param<normalize_uri::DefaultAuthority> for Accept {
-    fn param(&self) -> normalize_uri::DefaultAuthority {
-        normalize_uri::DefaultAuthority(Some(
-            uri::Authority::from_str(&self.orig_dst.to_string())
-                .expect("Address must be a valid authority"),
-        ))
     }
 }
 

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -52,7 +52,7 @@ impl<N> Outbound<N> {
                         .layer(stack_labels("http", "endpoint")),
                 )
                 .instrument(|e: &Endpoint| info_span!("endpoint", addr = %e.addr))
-                .push_new_clone()
+                .lift_new()
                 .push(endpoint::NewFromMetadata::layer(config.inbound_ips.clone()))
                 .push(http::NewBalancePeakEwma::layer(resolve))
                 // Drives the initial resolution via the service's readiness.

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -123,7 +123,7 @@ impl<N> Outbound<N> {
             // router stack.
             concrete
                 // Share the concrete stack with each router stack.
-                .push_new_clone()
+                .lift_new()
                 // Rebuild this router stack every time the profile changes.
                 .push_on_service(router)
                 .push(svc::NewSpawnWatch::<Profile, _>::layer_into::<Params>())

--- a/linkerd/app/outbound/src/tcp/concrete.rs
+++ b/linkerd/app/outbound/src/tcp/concrete.rs
@@ -57,7 +57,7 @@ impl<C> Outbound<C> {
                         .layer(stack_labels("tcp", "endpoint")),
                 )
                 .instrument(|e: &Endpoint| info_span!("endpoint", addr = %e.addr))
-                .push_new_clone()
+                .lift_new()
                 .push(endpoint::NewFromMetadata::layer(config.inbound_ips.clone()))
                 .push(tcp::NewBalancePeakEwma::layer(resolve))
                 .push_on_service(

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -77,7 +77,7 @@ impl<N> Outbound<N> {
             // cache of all concrete services used by the router.
             concrete
                 // Share the concrete stack with each router stack.
-                .push_new_clone()
+                .lift_new()
                 // Rebuild this router stack every time the profile changes.
                 .push_on_service(router)
                 .push(svc::NewSpawnWatch::<Profile, _>::layer_into::<Params>())

--- a/linkerd/service-profiles/src/default.rs
+++ b/linkerd/service-profiles/src/default.rs
@@ -1,4 +1,4 @@
-use crate::{GetProfile, Receiver};
+use crate::{GetProfile, LookupAddr, Receiver};
 use futures::{future, prelude::*};
 use linkerd_error::Error;
 use std::task::{Context, Poll};
@@ -20,9 +20,9 @@ type RspFuture<F, E> = future::OrElse<
     fn(E) -> future::Ready<Result<Option<Receiver>, Error>>,
 >;
 
-impl<T, S> tower::Service<T> for RecoverDefault<S>
+impl<S> tower::Service<LookupAddr> for RecoverDefault<S>
 where
-    S: GetProfile<T>,
+    S: GetProfile,
     S::Error: Into<Error>,
 {
     type Response = Option<Receiver>;
@@ -33,7 +33,7 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, dst: T) -> Self::Future {
+    fn call(&mut self, dst: LookupAddr) -> Self::Future {
         self.0.get_profile(dst).or_else(|e| {
             let error: Error = e.into();
             if crate::DiscoveryRejected::is_rejected(error.as_ref()) {

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -46,7 +46,7 @@ pub use self::{
     map_err::MapErr,
     map_target::{MapTarget, MapTargetLayer, MapTargetService},
     monitor::{Monitor, MonitorError, MonitorNewService, MonitorService, NewMonitor},
-    new_service::{NewCloneService, NewService},
+    new_service::{NewCloneService, NewFromTargets, NewFromTargetsInner, NewService},
     on_service::{OnService, OnServiceLayer},
     proxy::Proxy,
     result::ResultService,

--- a/linkerd/stack/src/new_service.rs
+++ b/linkerd/stack/src/new_service.rs
@@ -23,13 +23,16 @@ pub struct FromMakeService<S> {
 #[derive(Clone, Debug)]
 pub struct NewCloneService<S>(S);
 
+// A double-layered `NewService` that wraps NewServices produced by the inner
+// stack in `NewFromTargetsInner`.
 #[derive(Debug)]
 pub struct NewFromTargets<P, N> {
     inner: N,
     _marker: PhantomData<fn() -> P>,
 }
 
-/// Builds services by passing `P` typed values to an `N`-typed inner stack.
+/// A `NewService` that builds inner services from a `P`-typed target. P is
+/// constructed using `From<(U, T)>` where `U` is the provided target type.
 #[derive(Debug)]
 pub struct NewFromTargetsInner<T, P, N> {
     target: T,

--- a/linkerd/stack/src/new_service.rs
+++ b/linkerd/stack/src/new_service.rs
@@ -1,4 +1,6 @@
+use crate::layer;
 use crate::FutureService;
+use std::marker::PhantomData;
 use tower::util::{Oneshot, ServiceExt};
 
 /// Immediately and infalliby creates (usually) a Service.
@@ -20,6 +22,20 @@ pub struct FromMakeService<S> {
 
 #[derive(Clone, Debug)]
 pub struct NewCloneService<S>(S);
+
+#[derive(Debug)]
+pub struct NewFromTargets<P, N> {
+    inner: N,
+    _marker: PhantomData<fn() -> P>,
+}
+
+/// Builds services by passing `P` typed values to an `N`-typed inner stack.
+#[derive(Debug)]
+pub struct NewFromTargetsInner<T, P, N> {
+    target: T,
+    inner: N,
+    _marker: PhantomData<fn() -> P>,
+}
 
 // === impl NewService ===
 
@@ -55,6 +71,12 @@ where
 
 // === impl NewCloneService ===
 
+impl<N> NewCloneService<N> {
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(Self)
+    }
+}
+
 impl<S> From<S> for NewCloneService<S> {
     fn from(inner: S) -> Self {
         Self(inner)
@@ -66,5 +88,76 @@ impl<T, S: Clone> NewService<T> for NewCloneService<S> {
 
     fn new_service(&self, _: T) -> Self::Service {
         self.0.clone()
+    }
+}
+
+// === impl NewFromTargets ===
+
+impl<P, N> NewFromTargets<P, N> {
+    pub fn new(inner: N) -> Self {
+        Self {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn layer() -> impl tower::layer::Layer<N, Service = Self> + Clone {
+        layer::mk(NewFromTargets::new)
+    }
+}
+
+impl<T, P, N> NewService<T> for NewFromTargets<P, N>
+where
+    T: Clone,
+    N: NewService<T>,
+{
+    type Service = NewFromTargetsInner<T, P, N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        // Create a `NewService` that is used to process updates to the watched
+        // value. This allows inner stacks to, for instance, scope caches to the
+        // target.
+        let inner = self.inner.new_service(target.clone());
+
+        NewFromTargetsInner {
+            target,
+            inner,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<P, N: Clone> Clone for NewFromTargets<P, N> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+// === impl NewFromTargetsInner ===
+
+impl<T, U, P, N> NewService<U> for NewFromTargetsInner<T, P, N>
+where
+    T: Clone,
+    P: From<(U, T)>,
+    N: NewService<P>,
+{
+    type Service = N::Service;
+
+    fn new_service(&self, target: U) -> Self::Service {
+        let p = P::from((target, self.target.clone()));
+        self.inner.new_service(p)
+    }
+}
+
+impl<T: Clone, P, N: Clone> Clone for NewFromTargetsInner<T, P, N> {
+    fn clone(&self) -> Self {
+        Self {
+            target: self.target.clone(),
+            inner: self.inner.clone(),
+            _marker: PhantomData,
+        }
     }
 }


### PR DESCRIPTION
The profile discovery module--especially on the outbound side--requires some structural changes to begin adding more logic to it.

1. The outbound::discover module is simplified. It is no longer specific to sockets in the accept stack and may be used for other request types. Its cache, buffer, and stack metrics are no longer coupled to the discovery stack.
2. The `profiles::Discovery` module determines whether discovery is allowed (via a predicate). This has logic has been moved into the calling stack explicitly so that the discovery module always performs discovery as requested.
3. The `profiles::Discovery` module now wraps a two-tiered `NewService`, the first of which takes the original target value and the second of which takes the profile resolution.
   * Stack manipulation layers are added to preserve the original behavior of passing tuples.
4. The `GetProfile` trait has been simplified by specifying a request type.