### PR TITLE
client-policy: Simplify route backend collection.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
 name = "linkerd-proxy-client-policy"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "http",
  "ipnet",
  "linkerd-error",

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -16,16 +16,19 @@ proto = [
 ]
 
 [dependencies]
+ahash = "0.8"
 ipnet = "2"
 http = "0.2"
-linkerd2-proxy-api = { version = "0.8", optional = true, features = ["outbound"] }
+linkerd2-proxy-api = { version = "0.8", optional = true, features = [
+    "outbound",
+] }
 linkerd-error = { path = "../../error" }
 linkerd-http-route = { path = "../../http-route" }
 linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }
 once_cell = { version = "1", optional = true }
 prost-types = { version = "0.11", optional = true }
-thiserror ={ version = "1", optional = true }
+thiserror = { version = "1", optional = true }
 
 [dev-dependencies]
 maplit = "1"

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -46,7 +46,7 @@ impl Default for Grpc {
 pub mod proto {
     use super::*;
     use crate::{
-        proto::{InvalidBackend, InvalidDistribution, InvalidMeta},
+        proto::{BackendSet, InvalidBackend, InvalidDistribution, InvalidMeta},
         Meta, RouteBackend, RouteDistribution,
     };
     use linkerd2_proxy_api::outbound::{self, grpc_route};
@@ -112,12 +112,12 @@ pub mod proto {
     }
 
     impl Grpc {
-        pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
-            self.routes.iter().flat_map(|Route { ref rules, .. }| {
-                rules
-                    .iter()
-                    .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
-            })
+        pub fn fill_backends(&self, set: &mut BackendSet) {
+            for Route { ref rules, .. } in &*self.routes {
+                for Rule { ref policy, .. } in rules {
+                    policy.distribution.fill_backends(set);
+                }
+            }
         }
     }
 

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -65,7 +65,7 @@ impl Default for Http2 {
 pub mod proto {
     use super::*;
     use crate::{
-        proto::{InvalidBackend, InvalidDistribution, InvalidMeta},
+        proto::{BackendSet, InvalidBackend, InvalidDistribution, InvalidMeta},
         Meta, RouteBackend, RouteDistribution,
     };
     use linkerd2_proxy_api::outbound::{self, http_route};
@@ -113,12 +113,12 @@ pub mod proto {
         Redirect(#[from] InvalidRequestRedirect),
     }
 
-    pub(crate) fn route_backends(rts: &[Route]) -> impl Iterator<Item = &crate::Backend> {
-        rts.iter().flat_map(|Route { ref rules, .. }| {
-            rules
-                .iter()
-                .flat_map(|Rule { ref policy, .. }| policy.distribution.backends())
-        })
+    pub(crate) fn fill_route_backends(rts: &[Route], set: &mut BackendSet) {
+        for Route { ref rules, .. } in rts {
+            for Rule { ref policy, .. } in rules {
+                policy.distribution.fill_backends(set);
+            }
+        }
     }
 
     impl TryFrom<outbound::proxy_protocol::Http1> for Http1 {

--- a/linkerd/proxy/client-policy/src/opaq.rs
+++ b/linkerd/proxy/client-policy/src/opaq.rs
@@ -14,7 +14,7 @@ pub enum Filter {}
 pub(crate) mod proto {
     use super::*;
     use crate::{
-        proto::{InvalidBackend, InvalidDistribution, InvalidMeta},
+        proto::{BackendSet, InvalidBackend, InvalidDistribution, InvalidMeta},
         Meta, RouteBackend, RouteDistribution,
     };
     use linkerd2_proxy_api::outbound::{self, opaque_route};
@@ -97,8 +97,10 @@ pub(crate) mod proto {
     }
 
     impl Opaque {
-        pub(crate) fn backends(&self) -> impl Iterator<Item = &crate::Backend> {
-            self.policy.iter().flat_map(|p| p.distribution.backends())
+        pub(crate) fn fill_backends(&self, set: &mut BackendSet) {
+            for p in &self.policy {
+                p.distribution.fill_backends(set);
+            }
         }
     }
 


### PR DESCRIPTION
There's some pretty obtuse code to render route iterators. This change avoids this by passing around a hash set to collect backends into. This is sufficient, especially, as this is all handled internally to the crate.