### PR TITLE
update `linkerd2-proxy-api` to v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9461e1bf61263ffa493117f2177c15a470b4b66f6b58c74e548401293f9ea639"
+checksum = "3bcbd793b73b504f16514e3aa376b41d00884e12e62ba92505eab3c4258671a0"
 dependencies = [
  "h2",
  "http",

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -18,7 +18,7 @@ linkerd-http-access-log = { path = "../../http-access-log" }
 linkerd-idle-cache = { path = "../../idle-cache" }
 linkerd-server-policy = { path = "../../server-policy", features = ["proto"] }
 linkerd-tonic-watch = { path = "../../tonic-watch" }
-linkerd2-proxy-api = { version = "0.7", features = ["inbound"] }
+linkerd2-proxy-api = { version = "0.8", features = ["inbound"] }
 once_cell = "1"
 parking_lot = "0.12"
 thiserror = "1"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -33,7 +33,7 @@ hyper = { version = "0.14", features = [
 linkerd-app = { path = "..", features = ["allow-loopback"] }
 linkerd-app-core = { path = "../core" }
 linkerd-metrics = { path = "../../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { version = "0.7", features = [
+linkerd2-proxy-api = { version = "0.8", features = [
     "destination",
     "arbitrary",
 ] }

--- a/linkerd/http-route/Cargo.toml
+++ b/linkerd/http-route/Cargo.toml
@@ -17,7 +17,7 @@ tracing = "0.1"
 url = "2"
 
 [dependencies.linkerd2-proxy-api]
-version = "0.7"
+version = "0.8"
 features = ["http-route", "grpc-route"]
 optional = true
 

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -14,7 +14,7 @@ async-stream = "0.3"
 futures = { version = "0.3", default-features = false }
 linkerd-addr = { path = "../../addr" }
 linkerd-error = { path = "../../error" }
-linkerd2-proxy-api = { version = "0.7", features = ["destination"] }
+linkerd2-proxy-api = { version = "0.8", features = ["destination"] }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }

--- a/linkerd/proxy/api-resolve/src/pb.rs
+++ b/linkerd/proxy/api-resolve/src/pb.rs
@@ -26,11 +26,14 @@ pub fn to_addr_meta(
     let mut proto_hint = ProtocolHint::Unknown;
     let mut opaque_transport_port = None;
     if let Some(hint) = pb.protocol_hint {
+        // the match will make sense later...
+        #[allow(clippy::collapsible_match, clippy::single_match)]
         if let Some(proto) = hint.protocol {
             match proto {
                 Protocol::H2(..) => {
                     proto_hint = ProtocolHint::Http2;
                 }
+                _ => {} // TODO(eliza): handle opaque protocol hints
             }
         }
 

--- a/linkerd/proxy/identity-client/Cargo.toml
+++ b/linkerd/proxy/identity-client/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { version = "0.7", features = ["identity"] }
+linkerd2-proxy-api = { version = "0.8", features = ["identity"] }
 linkerd-error = { path = "../../error" }
 linkerd-identity = { path = "../../identity" }
 linkerd-metrics = { path = "../../metrics" }

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -11,7 +11,7 @@ http = "0.2"
 hyper = { version = "0.14", features = ["http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.7"
-linkerd2-proxy-api = { version = "0.7", features = ["tap"] }
+linkerd2-proxy-api = { version = "0.8", features = ["tap"] }
 linkerd-conditional = { path = "../../conditional" }
 linkerd-error = { path = "../../error" }
 linkerd-meshtls = { path = "../../meshtls" }
@@ -30,5 +30,5 @@ tracing = "0.1"
 pin-project = "1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { version = "0.7", features = ["arbitrary"] }
+linkerd2-proxy-api = { version = "0.8", features = ["arbitrary"] }
 quickcheck = { version = "1", default-features = false }

--- a/linkerd/server-policy/Cargo.toml
+++ b/linkerd/server-policy/Cargo.toml
@@ -17,7 +17,7 @@ prost-types = { version = "0.11", optional = true }
 thiserror = "1"
 
 [dependencies.linkerd2-proxy-api]
-version = "0.7"
+version = "0.8"
 features = ["inbound"]
 optional = true
 

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -21,7 +21,7 @@ linkerd-http-box = { path = "../http-box" }
 linkerd-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd-stack = { path = "../stack" }
 linkerd-tonic-watch = { path = "../tonic-watch" }
-linkerd2-proxy-api = { version = "0.7", features = ["destination"] }
+linkerd2-proxy-api = { version = "0.8", features = ["destination"] }
 once_cell = "1.17"
 prost-types = "0.11"
 regex = "1"
@@ -33,5 +33,5 @@ thiserror = "1"
 tracing = "0.1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { version = "0.7", features = ["arbitrary"] }
+linkerd2-proxy-api = { version = "0.8", features = ["arbitrary"] }
 quickcheck = { version = "1", default-features = false }


### PR DESCRIPTION
v0.8.0 of `linkerd2-proxy-api` adds a `ProtocolHint::Opaque` variant to
the Destination API to indicate that an endpoint will not perform
application-level processing. This branch updates the proxy to depend on
v0.8.0. Currently, the `Opaque` hint does not change the proxy's
behavior; this will be added in a follow-up branch.