### PR TITLE
outbound: Split out separate 'opaq' modules

### DIFF
--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -247,12 +247,12 @@ where
     let logical = outbound
         .clone()
         .push_tcp_endpoint()
-        .push_tcp_concrete(resolve)
-        .push_tcp_logical();
+        .push_opaq_concrete(resolve)
+        .push_opaq_logical();
     let endpoint = outbound
         .clone()
         .push_tcp_endpoint()
-        .push_tcp_forward()
+        .push_opaq_forward()
         .into_stack();
     let inbound_ips = outbound.config().inbound_ips.clone();
     endpoint

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -281,7 +281,7 @@ impl<S> Outbound<S> {
             .push_http_server()
             .into_inner();
 
-        let opaque = self.push_tcp_endpoint().push_tcp_forward();
+        let opaque = self.push_tcp_endpoint().push_opaq_forward();
 
         opaque.push_detect_http(http).map_stack(|_, _, stk| {
             stk.instrument(|e: &tcp::Endpoint| info_span!("forward", endpoint = %e.addr))

--- a/linkerd/app/outbound/src/endpoint.rs
+++ b/linkerd/app/outbound/src/endpoint.rs
@@ -113,11 +113,11 @@ impl<P> svc::Param<Option<http::detect::Skip>> for Endpoint<P> {
     }
 }
 
-impl<P> svc::Param<Option<tcp::opaque_transport::PortOverride>> for Endpoint<P> {
-    fn param(&self) -> Option<tcp::opaque_transport::PortOverride> {
+impl<P> svc::Param<Option<tcp::tagged_transport::PortOverride>> for Endpoint<P> {
+    fn param(&self) -> Option<tcp::tagged_transport::PortOverride> {
         self.metadata
-            .opaque_transport_port()
-            .map(tcp::opaque_transport::PortOverride)
+            .tagged_transport_port()
+            .map(tcp::tagged_transport::PortOverride)
     }
 }
 
@@ -164,7 +164,7 @@ fn client_tls(metadata: &Metadata, reason: tls::NoClientTls) -> tls::Conditional
     // a gateway, then set an ALPN value indicating support for a transport
     // header.
     let use_transport_header =
-        metadata.opaque_transport_port().is_some() || metadata.authority_override().is_some();
+        metadata.tagged_transport_port().is_some() || metadata.authority_override().is_some();
 
     metadata
         .identity()

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -1,5 +1,5 @@
 use super::{NewRequireIdentity, NewStripProxyError, ProxyConnectionClose};
-use crate::{tcp::opaque_transport, Outbound};
+use crate::{tcp::tagged_transport, Outbound};
 use linkerd_app_core::{
     classify, config, errors, http_tracing, metrics,
     proxy::{http, tap},
@@ -183,11 +183,11 @@ impl<T: svc::Param<tls::ConditionalClientTls>> svc::Param<tls::ConditionalClient
     }
 }
 
-impl<T: svc::Param<Option<opaque_transport::PortOverride>>>
-    svc::Param<Option<opaque_transport::PortOverride>> for Connect<T>
+impl<T: svc::Param<Option<tagged_transport::PortOverride>>>
+    svc::Param<Option<tagged_transport::PortOverride>> for Connect<T>
 {
     #[inline]
-    fn param(&self) -> Option<opaque_transport::PortOverride> {
+    fn param(&self) -> Option<tagged_transport::PortOverride> {
         self.inner.param()
     }
 }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -11,6 +11,7 @@ pub mod http;
 mod ingress;
 pub mod logical;
 mod metrics;
+pub mod opaq;
 mod switch_logical;
 pub mod tcp;
 #[cfg(test)]

--- a/linkerd/app/outbound/src/logical.rs
+++ b/linkerd/app/outbound/src/logical.rs
@@ -160,8 +160,8 @@ impl<C> Outbound<C> {
 
         let opaque = self
             .push_tcp_endpoint()
-            .push_tcp_concrete(resolve)
-            .push_tcp_logical()
+            .push_opaq_concrete(resolve)
+            .push_opaq_logical()
             // The detect stack doesn't cache its inner service, so we need a
             // process-global cache of logical TCP stacks.
             .map_stack(|config, _, stk| stk.push_new_idle_cached(config.discovery_idle_timeout));

--- a/linkerd/app/outbound/src/opaq.rs
+++ b/linkerd/app/outbound/src/opaq.rs
@@ -1,9 +1,9 @@
 //! Stacks for proxying 'opaque' TCP connections.
 
-pub mod concrete;
-pub mod forward;
-pub mod logical;
+mod concrete;
+mod forward;
+mod logical;
 
-pub type Logical = crate::logical::Logical<()>;
-pub type Concrete = crate::logical::Concrete<()>;
-pub type Endpoint = crate::endpoint::Endpoint<()>;
+type Logical = crate::logical::Logical<()>;
+type Concrete = crate::logical::Concrete<()>;
+type Endpoint = crate::endpoint::Endpoint<()>;

--- a/linkerd/app/outbound/src/opaq.rs
+++ b/linkerd/app/outbound/src/opaq.rs
@@ -1,0 +1,9 @@
+//! Stacks for proxying 'opaque' TCP connections.
+
+pub mod concrete;
+pub mod forward;
+pub mod logical;
+
+pub type Logical = crate::logical::Logical<()>;
+pub type Concrete = crate::logical::Concrete<()>;
+pub type Endpoint = crate::endpoint::Endpoint<()>;

--- a/linkerd/app/outbound/src/opaq/concrete.rs
+++ b/linkerd/app/outbound/src/opaq/concrete.rs
@@ -24,7 +24,7 @@ pub struct ConcreteError {
 
 impl<C> Outbound<C> {
     /// Builds a [`svc::NewService`] stack that builds buffered opaque TCP load
-    /// balancer services for [`Concrete`] targets.
+    /// balancer services for `Concrete` targets.
     ///
     /// When a balancer has no available inner services, it goes into
     /// 'failfast'. While in failfast, buffered requests are failed and the

--- a/linkerd/app/outbound/src/opaq/concrete.rs
+++ b/linkerd/app/outbound/src/opaq/concrete.rs
@@ -32,7 +32,7 @@ impl<C> Outbound<C> {
     /// services.
     //
     // TODO(ver) make the outer target type generic/parameterized.
-    pub fn push_tcp_concrete<I, R>(
+    pub fn push_opaq_concrete<I, R>(
         self,
         resolve: R,
     ) -> Outbound<

--- a/linkerd/app/outbound/src/opaq/forward.rs
+++ b/linkerd/app/outbound/src/opaq/forward.rs
@@ -1,0 +1,107 @@
+use crate::{tcp, Outbound};
+use linkerd_app_core::{io, svc, transport::addrs::*, Error};
+
+#[derive(Debug, thiserror::Error)]
+#[error("forward {addr}: {source}")]
+pub struct ForwardError {
+    addr: Remote<ServerAddr>,
+    #[source]
+    source: Error,
+}
+
+// === impl Outbound ===
+
+impl<C> Outbound<C> {
+    pub fn push_opaq_forward<T, I>(
+        self,
+    ) -> Outbound<
+        svc::ArcNewService<
+            T,
+            impl svc::Service<I, Response = (), Error = ForwardError, Future = impl Send> + Clone,
+        >,
+    >
+    where
+        T: svc::Param<Remote<ServerAddr>> + Clone + Send + Sync + 'static,
+        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+        C: svc::MakeConnection<T> + Clone + Send + Sync + 'static,
+        C::Connection: Send + Unpin,
+        C::Metadata: Send + Unpin,
+        C::Future: Send,
+    {
+        self.map_stack(|_, _, conn| {
+            conn.push(svc::stack::WithoutConnectionMetadata::layer())
+                .push_new_thunk()
+                .push_on_service(tcp::Forward::layer())
+                .push(svc::NewMapErr::layer_from_target())
+                .push(svc::ArcNewService::layer())
+        })
+    }
+}
+
+// === impl ForwardError ===
+
+impl<T> From<(&T, Error)> for ForwardError
+where
+    T: svc::Param<Remote<ServerAddr>>,
+{
+    fn from((target, source): (&T, Error)) -> Self {
+        Self {
+            addr: target.param(),
+            source,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::*;
+    use linkerd_app_core::{
+        svc::{self, NewService, ServiceExt},
+        transport::{ClientAddr, Local},
+    };
+    use std::net::SocketAddr;
+
+    #[derive(Clone)]
+    struct Target(SocketAddr);
+
+    impl svc::Param<Option<crate::http::Version>> for Target {
+        fn param(&self) -> Option<crate::http::Version> {
+            None
+        }
+    }
+
+    impl svc::Param<Remote<ServerAddr>> for Target {
+        fn param(&self) -> Remote<ServerAddr> {
+            Remote(ServerAddr(self.0))
+        }
+    }
+
+    #[tokio::test]
+    async fn forward() {
+        let _trace = linkerd_tracing::test::trace_init();
+
+        let addr = SocketAddr::new([192, 0, 2, 2].into(), 2222);
+        let (rt, _shutdown) = runtime();
+        let stack = Outbound::new(default_config(), rt)
+            .with_stack(svc::mk(move |Target(a): Target| {
+                assert_eq!(a, addr);
+                let mut io = support::io();
+                io.write(b"hello").read(b"world");
+                future::ok::<_, support::io::Error>((
+                    io.build(),
+                    Local(ClientAddr(([0, 0, 0, 0], 0).into())),
+                ))
+            }))
+            .push_opaq_forward()
+            .into_inner();
+
+        let mut io = support::io();
+        io.read(b"hello").write(b"world");
+        stack
+            .new_service(Target(addr))
+            .oneshot(io.build())
+            .await
+            .expect("forward must complete successfully");
+    }
+}

--- a/linkerd/app/outbound/src/opaq/logical.rs
+++ b/linkerd/app/outbound/src/opaq/logical.rs
@@ -1,4 +1,5 @@
-use super::{Concrete, Logical, Outbound};
+use super::{Concrete, Logical};
+use crate::Outbound;
 use linkerd_app_core::{
     io,
     profiles::{self, Profile},

--- a/linkerd/app/outbound/src/opaq/logical/tests.rs
+++ b/linkerd/app/outbound/src/opaq/logical/tests.rs
@@ -46,8 +46,8 @@ async fn forward() {
             let local = Local(ClientAddr(([0, 0, 0, 0], 4444).into()));
             future::ok::<_, support::io::Error>((io.build(), local))
         }))
-        .push_tcp_concrete(resolve)
-        .push_tcp_logical()
+        .push_opaq_concrete(resolve)
+        .push_opaq_logical()
         .into_inner();
 
     // Build a client to the endpoint and proxy a connection.
@@ -123,8 +123,8 @@ async fn balances() {
             }
             addr => unreachable!("unexpected endpoint: {}", addr),
         }))
-        .push_tcp_concrete(resolve)
-        .push_tcp_logical()
+        .push_opaq_concrete(resolve)
+        .push_opaq_logical()
         .into_inner()
         .new_service(logical);
 

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -8,6 +8,7 @@ use linkerd_app_core::{
 
 pub mod concrete;
 pub mod connect;
+mod endpoint;
 pub mod logical;
 pub mod opaque_transport;
 

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -6,10 +6,8 @@ use linkerd_app_core::{
     Error,
 };
 
-pub mod concrete;
 pub mod connect;
 mod endpoint;
-pub mod logical;
 pub mod opaque_transport;
 
 pub use self::connect::Connect;

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -8,7 +8,7 @@ use linkerd_app_core::{
 
 pub mod connect;
 mod endpoint;
-pub mod opaque_transport;
+pub mod tagged_transport;
 
 pub use self::connect::Connect;
 pub use linkerd_app_core::proxy::tcp::Forward;

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -35,34 +35,6 @@ impl Outbound<()> {
     }
 }
 
-impl<C> Outbound<C> {
-    pub fn push_tcp_forward<T, I>(
-        self,
-    ) -> Outbound<
-        svc::ArcNewService<
-            T,
-            impl svc::Service<I, Response = (), Error = EndpointError, Future = impl Send> + Clone,
-        >,
-    >
-    where
-        T: svc::Param<Remote<ServerAddr>> + Clone + Send + Sync + 'static,
-        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
-        C: svc::MakeConnection<T> + Clone + Send + Sync + 'static,
-        C::Connection: Send + Unpin,
-        C::Metadata: Send + Unpin,
-        C::Future: Send,
-    {
-        self.map_stack(|_, _, conn| {
-            conn.push(svc::stack::WithoutConnectionMetadata::layer())
-                .push_new_thunk()
-                .push_on_service(super::Forward::layer())
-                .push(svc::NewMapErr::layer_from_target())
-                .push(svc::ArcNewService::layer())
-                .check_new_service::<T, I>()
-        })
-    }
-}
-
 // === impl PreventLoopback ===
 
 impl<S> PreventLoopback<S> {
@@ -134,59 +106,5 @@ where
             addr: target.param(),
             source,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{
-        svc::{self, NewService, ServiceExt},
-        test_util::*,
-        transport::{ClientAddr, Local},
-    };
-    use std::net::SocketAddr;
-
-    #[derive(Clone)]
-    struct Target(SocketAddr);
-
-    impl svc::Param<Option<crate::http::Version>> for Target {
-        fn param(&self) -> Option<crate::http::Version> {
-            None
-        }
-    }
-
-    impl svc::Param<Remote<ServerAddr>> for Target {
-        fn param(&self) -> Remote<ServerAddr> {
-            Remote(ServerAddr(self.0))
-        }
-    }
-
-    #[tokio::test]
-    async fn forward() {
-        let _trace = linkerd_tracing::test::trace_init();
-
-        let addr = SocketAddr::new([192, 0, 2, 2].into(), 2222);
-        let (rt, _shutdown) = runtime();
-        let stack = Outbound::new(default_config(), rt)
-            .with_stack(svc::mk(move |Target(a): Target| {
-                assert_eq!(a, addr);
-                let mut io = support::io();
-                io.write(b"hello").read(b"world");
-                future::ok::<_, support::io::Error>((
-                    io.build(),
-                    Local(ClientAddr(([0, 0, 0, 0], 0).into())),
-                ))
-            }))
-            .push_tcp_forward()
-            .into_inner();
-
-        let mut io = support::io();
-        io.read(b"hello").write(b"world");
-        stack
-            .new_service(Target(addr))
-            .oneshot(io.build())
-            .await
-            .expect("forward must complete successfully");
     }
 }

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -1,12 +1,8 @@
-use super::opaque_transport::{self, OpaqueTransport};
-use crate::{ConnectMeta, Outbound};
+use crate::Outbound;
 use futures::future;
 use linkerd_app_core::{
-    io,
-    proxy::http,
-    svc, tls,
-    transport::{self, ClientAddr, ConnectTcp, Local, Remote, ServerAddr},
-    transport_header::SessionProtocol,
+    io, svc, tls,
+    transport::{ConnectTcp, Remote, ServerAddr},
     Error,
 };
 use std::task::{Context, Poll};
@@ -40,49 +36,6 @@ impl Outbound<()> {
 }
 
 impl<C> Outbound<C> {
-    pub fn push_tcp_endpoint<T>(
-        self,
-    ) -> Outbound<
-        impl svc::MakeConnection<
-                T,
-                Connection = impl Send + Unpin,
-                Metadata = ConnectMeta,
-                Error = Error,
-                Future = impl Send,
-            > + Clone,
-    >
-    where
-        T: svc::Param<Remote<ServerAddr>>
-            + svc::Param<tls::ConditionalClientTls>
-            + svc::Param<Option<opaque_transport::PortOverride>>
-            + svc::Param<Option<http::AuthorityOverride>>
-            + svc::Param<Option<SessionProtocol>>
-            + svc::Param<transport::labels::Key>,
-        C: svc::MakeConnection<Connect, Metadata = Local<ClientAddr>, Error = io::Error>,
-        C: Clone + Send + 'static,
-        C::Connection: Send + Unpin,
-        C::Metadata: Send + Unpin,
-        C::Future: Send + 'static,
-    {
-        self.map_stack(|config, rt, connect| {
-            connect
-                // Initiates mTLS if the target is configured with identity. The
-                // endpoint configures ALPN when there is an opaque transport hint OR
-                // when an authority override is present (indicating the target is a
-                // remote cluster gateway).
-                .push(tls::Client::layer(rt.identity.clone()))
-                // Encodes a transport header if the established connection is TLS'd and
-                // ALPN negotiation indicates support.
-                .push(OpaqueTransport::layer())
-                // Limits the time we wait for a connection to be established.
-                .push_connect_timeout(config.proxy.connect.timeout)
-                .push(svc::stack::BoxFuture::layer())
-                .push(transport::metrics::Client::layer(
-                    rt.metrics.proxy.transport.clone(),
-                ))
-        })
-    }
-
     pub fn push_tcp_forward<T, I>(
         self,
     ) -> Outbound<

--- a/linkerd/app/outbound/src/tcp/endpoint.rs
+++ b/linkerd/app/outbound/src/tcp/endpoint.rs
@@ -1,0 +1,57 @@
+use super::{opaque_transport::OpaqueTransport, *};
+use crate::{ConnectMeta, Outbound};
+use linkerd_app_core::{
+    io,
+    proxy::http,
+    svc, tls,
+    transport::{self, ClientAddr, Local, Remote, ServerAddr},
+    transport_header::SessionProtocol,
+    Error,
+};
+
+impl<C> Outbound<C> {
+    pub fn push_tcp_endpoint<T>(
+        self,
+    ) -> Outbound<
+        impl svc::MakeConnection<
+                T,
+                Connection = impl Send + Unpin,
+                Metadata = ConnectMeta,
+                Error = Error,
+                Future = impl Send,
+            > + Clone,
+    >
+    where
+        // TCP endpoint target.
+        T: svc::Param<Remote<ServerAddr>>,
+        T: svc::Param<tls::ConditionalClientTls>,
+        T: svc::Param<Option<opaque_transport::PortOverride>>,
+        T: svc::Param<Option<http::AuthorityOverride>>,
+        T: svc::Param<Option<SessionProtocol>>,
+        T: svc::Param<transport::labels::Key>,
+        // Connector stack.
+        C: svc::MakeConnection<Connect, Metadata = Local<ClientAddr>, Error = io::Error>,
+        C: Clone + Send + 'static,
+        C::Connection: Send + Unpin,
+        C::Metadata: Send + Unpin,
+        C::Future: Send + 'static,
+    {
+        self.map_stack(|config, rt, connect| {
+            connect
+                // Initiates mTLS if the target is configured with identity. The
+                // endpoint configures ALPN when there is an opaque transport hint OR
+                // when an authority override is present (indicating the target is a
+                // remote cluster gateway).
+                .push(tls::Client::layer(rt.identity.clone()))
+                // Encodes a transport header if the established connection is TLS'd and
+                // ALPN negotiation indicates support.
+                .push(OpaqueTransport::layer())
+                // Limits the time we wait for a connection to be established.
+                .push_connect_timeout(config.proxy.connect.timeout)
+                .push(svc::stack::BoxFuture::layer())
+                .push(transport::metrics::Client::layer(
+                    rt.metrics.proxy.transport.clone(),
+                ))
+        })
+    }
+}

--- a/linkerd/app/outbound/src/tcp/endpoint.rs
+++ b/linkerd/app/outbound/src/tcp/endpoint.rs
@@ -1,4 +1,4 @@
-use super::{opaque_transport::OpaqueTransport, *};
+use super::{tagged_transport::TaggedTransport, *};
 use crate::{ConnectMeta, Outbound};
 use linkerd_app_core::{
     io,
@@ -25,7 +25,7 @@ impl<C> Outbound<C> {
         // TCP endpoint target.
         T: svc::Param<Remote<ServerAddr>>,
         T: svc::Param<tls::ConditionalClientTls>,
-        T: svc::Param<Option<opaque_transport::PortOverride>>,
+        T: svc::Param<Option<tagged_transport::PortOverride>>,
         T: svc::Param<Option<http::AuthorityOverride>>,
         T: svc::Param<Option<SessionProtocol>>,
         T: svc::Param<transport::labels::Key>,
@@ -45,7 +45,7 @@ impl<C> Outbound<C> {
                 .push(tls::Client::layer(rt.identity.clone()))
                 // Encodes a transport header if the established connection is TLS'd and
                 // ALPN negotiation indicates support.
-                .push(OpaqueTransport::layer())
+                .push(TaggedTransport::layer())
                 // Limits the time we wait for a connection to be established.
                 .push_connect_timeout(config.proxy.connect.timeout)
                 .push(svc::stack::BoxFuture::layer())

--- a/linkerd/app/outbound/src/tcp/tagged_transport.rs
+++ b/linkerd/app/outbound/src/tcp/tagged_transport.rs
@@ -20,15 +20,15 @@ use tracing::{debug, trace, warn};
 pub struct PortOverride(pub u16);
 
 #[derive(Clone, Debug)]
-pub struct OpaqueTransport<S> {
+pub struct TaggedTransport<S> {
     inner: S,
 }
 
-// === impl OpaqueTransport ===
+// === impl TaggedTransport ===
 
-impl<S> OpaqueTransport<S> {
+impl<S> TaggedTransport<S> {
     pub fn layer() -> impl svc::Layer<S, Service = Self> + Copy {
-        svc::layer::mk(|inner| OpaqueTransport { inner })
+        svc::layer::mk(|inner| TaggedTransport { inner })
     }
 
     /// Determines whether the connection has negotiated support for the
@@ -43,7 +43,7 @@ impl<S> OpaqueTransport<S> {
     }
 }
 
-impl<T, S> svc::Service<T> for OpaqueTransport<S>
+impl<T, S> svc::Service<T> for TaggedTransport<S>
 where
     T: svc::Param<tls::ConditionalClientTls>
         + svc::Param<Remote<ServerAddr>>
@@ -166,7 +166,7 @@ mod test {
     async fn plain() {
         let _trace = linkerd_tracing::test::trace_init();
 
-        let svc = OpaqueTransport {
+        let svc = TaggedTransport {
             inner: service_fn(|ep: Connect| {
                 let Remote(ServerAddr(sa)) = ep.addr;
                 assert_eq!(sa.port(), 4321);
@@ -190,7 +190,7 @@ mod test {
     async fn opaque_no_name() {
         let _trace = linkerd_tracing::test::trace_init();
 
-        let svc = OpaqueTransport {
+        let svc = TaggedTransport {
             inner: service_fn(|ep: Connect| {
                 let Remote(ServerAddr(sa)) = ep.addr;
                 assert_eq!(sa.port(), 4143);
@@ -230,7 +230,7 @@ mod test {
     async fn opaque_named_with_port() {
         let _trace = linkerd_tracing::test::trace_init();
 
-        let svc = OpaqueTransport {
+        let svc = TaggedTransport {
             inner: service_fn(|ep: Connect| {
                 let Remote(ServerAddr(sa)) = ep.addr;
                 assert_eq!(sa.port(), 4143);
@@ -270,7 +270,7 @@ mod test {
     async fn opaque_named_no_port() {
         let _trace = linkerd_tracing::test::trace_init();
 
-        let svc = OpaqueTransport {
+        let svc = TaggedTransport {
             inner: service_fn(|ep: Connect| {
                 let Remote(ServerAddr(sa)) = ep.addr;
                 assert_eq!(sa.port(), 4143);

--- a/linkerd/proxy/api-resolve/src/metadata.rs
+++ b/linkerd/proxy/api-resolve/src/metadata.rs
@@ -15,7 +15,7 @@ pub struct Metadata {
     /// destination understands.
     protocol_hint: ProtocolHint,
 
-    opaque_transport_port: Option<u16>,
+    tagged_transport_port: Option<u16>,
 
     /// How to verify TLS for the endpoint.
     identity: Option<ServerId>,
@@ -41,7 +41,7 @@ impl Default for Metadata {
             labels: Labels::default(),
             identity: None,
             authority_override: None,
-            opaque_transport_port: None,
+            tagged_transport_port: None,
             protocol_hint: ProtocolHint::Unknown,
         }
     }
@@ -51,14 +51,14 @@ impl Metadata {
     pub fn new(
         labels: impl IntoIterator<Item = (String, String)>,
         protocol_hint: ProtocolHint,
-        opaque_transport_port: Option<u16>,
+        tagged_transport_port: Option<u16>,
         identity: Option<ServerId>,
         authority_override: Option<Authority>,
     ) -> Self {
         Self {
             labels: labels.into_iter().collect::<BTreeMap<_, _>>().into(),
             protocol_hint,
-            opaque_transport_port,
+            tagged_transport_port,
             identity,
             authority_override,
         }
@@ -77,8 +77,8 @@ impl Metadata {
         self.identity.as_ref()
     }
 
-    pub fn opaque_transport_port(&self) -> Option<u16> {
-        self.opaque_transport_port
+    pub fn tagged_transport_port(&self) -> Option<u16> {
+        self.tagged_transport_port
     }
 
     pub fn authority_override(&self) -> Option<&Authority> {
@@ -87,7 +87,7 @@ impl Metadata {
 
     pub fn clear_upgrade(&mut self) {
         self.protocol_hint = ProtocolHint::Unknown;
-        self.opaque_transport_port = None;
+        self.tagged_transport_port = None;
         self.authority_override = None;
     }
 }

--- a/linkerd/proxy/api-resolve/src/pb.rs
+++ b/linkerd/proxy/api-resolve/src/pb.rs
@@ -24,7 +24,7 @@ pub fn to_addr_meta(
         .map(|(k, v)| (k.clone(), v.clone()));
 
     let mut proto_hint = ProtocolHint::Unknown;
-    let mut opaque_transport_port = None;
+    let mut tagged_transport_port = None;
     if let Some(hint) = pb.protocol_hint {
         if let Some(proto) = hint.protocol {
             match proto {
@@ -36,7 +36,7 @@ pub fn to_addr_meta(
 
         if let Some(OpaqueTransport { inbound_port }) = hint.opaque_transport {
             if inbound_port > 0 && inbound_port < u16::MAX as u32 {
-                opaque_transport_port = Some(inbound_port as u16);
+                tagged_transport_port = Some(inbound_port as u16);
             }
         }
     }
@@ -45,7 +45,7 @@ pub fn to_addr_meta(
     let meta = Metadata::new(
         labels,
         proto_hint,
-        opaque_transport_port,
+        tagged_transport_port,
         tls_id,
         authority_override,
     );


### PR DESCRIPTION
We differentiate "opaque" and "tcp" stacks because some TCP stacks may
also apply for HTTP traffic. We shorten this in code as "opaq" because
it's unambiguous and the same length as "http"

* Add an `outbound::opaq` module for opaque stacks. ("opaq").
* Rename `push_tcp_{logical,concrete,forward}` to `push_opaq_*`
* Rename `OpaqueTransport` to `TaggedTransport` (Closes #2212).