### PR TITLE
Add traceparent header parsing for w3c tracecontext

### DIFF
--- a/linkerd/trace-context/src/lib.rs
+++ b/linkerd/trace-context/src/lib.rs
@@ -16,10 +16,10 @@ use thiserror::Error;
 
 const SPAN_ID_LEN: usize = 8;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Id(Vec<u8>);
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Flags(u8);
 
 #[derive(Debug, Error)]

--- a/linkerd/trace-context/src/lib.rs
+++ b/linkerd/trace-context/src/lib.rs
@@ -16,10 +16,10 @@ use thiserror::Error;
 
 const SPAN_ID_LEN: usize = 8;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct Id(Vec<u8>);
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct Flags(u8);
 
 #[derive(Debug, Error)]

--- a/linkerd/trace-context/src/propagation.rs
+++ b/linkerd/trace-context/src/propagation.rs
@@ -61,7 +61,7 @@ pub fn increment_span_id<B>(request: &mut http::Request<B>, context: &TraceConte
 fn get_header_str<'a, B>(request: &'a http::Request<B>, header: &str) -> Option<&'a str> {
     let hv = request.headers().get(header)?;
     hv.to_str()
-        .map_err(|e| warn!("Invalid trace header {}: {}", header, e))
+        .map_err(|e| warn!("Invalid trace header {header}: {e}"))
         .ok()
 }
 
@@ -79,7 +79,7 @@ fn decode_id_with_padding(value: &str, pad_to: usize) -> Option<Id> {
                 Id(data)
             }
         })
-        .map_err(|e| warn!("Header value {} does not contain a hex: {}", value, e))
+        .map_err(|e| warn!("Header value {value} does not contain a hex: {e}"))
         .ok()
 }
 

--- a/linkerd/trace-context/src/propagation.rs
+++ b/linkerd/trace-context/src/propagation.rs
@@ -58,7 +58,10 @@ pub fn increment_span_id<B>(request: &mut http::Request<B>, context: &TraceConte
 
 // === Header parse utils ===
 
-fn get_header_str<'a, B>(request: &'a http::Request<B>, header: &str) -> Option<&'a str> {
+fn get_header_str<'a, B>(
+    request: &'a http::Request<B>,
+    header: http::header::HeaderName,
+) -> Option<&'a str> {
     let hv = request.headers().get(header)?;
     hv.to_str()
         .map_err(|e| warn!("Invalid trace header {header}: {e}"))

--- a/linkerd/trace-context/src/propagation.rs
+++ b/linkerd/trace-context/src/propagation.rs
@@ -1,23 +1,11 @@
 use crate::{Flags, Id, InsufficientBytes};
 use bytes::Bytes;
-use http::header::HeaderValue;
-use linkerd_error::Error;
-use rand::thread_rng;
+
 use thiserror::Error;
-use tracing::{trace, warn};
+use tracing::warn;
 
-const HTTP_TRACE_ID_HEADER: &str = "x-b3-traceid";
-const HTTP_SPAN_ID_HEADER: &str = "x-b3-spanid";
-const HTTP_SAMPLED_HEADER: &str = "x-b3-sampled";
-
-const W3C_HTTP_TRACEPARENT: &str = "traceparent";
-const W3C_HEADER_VALUE_SEPARATOR: &str = "-";
-const W3C_HEADER_VERSION: &str = "00";
-
-const GRPC_TRACE_HEADER: &str = "grpc-trace-bin";
-const GRPC_TRACE_FIELD_TRACE_ID: u8 = 0;
-const GRPC_TRACE_FIELD_SPAN_ID: u8 = 1;
-const GRPC_TRACE_FIELD_TRACE_OPTIONS: u8 = 2;
+mod b3;
+mod w3c;
 
 #[derive(Debug)]
 pub enum Propagation {
@@ -46,259 +34,29 @@ impl TraceContext {
     }
 }
 
+/// Given an http request, attempt to unpack a distributed tracing context from
+/// the headers. Only w3c and b3 context propagation formats are supported. The
+/// former is tried first, and if no headers are present, function will attempt
+/// to unpack as b3.
 pub fn unpack_trace_context<B>(request: &http::Request<B>) -> Option<TraceContext> {
     // Attempt to parse as w3c first since it's the newest interface in
     // distributed tracing ecosystem
-    unpack_w3c_trace_context(request)
-        .or_else(|| unpack_grpc_trace_context(request))
-        .or_else(|| unpack_http_trace_context(request))
+    w3c::unpack_w3c_trace_context(request)
+        .or_else(|| b3::unpack_grpc_trace_context(request))
+        .or_else(|| b3::unpack_http_trace_context(request))
 }
 
 // Generates a new span id, writes it to the request in the appropriate
 // propagation format and returns the generated span id.
 pub fn increment_span_id<B>(request: &mut http::Request<B>, context: &TraceContext) -> Id {
     match context.propagation {
-        Propagation::B3Grpc => increment_grpc_span_id(request, context),
-        Propagation::B3Http => increment_http_span_id(request),
-        Propagation::W3CHttp => increment_w3c_http_span_id(request, context),
+        Propagation::B3Grpc => b3::increment_grpc_span_id(request, context),
+        Propagation::B3Http => b3::increment_http_span_id(request),
+        Propagation::W3CHttp => w3c::increment_http_span_id(request, context),
     }
 }
 
