### PR TITLE
cache discovery based on the discovered target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,8 +851,10 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-test",
  "tonic",
  "tower",
+ "tower-test",
  "tracing",
 ]
 

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -78,3 +78,6 @@ linkerd-system = { path = "../../system" }
 
 [dev-dependencies]
 quickcheck = { version = "1", default-features = false }
+tower-test = "0.4"
+tokio = { version = "1", features = ["time"] }
+tokio-test = "0.4"

--- a/linkerd/app/core/src/discover.rs
+++ b/linkerd/app/core/src/discover.rs
@@ -1,0 +1,125 @@
+use crate::{
+    svc::{self, ServiceExt},
+    Error,
+};
+use futures::{future, prelude::*};
+use std::{
+    fmt,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// A thunked `MakeService<()>` implementation which, when constructed with a
+/// target, performs a discovery resolution for that target and then produces
+/// new `Service`s by cloning the discovered service.
+#[derive(Debug)]
+pub struct Discover<T, D, S> {
+    state: State<T, D, S>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewDiscover<D> {
+    discover: D,
+}
+
+// === impl NewDiscover ===
+
+impl<D> NewDiscover<D> {
+    pub fn layer() -> impl svc::Layer<D, Service = Self> + Clone {
+        svc::layer::mk(|discover| Self { discover })
+    }
+}
+
+impl<T, D> svc::NewService<T> for NewDiscover<D>
+where
+    D: svc::Service<T, Error = Error> + Clone,
+{
+    type Service = Discover<T, D, D::Response>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        Discover::new(self.discover.clone(), target)
+    }
+}
+// === impl Discover ===
+
+impl<T, D, S> Discover<T, D, S> {
+    pub fn new(discover: D, target: T) -> Self {
+        Self {
+            state: State::NotDiscovered(Some((discover, target))),
+        }
+    }
+}
+
+enum State<T, D, S> {
+    NotDiscovered(Option<(D, T)>),
+    Discovering(Pin<Box<dyn Future<Output = Result<S, Error>> + Send + 'static>>),
+    Discovered(S),
+}
+
+impl<T, D, S: Clone> svc::Service<()> for Discover<T, D, S>
+where
+    D: svc::Service<T, Response = S, Error = Error> + Send + 'static,
+    D::Future: Send + 'static,
+    T: Send + 'static,
+{
+    type Response = S;
+    type Error = Error;
+    type Future = future::Ready<Result<S, Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        loop {
+            match self.state {
+                // Discovery for `target` has not yet been started.
+                State::NotDiscovered(ref mut inner) => {
+                    let (svc, target) =
+                        inner.take().expect("discovery should not be started twice");
+                    self.state = State::Discovering(Box::pin(svc.oneshot(target)));
+                }
+                // Waiting for discovery to complete for `target`.
+                State::Discovering(ref mut f) => match futures::ready!(f.poll_unpin(cx)) {
+                    Ok(s) => {
+                        self.state = State::Discovered(s);
+                        return Poll::Ready(Ok(()));
+                    }
+                    Err(e) => return Poll::Ready(Err(e)),
+                },
+                // We have a service! We're now ready to clone this service.
+                State::Discovered(_) => return Poll::Ready(Ok(())),
+            }
+        }
+    }
+
+    fn call(&mut self, _nothing: ()) -> Self::Future {
+        match self.state {
+            State::Discovered(ref s) => future::ready(Ok(s.clone())),
+            _ => panic!("polled before ready"),
+        }
+    }
+}
+
+impl<T, D, S> fmt::Debug for State<T, D, S>
+where
+    T: fmt::Debug,
+    D: fmt::Debug,
+    S: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Discovered(s) => f.debug_tuple("Discovered").field(s).finish(),
+            Self::Discovering(_) => f
+                .debug_tuple("Discovering")
+                .field(&format_args!("..."))
+                .finish(),
+            Self::NotDiscovered(Some((disco, target))) => f
+                .debug_tuple("NotDiscovered")
+                .field(disco)
+                .field(target)
+                .finish(),
+            Self::NotDiscovered(None) => f
+                .debug_tuple("NotDiscovered")
+                .field(&format_args!("None"))
+                .finish(),
+        }
+    }
+}

