### PR TITLE
separate policy client config from `inbound::Config`

### DIFF
--- a/linkerd/app/inbound/src/policy/api.rs
+++ b/linkerd/app/inbound/src/policy/api.rs
@@ -10,11 +10,11 @@ use linkerd_app_core::{
 };
 use linkerd_proxy_server_policy::ServerPolicy;
 use linkerd_tonic_watch::StreamWatch;
-use std::time;
+use std::{sync::Arc, time};
 
 #[derive(Clone, Debug)]
 pub(super) struct Api<S> {
-    workload: String,
+    workload: Arc<str>,
     detect_timeout: time::Duration,
     client: Client<S>,
 }
@@ -34,7 +34,7 @@ where
     S::ResponseBody:
         http::HttpBody<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
 {
-    pub(super) fn new(workload: String, detect_timeout: time::Duration, client: S) -> Self {
+    pub(super) fn new(workload: Arc<str>, detect_timeout: time::Duration, client: S) -> Self {
         Self {
             workload,
             detect_timeout,
@@ -70,7 +70,7 @@ where
     fn call(&mut self, port: u16) -> Self::Future {
         let req = api::PortSpec {
             port: port.into(),
-            workload: self.workload.clone(),
+            workload: self.workload.as_ref().to_owned(),
         };
         let detect_timeout = self.detect_timeout;
         let mut client = self.client.clone();

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -7,6 +7,7 @@ pub mod dst;
 pub mod env;
 pub mod identity;
 pub mod oc_collector;
+pub mod policy;
 pub mod tap;
 
 pub use self::metrics::Metrics;
@@ -54,6 +55,7 @@ pub struct Config {
     pub dns: dns::Config,
     pub identity: identity::Config,
     pub dst: dst::Config,
+    pub policy: policy::Config,
     pub admin: admin::Config,
     pub tap: tap::Config,
     pub oc_collector: oc_collector::Config,
@@ -109,6 +111,7 @@ impl Config {
             admin,
             dns,
             dst,
+            policy,
             identity,
             inbound,
             oc_collector,
@@ -142,9 +145,16 @@ impl Config {
             info_span!("dst").in_scope(|| dst.build(dns, metrics, identity.receiver().new_client()))
         }?;
 
+        let policies = {
+            let dns = dns.resolver.clone();
+            let metrics = metrics.control.clone();
+            info_span!("policy")
+                .in_scope(|| policy.build(dns, metrics, identity.receiver().new_client()))
+        }?;
+
         let oc_collector = {
             let identity = identity.receiver().new_client();
-            let dns = dns.resolver.clone();
+            let dns = dns.resolver;
             let client_metrics = metrics.control.clone();
             let metrics = metrics.opencensus;
             info_span!("opencensus")
@@ -153,7 +163,7 @@ impl Config {
 
         let runtime = ProxyRuntime {
             identity: identity.receiver(),
-            metrics: metrics.proxy.clone(),
+            metrics: metrics.proxy,
             tap: tap.registry(),
             span_sink: oc_collector.span_sink(),
             drain: drain_rx.clone(),
@@ -161,11 +171,11 @@ impl Config {
         let inbound = Inbound::new(inbound, runtime.clone());
         let outbound = Outbound::new(outbound, runtime);
 
-        let inbound_policies = {
-            let dns = dns.resolver;
-            let metrics = metrics.control;
-            info_span!("policy").in_scope(|| inbound.build_policies(dns, metrics))
-        };
+        let inbound_policies = inbound.build_policies(
+            policies.workload.clone(),
+            policies.client.clone(),
+            policies.backoff,
+        );
 
         let admin = {
             let identity = identity.receiver().server();

--- a/linkerd/app/src/policy.rs
+++ b/linkerd/app/src/policy.rs
@@ -1,0 +1,67 @@
+use linkerd_app_core::{
+    control, dns,
+    exp_backoff::ExponentialBackoff,
+    identity, metrics,
+    proxy::http,
+    svc::{self, NewService, ServiceExt},
+    Error,
+};
+
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub control: control::Config,
+    pub workload: String,
+}
+
+/// Handles to policy service clients.
+pub struct Policy<S> {
+    /// The address of the policy service, used for logging.
+    pub addr: control::ControlAddr,
+
+    /// Policy service gRPC client.
+    pub client: S,
+
+    /// Workload identifier
+    pub workload: Arc<str>,
+
+    pub backoff: ExponentialBackoff,
+}
+
+// === impl Config ===
+
+impl Config {
+    pub fn build(
+        self,
+        dns: dns::Resolver,
+        metrics: metrics::ControlHttp,
+        identity: identity::NewClient,
+    ) -> Result<
+        Policy<
+            impl svc::Service<
+                    http::Request<tonic::body::BoxBody>,
+                    Response = http::Response<control::RspBody>,
+                    Error = Error,
+                    Future = impl Send,
+                > + Clone,
+        >,
+        Error,
+    > {
+        let addr = self.control.addr.clone();
+        let workload = self.workload.into();
+        let backoff = self.control.connect.backoff;
+        let client = self
+            .control
+            .build(dns, metrics, identity)
+            .new_service(())
+            .map_err(Error::from);
+
+        Ok(Policy {
+            addr,
+            client,
+            workload,
+            backoff,
+        })
+    }
+}


### PR DESCRIPTION
Currently, configuration for the policy controller client is part of the `linkerd_app_inbound` crate's `Config` struct. This is because only the inbound proxy currently communicates with the policy controller.

In order to change the outbound side of the proxy to resolve client policies from the new `OutboundPolicy` API, the outbound proxy will now also need a policy controller client. Preferrably, both the client configuration and the actual client connection(s) should be shared between both halves of the proxy, similar to how the destination controller client is shared by both the inbound and outbound proxies.

Therefore, this branch pulls the shared policy client configuration out of the inbound config and onto the top-level `linkerd_app` crate's `Config` struct. The shape of the `Inbound::build_policies` function is changed somewhat, as it now takes a client service and wraps it with the gRPC API client for the inbound policy API. This looks a bit different from how the destination controller client is shared between the inbound and outbound proxies, because in this case, the two halves of the proxy are using different gRPC APIs served by the same controller, rather than the same API.

Additionally, the policy controller address and name environment variables are now required, and starting the proxy without them is a hard error. In practice, these are always set, and running without a policy controller was only used in proxy integration tests. PR #2288 changed the integration tests to run with a mock policy controller, so running the proxy without a policy controller is no longer necessary. Removing this mode simplifies the config-parsing code somewhat.

This change was factored out from PR #2265.