-fn unpack_w3c_trace_context<B>(request: &http::Request<B>) -> Option<TraceContext> {
-    get_header_str(request, W3C_HTTP_TRACEPARENT).and_then(parse_w3c_context)
-}
-
-fn parse_w3c_context(header_value: &str) -> Option<TraceContext> {
-    let rest = match header_value.split_once(W3C_HEADER_VALUE_SEPARATOR) {
-        Some((version, rest)) => {
-            if version != W3C_HEADER_VERSION {
-                warn!(
-                    "Tracecontext header {} contains invalid version: {}",
-                    header_value, version
-                );
-                return None;
-            }
-            rest
-        }
-        None => {
-            warn!("Tracecontext header {} is invalid", header_value);
-            return None;
-        }
-    };
-
-    let (trace_id, rest) = if let Some((id, rest)) = parse_w3c_header_value(rest, 16) {
-        (id, rest)
-    } else {
-        warn!("Tracecontext header {} contains invalid id", header_value);
-        return None;
-    };
-
-    let (parent_id, rest) = if let Some((id, rest)) = parse_w3c_header_value(rest, 8) {
-        (id, rest)
-    } else {
-        warn!("Tracecontext header {} contains invalid id", header_value);
-        return None;
-    };
-
-    let flags = match hex::decode(rest) {
-        // If valid hex, take final bit and AND with 1. W3C only uses one bit
-        // for flags in version 00, and the bit is used to control sampling
-        Ok(decoded) => Flags(decoded[0] & 0x1),
-        // If invalid hex, do not sample trace
-        Err(e) => {
-            warn!("Failed to decode flags for header {}: {}", header_value, e);
-            Flags(0)
-        }
-    };
-
-    Some(TraceContext {
-        propagation: Propagation::W3CHttp,
-        trace_id,
-        parent_id,
-        flags,
-    })
-}
-
-fn parse_w3c_header_value(next_header: &str, pad_to: usize) -> Option<(Id, &str)> {
-    next_header
-        .split_once(W3C_HEADER_VALUE_SEPARATOR)
-        .filter(|(id, _rest)| !id.chars().all(|c| c == '0'))
-        .and_then(|(id, rest)| decode_id_with_padding(id, pad_to).zip(Some(rest)))
-}
-
-fn increment_w3c_http_span_id<B>(request: &mut http::Request<B>, context: &TraceContext) -> Id {
-    let span_id = Id::new_span_id(&mut thread_rng());
-
-    trace!("incremented span id: {}", span_id);
-
-    let new_header = {
-        let mut buf = String::with_capacity(60);
-        buf.push_str(W3C_HEADER_VERSION);
-        buf.push_str(W3C_HEADER_VALUE_SEPARATOR);
-        buf.push_str(&hex::encode(context.trace_id.as_ref()));
-        buf.push_str(W3C_HEADER_VALUE_SEPARATOR);
-        buf.push_str(&hex::encode(context.parent_id.as_ref()));
-        buf.push_str(W3C_HEADER_VALUE_SEPARATOR);
-        buf.push_str(&hex::encode(vec![context.flags.0]));
-        buf
-    };
-
-    if let Result::Ok(hv) = HeaderValue::from_str(&new_header) {
-        request.headers_mut().insert(W3C_HTTP_TRACEPARENT, hv);
-    } else {
-        warn!("invalid value {} for tracecontext header", new_header);
-    }
-
-    span_id
-}
-
-fn unpack_grpc_trace_context<B>(request: &http::Request<B>) -> Option<TraceContext> {
-    get_header_str(request, GRPC_TRACE_HEADER)
-        .and_then(|header_str| {
-            base64::decode(header_str)
-                .map_err(|e| {
-                    warn!(
-                        "trace header {} is not base64 encoded: {}",
-                        GRPC_TRACE_HEADER, e
-                    )
-                })
-                .ok()
-        })
-        .and_then(|vec| {
-            let mut bytes = vec.into();
-            parse_grpc_trace_context_fields(&mut bytes)
-        })
-}
-
-fn parse_grpc_trace_context_fields(buf: &mut Bytes) -> Option<TraceContext> {
-    trace!(message = "reading binary trace context", ?buf);
-
-    let _version = try_split_to(buf, 1).ok()?;
-
-    let mut context = TraceContext {
-        propagation: Propagation::B3Grpc,
-        trace_id: Default::default(),
-        parent_id: Default::default(),
-        flags: Default::default(),
-    };
-
-    while !buf.is_empty() {
-        match parse_grpc_trace_context_field(buf, &mut context) {
-            Ok(()) => {}
-            Err(ref e) if e.is::<UnknownFieldId>() => break,
-            Err(e) => {
-                warn!("error parsing {} header: {}", GRPC_TRACE_HEADER, e);
-                return None;
-            }
-        };
-    }
-    Some(context)
-}
-
-fn parse_grpc_trace_context_field(
-    buf: &mut Bytes,
-    context: &mut TraceContext,
-) -> Result<(), Error> {
-    let field_id = try_split_to(buf, 1)?[0];
-    match field_id {
-        GRPC_TRACE_FIELD_SPAN_ID => {
-            let id = try_split_to(buf, 8)?;
-            trace!(
-                "reading binary trace field {:?}: {:?}",
-                GRPC_TRACE_FIELD_SPAN_ID,
-                id
-            );
-            context.parent_id = id.into();
-        }
-        GRPC_TRACE_FIELD_TRACE_ID => {
-            let id = try_split_to(buf, 16)?;
-            trace!(
-                "reading binary trace field {:?}: {:?}",
-                GRPC_TRACE_FIELD_TRACE_ID,
-                id
-            );
-            context.trace_id = id.into();
-        }
-        GRPC_TRACE_FIELD_TRACE_OPTIONS => {
-            let flags = try_split_to(buf, 1)?;
-            trace!(
-                "reading binary trace field {:?}: {:?}",
-                GRPC_TRACE_FIELD_TRACE_OPTIONS,
-                flags
-            );
-            context.flags = flags.try_into()?;
-        }
-        id => {
-            return Err(UnknownFieldId(id).into());
-        }
-    };
-    Ok(())
-}
-
-// This code looks significantly weirder if some of the elements are added using
-// the `vec![]` macro, despite clippy's suggestions otherwise...
-#[allow(clippy::vec_init_then_push)]
-fn increment_grpc_span_id<B>(request: &mut http::Request<B>, context: &TraceContext) -> Id {
-    let span_id = Id::new_span_id(&mut thread_rng());
-
-    trace!(message = "incremented span id", %span_id);
-
-    let mut bytes = Vec::<u8>::new();
-
-    // version
-    bytes.push(0);
-
-    // trace id
-    bytes.push(GRPC_TRACE_FIELD_TRACE_ID);
-    bytes.extend(context.trace_id.0.iter());
-
-    // span id
-    bytes.push(GRPC_TRACE_FIELD_SPAN_ID);
-    bytes.extend(span_id.0.iter());
-
-    // trace options
-    bytes.push(GRPC_TRACE_FIELD_TRACE_OPTIONS);
-    bytes.push(context.flags.0);
-
-    let bytes_b64 = base64::encode(&bytes);
-
-    if let Result::Ok(hv) = HeaderValue::from_str(&bytes_b64) {
-        request.headers_mut().insert(GRPC_TRACE_HEADER, hv);
-    } else {
-        warn!("invalid header: {:?}", &bytes_b64);
-    }
-    span_id
-}
-
-fn unpack_http_trace_context<B>(request: &http::Request<B>) -> Option<TraceContext> {
-    let parent_id = parse_header_id(request, HTTP_SPAN_ID_HEADER, 8)?;
-    let trace_id = parse_header_id(request, HTTP_TRACE_ID_HEADER, 16)?;
-    let flags = match get_header_str(request, HTTP_SAMPLED_HEADER) {
-        Some("1") => Flags(1),
-        _ => Flags(0),
-    };
-    Some(TraceContext {
-        propagation: Propagation::B3Http,
-        trace_id,
-        parent_id,
-        flags,
-    })
-}
-
-fn increment_http_span_id<B>(request: &mut http::Request<B>) -> Id {
-    let span_id = Id::new_span_id(&mut thread_rng());
-
-    trace!("incremented span id: {}", span_id);
-
-    let span_str = hex::encode(span_id.as_ref());
-
-    if let Result::Ok(hv) = HeaderValue::from_str(&span_str) {
-        request.headers_mut().insert(HTTP_SPAN_ID_HEADER, hv);
-    } else {
-        warn!("invalid {} header: {:?}", HTTP_SPAN_ID_HEADER, span_str);
-    }
-    span_id
-}
+// === Header parse utils ===
 
 fn get_header_str<'a, B>(request: &'a http::Request<B>, header: &str) -> Option<&'a str> {
     let hv = request.headers().get(header)?;
