### PR TITLE
http: Replace `classify::CanClassify` with `Param`

### DIFF
--- a/linkerd/app/core/src/classify.rs
+++ b/linkerd/app/core/src/classify.rs
@@ -1,19 +1,20 @@
 use crate::profiles;
 use linkerd_error::Error;
 use linkerd_http_classify as classify;
-pub use linkerd_http_classify::{CanClassify, NewClassify};
 use linkerd_proxy_http::{HasH2Reason, ResponseTimeoutError};
 use std::borrow::Cow;
 use tonic as grpc;
 use tracing::trace;
 
-#[derive(Clone, Debug)]
+pub type NewClassify<N, X = ()> = classify::NewClassify<Request, X, N>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Request {
     Default,
     Profile(profiles::http::ResponseClasses),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Response {
     Default,
     Grpc,

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -351,10 +351,8 @@ impl Param<metrics::ProfileRouteLabels> for ProfileRoute {
     }
 }
 
-impl classify::CanClassify for ProfileRoute {
-    type Classify = classify::Request;
-
-    fn classify(&self) -> classify::Request {
+impl Param<classify::Request> for ProfileRoute {
+    fn param(&self) -> classify::Request {
         self.route.response_classes().clone().into()
     }
 }
@@ -416,10 +414,8 @@ impl Param<metrics::EndpointLabels> for Logical {
     }
 }
 
-impl classify::CanClassify for Logical {
-    type Classify = classify::Request;
-
-    fn classify(&self) -> classify::Request {
+impl Param<classify::Request> for Logical {
+    fn param(&self) -> classify::Request {
         classify::Request::default()
     }
 }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -358,10 +358,8 @@ impl<T> svc::Param<http::ResponseTimeout> for RouteParams<T> {
     }
 }
 
-impl<T> classify::CanClassify for RouteParams<T> {
-    type Classify = classify::Request;
-
-    fn classify(&self) -> classify::Request {
+impl<T> svc::Param<classify::Request> for RouteParams<T> {
+    fn param(&self) -> classify::Request {
         self.profile.response_classes().clone().into()
     }
 }

--- a/linkerd/http-classify/src/lib.rs
+++ b/linkerd/http-classify/src/lib.rs
@@ -52,10 +52,3 @@ pub trait ClassifyEos {
     /// returned.
     fn error(self, error: &Error) -> Self::Class;
 }
-
-// Used for stack targets that can produce a `Classify` implementation.
-pub trait CanClassify {
-    type Classify: Classify;
-
-    fn classify(&self) -> Self::Classify;
-}


### PR DESCRIPTION
We have no need for a one-off trait for the response classificatino module. This change removes the `CanClassify` trait and updates the `NewClassify` module to take an `ExtractParam` for greater flexibility. `app::core` is updated with type aliases for our current uses.