### PR TITLE
client-policy: add protobuf conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1808,7 +1808,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.8.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=alex/outbound#409453b124b254e96a87462800e9dd28573b0cc9"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#9efe50fd769cf8fbba4f0eedf95fa8ca896d7355"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,6 @@ version = "0.1.0"
 dependencies = [
  "http",
  "ipnet",
- "linkerd-addr",
  "linkerd-error",
  "linkerd-http-route",
  "linkerd-proxy-api-resolve",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
 name = "linkerd-proxy-client-policy"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "http",
  "ipnet",
  "linkerd-error",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,11 +1384,17 @@ version = "0.1.0"
 dependencies = [
  "http",
  "ipnet",
+ "linkerd-addr",
+ "linkerd-error",
  "linkerd-http-route",
  "linkerd-proxy-api-resolve",
  "linkerd-proxy-core",
+ "linkerd2-proxy-api",
  "maplit",
+ "once_cell",
+ "prost-types",
  "quickcheck",
+ "thiserror",
 ]
 
 [[package]]
@@ -1802,8 +1808,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcbd793b73b504f16514e3aa376b41d00884e12e62ba92505eab3c4258671a0"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=alex/outbound#409453b124b254e96a87462800e9dd28573b0cc9"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,4 +85,4 @@ lto = true
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.22" }
 boring = { git = "https://github.com/cloudflare/boring" }
 tokio-boring = { git = "https://github.com/cloudflare/boring" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "alex/outbound" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,4 @@ lto = true
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.22" }
 boring = { git = "https://github.com/cloudflare/boring" }
 tokio-boring = { git = "https://github.com/cloudflare/boring" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", branch = "alex/outbound" }

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -7,26 +7,25 @@ edition = "2021"
 publish = false
 
 [features]
-default = ["proto"]
 proto = [
     "linkerd-http-route/proto",
     "linkerd2-proxy-api",
     "prost-types",
-    "thiserror"
+    "thiserror",
+    "once_cell",
 ]
 
 [dependencies]
 ipnet = "2"
 http = "0.2"
 linkerd2-proxy-api = { version = "0.8", optional = true, features = ["outbound"] }
-linkerd-addr = { path = "../../addr" }
 linkerd-error = { path = "../../error" }
 linkerd-http-route = { path = "../../http-route" }
 linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }
 prost-types = { version = "0.11", optional = true }
 thiserror ={ version = "1", optional = true }
-once_cell = "1"
+once_cell = { version = "1", optional = true }
 
 [dev-dependencies]
 maplit = "1"

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -23,9 +23,9 @@ linkerd-error = { path = "../../error" }
 linkerd-http-route = { path = "../../http-route" }
 linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }
+once_cell = { version = "1", optional = true }
 prost-types = { version = "0.11", optional = true }
 thiserror ={ version = "1", optional = true }
-once_cell = { version = "1", optional = true }
 
 [dev-dependencies]
 maplit = "1"

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 publish = false
 
 [features]
+default = ["proto"]
 proto = [
     "linkerd-http-route/proto",
     "linkerd2-proxy-api",

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -7,21 +7,25 @@ edition = "2021"
 publish = false
 
 [features]
-# proto = [
-#     "linkerd-http-route/proto",
-#     "linkerd-proxy-core/proto",
-#     "linkerd2-proxy-api",
-#     "prost-types",
-# ]
+proto = [
+    "linkerd-http-route/proto",
+    "linkerd2-proxy-api",
+    "prost-types",
+    "thiserror"
+]
 
 [dependencies]
 ipnet = "2"
 http = "0.2"
+linkerd2-proxy-api = { version = "0.8", optional = true, features = ["outbound"] }
+linkerd-addr = { path = "../../addr" }
+linkerd-error = { path = "../../error" }
+linkerd-http-route = { path = "../../http-route" }
 linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }
-linkerd-http-route = { path = "../../http-route" }
-# prost-types = { version = "0.11", optional = true }
-# thiserror = "1"
+prost-types = { version = "0.11", optional = true }
+thiserror ={ version = "1", optional = true }
+once_cell = "1"
 
 [dev-dependencies]
 maplit = "1"

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -16,16 +16,19 @@ proto = [
 ]
 
 [dependencies]
+ahash = "0.8"
 ipnet = "2"
 http = "0.2"
-linkerd2-proxy-api = { version = "0.8", optional = true, features = ["outbound"] }
+linkerd2-proxy-api = { version = "0.8", optional = true, features = [
+    "outbound",
+] }
 linkerd-error = { path = "../../error" }
 linkerd-http-route = { path = "../../http-route" }
 linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }
 once_cell = { version = "1", optional = true }
 prost-types = { version = "0.11", optional = true }
-thiserror ={ version = "1", optional = true }
+thiserror = { version = "1", optional = true }
 
 [dev-dependencies]
 maplit = "1"

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -41,3 +41,201 @@ impl Default for Grpc {
         }
     }
 }