@@ -307,13 +65,8 @@ fn get_header_str<'a, B>(request: &'a http::Request<B>, header: &str) -> Option<
         .ok()
 }
 
-fn parse_header_id<B>(request: &http::Request<B>, header: &str, pad_to: usize) -> Option<Id> {
-    let header_value = get_header_str(request, header)?;
-    decode_id_with_padding(header_value, pad_to)
-}
-
-/// Attempt to decode a hex value to an id, padding the buffer up to the
-/// specified argument. Used to decode header values from hex to binary.
+// Attempt to decode a hex value to an id, padding the buffer up to the
+// specified argument. Used to decode header values from hex to binary.
 fn decode_id_with_padding(value: &str, pad_to: usize) -> Option<Id> {
     hex::decode(value)
         .map(|mut data| {
@@ -338,22 +91,4 @@ fn try_split_to(buf: &mut Bytes, n: usize) -> Result<Bytes, InsufficientBytes> {
     } else {
         Err(InsufficientBytes)
     }
-}
-
-#[test]
-fn test_w3c_context_parsed_successfully() {
-    let input = "00-94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614-01";
-    let actual = parse_w3c_context(input);
-
-    let expected_trace = hex::decode("94d7f6ec6b95f3e916179cb6cfd01390")
-        .expect("Failed to decode trace parent from hex");
-    let expected_parent =
-        hex::decode("55ccfce77f972614").expect("Failed to decode span parent from hex");
-    let expected_flags = 1;
-
-    assert!(actual.is_some());
-    let actual = actual.unwrap();
-    assert_eq!(expected_trace, actual.trace_id.0);
-    assert_eq!(expected_parent, actual.parent_id.0);
-    assert_eq!(expected_flags, actual.flags.0);
 }

--- a/linkerd/trace-context/src/propagation.rs
+++ b/linkerd/trace-context/src/propagation.rs
@@ -60,7 +60,7 @@ pub fn increment_span_id<B>(request: &mut http::Request<B>, context: &TraceConte
 
 fn get_header_str<'a, B>(
     request: &'a http::Request<B>,
-    header: http::header::HeaderName,
+    header: &http::header::HeaderName,
 ) -> Option<&'a str> {
     let hv = request.headers().get(header)?;
     hv.to_str()

--- a/linkerd/trace-context/src/propagation.rs
+++ b/linkerd/trace-context/src/propagation.rs
@@ -64,7 +64,7 @@ fn get_header_str<'a, B>(
 ) -> Option<&'a str> {
     let hv = request.headers().get(header)?;
     hv.to_str()
-        .map_err(|_| debug!(header_value = %header, "Trace header value contains invalid ASCII characters"))
+        .map_err(|_| debug!(header_value = %header, "Invalid non-ASCII or control character in header value"))
         .ok()
 }
 

