### PR TITLE
outbound: Lint stack target types

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -90,6 +90,19 @@ impl<L> Layers<L> {
         self.push(layer::mk(NewCloneService::from))
     }
 
+    // Wraps the inner `N`-typed [`NewService`] with a layer that applies the
+    // given target to all inner stacks to produce its service.
+    pub fn push_flatten_new<T, N>(
+        self,
+        target: T,
+    ) -> Layers<Pair<L, impl Layer<N, Service = N::Service> + Clone>>
+    where
+        T: Clone,
+        N: NewService<T>,
+    {
+        self.push(layer::mk(move |inner: N| inner.new_service(target.clone())))
+    }
+
     pub fn push_instrument<G: Clone>(self, get_span: G) -> Layers<Pair<L, NewInstrumentLayer<G>>> {
         self.push(NewInstrumentLayer::new(get_span))
     }

--- a/linkerd/app/inbound/src/metrics/error/http.rs
+++ b/linkerd/app/inbound/src/metrics/error/http.rs
@@ -33,7 +33,8 @@ impl HttpErrorMetrics {
 
 impl<T> svc::stack::MonitorNewService<T> for HttpErrorMetrics
 where
-    T: svc::Param<OrigDstAddr> + svc::Param<ServerLabel>,
+    T: svc::Param<OrigDstAddr>,
+    T: svc::Param<ServerLabel>,
 {
     type MonitorService = MonitorHttpErrorMetrics;
 

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -96,9 +96,9 @@ impl<N> NewHttpPolicy<N> {
 
 impl<T, N> svc::NewService<T> for NewHttpPolicy<N>
 where
-    T: svc::Param<AllowPolicy>
-        + svc::Param<Remote<ClientAddr>>
-        + svc::Param<tls::ConditionalServerTls>,
+    T: svc::Param<AllowPolicy>,
+    T: svc::Param<Remote<ClientAddr>>,
+    T: svc::Param<tls::ConditionalServerTls>,
     N: Clone,
 {
     type Service = HttpPolicyService<T, N>;

--- a/linkerd/app/integration/src/tests/discovery.rs
+++ b/linkerd/app/integration/src/tests/discovery.rs
@@ -84,7 +84,6 @@ mod cross_version {
             .await;
 
         let client = (test.mk_client)(&proxy, HOST);
-
         assert_eq!(client.get("/").await, "hello");
         drop(client);
 

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -18,8 +18,7 @@ pub use linkerd_app_core::proxy::http::*;
 use linkerd_app_core::{
     profiles::{self, LogicalAddr},
     proxy::{api_resolve::ProtocolHint, tap},
-    svc::Param,
-    tls, Addr, Conditional, CANONICAL_DST_HEADER,
+    svc, tls, Addr, Conditional, CANONICAL_DST_HEADER,
 };
 use std::{net::SocketAddr, str::FromStr};
 
@@ -55,25 +54,25 @@ impl From<(Version, tcp::Logical)> for Logical {
     }
 }
 
-impl Param<CanonicalDstHeader> for Logical {
+impl svc::Param<CanonicalDstHeader> for Logical {
     fn param(&self) -> CanonicalDstHeader {
         CanonicalDstHeader(self.addr())
     }
 }
 
-impl Param<Version> for Logical {
+impl svc::Param<Version> for Logical {
     fn param(&self) -> Version {
         self.protocol
     }
 }
 
-impl Param<Option<Version>> for Logical {
+impl svc::Param<Option<Version>> for Logical {
     fn param(&self) -> Option<Version> {
         Some(self.protocol)
     }
 }
 
-impl Param<normalize_uri::DefaultAuthority> for Logical {
+impl svc::Param<normalize_uri::DefaultAuthority> for Logical {
     fn param(&self) -> normalize_uri::DefaultAuthority {
         normalize_uri::DefaultAuthority(Some(
             uri::Authority::from_str(&self.logical_addr.to_string())
@@ -98,7 +97,7 @@ impl From<(Version, tcp::Endpoint)> for Endpoint {
     }
 }
 
-impl Param<normalize_uri::DefaultAuthority> for Endpoint {
+impl svc::Param<normalize_uri::DefaultAuthority> for Endpoint {
     fn param(&self) -> normalize_uri::DefaultAuthority {
         if let Some(LogicalAddr(ref a)) = self.logical_addr {
             normalize_uri::DefaultAuthority(Some(
@@ -114,13 +113,13 @@ impl Param<normalize_uri::DefaultAuthority> for Endpoint {
     }
 }
 
-impl Param<Version> for Endpoint {
+impl svc::Param<Version> for Endpoint {
     fn param(&self) -> Version {
         self.protocol
     }
 }
 
-impl Param<client::Settings> for Endpoint {
+impl svc::Param<client::Settings> for Endpoint {
     fn param(&self) -> client::Settings {
         match self.protocol {
             Version::H2 => client::Settings::H2,

--- a/linkerd/app/outbound/src/http/endpoint/tests.rs
+++ b/linkerd/app/outbound/src/http/endpoint/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{http, test_util::*};
+use crate::{http, tcp, test_util::*};
 use ::http::header::{CONNECTION, UPGRADE};
 use linkerd_app_core::{
     io,
@@ -19,8 +19,8 @@ async fn http11_forward() {
 
     let addr = SocketAddr::new([192, 0, 2, 41].into(), 2041);
 
-    let connect = support::connect()
-        .endpoint_fn_boxed(addr, |_: http::Connect| serve(::http::Version::HTTP_11));
+    let connect =
+        support::connect().endpoint_fn_boxed(addr, |_: _| serve(::http::Version::HTTP_11));
 
     // Build the outbound server
     let (rt, _shutdown) = runtime();
@@ -29,12 +29,9 @@ async fn http11_forward() {
         .push_http_endpoint::<_, http::BoxBody>()
         .into_inner();
 
-    let svc = stack.new_service(http::Endpoint {
+    let svc = stack.new_service(Endpoint {
         addr: Remote(ServerAddr(addr)),
-        protocol: http::Version::Http1,
-        logical_addr: None,
-        opaque_protocol: false,
-        tls: tls::ConditionalClientTls::None(tls::NoClientTls::Disabled),
+        version: http::Version::Http1,
         metadata: Metadata::default(),
     });
 
@@ -56,8 +53,7 @@ async fn http2_forward() {
 
     let addr = SocketAddr::new([192, 0, 2, 41].into(), 2042);
 
-    let connect = support::connect()
-        .endpoint_fn_boxed(addr, |_: http::Connect| serve(::http::Version::HTTP_2));
+    let connect = support::connect().endpoint_fn_boxed(addr, |_: _| serve(::http::Version::HTTP_2));
 
     // Build the outbound server
     let (rt, _shutdown) = runtime();
@@ -66,12 +62,9 @@ async fn http2_forward() {
         .push_http_endpoint::<_, http::BoxBody>()
         .into_inner();
 
-    let svc = stack.new_service(http::Endpoint {
+    let svc = stack.new_service(Endpoint {
         addr: Remote(ServerAddr(addr)),
-        protocol: http::Version::H2,
-        logical_addr: None,
-        opaque_protocol: false,
-        tls: tls::ConditionalClientTls::None(tls::NoClientTls::Disabled),
+        version: http::Version::H2,
         metadata: Metadata::default(),
     });
 
@@ -95,8 +88,7 @@ async fn orig_proto_upgrade() {
     let addr = SocketAddr::new([192, 0, 2, 41].into(), 2041);
 
     // Pretend the upstream is a proxy that supports proto upgrades...
-    let connect = support::connect()
-        .endpoint_fn_boxed(addr, |_: http::Connect| serve(::http::Version::HTTP_2));
+    let connect = support::connect().endpoint_fn_boxed(addr, |_: _| serve(::http::Version::HTTP_2));
 
     // Build the outbound server
     let (rt, _shutdown) = runtime();
@@ -105,12 +97,9 @@ async fn orig_proto_upgrade() {
         .push_http_endpoint::<_, http::BoxBody>()
         .into_inner();
 
-    let svc = stack.new_service(http::Endpoint {
+    let svc = stack.new_service(Endpoint {
         addr: Remote(ServerAddr(addr)),
-        protocol: http::Version::Http1,
-        logical_addr: None,
-        opaque_protocol: false,
-        tls: tls::ConditionalClientTls::None(tls::NoClientTls::Disabled),
+        version: http::Version::Http1,
         metadata: Metadata::new(None, ProtocolHint::Http2, None, None, None),
     });
 
@@ -139,7 +128,7 @@ async fn orig_proto_skipped_on_http_upgrade() {
     // Pretend the upstream is a proxy that supports proto upgrades. The service needs to
     // support both HTTP/1 and HTTP/2 because an HTTP/2 connection is maintained by default and
     // HTTP/1 connections are created as-needed.
-    let connect = support::connect().endpoint_fn_boxed(addr, |c: http::Connect| {
+    let connect = support::connect().endpoint_fn_boxed(addr, |c: Connect<_>| {
         serve(match svc::Param::param(&c) {
             Some(SessionProtocol::Http1) => ::http::Version::HTTP_11,
             Some(SessionProtocol::Http2) => ::http::Version::HTTP_2,
@@ -162,12 +151,9 @@ async fn orig_proto_skipped_on_http_upgrade() {
         }))
         .into_inner();
 
-    let svc = stack.new_service(http::Endpoint {
+    let svc = stack.new_service(Endpoint {
         addr: Remote(ServerAddr(addr)),
-        protocol: http::Version::Http1,
-        logical_addr: None,
-        opaque_protocol: false,
-        tls: tls::ConditionalClientTls::None(tls::NoClientTls::Disabled),
+        version: http::Version::Http1,
         metadata: Metadata::new(None, ProtocolHint::Http2, None, None, None),
     });
 
@@ -195,8 +181,7 @@ async fn orig_proto_http2_noop() {
     let addr = SocketAddr::new([192, 0, 2, 41].into(), 2041);
 
     // Pretend the upstream is a proxy that supports proto upgrades...
-    let connect = support::connect()
-        .endpoint_fn_boxed(addr, |_: http::Connect| serve(::http::Version::HTTP_2));
+    let connect = support::connect().endpoint_fn_boxed(addr, |_: _| serve(::http::Version::HTTP_2));
 
     // Build the outbound server
     let (rt, _shutdown) = runtime();
@@ -205,12 +190,9 @@ async fn orig_proto_http2_noop() {
         .push_http_endpoint::<_, http::BoxBody>()
         .into_inner();
 
-    let svc = stack.new_service(http::Endpoint {
+    let svc = stack.new_service(Endpoint {
         addr: Remote(ServerAddr(addr)),
-        protocol: http::Version::H2,
-        logical_addr: None,
-        opaque_protocol: false,
-        tls: tls::ConditionalClientTls::None(tls::NoClientTls::Disabled),
+        version: http::Version::H2,
         metadata: Metadata::new(None, ProtocolHint::Http2, None, None, None),
     });
 
@@ -253,4 +235,114 @@ fn serve(version: ::http::Version) -> io::Result<io::BoxedIo> {
     let (client_io, server_io) = io::duplex(4096);
     tokio::spawn(http.serve_connection(server_io, svc));
     Ok(io::BoxedIo::new(client_io))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Endpoint {
+    addr: Remote<ServerAddr>,
+    metadata: Metadata,
+    version: http::Version,
+}
+
+// === impl Endpoint ===
+
+impl svc::Param<Remote<ServerAddr>> for Endpoint {
+    fn param(&self) -> Remote<ServerAddr> {
+        self.addr
+    }
+}
+
+impl svc::Param<tls::ConditionalClientTls> for Endpoint {
+    fn param(&self) -> tls::ConditionalClientTls {
+        tls::ConditionalClientTls::None(tls::NoClientTls::Disabled)
+    }
+}
+
+impl svc::Param<Option<http::detect::Skip>> for Endpoint {
+    fn param(&self) -> Option<http::detect::Skip> {
+        None
+    }
+}
+
+impl svc::Param<Option<tcp::tagged_transport::PortOverride>> for Endpoint {
+    fn param(&self) -> Option<tcp::tagged_transport::PortOverride> {
+        None
+    }
+}
+
+impl svc::Param<Option<http::AuthorityOverride>> for Endpoint {
+    fn param(&self) -> Option<http::AuthorityOverride> {
+        None
+    }
+}
+
+impl svc::Param<transport::labels::Key> for Endpoint {
+    fn param(&self) -> transport::labels::Key {
+        transport::labels::Key::OutboundClient(self.param())
+    }
+}
+
+impl svc::Param<metrics::OutboundEndpointLabels> for Endpoint {
+    fn param(&self) -> metrics::OutboundEndpointLabels {
+        metrics::OutboundEndpointLabels {
+            authority: None,
+            labels: None,
+            server_id: self.param(),
+            target_addr: self.addr.into(),
+        }
+    }
+}
+
+impl svc::Param<metrics::EndpointLabels> for Endpoint {
+    fn param(&self) -> metrics::EndpointLabels {
+        svc::Param::<metrics::OutboundEndpointLabels>::param(self).into()
+    }
+}
+
+impl svc::Param<http::Version> for Endpoint {
+    fn param(&self) -> http::Version {
+        self.version
+    }
+}
+
+impl svc::Param<http::client::Settings> for Endpoint {
+    fn param(&self) -> http::client::Settings {
+        match self.version {
+            http::Version::H2 => http::client::Settings::H2,
+            http::Version::Http1 => match self.metadata.protocol_hint() {
+                ProtocolHint::Unknown => http::client::Settings::Http1,
+                ProtocolHint::Http2 => http::client::Settings::OrigProtoUpgrade,
+            },
+        }
+    }
+}
+
+impl tap::Inspect for Endpoint {
+    fn src_addr<B>(&self, req: &http::Request<B>) -> Option<SocketAddr> {
+        req.extensions().get::<http::ClientHandle>().map(|c| c.addr)
+    }
+
+    fn src_tls<B>(&self, _: &http::Request<B>) -> tls::ConditionalServerTls {
+        tls::ConditionalServerTls::None(tls::NoServerTls::Loopback)
+    }
+
+    fn dst_addr<B>(&self, _: &http::Request<B>) -> Option<SocketAddr> {
+        Some(self.addr.into())
+    }
+
+    fn dst_labels<B>(&self, _: &http::Request<B>) -> Option<tap::Labels> {
+        None
+    }
+
+    fn dst_tls<B>(&self, _: &http::Request<B>) -> tls::ConditionalClientTls {
+        svc::Param::param(self)
+    }
+
+    fn route_labels<B>(&self, _: &http::Request<B>) -> Option<tap::Labels> {
+        None
+    }
+
+    fn is_outbound<B>(&self, _: &http::Request<B>) -> bool {
+        true
+    }
 }

--- a/linkerd/app/outbound/src/http/endpoint/tests.rs
+++ b/linkerd/app/outbound/src/http/endpoint/tests.rs
@@ -3,7 +3,7 @@ use crate::{http, tcp, test_util::*};
 use ::http::header::{CONNECTION, UPGRADE};
 use linkerd_app_core::{
     io,
-    proxy::api_resolve::{ProtocolHint},
+    proxy::api_resolve::ProtocolHint,
     svc::{NewService, ServiceExt},
     Infallible,
 };

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -2,8 +2,7 @@ use crate::Outbound;
 use futures::future;
 use linkerd_app_core::{
     io, svc, tls,
-    transport::{ConnectTcp, Remote, ServerAddr},
-    Error,
+    transport::{addrs::*, ConnectTcp},
 };
 use std::task::{Context, Poll};
 
@@ -17,14 +16,6 @@ pub struct Connect {
 /// `allow-loopback` feature is enabled.
 #[derive(Clone, Debug)]
 pub struct PreventLoopback<S>(S);
-
-#[derive(Debug, thiserror::Error)]
-#[error("endpoint {addr}: {source}")]
-pub struct EndpointError {
-    addr: Remote<ServerAddr>,
-    #[source]
-    source: Error,
-}
 
 // === impl Outbound ===
 
@@ -92,19 +83,5 @@ impl svc::Param<Remote<ServerAddr>> for Connect {
 impl svc::Param<tls::ConditionalClientTls> for Connect {
     fn param(&self) -> tls::ConditionalClientTls {
         self.tls.clone()
-    }
-}
-
-// === impl EndpointError ===
-
-impl<T> From<(&T, Error)> for EndpointError
-where
-    T: svc::Param<Remote<ServerAddr>>,
-{
-    fn from((target, source): (&T, Error)) -> Self {
-        Self {
-            addr: target.param(),
-            source,
-        }
     }
 }

--- a/linkerd/app/outbound/src/tcp/tagged_transport.rs
+++ b/linkerd/app/outbound/src/tcp/tagged_transport.rs
@@ -140,26 +140,65 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::endpoint::Endpoint;
     use futures::future;
     use linkerd_app_core::{
         identity,
         io::{self, AsyncWriteExt},
-        proxy::api_resolve::{Metadata, ProtocolHint},
         tls,
         transport::{ClientAddr, Local},
-        transport_header::TransportHeader,
+        transport_header::{self, TransportHeader},
     };
     use tower::util::{service_fn, ServiceExt};
 
-    fn ep(metadata: Metadata) -> Endpoint<()> {
-        Endpoint::from_metadata(
-            ([127, 0, 0, 2], 4321),
-            metadata,
-            tls::NoClientTls::NotProvidedByServiceDiscovery,
-            false,
-            &Default::default(),
-        )
+    #[derive(Clone, Debug, Default)]
+    struct Endpoint {
+        port_override: Option<u16>,
+        authority: Option<http::uri::Authority>,
+        server_id: Option<tls::ServerId>,
+    }
+
+    impl svc::Param<tls::ConditionalClientTls> for Endpoint {
+        fn param(&self) -> tls::ConditionalClientTls {
+            self.server_id
+                .clone()
+                .map(|server_id| {
+                    tls::ConditionalClientTls::Some(tls::ClientTls {
+                        server_id,
+                        alpn: Some(tls::client::AlpnProtocols(vec![
+                            transport_header::PROTOCOL.into()
+                        ])),
+                    })
+                })
+                .unwrap_or(tls::ConditionalClientTls::None(
+                    tls::NoClientTls::NotProvidedByServiceDiscovery,
+                ))
+        }
+    }
+
+    impl svc::Param<Remote<ServerAddr>> for Endpoint {
+        fn param(&self) -> Remote<ServerAddr> {
+            Remote(ServerAddr(([127, 0, 0, 1], 4321).into()))
+        }
+    }
+
+    impl svc::Param<Option<PortOverride>> for Endpoint {
+        fn param(&self) -> Option<PortOverride> {
+            self.port_override.map(PortOverride)
+        }
+    }
+
+    impl svc::Param<Option<http::AuthorityOverride>> for Endpoint {
+        fn param(&self) -> Option<http::AuthorityOverride> {
+            self.authority
+                .as_ref()
+                .map(|a| http::AuthorityOverride(a.clone()))
+        }
+    }
+
+    impl svc::Param<Option<SessionProtocol>> for Endpoint {
+        fn param(&self) -> Option<SessionProtocol> {
+            None
+        }
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -180,7 +219,7 @@ mod test {
             }),
         };
         let (mut io, _meta) = svc
-            .oneshot(ep(Metadata::default()))
+            .oneshot(Endpoint::default())
             .await
             .expect("Connect must not fail");
         io.write_all(b"hello").await.expect("Write must succeed");
@@ -213,15 +252,13 @@ mod test {
             }),
         };
 
-        let e = ep(Metadata::new(
-            None,
-            ProtocolHint::Unknown,
-            Some(4143),
-            Some(tls::ServerId(
+        let e = Endpoint {
+            port_override: Some(4143),
+            server_id: Some(tls::ServerId(
                 identity::Name::from_str("server.id").unwrap(),
             )),
-            None,
-        ));
+            authority: None,
+        };
         let (mut io, _meta) = svc.oneshot(e).await.expect("Connect must not fail");
         io.write_all(b"hello").await.expect("Write must succeed");
     }
@@ -253,15 +290,13 @@ mod test {
             }),
         };
 
-        let e = ep(Metadata::new(
-            None,
-            ProtocolHint::Unknown,
-            Some(4143),
-            Some(tls::ServerId(
+        let e = Endpoint {
+            port_override: Some(4143),
+            server_id: Some(tls::ServerId(
                 identity::Name::from_str("server.id").unwrap(),
             )),
-            Some(http::uri::Authority::from_str("foo.bar.example.com:5555").unwrap()),
-        ));
+            authority: Some(http::uri::Authority::from_str("foo.bar.example.com:5555").unwrap()),
+        };
         let (mut io, _meta) = svc.oneshot(e).await.expect("Connect must not fail");
         io.write_all(b"hello").await.expect("Write must succeed");
     }
@@ -293,15 +328,13 @@ mod test {
             }),
         };
 
-        let e = ep(Metadata::new(
-            None,
-            ProtocolHint::Unknown,
-            Some(4143),
-            Some(tls::ServerId(
+        let e = Endpoint {
+            port_override: Some(4143),
+            server_id: Some(tls::ServerId(
                 identity::Name::from_str("server.id").unwrap(),
             )),
-            None,
-        ));
+            authority: None,
+        };
         let (mut io, _meta) = svc.oneshot(e).await.expect("Connect must not fail");
         io.write_all(b"hello").await.expect("Write must succeed");
     }

--- a/linkerd/http-box/src/request.rs
+++ b/linkerd/http-box/src/request.rs
@@ -12,8 +12,12 @@ use std::{
 pub struct BoxRequest<B, S>(S, PhantomData<fn(B)>);
 
 impl<B, S> BoxRequest<B, S> {
+    pub fn new(inner: S) -> Self {
+        BoxRequest(inner, PhantomData)
+    }
+
     pub fn layer() -> impl layer::Layer<S, Service = Self> + Clone + Copy {
-        layer::mk(|inner| BoxRequest(inner, PhantomData))
+        layer::mk(Self::new)
     }
 }
 

--- a/linkerd/proxy/api-resolve/src/metadata.rs
+++ b/linkerd/proxy/api-resolve/src/metadata.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 pub type Labels = std::sync::Arc<BTreeMap<String, String>>;
 
 /// Metadata describing an endpoint.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Metadata {
     /// Arbitrary endpoint labels. Primarily used for telemetry.
     labels: Labels,
@@ -24,7 +24,7 @@ pub struct Metadata {
     authority_override: Option<Authority>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum ProtocolHint {
     /// We don't know what the destination understands, so forward messages in the
     /// protocol we received them in.

--- a/linkerd/proxy/balance/src/lib.rs
+++ b/linkerd/proxy/balance/src/lib.rs
@@ -1,18 +1,18 @@
-mod discover;
-
 use linkerd_error::Error;
 use linkerd_proxy_core::Resolve;
 use linkerd_stack::{layer, NewService, Param, Service};
 use rand::thread_rng;
-use std::{fmt::Debug, marker::PhantomData, net::SocketAddr, time::Duration};
+use std::{fmt::Debug, hash::Hash, marker::PhantomData, net::SocketAddr, time::Duration};
 use tower::{
     balance::p2c,
     load::{self, PeakEwma},
 };
 
+mod discover;
+
 pub use tower::load::peak_ewma::Handle;
 
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct EwmaConfig {
     pub default_rtt: Duration,
     pub decay: Duration,

--- a/linkerd/stack/metrics/src/service.rs
+++ b/linkerd/stack/metrics/src/service.rs
@@ -5,6 +5,10 @@ use std::{
 };
 use tokio::time::Instant;
 
+/// A service that tracks metrics about its readiness.
+///
+/// This service does NOT implement `Clone` because we want the drop count to
+/// reflect actual drops.
 #[derive(Debug)]
 pub struct TrackService<S> {
     inner: S,


### PR DESCRIPTION
To support new discovery types, we want to changing how stacks are composed so that target types are domain-specific and configuration is instrumented via target wrappers.

This change sets up stack changes as follows:

* `Layers::push_flatten_new` is a utility for flatten "cascaded" `NewService` types by providing a target for child `NewService` impls.
* Target/Param constraints and impls are made uniform.
* In tests, we provide new test-specific target types.
* Configuration types are made ready to be stored in a cache.