### PR TITLE
test: Disable tap::rejects_incorrect_identity_when_identity_is_expected

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,23 +1,27 @@
 {
 	"name": "linkerd2-proxy",
 	"image": "ghcr.io/linkerd/dev:v38",
-	"extensions": [
-		"DavidAnson.vscode-markdownlint",
-		"kokakiwi.vscode-just",
-		"NathanRidley.autotrim",
-		"rust-lang.rust-analyzer",
-		"samverschueren.final-newline",
-		"tamasfe.even-better-toml",
-		"zxh404.vscode-proto3"
-	],
-	"settings": {},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"DavidAnson.vscode-markdownlint",
+				"kokakiwi.vscode-just",
+				"NathanRidley.autotrim",
+				"rust-lang.rust-analyzer",
+				"samverschueren.final-newline",
+				"tamasfe.even-better-toml",
+				"zxh404.vscode-proto3"
+			],
+			"settings": {}
+		}
+	},
 	"onCreateCommand": ".devcontainer/on-create.sh",
 	// Support docker + debugger
 	"runArgs": [
 		"--init",
 		// Limit container memory usage.
-		"--memory=12g",
-		"--memory-swap=12g",
+		"--memory=24g",
+		"--memory-swap=24g",
 		// Use the host network so we can access k3d, etc.
 		"--net=host",
 		// For lldb


### PR DESCRIPTION
The `tap::rejects_incorrect_identity_when_identity_is_expected` test passes incorrectly. This change updates the test to assert the expected condition; and then the test is skipped (like the other tap integration tests). These tests all need discovery configuration to operate as intended.

This change also updates the devcontainer.json spec with an increased memory limit. This is necessary to run tests.