### PR TITLE
downgrade `miniz_oxide` from yanked 0.6.4 to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,9 +1842,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e212582ede878b109755efd0773a4f0f4ec851584cf0aefbeb4d9ecc114822"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]


### PR DESCRIPTION
Versions 0.6.4 and 0.6.3 of the `miniz_oxide` crate have been yanked from crates.io, due to an accidental MSRV violation (see Frommi/miniz_oxide#135). `miniz_oxide` is a dependency of `flate2`, which is used by `linkerd-app-integration` for testing gzip metrics compression.

Because the lockfile currently contains a yanked version of `miniz_oxide`, our `cargo deny` checks are failing on CI. This PR downgrades the `miniz_oxide` dependency to 0.6.2, which is not yanked. This should fix CI.