### PR TITLE
core: Rename Stack utilities for clarity

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -100,7 +100,7 @@ impl Config {
             .push(Rescue::layer())
             .push_on_service(http::BoxResponse::layer())
             .push(http::NewServeHttp::layer(Default::default(), drain.clone()))
-            .push_request_filter(
+            .push_filter(
                 |(http, tcp): (
                     Result<Option<http::Version>, detect::DetectTimeoutError<_>>,
                     Tcp,

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -111,7 +111,7 @@ impl<S> Stack<S> {
         self.push(stack::MapTargetLayer::new(map_target))
     }
 
-    pub fn push_request_filter<F: Clone>(self, filter: F) -> Stack<stack::Filter<S, F>> {
+    pub fn push_filter<F: Clone>(self, filter: F) -> Stack<stack::Filter<S, F>> {
         self.push(stack::Filter::<S, F>::layer(filter))
     }
 
@@ -200,7 +200,7 @@ impl<S> Stack<S> {
         self.push(http::insert::NewResponseInsert::layer())
     }
 
-    pub fn push_idle_cache<T>(self, idle: Duration) -> Stack<idle_cache::NewIdleCached<T, S>>
+    pub fn push_new_idle_cached<T>(self, idle: Duration) -> Stack<idle_cache::NewIdleCached<T, S>>
     where
         T: Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
         S: NewService<T> + 'static,

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -166,7 +166,7 @@ where
             .push(svc::NewQueue::layer_via(
                 outbound.config().tcp_connection_queue,
             ))
-            .push_idle_cache(outbound.config().discovery_idle_timeout)
+            .push_new_idle_cached(outbound.config().discovery_idle_timeout)
             .check_new_service::<NameAddr, I>()
     };
 
@@ -218,7 +218,7 @@ where
                 ),
             )
             .push(svc::NewQueue::layer_via(inbound_config.http_request_queue))
-            .push_idle_cache(inbound_config.discovery_idle_timeout)
+            .push_new_idle_cached(inbound_config.discovery_idle_timeout)
             .push_on_service(
                 svc::layers()
                     .push(http::Retain::layer())

--- a/linkerd/app/inbound/src/accept.rs
+++ b/linkerd/app/inbound/src/accept.rs
@@ -67,7 +67,7 @@ impl<N> Inbound<N> {
                     direct,
                 )
                 .check_new_service::<T, I>()
-                .push_request_filter(cfg.allowed_ips.clone())
+                .push_filter(cfg.allowed_ips.clone())
                 .push(rt.metrics.tcp_errors.to_layer())
                 .check_new_service::<T, I>()
                 .instrument(|t: &T| {

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -215,7 +215,7 @@ impl<N> Inbound<N> {
                 // Use ALPN to determine whether a transport header should be read.
                 .push(NewTransportHeaderServer::layer(detect_timeout))
                 .check_new_service::<ClientInfo, _>()
-                .push_request_filter(|client: ClientInfo| -> Result<_> {
+                .push_filter(|client: ClientInfo| -> Result<_> {
                     if client.header_negotiated() {
                         Ok(client)
                     } else {
@@ -224,7 +224,7 @@ impl<N> Inbound<N> {
                 })
                 // Build a ClientInfo target for each accepted connection. Refuse the
                 // connection if it doesn't include an mTLS identity.
-                .push_request_filter(ClientInfo::try_from)
+                .push_filter(ClientInfo::try_from)
                 .push(svc::ArcNewService::layer())
                 .push(tls::NewDetectTls::<identity::Server, _, _>::layer(
                     TlsParams {

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -233,7 +233,7 @@ impl<C> Inbound<C> {
                         .push(rt.metrics.proxy.stack.layer(stack_labels("http", "logical")))
                 )
                 .push(svc::NewQueue::layer_via(config.http_request_queue))
-                .push_idle_cache(config.discovery_idle_timeout)
+                .push_new_idle_cached(config.discovery_idle_timeout)
                 .push_on_service(
                     svc::layers()
                         .push(http::Retain::layer())

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -200,7 +200,7 @@ impl Inbound<()> {
                 // Limits the time we wait for a connection to be established.
                 .push_connect_timeout(*timeout)
                 // Prevent connections that would target the inbound proxy port from looping.
-                .push_request_filter(move |t: T| {
+                .push_filter(move |t: T| {
                     let addr = t.param();
                     let port = addr.port();
                     if port == proxy_port {

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -81,7 +81,7 @@ impl<N> Outbound<N> {
                     .layer(crate::stack_labels("tcp", "discover")),
             )
             .push(svc::NewQueue::layer_via(config.tcp_connection_queue))
-            .push_idle_cache(config.discovery_idle_timeout)
+            .push_new_idle_cached(config.discovery_idle_timeout)
             .push(svc::ArcNewService::layer())
             .check_new_service::<T, Req>()
         })

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -119,7 +119,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                     // If a profile was discovered, use it to build a logical stack.
                     // Otherwise, the override header was present but no profile
                     // information could be discovered, so fail the request.
-                    .push_request_filter(
+                    .push_filter(
                         |(profile, http): (Option<profiles::Receiver>, Http<NameAddr>)| {
                             if let Some(profile) = profile {
                                 if let Some(logical_addr) = profile.logical_addr() {
@@ -138,7 +138,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                     .lift_new_with_target()
                     .push_new_cached_discover(profiles.into_service(), config.discovery_idle_timeout)
                     .check_new_service::<Http<NameAddr>, http::Request<_>>()
-                    .push_request_filter(move |h: Http<NameAddr>| {
+                    .push_filter(move |h: Http<NameAddr>| {
                         // Lookup the profile if the override header was set and it
                         // is in the configured profile domains. Otherwise, profile
                         // discovery is skipped.
@@ -170,7 +170,7 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
                     .push(svc::NewQueue::layer_via(*http_request_queue))
                     // Caches the profile-based stack so that it can be reused across
                     // multiple requests to the same canonical destination.
-                    .push_idle_cache(*discovery_idle_timeout)
+                    .push_new_idle_cached(*discovery_idle_timeout)
                     .push_on_service(
                         svc::layers()
                             .push(http::strip_header::request::layer(DST_OVERRIDE_HEADER))

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -154,7 +154,7 @@ impl<C> Outbound<C> {
             // The detect stack doesn't cache its inner service, so we need a
             // process-global cache of logical HTTP stacks.
             .map_stack(|config, _, stk| {
-                stk.push_idle_cache(config.discovery_idle_timeout)
+                stk.push_new_idle_cached(config.discovery_idle_timeout)
                     .push_on_service(
                         svc::layers()
                             .push(http::Retain::layer())
@@ -169,7 +169,7 @@ impl<C> Outbound<C> {
             .push_tcp_logical()
             // The detect stack doesn't cache its inner service, so we need a
             // process-global cache of logical TCP stacks.
-            .map_stack(|config, _, stk| stk.push_idle_cache(config.discovery_idle_timeout));
+            .map_stack(|config, _, stk| stk.push_new_idle_cached(config.discovery_idle_timeout));
 
         opaque.push_detect_http(http).map_stack(|_, _, stk| {
             stk.instrument(|l: &tcp::Logical| info_span!("logical",  svc = %l.logical_addr))

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -69,7 +69,7 @@ impl<N> Outbound<N> {
                 .push(metrics::NewServer::layer(
                     rt.metrics.proxy.transport.clone(),
                 ))
-                .push_request_filter(|t: T| Accept::try_from(t.param()))
+                .push_filter(|t: T| Accept::try_from(t.param()))
                 .push(rt.metrics.tcp_errors.to_layer())
                 .instrument(mk_span)
                 .check_new_service::<T, I>()


### PR DESCRIPTION
`Stack::push_request_filter` may apply to either `Service` or `NewService` stacks. The use of "request" makes it sound like it only applies to services. This change renames it to `Stack::push_filter`.

`Stack::push_idle_cache` is renamed to `Stack::push_new_idle_cached` to reflect that the stack is a `NewService`.