--- a/linkerd/trace-context/src/propagation/b3.rs
+++ b/linkerd/trace-context/src/propagation/b3.rs
@@ -1,0 +1,172 @@
+use crate::propagation::try_split_to;
+use crate::{Flags, Id};
+use bytes::Bytes;
+use http::header::HeaderValue;
+use linkerd_error::Error;
+use rand::thread_rng;
+
+use tracing::{trace, warn};
+
+use super::{decode_id_with_padding, get_header_str, Propagation, TraceContext, UnknownFieldId};
+
+const HTTP_TRACE_ID_HEADER: &str = "x-b3-traceid";
+const HTTP_SPAN_ID_HEADER: &str = "x-b3-spanid";
+const HTTP_SAMPLED_HEADER: &str = "x-b3-sampled";
+
+const GRPC_TRACE_HEADER: &str = "grpc-trace-bin";
+const GRPC_TRACE_FIELD_TRACE_ID: u8 = 0;
+const GRPC_TRACE_FIELD_SPAN_ID: u8 = 1;
+const GRPC_TRACE_FIELD_TRACE_OPTIONS: u8 = 2;
+
+// This code looks significantly weirder if some of the elements are added using
+// the `vec![]` macro, despite clippy's suggestions otherwise...
+#[allow(clippy::vec_init_then_push)]
+pub fn increment_grpc_span_id<B>(request: &mut http::Request<B>, context: &TraceContext) -> Id {
+    let span_id = Id::new_span_id(&mut thread_rng());
+
+    trace!(message = "incremented span id", %span_id);
+
+    let mut bytes = Vec::<u8>::new();
+
+    // version
+    bytes.push(0);
+
+    // trace id
+    bytes.push(GRPC_TRACE_FIELD_TRACE_ID);
+    bytes.extend(context.trace_id.0.iter());
+
+    // span id
+    bytes.push(GRPC_TRACE_FIELD_SPAN_ID);
+    bytes.extend(span_id.0.iter());
+
+    // trace options
+    bytes.push(GRPC_TRACE_FIELD_TRACE_OPTIONS);
+    bytes.push(context.flags.0);
+
+    let bytes_b64 = base64::encode(&bytes);
+
+    if let Result::Ok(hv) = HeaderValue::from_str(&bytes_b64) {
+        request.headers_mut().insert(GRPC_TRACE_HEADER, hv);
+    } else {
+        warn!("invalid header: {:?}", &bytes_b64);
+    }
+    span_id
+}
+
+pub fn increment_http_span_id<B>(request: &mut http::Request<B>) -> Id {
+    let span_id = Id::new_span_id(&mut thread_rng());
+
+    trace!("incremented span id: {}", span_id);
+
+    let span_str = hex::encode(span_id.as_ref());
+
+    if let Result::Ok(hv) = HeaderValue::from_str(&span_str) {
+        request.headers_mut().insert(HTTP_SPAN_ID_HEADER, hv);
+    } else {
+        warn!("invalid {} header: {:?}", HTTP_SPAN_ID_HEADER, span_str);
+    }
+    span_id
+}
+
+pub fn unpack_grpc_trace_context<B>(request: &http::Request<B>) -> Option<TraceContext> {
+    get_header_str(request, GRPC_TRACE_HEADER)
+        .and_then(|header_str| {
+            base64::decode(header_str)
+                .map_err(|e| {
+                    warn!(
+                        "trace header {} is not base64 encoded: {}",
+                        GRPC_TRACE_HEADER, e
+                    )
+                })
+                .ok()
+        })
+        .and_then(|vec| {
+            let mut bytes = vec.into();
+            parse_grpc_trace_context_fields(&mut bytes)
+        })
+}
+
+pub fn unpack_http_trace_context<B>(request: &http::Request<B>) -> Option<TraceContext> {
+    let parent_id = parse_header_id(request, HTTP_SPAN_ID_HEADER, 8)?;
+    let trace_id = parse_header_id(request, HTTP_TRACE_ID_HEADER, 16)?;
+    let flags = match get_header_str(request, HTTP_SAMPLED_HEADER) {
+        Some("1") => Flags(1),
+        _ => Flags(0),
+    };
+    Some(TraceContext {
+        propagation: Propagation::B3Http,
+        trace_id,
+        parent_id,
+        flags,
+    })
+}
+
+fn parse_grpc_trace_context_fields(buf: &mut Bytes) -> Option<TraceContext> {
+    trace!(message = "reading binary trace context", ?buf);
+
+    let _version = try_split_to(buf, 1).ok()?;
+
+    let mut context = TraceContext {
+        propagation: Propagation::B3Grpc,
+        trace_id: Default::default(),
+        parent_id: Default::default(),
+        flags: Default::default(),
+    };
+
+    while !buf.is_empty() {
+        match parse_grpc_trace_context_field(buf, &mut context) {
+            Ok(()) => {}
+            Err(ref e) if e.is::<UnknownFieldId>() => break,
+            Err(e) => {
+                warn!("error parsing {} header: {}", GRPC_TRACE_HEADER, e);
+                return None;
+            }
+        };
+    }
+    Some(context)
+}
+
+fn parse_grpc_trace_context_field(
+    buf: &mut Bytes,
+    context: &mut TraceContext,
+) -> Result<(), Error> {
+    let field_id = try_split_to(buf, 1)?[0];
+    match field_id {
+        GRPC_TRACE_FIELD_SPAN_ID => {
+            let id = try_split_to(buf, 8)?;
+            trace!(
+                "reading binary trace field {:?}: {:?}",
+                GRPC_TRACE_FIELD_SPAN_ID,
+                id
+            );
+            context.parent_id = id.into();
+        }
+        GRPC_TRACE_FIELD_TRACE_ID => {
+            let id = try_split_to(buf, 16)?;
+            trace!(
+                "reading binary trace field {:?}: {:?}",
+                GRPC_TRACE_FIELD_TRACE_ID,
+                id
+            );
+            context.trace_id = id.into();
+        }
+        GRPC_TRACE_FIELD_TRACE_OPTIONS => {
+            let flags = try_split_to(buf, 1)?;
+            trace!(
+                "reading binary trace field {:?}: {:?}",
+                GRPC_TRACE_FIELD_TRACE_OPTIONS,
+                flags
+            );
+            context.flags = flags.try_into()?;
+        }
+        id => {
+            return Err(UnknownFieldId(id).into());
+        }
+    };
+    Ok(())
+}
+
+fn parse_header_id<B>(request: &http::Request<B>, header: &str, pad_to: usize) -> Option<Id> {
+    let header_value = get_header_str(request, header)?;
+    decode_id_with_padding(header_value, pad_to)
+}

