### PR TITLE
integration: add destination update builders

### DIFF
--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -464,16 +464,17 @@ impl DestinationBuilder {
     }
 }
 
-impl Into<pb::Update> for DestinationBuilder {
-    fn into(self) -> pb::Update {
-        let Self {
+impl From<DestinationBuilder> for pb::Update {
+    fn from(
+        DestinationBuilder {
             addr,
             hint,
             opaque_port,
             set_labels,
             addr_labels,
             identity,
-        } = self;
+        }: DestinationBuilder,
+    ) -> pb::Update {
         let protocol_hint = match (hint, opaque_port) {
             (Hint::Unknown, None) => None,
             (Hint::Unknown, Some(port)) => Some(pb::ProtocolHint {

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -502,11 +502,9 @@ impl From<DestinationBuilder> for pb::Update {
             }
         };
 
-        let tls_identity = identity.map(|identity| pb::TlsIdentity {
+        let tls_identity = identity.map(|name| pb::TlsIdentity {
             strategy: Some(pb::tls_identity::Strategy::DnsLikeIdentity(
-                pb::tls_identity::DnsLikeIdentity {
-                    name: identity.into(),
-                },
+                pb::tls_identity::DnsLikeIdentity { name },
             )),
         });
 

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -177,8 +177,8 @@ fn grpc_unexpected_request() -> grpc::Status {
 }
 
 impl DstSender {
-    pub fn send(&self, up: pb::Update) {
-        self.0.send(Ok(up)).expect("send dst update")
+    pub fn send(&self, up: impl Into<pb::Update>) {
+        self.0.send(Ok(up.into())).expect("send dst update")
     }
 
     pub fn send_err(&self, e: grpc::Status) {
@@ -189,17 +189,8 @@ impl DstSender {
         self.send(destination_add(addr))
     }
 
-    pub fn send_labeled(&self, addr: SocketAddr, addr_labels: Labels, parent_labels: Labels) {
-        self.send(destination_add_labeled(
-            addr,
-            Hint::Unknown,
-            addr_labels,
-            parent_labels,
-        ));
-    }
-
     pub fn send_h2_hinted(&self, addr: SocketAddr) {
-        self.send(destination_add_hinted(addr, Hint::H2));
+        self.send(destination_add(addr).hint(Hint::H2));
     }
 
     pub fn send_no_endpoints(&self) {
@@ -408,66 +399,137 @@ where
 pub enum Hint {
     Unknown,
     H2,
+    Opaque,
 }
 
-pub fn destination_add(addr: SocketAddr) -> pb::Update {
-    destination_add_hinted(addr, Hint::Unknown)
-}
-
-pub fn destination_add_hinted(addr: SocketAddr, hint: Hint) -> pb::Update {
-    destination_add_labeled(addr, hint, HashMap::new(), HashMap::new())
-}
-
-pub fn destination_add_labeled(
+pub struct DestinationBuilder {
     addr: SocketAddr,
     hint: Hint,
+    opaque_port: Option<u16>,
     set_labels: HashMap<String, String>,
     addr_labels: HashMap<String, String>,
-) -> pb::Update {
-    let protocol_hint = match hint {
-        Hint::Unknown => None,
-        Hint::H2 => Some(pb::ProtocolHint {
-            protocol: Some(pb::protocol_hint::Protocol::H2(pb::protocol_hint::H2 {})),
-            ..Default::default()
-        }),
-    };
-    pb::Update {
-        update: Some(pb::update::Update::Add(pb::WeightedAddrSet {
-            addrs: vec![pb::WeightedAddr {
-                addr: Some(net::TcpAddress {
-                    ip: Some(ip_conv(addr.ip())),
-                    port: u32::from(addr.port()),
-                }),
-                weight: 0,
-                metric_labels: addr_labels,
-                protocol_hint,
-                ..Default::default()
-            }],
-            metric_labels: set_labels,
-        })),
+    identity: Option<String>,
+}
+
+impl DestinationBuilder {
+    pub fn new(addr: SocketAddr) -> Self {
+        Self {
+            addr,
+            hint: Hint::Unknown,
+            opaque_port: None,
+            set_labels: Default::default(),
+            addr_labels: Default::default(),
+            identity: None,
+        }
+    }
+
+    pub fn hint(self, hint: Hint) -> Self {
+        Self { hint, ..self }
+    }
+
+    pub fn opaque_port(self, port: impl Into<Option<u16>>) -> Self {
+        let opaque_port = port.into();
+        Self {
+            opaque_port,
+            ..self
+        }
+    }
+
+    pub fn identity(self, identity: impl ToString) -> Self {
+        Self {
+            identity: Some(identity.to_string()),
+            ..self
+        }
+    }
+
+    pub fn set_labels(mut self, labels: impl IntoIterator<Item = (String, String)>) -> Self {
+        self.set_labels.extend(labels);
+        self
+    }
+
+    pub fn addr_labels(mut self, labels: impl IntoIterator<Item = (String, String)>) -> Self {
+        self.addr_labels.extend(labels);
+        self
+    }
+
+    pub fn set_label(mut self, label: impl ToString, value: impl ToString) -> Self {
+        self.set_labels.insert(label.to_string(), value.to_string());
+        self
+    }
+
+    pub fn addr_label(mut self, label: impl ToString, value: impl ToString) -> Self {
+        self.addr_labels
+            .insert(label.to_string(), value.to_string());
+        self
     }
 }
 
-pub fn destination_add_tls(addr: SocketAddr, local_id: &str) -> pb::Update {
-    pb::Update {
-        update: Some(pb::update::Update::Add(pb::WeightedAddrSet {
-            addrs: vec![pb::WeightedAddr {
-                addr: Some(net::TcpAddress {
-                    ip: Some(ip_conv(addr.ip())),
-                    port: u32::from(addr.port()),
+impl Into<pb::Update> for DestinationBuilder {
+    fn into(self) -> pb::Update {
+        let Self {
+            addr,
+            hint,
+            opaque_port,
+            set_labels,
+            addr_labels,
+            identity,
+        } = self;
+        let protocol_hint = match (hint, opaque_port) {
+            (Hint::Unknown, None) => None,
+            (Hint::Unknown, Some(port)) => Some(pb::ProtocolHint {
+                protocol: None,
+                opaque_transport: Some(pb::protocol_hint::OpaqueTransport {
+                    inbound_port: port as u32,
                 }),
-                tls_identity: Some(pb::TlsIdentity {
-                    strategy: Some(pb::tls_identity::Strategy::DnsLikeIdentity(
-                        pb::tls_identity::DnsLikeIdentity {
-                            name: local_id.into(),
-                        },
+            }),
+            (hint, port) => {
+                let protocol = match hint {
+                    Hint::Unknown => None,
+                    Hint::H2 => Some(pb::protocol_hint::Protocol::H2(pb::protocol_hint::H2 {})),
+                    Hint::Opaque => Some(pb::protocol_hint::Protocol::Opaque(
+                        pb::protocol_hint::Opaque {},
                     )),
-                }),
-                ..Default::default()
-            }],
-            ..Default::default()
-        })),
+                };
+                let opaque_transport = port.map(|port| pb::protocol_hint::OpaqueTransport {
+                    inbound_port: port as u32,
+                });
+
+                Some(pb::ProtocolHint {
+                    protocol,
+                    opaque_transport,
+                })
+            }
+        };
+
+        let tls_identity = identity.map(|identity| pb::TlsIdentity {
+            strategy: Some(pb::tls_identity::Strategy::DnsLikeIdentity(
+                pb::tls_identity::DnsLikeIdentity {
+                    name: identity.into(),
+                },
+            )),
+        });
+
+        pb::Update {
+            update: Some(pb::update::Update::Add(pb::WeightedAddrSet {
+                addrs: vec![pb::WeightedAddr {
+                    addr: Some(net::TcpAddress {
+                        ip: Some(ip_conv(addr.ip())),
+                        port: u32::from(addr.port()),
+                    }),
+                    weight: 1,
+                    metric_labels: addr_labels,
+                    protocol_hint,
+                    tls_identity,
+                    authority_override: None,
+                }],
+                metric_labels: set_labels,
+            })),
+        }
     }
+}
+
+pub fn destination_add(addr: SocketAddr) -> DestinationBuilder {
+    DestinationBuilder::new(addr)
 }
 
 pub fn destination_add_none() -> pb::Update {

--- a/linkerd/app/integration/src/tests/identity.rs
+++ b/linkerd/app/integration/src/tests/identity.rs
@@ -337,7 +337,7 @@ mod require_id_header {
                 let _profile = ctrl.profile_tx_default(srv.addr, "disco.test.svc.cluster.local");
                 let dst = ctrl
                     .destination_tx(format!("disco.test.svc.cluster.local:{}", srv.addr.port()));
-                dst.send(controller::destination_add_tls(srv.addr, app_name));
+                dst.send(controller::destination_add(srv.addr).identity(app_name));
 
                 // Make a proxy that has `proxy_identity` identity and no
                 // SO_ORIGINAL_DST backup

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -570,12 +570,11 @@ mod outbound_dst_labels {
             addr,
         ) = fixture("labeled.test.svc.cluster.local").await;
         let dst_tx = dst_tx.unwrap();
-        {
-            let mut labels = HashMap::new();
-            labels.insert("addr_label1".to_owned(), "foo".to_owned());
-            labels.insert("addr_label2".to_owned(), "bar".to_owned());
-            dst_tx.send_labeled(addr, labels, HashMap::new());
-        }
+        dst_tx.send(
+            controller::destination_add(addr)
+                .addr_label("addr_label1", "foo")
+                .addr_label("addr_label2", "bar"),
+        );
 
         info!("client.get(/)");
         assert_eq!(client.get("/").await, "hello");
@@ -614,7 +613,11 @@ mod outbound_dst_labels {
             let mut labels = HashMap::new();
             labels.insert("set_label1".to_owned(), "foo".to_owned());
             labels.insert("set_label2".to_owned(), "bar".to_owned());
-            dst_tx.send_labeled(addr, HashMap::new(), labels);
+            dst_tx.send(
+                controller::destination_add(addr)
+                    .set_label("set_label1", "foo")
+                    .set_label("set_label2", "bar"),
+            );
         }
 
         info!("client.get(/)");
@@ -655,7 +658,11 @@ mod outbound_dst_labels {
             alabels.insert("addr_label".to_owned(), "foo".to_owned());
             let mut slabels = HashMap::new();
             slabels.insert("set_label".to_owned(), "bar".to_owned());
-            dst_tx.send_labeled(addr, alabels, slabels);
+            dst_tx.send(
+                controller::destination_add(addr)
+                    .addr_label("addr_label", "foo")
+                    .set_label("set_label", "bar"),
+            );
         }
 
         info!("client.get(/)");
@@ -694,13 +701,11 @@ mod outbound_dst_labels {
             addr,
         ) = fixture("labeled.test.svc.cluster.local").await;
         let dst_tx = dst_tx.unwrap();
-        {
-            let mut alabels = HashMap::new();
-            alabels.insert("addr_label".to_owned(), "foo".to_owned());
-            let mut slabels = HashMap::new();
-            slabels.insert("set_label".to_owned(), "unchanged".to_owned());
-            dst_tx.send_labeled(addr, alabels, slabels);
-        }
+        dst_tx.send(
+            controller::destination_add(addr)
+                .addr_label("addr_label", "foo")
+                .set_label("set_label", "unchanged"),
+        );
 
         let labels1 = labels
             .clone()
@@ -719,13 +724,11 @@ mod outbound_dst_labels {
             labels1.metric(metric).value(1u64).assert_in(&metrics).await;
         }
 
-        {
-            let mut alabels = HashMap::new();
-            alabels.insert("addr_label".to_owned(), "bar".to_owned());
-            let mut slabels = HashMap::new();
-            slabels.insert("set_label".to_owned(), "unchanged".to_owned());
-            dst_tx.send_labeled(addr, alabels, slabels);
-        }
+        dst_tx.send(
+            controller::destination_add(addr)
+                .addr_label("addr_label", "bar")
+                .set_label("set_label", "unchanged"),
+        );
 
         let labels2 = labels
             .label("dst_addr_label", "bar")
@@ -774,12 +777,8 @@ mod outbound_dst_labels {
             addr,
         ) = fixture("labeled.test.svc.cluster.local").await;
         let dst_tx = dst_tx.unwrap();
-        {
-            let alabels = HashMap::new();
-            let mut slabels = HashMap::new();
-            slabels.insert("set_label".to_owned(), "foo".to_owned());
-            dst_tx.send_labeled(addr, alabels, slabels);
-        }
+        dst_tx.send(controller::destination_add(addr).set_label("set_label", "foo"));
+
         let labels1 = labels.clone().label("dst_set_label", "foo");
 
         info!("client.get(/)");
@@ -793,12 +792,7 @@ mod outbound_dst_labels {
             labels1.metric(metric).value(1u64).assert_in(&client).await;
         }
 
-        {
-            let alabels = HashMap::new();
-            let mut slabels = HashMap::new();
-            slabels.insert("set_label".to_owned(), "bar".to_owned());
-            dst_tx.send_labeled(addr, alabels, slabels);
-        }
+        dst_tx.send(controller::destination_add(addr).set_label("set_label", "bar"));
         let labels2 = labels.label("dst_set_label", "bar");
 
         info!("client.get(/)");

--- a/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
+++ b/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
@@ -344,10 +344,7 @@ async fn inbound_direct_success() {
     );
     let _profile_out = ctrl.profile_tx_default(proxy1.inbound, auth);
     let dst = ctrl.destination_tx(dst);
-    dst.send(controller::destination_add_tls(
-        proxy1.inbound,
-        proxy1_id_name,
-    ));
+    dst.send(controller::destination_add(proxy1.inbound).identity(proxy1_id_name));
     let ctrl = ctrl.run().await;
     let proxy2 = proxy::new().outbound_ip(proxy1.inbound).controller(ctrl);
     let proxy2_id_name = "bar.ns1.serviceaccount.identity.linkerd.cluster.local";


### PR DESCRIPTION
Currently, updates sent by the mock destination controller used in integration tests are constructed by a number of free functions with names like `destination_add_tls` and `destination_add_h2_hinted` and so on. These functions determine different aspects of the generated destination updates, such as protocol hints, labels, and TLS identity. This works acceptably for the current integration tests. However, in order to add new tests, it may be desirable to add additional destination configurations. For example, for testing the handling of various protocol hints on direct connections, it's necessary to set both a protocol hint *and* a TLS identity (direct connections require TLS). The current approach has separate functions for constructing updates with a protocol hint and updates with TLS.

In order to make the construction of test destinations more flexible, this PR replaces the current approach with a builder. This way, the logic for constructing updates with different attributes can be composed more easily, without having to implement separate constructors for the entire matrix of (protocol hint, TLS identity, addr labels, addr set labels) combinations.

This was factored out of PR #2209 so that the test framework changes can be merged separately.