### PR TITLE
integration: add test policy controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8582122b8edba2af43eaf6b80dbfd33f421b5a0eb3a3113d21bc096ac5b44faf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -560,6 +606,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,6 +664,18 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tower",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -942,6 +1006,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "linkerd-app",
  "linkerd-app-admin",
  "linkerd-app-core",
@@ -950,6 +1015,7 @@ dependencies = [
  "linkerd-metrics",
  "linkerd-tracing",
  "linkerd2-proxy-api",
+ "maplit",
  "parking_lot",
  "regex",
  "rustls-pemfile",
@@ -1877,10 +1943,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minimal-lexical"
@@ -2317,6 +2395,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+
+[[package]]
 name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2521,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "tempfile"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,6 +2625,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2603,21 +2703,28 @@ checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
 dependencies = [
  "async-stream",
  "async-trait",
+ "axum",
  "base64",
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
+ "hyper",
+ "hyper-timeout",
  "percent-encoding",
  "pin-project",
  "prost",
  "prost-derive",
+ "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -2658,6 +2765,25 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2718,6 +2844,16 @@ checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -30,6 +30,7 @@ hyper = { version = "0.14", features = [
     "client",
     "server",
 ] }
+ipnet = "2"
 linkerd-app = { path = "..", features = ["allow-loopback"] }
 linkerd-app-core = { path = "../core" }
 linkerd-metrics = { path = "../../metrics", features = ["test_util"] }
@@ -39,6 +40,7 @@ linkerd2-proxy-api = { version = "0.8", features = [
 ] }
 linkerd-app-test = { path = "../test" }
 linkerd-tracing = { path = "../../tracing" }
+maplit = "1"
 parking_lot = "0.12"
 regex = "1"
 socket2 = "0.4"
@@ -47,7 +49,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-rustls = "0.23"
 rustls-pemfile = "1.0"
 tower = { version = "0.4", default-features = false }
