### PR TITLE
orig_proto: don't set `connection: close` on errors

### DIFF
--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -2,7 +2,7 @@ use crate::svc;
 use http::header::{HeaderValue, LOCATION};
 use linkerd_error::{Error, Result};
 use linkerd_error_respond as respond;
-pub use linkerd_proxy_http::{ClientHandle, HasH2Reason};
+pub use linkerd_proxy_http::{orig_proto::L5D_PROXY_CONNECTION, ClientHandle, HasH2Reason};
 use linkerd_stack::ExtractParam;
 use pin_project::pin_project;
 use std::{
@@ -12,7 +12,6 @@ use std::{
 };
 use tracing::{debug, info_span, warn};
 
-pub const L5D_PROXY_CONNECTION: &str = "l5d-proxy-connection";
 pub const L5D_PROXY_ERROR: &str = "l5d-proxy-error";
 
 pub fn layer<R, P: Clone, N>(
@@ -225,7 +224,7 @@ impl SyntheticHttpResponse {
 
         if self.close_connection && emit_headers {
             // TODO only set when meshed.
-            rsp = rsp.header(L5D_PROXY_CONNECTION, "close");
+            rsp = rsp.header(L5D_PROXY_CONNECTION.clone(), "close");
         }
 
         rsp.body(B::default())
@@ -263,7 +262,7 @@ impl SyntheticHttpResponse {
             // application, i.e. so the application can choose another replica.
             if emit_headers {
                 // TODO only set when meshed.
-                rsp = rsp.header(L5D_PROXY_CONNECTION, "close");
+                rsp = rsp.header(L5D_PROXY_CONNECTION.clone(), "close");
             }
         }
 

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1224,43 +1224,74 @@ mod proxy_to_proxy {
                 self.out_proxy.join_servers(),
             };
         }
+
+        async fn mk(srv: server::Listening) -> Self {
+            let ctrl = controller::new();
+            let srv_addr = srv.addr;
+            let dst = format!("transparency.test.svc.cluster.local:{}", srv_addr.port());
+            let _profile_in = ctrl.profile_tx_default(&dst, "transparency.test.svc.cluster.local");
+            let ctrl = ctrl
+                .run()
+                .instrument(tracing::info_span!("ctrl", "inbound"))
+                .await;
+            let inbound = proxy::new().controller(ctrl).inbound(srv).run().await;
+
+            let ctrl = controller::new();
+            let _profile_out =
+                ctrl.profile_tx_default(srv_addr, "transparency.test.svc.cluster.local");
+            let dst = ctrl.destination_tx(dst);
+            dst.send_h2_hinted(inbound.inbound);
+
+            let ctrl = ctrl
+                .run()
+                .instrument(tracing::info_span!("ctrl", "outbound"))
+                .await;
+            let outbound = proxy::new()
+                .controller(ctrl)
+                .outbound_ip(srv_addr)
+                .run()
+                .await;
+
+            let addr = outbound.outbound;
+            ProxyToProxy {
+                _dst: dst,
+                _profile_in,
+                _profile_out,
+                in_proxy: inbound,
+                out_proxy: outbound,
+                inbound: addr,
+            }
+        }
     }
 
-    http1_tests! { proxy: |srv: server::Listening| async move {
-        let ctrl = controller::new();
-        let srv_addr = srv.addr;
-        let dst = format!("transparency.test.svc.cluster.local:{}", srv_addr.port());
-        let _profile_in = ctrl.profile_tx_default(&dst, "transparency.test.svc.cluster.local");
-        let ctrl = ctrl
-            .run()
-            .instrument(tracing::info_span!("ctrl", "inbound"))
+    http1_tests! { proxy: |srv: server::Listening| ProxyToProxy::mk(srv) }
+
+    /// Reproduces https://github.com/linkerd/linkerd2/issues/10090 --- an error
+    /// is logged by the inbound proxy's Hyper server due to the presence of a
+    /// `connection: close` header on the HTTP response, which is invalid in HTTP/2.
+    ///
+    /// Unfortunately, this test cannot actually *panic* when this error is
+    /// logged, but the test still exercises the behavior.
+    #[tokio::test]
+    async fn http1_inbound_timeout() {
+        let _trace = trace_init();
+
+        // server will always time out
+        let srv = server::http1()
+            .delay_listen(futures::future::pending())
             .await;
-        let inbound = proxy::new().controller(ctrl).inbound(srv).run().await;
+        let proxies = ProxyToProxy::mk(srv).await;
+        let client = client::http1(
+            proxies.out_proxy.outbound,
+            "transparency.test.svc.cluster.local",
+        );
+        let res = client.request(client.request_builder("/")).await.unwrap();
+        // tracing::info!(res);
+        assert_eq!(res.status(), http::StatusCode::BAD_GATEWAY);
 
-        let ctrl = controller::new();
-        let _profile_out = ctrl.profile_tx_default(srv_addr, "transparency.test.svc.cluster.local");
-        let dst = ctrl.destination_tx(dst);
-        dst.send_h2_hinted(inbound.inbound);
-
-        let ctrl = ctrl
-            .run()
-            .instrument(tracing::info_span!("ctrl", "outbound"))
-            .await;
-        let outbound = proxy::new()
-            .controller(ctrl)
-            .outbound_ip(srv_addr)
-            .run().await;
-
-        let addr = outbound.outbound;
-        ProxyToProxy {
-            _dst: dst,
-            _profile_in,
-            _profile_out,
-            in_proxy: inbound,
-            out_proxy: outbound,
-            inbound: addr,
-        }
-    } }
+        // ensure panics from the server are propagated
+        proxies.join_servers().await;
+    }
 }
 
 #[tokio::test]

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1264,7 +1264,7 @@ mod proxy_to_proxy {
         }
     }
 
