### PR TITLE
allow `opaque_hidden_inferred_bound` warning on nightly

### DIFF
--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -17,7 +17,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
-  RUSTFLAGS: "-D warnings -A deprecated"
+  RUSTFLAGS: "-D warnings -A deprecated -A opaque_hidden_inferred_bound"
   RUSTUP_MAX_RETRIES: 10
 
 permissions:

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -17,7 +17,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
-  RUSTFLAGS: "-D warnings -A deprecated -A opaque_hidden_inferred_bound"
+  RUSTFLAGS: "-D warnings -A deprecated"
   RUSTUP_MAX_RETRIES: 10
 
 permissions:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,7 +13,7 @@ on:
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
-  RUSTFLAGS: "-D warnings"
+  RUSTFLAGS: "-D warnings -A opaque_hidden_inferred_bound"
   RUSTUP_MAX_RETRIES: 10
 
 permissions:


### PR DESCRIPTION
Currently, our nightly builds are failing due to the new warning `opaque_hidden_inferred_bound`, which triggers when an opaque type (`impl Trait`) in an associated type position does not explicitly include the associated type's trait bounds (e.g. returning a `Service<Future = impl Send, ...>`) or similar.

Unfortunately, we cannot simply change our code to make the trait bound's type explicit, as changing `impl Send` to
`impl Future<...> + Send` in this position results in a surprising error which I don't think is correct:

```
error[E0277]: `impl std::marker::Send` is not a future
  --> linkerd/app/outbound/src/http/logical.rs:97:30
   |
97 |                     Future = impl Future<Output = Result<http::Response<http::BoxBody>, Error>> + Send,
   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `impl std::marker::Send` is not a future
   |
   = help: the trait `futures::Future` is not implemented for `impl std::marker::Send`
   = note: impl std::marker::Send must be a future or must implement `IntoFuture` to be awaited
   = note: required for `stack::map_err::ResponseFuture<(), impl std::marker::Send>` to implement `futures::Future`

For more information about this error, try `rustc --explain E0277`.
```

See https://github.com/linkerd/linkerd2-proxy/pull/2268#issuecomment-1446738668 for details.

This should probably be reported on the Rust issue tracker, since a warning that's (apparently) impossible to fix seems not great. However, for now, we can simply allow this warning for our nightly builds.

This should fix CI.