--- a/linkerd/trace-context/src/propagation/b3.rs
+++ b/linkerd/trace-context/src/propagation/b3.rs
@@ -9,11 +9,15 @@ use tracing::{trace, warn};
 
 use super::{decode_id_with_padding, get_header_str, Propagation, TraceContext, UnknownFieldId};
 
-const HTTP_TRACE_ID_HEADER: &str = "x-b3-traceid";
-const HTTP_SPAN_ID_HEADER: &str = "x-b3-spanid";
-const HTTP_SAMPLED_HEADER: &str = "x-b3-sampled";
+const HTTP_TRACE_ID_HEADER: http::header::HeaderName =
+    http::header::HeaderName::from_static("x-b3-traceid");
+const HTTP_SPAN_ID_HEADER: http::header::HeaderName =
+    http::header::HeaderName::from_static("x-b3-spanid");
+const HTTP_SAMPLED_HEADER: http::header::HeaderName =
+    http::header::HeaderName::from_static("x-b3-sampled");
 
-const GRPC_TRACE_HEADER: &str = "grpc-trace-bin";
+const GRPC_TRACE_HEADER: http::header::HeaderName =
+    http::header::HeaderName::from_static("grpc-trace-bin");
 const GRPC_TRACE_FIELD_TRACE_ID: u8 = 0;
 const GRPC_TRACE_FIELD_SPAN_ID: u8 = 1;
 const GRPC_TRACE_FIELD_TRACE_OPTIONS: u8 = 2;
@@ -149,7 +153,11 @@ fn parse_grpc_trace_context_field(
     Ok(())
 }
 