-    http1_tests! { proxy: |srv: server::Listening| ProxyToProxy::mk(srv) }
+    http1_tests! { proxy: ProxyToProxy::mk }
 
     /// Reproduces https://github.com/linkerd/linkerd2/issues/10090 --- an error
     /// is logged by the inbound proxy's Hyper server due to the presence of a

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -1,6 +1,6 @@
 use super::{h1, h2, upgrade};
 use futures::{future, prelude::*};
-use http::header::{HeaderValue, TRANSFER_ENCODING};
+use http::header::{HeaderName, HeaderValue, CONNECTION, TRANSFER_ENCODING};
 use hyper::body::HttpBody;
 use linkerd_error::{Error, Result};
 use linkerd_http_box::BoxBody;
@@ -14,6 +14,7 @@ use thiserror::Error;
 use tracing::{debug, trace, warn};
 
 pub const L5D_ORIG_PROTO: &str = "l5d-orig-proto";
+pub static L5D_PROXY_CONNECTION: HeaderName = HeaderName::from_static("l5d-orig-proto");
 
 /// Upgrades HTTP requests from their original protocol to HTTP2.
 #[derive(Debug)]
@@ -285,6 +286,17 @@ where
 
                 // transfer-encoding is illegal in HTTP2
                 res.headers_mut().remove(TRANSFER_ENCODING);
+                // `connection` headers are illegal in HTTP/2, but if a
+                // `connection: close` is present, we can use
+                // `l5d-proxy-connection` to tell the upgrading proxy to close
+                // the connection.
+                if let Some(connection) = res.headers_mut().remove(CONNECTION) {
+                    static CLOSE: HeaderValue = HeaderValue::from_static("close");
+                    if connection == CLOSE {
+                        res.headers_mut()
+                            .insert(L5D_PROXY_CONNECTION.clone(), CLOSE.clone());
+                    }
+                }
 
                 *res.version_mut() = http::Version::HTTP_2;
                 res


### PR DESCRIPTION
When the inbound proxy's `ClientRescue` layer sees a client connection
error for a connection initiated for an HTTP/1 request, it will add a
`connection: close` header to the synthesized error response. The
`ClientRescue` layer is not currently aware of whether an HTTP/1 request
was recieved from an upstream proxy as part of an orig-proto upgrade or
not. If the request _is_ part of an orig-proto upgrade, the server side
of the inbound proxy is an HTTP/2 server. When Hyper's HTTP/2 server
sees a response with a `connection: close` header, it emits a warning,
because `connection` headers are illegal in HTTP/2.

The inbound proxy *does* strip any headers set by the server that are
illegal in HTTP/2 when performing an orig-proto downgrade. However, this
stripping occurs only when handling a response received from the server
peer, and *not* on synthesized error responses generated by the proxy.
Therefore, if a connection-level error occurs on a downgraded request,
the inbound proxy will log an illegal header warning. This can be
confusing to users, as this is not the actual root cause of the error
(see linkerd/linkerd2#10090).

This branch changes the `ErrorRespond` middleware to only add
`connection: close` to synthesized HTTP/1 responses that are *not* part
of an orig-proto downgrade. This is accomplished by adding a request
extension which is set in the `orig_proto::Downgrade` layer indicating
that a request was downgraded to the original protocol. The 
`connection: close` header is now only added if the downgrade marker
extension is not present, and the warning is now no longer logged.

Fixes linkerd/linkerd2#10090