### PR TITLE
Do not gracefully drain the proxy on SIGTERM

### DIFF
--- a/linkerd/app/admin/src/lib.rs
+++ b/linkerd/app/admin/src/lib.rs
@@ -4,5 +4,5 @@
 mod server;
 mod stack;
 
-pub use self::server::{Admin, Latch, Readiness};
+pub use self::server::{Admin, Readiness};
 pub use self::stack::{Config, Task};

--- a/linkerd/app/admin/src/server/readiness.rs
+++ b/linkerd/app/admin/src/server/readiness.rs
@@ -1,36 +1,18 @@
-use std::sync::{Arc, Weak};
+use std::sync::{atomic::AtomicBool, Arc};
 
-/// Tracks the processes's readiness to serve traffic.
-///
-/// Once `is_ready()` returns true, it will never return false.
 #[derive(Clone, Debug)]
-pub struct Readiness(Weak<()>);
-
-/// When all latches are dropped, the process is considered ready.
-#[derive(Clone, Debug)]
-pub struct Latch(Arc<()>);
+pub struct Readiness(Arc<AtomicBool>);
 
 impl Readiness {
-    pub fn new() -> (Readiness, Latch) {
-        let r = Arc::new(());
-        (Readiness(Arc::downgrade(&r)), Latch(r))
+    pub fn new(init: bool) -> Readiness {
+        Readiness(Arc::new(init.into()))
     }
 
-    pub fn is_ready(&self) -> bool {
-        self.0.upgrade().is_none()
+    pub fn get(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Acquire)
     }
-}
 
-/// ALways ready.
-impl Default for Readiness {
-    fn default() -> Self {
-        Self::new().0
-    }
-}
-
-impl Latch {
-    /// Releases this readiness latch.
-    pub fn release(self) {
-        drop(self);
+    pub fn set(&self, ready: bool) {
+        self.0.store(ready, std::sync::atomic::Ordering::Release)
     }
 }

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -442,7 +442,7 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
                             Poll::Ready(())
                         });
 
-                        let drain = main.spawn();
+                        let (_, drain) = main.spawn();
 
                         tokio::select! {
                             _ = on_shutdown => {


### PR DESCRIPTION
Per the discussion in linkerd/linkerd2#10379, the proxy's shutdown behavior is overly aggressive and does not properly honor a pod's `terminationGracePeriodSeconds` configuration: while an application container may continue to run with a server for some period after the pod's delete process begins, the proxy will not permit any new connections in or out of the pod. This may also interfere with administrative probes during the shutdown process.

To address this, the proxy is updated to only change its readiness probe state when it receives a SIGTERM. The proxy continues to run-- without closing any connections or rejecting any work--until it is terminated (i.e., by kubelet) with a SIGKILL.

It is expected that, in most cases, clients will voluntarily move traffic as they process discovery updates. We need not do anything to interfere with the application's graceful termination behavior.

The proxy continues its former graceful shutdown behavior when shutdown is initiated via the admin server `/shutdown` endpoint (e.g., by linkerd-await).