-fn parse_header_id<B>(request: &http::Request<B>, header: &str, pad_to: usize) -> Option<Id> {
+fn parse_header_id<B>(
+    request: &http::Request<B>,
+    header: http::header::HeaderName,
+    pad_to: usize,
+) -> Option<Id> {
     let header_value = get_header_str(request, header)?;
     decode_id_with_padding(header_value, pad_to)
 }

--- a/linkerd/trace-context/src/propagation/b3.rs
+++ b/linkerd/trace-context/src/propagation/b3.rs
@@ -64,7 +64,7 @@ pub fn increment_http_span_id<B>(request: &mut http::Request<B>) -> Id {
 
     let span_str = hex::encode(span_id.as_ref());
 
-    if let Result::Ok(hv) = HeaderValue::from_str(&span_str) {
+    if let Ok(hv) = HeaderValue::from_str(&span_str) {
         request.headers_mut().insert(HTTP_SPAN_ID_HEADER, hv);
     } else {
         warn!("invalid {HTTP_SPAN_ID_HEADER} header: {span_str:?}");

--- a/linkerd/trace-context/src/propagation/b3.rs
+++ b/linkerd/trace-context/src/propagation/b3.rs
@@ -1,7 +1,7 @@
 use crate::propagation::try_split_to;
 use crate::{Flags, Id};
 use bytes::Bytes;
-use http::header::HeaderValue;
+use http::header::{HeaderName, HeaderValue};
 use linkerd_error::Error;
 use rand::thread_rng;
 
@@ -9,15 +9,11 @@ use tracing::{trace, warn};
 
 use super::{decode_id_with_padding, get_header_str, Propagation, TraceContext, UnknownFieldId};
 
-static HTTP_TRACE_ID_HEADER: http::header::HeaderName =
-    http::header::HeaderName::from_static("x-b3-traceid");
-static HTTP_SPAN_ID_HEADER: http::header::HeaderName =
-    http::header::HeaderName::from_static("x-b3-spanid");
-static HTTP_SAMPLED_HEADER: http::header::HeaderName =
-    http::header::HeaderName::from_static("x-b3-sampled");
+static HTTP_TRACE_ID_HEADER: HeaderName = HeaderName::from_static("x-b3-traceid");
+static HTTP_SPAN_ID_HEADER: HeaderName = HeaderName::from_static("x-b3-spanid");
+static HTTP_SAMPLED_HEADER: HeaderName = HeaderName::from_static("x-b3-sampled");
 
-static GRPC_TRACE_HEADER: http::header::HeaderName =
-    http::header::HeaderName::from_static("grpc-trace-bin");
+static GRPC_TRACE_HEADER: HeaderName = HeaderName::from_static("grpc-trace-bin");
 const GRPC_TRACE_FIELD_TRACE_ID: u8 = 0;
 const GRPC_TRACE_FIELD_SPAN_ID: u8 = 1;
 const GRPC_TRACE_FIELD_TRACE_OPTIONS: u8 = 2;
@@ -155,7 +151,7 @@ fn parse_grpc_trace_context_field(
 
 fn parse_header_id<B>(
     request: &http::Request<B>,
-    header: &http::header::HeaderName,
+    header: &HeaderName,
     pad_to: usize,
 ) -> Option<Id> {
     let header_value = get_header_str(request, header)?;

--- a/linkerd/trace-context/src/propagation/w3c.rs
+++ b/linkerd/trace-context/src/propagation/w3c.rs
@@ -3,12 +3,12 @@ use tracing::{trace, warn};
 use super::{decode_id_with_padding, get_header_str, Propagation, TraceContext};
 use crate::{Flags, Id};
 
-pub const HTTP_TRACEPARENT: http::header::HeaderName =
+static HTTP_TRACEPARENT: http::header::HeaderName =
     http::header::HeaderName::from_static("traceparent");
-pub const VERSION_00: &str = "00";
+const VERSION_00: &str = "00";
 
 pub fn unpack_w3c_trace_context<B>(request: &http::Request<B>) -> Option<TraceContext> {
-    get_header_str(request, HTTP_TRACEPARENT).and_then(parse_context)
+    get_header_str(request, &HTTP_TRACEPARENT).and_then(parse_context)
 }
 
 /// Given an http request and a w3c trace context, create a new Span ID and
@@ -32,7 +32,7 @@ pub fn increment_http_span_id<B>(request: &mut http::Request<B>, context: &Trace
     };
 
     if let Ok(hv) = http::HeaderValue::from_str(&new_header) {
-        request.headers_mut().insert(HTTP_TRACEPARENT, hv);
+        request.headers_mut().insert(&HTTP_TRACEPARENT, hv);
     } else {
         warn!("invalid value {new_header} for tracecontext header");
     }

--- a/linkerd/trace-context/src/propagation/w3c.rs
+++ b/linkerd/trace-context/src/propagation/w3c.rs
@@ -99,47 +99,52 @@ fn parse_header_value(next_header: &str, pad_to: usize) -> Option<(Id, &str)> {
         .and_then(|(id, rest)| decode_id_with_padding(id, pad_to).zip(Some(rest)))
 }
 
-#[test]
-fn w3c_context_parsed_successfully() {
-    let input = "00-94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614-01";
-    let actual = parse_context(input);
+#[cfg(test)]
+mod tests {
+    use super::parse_context;
 
-    let expected_trace = hex::decode("94d7f6ec6b95f3e916179cb6cfd01390")
-        .expect("Failed to decode trace parent from hex");
-    let expected_parent =
-        hex::decode("55ccfce77f972614").expect("Failed to decode span parent from hex");
-    let expected_flags = 1;
+    #[test]
+    fn w3c_context_parsed_successfully() {
+        let input = "00-94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614-01";
+        let actual = parse_context(input);
 
-    assert!(actual.is_some());
-    let actual = actual.unwrap();
-    assert_eq!(expected_trace, actual.trace_id.0);
-    assert_eq!(expected_parent, actual.parent_id.0);
-    assert_eq!(expected_flags, actual.flags.0);
-}
+        let expected_trace = hex::decode("94d7f6ec6b95f3e916179cb6cfd01390")
+            .expect("Failed to decode trace parent from hex");
+        let expected_parent =
+            hex::decode("55ccfce77f972614").expect("Failed to decode span parent from hex");
+        let expected_flags = 1;
 
-#[test]
-fn w3c_context_invalid_flags() {
-    let input = "00-94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614-011";
-    let actual = parse_context(input);
-    assert!(actual.is_none());
+        assert!(actual.is_some());
+        let actual = actual.unwrap();
+        assert_eq!(expected_trace, actual.trace_id.0);
+        assert_eq!(expected_parent, actual.parent_id.0);
+        assert_eq!(expected_flags, actual.flags.0);
+    }
 
-    let input = "00-94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614";
-    let actual = parse_context(input);
-    assert!(actual.is_none());
-}
+    #[test]
+    fn w3c_context_invalid_flags() {
+        let input = "00-94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614-011";
+        let actual = parse_context(input);
+        assert!(actual.is_none());
 
-#[test]
-fn w3c_context_invalid_version() {
-    let input = "22-94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614-01";
-    assert!(parse_context(input).is_none());
+        let input = "00-94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614";
+        let actual = parse_context(input);
+        assert!(actual.is_none());
+    }
 
-    let input = "94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614-01";
-    assert!(parse_context(input).is_none());
-}
+    #[test]
+    fn w3c_context_invalid_version() {
+        let input = "22-94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614-01";
+        assert!(parse_context(input).is_none());
 
-#[test]
-fn w3c_context_invalid_hex() {
-    // length of id 94d(...) is odd, results in invalid hex.
-    let input = "00-94d7f6ec6b95f3e916179cb6cfd013901-55ccfce77972614-01";
-    assert!(parse_context(input).is_none());
+        let input = "94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614-01";
+        assert!(parse_context(input).is_none());
+    }
+
+    #[test]
+    fn w3c_context_invalid_hex() {
+        // length of id 94d(...) is odd, results in invalid hex.
+        let input = "00-94d7f6ec6b95f3e916179cb6cfd013901-55ccfce77972614-01";
+        assert!(parse_context(input).is_none());
+    }
 }

--- a/linkerd/trace-context/src/propagation/w3c.rs
+++ b/linkerd/trace-context/src/propagation/w3c.rs
@@ -45,16 +45,13 @@ fn parse_context(header_value: &str) -> Option<TraceContext> {
     let rest = match header_value.split_once('-') {
         Some((version, rest)) => {
             if version != HEADER_VERSION_00 {
-                warn!(
-                    "Tracecontext header {} contains invalid version: {}",
-                    header_value, version
-                );
+                warn!("Tracecontext header {header_value} contains invalid version: {version}",);
                 return None;
             }
             rest
         }
         None => {
-            warn!("Tracecontext header {} is invalid", header_value);
+            warn!("Tracecontext header {header_value} is invalid");
             return None;
         }
     };
@@ -62,14 +59,14 @@ fn parse_context(header_value: &str) -> Option<TraceContext> {
     let (trace_id, rest) = if let Some((id, rest)) = parse_header_value(rest, 16) {
         (id, rest)
     } else {
-        warn!("Tracecontext header {} contains invalid id", header_value);
+        warn!("Tracecontext header {header_value} contains invalid id");
         return None;
     };
 
     let (parent_id, rest) = if let Some((id, rest)) = parse_header_value(rest, 8) {
         (id, rest)
     } else {
-        warn!("Tracecontext header {} contains invalid id", header_value);
+        warn!("Tracecontext header {header_value} contains invalid id");
         return None;
     };
 
@@ -79,7 +76,7 @@ fn parse_context(header_value: &str) -> Option<TraceContext> {
         Ok(decoded) => Flags(decoded[0]),
         // If invalid hex, invalidate trace
         Err(e) => {
-            warn!("Failed to decode flags for header {}: {}", header_value, e);
+            warn!("Failed to decode flags for header {header_value}: {e}");
             return None;
         }
     };

--- a/linkerd/trace-context/src/propagation/w3c.rs
+++ b/linkerd/trace-context/src/propagation/w3c.rs
@@ -1,0 +1,118 @@
+use http::HeaderValue;
+use tracing::{trace, warn};
+
+use super::{decode_id_with_padding, get_header_str, Propagation, TraceContext};
+use crate::{Flags, Id};
+
+pub const HTTP_TRACEPARENT: &str = "traceparent";
+pub const HEADER_VERSION_00: &str = "00";
+
+pub fn unpack_w3c_trace_context<B>(request: &http::Request<B>) -> Option<TraceContext> {
+    get_header_str(request, HTTP_TRACEPARENT).and_then(parse_context)
+}
+
+/// Given an http request and a w3c trace context, create a new Span ID and
+/// assign it to the tracecontext header value, in order to propagate
+/// the trace context downstream.
+pub fn increment_http_span_id<B>(request: &mut http::Request<B>, context: &TraceContext) -> Id {
+    let span_id = Id::new_span_id(&mut rand::thread_rng());
+
+    trace!("incremented span id: {}", span_id);
+
+    let new_header = {
+        let mut buf = String::with_capacity(60);
+        buf.push_str(HEADER_VERSION_00);
+        buf.push('-');
+        buf.push_str(&hex::encode(context.trace_id.as_ref()));
+        buf.push('-');
+        buf.push_str(&hex::encode(context.parent_id.as_ref()));
+        buf.push('-');
+        buf.push_str(&hex::encode(vec![context.flags.0]));
+        buf
+    };
+
+    if let Result::Ok(hv) = HeaderValue::from_str(&new_header) {
+        request.headers_mut().insert(HTTP_TRACEPARENT, hv);
+    } else {
+        warn!("invalid value {} for tracecontext header", new_header);
+    }
+
+    span_id
+}
+
+/// Parse a given header value as a w3c TraceContext value.
+fn parse_context(header_value: &str) -> Option<TraceContext> {
+    let rest = match header_value.split_once('-') {
+        Some((version, rest)) => {
+            if version != HEADER_VERSION_00 {
+                warn!(
+                    "Tracecontext header {} contains invalid version: {}",
+                    header_value, version
+                );
+                return None;
+            }
+            rest
+        }
+        None => {
+            warn!("Tracecontext header {} is invalid", header_value);
+            return None;
+        }
+    };
+
+    let (trace_id, rest) = if let Some((id, rest)) = parse_header_value(rest, 16) {
+        (id, rest)
+    } else {
+        warn!("Tracecontext header {} contains invalid id", header_value);
+        return None;
+    };
+
+    let (parent_id, rest) = if let Some((id, rest)) = parse_header_value(rest, 8) {
+        (id, rest)
+    } else {
+        warn!("Tracecontext header {} contains invalid id", header_value);
+        return None;
+    };
+
+    let flags = match hex::decode(rest) {
+        // If valid hex, take final bit and AND with 1. W3C only uses one bit
+        // for flags in version 00, and the bit is used to control sampling
+        Ok(decoded) => Flags(decoded[0]),
+        // If invalid hex, do not sample trace
+        Err(e) => {
+            warn!("Failed to decode flags for header {}: {}", header_value, e);
+            Flags(0)
+        }
+    };
+
+    Some(TraceContext {
+        propagation: Propagation::W3CHttp,
+        trace_id,
+        parent_id,
+        flags,
+    })
+}
+
+fn parse_header_value(next_header: &str, pad_to: usize) -> Option<(Id, &str)> {
+    next_header
+        .split_once('-')
+        .filter(|(id, _rest)| !id.chars().all(|c| c == '0'))
+        .and_then(|(id, rest)| decode_id_with_padding(id, pad_to).zip(Some(rest)))
+}
+
+#[test]
+fn test_w3c_context_parsed_successfully() {
+    let input = "00-94d7f6ec6b95f3e916179cb6cfd01390-55ccfce77f972614-01";
+    let actual = parse_context(input);
+
+    let expected_trace = hex::decode("94d7f6ec6b95f3e916179cb6cfd01390")
+        .expect("Failed to decode trace parent from hex");
+    let expected_parent =
+        hex::decode("55ccfce77f972614").expect("Failed to decode span parent from hex");
+    let expected_flags = 1;
+
+    assert!(actual.is_some());
+    let actual = actual.unwrap();
+    assert_eq!(expected_trace, actual.trace_id.0);
+    assert_eq!(expected_parent, actual.parent_id.0);
+    assert_eq!(expected_flags, actual.flags.0);
+}

--- a/linkerd/trace-context/src/propagation/w3c.rs
+++ b/linkerd/trace-context/src/propagation/w3c.rs
@@ -17,7 +17,7 @@ pub fn unpack_w3c_trace_context<B>(request: &http::Request<B>) -> Option<TraceCo
 pub fn increment_http_span_id<B>(request: &mut http::Request<B>, context: &TraceContext) -> Id {
     let span_id = Id::new_span_id(&mut rand::thread_rng());
 
-    trace!("incremented span id: {}", span_id);
+    trace!("incremented span id: {span_id}");
 
     let new_header = {
         let mut buf = String::with_capacity(60);
@@ -34,7 +34,7 @@ pub fn increment_http_span_id<B>(request: &mut http::Request<B>, context: &Trace
     if let Result::Ok(hv) = HeaderValue::from_str(&new_header) {
         request.headers_mut().insert(HTTP_TRACEPARENT, hv);
     } else {
-        warn!("invalid value {} for tracecontext header", new_header);
+        warn!("invalid value {new_header} for tracecontext header");
     }
 
     span_id

--- a/linkerd/trace-context/src/propagation/w3c.rs
+++ b/linkerd/trace-context/src/propagation/w3c.rs
@@ -1,10 +1,10 @@
+use http::header::HeaderName;
 use tracing::{trace, warn};
 
 use super::{decode_id_with_padding, get_header_str, Propagation, TraceContext};
 use crate::{Flags, Id};
 
-static HTTP_TRACEPARENT: http::header::HeaderName =
-    http::header::HeaderName::from_static("traceparent");
+static HTTP_TRACEPARENT: HeaderName = HeaderName::from_static("traceparent");
 const VERSION_00: &str = "00";
 
 pub fn unpack_w3c_trace_context<B>(request: &http::Request<B>) -> Option<TraceContext> {


### PR DESCRIPTION
This is a proof of concept PR to show what changes would be necessary to support `tracecontext`, the OpenTelemetry "standardised" way of propagating distributed tracing context (aka `w3c` format).

A copy of the RFC [can be found here](https://www.w3.org/TR/trace-context-1/#processing-model-for-working-with-trace-context). The RFC/specification has a processing model for how the header(s) should be parsed. This proof of concept contains _most_ cases, some which are a bit more trivial to implement have been left out and will be done when (or if) this moves forward. The parsing logic is also a bit rushed and I will want to revisit it if conceptually this all looks sound.

Also, most notably, `tracestate` is not being handled at all, since it's optional:

> Vendors receiving a tracestate request header MUST send it to outgoing requests. It MAY mutate the value of this header before passing to outgoing requests. When mutating tracestate, the order of unmodified key/value pairs MUST be preserved. Modified keys SHOULD be moved to the beginning (left) of the list.

Likewise, the proxy will likely not want to implement some parts of the specification, the one that stands out to me is the absence of a traceparent header. On absence, the spec says we should start a trace, we will want to instead parse `b3` headers (we shouldn't create our own trace if it's not present on the request).

To test, I used an emojivoto fork configured with otel instead of opencensus library. If we go ahead with this, I plan on pushing my branch to the emojivoto repo along with manifests so that reviewers can test in their environments. For now, I've included pictures from a trace (`vote-bot` --> `voting`, note that `bot-vote` naming is to distinguish my fork from the original code, bit confusing maybe, sorry).

Note: in the first picture notice how the last service (voting) didn't really have a proxy span. On refresh, the span appeared. Think this is just Jaeger being flakey.

<details>

<summary> Pictures of Jaeger query </summary>

![Screenshot 2023-01-23 at 14 39 18](https://user-images.githubusercontent.com/18265670/214100845-410d5b6b-7c0e-4e91-80f3-5bd53f27690f.png)
![Screenshot 2023-01-23 at 14 41 58](https://user-images.githubusercontent.com/18265670/214100850-166dbe96-e8ce-44b2-ab00-30699d32280c.png)
![Screenshot 2023-01-23 at 14 42 15](https://user-images.githubusercontent.com/18265670/214100859-3743e037-f6f9-467b-81ee-d6783e4ae914.png)

</details>

Signed-off-by: Matei David <matei@buoyant.io>