### PR TITLE
Error type suggestions for #2162

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,13 +28,13 @@ jobs:
     steps:
       - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
       - run: just fetch
-      - run: just clippy-crate linkerd-meshtls --all-features
+      - run: just clippy-crate linkerd-meshtls --no-default-features --features=boring,rustls
       - run: |
-          just test-crate linkerd-meshtls --all-features --no-run \
+          just test-crate linkerd-meshtls --no-default-features --features=boring,rustls --no-run \
             --package=linkerd-meshtls-boring \
             --package=linkerd-meshtls-rustls
       - run: |
-          just test-crate linkerd-meshtls --all-features \
+          just test-crate linkerd-meshtls --no-default-features --features=boring,rustls \
             --package=linkerd-meshtls-boring \
             --package=linkerd-meshtls-rustls
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705339e0e4a9690e2908d2b3d049d85682cf19fbd5782494498fbf7003a6a282"
+checksum = "eff18d764974428cf3a9328e23fc5c986f5fbed46e6cd4cdf42544df5d297ec1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -122,8 +122,7 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "boring"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c713ad6d8d7a681a43870ac37b89efd2a08015ceb4b256d82707509c1f0b6bb"
+source = "git+https://github.com/cloudflare/boring#3059ba6e102599f8ae0a962223ca1e216bb61902"
 dependencies = [
  "bitflags",
  "boring-sys",
@@ -135,8 +134,7 @@ dependencies = [
 [[package]]
 name = "boring-sys"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7663d3069437a5ccdb2b5f4f481c8b80446daea10fa8503844e89ac65fcdc363"
+source = "git+https://github.com/cloudflare/boring#3059ba6e102599f8ae0a962223ca1e216bb61902"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2456,9 +2454,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.24.1"
+version = "1.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9f76183f91ecfb55e1d7d5602bd1d979e38a3a522fe900241cf195624d67ae"
+checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2477,8 +2475,7 @@ dependencies = [
 [[package]]
 name = "tokio-boring"
 version = "2.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb059337235a89f03252c6285da8f0a6747a85bbd42e9ece70178d578054cba7"
+source = "git+https://github.com/cloudflare/boring#3059ba6e102599f8ae0a962223ca1e216bb61902"
 dependencies = [
  "boring",
  "boring-sys",
@@ -2966,9 +2963,9 @@ checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,5 @@ lto = true
 
 [patch.crates-io]
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.22" }
+boring = { git = "https://github.com/cloudflare/boring" }
+tokio-boring = { git = "https://github.com/cloudflare/boring" }

--- a/deny.toml
+++ b/deny.toml
@@ -62,6 +62,7 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = ["https://github.com/cloudflare/boring.git"]
 
 [sources.allow-org]
 github = [

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -127,7 +127,7 @@ impl Config {
                                     return Err(Error::from(UnexpectedSni(sni, tcp.client)));
                                 }
                             };
-                            debug!(%version, "HTTP detection timed out; assuming HTTP");
+                            debug!(?version, "HTTP detection timed out; assuming HTTP");
                             Ok(Http { version, tcp })
                         }
                         // If the connection failed HTTP detection, check if we detected TLS for

--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -385,7 +385,12 @@ where
         };
 
         let rsp = info_span!("rescue", client.addr = %self.client_addr()).in_scope(|| {
-            tracing::info!(error, "Request failed");
+            if self.is_grpc {
+                let version = self.version;
+                tracing::info!(error, "{version:?} request failed",);
+            } else {
+                tracing::info!(error, "gRPC request failed");
+            };
             self.rescue.rescue(error)
         })?;
 

--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -385,7 +385,7 @@ where
         };
 
         let rsp = info_span!("rescue", client.addr = %self.client_addr()).in_scope(|| {
-            if self.is_grpc {
+            if !self.is_grpc {
                 let version = self.version;
                 tracing::info!(error, "{version:?} request failed",);
             } else {

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -204,7 +204,7 @@ where
             );
 
         discover
-            .instrument(|h: &HttpTarget| debug_span!("gateway", target = %h.target, v = %h.version))
+            .instrument(|h: &HttpTarget| debug_span!("gateway", target = %h.target, v = ?h.version))
             .push_on_service(
                 svc::layers().push(
                     inbound

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -204,7 +204,7 @@ where
             );
 
         discover
-            .instrument(|h: &HttpTarget| debug_span!("gateway", target = %h.target, v = ?h.version))
+            .instrument(|h: &HttpTarget| debug_span!("gateway", target = %h.target))
             .push_on_service(
                 svc::layers().push(
                     inbound

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -105,8 +105,8 @@ impl<N> Inbound<N> {
         NSvc::Future: Send,
         F: svc::NewService<Forward, Service = FSvc> + Clone + Send + Sync + Unpin + 'static,
         FSvc: svc::Service<io::BoxedIo, Response = ()> + Send + 'static,
-        FSvc::Future: Send,
         FSvc::Error: Into<Error>,
+        FSvc::Future: Send,
     {
         self.map_stack(|cfg, rt, detect| {
             let forward = svc::stack(forward)
@@ -194,8 +194,8 @@ impl<N> Inbound<N> {
         NSvc::Future: Send,
         F: svc::NewService<Forward, Service = FSvc> + Clone + Send + Sync + Unpin + 'static,
         FSvc: svc::Service<io::BoxedIo, Response = ()> + Send + 'static,
-        FSvc::Future: Send,
         FSvc::Error: Into<Error>,
+        FSvc::Future: Send,
     {
         self.map_stack(|cfg, rt, http| {
             let forward = svc::stack(forward)

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -244,10 +244,7 @@ impl<C> Inbound<C> {
                 .check_new_service::<Logical, http::Request<http::BoxBody>>()
                 .instrument(|t: &Logical| {
                     let name = t.logical.as_ref().map(tracing::field::display);
-                    match t.http {
-                        http::Version::H2 => debug_span!("http2", name),
-                        http::Version::Http1 => debug_span!("http1", name),
-                    }
+                    debug_span!("http", name)
                 })
                 // Routes each request to a target, obtains a service for that target, and
                 // dispatches the request.

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -7,7 +7,7 @@ use linkerd_app_core::{
     transport::{self, ClientAddr, Remote, ServerAddr},
     Error, Infallible, NameAddr, Result,
 };
-use std::{fmt, net::SocketAddr, sync::Arc};
+use std::{fmt, net::SocketAddr};
 use tracing::{debug, debug_span};
 
 /// Describes an HTTP client target.
@@ -60,15 +60,6 @@ struct ClientRescue;
 struct LogicalError {
     logical: Option<NameAddr>,
     addr: Remote<ServerAddr>,
-    http: http::Version,
-    #[source]
-    source: Error,
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("route ({:?}): {}", .route_labels, .source)]
-struct RouteError {
-    route_labels: Arc<std::collections::BTreeMap<String, String>>,
     #[source]
     source: Error,
 }
@@ -177,7 +168,6 @@ impl<C> Inbound<C> {
                         .push_on_service(http::BoxResponse::layer())
                         .push(classify::NewClassify::layer())
                         .push_http_insert_target::<profiles::http::Route>()
-                        .push(svc::NewMapErr::layer_from_target::<RouteError, _>())
                         .push_map_target(|(route, profile)| ProfileRoute { route, profile })
                         .push_on_service(svc::MapErr::layer(Error::from))
                         .into_inner(),
@@ -556,7 +546,6 @@ impl From<(&Logical, Error)> for LogicalError {
         Self {
             logical: logical.logical.clone(),
             addr: logical.addr,
-            http: logical.http,
             source,
         }
     }
@@ -567,28 +556,12 @@ impl fmt::Display for LogicalError {
         let Self {
             logical,
             addr,
-            http,
             source,
         } = self;
-        let version = match http {
-            http::Version::H2 => "HTTP/2",
-            http::Version::Http1 => "HTTP/1",
-        };
-
-        match logical {
-            Some(logical) => write!(f, "{version} logical ({logical}, addr={addr}): {source}"),
-            None => write!(f, "{version} ({addr}): {source}"),
+        write!(f, "server {addr}")?;
+        if let Some(logical) = logical {
+            write!(f, ": service {logical}")?;
         }
-    }
-}
-
-// === impl RouteError ===
-
-impl From<(&ProfileRoute, Error)> for RouteError {
-    fn from((route, source): (&ProfileRoute, Error)) -> Self {
-        Self {
-            route_labels: route.route.labels().clone(),
-            source,
-        }
+        write!(f, ": {source}")
     }
 }

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -85,7 +85,7 @@ impl<H> Inbound<H> {
                 )
                 .check_new_service::<T, http::Request<_>>()
                 .push(NewAccessLog::layer())
-                .instrument(|t: &T| debug_span!("http", v = %Param::<Version>::param(t)))
+                .instrument(|t: &T| debug_span!("http", v = ?Param::<Version>::param(t)))
                 .push(http::NewServeHttp::layer(h2_settings, rt.drain.clone()))
                 .push_on_service(svc::BoxService::layer())
                 .push(svc::ArcNewService::layer())

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -85,7 +85,7 @@ impl<H> Inbound<H> {
                 )
                 .check_new_service::<T, http::Request<_>>()
                 .push(NewAccessLog::layer())
-                .instrument(|t: &T| debug_span!("http", v = ?Param::<Version>::param(t)))
+                .instrument(|_: &T| debug_span!("http"))
                 .push(http::NewServeHttp::layer(h2_settings, rt.drain.clone()))
                 .push_on_service(svc::BoxService::layer())
                 .push(svc::ArcNewService::layer())

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -85,7 +85,7 @@ pub struct GatewayDomainInvalid;
 pub struct GatewayLoop;
 
 #[derive(Debug, thiserror::Error)]
-#[error("opaque forward ({}): {}", .addr, .source)]
+#[error("server {addr}: {source}")]
 pub struct ForwardError {
     addr: Remote<ServerAddr>,
     source: Error,

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -39,14 +39,6 @@ pub struct FromMetadata<P, N> {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("endpoint {addr}: {source}")]
-pub struct EndpointError {
-    addr: Remote<ServerAddr>,
-    #[source]
-    source: Error,
-}
-
-#[derive(Debug, thiserror::Error)]
 #[error("forwarding to {addr}: {source}")]
 pub struct ForwardError {
     addr: Remote<ServerAddr>,
@@ -298,20 +290,6 @@ impl<S> Outbound<S> {
                 .push_on_service(svc::BoxService::layer())
                 .push(svc::ArcNewService::layer())
         })
-    }
-}
-
-// === impl EndpointError ===
-
-impl<T> From<(&T, Error)> for EndpointError
-where
-    T: svc::Param<Remote<ServerAddr>>,
-{
-    fn from((target, source): (&T, Error)) -> Self {
-        Self {
-            addr: target.param(),
-            source,
-        }
     }
 }
 

--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -54,7 +54,7 @@ impl<N> Outbound<N> {
                 .check_new_service::<U, _>()
                 .push(http::NewServeHttp::layer(h2_settings, rt.drain.clone()))
                 .push_map_target(U::from)
-                .instrument(|(v, _): &(http::Version, _)| debug_span!("http", ?v))
+                .instrument(|_: &_| debug_span!("http"))
                 .push(svc::UnwrapOr::layer(
                     tcp.clone()
                         .push_on_service(svc::MapTargetLayer::new(io::EitherIo::Right))

--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -54,7 +54,7 @@ impl<N> Outbound<N> {
                 .check_new_service::<U, _>()
                 .push(http::NewServeHttp::layer(h2_settings, rt.drain.clone()))
                 .push_map_target(U::from)
-                .instrument(|(v, _): &(http::Version, _)| debug_span!("http", %v))
+                .instrument(|(v, _): &(http::Version, _)| debug_span!("http", ?v))
                 .push(svc::UnwrapOr::layer(
                     tcp.clone()
                         .push_on_service(svc::MapTargetLayer::new(io::EitherIo::Right))

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -1,6 +1,5 @@
 use super::{retry, CanonicalDstHeader, Concrete, Logical};
 use crate::Outbound;
-use core::fmt;
 use linkerd_app_core::{
     classify, metrics,
     profiles::{self, Profile},
@@ -16,10 +15,9 @@ use std::sync::Arc;
 pub struct NoRoute;
 
 #[derive(Debug, thiserror::Error)]
-#[error("logical {version:?} service {addr}: {source}")]
+#[error("logical service {addr}: {source}")]
 pub struct LogicalError {
     addr: profiles::LogicalAddr,
-    version: http::Version,
     #[source]
     source: Error,
 }
@@ -36,13 +34,6 @@ struct RouteParams {
     logical: Logical,
     profile: profiles::http::Route,
     distribution: Distribution,
-}
-
-#[derive(Debug, thiserror::Error)]
-struct RouteError {
-    #[source]
-    source: Error,
-    route_labels: Arc<std::collections::BTreeMap<String, String>>,
 }
 
 type BackendCache<N, S> = distribute::BackendCache<Concrete, N, S>;
@@ -117,10 +108,10 @@ impl<N> Outbound<N> {
                         .http_profile_route
                         .to_layer::<classify::Response, _, RouteParams>(),
                 )
-                .push(svc::NewMapErr::layer_from_target::<RouteError, _>())
                 // Sets the per-route response classifier as a request
                 // extension.
                 .push(classify::NewClassify::layer())
+                // TODO(ver) .push(svc::NewMapErr::layer_from_target::<RouteError, _>())
                 .push_on_service(http::BoxResponse::layer());
 
             // A `NewService`--instantiated once per logical target--that caches
@@ -286,40 +277,12 @@ impl classify::CanClassify for RouteParams {
     }
 }
 
-// === impl RouteError ===
-
-impl fmt::Display for RouteError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self {
-            route_labels,
-            source,
-        } = self;
-        write!(f, "route ({route_labels:?}): {source}")
-    }
-}
-
-impl<T> From<(&T, Error)> for RouteError
-where
-    T: svc::Param<profiles::http::Route>,
-{
-    fn from((route, source): (&T, Error)) -> Self {
-        Self {
-            route_labels: route.param().labels().clone(),
-            source,
-        }
-    }
-}
-
 // === impl LogicalError ===
 
-impl<T> From<(&T, Error)> for LogicalError
-where
-    T: svc::Param<profiles::LogicalAddr> + svc::Param<http::Version>,
-{
+impl<T: svc::Param<profiles::LogicalAddr>> From<(&T, Error)> for LogicalError {
     fn from((target, source): (&T, Error)) -> Self {
         Self {
             addr: target.param(),
-            version: target.param(),
             source,
         }
     }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 pub struct NoRoute;
 
 #[derive(Debug, thiserror::Error)]
-#[error("logical {version} service {addr}: {source}")]
+#[error("logical {version:?} service {addr}: {source}")]
 pub struct LogicalError {
     addr: profiles::LogicalAddr,
     version: http::Version,

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -242,7 +242,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                             .push(http::BoxRequest::layer()),
                     )
                     .check_new_service::<Http<tcp::Accept>, http::Request<_>>()
-                    .instrument(|a: &Http<tcp::Accept>| debug_span!("http", v = %a.version));
+                    .instrument(|a: &Http<tcp::Accept>| debug_span!("http", v = ?a.version));
 
                 // HTTP detection is **always** performed. If detection fails, then we
                 // use the `fallback` stack to process the connection by its original

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -241,8 +241,8 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                             .push(http::BoxResponse::layer())
                             .push(http::BoxRequest::layer()),
                     )
-                    .check_new_service::<Http<tcp::Accept>, http::Request<_>>()
-                    .instrument(|a: &Http<tcp::Accept>| debug_span!("http", v = ?a.version));
+                    .instrument(|_: &_| debug_span!("http"))
+                    .check_new_service::<Http<tcp::Accept>, http::Request<_>>();
 
                 // HTTP detection is **always** performed. If detection fails, then we
                 // use the `fallback` stack to process the connection by its original

--- a/linkerd/app/outbound/src/tcp/concrete.rs
+++ b/linkerd/app/outbound/src/tcp/concrete.rs
@@ -1,12 +1,24 @@
 use super::{Concrete, Endpoint};
-use crate::{endpoint, logical::ConcreteError, stack_labels, Outbound};
+use crate::{endpoint, stack_labels, Outbound};
 use linkerd_app_core::{
     drain, io,
-    proxy::{api_resolve::Metadata, core::Resolve, tcp},
+    proxy::{
+        api_resolve::{ConcreteAddr, Metadata},
+        core::Resolve,
+        tcp,
+    },
     svc, Error,
 };
 use std::time;
 use tracing::info_span;
+
+#[derive(Debug, thiserror::Error)]
+#[error("concrete service {addr}: {source}")]
+pub struct ConcreteError {
+    addr: ConcreteAddr,
+    #[source]
+    source: Error,
+}
 
 // === impl Outbound ===
 
@@ -84,6 +96,17 @@ impl svc::Param<tcp::balance::EwmaConfig> for Concrete {
         tcp::balance::EwmaConfig {
             default_rtt: time::Duration::from_millis(30),
             decay: time::Duration::from_secs(10),
+        }
+    }
+}
+
+// === impl ConcreteError ===
+
+impl<T: svc::Param<ConcreteAddr>> From<(&T, Error)> for ConcreteError {
+    fn from((target, source): (&T, Error)) -> Self {
+        Self {
+            addr: target.param(),
+            source,
         }
     }
 }

--- a/linkerd/meshtls/Cargo.toml
+++ b/linkerd/meshtls/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [features]
 rustls = ["linkerd-meshtls-rustls", "__has_any_tls_impls"]
 boring = ["linkerd-meshtls-boring", "__has_any_tls_impls"]
+boring-fips = ["linkerd-meshtls-boring?/fips"]
 # Enabled if *any* TLS impl is enabled.
 __has_any_tls_impls = []
 

--- a/linkerd/meshtls/boring/Cargo.toml
+++ b/linkerd/meshtls/boring/Cargo.toml
@@ -20,5 +20,8 @@ tokio = { version = "1", features = ["macros", "sync"] }
 tokio-boring = "2"
 tracing = "0.1"
 
+[features]
+fips = ["boring/fips"]
+
 [dev-dependencies]
 linkerd-tls-test-util = { path = "../../tls/test-util" }

--- a/linkerd/proxy/http/src/version.rs
+++ b/linkerd/proxy/http/src/version.rs
@@ -21,12 +21,12 @@ impl std::convert::TryFrom<http::Version> for Version {
     }
 }
 
-// A convenience for tracing contexts.
+// A convenience for tracing/logging.
 impl std::fmt::Display for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Http1 => write!(f, "1.x"),
-            Self::H2 => write!(f, "h2"),
+            Self::Http1 => write!(f, "HTTP/1"),
+            Self::H2 => write!(f, "HTTP/2"),
         }
     }
 }

--- a/linkerd/proxy/http/src/version.rs
+++ b/linkerd/proxy/http/src/version.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Version {
     Http1,
     H2,
@@ -21,8 +21,7 @@ impl std::convert::TryFrom<http::Version> for Version {
     }
 }
 
-// A convenience for tracing/logging.
-impl std::fmt::Display for Version {
+impl std::fmt::Debug for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Http1 => write!(f, "HTTP/1"),

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -11,6 +11,7 @@ description = "The main proxy executable"
 default = ["multicore", "meshtls-rustls"]
 multicore = ["tokio/rt-multi-thread", "num_cpus"]
 meshtls-boring = ["linkerd-meshtls/boring"]
+meshtls-boring-fips = ["linkerd-meshtls/boring-fips"]
 meshtls-rustls = ["linkerd-meshtls/rustls"]
 log-streaming = ["linkerd-app/log-streaming"]
 


### PR DESCRIPTION
* Move HTTP version logging into the `Respond` handler (since it already includes all of this information). This also let's us be explicit about gRPC. This removes needing to wire it through elsewhere.
* All error types are defined in the module in which they are used, even when they exactly match error types elsewhere. As we move forward with the upcoming changes, we want each stack to be as independent as possible.
* `http::Version` now implements `Debug` with full "HTTP/1" or "HTTP/2" strings. We change uses of `Display` to `Debug`.
* Remove `RouteError` types for now. They're not really critical for debugging. We may restore them later as those stacks evolve.