### PR TITLE
rename `OpaqueTransport` to `TaggedTransport`

### DIFF
--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -113,11 +113,11 @@ impl<P> svc::Param<Option<http::detect::Skip>> for Endpoint<P> {
     }
 }
 
-impl<P> svc::Param<Option<tcp::opaque_transport::PortOverride>> for Endpoint<P> {
-    fn param(&self) -> Option<tcp::opaque_transport::PortOverride> {
+impl<P> svc::Param<Option<tcp::tagged_transport::PortOverride>> for Endpoint<P> {
+    fn param(&self) -> Option<tcp::tagged_transport::PortOverride> {
         self.metadata
             .opaque_transport_port()
-            .map(tcp::opaque_transport::PortOverride)
+            .map(tcp::tagged_transport::PortOverride)
     }
 }
 

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -1,5 +1,5 @@
 use super::{NewRequireIdentity, NewStripProxyError, ProxyConnectionClose};
-use crate::{tcp::opaque_transport, Outbound};
+use crate::{tcp::tagged_transport, Outbound};
 use linkerd_app_core::{
     classify, config, errors, http_tracing, metrics,
     proxy::{api_resolve::ProtocolHint, http, tap},
@@ -197,11 +197,11 @@ impl<T: svc::Param<tls::ConditionalClientTls>> svc::Param<tls::ConditionalClient
     }
 }
 
-impl<T: svc::Param<Option<opaque_transport::PortOverride>>>
-    svc::Param<Option<opaque_transport::PortOverride>> for Connect<T>
+impl<T: svc::Param<Option<tagged_transport::PortOverride>>>
+    svc::Param<Option<tagged_transport::PortOverride>> for Connect<T>
 {
     #[inline]
-    fn param(&self) -> Option<opaque_transport::PortOverride> {
+    fn param(&self) -> Option<tagged_transport::PortOverride> {
         self.inner.param()
     }
 }

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -9,7 +9,7 @@ use linkerd_app_core::{
 pub mod concrete;
 pub mod connect;
 pub mod logical;
-pub mod opaque_transport;
+pub mod tagged_transport;
 
 pub use self::connect::Connect;
 pub use linkerd_app_core::proxy::tcp::Forward;

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -1,4 +1,4 @@
-use super::opaque_transport::{self, OpaqueTransport};
+use super::tagged_transport::{self, TaggedTransport};
 use crate::{ConnectMeta, Outbound};
 use futures::future;
 use linkerd_app_core::{
@@ -54,7 +54,7 @@ impl<C> Outbound<C> {
     where
         T: svc::Param<Remote<ServerAddr>>
             + svc::Param<tls::ConditionalClientTls>
-            + svc::Param<Option<opaque_transport::PortOverride>>
+            + svc::Param<Option<tagged_transport::PortOverride>>
             + svc::Param<Option<http::AuthorityOverride>>
             + svc::Param<Option<SessionProtocol>>
             + svc::Param<transport::labels::Key>,
@@ -73,7 +73,7 @@ impl<C> Outbound<C> {
                 .push(tls::Client::layer(rt.identity.clone()))
                 // Encodes a transport header if the established connection is TLS'd and
                 // ALPN negotiation indicates support.
-                .push(OpaqueTransport::layer())
+                .push(TaggedTransport::layer())
                 // Limits the time we wait for a connection to be established.
                 .push_connect_timeout(config.proxy.connect.timeout)
                 .push(svc::stack::BoxFuture::layer())


### PR DESCRIPTION
Depends on #2209 

The "opaque transport" feature is somewhat confusingly named. This
feature refers to a system where the outbound proxy makes a direct
connection to the inbound proxy's inbound port, and sends a
`TransportHeader` containing the actual target port, along with an
optional authority and protocol hint. This feature can be used to
transport actually opaque protocols, but it is *also* used by
multicluster gateways to transport HTTP traffic non-opaquely. Therefore,
the name "opaque transport" is somewhat confusing here.

This branch renames the "opaque transport" middleware to "tagged
transport", which is (hopefully) somewhat clearer, as it no longer
suggests that this form of tagging inherently means that no
protocol-aware behavior is performed.