+
+impl Grpc {
+    pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
+        self.routes.iter().flat_map(|Route { ref rules, .. }| {
+            rules
+                .iter()
+                .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
+        })
+    }
+}
+
+#[cfg(feature = "proto")]
+pub mod proto {
+    use super::*;
+    use crate::{
+        proto::{InvalidBackend, InvalidDistribution, InvalidMeta},
+        Meta, RouteBackend, RouteDistribution,
+    };
+    use linkerd2_proxy_api::outbound::{self, grpc_route};
+    use linkerd_http_route::{
+        grpc::{
+            filter::inject_failure::proto::InvalidFailureResponse,
+            r#match::proto::InvalidRouteMatch,
+        },
+        http::{
+            filter::{
+                modify_header::proto::InvalidModifyHeader, redirect::proto::InvalidRequestRedirect,
+            },
+            r#match::host::{proto::InvalidHostMatch, MatchHost},
+        },
+    };
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidGrpcRoute {
+        #[error("invalid host match: {0}")]
+        HostMatch(#[from] InvalidHostMatch),
+
+        #[error("invalid route match: {0}")]
+        RouteMatch(#[from] InvalidRouteMatch),
+
+        #[error("invalid route metadata: {0}")]
+        Meta(#[from] InvalidMeta),
+
+        #[error("invalid distribution: {0}")]
+        Distribution(#[from] InvalidDistribution),
+
+        #[error("invalid filter: {0}")]
+        Filter(#[from] InvalidFilter),
+
+        #[error("missing {0}")]
+        Missing(&'static str),
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidFilter {
+        #[error("missing filter kind")]
+        Missing,
+
+        #[error("invalid HTTP failure injector: {0}")]
+        FailureInjector(#[from] InvalidFailureResponse),
+
+        #[error("invalid HTTP header modifier: {0}")]
+        ModifyHeader(#[from] InvalidModifyHeader),
+
+        #[error("invalid HTTP redirect: {0}")]
+        Redirect(#[from] InvalidRequestRedirect),
+    }
+
+    impl TryFrom<outbound::proxy_protocol::Grpc> for Grpc {
+        type Error = InvalidGrpcRoute;
+        fn try_from(proto: outbound::proxy_protocol::Grpc) -> Result<Self, Self::Error> {
+            let routes = proto
+                .routes
+                .into_iter()
+                .map(try_route)
+                .collect::<Result<Arc<[_]>, _>>()?;
+            Ok(Self { routes })
+        }
+    }
+
+    fn try_route(proto: outbound::GrpcRoute) -> Result<Route, InvalidGrpcRoute> {
+        let outbound::GrpcRoute {
+            hosts,
+            rules,
+            metadata,
+        } = proto;
+        let meta = Arc::new(
+            metadata
+                .ok_or(InvalidMeta("missing metadata"))?
+                .try_into()?,
+        );
+        let hosts = hosts
+            .into_iter()
+            .map(MatchHost::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let rules = rules
+            .into_iter()
+            .map(|rule| try_rule(&meta, rule))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Route { hosts, rules })
+    }
+
+    fn try_rule(
+        meta: &Arc<Meta>,
+        proto: outbound::grpc_route::Rule,
+    ) -> Result<Rule, InvalidGrpcRoute> {
+        let outbound::grpc_route::Rule {
+            matches,
+            backends,
+            filters,
+        } = proto;
+
+        let matches = matches
+            .into_iter()
+            .map(r#match::MatchRoute::try_from)
+            .collect::<Result<Vec<_>, InvalidRouteMatch>>()?;
+
+        let filters = filters
+            .into_iter()
+            .map(Filter::try_from)
+            .collect::<Result<Arc<[_]>, _>>()?;
+
+        let distribution = {
+            let backends = backends.ok_or(InvalidGrpcRoute::Missing("distribution"))?;
+            try_distribution(meta, backends)?
+        };
+
+        Ok(Rule {
+            matches,
+            policy: Policy {
+                meta: meta.clone(),
+                filters,
+                distribution,
+            },
+        })
+    }
+
+    fn try_distribution(
+        meta: &Arc<Meta>,
+        distribution: grpc_route::Distribution,
+    ) -> Result<RouteDistribution<Filter>, InvalidDistribution> {
+        use grpc_route::{distribution, WeightedRouteBackend};
+
+        Ok(
+            match distribution.kind.ok_or(InvalidDistribution::Missing)? {
+                distribution::Kind::Empty(_) => RouteDistribution::Empty,
+                distribution::Kind::RandomAvailable(distribution::RandomAvailable { backends }) => {
+                    let backends = backends
+                        .into_iter()
+                        .map(|WeightedRouteBackend { weight, backend }| {
+                            let backend = backend.ok_or(InvalidDistribution::MissingBackend)?;
+                            Ok((try_route_backend(meta, backend)?, weight))
+                        })
+                        .collect::<Result<Arc<[_]>, InvalidDistribution>>()?;
+                    if backends.is_empty() {
+                        return Err(InvalidDistribution::Empty("RandomAvailable"));
+                    }
+                    RouteDistribution::RandomAvailable(backends)
+                }
+                distribution::Kind::FirstAvailable(distribution::FirstAvailable { backends }) => {
+                    let backends = backends
+                        .into_iter()
+                        .map(|backend| try_route_backend(meta, backend))
+                        .collect::<Result<Arc<[_]>, InvalidBackend>>()?;
+                    if backends.is_empty() {
+                        return Err(InvalidDistribution::Empty("FirstAvailable"));
+                    }
+                    RouteDistribution::FirstAvailable(backends)
+                }
+            },
+        )
+    }
+
+    fn try_route_backend(
+        meta: &Arc<Meta>,
+        grpc_route::RouteBackend { backend, filters }: grpc_route::RouteBackend,
+    ) -> Result<RouteBackend<Filter>, InvalidBackend> {
+        let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
+        RouteBackend::try_from_proto(meta, backend, filters)
+    }
+
+    impl TryFrom<grpc_route::Filter> for Filter {
+        type Error = InvalidFilter;
+
+        fn try_from(filter: grpc_route::Filter) -> Result<Self, Self::Error> {
+            use grpc_route::filter::Kind;
+
+            match filter.kind.ok_or(InvalidFilter::Missing)? {
+                Kind::FailureInjector(filter) => Ok(Filter::InjectFailure(filter.try_into()?)),
+                Kind::RequestHeaderModifier(filter) => {
+                    Ok(Filter::RequestHeaders(filter.try_into()?))
+                }
+            }
+        }
+    }
+}

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -46,7 +46,7 @@ impl Default for Grpc {
 pub mod proto {
     use super::*;
     use crate::{
-        proto::{InvalidBackend, InvalidDistribution, InvalidMeta},
+        proto::{BackendSet, InvalidBackend, InvalidDistribution, InvalidMeta},
         Meta, RouteBackend, RouteDistribution,
     };
     use linkerd2_proxy_api::outbound::{self, grpc_route};
@@ -112,12 +112,12 @@ pub mod proto {
     }
 
     impl Grpc {
-        pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
-            self.routes.iter().flat_map(|Route { ref rules, .. }| {
-                rules
-                    .iter()
-                    .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
-            })
+        pub fn fill_backends(&self, set: &mut BackendSet) {
+            for Route { ref rules, .. } in &*self.routes {
+                for Rule { ref policy, .. } in rules {
+                    policy.distribution.fill_backends(set);
+                }
+            }
         }
     }
 

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -42,16 +42,6 @@ impl Default for Grpc {
     }
 }
 
-impl Grpc {
-    pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
-        self.routes.iter().flat_map(|Route { ref rules, .. }| {
-            rules
-                .iter()
-                .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
-        })
-    }
-}
-
 #[cfg(feature = "proto")]
 pub mod proto {
     use super::*;
@@ -118,6 +108,16 @@ pub mod proto {
                 .map(try_route)
                 .collect::<Result<Arc<[_]>, _>>()?;
             Ok(Self { routes })
+        }
+    }
+
+    impl Grpc {
+        pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
+            self.routes.iter().flat_map(|Route { ref rules, .. }| {
+                rules
+                    .iter()
+                    .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
+            })
         }
     }
 

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -41,6 +41,8 @@ pub fn default(distribution: crate::RouteDistribution<Filter>) -> Route {
     }
 }
 
+// === impl Http1 ===
+
 impl Default for Http1 {
     fn default() -> Self {
         Self {
@@ -48,6 +50,14 @@ impl Default for Http1 {
         }
     }
 }
+
+impl Http1 {
+    pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
+        route_backends(&self.routes)
+    }
+}
+
+// === impl Http2 ===
 
 impl Default for Http2 {
     fn default() -> Self {
@@ -57,16 +67,32 @@ impl Default for Http2 {
     }
 }
 
+impl Http2 {
+    pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
+        route_backends(&self.routes)
+    }
+}
+
+fn route_backends(rts: &[Route]) -> impl Iterator<Item = &crate::Backend> {
+    rts.iter().flat_map(|Route { ref rules, .. }| {
+        rules
+            .iter()
+            .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
+    })
+}
 #[cfg(feature = "proto")]
 pub mod proto {
     use super::*;
     use crate::{
-        proto::{InvalidDistribution, InvalidMeta},
-        Meta, RouteDistribution,
+        proto::{InvalidBackend, InvalidDistribution, InvalidMeta},
+        Meta, RouteBackend, RouteDistribution,
     };
-    use linkerd2_proxy_api::outbound;
+    use linkerd2_proxy_api::outbound::{self, http_route};
     use linkerd_http_route::http::{
-        filter::inject_failure::proto::InvalidFailureResponse,
+        filter::{
+            inject_failure::proto::InvalidFailureResponse,
+            modify_header::proto::InvalidModifyHeader, redirect::proto::InvalidRequestRedirect,
+        },
         r#match::{host::proto::InvalidHostMatch, proto::InvalidRouteMatch},
     };
 
@@ -98,21 +124,19 @@ pub mod proto {
 
         #[error("invalid HTTP failure injector: {0}")]
         FailureInjector(#[from] InvalidFailureResponse),
-    }
 
-    pub(crate) fn route_backends(rts: &[Route]) -> impl Iterator<Item = &crate::Backend> {
-        rts.iter().flat_map(|Route { ref rules, .. }| {
-            rules
-                .iter()
-                .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
-        })
+        #[error("invalid HTTP header modifier: {0}")]
+        ModifyHeader(#[from] InvalidModifyHeader),
+
+        #[error("invalid HTTP redirect: {0}")]
+        Redirect(#[from] InvalidRequestRedirect),
     }
 
     impl TryFrom<outbound::proxy_protocol::Http1> for Http1 {
         type Error = InvalidHttpRoute;
         fn try_from(proto: outbound::proxy_protocol::Http1) -> Result<Self, Self::Error> {
             let routes = proto
-                .http_routes
+                .routes
                 .into_iter()
                 .map(try_route)
                 .collect::<Result<Arc<[_]>, _>>()?;
@@ -124,7 +148,7 @@ pub mod proto {
         type Error = InvalidHttpRoute;
         fn try_from(proto: outbound::proxy_protocol::Http2) -> Result<Self, Self::Error> {
             let routes = proto
-                .http_routes
+                .routes
                 .into_iter()
                 .map(try_route)
                 .collect::<Result<Arc<[_]>, _>>()?;
@@ -178,7 +202,7 @@ pub mod proto {
 
         let distribution = {
             let backends = backends.ok_or(InvalidHttpRoute::Missing("distribution"))?;
-            RouteDistribution::try_from_proto(meta, backends)?
+            try_distribution(meta, backends)?
         };
 
         Ok(Rule {
@@ -191,14 +215,62 @@ pub mod proto {
         })
     }
 
-    impl TryFrom<outbound::Filter> for Filter {
+    fn try_distribution(
+        meta: &Arc<Meta>,
+        distribution: http_route::Distribution,
+    ) -> Result<RouteDistribution<Filter>, InvalidDistribution> {
+        use http_route::{distribution, WeightedRouteBackend};
+
+        Ok(
+            match distribution.kind.ok_or(InvalidDistribution::Missing)? {
+                distribution::Kind::Empty(_) => RouteDistribution::Empty,
+                distribution::Kind::RandomAvailable(distribution::RandomAvailable { backends }) => {
+                    let backends = backends
+                        .into_iter()
+                        .map(|WeightedRouteBackend { weight, backend }| {
+                            let backend = backend.ok_or(InvalidDistribution::MissingBackend)?;
+                            Ok((try_route_backend(meta, backend)?, weight))
+                        })
+                        .collect::<Result<Arc<[_]>, InvalidDistribution>>()?;
+                    if backends.is_empty() {
+                        return Err(InvalidDistribution::Empty("RandomAvailable"));
+                    }
+                    RouteDistribution::RandomAvailable(backends)
+                }
+                distribution::Kind::FirstAvailable(distribution::FirstAvailable { backends }) => {
+                    let backends = backends
+                        .into_iter()
+                        .map(|backend| try_route_backend(meta, backend))
+                        .collect::<Result<Arc<[_]>, InvalidBackend>>()?;
+                    if backends.is_empty() {
+                        return Err(InvalidDistribution::Empty("FirstAvailable"));
+                    }
+                    RouteDistribution::FirstAvailable(backends)
+                }
+            },
+        )
+    }
+
+    fn try_route_backend(
+        meta: &Arc<Meta>,
+        http_route::RouteBackend { backend, filters }: http_route::RouteBackend,
+    ) -> Result<RouteBackend<Filter>, InvalidBackend> {
+        let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
+        RouteBackend::try_from_proto(meta, backend, filters)
+    }
+
+    impl TryFrom<http_route::Filter> for Filter {
         type Error = InvalidFilter;
 
-        fn try_from(filter: outbound::Filter) -> Result<Self, Self::Error> {
-            use outbound::filter::Kind;
+        fn try_from(filter: http_route::Filter) -> Result<Self, Self::Error> {
+            use http_route::filter::Kind;
 
             match filter.kind.ok_or(InvalidFilter::Missing)? {
                 Kind::FailureInjector(filter) => Ok(Filter::InjectFailure(filter.try_into()?)),
+                Kind::RequestHeaderModifier(filter) => {
+                    Ok(Filter::RequestHeaders(filter.try_into()?))
+                }
+                Kind::Redirect(filter) => Ok(Filter::Redirect(filter.try_into()?)),
             }
         }
     }

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -65,7 +65,7 @@ impl Default for Http2 {
 pub mod proto {
     use super::*;
     use crate::{
-        proto::{InvalidBackend, InvalidDistribution, InvalidMeta},
+        proto::{BackendSet, InvalidBackend, InvalidDistribution, InvalidMeta},
         Meta, RouteBackend, RouteDistribution,
     };
     use linkerd2_proxy_api::outbound::{self, http_route};
@@ -113,12 +113,12 @@ pub mod proto {
         Redirect(#[from] InvalidRequestRedirect),
     }
 
-    pub(crate) fn route_backends(rts: &[Route]) -> impl Iterator<Item = &crate::Backend> {
-        rts.iter().flat_map(|Route { ref rules, .. }| {
-            rules
-                .iter()
-                .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
-        })
+    pub(crate) fn fill_route_backends(rts: &[Route], set: &mut BackendSet) {
+        for Route { ref rules, .. } in rts {
+            for Rule { ref policy, .. } in rules {
+                policy.distribution.fill_backends(set);
+            }
+        }
     }
 
     impl TryFrom<outbound::proxy_protocol::Http1> for Http1 {

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -56,3 +56,150 @@ impl Default for Http2 {
         }
     }
 }
+
+#[cfg(feature = "proto")]
+pub mod proto {
+    use super::*;
+    use crate::{
+        proto::{InvalidDistribution, InvalidMeta},
+        Meta, RouteDistribution,
+    };
+    use linkerd2_proxy_api::outbound;
+    use linkerd_http_route::http::{
+        filter::inject_failure::proto::InvalidFailureResponse,
+        r#match::{host::proto::InvalidHostMatch, proto::InvalidRouteMatch},
+    };
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidHttpRoute {
+        #[error("invalid host match: {0}")]
+        HostMatch(#[from] InvalidHostMatch),
+
+        #[error("invalid route match: {0}")]
+        RouteMatch(#[from] InvalidRouteMatch),
+
+        #[error("invalid route metadata: {0}")]
+        Meta(#[from] InvalidMeta),
+
+        #[error("invalid distribution: {0}")]
+        Distribution(#[from] InvalidDistribution),
+
+        #[error("invalid filter: {0}")]
+        Filter(#[from] InvalidFilter),
+
+        #[error("missing {0}")]
+        Missing(&'static str),
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidFilter {
+        #[error("missing filter kind")]
+        Missing,
+
+        #[error("invalid HTTP failure injector: {0}")]
+        FailureInjector(#[from] InvalidFailureResponse),
+    }
+
+    pub(crate) fn route_backends(rts: &[Route]) -> impl Iterator<Item = &crate::Backend> {
+        rts.iter().flat_map(|Route { ref rules, .. }| {
+            rules
+                .iter()
+                .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
+        })
+    }
+
+    impl TryFrom<outbound::proxy_protocol::Http1> for Http1 {
+        type Error = InvalidHttpRoute;
+        fn try_from(proto: outbound::proxy_protocol::Http1) -> Result<Self, Self::Error> {
+            let routes = proto
+                .http_routes
+                .into_iter()
+                .map(try_route)
+                .collect::<Result<Arc<[_]>, _>>()?;
+            Ok(Self { routes })
+        }
+    }
+
+    impl TryFrom<outbound::proxy_protocol::Http2> for Http2 {
+        type Error = InvalidHttpRoute;
+        fn try_from(proto: outbound::proxy_protocol::Http2) -> Result<Self, Self::Error> {
+            let routes = proto
+                .http_routes
+                .into_iter()
+                .map(try_route)
+                .collect::<Result<Arc<[_]>, _>>()?;
+            Ok(Self { routes })
+        }
+    }
+
+    fn try_route(proto: outbound::HttpRoute) -> Result<Route, InvalidHttpRoute> {
+        let outbound::HttpRoute {
+            hosts,
+            rules,
+            metadata,
+        } = proto;
+        let meta = Arc::new(
+            metadata
+                .ok_or(InvalidMeta("missing metadata"))?
+                .try_into()?,
+        );
+        let hosts = hosts
+            .into_iter()
+            .map(r#match::MatchHost::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let rules = rules
+            .into_iter()
+            .map(|rule| try_rule(&meta, rule))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Route { hosts, rules })
+    }
+
+    fn try_rule(
+        meta: &Arc<Meta>,
+        proto: outbound::http_route::Rule,
+    ) -> Result<Rule, InvalidHttpRoute> {
+        let outbound::http_route::Rule {
+            matches,
+            backends,
+            filters,
+        } = proto;
+
+        let matches = matches
+            .into_iter()
+            .map(r#match::MatchRequest::try_from)
+            .collect::<Result<Vec<_>, InvalidRouteMatch>>()?;
+
+        let filters = filters
+            .into_iter()
+            .map(Filter::try_from)
+            .collect::<Result<Arc<[_]>, _>>()?;
+
+        let distribution = {
+            let backends = backends.ok_or(InvalidHttpRoute::Missing("distribution"))?;
+            RouteDistribution::try_from_proto(meta, backends)?
+        };
+
+        Ok(Rule {
+            matches,
+            policy: Policy {
+                meta: meta.clone(),
+                filters,
+                distribution,
+            },
+        })
+    }
+
+    impl TryFrom<outbound::Filter> for Filter {
+        type Error = InvalidFilter;
+
+        fn try_from(filter: outbound::Filter) -> Result<Self, Self::Error> {
+            use outbound::filter::Kind;
+
+            match filter.kind.ok_or(InvalidFilter::Missing)? {
+                Kind::FailureInjector(filter) => Ok(Filter::InjectFailure(filter.try_into()?)),
+            }
+        }
+    }
+}

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -51,12 +51,6 @@ impl Default for Http1 {
     }
 }
 
-impl Http1 {
-    pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
-        route_backends(&self.routes)
-    }
-}
-
 // === impl Http2 ===
 
 impl Default for Http2 {
@@ -67,19 +61,6 @@ impl Default for Http2 {
     }
 }
 
-impl Http2 {
-    pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
-        route_backends(&self.routes)
-    }
-}
-
-fn route_backends(rts: &[Route]) -> impl Iterator<Item = &crate::Backend> {
-    rts.iter().flat_map(|Route { ref rules, .. }| {
-        rules
-            .iter()
-            .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
-    })
-}
 #[cfg(feature = "proto")]
 pub mod proto {
     use super::*;
@@ -130,6 +111,14 @@ pub mod proto {
 
         #[error("invalid HTTP redirect: {0}")]
         Redirect(#[from] InvalidRequestRedirect),
+    }
+
+    pub(crate) fn route_backends(rts: &[Route]) -> impl Iterator<Item = &crate::Backend> {
+        rts.iter().flat_map(|Route { ref rules, .. }| {
+            rules
+                .iter()
+                .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
+        })
     }
 
     impl TryFrom<outbound::proxy_protocol::Http1> for Http1 {

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
+use linkerd_addr::Addr;
 use std::{borrow::Cow, hash::Hash, net::SocketAddr, sync::Arc, time};
 
 pub mod grpc;
@@ -12,6 +13,7 @@ pub use linkerd_proxy_api_resolve::Metadata as EndpointMetadata;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ClientPolicy {
+    pub addr: Addr,
     pub protocol: Protocol,
     pub backends: Arc<[Backend]>,
 }
@@ -111,6 +113,47 @@ pub struct PeakEwma {
     pub default_rtt: time::Duration,
 }
 
+// === impl ClientPolicy ===
+
+impl ClientPolicy {
+    pub fn invalid(addr: impl Into<Addr>, timeout: time::Duration) -> Self {
+        let meta = Arc::new(Meta::Default {
+            name: "invalid".into(),
+        });
+        let routes = Arc::new([http::Route {
+            hosts: vec![],
+            rules: vec![http::Rule {
+                matches: vec![http::r#match::MatchRequest::default()],
+                policy: http::Policy {
+                    meta,
+                    filters: std::iter::once(http::Filter::InternalError(
+                        "invalid client policy configuration",
+                    ))
+                    .collect(),
+                    distribution: RouteDistribution::Empty,
+                },
+            }],
+        }]);
+        Self {
+            addr: addr.into(),
+            // XXX(eliza): don't love this...
+            protocol: Protocol::Detect {
+                timeout,
+                http1: http::Http1 {
+                    routes: routes.clone(),
+                },
+                http2: http::Http2 { routes },
+                opaque: opaq::Opaque {
+                    // TODO(eliza): eventually, can we configure the opaque
+                    // policy to fail conns?
+                    policy: None,
+                },
+            },
+            backends: Arc::new([]),
+        }
+    }
+}
+
 // === impl Meta ===
 
 impl Meta {
@@ -152,6 +195,10 @@ impl Meta {
             Self::Resource { section, .. } => section.as_deref().unwrap_or(""),
         }
     }
+
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::Default { .. })
+    }
 }
 
 impl std::cmp::PartialEq for Meta {
@@ -167,5 +214,399 @@ impl std::hash::Hash for Meta {
         self.group().hash(state);
         self.kind().hash(state);
         self.name().hash(state);
+    }
+}
+
+#[cfg(feature = "proto")]
+pub mod proto {
+    use super::*;
+    use linkerd2_proxy_api::{
+        meta,
+        outbound::{self, backend::BalanceP2c},
+    };
+    use linkerd_error::Error;
+    use linkerd_proxy_api_resolve::pb as resolve;
+    use once_cell::sync::Lazy;
+    use std::{collections::HashSet, time::Duration};
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidPolicy {
+        #[error("invalid HTTP route: {0}")]
+        Route(#[from] http::proto::InvalidHttpRoute),
+
+        #[error("invalid backend: {0}")]
+        Backend(#[from] InvalidBackend),
+
+        #[error("invalid ProxyProtocol: {0}")]
+        Protocol(&'static str),
+
+        #[error("invalid protocol detection timeout: {0}")]
+        Timeout(#[from] prost_types::DurationError),
+
+        #[error("missing top-level backend")]
+        MissingBackend,
+
+        #[error("invalid backend addr: {0}")]
+        InvalidAddr(#[from] linkerd_addr::Error),
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("invalid metadata: {0}")]
+    pub struct InvalidMeta(pub(crate) &'static str);
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidBackend {
+        #[error("invalid backend filter: {0}")]
+        Filter(#[from] Error),
+
+        #[error("missing {0}")]
+        Missing(&'static str),
+
+        #[error("invalid {field} duration: {error}")]
+        Duration {
+            field: &'static str,
+            #[source]
+            error: prost_types::DurationError,
+        },
+
+        // TODO(eliza): `resolve::to_addr_meta` doesn't expose more specific
+        // errors...maybe this ought to...
+        #[error("invalid forward endpoint")]
+        ForwardAddr,
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidDistribution {
+        #[error("invalid backend: {0}")]
+        Backend(#[from] InvalidBackend),
+        #[error("a {0} distribution may not be empty")]
+        Empty(&'static str),
+        #[error("missing distribution kind")]
+        Missing,
+    }
+
+    static DEFAULT_META: Lazy<Arc<Meta>> = Lazy::new(|| Meta::new_default("default"));
+
+    impl TryFrom<outbound::OutboundPolicy> for ClientPolicy {
+        type Error = InvalidPolicy;
+        fn try_from(policy: outbound::OutboundPolicy) -> Result<Self, Self::Error> {
+            use outbound::proxy_protocol;
+
+            let protocol = policy
+                .protocol
+                .ok_or(InvalidPolicy::Protocol("missing protocol"))?
+                .kind
+                .ok_or(InvalidPolicy::Protocol("missing kind"))?;
+
+            // A hashset is used here to de-duplicate the set of backends.
+            // Not sure why Clippy's mutable key type lint triggers here --
+            // AFAICT `Backend` doesn't contain anything that's interior
+            // mutable? in any case, though, this is fine, because nothing will
+            // mutate the backends while they are in this hashset...
+            #[allow(clippy::mutable_key_type)]
+            let mut backends = HashSet::new();
+
+            // top-level backend
+            let (backend, addr) = {
+                let backend = policy.backend.ok_or(InvalidPolicy::MissingBackend)?;
+                let (backend, _) = Backend::try_from_proto(&DEFAULT_META, backend)?;
+                let addr = match backend.dispatcher {
+                    BackendDispatcher::BalanceP2c(
+                        _,
+                        EndpointDiscovery::DestinationGet { ref path },
+                    ) => path.parse()?,
+                    BackendDispatcher::Forward(sock, _) => sock.into(),
+                };
+                (backend, addr)
+            };
+
+            let protocol = match protocol {
+                proxy_protocol::Kind::Detect(proxy_protocol::Detect {
+                    http1,
+                    http2,
+                    timeout,
+                }) => {
+                    let timeout = timeout
+                        .ok_or(InvalidPolicy::Protocol(
+                            "Detect missing protocol detection timeout",
+                        ))?
+                        .try_into()?;
+                    let http1: http::Http1 = http1
+                        .ok_or(InvalidPolicy::Protocol(
+                            "Detect missing HTTP/1 configuration",
+                        ))?
+                        .try_into()?;
+                    let http2: http::Http2 = http2
+                        .ok_or(InvalidPolicy::Protocol(
+                            "Detect missing HTTP/2 configuration",
+                        ))?
+                        .try_into()?;
+
+                    backends.extend(
+                        http::proto::route_backends(&http1.routes)
+                            .chain(http::proto::route_backends(&http2.routes))
+                            .cloned(),
+                    );
+
+                    // TODO(eliza): proxy-api doesn't currently include
+                    // distributions for opaque...add that!
+                    let opaque = opaq::Opaque {
+                        policy: Some(RoutePolicy {
+                            meta: DEFAULT_META.clone(),
+                            filters: opaq::proto::NO_FILTERS.clone(),
+                            distribution: RouteDistribution::FirstAvailable(
+                                std::iter::once(RouteBackend {
+                                    filters: opaq::proto::NO_FILTERS.clone(),
+                                    backend: backend.clone(),
+                                })
+                                .collect(),
+                            ),
+                        }),
+                    };
+
+                    Protocol::Detect {
+                        http1,
+                        http2,
+                        timeout,
+                        opaque,
+                    }
+                }
+                proxy_protocol::Kind::Opaque(proxy_protocol::Opaque {}) => {
+                    // TODO(eliza): proxy-api doesn't currently include
+                    // distributions for opaque...add that!
+                    Protocol::Opaque(opaq::Opaque {
+                        policy: Some(RoutePolicy {
+                            meta: DEFAULT_META.clone(),
+                            filters: opaq::proto::NO_FILTERS.clone(),
+                            distribution: RouteDistribution::FirstAvailable(
+                                std::iter::once(RouteBackend {
+                                    filters: opaq::proto::NO_FILTERS.clone(),
+                                    backend: backend.clone(),
+                                })
+                                .collect(),
+                            ),
+                        }),
+                    })
+                }
+            };
+
+            backends.insert(backend);
+
+            Ok(ClientPolicy {
+                addr,
+                protocol,
+                backends: backends.drain().collect(),
+            })
+        }
+    }
+
+    impl TryFrom<meta::Metadata> for Meta {
+        type Error = InvalidMeta;
+        fn try_from(proto: meta::Metadata) -> Result<Self, Self::Error> {
+            use meta::metadata;
+
+            let kind = proto.kind.ok_or(InvalidMeta("missing kind"))?;
+            match kind {
+                metadata::Kind::Default(name) => Ok(Meta::Default {
+                    name: Cow::Owned(name),
+                }),
+                metadata::Kind::Resource(meta::Resource {
+                    group,
+                    kind,
+                    name,
+                    namespace,
+                    section,
+                }) => {
+                    macro_rules! ensure_nonempty{
+                        ($($name:ident),+) => {
+                            $(
+                                if $name.is_empty() {
+                                    return Err(InvalidMeta(concat!(stringify!($name, "must not be empty"))));
+                                }
+                            )+
+                        }
+                    }
+                    ensure_nonempty! { group, kind, name, namespace };
+
+                    let section = if section.is_empty() {
+                        None
+                    } else {
+                        Some(section)
+                    };
+
+                    Ok(Meta::Resource {
+                        group,
+                        kind,
+                        name,
+                        namespace,
+                        section,
+                    })
+                }
+            }
+        }
+    }
+
+    // === impl RouteDistribution ===
+
+    impl<T> RouteDistribution<T>
+    where
+        T: TryFrom<outbound::Filter>,
+        T::Error: Into<Error>,
+    {
+        pub(crate) fn try_from_proto(
+            meta: &Arc<Meta>,
+            distribution: outbound::Distribution,
+        ) -> Result<Self, InvalidDistribution> {
+            use outbound::distribution::{self, Distribution};
+
+            Ok(
+                match distribution
+                    .distribution
+                    .ok_or(InvalidDistribution::Missing)?
+                {
+                    Distribution::Empty(_) => RouteDistribution::Empty,
+                    Distribution::RandomAvailable(distribution::RandomAvailable { backends }) => {
+                        let backends = backends
+                            .into_iter()
+                            .map(|backend| RouteBackend::try_from_proto(meta, backend))
+                            .collect::<Result<Arc<[_]>, _>>()?;
+                        if backends.is_empty() {
+                            return Err(InvalidDistribution::Empty("RandomAvailable"));
+                        }
+                        RouteDistribution::RandomAvailable(backends)
+                    }
+                    Distribution::FirstAvailable(distribution::FirstAvailable { backends }) => {
+                        let backends = backends
+                            .into_iter()
+                            .map(|backend| {
+                                let (backend, _) = RouteBackend::try_from_proto(meta, backend)?;
+                                Ok(backend)
+                            })
+                            .collect::<Result<Arc<[_]>, InvalidBackend>>()?;
+                        if backends.is_empty() {
+                            return Err(InvalidDistribution::Empty("FirstAvailable"));
+                        }
+                        RouteDistribution::FirstAvailable(backends)
+                    }
+                },
+            )
+        }
+    }
+
+    impl<T> RouteDistribution<T> {
+        /// Returns an iterator over all the backends of this distribution.
+        pub(crate) fn backends(&self) -> impl Iterator<Item = &Backend> {
+            fn discard_weight<T>(&(ref backend, _): &(RouteBackend<T>, u32)) -> &RouteBackend<T> {
+                backend
+            }
+
+            // The use of `Iterator::chain` here is, admittedly, a bit weird:
+            // `chain`ing with empty iterators allows us to return the same type in
+            // every match arm.
+            match self {
+                Self::Empty => [].iter().chain([].iter().map(discard_weight)),
+                Self::FirstAvailable(backends) => {
+                    backends.iter().chain([].iter().map(discard_weight))
+                }
+                Self::RandomAvailable(backends) => {
+                    [].iter().chain(backends.iter().map(discard_weight))
+                }
+            }
+            .map(|backend| &backend.backend)
+        }
+    }
+
+    // === impl RouteBackend ===
+
+    impl<T> RouteBackend<T>
+    where
+        T: TryFrom<outbound::Filter>,
+        T::Error: Into<Error>,
+    {
+        pub(crate) fn try_from_proto(
+            meta: &Arc<Meta>,
+            mut backend: outbound::Backend,
+        ) -> Result<(Self, u32), InvalidBackend> {
+            let filters = backend
+                .filters
+                .drain(..)
+                .map(T::try_from)
+                .collect::<Result<Arc<[_]>, _>>()
+                .map_err(|error| InvalidBackend::Filter(error.into()))?;
+
+            let (backend, weight) = Backend::try_from_proto(meta, backend)?;
+            let backend = RouteBackend { filters, backend };
+
+            Ok((backend, weight))
+        }
+    }
+
+    impl Backend {
+        fn try_from_proto(
+            meta: &Arc<Meta>,
+            backend: outbound::Backend,
+        ) -> Result<(Self, u32), InvalidBackend> {
+            use outbound::backend::{balance_p2c, Backend as PbDispatcher};
+
+            fn duration(
+                field: &'static str,
+                duration: Option<prost_types::Duration>,
+            ) -> Result<Duration, InvalidBackend> {
+                duration
+                    .ok_or(InvalidBackend::Missing(field))?
+                    .try_into()
+                    .map_err(|error| InvalidBackend::Duration { field, error })
+            }
+
+            let (dispatcher, weight) = {
+                let pb = backend
+                    .backend
+                    .ok_or(InvalidBackend::Missing("backend dispatcher"))?;
+                match pb {
+                    PbDispatcher::Balancer(BalanceP2c { dst, load }) => {
+                        let dst = dst.ok_or(InvalidBackend::Missing("balancer destination"))?;
+                        let load = match load.ok_or(InvalidBackend::Missing("balancer load"))? {
+                            balance_p2c::Load::PeakEwma(balance_p2c::PeakEwma {
+                                default_rtt,
+                                decay,
+                            }) => Load::PeakEwma(PeakEwma {
+                                default_rtt: duration("peak EWMA default RTT", default_rtt)?,
+                                decay: duration("peak EWMA decay", decay)?,
+                            }),
+                        };
+                        let dispatcher = BackendDispatcher::BalanceP2c(
+                            load,
+                            EndpointDiscovery::DestinationGet {
+                                path: dst.authority,
+                            },
+                        );
+                        (dispatcher, dst.weight)
+                    }
+                    PbDispatcher::Forward(ep) => {
+                        let weight = ep.weight;
+                        let (addr, meta) = resolve::to_addr_meta(ep, &Default::default())
+                            .ok_or(InvalidBackend::ForwardAddr)?;
+                        let dispatcher = BackendDispatcher::Forward(addr, meta);
+                        (dispatcher, weight)
+                    }
+                }
+            };
+
+            let queue = {
+                let queue = backend.queue.ok_or(InvalidBackend::Missing("queue"))?;
+                Queue {
+                    capacity: queue.capacity as usize,
+                    failfast_timeout: duration("queue failfast timeout", queue.failfast_timeout)?,
+                }
+            };
+
+            let backend = Backend {
+                queue,
+                dispatcher,
+                meta: meta.clone(),
+            };
+
+            Ok((backend, weight))
+        }
     }
 }

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -191,10 +191,6 @@ impl Meta {
             Self::Resource { section, .. } => section.as_deref().unwrap_or(""),
         }
     }
-
-    pub fn is_default(&self) -> bool {
-        matches!(self, Self::Default { .. })
-    }
 }
 
 impl std::cmp::PartialEq for Meta {

--- a/linkerd/proxy/client-policy/src/opaq.rs
+++ b/linkerd/proxy/client-policy/src/opaq.rs
@@ -14,7 +14,7 @@ pub enum Filter {}
 pub(crate) mod proto {
     use super::*;
     use crate::{
-        proto::{InvalidBackend, InvalidDistribution, InvalidMeta},
+        proto::{BackendSet, InvalidBackend, InvalidDistribution, InvalidMeta},
         Meta, RouteBackend, RouteDistribution,
     };
     use linkerd2_proxy_api::outbound::{self, opaque_route};
@@ -97,8 +97,10 @@ pub(crate) mod proto {
     }
 
     impl Opaque {
-        pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
-            self.policy.iter().flat_map(|p| p.distribution.backends())
+        pub(crate) fn fill_backends(&self, set: &mut BackendSet) {
+            for p in &self.policy {
+                p.distribution.fill_backends(set);
+            }
         }
     }
 

--- a/linkerd/proxy/client-policy/src/opaq.rs
+++ b/linkerd/proxy/client-policy/src/opaq.rs
@@ -9,3 +9,13 @@ pub type Policy = RoutePolicy<Filter>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Filter {}
+
+#[cfg(feature = "proto")]
+pub(crate) mod proto {
+    use super::*;
+
+    use once_cell::sync::Lazy;
+    use std::sync::Arc;
+
+    pub(crate) static NO_FILTERS: Lazy<Arc<[Filter]>> = Lazy::new(|| Arc::new([]));
+}

--- a/linkerd/proxy/client-policy/src/opaq.rs
+++ b/linkerd/proxy/client-policy/src/opaq.rs
@@ -10,12 +10,6 @@ pub type Policy = RoutePolicy<Filter>;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Filter {}
 
-impl Opaque {
-    pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
-        self.policy.iter().flat_map(|p| p.distribution.backends())
-    }
-}
-
 #[cfg(feature = "proto")]
 pub(crate) mod proto {
     use super::*;
@@ -99,6 +93,12 @@ pub(crate) mod proto {
             Ok(Self {
                 policy: Some(policy),
             })
+        }
+    }
+
+    impl Opaque {
+        pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
+            self.policy.iter().flat_map(|p| p.distribution.backends())
         }
     }
 

--- a/linkerd/proxy/client-policy/src/opaq.rs
+++ b/linkerd/proxy/client-policy/src/opaq.rs
@@ -10,12 +10,164 @@ pub type Policy = RoutePolicy<Filter>;
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Filter {}
 
+impl Opaque {
+    pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
+        self.policy.iter().flat_map(|p| p.distribution.backends())
+    }
+}
+
 #[cfg(feature = "proto")]
 pub(crate) mod proto {
     use super::*;
+    use crate::{
+        proto::{InvalidBackend, InvalidDistribution, InvalidMeta},
+        Meta, RouteBackend, RouteDistribution,
+    };
+    use linkerd2_proxy_api::outbound::{self, opaque_route};
 
     use once_cell::sync::Lazy;
     use std::sync::Arc;
 
     pub(crate) static NO_FILTERS: Lazy<Arc<[Filter]>> = Lazy::new(|| Arc::new([]));
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidOpaqueRoute {
+        #[error("invalid route metadata: {0}")]
+        Meta(#[from] InvalidMeta),
+
+        #[error("invalid distribution: {0}")]
+        Distribution(#[from] InvalidDistribution),
+
+        /// Note: this restriction may be removed in the future, if a way of
+        /// actually matching rules for opaque routes is added.
+        #[error("an opaque route must have exactly one rule, but {0} were provided")]
+        OnlyOneRule(usize),
+
+        /// Note: this restriction may be removed in the future, if a way of
+        /// actually matching rules for opaque routes is added.
+        #[error("a `ProxyProtocol::Opaque` must have exactly one route, but {0} were provided")]
+        OnlyOneRoute(usize),
+
+        #[error("no filters can be configured on opaque routes yet")]
+        NoFilters,
+
+        #[error("missing {0}")]
+        Missing(&'static str),
+    }
+
+    impl TryFrom<outbound::proxy_protocol::Opaque> for Opaque {
+        type Error = InvalidOpaqueRoute;
+        fn try_from(proto: outbound::proxy_protocol::Opaque) -> Result<Self, Self::Error> {
+            if proto.routes.len() != 1 {
+                return Err(InvalidOpaqueRoute::OnlyOneRoute(proto.routes.len()));
+            }
+
+            proto
+                .routes
+                .into_iter()
+                .next()
+                .ok_or(InvalidOpaqueRoute::OnlyOneRoute(0))?
+                .try_into()
+        }
+    }
+
+    impl TryFrom<outbound::OpaqueRoute> for Opaque {
+        type Error = InvalidOpaqueRoute;
+
+        fn try_from(
+            outbound::OpaqueRoute { metadata, rules }: outbound::OpaqueRoute,
+        ) -> Result<Self, Self::Error> {
+            let meta = Arc::new(
+                metadata
+                    .ok_or(InvalidMeta("missing metadata"))?
+                    .try_into()?,
+            );
+
+            // Currently, opaque rules have no match expressions, so if there's
+            // more than one rule, we have no way of determining which one to
+            // use. Therefore, require that there's exactly one rule.
+            if rules.len() != 1 {
+                return Err(InvalidOpaqueRoute::OnlyOneRule(rules.len()));
+            }
+
+            let policy = rules
+                .into_iter()
+                .map(|rule| try_rule(&meta, rule))
+                .next()
+                .ok_or(InvalidOpaqueRoute::OnlyOneRule(0))??;
+
+            Ok(Self {
+                policy: Some(policy),
+            })
+        }
+    }
+
+    fn try_rule(
+        meta: &Arc<Meta>,
+        opaque_route::Rule { backends }: opaque_route::Rule,
+    ) -> Result<Policy, InvalidOpaqueRoute> {
+        let distribution = {
+            let backends = backends.ok_or(InvalidOpaqueRoute::Missing("distribution"))?;
+            try_distribution(meta, backends)?
+        };
+
+        Ok(Policy {
+            meta: meta.clone(),
+            filters: NO_FILTERS.clone(),
+            distribution,
+        })
+    }
+
+    fn try_distribution(
+        meta: &Arc<Meta>,
+        distribution: opaque_route::Distribution,
+    ) -> Result<RouteDistribution<Filter>, InvalidDistribution> {
+        use opaque_route::{distribution, WeightedRouteBackend};
+
+        Ok(
+            match distribution.kind.ok_or(InvalidDistribution::Missing)? {
+                distribution::Kind::Empty(_) => RouteDistribution::Empty,
+                distribution::Kind::RandomAvailable(distribution::RandomAvailable { backends }) => {
+                    let backends = backends
+                        .into_iter()
+                        .map(|WeightedRouteBackend { weight, backend }| {
+                            let backend = backend.ok_or(InvalidDistribution::MissingBackend)?;
+                            Ok((try_route_backend(meta, backend)?, weight))
+                        })
+                        .collect::<Result<Arc<[_]>, InvalidDistribution>>()?;
+                    if backends.is_empty() {
+                        return Err(InvalidDistribution::Empty("RandomAvailable"));
+                    }
+                    RouteDistribution::RandomAvailable(backends)
+                }
+                distribution::Kind::FirstAvailable(distribution::FirstAvailable { backends }) => {
+                    let backends = backends
+                        .into_iter()
+                        .map(|backend| try_route_backend(meta, backend))
+                        .collect::<Result<Arc<[_]>, InvalidBackend>>()?;
+                    if backends.is_empty() {
+                        return Err(InvalidDistribution::Empty("FirstAvailable"));
+                    }
+                    RouteDistribution::FirstAvailable(backends)
+                }
+            },
+        )
+    }
+
+    fn try_route_backend(
+        meta: &Arc<Meta>,
+        opaque_route::RouteBackend { backend }: opaque_route::RouteBackend,
+    ) -> Result<RouteBackend<Filter>, InvalidBackend> {
+        let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
+        RouteBackend::try_from_proto(meta, backend, std::iter::empty::<()>())
+    }
+
+    // Necessary to satisfy `RouteBackend::try_from_proto` type constraints.
+    // TODO(eliza): if filters are added to opaque routes, change this to a
+    // proper `TryFrom` impl...
+    impl From<()> for Filter {
+        fn from(_: ()) -> Self {
+            unreachable!("no filters can be configured on opaque routes yet")
+        }
+    }
 }


### PR DESCRIPTION
This branch adds functions to the `linkerd-proxy-client-policy` crate for converting the `linkerd2-proxy-api` outbound policy protobuf types into the proxy's internal representations. These are not used in this branch, but will be used in subsequent changes that actually wire up outbound policy discovery.

This change was factored out from #2265, so that it can be reviewed independently of the rest of the client policy discovery plumbing.

Note that this branch changes the `linkerd2-proxy-api` dependency to a Git dep on the outbound policy branch (linkerd/linkerd2-proxy-api#165), as the new APIs have not yet been published.