### PR TITLE
Update HTTP error responder to log version info

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -127,7 +127,7 @@ impl Config {
                                     return Err(Error::from(UnexpectedSni(sni, tcp.client)));
                                 }
                             };
-                            debug!(%version, "HTTP detection timed out; assuming HTTP");
+                            debug!(?version, "HTTP detection timed out; assuming HTTP");
                             Ok(Http { version, tcp })
                         }
                         // If the connection failed HTTP detection, check if we detected TLS for

--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -385,7 +385,12 @@ where
         };
 
         let rsp = info_span!("rescue", client.addr = %self.client_addr()).in_scope(|| {
-            tracing::info!(error, "Request failed");
+            if self.is_grpc {
+                let version = self.version;
+                tracing::info!(error, "{version:?} request failed",);
+            } else {
+                tracing::info!(error, "gRPC request failed");
+            };
             self.rescue.rescue(error)
         })?;
 

--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -385,7 +385,7 @@ where
         };
 
         let rsp = info_span!("rescue", client.addr = %self.client_addr()).in_scope(|| {
-            if self.is_grpc {
+            if !self.is_grpc {
                 let version = self.version;
                 tracing::info!(error, "{version:?} request failed",);
             } else {

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -204,7 +204,7 @@ where
             );
 
         discover
-            .instrument(|h: &HttpTarget| debug_span!("gateway", target = %h.target, v = %h.version))
+            .instrument(|h: &HttpTarget| debug_span!("gateway", target = %h.target))
             .push_on_service(
                 svc::layers().push(
                     inbound

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -232,10 +232,7 @@ impl<C> Inbound<C> {
                 .check_new_service::<Logical, http::Request<http::BoxBody>>()
                 .instrument(|t: &Logical| {
                     let name = t.logical.as_ref().map(tracing::field::display);
-                    match t.http {
-                        http::Version::H2 => debug_span!("http2", name),
-                        http::Version::Http1 => debug_span!("http1", name),
-                    }
+                    debug_span!("http", name)
                 })
                 // Routes each request to a target, obtains a service for that target, and
                 // dispatches the request.

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -85,7 +85,7 @@ impl<H> Inbound<H> {
                 )
                 .check_new_service::<T, http::Request<_>>()
                 .push(NewAccessLog::layer())
-                .instrument(|t: &T| debug_span!("http", v = %Param::<Version>::param(t)))
+                .instrument(|_: &T| debug_span!("http"))
                 .push(http::NewServeHttp::layer(h2_settings, rt.drain.clone()))
                 .push_on_service(svc::BoxService::layer())
                 .push(svc::ArcNewService::layer())

--- a/linkerd/app/outbound/src/http/detect.rs
+++ b/linkerd/app/outbound/src/http/detect.rs
@@ -54,7 +54,7 @@ impl<N> Outbound<N> {
                 .check_new_service::<U, _>()
                 .push(http::NewServeHttp::layer(h2_settings, rt.drain.clone()))
                 .push_map_target(U::from)
-                .instrument(|(v, _): &(http::Version, _)| debug_span!("http", %v))
+                .instrument(|_: &_| debug_span!("http"))
                 .push(svc::UnwrapOr::layer(
                     tcp.clone()
                         .push_on_service(svc::MapTargetLayer::new(io::EitherIo::Right))

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -241,8 +241,8 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                             .push(http::BoxResponse::layer())
                             .push(http::BoxRequest::layer()),
                     )
-                    .check_new_service::<Http<tcp::Accept>, http::Request<_>>()
-                    .instrument(|a: &Http<tcp::Accept>| debug_span!("http", v = %a.version));
+                    .instrument(|_: &_| debug_span!("http"))
+                    .check_new_service::<Http<tcp::Accept>, http::Request<_>>();
 
                 // HTTP detection is **always** performed. If detection fails, then we
                 // use the `fallback` stack to process the connection by its original

--- a/linkerd/proxy/http/src/version.rs
+++ b/linkerd/proxy/http/src/version.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Version {
     Http1,
     H2,
@@ -21,12 +21,11 @@ impl std::convert::TryFrom<http::Version> for Version {
     }
 }
 
-// A convenience for tracing contexts.
-impl std::fmt::Display for Version {
+impl std::fmt::Debug for Version {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Http1 => write!(f, "1.x"),
-            Self::H2 => write!(f, "h2"),
+            Self::Http1 => write!(f, "HTTP/1"),
+            Self::H2 => write!(f, "HTTP/2"),
         }
     }
 }


### PR DESCRIPTION
The HTTP error responder already knows whether a request is considered HTTP/1, HTTP/2, or gRPC.

This change updates these log messages to include the relevant protocol information for each failed request.

Furthermore, this change updates the `http::Version` enum to implement `Debug` with full HTTP version strings like "HTTP/1" and "HTTP/2". We then remove the version for debug spans, as it's needlessly verbose for most uses. When debugging, we can identify the version based on specific events in a span. It need not exist on every event on the span.