--- a/linkerd/app/core/src/discover.rs
+++ b/linkerd/app/core/src/discover.rs
@@ -84,7 +84,7 @@ where
                     }
                     Err(e) => return Poll::Ready(Err(e)),
                 },
-                // We have a service! We're now ready to clone this service.
+                // We have a service! We're now ready to clone this service
                 State::Discovered(_) => return Poll::Ready(Ok(())),
             }
         }

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -35,6 +35,7 @@ mod addr_match;
 pub mod classify;
 pub mod config;
 pub mod control;
+pub mod discover;
 pub mod dns;
 pub mod errors;
 pub mod http_tracing;

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -70,7 +70,6 @@ where
     O::Future: Send + Unpin + 'static,
     P: profiles::GetProfile + Clone + Send + Sync + Unpin + 'static,
     P::Future: Send + 'static,
-    P::Error: Send,
     R: Clone + Send + Sync + Unpin + 'static,
     R: Resolve<outbound::tcp::Concrete, Endpoint = Metadata, Error = Error>,
     <R as Resolve<outbound::tcp::Concrete>>::Resolution: Send,

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -92,7 +92,6 @@ impl<C> Inbound<C> {
         T: Clone + Send + Unpin + 'static,
         P: profiles::GetProfile + Clone + Send + Sync + Unpin + 'static,
         P::Future: Send,
-        P::Error: Send,
         C: svc::MakeConnection<Http> + Clone + Send + Sync + Unpin + 'static,
         C::Connection: Send + Unpin,
         C::Metadata: Send,

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -44,7 +44,6 @@ impl Inbound<()> {
         GSvc::Error: Into<Error>,
         GSvc::Future: Send,
         P: profiles::GetProfile + Clone + Send + Sync + Unpin + 'static,
-        P::Error: Send,
         P::Future: Send,
     {
         let shutdown = self.runtime.drain.clone().signaled();

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -1,6 +1,6 @@
 use crate::Outbound;
 use linkerd_app_core::{
-    discover, profiles,
+    profiles,
     svc::{self, stack::Param},
     Error, Infallible,
 };
@@ -27,24 +27,11 @@ impl<N> Outbound<N> {
     {
         self.map_stack(|config, _, stk| {
             let allow = config.allow_discovery.clone();
-            let profiles = svc::stack(profiles.into_service())
-                .push(svc::MapErr::layer_boxed())
-                .check_service::<profiles::LookupAddr>();
-            let discovery = profiles
-                .push(discover::NewDiscover::layer())
-                .check_new_service::<profiles::LookupAddr, ()>()
-                .push(svc::NewQueue::layer_fixed(config.tcp_connection_buffer))
-                .check_new_service::<profiles::LookupAddr, ()>()
-                .push_idle_cache(config.discovery_idle_timeout)
-                .check_new_service::<profiles::LookupAddr, ()>()
-                .push(svc::Unthunk::layer::<profiles::LookupAddr>())
-                .check_service::<profiles::LookupAddr>();
-
             stk.clone()
                 .check_new_service::<(Option<profiles::Receiver>, T), Req>()
                 .lift_new_with_target()
                 .check_new_new_service::<T, Option<profiles::Receiver>, Req>()
-                .push(profiles::Discover::layer(discovery))
+                .push(profiles::Discover::layer(profiles))
                 .check_new::<T>()
                 .check_new_service::<T, Req>()
                 .push_switch(

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -24,7 +24,6 @@ impl<N> Outbound<N> {
         NSvc::Future: Send,
         P: profiles::GetProfile + Clone + Send + Sync + 'static,
         P::Future: Send,
-        P::Error: Send,
     {
         self.map_stack(|config, _, stk| {
             let allow = config.allow_discovery.clone();

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -86,7 +86,6 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
         T: Param<OrigDstAddr> + Clone + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
         P: profiles::GetProfile + Clone + Send + Sync + Unpin + 'static,
-        P::Error: Send,
         P::Future: Send,
         R: Clone + Send + Sync + 'static,
         R: Resolve<http::Concrete, Endpoint = Metadata, Error = Error>,

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -171,7 +171,6 @@ impl Outbound<()> {
         <R as Resolve<http::Concrete>>::Future: Send + Unpin,
         P: profiles::GetProfile + Clone + Send + Sync + Unpin + 'static,
         P::Future: Send,
-        P::Error: Send,
     {
         if self.config.ingress_mode {
             info!("Outbound routing in ingress-mode");
@@ -199,7 +198,6 @@ impl Outbound<()> {
         <R as Resolve<http::Concrete>>::Future: Send + Unpin,
         P: profiles::GetProfile + Clone + Send + Sync + Unpin + 'static,
         P::Future: Send,
-        P::Error: Send,
     {
         let logical = self.to_tcp_connect().push_logical(resolve);
         let forward = self.to_tcp_connect().push_forward();
@@ -230,7 +228,6 @@ impl Outbound<()> {
         <R as Resolve<http::Concrete>>::Future: Send + Unpin,
         P: profiles::GetProfile + Clone + Send + Sync + Unpin + 'static,
         P::Future: Send,
-        P::Error: Send,
     {
         // The fallback stack is the same thing as the normal proxy stack, but
         // it doesn't include TCP metrics, since they are already instrumented

--- a/linkerd/service-profiles/src/default.rs
+++ b/linkerd/service-profiles/src/default.rs
@@ -23,19 +23,17 @@ type RspFuture<F, E> = future::OrElse<
 impl<S> tower::Service<LookupAddr> for RecoverDefault<S>
 where
     S: GetProfile,
-    S::Error: Into<Error>,
 {
     type Response = Option<Receiver>;
     type Error = Error;
-    type Future = RspFuture<S::Future, S::Error>;
+    type Future = RspFuture<S::Future, Error>;
 
     fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Error>> {
         Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, dst: LookupAddr) -> Self::Future {
-        self.0.get_profile(dst).or_else(|e| {
-            let error: Error = e.into();
+        self.0.get_profile(dst).or_else(|error| {
             if crate::DiscoveryRejected::is_rejected(error.as_ref()) {
                 debug!(error, "Handling rejected discovery");
                 return future::ok(None);

--- a/linkerd/service-profiles/src/discover.rs
+++ b/linkerd/service-profiles/src/discover.rs
@@ -2,6 +2,7 @@ use crate::LookupAddr;
 
 use super::{default::RecoverDefault, GetProfile, Receiver};
 use futures::prelude::*;
+use linkerd_error::Error;
 use linkerd_stack::{layer, FutureService, NewService, Param};
 use std::{future::Future, pin::Pin};
 
@@ -26,12 +27,11 @@ where
     T: Clone + Send + 'static,
     G: GetProfile + Clone,
     G::Future: Send + 'static,
-    G::Error: Send,
     N: NewService<T, Service = M> + Send + 'static,
     M: NewService<Option<Receiver>> + Send + 'static,
 {
     type Service = FutureService<
-        Pin<Box<dyn Future<Output = Result<M::Service, G::Error>> + Send + 'static>>,
+        Pin<Box<dyn Future<Output = Result<M::Service, Error>> + Send + 'static>>,
         M::Service,
     >;
 

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -41,7 +41,7 @@ pub use self::{
     filter::{Filter, FilterLayer, Predicate},
     lazy::{Lazy, NewLazy},
     loadshed::{LoadShed, LoadShedError},
-    make_thunk::MakeThunk,
+    make_thunk::{MakeThunk, Unthunk},
     map_err::{MapErr, NewMapErr, WrapErr},
     map_target::{MapTarget, MapTargetLayer, MapTargetService},
     monitor::{Monitor, MonitorError, MonitorNewService, MonitorService, NewMonitor},

--- a/linkerd/stack/src/make_thunk.rs
+++ b/linkerd/stack/src/make_thunk.rs
@@ -18,10 +18,20 @@ pub struct Thunk<S, T> {
     target: T,
 }
 
+/// Un-thunks a `NewService<T>` that produces thunked `Service<()>`s back into a
+/// `Service<T>`.
+///
+/// This type's `Service<T>` implementation calls `N::new_service` with a `T`,
+/// returning a `Service<()>`, and oneshots that service in its `call` method.
+///
+/// Because the produced service thunk is oneshotted, the `Unthunk` service is
+/// always ready.
 #[derive(Clone, Debug)]
 pub struct Unthunk<N> {
     new: N,
 }
+
+// === impl MakeThunk ===
 
 impl<S> MakeThunk<S> {
     pub fn new(inner: S) -> Self {
@@ -52,6 +62,8 @@ impl<S: Clone, T> tower::Service<T> for MakeThunk<S> {
         future::ok(Thunk { inner, target })
     }
 }
+
+// === impl Thunk ===
 
 impl<S, T> tower::Service<()> for Thunk<S, T>
 where

--- a/linkerd/stack/src/make_thunk.rs
+++ b/linkerd/stack/src/make_thunk.rs
@@ -1,6 +1,7 @@
 use futures::future;
 use linkerd_error::Infallible;
 use std::task::{Context, Poll};
+use tower::ServiceExt;
 
 /// Wraps a `Service<T>` as a `Service<()>`.
 ///
@@ -15,6 +16,11 @@ pub struct MakeThunk<S> {
 pub struct Thunk<S, T> {
     inner: S,
     target: T,
+}
+
+#[derive(Clone, Debug)]
+pub struct Unthunk<N> {
+    new: N,
 }
 
 impl<S> MakeThunk<S> {
@@ -62,5 +68,37 @@ where
 
     fn call(&mut self, (): ()) -> S::Future {
         self.inner.call(self.target.clone())
+    }
+}
+
+// === impl Unthunk ===
+
+impl<N> Unthunk<N> {
+    pub fn layer<T>() -> impl crate::layer::Layer<N, Service = Self> + Clone
+    where
+        N: crate::NewService<T> + Clone,
+        N::Service: tower::Service<()>,
+        Self: tower::Service<T>,
+    {
+        crate::layer::mk(|new| Self { new })
+    }
+}
+
+impl<N, T> tower::Service<T> for Unthunk<N>
+where
+    N: crate::NewService<T>,
+    N::Service: tower::Service<()>,
+{
+    type Response = <N::Service as tower::Service<()>>::Response;
+    type Error = <N::Service as tower::Service<()>>::Error;
+    type Future = tower::util::Oneshot<N::Service, ()>;
+
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: T) -> Self::Future {
+        let svc = self.new.new_service(req);
+        svc.oneshot(())
     }
 }


### PR DESCRIPTION
Currently, caching of discovery watches is at the level of the
discovered `Service`s. These caches are keyed by the stack target that
constructed that `Service`. In some cases, tese stack targets contain
more data than just the destination address that a profile is discovered
for, such as in the gateway stack, where targets also include client
info. This means that we may perform duplicate discovery lookups for the
same destination address when other parts of the key differ, and these
separate lookups may be evicted separately as well.

Instead, we should have a single cache for all watches for a particular
type of discovery (e.g. profiles, client policies, server policies,
etc). These watches should only be subject to idle eviction from the
cache only when no service is using that watch.

This branch introduces a new `Stack::push_discovery_cache` function
which, when given a `Service` stack representing a discovery client,
returns a new `Service` which caches the discovery results from that
client service. The existing ServiceProfile client has been wrapped in a
discovery caching stack. The same stack functions may be useful for
future client and server policy watches as well.