### PR TITLE
Use `ExtractParam` in `http::NewHeaderFromTarget`

### DIFF
--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -176,7 +176,7 @@ impl<N> Outbound<N> {
                 // set this on meshed connections.
                 //
                 // TODO(ver) do we need to strip headers here?
-                .push(http::NewHeaderFromTarget::<CanonicalDstHeader, _>::layer())
+                .push(http::NewHeaderFromTarget::<CanonicalDstHeader, (), _>::layer())
                 .push(svc::NewMapErr::layer_from_target::<LogicalError, _>())
                 .push_switch(
                     |parent: T| -> Result<_, Infallible> {


### PR DESCRIPTION
To allow callers of `NewHeaderFromTarget` to provide bespoke param implementations, this change updates the module to use `ExtractParam` instead of `Param`.