### PR TITLE
gateway: Fix URI form for gatewayed HTTP/1 requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "linkerd-app-inbound",
  "linkerd-app-outbound",
  "linkerd-app-test",
+ "linkerd-proxy-server-policy",
  "thiserror",
  "tokio",
  "tokio-test",

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -18,6 +18,9 @@ tower = { version = "0.4", default-features = false }
 tracing = "0.1"
 
 [dev-dependencies]
+linkerd-app-inbound = { path = "../inbound", features = ["test-util"] }
+linkerd-app-outbound = { path = "../outbound", features = ["test-util"] }
+linkerd-proxy-server-policy = { path = "../../proxy/server-policy" }
 tokio = { version = "1", features = ["rt", "macros"] }
 tokio-test = "0.4"
 tower = { version = "0.4", default-features = false, features = ["util"] }

--- a/linkerd/app/gateway/src/http.rs
+++ b/linkerd/app/gateway/src/http.rs
@@ -46,8 +46,9 @@ pub struct Target<T = ()> {
 struct ByRequestVersion<T>(Target<T>);
 
 impl Gateway {
-    /// Wrap the provided outbound HTTP stack with an HTTP server, inbound
-    /// authorization, and gateway request routing.
+    /// Wrap the provided outbound HTTP client with the inbound HTTP server,
+    /// inbound authorization, tagged-transport gateway routing, and the
+    /// outbound router.
     pub fn http<T, N, R, NSvc>(
         &self,
         inner: N,

--- a/linkerd/app/gateway/src/http.rs
+++ b/linkerd/app/gateway/src/http.rs
@@ -1,6 +1,18 @@
-use super::{server::Http, Gateway};
+use super::Gateway;
 use inbound::{GatewayAddr, GatewayDomainInvalid};
-use linkerd_app_core::{identity, io, profiles, proxy::http, svc, tls, transport::addrs::*, Error};
+use linkerd_app_core::{
+    identity,
+    metrics::ServerLabel,
+    profiles,
+    proxy::{
+        api_resolve::{ConcreteAddr, Metadata},
+        core::Resolve,
+        http,
+    },
+    svc, tls,
+    transport::addrs::*,
+    Error,
+};
 use linkerd_app_inbound as inbound;
 use linkerd_app_outbound as outbound;
 use std::{
@@ -36,22 +48,43 @@ struct ByRequestVersion<T>(Target<T>);
 impl Gateway {
     /// Wrap the provided outbound HTTP stack with an HTTP server, inbound
     /// authorization, and gateway request routing.
-    pub fn http<T, I, N, NSvc>(&self, inner: N) -> svc::Stack<svc::ArcNewTcp<Http<T>, I>>
+    pub fn http<T, N, R, NSvc>(
+        &self,
+        inner: N,
+        resolve: R,
+    ) -> svc::Stack<
+        svc::ArcNewService<
+            T,
+            impl svc::Service<
+                    http::Request<http::BoxBody>,
+                    Response = http::Response<http::BoxBody>,
+                    Error = Error,
+                    Future = impl Send,
+                > + Clone,
+        >,
+    >
     where
         // Target describing an inbound gateway connection.
         T: svc::Param<GatewayAddr>,
         T: svc::Param<OrigDstAddr>,
         T: svc::Param<Remote<ClientAddr>>,
+        T: svc::Param<ServerLabel>,
         T: svc::Param<tls::ConditionalServerTls>,
         T: svc::Param<tls::ClientId>,
         T: svc::Param<inbound::policy::AllowPolicy>,
-        T: svc::Param<profiles::LookupAddr>,
+        T: svc::Param<Option<profiles::Receiver>>,
+        T: svc::Param<http::Version>,
+        T: svc::Param<http::normalize_uri::DefaultAuthority>,
         T: Clone + Send + Sync + Unpin + 'static,
-        // Server-side socket.
-        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr,
-        I: Send + Unpin + 'static,
+        // Endpoint resolution.
+        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
         // HTTP outbound stack.
-        N: svc::NewService<Target, Service = NSvc>,
+        N: svc::NewService<
+            outbound::http::concrete::Endpoint<
+                outbound::http::logical::Concrete<outbound::http::Http>,
+            >,
+            Service = NSvc,
+        >,
         N: Clone + Send + Sync + Unpin + 'static,
         NSvc: svc::Service<
             http::Request<http::BoxBody>,
@@ -59,9 +92,14 @@ impl Gateway {
             Error = Error,
         >,
         NSvc: Send + Unpin + 'static,
-        NSvc::Future: Send + 'static,
+        NSvc::Future: Send + Unpin + 'static,
     {
-        let http = svc::stack(inner)
+        let http = self
+            .outbound
+            .clone()
+            .with_stack(inner)
+            .push_http_cached(resolve)
+            .into_stack()
             // Discard `T` and its associated client-specific metadata.
             .push_map_target(Target::discard_parent)
             // Add headers to prevent loops.
@@ -77,29 +115,27 @@ impl Gateway {
             }))
             // Only permit gateway traffic to endpoints for which we have
             // discovery information.
-            .push_filter(
-                |(_, parent): (_, Http<T>)| -> Result<_, GatewayDomainInvalid> {
-                    let target = {
-                        let profile = svc::Param::<Option<profiles::Receiver>>::param(&parent)
-                            .ok_or(GatewayDomainInvalid)?;
+            .push_filter(|(_, parent): (_, T)| -> Result<_, GatewayDomainInvalid> {
+                let target = {
+                    let profile = svc::Param::<Option<profiles::Receiver>>::param(&parent)
+                        .ok_or(GatewayDomainInvalid)?;
 
-                        if let Some(profiles::LogicalAddr(addr)) = profile.logical_addr() {
-                            outbound::http::Logical::Route(addr, profile)
-                        } else if let Some((addr, metadata)) = profile.endpoint() {
-                            outbound::http::Logical::Forward(Remote(ServerAddr(addr)), metadata)
-                        } else {
-                            return Err(GatewayDomainInvalid);
-                        }
-                    };
+                    if let Some(profiles::LogicalAddr(addr)) = profile.logical_addr() {
+                        outbound::http::Logical::Route(addr, profile)
+                    } else if let Some((addr, metadata)) = profile.endpoint() {
+                        outbound::http::Logical::Forward(Remote(ServerAddr(addr)), metadata)
+                    } else {
+                        return Err(GatewayDomainInvalid);
+                    }
+                };
 
-                    Ok(Target {
-                        target,
-                        addr: (*parent).param(),
-                        version: svc::Param::param(&parent),
-                        parent: (**parent).clone(),
-                    })
-                },
-            )
+                Ok(Target {
+                    target,
+                    addr: parent.param(),
+                    version: parent.param(),
+                    parent,
+                })
+            })
             // Authorize requests to the gateway.
             .push(self.inbound.authorize_http());
 

--- a/linkerd/app/gateway/src/http/tests.rs
+++ b/linkerd/app/gateway/src/http/tests.rs
@@ -31,6 +31,12 @@ async fn forward_loop() {
     assert!(e.is::<GatewayLoop>());
 }
 
+/// If the HTTP stack is misconfigured--specifically if two server stacks are
+/// instrumented--it may incorrectly determine that an upgraded origin-form
+/// HTTP/1.1 request should be in absolute-form.
+///
+/// This test validates that origin-form requests are not marked as
+/// absolute-form.
 #[tokio::test(flavor = "current_thread")]
 async fn upgraded_request_remains_relative_form() {
     let _trace = trace_init();

--- a/linkerd/app/gateway/src/http/tests.rs
+++ b/linkerd/app/gateway/src/http/tests.rs
@@ -1,44 +1,20 @@
 use super::*;
 use linkerd_app_core::{
-    dns, profiles,
-    proxy::{api_resolve::Metadata, http},
-    svc::NewService,
-    tls, Error, NameAddr, NameMatch,
+    proxy::http,
+    svc::{NewService, ServiceExt},
+    tls,
+    trace::test::trace_init,
+    Error, NameAddr,
 };
 use linkerd_app_inbound::GatewayLoop;
-use linkerd_app_test as support;
-use std::str::FromStr;
-use tower::util::ServiceExt;
+use linkerd_proxy_server_policy as policy;
+use std::{str::FromStr, sync::Arc, time};
 use tower_test::mock;
 
 #[tokio::test]
 async fn gateway() {
     assert_eq!(
-        Test::default()
-            .with_default_profile()
-            .run()
-            .await
-            .unwrap()
-            .status(),
-        http::StatusCode::NO_CONTENT
-    );
-}
-
-#[tokio::test]
-async fn gateway_endpoint() {
-    let addr = std::net::SocketAddr::new([192, 0, 2, 10].into(), 777);
-    let profile = support::profile::only(profiles::Profile {
-        endpoint: Some((addr, Metadata::default())),
-        ..profiles::Profile::default()
-    });
-
-    assert_eq!(
-        Test::default()
-            .with_profile(profile)
-            .run()
-            .await
-            .unwrap()
-            .status(),
+        Test::default().run().await.unwrap().status(),
         http::StatusCode::NO_CONTENT
     );
 }
@@ -51,26 +27,172 @@ async fn forward_loop() {
         ),
         ..Default::default()
     };
-    let e = test.with_default_profile().run().await.unwrap_err();
+    let e = test.run().await.unwrap_err();
     assert!(e.is::<GatewayLoop>());
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn upgraded_request_remains_relative_form() {
+    let _trace = trace_init();
+
+    #[derive(Clone, Debug)]
+    struct Target;
+
+    impl svc::Param<GatewayAddr> for Target {
+        fn param(&self) -> GatewayAddr {
+            GatewayAddr("web.test.example.com:80".parse().unwrap())
+        }
+    }
+
+    impl svc::Param<OrigDstAddr> for Target {
+        fn param(&self) -> OrigDstAddr {
+            OrigDstAddr(([10, 10, 10, 10], 4143).into())
+        }
+    }
+
+    impl svc::Param<Remote<ClientAddr>> for Target {
+        fn param(&self) -> Remote<ClientAddr> {
+            Remote(ClientAddr(([10, 10, 10, 11], 41430).into()))
+        }
+    }
+
+    impl svc::Param<ServerLabel> for Target {
+        fn param(&self) -> ServerLabel {
+            ServerLabel(policy::Meta::new_default("test"))
+        }
+    }
+
+    impl svc::Param<tls::ClientId> for Target {
+        fn param(&self) -> tls::ClientId {
+            tls::ClientId::from_str("client.id.test").unwrap()
+        }
+    }
+
+    impl svc::Param<tls::ConditionalServerTls> for Target {
+        fn param(&self) -> tls::ConditionalServerTls {
+            tls::ConditionalServerTls::Some(tls::ServerTls::Established {
+                client_id: Some(self.param()),
+                negotiated_protocol: None,
+            })
+        }
+    }
+
+    impl svc::Param<Option<profiles::Receiver>> for Target {
+        fn param(&self) -> Option<profiles::Receiver> {
+            Some(linkerd_app_test::profile::only(profiles::Profile {
+                addr: Some(profiles::LogicalAddr(
+                    "web.test.example.com:80".parse().unwrap(),
+                )),
+                ..profiles::Profile::default()
+            }))
+        }
+    }
+
+    impl svc::Param<http::Version> for Target {
+        fn param(&self) -> http::Version {
+            http::Version::H2
+        }
+    }
+
+    impl svc::Param<http::normalize_uri::DefaultAuthority> for Target {
+        fn param(&self) -> http::normalize_uri::DefaultAuthority {
+            http::normalize_uri::DefaultAuthority(Some(
+                http::uri::Authority::from_str("web.test.example.com").unwrap(),
+            ))
+        }
+    }
+
+    impl svc::Param<inbound::policy::AllowPolicy> for Target {
+        fn param(&self) -> inbound::policy::AllowPolicy {
+            let policy = policy::ServerPolicy {
+                meta: inbound::policy::Meta::new_default("test"),
+                protocol: policy::Protocol::Detect {
+                    timeout: time::Duration::from_secs(10),
+                    tcp_authorizations: Arc::new([]),
+                    http: Arc::new([policy::http::default(Arc::new([policy::Authorization {
+                        authentication: policy::Authentication::TlsUnauthenticated,
+                        networks: vec![svc::Param::<Remote<ClientAddr>>::param(self).ip().into()],
+                        meta: Arc::new(policy::Meta::Resource {
+                            group: "policy.linkerd.io".into(),
+                            kind: "authorizationpolicy".into(),
+                            name: "testsaz".into(),
+                        }),
+                    }]))]),
+                },
+            };
+            let (policy, tx) = inbound::policy::AllowPolicy::for_test(self.param(), policy);
+            tokio::spawn(async move {
+                tx.closed().await;
+            });
+            policy
+        }
+    }
+
+    let (outbound, _outbound_shutdown) = crate::Outbound::for_test();
+    let (inbound, _inbound_shutdown) = crate::Inbound::for_test();
+    let gateway = Gateway {
+        config: crate::Config {
+            allow_discovery: std::iter::once("example.com".parse().unwrap())
+                .into_iter()
+                .collect(),
+        },
+        inbound,
+        outbound,
+    };
+
+    let (inner, mut handle) =
+        mock::pair::<http::Request<http::BoxBody>, http::Response<http::BoxBody>>();
+    handle.allow(1);
+    let inner = gateway
+        .outbound
+        .clone()
+        .with_stack(move |_: _| inner.clone());
+    // let (resolve, resolve_handle) = linkerd_app_test::resolver::Dst::<Metadata>::with_handle();
+    let resolve = linkerd_app_test::resolver::Dst::<Metadata>::default().endpoint_exists(
+        svc::Param::<GatewayAddr>::param(&Target).0,
+        svc::Param::<Remote<ClientAddr>>::param(&Target).into(),
+        Default::default(),
+    );
+    let service = gateway
+        .http(inner.into_inner(), resolve)
+        .new_service(Target);
+
+    // Process a request in the background so we can handle it ourselves to see
+    // how the request was mutated
+    tokio::spawn(async move {
+        let (handle, _closed) =
+            http::ClientHandle::new(svc::Param::<Remote<ClientAddr>>::param(&Target).into());
+        let req = http::Request::builder()
+            .method(http::Method::GET)
+            .version(::http::Version::HTTP_2)
+            .uri("http://web-original.test.example.com/test.txt")
+            .header("l5d-orig-proto", "HTTP/1.1")
+            .extension(handle)
+            .body(http::BoxBody::default())
+            .unwrap();
+        let _rsp = service.oneshot(req).await.unwrap();
+        drop(_closed);
+    });
+
+    let (request, _respond) = handle.next_request().await.unwrap();
+    assert!(request
+        .extensions()
+        .get::<http::h1::WasAbsoluteForm>()
+        .is_none());
+}
+
 struct Test {
-    suffix: &'static str,
     target: NameAddr,
     client_id: tls::ClientId,
     orig_fwd: Option<&'static str>,
-    profile: Option<profiles::Receiver>,
 }
 
 impl Default for Test {
     fn default() -> Self {
         Self {
-            suffix: "test.example.com",
             target: NameAddr::from_str("dst.test.example.com:4321").unwrap(),
             client_id: tls::ClientId::from_str("client.id.test").unwrap(),
             orig_fwd: None,
-            profile: None,
         }
     }
 }
@@ -141,23 +263,5 @@ impl Test {
         let rsp = gateway.oneshot(req).await?;
         bg.await?;
         Ok(rsp)
-    }
-
-    fn with_profile(mut self, profile: profiles::Receiver) -> Self {
-        let allow = Some(dns::Suffix::from_str(self.suffix).unwrap())
-            .into_iter()
-            .collect::<NameMatch>();
-        if allow.matches(self.target.name()) {
-            self.profile = Some(profile);
-        }
-        self
-    }
-
-    fn with_default_profile(self) -> Self {
-        let target = self.target.clone();
-        self.with_profile(support::profile::only(profiles::Profile {
-            addr: Some(target.into()),
-            ..profiles::Profile::default()
-        }))
     }
 }

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -71,8 +71,17 @@ impl Gateway {
         };
 
         let http = {
-            let http = self.outbound.to_tcp_connect().push_http_cached(resolve);
-            self.http(http.into_inner()).into_inner()
+            let http = self
+                .outbound
+                .to_tcp_connect()
+                .push_tcp_endpoint()
+                .push_http_client();
+            let http = self.http(http.into_inner(), resolve);
+            self.inbound
+                .clone()
+                .with_stack(http.into_inner())
+                .push_http_tcp_server()
+                .into_inner()
         };
 
         self.server(disco, opaq, http)

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -75,7 +75,7 @@ impl Gateway {
                 .outbound
                 .to_tcp_connect()
                 .push_tcp_endpoint()
-                .push_http_client();
+                .push_http_tcp_client();
             let http = self.http(http.into_inner(), resolve);
             self.inbound
                 .clone()

--- a/linkerd/app/gateway/src/server.rs
+++ b/linkerd/app/gateway/src/server.rs
@@ -182,6 +182,15 @@ where
     }
 }
 
+impl<T> svc::Param<GatewayAddr> for Http<T>
+where
+    T: svc::Param<GatewayAddr>,
+{
+    fn param(&self) -> GatewayAddr {
+        (***self).param()
+    }
+}
+
 impl<T> svc::Param<OrigDstAddr> for Http<T>
 where
     T: svc::Param<OrigDstAddr>,

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -9,13 +9,24 @@ description = """
 Configures and runs the inbound proxy
 """
 
+[features]
+test-util = [
+    "linkerd-app-test",
+    "linkerd-idle-cache/test-util",
+    "linkerd-meshtls/rustls",
+    "linkerd-meshtls-rustls/test-util",
+]
+
 [dependencies]
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }
 linkerd-app-core = { path = "../core" }
+linkerd-app-test = { path = "../test", optional = true }
 linkerd-http-access-log = { path = "../../http-access-log" }
 linkerd-idle-cache = { path = "../../idle-cache" }
+linkerd-meshtls = { path = "../../meshtls", optional = true }
+linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true }
 linkerd-tonic-watch = { path = "../../tonic-watch" }
 linkerd2-proxy-api = { version = "0.8", features = ["inbound"] }
 once_cell = "1"

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -99,7 +99,6 @@ impl<H> Inbound<H> {
         })
     }
 
