### PR TITLE
Ver/eliza/error context

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -123,7 +123,7 @@ impl Config {
             // continually reconnect without checking for discovery updates.
             .push_on_service(svc::layer::mk(svc::SpawnReady::new))
             .check_new_service::<self::client::Target, _>()
-            .push(svc::map_err::layer_new_from_target::<EndpointError, _, _>())
+            .push(svc::NewMapErr::layer_from_target::<EndpointError, _>())
             .check_new_service::<self::client::Target, _>()
             .push_new_reconnect(self.connect.backoff)
             .instrument(|t: &self::client::Target| info_span!("endpoint", addr = %t.addr));
@@ -143,7 +143,7 @@ impl Config {
 
         balance
             .push(self::add_origin::layer())
-            .push(svc::map_err::layer_new_from_target::<ControlError, _, _>())
+            .push(svc::NewMapErr::layer_from_target::<ControlError, _>())
             .instrument(|c: &ControlAddr| info_span!("controller", addr = %c.addr))
             .push_map_target(move |()| addr.clone())
             .push(svc::ArcNewService::layer())

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -154,7 +154,7 @@ impl<S> Stack<S> {
     pub fn push_connect_timeout(
         self,
         timeout: Duration,
-    ) -> Stack<MapErr<stack::Timeout<S>, impl FnOnce(Error) -> Error + Clone>> {
+    ) -> Stack<MapErr<impl FnOnce(Error) -> Error + Clone, stack::Timeout<S>>> {
         self.push(stack::Timeout::layer(timeout))
             .push(MapErr::layer(move |err: Error| {
                 if err.is::<stack::TimeoutError>() {

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -178,7 +178,7 @@ impl<C> Inbound<C> {
                         .push_on_service(http::BoxResponse::layer())
                         .push(classify::NewClassify::layer())
                         .push_http_insert_target::<profiles::http::Route>()
-                        .push(svc::map_err::layer_new_from_target::<RouteError, _, _>())
+                        .push(svc::NewMapErr::layer_from_target::<RouteError, _>())
                         .push_map_target(|(route, profile)| ProfileRoute { route, profile })
                         .push_on_service(svc::MapErr::layer(Error::from))
                         .into_inner(),
@@ -247,7 +247,7 @@ impl<C> Inbound<C> {
                 // dispatches the request.
                 .check_new_service::<Logical, http::Request<http::BoxBody>>()
                 .push_on_service(svc::LoadShed::layer())
-                .push(svc::map_err::layer_new_from_target::<LogicalError, _, _>())
+                .push(svc::NewMapErr::layer_from_target::<LogicalError, _>())
                 .push_new_clone()
                 .check_new_new::<(policy::HttpRoutePermit, T), Logical>()
                 .push(svc::NewOneshotRoute::layer_via(|(permit, t): &(policy::HttpRoutePermit, T)| {

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -178,8 +178,7 @@ impl<C> Inbound<C> {
                         .push_on_service(http::BoxResponse::layer())
                         .push(classify::NewClassify::layer())
                         .push_http_insert_target::<profiles::http::Route>()
-                        .push(svc::NewAnnotateError::<
-                            svc::annotate_error::FromTarget<_, RouteError>, _, _>::layer_from_target())
+                        .push(svc::map_err::layer_new_from_target::<RouteError, _, _>())
                         .push_map_target(|(route, profile)| ProfileRoute { route, profile })
                         .push_on_service(svc::MapErr::layer(Error::from))
                         .into_inner(),
@@ -248,7 +247,7 @@ impl<C> Inbound<C> {
                 // dispatches the request.
                 .check_new_service::<Logical, http::Request<http::BoxBody>>()
                 .push_on_service(svc::LoadShed::layer())
-                .push(svc::NewAnnotateError::<svc::annotate_error::FromTarget<_, LogicalError>, _, _>::layer_from_target())
+                .push(svc::map_err::layer_new_from_target::<LogicalError, _, _>())
                 .push_new_clone()
                 .check_new_new::<(policy::HttpRoutePermit, T), Logical>()
                 .push(svc::NewOneshotRoute::layer_via(|(permit, t): &(policy::HttpRoutePermit, T)| {

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -255,7 +255,7 @@ impl<S> Inbound<S> {
                         .push(drain::Retain::layer(rt.drain.clone())),
                 )
                 .instrument(|_: &_| debug_span!("tcp"))
-                .push(svc::map_err::layer_new_from_target::<ForwardError, _, _>())
+                .push(svc::NewMapErr::layer_from_target::<ForwardError, _>())
                 .push(svc::ArcNewService::layer())
                 .check_new::<T>()
         })

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -255,7 +255,7 @@ impl<S> Inbound<S> {
                         .push(drain::Retain::layer(rt.drain.clone())),
                 )
                 .instrument(|_: &_| debug_span!("tcp"))
-                .push(svc::NewAnnotateError::layer_from_target())
+                .push(svc::map_err::layer_new_from_target::<ForwardError, _, _>())
                 .push(svc::ArcNewService::layer())
                 .check_new::<T>()
         })

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -293,11 +293,7 @@ impl<S> Outbound<S> {
 
         opaque.push_detect_http(http).map_stack(|_, _, stk| {
             stk.instrument(|e: &tcp::Endpoint| info_span!("forward", endpoint = %e.addr))
-                .push(svc::NewAnnotateError::<
-                    svc::annotate_error::FromTarget<_, ForwardError>,
-                    _,
-                    _,
-                >::layer_from_target())
+                .push(svc::map_err::layer_new_from_target::<ForwardError, _, _>())
                 .push_on_service(svc::MapErr::layer(Error::from))
                 .push_on_service(svc::BoxService::layer())
                 .push(svc::ArcNewService::layer())

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -293,7 +293,7 @@ impl<S> Outbound<S> {
 
         opaque.push_detect_http(http).map_stack(|_, _, stk| {
             stk.instrument(|e: &tcp::Endpoint| info_span!("forward", endpoint = %e.addr))
-                .push(svc::map_err::layer_new_from_target::<ForwardError, _, _>())
+                .push(svc::NewMapErr::layer_from_target::<ForwardError, _>())
                 .push_on_service(svc::MapErr::layer(Error::from))
                 .push_on_service(svc::BoxService::layer())
                 .push(svc::ArcNewService::layer())

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -66,7 +66,7 @@ impl<N> Outbound<N> {
                 )
                 .push(svc::NewQueue::layer_fixed(config.http_request_buffer))
                 .instrument(|c: &Concrete| info_span!("concrete", svc = %c.resolve))
-                .push(svc::map_err::layer_new_from_target())
+                .push(svc::NewMapErr::layer_from_target())
                 .push(svc::ArcNewService::layer())
         })
     }

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -66,7 +66,7 @@ impl<N> Outbound<N> {
                 )
                 .push(svc::NewQueue::layer_fixed(config.http_request_buffer))
                 .instrument(|c: &Concrete| info_span!("concrete", svc = %c.resolve))
-                .push(svc::NewAnnotateError::layer_from_target())
+                .push(svc::map_err::layer_new_from_target())
                 .push(svc::ArcNewService::layer())
         })
     }

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -63,11 +63,7 @@ impl<C> Outbound<C> {
                 // Set the TLS status on responses so that the stack can detect whether the request
                 // was sent over a meshed connection.
                 .push_http_response_insert_target::<tls::ConditionalClientTls>()
-                .push(svc::NewAnnotateError::<
-                    svc::annotate_error::FromTarget<_, EndpointError>,
-                    _,
-                    _,
-                >::layer_from_target())
+                .push(svc::map_err::layer_new_from_target::<EndpointError, _, _>())
                 // If the outbound proxy is not configured to emit headers, then strip the
                 // `l5d-proxy-errors` header if set by the peer.
                 .push(NewStripProxyError::layer(config.emit_headers))

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -63,7 +63,7 @@ impl<C> Outbound<C> {
                 // Set the TLS status on responses so that the stack can detect whether the request
                 // was sent over a meshed connection.
                 .push_http_response_insert_target::<tls::ConditionalClientTls>()
-                .push(svc::map_err::layer_new_from_target::<EndpointError, _, _>())
+                .push(svc::NewMapErr::layer_from_target::<EndpointError, _>())
                 // If the outbound proxy is not configured to emit headers, then strip the
                 // `l5d-proxy-errors` header if set by the peer.
                 .push(NewStripProxyError::layer(config.emit_headers))

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -26,7 +26,6 @@ impl<C> Outbound<C> {
     where
         T: Clone + Send + Sync + 'static,
         T: svc::Param<http::client::Settings>
-            + svc::Param<Option<http::Version>>
             + svc::Param<Remote<ServerAddr>>
             + svc::Param<Option<http::AuthorityOverride>>
             + svc::Param<metrics::EndpointLabels>

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -109,11 +109,7 @@ impl<N> Outbound<N> {
                         .http_profile_route
                         .to_layer::<classify::Response, _, RouteParams>(),
                 )
-                .push(svc::NewAnnotateError::<
-                    svc::annotate_error::FromTarget<_, RouteError>,
-                    _,
-                    _,
-                >::layer_from_target())
+                .push(svc::map_err::layer_new_from_target::<RouteError, _, _>())
                 // Sets the per-route response classifier as a request
                 // extension.
                 .push(classify::NewClassify::layer())
@@ -146,7 +142,7 @@ impl<N> Outbound<N> {
                 //
                 // TODO(ver) do we need to strip headers here?
                 .push(http::NewHeaderFromTarget::<CanonicalDstHeader, _>::layer())
-                .push(svc::NewAnnotateError::layer_from_target())
+                .push(svc::map_err::layer_new_from_target())
                 .push(svc::ArcNewService::layer())
         })
     }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -109,7 +109,7 @@ impl<N> Outbound<N> {
                         .http_profile_route
                         .to_layer::<classify::Response, _, RouteParams>(),
                 )
-                .push(svc::map_err::layer_new_from_target::<RouteError, _, _>())
+                .push(svc::NewMapErr::layer_from_target::<RouteError, _>())
                 // Sets the per-route response classifier as a request
                 // extension.
                 .push(classify::NewClassify::layer())
@@ -142,7 +142,7 @@ impl<N> Outbound<N> {
                 //
                 // TODO(ver) do we need to strip headers here?
                 .push(http::NewHeaderFromTarget::<CanonicalDstHeader, _>::layer())
-                .push(svc::map_err::layer_new_from_target())
+                .push(svc::NewMapErr::layer_from_target())
                 .push(svc::ArcNewService::layer())
         })
     }

--- a/linkerd/app/outbound/src/tcp/concrete.rs
+++ b/linkerd/app/outbound/src/tcp/concrete.rs
@@ -73,7 +73,7 @@ impl<C> Outbound<C> {
                 )
                 .push(svc::NewQueue::layer_fixed(*tcp_connection_buffer))
                 .instrument(|c: &Concrete| info_span!("concrete", addr = %c.resolve))
-                .push(svc::NewAnnotateError::layer_from_target())
+                .push(svc::map_err::layer_new_from_target())
                 .push(svc::ArcNewService::layer())
         })
     }

--- a/linkerd/app/outbound/src/tcp/concrete.rs
+++ b/linkerd/app/outbound/src/tcp/concrete.rs
@@ -73,7 +73,7 @@ impl<C> Outbound<C> {
                 )
                 .push(svc::NewQueue::layer_fixed(*tcp_connection_buffer))
                 .instrument(|c: &Concrete| info_span!("concrete", addr = %c.resolve))
-                .push(svc::map_err::layer_new_from_target())
+                .push(svc::NewMapErr::layer_from_target())
                 .push(svc::ArcNewService::layer())
         })
     }

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -84,12 +84,7 @@ impl<C> Outbound<C> {
         >,
     >
     where
-        T: svc::Param<Remote<ServerAddr>>
-            + svc::Param<Option<http::Version>>
-            + Clone
-            + Send
-            + Sync
-            + 'static,
+        T: svc::Param<Remote<ServerAddr>> + Clone + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
         C: svc::MakeConnection<T> + Clone + Send + Sync + 'static,
         C::Connection: Send + Unpin,

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -95,7 +95,7 @@ impl<C> Outbound<C> {
             conn.push(svc::stack::WithoutConnectionMetadata::layer())
                 .push_make_thunk()
                 .push_on_service(super::Forward::layer())
-                .push(svc::map_err::layer_new_from_target())
+                .push(svc::NewMapErr::layer_from_target())
                 .push(svc::ArcNewService::layer())
                 .check_new_service::<T, I>()
         })

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -95,7 +95,7 @@ impl<C> Outbound<C> {
             conn.push(svc::stack::WithoutConnectionMetadata::layer())
                 .push_make_thunk()
                 .push_on_service(super::Forward::layer())
-                .push(svc::NewAnnotateError::layer_from_target())
+                .push(svc::map_err::layer_new_from_target())
                 .push(svc::ArcNewService::layer())
                 .check_new_service::<T, I>()
         })

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -83,7 +83,7 @@ impl<N> Outbound<N> {
                 // Rebuild this router stack every time the profile changes.
                 .push_on_service(router)
                 .push(svc::NewSpawnWatch::<Profile, _>::layer_into::<Params>())
-                .push(svc::NewAnnotateError::layer_from_target())
+                .push(svc::map_err::layer_new_from_target())
                 .push(svc::ArcNewService::layer())
         })
     }

--- a/linkerd/app/outbound/src/tcp/logical.rs
+++ b/linkerd/app/outbound/src/tcp/logical.rs
@@ -83,7 +83,7 @@ impl<N> Outbound<N> {
                 // Rebuild this router stack every time the profile changes.
                 .push_on_service(router)
                 .push(svc::NewSpawnWatch::<Profile, _>::layer_into::<Params>())
-                .push(svc::map_err::layer_new_from_target())
+                .push(svc::NewMapErr::layer_from_target())
                 .push(svc::ArcNewService::layer())
         })
     }

--- a/linkerd/proxy/http/src/timeout.rs
+++ b/linkerd/proxy/http/src/timeout.rs
@@ -33,7 +33,7 @@ where
     T: Param<ResponseTimeout>,
     M: NewService<T>,
 {
-    type Service = MapErr<Timeout<M::Service>, fn(Error) -> Error>;
+    type Service = MapErr<fn(Error) -> Error, Timeout<M::Service>>;
 
     fn new_service(&self, target: T) -> Self::Service {
         let svc = match target.param() {

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -16,7 +16,7 @@ pub mod layer;
 mod lazy;
 mod loadshed;
 mod make_thunk;
-pub mod map_err;
+mod map_err;
 mod map_target;
 pub mod monitor;
 pub mod new_service;

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -3,7 +3,6 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
-pub mod annotate_error;
 mod arc_new_service;
 mod box_future;
 mod box_service;
@@ -17,7 +16,7 @@ pub mod layer;
 mod lazy;
 mod loadshed;
 mod make_thunk;
-mod map_err;
+pub mod map_err;
 mod map_target;
 pub mod monitor;
 pub mod new_service;
@@ -31,7 +30,6 @@ mod unwrap_or;
 mod watch;
 
 pub use self::{
-    annotate_error::NewAnnotateError,
     arc_new_service::ArcNewService,
     box_future::BoxFuture,
     box_service::{BoxService, BoxServiceLayer},
@@ -44,7 +42,7 @@ pub use self::{
     lazy::{Lazy, NewLazy},
     loadshed::{LoadShed, LoadShedError},
     make_thunk::MakeThunk,
-    map_err::MapErr,
+    map_err::{MapErr, NewMapErr, WrapErr},
     map_target::{MapTarget, MapTargetLayer, MapTargetService},
     monitor::{Monitor, MonitorError, MonitorNewService, MonitorService, NewMonitor},
     new_service::{NewCloneService, NewService},

--- a/linkerd/stack/src/map_err.rs
+++ b/linkerd/stack/src/map_err.rs
@@ -1,58 +1,263 @@
-use futures::TryFutureExt;
+use crate::{layer, ExtractParam, NewService};
 use linkerd_error::Error;
-use std::task::{Context, Poll};
+use std::{
+    fmt,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pub trait WrapErr<E> {
+    type Error: Into<Error>;
+
+    fn wrap_err(&self, error: E) -> Self::Error;
+}
+
+impl<E: Into<Error>> WrapErr<E> for () {
+    type Error = Error;
+
+    fn wrap_err(&self, error: E) -> Error {
+        error.into()
+    }
+}
+
+impl<InE, OutE, F> WrapErr<InE> for F
+where
+    F: FnOnce(InE) -> OutE + Clone,
+    OutE: Into<Error>,
+{
+    type Error = OutE;
+
+    fn wrap_err(&self, error: InE) -> OutE {
+        (self.clone())(error)
+    }
+}
+
+/// A [`NewService`] that extracts a [`WrapErr`] implementation from its target
+/// and produces a [`MapErr`] middleware that wrapps inner error types.
+pub struct NewMapErr<W, X, N> {
+    inner: N,
+    extract: X,
+    _cx: PhantomData<fn(W)>,
+}
 
 /// Like `tower::util::MapErr`, but with an implementation of `Proxy`.
 #[derive(Clone, Debug)]
-pub struct MapErr<S, F> {
+pub struct MapErr<W, S> {
     inner: S,
-    f: F,
+    wrap: W,
 }
 
-impl<S, F: Clone> MapErr<S, F> {
-    pub fn new(inner: S, f: F) -> Self {
-        Self { inner, f }
-    }
+/// Futures returned by [`AnnotateError`].
+#[derive(Debug)]
+#[pin_project::pin_project]
+pub struct ResponseFuture<W, F> {
+    #[pin]
+    inner: F,
+    wrap: W,
+}
 
-    pub fn layer(f: F) -> impl super::layer::Layer<S, Service = Self> + Clone {
-        super::layer::mk(move |inner| Self::new(inner, f.clone()))
+/// A [`WrapErr`] that converts inner errors to an `E` via `From<(&T, Error)`,
+/// where `T` is a stack target.
+pub struct WrapFromTarget<T, E> {
+    target: T,
+    _err: PhantomData<fn(E)>,
+}
+
+// === impl NewMapErr===
+
+impl<W, X, N> NewMapErr<W, X, N> {
+    fn new(inner: N, extract: X) -> Self {
+        Self {
+            inner,
+            extract,
+            _cx: PhantomData,
+        }
     }
 }
 
-impl<Req, E, S, F: Clone> super::Service<Req> for MapErr<S, F>
+impl<W, X: Clone, N> NewMapErr<W, X, N> {
+    /// A `NewService` layer that extracts a `WrapErr` implementation via the
+    /// `X`-typex `ExtractParam`.
+    pub fn layer_with(extract: X) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self::new(inner, extract.clone()))
+    }
+}
+
+impl<W, N> NewMapErr<W, (), N> {
+    /// A `NewService` layer that extracts a `W`-typed `WrapErr` implementation
+    /// from each target.
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Clone {
+        NewMapErr::layer_with(())
+    }
+}
+
+type ExtractWrapFromTarget<T, E> = fn(&T) -> WrapFromTarget<T, E>;
+
+/// A `NewService` layer that converts inner errors to an `E`-typed error via
+/// `From<(&T, Error)`, where `T` is a stack target.
+pub fn layer_new_from_target<E, T, N>(
+) -> impl layer::Layer<N, Service = NewMapErr<WrapFromTarget<T, E>, ExtractWrapFromTarget<T, E>, N>>
+       + Clone
+where
+    T: Clone,
+    WrapFromTarget<T, E>: WrapErr<Error> + Clone,
+{
+    NewMapErr::layer_with(
+        (|t: &T| WrapFromTarget {
+            target: t.clone(),
+            _err: PhantomData,
+        }) as ExtractWrapFromTarget<T, E>,
+    )
+}
+
+impl<T, W, X, N> NewService<T> for NewMapErr<W, X, N>
+where
+    X: ExtractParam<W, T>,
+    N: NewService<T>,
+{
+    type Service = MapErr<W, N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let wrap = self.extract.extract_param(&target);
+        let inner = self.inner.new_service(target);
+
+        MapErr { inner, wrap }
+    }
+}
+
+impl<W, X, N> Clone for NewMapErr<W, X, N>
+where
+    N: Clone,
+    X: Clone,
+{
+    fn clone(&self) -> Self {
+        Self::new(self.inner.clone(), self.extract.clone())
+    }
+}
+
+impl<W, X, N> fmt::Debug for NewMapErr<W, X, N>
+where
+    N: fmt::Debug,
+    X: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            inner,
+            extract,
+            _cx,
+        } = self;
+        f.debug_struct("NewMapErr")
+            .field("inner", inner)
+            .field("extract", extract)
+            .finish()
+    }
+}
+
+// === impl MapErr ===
+
+impl<W, S> MapErr<W, S> {
+    pub fn new(inner: S, wrap: W) -> Self {
+        Self { inner, wrap }
+    }
+
+    pub fn layer(wrap: W) -> impl super::layer::Layer<S, Service = Self> + Clone
+    where
+        W: Clone,
+    {
+        super::layer::mk(move |inner| Self::new(inner, wrap.clone()))
+    }
+}
+
+impl<S> MapErr<(), S> {
+    pub fn layer_boxed() -> impl layer::Layer<S, Service = Self> + Clone {
+        MapErr::layer(())
+    }
+}
+
+impl<Req, W, S> super::Service<Req> for MapErr<W, S>
 where
     S: super::Service<Req>,
-    F: FnOnce(S::Error) -> E,
+    W: WrapErr<S::Error> + Clone,
 {
     type Response = S::Response;
-    type Error = E;
-    type Future = futures::future::MapErr<S::Future, F>;
+    type Error = W::Error;
+    type Future = ResponseFuture<W, S::Future>;
 
     #[inline]
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), E>> {
-        self.inner.poll_ready(cx).map_err(self.f.clone())
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(|e| self.wrap.wrap_err(e))
     }
 
     #[inline]
     fn call(&mut self, req: Req) -> Self::Future {
-        self.inner.call(req).map_err(self.f.clone())
+        let inner = self.inner.call(req);
+        ResponseFuture {
+            inner,
+            wrap: self.wrap.clone(),
+        }
     }
 }
 
-impl<Req, E, P, S, F: Clone> super::Proxy<Req, S> for MapErr<P, F>
+impl<Req, W, P, S> super::Proxy<Req, S> for MapErr<W, P>
 where
+    W: WrapErr<P::Error> + Clone,
     P: super::Proxy<Req, S>,
     S: super::Service<P::Request>,
-    F: FnOnce(P::Error) -> E,
-    E: Into<Error>,
 {
     type Request = P::Request;
     type Response = P::Response;
-    type Error = E;
-    type Future = futures::future::MapErr<P::Future, F>;
+    type Error = W::Error;
+    type Future = ResponseFuture<W, P::Future>;
 
     #[inline]
     fn proxy(&self, inner: &mut S, req: Req) -> Self::Future {
-        self.inner.proxy(inner, req).map_err(self.f.clone())
+        let inner = self.inner.proxy(inner, req);
+        ResponseFuture {
+            inner,
+            wrap: self.wrap.clone(),
+        }
+    }
+}
+
+// === impl ResponseFuture ===
+
+impl<T, E, W, F> Future for ResponseFuture<W, F>
+where
+    W: WrapErr<E>,
+    F: Future<Output = Result<T, E>>,
+{
+    type Output = Result<T, W::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        this.inner
+            .poll(cx)
+            .map_err(|error| this.wrap.wrap_err(error))
+    }
+}
+
+// === impl WrapFromTarget ===
+
+impl<T, InE, OutE> WrapErr<InE> for WrapFromTarget<T, OutE>
+where
+    InE: Into<Error>,
+    OutE: for<'a> From<(&'a T, Error)>,
+    OutE: Into<Error>,
+{
+    type Error = OutE;
+
+    fn wrap_err(&self, error: InE) -> OutE {
+        OutE::from((&self.target, error.into()))
+    }
+}
+
+impl<T: Clone, E> Clone for WrapFromTarget<T, E> {
+    fn clone(&self) -> Self {
+        Self {
+            target: self.target.clone(),
+            _err: PhantomData,
+        }
     }
 }

--- a/linkerd/stack/src/map_err.rs
+++ b/linkerd/stack/src/map_err.rs
@@ -49,7 +49,7 @@ pub struct MapErr<W, S> {
     wrap: W,
 }
 
-/// Futures returned by [`AnnotateError`].
+/// Future returned by [`MapErr`].
 #[derive(Debug)]
 #[pin_project::pin_project]
 pub struct ResponseFuture<W, F> {

--- a/linkerd/stack/src/map_err.rs
+++ b/linkerd/stack/src/map_err.rs
@@ -79,7 +79,7 @@ impl<W, X, N> NewMapErr<W, X, N> {
 
 impl<W, X: Clone, N> NewMapErr<W, X, N> {
     /// A `NewService` layer that extracts a `WrapErr` implementation via the
-    /// `X`-typex `ExtractParam`.
+    /// `X`-typed `ExtractParam`.
     pub fn layer_with(extract: X) -> impl layer::Layer<N, Service = Self> + Clone {
         layer::mk(move |inner| Self::new(inner, extract.clone()))
     }

--- a/linkerd/stack/src/map_err.rs
+++ b/linkerd/stack/src/map_err.rs
@@ -253,6 +253,14 @@ where
     }
 }
 
+impl<T: fmt::Debug, E> fmt::Debug for WrapFromTarget<T, E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WrapFromTarget")
+            .field("target", &self.target)
+            .finish()
+    }
+}
+
 impl<T: Clone, E> Clone for WrapFromTarget<T, E> {
     fn clone(&self) -> Self {
         Self {

--- a/linkerd/tonic-watch/src/lib.rs
+++ b/linkerd/tonic-watch/src/lib.rs
@@ -252,8 +252,8 @@ mod tests {
 
     fn mk_svc<T, U>() -> (
         MapErr<
-            mock::Mock<T, InnerRsp<U>>,
             impl Clone + Send + Sync + 'static + Fn(Error) -> tonic::Status,
+            mock::Mock<T, InnerRsp<U>>,
         >,
         mock::Handle<T, InnerRsp<U>>,
     ) {


### PR DESCRIPTION
`AnnotateError` is really, really similar to `MapErr`. This change
merges the implementations and cleans up some of the caller type
boilerplate.

This also includes some changes to error formatting.

I've removed the http version param constraints from Endpoint -- we should have that information elsewhere on the stack.