### PR TITLE
Use a cascading stack with protocol detection

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -142,7 +142,7 @@ impl Config {
                     }
                 },
             )
-            .push(svc::ArcNewService::layer())
+            .lift_new_with_target()
             .push(detect::NewDetectService::layer(svc::stack::CloneParam::from(
                 detect::Config::<http::DetectHttp>::from_timeout(DETECT_TIMEOUT),
             )))
@@ -155,7 +155,6 @@ impl Config {
                     policy: policy.clone(),
                 }
             })
-            .push(svc::ArcNewService::layer())
             .push(tls::NewDetectTls::<identity::Server, _, _>::layer(TlsParams {
                 identity,
             }))

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -1,13 +1,8 @@
 // Possibly unused, but useful during development.
 
-pub use crate::proxy::http;
-use crate::{disco_cache::NewCachedDiscover, idle_cache, Error};
+use crate::{disco_cache::NewCachedDiscover, Error};
 use linkerd_error::Recover;
 use linkerd_exp_backoff::{ExponentialBackoff, ExponentialBackoffStream};
-pub use linkerd_reconnect::NewReconnect;
-pub use linkerd_router::{self as router, NewOneshotRoute};
-pub use linkerd_stack::{self as stack, *};
-pub use linkerd_stack_tracing::{GetSpan, NewInstrument, NewInstrumentLayer};
 use std::{
     fmt,
     hash::Hash,
@@ -22,6 +17,13 @@ pub use tower::{
     layer::Layer, limit::GlobalConcurrencyLimitLayer as ConcurrencyLimitLayer, service_fn as mk,
     spawn_ready::SpawnReady, Service, ServiceExt,
 };
+
+pub use crate::proxy::http;
+pub use linkerd_idle_cache as idle_cache;
+pub use linkerd_reconnect::NewReconnect;
+pub use linkerd_router::{self as router, NewOneshotRoute};
+pub use linkerd_stack::{self as stack, *};
+pub use linkerd_stack_tracing::{GetSpan, NewInstrument, NewInstrumentLayer};
 
 #[derive(Copy, Clone, Debug)]
 pub struct AlwaysReconnect(ExponentialBackoff);

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -250,6 +250,7 @@ impl<N> Inbound<N> {
                     },
                     forward.into_inner(),
                 )
+                .lift_new_with_target()
                 .push(detect::NewDetectService::layer(ConfigureHttpDetect));
 
             http.push_on_service(svc::MapTargetLayer::new(io::BoxedIo::new))

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -22,7 +22,7 @@ pub mod strip_header;
 pub mod timeout;
 pub mod trace;
 pub mod upgrade;
-mod version;
+pub mod version;
 
 pub use self::{
     balance::NewBalancePeakEwma,
@@ -33,7 +33,7 @@ pub use self::{
     normalize_uri::{MarkAbsoluteForm, NewNormalizeUri},
     override_authority::{AuthorityOverride, NewOverrideAuthority},
     retain::Retain,
-    server::NewServeHttp,
+    server::{NewServeHttp, ServeHttp},
     strip_header::StripHeader,
     timeout::{NewTimeout, ResponseTimeout, ResponseTimeoutError},
     version::Version,


### PR DESCRIPTION
The protocol detection stack does not easily allow for its inner stack to hold any per-target state because it commingles the (async) detection result with the original target.

This change updates the detection module to use a cascading inner stack so that the caller may determine how to use these targets. All implementations lift the original targets to preserve the prior behavior.