### PR TITLE
Simplify the `Resolve` trait alias

### DIFF
--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -89,13 +89,8 @@ where
     O::Connection: Send + Unpin,
     O::Future: Send + Unpin + 'static,
     P: profiles::GetProfile<Error = Error>,
-    R: Clone + Send + Sync + Unpin + 'static,
     R: Resolve<outbound::tcp::Concrete, Endpoint = Metadata, Error = Error>,
-    <R as Resolve<outbound::tcp::Concrete>>::Resolution: Send,
-    <R as Resolve<outbound::tcp::Concrete>>::Future: Send + Unpin,
     R: Resolve<outbound::http::Concrete, Endpoint = Metadata, Error = Error>,
-    <R as Resolve<outbound::http::Concrete>>::Resolution: Send,
-    <R as Resolve<outbound::http::Concrete>>::Future: Send + Unpin,
 {
     let local_id = identity::LocalId(inbound.identity().name().clone());
 
@@ -215,10 +210,7 @@ where
     O: svc::MakeConnection<outbound::tcp::Connect, Metadata = Local<ClientAddr>, Error = io::Error>,
     O::Connection: Send + Unpin,
     O::Future: Send + Unpin + 'static,
-    R: Clone + Send + Sync + Unpin + 'static,
     R: Resolve<outbound::http::Concrete, Endpoint = Metadata, Error = Error>,
-    <R as Resolve<outbound::http::Concrete>>::Resolution: Send,
-    <R as Resolve<outbound::http::Concrete>>::Future: Send + Unpin,
 {
     let endpoint = outbound.push_tcp_endpoint().push_http_endpoint();
     endpoint
@@ -250,10 +242,7 @@ where
     O: svc::MakeConnection<outbound::tcp::Connect, Metadata = Local<ClientAddr>, Error = io::Error>,
     O::Connection: Send + Unpin,
     O::Future: Send + Unpin + 'static,
-    R: Clone + Send + Sync + Unpin + 'static,
     R: Resolve<outbound::tcp::Concrete, Endpoint = Metadata, Error = Error>,
-    <R as Resolve<outbound::tcp::Concrete>>::Resolution: Send,
-    <R as Resolve<outbound::tcp::Concrete>>::Future: Send + Unpin,
 {
     let logical = outbound
         .clone()

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -50,10 +50,7 @@ impl<N> Outbound<N> {
             + 'static,
         NSvc::Error: Into<Error>,
         NSvc::Future: Send,
-        R: Clone + Send + Sync + 'static,
         R: Resolve<Concrete, Error = Error, Endpoint = Metadata>,
-        R::Resolution: Send,
-        R::Future: Send + Unpin,
     {
         self.map_stack(|config, rt, endpoint| {
             endpoint

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -88,8 +88,6 @@ impl Outbound<svc::ArcNewHttp<http::Endpoint>> {
         P: profiles::GetProfile<Error = Error>,
         R: Clone + Send + Sync + 'static,
         R: Resolve<http::Concrete, Endpoint = Metadata, Error = Error>,
-        R::Resolution: Send,
-        R::Future: Send + Unpin,
         F: svc::NewService<tcp::Accept, Service = FSvc> + Clone + Send + Sync + 'static,
         FSvc: svc::Service<DetectIo<I>, Response = (), Error = Error> + Send + 'static,
         FSvc::Future: Send,

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -166,13 +166,8 @@ impl Outbound<()> {
         A: Param<Remote<ClientAddr>> + Param<OrigDstAddr> + Clone + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::Peek + io::PeerAddr,
         I: Debug + Unpin + Send + Sync + 'static,
-        R: Clone + Send + Sync + Unpin + 'static,
         R: Resolve<tcp::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<tcp::Concrete>>::Resolution: Send,
-        <R as Resolve<tcp::Concrete>>::Future: Send + Unpin,
         R: Resolve<http::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<http::Concrete>>::Resolution: Send,
-        <R as Resolve<http::Concrete>>::Future: Send + Unpin,
         P: profiles::GetProfile<Error = Error>,
     {
         if self.config.ingress_mode {
@@ -192,13 +187,8 @@ impl Outbound<()> {
         T: Param<OrigDstAddr> + Clone + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::Peek + io::PeerAddr,
         I: Debug + Unpin + Send + Sync + 'static,
-        R: Clone + Send + Sync + Unpin + 'static,
         R: Resolve<tcp::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<tcp::Concrete>>::Resolution: Send,
-        <R as Resolve<tcp::Concrete>>::Future: Send + Unpin,
         R: Resolve<http::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<http::Concrete>>::Resolution: Send,
-        <R as Resolve<http::Concrete>>::Future: Send + Unpin,
         P: profiles::GetProfile<Error = Error>,
     {
         let logical = self.to_tcp_connect().push_logical(resolve);
@@ -221,13 +211,8 @@ impl Outbound<()> {
         T: Param<OrigDstAddr> + Clone + Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + io::Peek + io::PeerAddr,
         I: Debug + Unpin + Send + Sync + 'static,
-        R: Clone + Send + Sync + Unpin + 'static,
         R: Resolve<tcp::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<tcp::Concrete>>::Resolution: Send,
-        <R as Resolve<tcp::Concrete>>::Future: Send + Unpin,
         R: Resolve<http::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<http::Concrete>>::Resolution: Send,
-        <R as Resolve<http::Concrete>>::Future: Send + Unpin,
         P: profiles::GetProfile<Error = Error>,
     {
         // The fallback stack is the same thing as the normal proxy stack, but

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -134,13 +134,8 @@ impl<C> Outbound<C> {
         C: svc::MakeConnection<tcp::Connect, Metadata = Local<ClientAddr>, Error = io::Error>,
         C::Connection: Send + Unpin,
         C::Future: Send + Unpin,
-        R: Clone + Send + Sync + Unpin + 'static,
         R: Resolve<tcp::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<tcp::Concrete>>::Resolution: Send,
-        <R as Resolve<tcp::Concrete>>::Future: Send + Unpin,
         R: Resolve<http::Concrete, Endpoint = Metadata, Error = Error>,
-        <R as Resolve<http::Concrete>>::Resolution: Send,
-        <R as Resolve<http::Concrete>>::Future: Send + Unpin,
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr,
         I: fmt::Debug + Send + Sync + Unpin + 'static,
     {

--- a/linkerd/app/outbound/src/tcp/concrete.rs
+++ b/linkerd/app/outbound/src/tcp/concrete.rs
@@ -48,10 +48,7 @@ impl<C> Outbound<C> {
         C::Future: Send,
         C: Send + Sync + 'static,
         I: io::AsyncRead + io::AsyncWrite + std::fmt::Debug + Send + Unpin + 'static,
-        R: Clone + Send + Sync + 'static,
-        R: Resolve<Concrete, Endpoint = Metadata, Error = Error> + Sync,
-        R::Resolution: Send,
-        R::Future: Send + Unpin,
+        R: Resolve<Concrete, Endpoint = Metadata, Error = Error>,
     {
         self.map_stack(|config, rt, connect| {
             let crate::Config {

--- a/linkerd/proxy/balance/src/discover.rs
+++ b/linkerd/proxy/balance/src/discover.rs
@@ -1,7 +1,7 @@
 use futures::prelude::*;
 use linkerd_proxy_core::Resolve;
 use linkerd_stack::NewService;
-use std::{fmt::Debug, net::SocketAddr};
+use std::net::SocketAddr;
 
 pub mod buffer;
 pub mod from_resolve;
@@ -19,10 +19,7 @@ pub(crate) fn spawn_new_from_resolve<T, R, M, N>(
 ) -> Buffer<N::Service>
 where
     T: Clone,
-    R: Resolve<T> + Clone,
-    R::Endpoint: Clone + Debug + Eq + Send + 'static,
-    R::Resolution: Send,
-    R::Future: Send + 'static,
+    R: Resolve<T>,
     M: NewService<T, Service = N>,
     N: NewService<(SocketAddr, R::Endpoint)> + Send + 'static,
     N::Service: Send,

--- a/linkerd/proxy/balance/src/lib.rs
+++ b/linkerd/proxy/balance/src/lib.rs
@@ -84,9 +84,6 @@ impl<C, T, Req, R, M, N, S> NewService<T> for NewBalancePeakEwma<C, Req, R, M>
 where
     T: Param<EwmaConfig> + Clone + Send,
     R: Resolve<T>,
-    R::Endpoint: Clone + Debug + Eq + Send + 'static,
-    R::Resolution: Send,
-    R::Future: Send + 'static,
     M: NewService<T, Service = N> + Clone,
     N: NewService<(SocketAddr, R::Endpoint), Service = S> + Send + 'static,
     S: Service<Req> + Send,

--- a/linkerd/proxy/core/src/resolve.rs
+++ b/linkerd/proxy/core/src/resolve.rs
@@ -1,6 +1,7 @@
 use futures::prelude::*;
 use linkerd_error::Error;
 use std::{
+    fmt::Debug,
     future::Future,
     net::SocketAddr,
     task::{Context, Poll},
@@ -8,11 +9,11 @@ use std::{
 use tower::util::Oneshot;
 
 /// Resolves `T`-typed names/addresses as an infinite stream of `Update<Self::Endpoint>`.
-pub trait Resolve<T>: Clone {
-    type Endpoint;
+pub trait Resolve<T>: Clone + Send + Sync + Unpin + 'static {
+    type Endpoint: Clone + Debug + Eq + Send + 'static;
     type Error: Into<Error>;
-    type Resolution: Stream<Item = Result<Update<Self::Endpoint>, Self::Error>>;
-    type Future: Future<Output = Result<Self::Resolution, Self::Error>>;
+    type Resolution: Stream<Item = Result<Update<Self::Endpoint>, Self::Error>> + Send + 'static;
+    type Future: Future<Output = Result<Self::Resolution, Self::Error>> + Send + Unpin + 'static;
 
     fn resolve(&self, target: T) -> Self::Future;
 
@@ -39,9 +40,13 @@ pub enum Update<T> {
 
 impl<S, T, R, E> Resolve<T> for S
 where
-    S: tower::Service<T, Response = R> + Clone,
+    T: Send + 'static,
+    S: tower::Service<T, Response = R> + Clone + Send + Sync + Unpin + 'static,
+    S::Response: Send + 'static,
     S::Error: Into<Error>,
-    R: Stream<Item = Result<Update<E>, S::Error>>,
+    S::Future: Send + Unpin + 'static,
+    R: Stream<Item = Result<Update<E>, S::Error>> + Send + 'static,
+    E: Clone + Debug + Eq + Send + 'static,
 {
     type Endpoint = E;
     type Error = S::Error;


### PR DESCRIPTION
`Resolve` trait references typically include many additional type constraints. This change moves this boilerplate into the trait alias so it need not be repeated.