### PR TITLE
configure buffers from target `Param`s

### DIFF
--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -71,7 +71,7 @@ pin-project = "1"
 [dependencies.tower]
 version = "0.4"
 default-features = false
-features = ["buffer", "make", "spawn-ready", "timeout", "util", "limit"]
+features = ["make", "spawn-ready", "timeout", "util", "limit"]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 linkerd-system = { path = "../../system" }

--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -1,5 +1,5 @@
 pub use crate::exp_backoff::ExponentialBackoff;
-pub use crate::svc::stack::QueueConfig;
+pub use crate::svc::QueueConfig;
 use crate::{
     proxy::http::{self, h1, h2},
     svc::{stack::CloneParam, Param},

--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -1,4 +1,5 @@
 pub use crate::exp_backoff::ExponentialBackoff;
+pub use crate::svc::stack::QueueConfig;
 use crate::{
     proxy::http::{self, h1, h2},
     svc::{stack::CloneParam, Param},
@@ -11,17 +12,6 @@ pub struct ServerConfig {
     pub addr: ListenAddr,
     pub keepalive: Keepalive,
     pub h2_settings: h2::Settings,
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct BufferConfig {
-    /// The number of requests (or connections, depending on the context) that
-    /// may be buffered
-    pub capacity: usize,
-
-    /// The maximum amount of time a request may be buffered before failfast
-    /// errors are emitted.
-    pub failfast_timeout: Duration,
 }
 
 #[derive(Clone, Debug)]

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -12,7 +12,7 @@ use tracing::{info_span, warn};
 pub struct Config {
     pub addr: ControlAddr,
     pub connect: config::ConnectConfig,
-    pub buffer: config::BufferConfig,
+    pub buffer: config::QueueConfig,
 }
 
 #[derive(Clone, Debug)]
@@ -107,7 +107,7 @@ impl Config {
             // This buffer allows a resolver client to be shared across stacks.
             // No load shed is applied here, however, so backpressure may leak
             // into the caller task.
-            .push_buffer_on_service("Controller client", &self.buffer)
+            .push(svc::NewQueue::layer_fixed(self.buffer))
             .instrument(|c: &ControlAddr| info_span!("controller", addr = %c.addr))
             .push_map_target(move |()| addr.clone())
             .push(svc::ArcNewService::layer())

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -1,21 +1,18 @@
 // Possibly unused, but useful during development.
 
 pub use crate::proxy::http;
-use crate::{config::BufferConfig, idle_cache, Error};
+use crate::{idle_cache, Error};
 use linkerd_error::Recover;
 use linkerd_exp_backoff::{ExponentialBackoff, ExponentialBackoffStream};
 pub use linkerd_reconnect::NewReconnect;
 pub use linkerd_router::{self as router, NewOneshotRoute};
 pub use linkerd_stack::{self as stack, *};
-use linkerd_stack::{failfast, OnService};
 pub use linkerd_stack_tracing::{GetSpan, NewInstrument, NewInstrumentLayer};
 use std::{
-    marker::PhantomData,
     task::{Context, Poll},
     time::Duration,
 };
 use tower::{
-    buffer::Buffer as TowerBuffer,
     layer::util::{Identity, Stack as Pair},
     make::MakeService,
 };
@@ -26,15 +23,6 @@ pub use tower::{
 
 #[derive(Copy, Clone, Debug)]
 pub struct AlwaysReconnect(ExponentialBackoff);
-
-pub type Buffer<Req, Rsp, E> = TowerBuffer<BoxService<Req, Rsp, E>, Req>;
-
-pub struct BufferLayer<Req> {
-    name: &'static str,
-    capacity: usize,
-    failfast_timeout: Duration,
-    _marker: PhantomData<fn(Req)>,
-}
 
 pub type BoxHttp<B = http::BoxBody> =
     BoxService<http::Request<B>, http::Response<http::BoxBody>, Error>;
@@ -83,26 +71,6 @@ impl<L> Layers<L> {
 
     pub fn push_map_target<M>(self, map_target: M) -> Layers<Pair<L, stack::MapTargetLayer<M>>> {
         self.push(stack::MapTargetLayer::new(map_target))
-    }
-
-    /// Buffers requests in an mpsc, spawning the inner service onto a dedicated
-    /// task.
-
-    ///
-    /// The service admits `config.capacity` requests before it returns
-    /// `Poll::Pending`.
-    ///
-    /// If the inner service is not ready for `config.failfast_timeout`, then
-    /// the service becomes unavailable and requests in the buffer are failed.
-    pub fn push_buffer<Req>(
-        self,
-        name: &'static str,
-        config: &BufferConfig,
-    ) -> Layers<Pair<L, BufferLayer<Req>>>
-    where
-        Req: Send + 'static,
-    {
-        self.push(buffer(name, config))
     }
 
     pub fn push_on_service<U>(self, layer: U) -> Layers<Pair<L, stack::OnServiceLayer<U>>> {
@@ -205,25 +173,6 @@ impl<S> Stack<S> {
         self,
     ) -> Stack<http::insert::NewResponseInsert<P, S>> {
         self.push(http::insert::NewResponseInsert::layer())
-    }
-
-    /// Buffers requests in an mpsc, spawning the inner service onto a dedicated
-    /// task.
-    ///
-    /// The service admits `config.capacity` requests before it returns
-    /// `Poll::Pending`.
-    ///
-    /// If the inner service is not ready for `config.failfast_timeout`, then
-    /// the service becomes unavailable and requests in the buffer are failed.
-    pub fn push_buffer_on_service<Req>(
-        self,
-        name: &'static str,
-        config: &BufferConfig,
-    ) -> Stack<OnService<BufferLayer<Req>, S>>
-    where
-        Req: Send + 'static,
-    {
-        self.push_on_service(buffer(name, config))
     }
 
     pub fn push_idle_cache<T>(self, idle: Duration) -> Stack<idle_cache::NewIdleCached<T, S>>
@@ -420,43 +369,5 @@ impl<E: Into<Error>> Recover<E> for AlwaysReconnect {
 
     fn recover(&self, _: E) -> Result<Self::Backoff, E> {
         Ok(self.0.stream())
-    }
-}
-
-// === impl BufferLayer ===
-
-fn buffer<Req>(name: &'static str, config: &BufferConfig) -> BufferLayer<Req> {
-    BufferLayer {
-        // TODO(ver) remove this.
-        name,
-        capacity: config.capacity,
-        failfast_timeout: config.failfast_timeout,
-        _marker: PhantomData,
-    }
-}
-
-impl<Req, S> Layer<S> for BufferLayer<Req>
-where
-    Req: Send + 'static,
-    S: Service<Req, Error = Error> + Send + 'static,
-    S::Future: Send,
-{
-    type Service = failfast::Gate<Buffer<Req, S::Response, Error>>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        let buf = layer::mk(move |inner| Buffer::new(BoxService::new(inner), self.capacity));
-        let buf = FailFast::layer_gated(self.failfast_timeout, buf);
-        buf.layer(inner)
-    }
-}
-
-impl<Req> Clone for BufferLayer<Req> {
-    fn clone(&self) -> Self {
-        Self {
-            capacity: self.capacity,
-            name: self.name,
-            failfast_timeout: self.failfast_timeout,
-            _marker: self._marker,
-        }
     }
 }

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -204,11 +204,9 @@ impl<C> Inbound<C> {
                 .instrument(|_: &Logical| debug_span!("profile"))
                 // Skip the profile stack if it takes too long to become ready.
                 .push_when_unready(config.profile_skip_timeout, http.into_inner())
-                .push_on_service(
-                    svc::layers()
-                        .push(rt.metrics.proxy.stack.layer(stack_labels("http", "logical")))
-                        .push_buffer("HTTP Logical", &config.http_request_buffer),
+                .push_on_service(rt.metrics.proxy.stack.layer(stack_labels("http", "logical"))
                 )
+                .push(svc::NewQueue::layer_fixed(config.http_request_buffer))
                 .push_idle_cache(config.discovery_idle_timeout)
                 .push_on_service(
                     svc::layers()

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -18,7 +18,7 @@ pub(crate) mod test_util;
 
 pub use self::{metrics::Metrics, policy::DefaultPolicy};
 use linkerd_app_core::{
-    config::{BufferConfig, ConnectConfig, ProxyConfig},
+    config::{ConnectConfig, ProxyConfig, QueueConfig},
     drain,
     http_tracing::OpenCensusSink,
     identity, io,
@@ -50,7 +50,7 @@ pub struct Config {
     pub discovery_idle_timeout: Duration,
 
     /// Configures how HTTP requests are buffered *for each inbound port*.
-    pub http_request_buffer: BufferConfig,
+    pub http_request_buffer: QueueConfig,
 }
 
 #[derive(Clone)]

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -77,7 +77,7 @@ pub fn default_config() -> Config {
             detect_protocol_timeout: Duration::from_secs(10),
         },
         allowed_ips: Default::default(),
-        http_request_buffer: config::BufferConfig {
+        http_request_buffer: config::QueueConfig {
             capacity: 10_000,
             failfast_timeout: Duration::from_secs(1),
         },

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -51,15 +51,12 @@ impl<N> Outbound<N> {
                     ))
                 }))
                 .push_on_service(
-                    svc::layers()
-                        .push(
-                            rt.metrics
-                                .proxy
-                                .stack
-                                .layer(crate::stack_labels("tcp", "server")),
-                        )
-                        .push_buffer("TCP Server", &config.tcp_connection_buffer),
+                    rt.metrics
+                        .proxy
+                        .stack
+                        .layer(crate::stack_labels("tcp", "server")),
                 )
+                .push(svc::NewQueue::layer_fixed(config.tcp_connection_buffer))
                 .push_idle_cache(config.discovery_idle_timeout)
                 .push(svc::ArcNewService::layer())
                 .check_new_service::<T, I>()

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -259,19 +259,16 @@ impl<S> Outbound<S> {
             .push_http_endpoint()
             .map_stack(|config, rt, stk| {
                 stk.push_on_service(
-                    svc::layers()
-                        .push(
-                            rt.metrics
-                                .proxy
-                                .stack
-                                .layer(stack_labels("http", "forward")),
-                        )
-                        // TODO(ver): This buffer config should be distinct from
-                        // that in the concrete stack. It should probably be
-                        // derived from the target so that we can configure it
-                        // via the API.
-                        .push_buffer("HTTP Forward", &config.http_request_buffer),
+                    rt.metrics
+                        .proxy
+                        .stack
+                        .layer(stack_labels("http", "forward")),
                 )
+                // TODO(ver): This buffer config should be distinct from
+                // that in the concrete stack. It should probably be
+                // derived from the target so that we can configure it
+                // via the API.
+                .push(svc::NewQueue::layer_fixed(config.http_request_buffer))
             })
             .push_http_server()
             .into_inner();

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -57,16 +57,14 @@ impl<N> Outbound<N> {
                 .push(http::NewBalancePeakEwma::layer(resolve))
                 // Drives the initial resolution via the service's readiness.
                 .push_on_service(
-                    svc::layers()
-                        .push(http::BoxResponse::layer())
-                        .push(
-                            rt.metrics
-                                .proxy
-                                .stack
-                                .layer(stack_labels("http", "concrete")),
-                        )
-                        .push_buffer("HTTP Concrete", &config.http_request_buffer),
+                    svc::layers().push(http::BoxResponse::layer()).push(
+                        rt.metrics
+                            .proxy
+                            .stack
+                            .layer(stack_labels("http", "concrete")),
+                    ),
                 )
+                .push(svc::NewQueue::layer_fixed(config.http_request_buffer))
                 .instrument(|c: &Concrete| info_span!("concrete", svc = %c.resolve))
                 .push(svc::ArcNewService::layer())
         })

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -131,21 +131,18 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                             ))
                         },
                     ))
+                    .push_on_service(
+                        rt.metrics
+                            .proxy
+                            .stack
+                            .layer(stack_labels("http", "logical")),
+                    )
                     // This service is buffered because it needs to initialize the
                     // profile resolution and a fail-fast is instrumented in case it
                     // becomes unavailable. When this service is in fail-fast, ensure
                     // that we drive the inner service to readiness even if new requests
                     // aren't received.
-                    .push_on_service(
-                        svc::layers()
-                            .push(
-                                rt.metrics
-                                    .proxy
-                                    .stack
-                                    .layer(stack_labels("http", "logical")),
-                            )
-                            .push_buffer("HTTP Logical", http_request_buffer),
-                    )
+                    .push(svc::NewQueue::layer_fixed(*http_request_buffer))
                     // Caches the profile-based stack so that it can be reused across
                     // multiple requests to the same canonical destination.
                     .push_idle_cache(*discovery_idle_timeout)

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -19,7 +19,7 @@ pub(crate) mod test_util;
 pub use self::metrics::Metrics;
 use futures::Stream;
 use linkerd_app_core::{
-    config::{BufferConfig, ProxyConfig},
+    config::{ProxyConfig, QueueConfig},
     drain,
     http_tracing::OpenCensusSink,
     identity, io, profiles,
@@ -54,13 +54,13 @@ pub struct Config {
     ///
     /// A buffer capacity of 100 means that 100 connections may be buffered for
     /// each IP:port to which an application attempts to connect.
-    pub tcp_connection_buffer: BufferConfig,
+    pub tcp_connection_buffer: QueueConfig,
 
     /// Configures how HTTP requests are buffered *for each outbound address*.
     ///
     /// A buffer capacity of 100 means that 100 requests may be buffered for
     /// each IP:port to which an application has opened an outbound TCP connection.
-    pub http_request_buffer: BufferConfig,
+    pub http_request_buffer: QueueConfig,
 
     // In "ingress mode", we assume we are always routing HTTP requests and do
     // not perform per-target-address discovery. Non-HTTP connections are

--- a/linkerd/app/outbound/src/tcp/concrete.rs
+++ b/linkerd/app/outbound/src/tcp/concrete.rs
@@ -69,9 +69,9 @@ impl<C> Outbound<C> {
                                 .proxy
                                 .stack
                                 .layer(stack_labels("opaque", "concrete")),
-                        )
-                        .push_buffer("Opaque Concrete", tcp_connection_buffer),
+                        ),
                 )
+                .push(svc::NewQueue::layer_fixed(*tcp_connection_buffer))
                 .instrument(|c: &Concrete| info_span!("concrete", addr = %c.resolve))
                 .push(svc::ArcNewService::layer())
         })

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -1,7 +1,7 @@
 use crate::Config;
 pub use futures::prelude::*;
 use linkerd_app_core::{
-    config::{self, BufferConfig},
+    config::{self, QueueConfig},
     drain, exp_backoff, metrics,
     proxy::{
         http::{h1, h2},
@@ -14,7 +14,7 @@ pub use linkerd_app_test as support;
 use std::{str::FromStr, time::Duration};
 
 pub(crate) fn default_config() -> Config {
-    let buffer = BufferConfig {
+    let buffer = QueueConfig {
         capacity: 10_000,
         failfast_timeout: Duration::from_secs(3),
     };

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -510,11 +510,11 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             },
             inbound_ips: inbound_ips.clone(),
             discovery_idle_timeout,
-            tcp_connection_buffer: BufferConfig {
+            tcp_connection_buffer: QueueConfig {
                 capacity: tcp_buffer_capacity,
                 failfast_timeout: tcp_failfast_timeout,
             },
-            http_request_buffer: BufferConfig {
+            http_request_buffer: QueueConfig {
                 capacity: http_buffer_capacity,
                 failfast_timeout: http_failfast_timeout,
             },
@@ -636,7 +636,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                         ControlConfig {
                             addr,
                             connect,
-                            buffer: BufferConfig {
+                            buffer: QueueConfig {
                                 capacity: DEFAULT_CONTROL_QUEUE_CAPACITY,
                                 failfast_timeout: DEFAULT_CONTROL_FAILFAST_TIMEOUT,
                             },
@@ -757,7 +757,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             allowed_ips: inbound_ips.into(),
 
             discovery_idle_timeout,
-            http_request_buffer: BufferConfig {
+            http_request_buffer: QueueConfig {
                 capacity: inbound_http_buffer_capacity?
                     .unwrap_or(DEFAULT_INBOUND_HTTP_QUEUE_CAPACITY),
                 failfast_timeout: inbound_http_failfast_timeout?
@@ -783,7 +783,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             control: ControlConfig {
                 addr,
                 connect,
-                buffer: BufferConfig {
+                buffer: QueueConfig {
                     capacity: DEFAULT_CONTROL_QUEUE_CAPACITY,
                     failfast_timeout,
                 },
@@ -834,7 +834,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 control: ControlConfig {
                     addr,
                     connect,
-                    buffer: BufferConfig {
+                    buffer: QueueConfig {
                         capacity: DEFAULT_CONTROL_QUEUE_CAPACITY,
                         failfast_timeout,
                     },
@@ -872,7 +872,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             control: ControlConfig {
                 addr,
                 connect,
-                buffer: BufferConfig {
+                buffer: QueueConfig {
                     capacity: DEFAULT_CONTROL_QUEUE_CAPACITY,
                     failfast_timeout,
                 },

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -17,7 +17,7 @@ pin-project = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-util = { version = "0.7" }
-tower = { version = "0.4", features = ["filter", "spawn-ready", "util"] }
+tower = { version = "0.4", features = ["buffer", "filter", "spawn-ready", "util"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -23,6 +23,7 @@ pub mod monitor;
 pub mod new_service;
 mod on_service;
 pub mod proxy;
+pub mod queue;
 mod result;
 mod switch_ready;
 mod timeout;

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -50,7 +50,7 @@ pub use self::{
     new_service::{NewCloneService, NewService},
     on_service::{OnService, OnServiceLayer},
     proxy::Proxy,
-    queue::{NewQueue, QueueParams},
+    queue::{NewQueue, QueueConfig},
     result::ResultService,
     switch_ready::{NewSwitchReady, SwitchReady},
     timeout::{Timeout, TimeoutError},

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -23,7 +23,7 @@ pub mod monitor;
 pub mod new_service;
 mod on_service;
 pub mod proxy;
-pub mod queue;
+mod queue;
 mod result;
 mod switch_ready;
 mod timeout;
@@ -50,6 +50,7 @@ pub use self::{
     new_service::{NewCloneService, NewService},
     on_service::{OnService, OnServiceLayer},
     proxy::Proxy,
+    queue::{NewQueue, QueueParams},
     result::ResultService,
     switch_ready::{NewSwitchReady, SwitchReady},
     timeout::{Timeout, TimeoutError},

--- a/linkerd/stack/src/queue.rs
+++ b/linkerd/stack/src/queue.rs
@@ -1,0 +1,128 @@
+use crate::{
+    failfast::{self, FailFast},
+    layer::{self, Layer},
+    BoxService, ExtractParam, NewService, Param, Service,
+};
+use linkerd_error::Error;
+use std::{fmt, marker::PhantomData, time::Duration};
+use tower::buffer::Buffer;
+
+#[derive(Debug, Copy, Clone)]
+pub struct QueueParams {
+    /// The number of requests (or connections, depending on the context) that
+    /// may be buffered
+    pub capacity: usize,
+
+    /// The maximum amount of time a request may be buffered before failfast
+    /// errors are emitted.
+    pub failfast_timeout: Duration,
+}
+
+pub struct NewQueue<N, Req, X = ()> {
+    inner: N,
+    extract: X,
+    _req: PhantomData<fn(Req)>,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct FixedParams(QueueParams);
+
+pub type Queue<Req, Rsp> = failfast::Gate<Buffer<BoxService<Req, Rsp, Error>, Req>>;
+
+// === impl NewQueue ===
+
+impl<T, N, X, Req> NewService<T> for NewQueue<N, Req, X>
+where
+    Req: Send + 'static,
+    X: ExtractParam<QueueParams, T>,
+    N: NewService<T>,
+    N::Service: Service<Req> + Send + 'static,
+    <N::Service as Service<Req>>::Future: Send,
+    <N::Service as Service<Req>>::Error: Into<Error>,
+    <N::Service as Service<Req>>::Response: 'static,
+{
+    type Service = Queue<Req, <N::Service as Service<Req>>::Response>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let QueueParams {
+            capacity,
+            failfast_timeout,
+        } = self.extract.extract_param(&target);
+        let buf = layer::mk(move |inner| Buffer::new(BoxService::new(inner), capacity));
+        let buf = FailFast::layer_gated(failfast_timeout, buf);
+        buf.layer(self.inner.new_service(target))
+    }
+}
+
+impl<T: Param<QueueParams>, Req> NewQueue<T, Req> {
+    /// Returns a [`Layer`] that constructs new [`Queue`]s configured by a
+    /// `T`-typed target that implements [`Param`]`<`[`QueueParams`]`>`.
+    #[inline]
+    #[must_use]
+    pub fn layer() -> impl Layer<T, Service = Self> + Clone {
+        Self::layer_with(())
+    }
+}
+
+impl<T, Req> NewQueue<T, Req, FixedParams> {
+    /// Returns a [`Layer`] that constructs new [`Queue`]s using a fixed set of
+    /// [`QueueParams`] regardless of the target.
+    #[inline]
+    #[must_use]
+    pub fn layer_fixed(params: QueueParams) -> impl Layer<T, Service = Self> + Clone {
+        Self::layer_with(FixedParams(params))
+    }
+}
+
+impl<T, Req, X> NewQueue<T, Req, X>
+where
+    X: ExtractParam<QueueParams, T> + Clone,
+{
+    /// Returns a [`Layer`] that constructs new [`Queue`]s using an `X`-typed
+    /// [`ExtractParam`] implementation to extract [`QueueParams`] from a
+    /// `T`-typed target.
+    #[inline]
+    #[must_use]
+    pub fn layer_with(extract: X) -> impl Layer<T, Service = Self> + Clone {
+        layer::mk(move |inner| Self {
+            inner,
+            extract: extract.clone(),
+            _req: PhantomData,
+        })
+    }
+}
+
+impl<N, Req, X> Clone for NewQueue<N, Req, X>
+where
+    N: Clone,
+    X: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            extract: self.extract.clone(),
+            _req: PhantomData,
+        }
+    }
+}
+
+impl<N, Req, X> fmt::Debug for NewQueue<N, Req, X>
+where
+    N: fmt::Debug,
+    X: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NewQueue")
+            .field("inner", &self.inner)
+            .field("extract", &self.extract)
+            .finish()
+    }
+}
+
+// === impl ExtractParams ===
+
+impl<T> ExtractParam<QueueParams, T> for FixedParams {
+    fn extract_param(&self, _: &T) -> QueueParams {
+        self.0
+    }
+}


### PR DESCRIPTION
Buffer services in the proxy are constructed with a queue capacity and a
failfast timeout. Currently, these parameters are configured based on
the proxy's config structs (parsed from environment variables), and each
buffer `Layer` is created with a fixed buffer configuration depending on
which stack it is used in, so all buffers constructed by that stack will
have the same configuration. In the future, we would like to allow these
parameters to be configured per-target by the control plane.

In order to support configuring buffer parameters dynamically, this
branch introduces a `NewQueue` type, which implements `NewService` and
produces `Buffer` + `FailFast` services configured using a `QueueConfig`
`Param` extracted from the target. This will allow target types to
implement `Param<QueueConfig>` to dynamically configure the buffer
parameters.

In order to continue supporting the current state of the world (i.e.,
fixed buffer parameters) without adding them to every target type,
`NewQueue`'s `NewService` implementation is generic over an
`ExtractParam` implementation to control how the `QueueConfig` params
are extracted from targets. Convenience constructors are provided for
`()` as the `ExtractParam` type, expecting that `T: Param<QueueConfig>`,
and for `CloneParam` as the `ExtractParam` type, to clone the same set
of params every time a buffer is constructed. Currently, all `NewQueue`
layers constructed in the proxy use `CloneParam`, to continue
implementing the existing fixed configuration behavior.

## Notes

* This branch also removes the `name` field passed when constructing
  buffers. The name is no longer passed to `FailFast` and doesn't
  currently do anything, but is still part of the `push_buffer` methods.
  Since this PR changed how buffers are constructed anyway, it didn't
  make sense to continue taking a `name` field. This may cause a small
  merge conflict with #2162, but it shouldn't be a huge deal.

* *A note on naming*: I decided to name the `NewService` type `NewQueue`
  rather than `NewBuffer`, and renamed the configuration params from
  `BufferConfig` to `QueueConfig`. I thought it was clearer to refer to
  these services as _queues_, rather than as _buffers_ (despite the fact
  that Tower calls the service `Buffer`), because the naming
  `BufferConfig` could be interpreted as configuring the byte buffers
  that bytes from the network are read into, especially for readers who
  aren't familiar with Tower's naming scheme. Also, @olix0r's draft PR
  #2151 named the client policy configuration type for buffer layer
  configs `Queue` rather than `Buffer`, so I thought I'd go with that
  naming here as well.

  However, I'm not super attached to this naming scheme, and am open to
  bikeshed over it. I can rename the uses of "queue" to "buffer" if
  consistency with Tower's naming scheme is important to us.