-    /// Fails requests when the `HSvc`-typed inner service is not ready.
     pub fn push_http_tcp_server<T, I, HSvc>(self) -> Inbound<svc::ArcNewTcp<T, I>>
     where
         T: Param<Version>,

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -37,6 +37,7 @@ where
                 .push_connect_timeout(cfg.proxy.connect.timeout)
         })
         .push_http_router(profiles)
+        .push_http_server()
         .push_http_tcp_server()
         .into_inner()
 }

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -37,7 +37,7 @@ where
                 .push_connect_timeout(cfg.proxy.connect.timeout)
         })
         .push_http_router(profiles)
-        .push_http_server()
+        .push_http_tcp_server()
         .into_inner()
 }
 

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -13,8 +13,9 @@ mod http;
 mod metrics;
 pub mod policy;
 mod server;
-#[cfg(any(test, fuzzing))]
-pub(crate) mod test_util;
+
+#[cfg(any(test, feature = "test-util", fuzzing))]
+pub mod test_util;
 
 pub use self::{metrics::Metrics, policy::DefaultPolicy};
 use linkerd_app_core::{
@@ -159,6 +160,13 @@ impl Inbound<()> {
             runtime,
             stack: svc::stack(()),
         }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn for_test() -> (Self, drain::Signal) {
+        let (rt, drain) = test_util::runtime();
+        let this = Self::new(test_util::default_config(), rt);
+        (this, drain)
     }
 
     pub fn metrics(&self) -> Metrics {

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -98,11 +98,8 @@ impl From<DefaultPolicy> for ServerPolicy {
 // === impl AllowPolicy ===
 
 impl AllowPolicy {
-    #[cfg(any(test, fuzzing))]
-    pub(crate) fn for_test(
-        dst: OrigDstAddr,
-        server: ServerPolicy,
-    ) -> (Self, watch::Sender<ServerPolicy>) {
+    #[cfg(any(test, fuzzing, feature = "test-util"))]
+    pub fn for_test(dst: OrigDstAddr, server: ServerPolicy) -> (Self, watch::Sender<ServerPolicy>) {
         let (tx, server) = watch::channel(server);
         let server = Cached::uncached(server);
         let p = Self { dst, server };

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -215,16 +215,18 @@ impl<T, N> HttpPolicyService<T, N> {
                     client.ip = %self.connection.client.ip(),
                     "Request denied",
                 );
-                if route.authorizations.is_empty() {
-                    tracing::debug!("No authorizations defined",);
-                }
-                for authz in &*route.authorizations {
-                    tracing::debug!(
-                        authz.group = %authz.meta.group(),
-                        authz.kind = %authz.meta.kind(),
-                        authz.name = %authz.meta.name(),
-                        "Authorization did not apply",
-                    );
+                if tracing::event_enabled!(tracing::Level::DEBUG) {
+                    if route.authorizations.is_empty() {
+                        tracing::debug!("No authorizations defined",);
+                    }
+                    for authz in &*route.authorizations {
+                        tracing::debug!(
+                            authz.group = %authz.meta.group(),
+                            authz.kind = %authz.meta.kind(),
+                            authz.name = %authz.meta.name(),
+                            "Authorization did not apply",
+                        );
+                    }
                 }
                 self.metrics
                     .deny(labels, self.connection.dst, self.connection.tls.clone());

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -215,6 +215,17 @@ impl<T, N> HttpPolicyService<T, N> {
                     client.ip = %self.connection.client.ip(),
                     "Request denied",
                 );
+                if route.authorizations.is_empty() {
+                    tracing::debug!("No authorizations defined",);
+                }
+                for authz in &*route.authorizations {
+                    tracing::debug!(
+                        authz.group = %authz.meta.group(),
+                        authz.kind = %authz.meta.kind(),
+                        authz.name = %authz.meta.name(),
+                        "Authorization did not apply",
+                    );
+                }
                 self.metrics
                     .deny(labels, self.connection.dst, self.connection.tls.clone());
                 return Err(HttpRouteUnauthorized(()).into());

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -67,6 +67,7 @@ impl Inbound<()> {
                 .into_tcp_connect(addr.port())
                 .push_http_router(profiles.clone())
                 .push_http_server()
+                .push_http_tcp_server()
                 .into_inner();
 
             self.clone()
@@ -88,6 +89,7 @@ impl Inbound<()> {
         // Determines how to handle an inbound connection, dispatching it to the appropriate
         // stack.
         let server = http
+            .push_http_tcp_server()
             .push_detect(forward)
             .push_accept(addr.port(), policies, direct)
             .into_inner();

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -10,19 +10,22 @@ Configures and runs the outbound proxy
 """
 
 [features]
+test-util = ["linkerd-app-test", "linkerd-meshtls-rustls/test-util"]
+
 default = []
 allow-loopback = []
 test-subscriber = []
-
 [dependencies]
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }
 linkerd-app-core = { path = "../core" }
+linkerd-app-test = { path = "../test", optional = true }
 linkerd-distribute = { path = "../../distribute" }
 linkerd-http-classify = { path = "../../http-classify" }
 linkerd-http-retry = { path = "../../http-retry" }
 linkerd-identity = { path = "../../identity" }
+linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true }
 linkerd-retry = { path = "../../retry" }
 parking_lot = "0.12"
 thiserror = "1"

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -35,8 +35,9 @@ pub struct Http {
 // === impl Outbound ===
 
 impl<N> Outbound<N> {
-    /// Builds a stack that handles protocol detection, routing, and
-    /// load balancing for a single logical destination.
+    /// Builds a stack that routes HTTP requests to endpoint stacks.
+    ///
+    /// Buffered concrete services are cached in and evicted when idle.
     pub fn push_http_cached<T, R, NSvc>(
         self,
         resolve: R,

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -2,22 +2,20 @@ use self::{
     proxy_connection_close::ProxyConnectionClose, require_id_header::NewRequireIdentity,
     strip_proxy_error::NewStripProxyError,
 };
-use crate::{tcp, Outbound};
+use crate::Outbound;
 use linkerd_app_core::{
-    io, profiles,
+    profiles,
     proxy::{
         api_resolve::{ConcreteAddr, Metadata},
         core::Resolve,
     },
-    svc,
-    transport::addrs::*,
-    Addr, Error,
+    svc, Error,
 };
 use std::{fmt::Debug, hash::Hash};
 
-mod concrete;
+pub mod concrete;
 mod endpoint;
-mod logical;
+pub mod logical;
 mod proxy_connection_close;
 mod require_id_header;
 mod retry;
@@ -29,17 +27,17 @@ pub(crate) use self::require_id_header::IdentityRequired;
 pub use linkerd_app_core::proxy::http::{self as http, *};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct Http {
+pub struct Http {
     target: Logical,
     version: http::Version,
 }
 
 // === impl Outbound ===
 
-impl<C> Outbound<C> {
+impl<N> Outbound<N> {
     /// Builds a stack that handles protocol detection, routing, and
     /// load balancing for a single logical destination.
-    pub fn push_http_cached<T, R>(
+    pub fn push_http_cached<T, R, NSvc>(
         self,
         resolve: R,
     ) -> Outbound<
@@ -60,17 +58,20 @@ impl<C> Outbound<C> {
         T: Clone + Send + Sync + 'static,
         // Endpoint resolution.
         R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
-        // TCP connector stack.
-        C: svc::MakeConnection<tcp::Connect, Metadata = Local<ClientAddr>, Error = io::Error>,
-        C: Clone + Send + Sync + Unpin + 'static,
-        C::Connection: Send + Unpin,
-        C::Future: Send,
+        // HTTP client stack
+        N: svc::NewService<concrete::Endpoint<logical::Concrete<Http>>, Service = NSvc>,
+        N: Clone + Send + Sync + Unpin + 'static,
+        NSvc: svc::Service<
+            http::Request<http::BoxBody>,
+            Response = http::Response<http::BoxBody>,
+            Error = Error,
+        >,
+        NSvc: Send + 'static,
+        NSvc::Future: Send + Unpin + 'static,
     {
-        self.push_tcp_endpoint()
-            .push_http_endpoint()
+        self.push_http_endpoint()
             .push_http_concrete(resolve)
             .push_http_logical()
-            .push_http_server()
             .map_stack(move |config, _, stk| {
                 stk.push_new_idle_cached(config.discovery_idle_timeout)
                     // Use a dedicated target type to configure parameters for the
@@ -107,17 +108,6 @@ impl svc::Param<http::Version> for Http {
 impl svc::Param<Logical> for Http {
     fn param(&self) -> Logical {
         self.target.clone()
-    }
-}
-
-impl svc::Param<http::normalize_uri::DefaultAuthority> for Http {
-    fn param(&self) -> http::normalize_uri::DefaultAuthority {
-        let addr = match self.target.param() {
-            Logical::Route(addr, _) => Addr::from(addr),
-            Logical::Forward(Remote(ServerAddr(addr)), _) => Addr::from(addr),
-        };
-
-        http::normalize_uri::DefaultAuthority(Some(addr.to_http_authority()))
     }
 }
 

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -1,7 +1,7 @@
 //! A stack that (optionally) resolves a service to a set of endpoint replicas
 //! and distributes HTTP requests among them.
 
-use super::{balance, client, normalize_uri};
+use super::{balance, client};
 use crate::{http, stack_labels, Outbound};
 use linkerd_app_core::{
     metrics, profiles,
@@ -285,28 +285,6 @@ impl<T> svc::Param<tls::ConditionalClientTls> for Endpoint<T> {
             .unwrap_or(tls::ConditionalClientTls::None(
                 tls::NoClientTls::NotProvidedByServiceDiscovery,
             ))
-    }
-}
-
-impl<T> svc::Param<normalize_uri::DefaultAuthority> for Endpoint<T>
-where
-    T: svc::Param<Option<profiles::LogicalAddr>>,
-{
-    fn param(&self) -> normalize_uri::DefaultAuthority {
-        if let Some(profiles::LogicalAddr(ref a)) = self.parent.param() {
-            return normalize_uri::DefaultAuthority(Some(
-                a.to_string()
-                    .parse()
-                    .expect("Address must be a valid authority"),
-            ));
-        }
-
-        normalize_uri::DefaultAuthority(Some(
-            self.addr
-                .to_string()
-                .parse()
-                .expect("Address must be a valid authority"),
-        ))
     }
 }
 

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -35,7 +35,7 @@ struct ClientRescue {
 }
 
 impl<C> Outbound<C> {
-    pub fn push_http_client<T, B>(
+    pub fn push_http_tcp_client<T, B>(
         self,
     ) -> Outbound<
         svc::ArcNewService<

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -35,15 +35,22 @@ struct ClientRescue {
 }
 
 impl<C> Outbound<C> {
-    pub fn push_http_endpoint<T, B>(self) -> Outbound<svc::ArcNewHttp<T, B>>
+    pub fn push_http_client<T, B>(
+        self,
+    ) -> Outbound<
+        svc::ArcNewService<
+            T,
+            impl svc::Service<
+                http::Request<B>,
+                Response = http::Response<http::BoxBody>,
+                Error = Error,
+                Future = impl Send,
+            >,
+        >,
+    >
     where
         // Http endpoint target.
         T: svc::Param<http::client::Settings>,
-        T: svc::Param<Remote<ServerAddr>>,
-        T: svc::Param<Option<http::AuthorityOverride>>,
-        T: svc::Param<metrics::EndpointLabels>,
-        T: svc::Param<tls::ConditionalClientTls>,
-        T: tap::Inspect,
         T: Clone + Send + Sync + 'static,
         // Http endpoint body.
         B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
@@ -54,11 +61,10 @@ impl<C> Outbound<C> {
         C::Metadata: Send + Unpin,
         C::Future: Send + Unpin + 'static,
     {
-        self.map_stack(|config, rt, inner| {
+        self.map_stack(|config, _, inner| {
             let config::ConnectConfig {
                 h1_settings,
                 h2_settings,
-                backoff,
                 ..
             } = config.proxy.connect;
 
@@ -72,6 +78,43 @@ impl<C> Outbound<C> {
                 .push_on_service(svc::MapErr::layer_boxed())
                 .check_service::<T>()
                 .into_new_service()
+                .push(svc::ArcNewService::layer())
+        })
+    }
+}
+
+impl<N> Outbound<N> {
+    pub fn push_http_endpoint<T, B, NSvc>(self) -> Outbound<svc::ArcNewHttp<T, B>>
+    where
+        // Http endpoint target.
+        T: svc::Param<http::client::Settings>,
+        T: svc::Param<Remote<ServerAddr>>,
+        T: svc::Param<Option<http::AuthorityOverride>>,
+        T: svc::Param<metrics::EndpointLabels>,
+        T: svc::Param<tls::ConditionalClientTls>,
+        T: tap::Inspect,
+        T: Clone + Send + Sync + 'static,
+        // Http endpoint body.
+        B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
+        B::Data: Send + 'static,
+        // HTTP client stack
+        N: svc::NewService<T, Service = NSvc>,
+        N: Clone + Send + Sync + Unpin + 'static,
+        NSvc: svc::Service<
+            http::Request<http::BoxBody>,
+            Response = http::Response<http::BoxBody>,
+            Error = Error,
+        >,
+        NSvc: Send + 'static,
+        NSvc::Future: Send + Unpin + 'static,
+    {
+        self.map_stack(|config, rt, inner| {
+            let config::ConnectConfig { backoff, .. } = config.proxy.connect;
+
+            // Initiates an HTTP client on the underlying transport. Prior-knowledge HTTP/2
+            // is typically used (i.e. when communicating with other proxies); though
+            // HTTP/1.x fallback is supported as needed.
+            inner
                 // Drive the connection to completion regardless of whether the reconnect is being
                 // actively polled.
                 .push_on_service(svc::layer::mk(svc::SpawnReady::new))
@@ -92,6 +135,7 @@ impl<C> Outbound<C> {
                 // double-counted--i.e., endpoint metrics track these responses and error metrics
                 // track proxy errors that occur higher in the stack.
                 .push(ClientRescue::layer(config.emit_headers))
+                .push_on_service(http::BoxRequest::layer())
                 .push(tap::NewTapHttp::layer(rt.tap.clone()))
                 .push(
                     rt.metrics

--- a/linkerd/app/outbound/src/http/endpoint/tests.rs
+++ b/linkerd/app/outbound/src/http/endpoint/tests.rs
@@ -25,7 +25,8 @@ async fn http11_forward() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(connect)
-        .push_http_endpoint::<_, http::BoxBody>()
+        .push_http_client()
+        .push_http_endpoint::<_, http::BoxBody, _>()
         .into_inner();
 
     let svc = stack.new_service(Endpoint {
@@ -58,7 +59,8 @@ async fn http2_forward() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(connect)
-        .push_http_endpoint::<_, http::BoxBody>()
+        .push_http_client()
+        .push_http_endpoint::<_, http::BoxBody, _>()
         .into_inner();
 
     let svc = stack.new_service(Endpoint {
@@ -93,7 +95,8 @@ async fn orig_proto_upgrade() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(connect)
-        .push_http_endpoint::<_, http::BoxBody>()
+        .push_http_client()
+        .push_http_endpoint::<_, http::BoxBody, _>()
         .into_inner();
 
     let svc = stack.new_service(Endpoint {
@@ -140,7 +143,8 @@ async fn orig_proto_skipped_on_http_upgrade() {
     let drain = rt.drain.clone();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(connect)
-        .push_http_endpoint::<_, http::BoxBody>()
+        .push_http_client()
+        .push_http_endpoint::<_, http::BoxBody, _>()
         .into_stack()
         .push_on_service(http::BoxRequest::layer())
         // We need the server-side upgrade layer to annotate the request so that the client
@@ -186,7 +190,8 @@ async fn orig_proto_http2_noop() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(connect)
-        .push_http_endpoint::<_, http::BoxBody>()
+        .push_http_client()
+        .push_http_endpoint::<_, http::BoxBody, _>()
         .into_inner();
 
     let svc = stack.new_service(Endpoint {

--- a/linkerd/app/outbound/src/http/endpoint/tests.rs
+++ b/linkerd/app/outbound/src/http/endpoint/tests.rs
@@ -25,7 +25,7 @@ async fn http11_forward() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(connect)
-        .push_http_client()
+        .push_http_tcp_client()
         .push_http_endpoint::<_, http::BoxBody, _>()
         .into_inner();
 
@@ -59,7 +59,7 @@ async fn http2_forward() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(connect)
-        .push_http_client()
+        .push_http_tcp_client()
         .push_http_endpoint::<_, http::BoxBody, _>()
         .into_inner();
 
@@ -95,7 +95,7 @@ async fn orig_proto_upgrade() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(connect)
-        .push_http_client()
+        .push_http_tcp_client()
         .push_http_endpoint::<_, http::BoxBody, _>()
         .into_inner();
 
@@ -143,7 +143,7 @@ async fn orig_proto_skipped_on_http_upgrade() {
     let drain = rt.drain.clone();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(connect)
-        .push_http_client()
+        .push_http_tcp_client()
         .push_http_endpoint::<_, http::BoxBody, _>()
         .into_stack()
         .push_on_service(http::BoxRequest::layer())
@@ -190,7 +190,7 @@ async fn orig_proto_http2_noop() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(connect)
-        .push_http_client()
+        .push_http_tcp_client()
         .push_http_endpoint::<_, http::BoxBody, _>()
         .into_inner();
 

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -161,14 +161,15 @@ impl<N> Outbound<N> {
 
             // For each `T` target, watch its `Profile`, rebuilding a
             // router stack.
-            concrete
+            let watch = concrete
                 .clone()
                 // Share the concrete stack with each router stack.
                 .lift_new()
                 // Rebuild this router stack every time the profile changes.
                 .push_on_service(router)
-                .push(svc::NewSpawnWatch::<Profile, _>::layer_into::<Params<T>>())
-                .push(svc::NewMapErr::layer_from_target::<LogicalError, _>())
+                .push(svc::NewSpawnWatch::<Profile, _>::layer_into::<Params<T>>());
+
+            watch
                 // Add l5d-dst-canonical header to requests.
                 //
                 // TODO(ver) move this into the endpoint stack so that we can only
@@ -176,6 +177,7 @@ impl<N> Outbound<N> {
                 //
                 // TODO(ver) do we need to strip headers here?
                 .push(http::NewHeaderFromTarget::<CanonicalDstHeader, _>::layer())
+                .push(svc::NewMapErr::layer_from_target::<LogicalError, _>())
                 .push_switch(
                     |parent: T| -> Result<_, Infallible> {
                         Ok(match parent.param() {

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -75,7 +75,7 @@ impl Outbound<()> {
         let http = self
             .to_tcp_connect()
             .push_tcp_endpoint()
-            .push_http_client()
+            .push_http_tcp_client()
             .push_http_cached(resolve)
             .push_http_server()
             .map_stack(|_, _, stk| {

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -74,7 +74,10 @@ impl Outbound<()> {
 
         let http = self
             .to_tcp_connect()
+            .push_tcp_endpoint()
+            .push_http_client()
             .push_http_cached(resolve)
+            .push_http_server()
             .map_stack(|_, _, stk| {
                 stk.check_new_service::<Http<http::Logical>, _>()
                     .push_filter(Http::try_from)

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -149,7 +149,7 @@ impl<S> Outbound<S> {
         self.stack.into_inner()
     }
 
-    /// Wraps the inner `S`-typed stack in the given `L`-typed [`Layer`].
+    /// Wraps the inner `S`-typed stack in the given `L`-typed [`svc::Layer`].
     pub fn push<L: svc::Layer<S>>(self, layer: L) -> Outbound<L::Service> {
         self.map_stack(move |_, _, stack| stack.push(layer))
     }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -38,8 +38,8 @@ pub mod opaq;
 mod protocol;
 mod sidecar;
 pub mod tcp;
-#[cfg(test)]
-pub(crate) mod test_util;
+#[cfg(any(test, feature = "test-util"))]
+pub mod test_util;
 
 pub use self::{discover::Discovery, metrics::Metrics};
 
@@ -110,6 +110,13 @@ impl Outbound<()> {
             runtime,
             stack: svc::stack(()),
         }
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn for_test() -> (Self, drain::Signal) {
+        let (rt, drain) = test_util::runtime();
+        let this = Self::new(test_util::default_config(), rt);
+        (this, drain)
     }
 }
 

--- a/linkerd/app/outbound/src/protocol.rs
+++ b/linkerd/app/outbound/src/protocol.rs
@@ -132,12 +132,3 @@ where
         self.parent.param()
     }
 }
-
-impl<T> svc::Param<http::normalize_uri::DefaultAuthority> for Http<T>
-where
-    T: svc::Param<http::normalize_uri::DefaultAuthority>,
-{
-    fn param(&self) -> http::normalize_uri::DefaultAuthority {
-        self.parent.param()
-    }
-}

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -37,7 +37,7 @@ impl Outbound<()> {
         let http = self
             .to_tcp_connect()
             .push_tcp_endpoint()
-            .push_http_client()
+            .push_http_tcp_client()
             .push_http_cached(resolve)
             .push_http_server();
 

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -34,7 +34,12 @@ impl Outbound<()> {
         R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
     {
         let opaq = self.to_tcp_connect().push_opaq_cached(resolve.clone());
-        let http = self.to_tcp_connect().push_http_cached(resolve);
+        let http = self
+            .to_tcp_connect()
+            .push_tcp_endpoint()
+            .push_http_client()
+            .push_http_cached(resolve)
+            .push_http_server();
 
         opaq.push_protocol(http.into_inner())
             // Use a dedicated target type to bind discovery results to the

--- a/linkerd/app/outbound/src/tcp/endpoint.rs
+++ b/linkerd/app/outbound/src/tcp/endpoint.rs
@@ -15,7 +15,7 @@ impl<C> Outbound<C> {
     ) -> Outbound<
         impl svc::MakeConnection<
                 T,
-                Connection = impl Send + Unpin,
+                Connection = impl io::AsyncRead + io::AsyncWrite + Send + Unpin,
                 Metadata = ConnectMeta,
                 Error = Error,
                 Future = impl Send,

--- a/linkerd/proxy/core/src/resolve.rs
+++ b/linkerd/proxy/core/src/resolve.rs
@@ -42,7 +42,6 @@ impl<S, T, R, E> Resolve<T> for S
 where
     T: Send + 'static,
     S: tower::Service<T, Response = R> + Clone + Send + Sync + Unpin + 'static,
-    S::Response: Send + 'static,
     S::Error: Into<Error>,
     S::Future: Send + Unpin + 'static,
     R: Stream<Item = Result<Update<E>, S::Error>> + Send + 'static,


### PR DESCRIPTION
A recent change broke how gateways handle the URI of upgraded HTTP/1.1 requests. This problem was caused by normaling the URI twice (once in the inbound HTTP server and once in the outbound HTTP server).

To fix this, the outbound HTTP server has been removed from the cached stack so that it is not included in gatewayed services.

Furthermore, to test this, this change splits `push_http_client` from the `Outbound::push_http_endpoint` stack and `push_http_tcp_server` from the `Inbound::push_http_server` stack. This allows us to write tests that mock HTTP-level services.