-tonic = { version = "0.8", default-features = false }
+tonic = { version = "0.8", features = ["transport"], default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "fmt",

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -25,6 +25,10 @@ pub fn identity() -> identity::Controller {
     identity::Controller::default()
 }
 
+pub fn policy() -> policy::Controller {
+    policy::Controller::default()
+}
+
 pub type Labels = HashMap<String, String>;
 
 pub type DstReceiver = UnboundedReceiverStream<Result<pb::Update, grpc::Status>>;
@@ -336,7 +340,7 @@ pub(crate) async fn run<T, B>(
 ) -> Listening
 where
     T: tower::Service<http::Request<hyper::body::Body>, Response = http::Response<B>>,
-    T: Clone + Send + Sync + 'static,
+    T: Clone + Send + 'static,
     T::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
     T::Future: Send,
     B: http_body::Body + Send + 'static,

--- a/linkerd/app/integration/src/identity.rs
+++ b/linkerd/app/integration/src/identity.rs
@@ -161,6 +161,7 @@ impl Identity {
         env.put(app::env::ENV_IDENTITY_DIR, id_dir);
         env.put(app::env::ENV_IDENTITY_TOKEN_FILE, token);
         env.put(app::env::ENV_IDENTITY_TRUST_ANCHORS, trust_anchors);
+        env.put(app::env::ENV_POLICY_WORKLOAD, format!("test:{local_name}"));
         env.put(app::env::ENV_IDENTITY_IDENTITY_LOCAL_NAME, local_name);
 
         Self {

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -163,6 +163,7 @@ pub mod client;
 pub mod controller;
 pub mod identity;
 pub mod metrics;
+pub mod policy;
 pub mod proxy;
 pub mod server;
 pub mod tap;

--- a/linkerd/app/integration/src/policy.rs
+++ b/linkerd/app/integration/src/policy.rs
@@ -1,0 +1,295 @@
+use super::*;
+pub use api::inbound;
+use api::inbound::inbound_server_policies_server;
+use futures::stream;
+use linkerd2_proxy_api as api;
+use parking_lot::Mutex;
+use std::{collections::VecDeque, sync::Arc, time::Duration};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tonic as grpc;
+
+#[derive(Debug, Default)]
+pub struct Controller {
+    inbound: Inner<u16, inbound::Server>,
+}
+
+#[derive(Debug, Clone)]
+struct Server<Req, Rsp>(Arc<Inner<Req, Rsp>>);
+
+#[derive(Debug)]
+struct Inner<Req, Rsp> {
+    calls: Mutex<VecDeque<(Req, Rx<Rsp>)>>,
+    default: Option<Rsp>,
+    expected_workload: Option<String>,
+    // hold onto senders for policies that won't be updated so that their
+    // streams don't close.
+    send_once_txs: Vec<Tx<Rsp>>,
+    calls_tx: Option<mpsc::UnboundedSender<Req>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InboundSender(Tx<inbound::Server>);
+
+type Tx<T> = mpsc::UnboundedSender<Result<T, grpc::Status>>;
+type Rx<T> = UnboundedReceiverStream<Result<T, grpc::Status>>;
+type WatchStream<T> = Pin<Box<dyn Stream<Item = Result<T, grpc::Status>> + Send + Sync + 'static>>;
+
+pub fn all_unauthenticated() -> inbound::Server {
+    inbound::Server {
+        protocol: Some(inbound::ProxyProtocol {
+            kind: Some(inbound::proxy_protocol::Kind::Detect(
+                inbound::proxy_protocol::Detect {
+                    timeout: Some(Duration::from_secs(10).try_into().unwrap()),
+                    http_routes: vec![],
+                },
+            )),
+        }),
+        authorizations: vec![inbound::Authz {
+            networks: vec![inbound::Network {
+                net: Some(ipnet::IpNet::default().into()),
+                except: Vec::new(),
+            }],
+            authentication: Some(inbound::Authn {
+                permit: Some(inbound::authn::Permit::Unauthenticated(
+                    inbound::authn::PermitUnauthenticated {},
+                )),
+            }),
+            labels: Default::default(),
+            metadata: Some(api::meta::Metadata {
+                kind: Some(api::meta::metadata::Kind::Default(
+                    "all-unauthenticated".into(),
+                )),
+            }),
+        }],
+        server_ips: vec![],
+        labels: maplit::hashmap![
+            "name".into() => "all-unauthenticated".into(),
+            "kind".into() => "default".into(),
+        ],
+    }
+}
+
+pub fn opaque_unauthenticated() -> inbound::Server {
+    inbound::Server {
+        protocol: Some(inbound::ProxyProtocol {
+            kind: Some(inbound::proxy_protocol::Kind::Opaque(
+                inbound::proxy_protocol::Opaque {},
+            )),
+        }),
+        authorizations: vec![inbound::Authz {
+            networks: vec![inbound::Network {
+                net: Some(ipnet::IpNet::default().into()),
+                except: Vec::new(),
+            }],
+            authentication: Some(inbound::Authn {
+                permit: Some(inbound::authn::Permit::Unauthenticated(
+                    inbound::authn::PermitUnauthenticated {},
+                )),
+            }),
+            labels: Default::default(),
+            metadata: Some(api::meta::Metadata {
+                kind: Some(api::meta::metadata::Kind::Default(
+                    "all-unauthenticated".into(),
+                )),
+            }),
+        }],
+        server_ips: vec![],
+        labels: maplit::hashmap![
+            "name".into() => "all-unauthenticated".into(),
+            "kind".into() => "default".into(),
+        ],
+    }
+}
+
+impl Controller {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn expect_workload(mut self, workload: String) -> Self {
+        self.inbound.expected_workload = Some(workload.clone());
+        self
+    }
+
+    /// Returns an [`InboundSender`] for inbound policies on `port`.
+    pub fn inbound_tx(&self, port: u16) -> InboundSender {
+        InboundSender(self.inbound.add_call(port))
+    }
+
+    /// Sets an inbound policy for `port` that sends a single update and then
+    /// remains open.
+    pub fn inbound(mut self, port: u16, policy: inbound::Server) -> Self {
+        let tx = self.inbound_tx(port);
+        tx.send(policy);
+        self.inbound.send_once_txs.push(tx.0);
+        self
+    }
+
+    /// Sets a global default inbound policy.
+    pub fn with_inbound_default(mut self, default: inbound::Server) -> Self {
+        self.inbound.default = Some(default);
+        self
+    }
+
+    pub fn inbound_calls(&mut self) -> mpsc::UnboundedReceiver<u16> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.inbound.calls_tx = Some(tx);
+        rx
+    }
+
+    pub async fn run(self) -> controller::Listening {
+        let svc = grpc::transport::Server::builder()
+            .add_service(
+                inbound_server_policies_server::InboundServerPoliciesServer::new(Server(Arc::new(
+                    self.inbound,
+                ))),
+            )
+            .into_service();
+        controller::run(svc, "support policy controller", None).await
+    }
+}
+
+// === impl InboundSender ===
+
+impl InboundSender {
+    pub fn send(&self, up: inbound::Server) {
+        self.0.send(Ok(up)).expect("send inbound Server update")
+    }
+
+    pub fn send_err(&self, err: grpc::Status) {
+        self.0.send(Err(err)).expect("send inbound error")
+    }
+}
+
+// === impl Server ===
+
+#[tonic::async_trait]
+impl inbound_server_policies_server::InboundServerPolicies for Server<u16, inbound::Server> {
+    type WatchPortStream =
+        Pin<Box<dyn Stream<Item = Result<inbound::Server, grpc::Status>> + Send + Sync + 'static>>;
+
+    async fn get_port(
+        &self,
+        _req: grpc::Request<inbound::PortSpec>,
+    ) -> Result<grpc::Response<inbound::Server>, grpc::Status> {
+        Err(grpc::Status::new(
+            grpc::Code::Unimplemented,
+            "the proxy should only make `InboundServerPolicies.WatchPort` RPCs \
+            to the inbound policy service, so `GetPort` is not implemented by \
+            the test controller",
+        ))
+    }
+
+    async fn watch_port(
+        &self,
+        req: grpc::Request<inbound::PortSpec>,
+    ) -> Result<grpc::Response<Self::WatchPortStream>, grpc::Status> {
+        let req = req.into_inner();
+        let _span = tracing::info_span!(
+            "InboundPolicies::watch_port",
+            req.port,
+            %req.workload,
+        )
+        .entered();
+        tracing::debug!(?req, "received request");
+        let ret = self.watch_inner(&req.workload, |&spec| req.port as u16 == spec);
+        if let Some(ref calls_tx) = self.0.calls_tx {
+            let _ = calls_tx.send(req.port as u16);
+        }
+        ret
+    }
+}
+
+// === impl Server ===
+
+impl<Req, Rsp> Server<Req, Rsp>
+where
+    Req: std::fmt::Debug,
+    Rsp: std::fmt::Debug + Clone + Send + Sync + 'static,
+{
+    fn watch_inner(
+        &self,
+        workload: &str,
+        matches: impl Fn(&Req) -> bool,
+    ) -> Result<grpc::Response<WatchStream<Rsp>>, grpc::Status> {
+        if let Some(ref expected_workload) = self.0.expected_workload {
+            if workload != *expected_workload {
+                tracing::warn!(
+                    actual = ?workload,
+                    expected = ?expected_workload,
+                    "request workload does not match"
+                );
+                return Err(grpc_unexpected_request());
+            }
+        }
+
+        // See if we have any configured expected calls that match this request.
+        let mut calls = self.0.calls.lock();
+        if let Some((spec, policy)) = calls.pop_front() {
+            tracing::debug!(?spec, "checking next call");
+            if matches(&spec) {
+                tracing::info!(?spec, ?policy, "found request");
+                return Ok(grpc::Response::new(Box::pin(policy)));
+            }
+
+            tracing::warn!(?spec, ?policy, "request does not match");
+            calls.push_front((spec, policy));
+        }
+
+        // Try the configured default policy...
+        if let Some(default) = self.0.default.clone() {
+            tracing::info!("using default policy");
+            let stream =
+                Box::pin(stream::once(async move { Ok(default) }).chain(stream::pending()));
+            return Ok(grpc::Response::new(stream));
+        }
+
+        if calls.is_empty() {
+            // We're not configured to expect any calls, and we have no default
+            // policy. Send a "no results" error.
+            Err(grpc_no_results())
+        } else {
+            // We recieved a request that did not match the expected calls, and
+            // we have no default policy. Return an error.
+            Err(grpc_unexpected_request())
+        }
+    }
+}
+
+// === impl Inner ===
+
+impl<Req, Rsp> Default for Inner<Req, Rsp> {
+    fn default() -> Self {
+        Self {
+            calls: Mutex::new(VecDeque::new()),
+            expected_workload: None,
+            default: None,
+            send_once_txs: Vec::new(),
+            calls_tx: None,
+        }
+    }
+}
+
+impl<Req, Rsp> Inner<Req, Rsp> {
+    fn add_call(&self, call: Req) -> mpsc::UnboundedSender<Result<Rsp, grpc::Status>> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let rx = UnboundedReceiverStream::new(rx);
+        self.calls.lock().push_back((call, rx));
+        tx
+    }
+}
+
+fn grpc_no_results() -> grpc::Status {
+    grpc::Status::new(
+        grpc::Code::NotFound,
+        "unit test policy controller has no results",
+    )
+}
+
+fn grpc_unexpected_request() -> grpc::Status {
+    grpc::Status::new(
+        grpc::Code::Unavailable,
+        "unit test policy controller expected different request",
+    )
+}


### PR DESCRIPTION
Currently, the proxy integration tests run without a policy controller, and instead use environment variables to configure default inbound server policies. However, we do not intend to add a similar environment based defaulting mechanism for outbound client policies. Therefore, when the proxy starts consuming the outbound client policy API, we will no longer be able to run the integration tests without a policy controller.

This branch adds an implementation of a mock policy controller for the integration tests. This was factored out from PR #2265, which implements outbound policy discovery and therefore requires a policy controller.

Note that the mock policy controller added in #2265 serves both the inbound and outbound APIs, while this PR implements only the inbound API. This is because the a version of `linkerd2-proxy-api` that includes the outbound policy API has not yet been released, and I wanted to be able to merge this branch without waiting for a proxy API release. However, the mock policy controller implementation here was taken directly from #2265 with the outbound half removed. Some aspects of the implementation may seem somewhat more complex than necessary to implement only the inbound policy API, but I thought it was nicer to have a smaller diff when the outbound half is added in the near future.

One small complexity here is that the inbound proxy will use default policies when it has not yet resolved. This means there is a potential for racy behavior in tests when a request is sent to an inbound proxy, if it has not yet started a watch on the policy for a port (or is in the process of starting that watch). This can result in flaky test failures: for example, in metrics tests, the name of the policy can change between requests if one request is handled with the default and the next request is handled with one resolved from the mock policy controller, resulting in two sets of labels rather than one. To avoid the test proxy flapping between the default policy and one resolved from the mock policy controller, I've also changed the proxy test harness so that any configured inbound ports in the test are added to
`LINKERD2_PROXY_INBOUND_PORTS`, so that the proxy will eagerly resolve them. The test harness now waits for the mock policy controller to tell it that the proxy has started watches on those ports before actually running the test code.