### PR TITLE
outbound: Decouple backend caching from request distribution

### DIFF
--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -63,7 +63,8 @@ enum RouterParams<T: Clone + Debug + Eq + Hash> {
     Endpoint(Remote<ServerAddr>, Metadata, T),
 }
 
-type BackendCache<T, N, S> = distribute::BackendCache<Concrete<T>, N, S>;
+type NewBackendCache<T, N, S> = distribute::NewBackendCache<Concrete<T>, (), N, S>;
+type NewDistribute<T, N> = distribute::NewDistribute<Concrete<T>, (), N>;
 type Distribution<T> = distribute::Distribution<Concrete<T>>;
 
 // Only applies to requests with profiles.

--- a/linkerd/app/outbound/src/opaq/logical.rs
+++ b/linkerd/app/outbound/src/opaq/logical.rs
@@ -52,7 +52,8 @@ struct RouteParams<T> {
     distribution: Distribution<T>,
 }
 
-type BackendCache<T, N, S> = distribute::BackendCache<Concrete<T>, N, S>;
+type NewBackendCache<T, N, S> = distribute::NewBackendCache<Concrete<T>, (), N, S>;
+type NewDistribute<T, N> = distribute::NewDistribute<Concrete<T>, (), N>;
 type Distribution<T> = distribute::Distribution<Concrete<T>>;
 
 #[derive(Clone, Debug)]
@@ -95,6 +96,8 @@ impl<N> Outbound<N> {
     {
         self.map_stack(|_, _, concrete| {
             let route = svc::layers()
+                .lift_new()
+                .push(NewDistribute::layer())
                 // The router does not take the backend's availability into
                 // consideration, so we must eagerly fail requests to prevent
                 // leaking tasks onto the runtime.
@@ -106,7 +109,8 @@ impl<N> Outbound<N> {
             let router = svc::layers()
                 // Each `RouteParams` provides a `Distribution` that is used to
                 // choose a concrete service for a given route.
-                .push(BackendCache::layer())
+                .lift_new()
+                .push(NewBackendCache::layer())
                 // Lazily cache a service for each `RouteParams`
                 // returned from the `SelectRoute` impl.
                 .push_on_service(route)

--- a/linkerd/distribute/src/lib.rs
+++ b/linkerd/distribute/src/lib.rs
@@ -9,7 +9,7 @@ mod service;
 mod stack;
 
 pub use self::{
-    cache::BackendCache,
+    cache::NewBackendCache,
     params::{Backends, Distribution, WeightedKeys},
     service::Distribute,
     stack::NewDistribute,

--- a/linkerd/distribute/src/lib.rs
+++ b/linkerd/distribute/src/lib.rs
@@ -9,7 +9,7 @@ mod service;
 mod stack;
 
 pub use self::{
-    cache::NewBackendCache,
+    cache::{BackendCache, NewBackendCache},
     params::{Backends, Distribution, WeightedKeys},
     service::Distribute,
     stack::NewDistribute,

--- a/linkerd/proxy/api-resolve/src/resolve.rs
+++ b/linkerd/proxy/api-resolve/src/resolve.rs
@@ -122,7 +122,7 @@ fn resolution(
                     } else {
                         Update::DoesNotExist
                     };
-                    yield update.into();
+                    yield update;
                 }
 
                 None => {} // continue


### PR DESCRIPTION
The `BackendCache` module currently produces `NewDistribute` instances. This does not allow any other layers to be insertedb between the distribution decision and the caching decision.

To support per-route-backend filters, we need to separate these modules.

This change updates `BackendCache` as `NewBackendCache` and adds a basic service to extract targets from the cache.

`NewDistribute` is updated so that it builds new inner services instead of using the cache directly. The distribution layers are moved up into the route stack to prepare for additional filters being applied.