### PR TITLE
Simplify outbound discovery target types

### DIFF
--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -13,7 +13,7 @@ use linkerd_app_core::{
     Error, NameMatch,
 };
 use linkerd_app_inbound::{self as inbound, GatewayAddr, Inbound};
-use linkerd_app_outbound::{self as outbound, Outbound};
+use linkerd_app_outbound::Outbound;
 use std::fmt::Debug;
 
 mod http;
@@ -54,7 +54,6 @@ impl Gateway {
         T: svc::Param<tls::ClientId>,
         T: svc::Param<inbound::policy::AllowPolicy>,
         T: svc::Param<Option<SessionProtocol>>,
-        T: svc::Param<outbound::discover::TargetAddr>,
         T: Clone + Send + Sync + Unpin + 'static,
         // Server-side socket
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr,

--- a/linkerd/app/gateway/src/server.rs
+++ b/linkerd/app/gateway/src/server.rs
@@ -38,7 +38,6 @@ impl Gateway {
         T: svc::Param<tls::ClientId>,
         T: svc::Param<inbound::policy::AllowPolicy>,
         T: svc::Param<Option<SessionProtocol>>,
-        T: svc::Param<outbound::discover::TargetAddr>,
         T: Clone + Send + Sync + Unpin + 'static,
         // Server-side socket
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr,
@@ -83,8 +82,8 @@ impl Gateway {
             let mut profiles = profiles::WithAllowlist::new(profiles, allowlist);
             self.outbound
                 .with_stack(protocol)
-                .push_discover(svc::mk(move |outbound::discover::TargetAddr(addr)| {
-                    profiles.get_profile(profiles::LookupAddr(addr))
+                .push_discover(svc::mk(move |GatewayAddr(addr)| {
+                    profiles.get_profile(profiles::LookupAddr(addr.into()))
                 }))
                 .into_stack()
         };

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -70,6 +70,7 @@ struct Runtime {
     drain: drain::Watch,
 }
 
+/// Indicates the name to be used to route gateway connections.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct GatewayAddr(pub NameAddr);
 

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -1,11 +1,7 @@
 use crate::{policy, Outbound};
-use linkerd_app_core::{
-    profiles,
-    svc::{self, stack::Param},
-    Error,
-};
-pub use policy::TargetAddr;
+use linkerd_app_core::{profiles, svc, Error};
 use std::{
+    fmt::Debug,
     hash::{Hash, Hasher},
     ops::Deref,
 };
@@ -23,18 +19,19 @@ pub struct Discovery<T> {
 
 impl<N> Outbound<N> {
     /// Discovers routing configuration.
-    pub fn push_discover<T, Req, NSvc, D>(
+    pub fn push_discover<T, K, Req, NSvc, D>(
         self,
         discover: D,
     ) -> Outbound<svc::ArcNewService<T, svc::BoxService<Req, NSvc::Response, Error>>>
     where
         // Discoverable target.
-        T: Param<TargetAddr>,
+        T: svc::Param<K>,
         T: Clone + Send + Sync + 'static,
+        K: Clone + Debug + Eq + Hash + Send + Sync + 'static,
         // Request type.
         Req: Send + 'static,
         // Discovery client.
-        D: svc::Service<TargetAddr, Error = Error> + Clone + Send + Sync + 'static,
+        D: svc::Service<K, Error = Error> + Clone + Send + Sync + 'static,
         D::Future: Send + Unpin + 'static,
         D::Error: Send + Sync + 'static,
         D::Response: Clone + Send + Sync + 'static,

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -19,7 +19,7 @@ use linkerd_app_core::{
         tap,
     },
     serve,
-    svc::{self, stack::Param},
+    svc::{self, ServiceExt},
     tls,
     transport::addrs::*,
     AddrMatch, Error, ProxyRuntime, Result,
@@ -32,7 +32,7 @@ use std::{
     time::Duration,
 };
 
-pub mod discover;
+mod discover;
 pub mod http;
 mod ingress;
 mod metrics;
@@ -128,7 +128,6 @@ impl Outbound<()> {
         C::ResponseBody: Default + Send + 'static,
         C::Future: Send,
     {
-        use tower::ServiceExt;
         policy::Api::new(workload, Duration::from_secs(10), client)
             .into_watch(backoff)
             .map_result(|response| match response {
@@ -210,8 +209,8 @@ impl Outbound<()> {
         resolve: R,
     ) where
         // Target describing a server-side connection.
-        T: Param<Remote<ClientAddr>>,
-        T: Param<OrigDstAddr>,
+        T: svc::Param<Remote<ClientAddr>>,
+        T: svc::Param<OrigDstAddr>,
         T: Clone + Send + Sync + 'static,
         // Server-side socket.
         I: io::AsyncRead + io::AsyncWrite + io::Peek + io::PeerAddr,

--- a/linkerd/app/outbound/src/policy/api.rs
+++ b/linkerd/app/outbound/src/policy/api.rs
@@ -1,4 +1,3 @@
-use crate::discover;
 use futures::prelude::*;
 use linkerd2_proxy_api::outbound::{
     self as api, outbound_policies_client::OutboundPoliciesClient as Client,
@@ -47,7 +46,7 @@ where
     }
 }
 
-impl<S> Service<discover::TargetAddr> for Api<S>
+impl<S> Service<Addr> for Api<S>
 where
     S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
     S: Clone + Send + Sync + 'static,
@@ -67,7 +66,7 @@ where
         std::task::Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, discover::TargetAddr(addr): discover::TargetAddr) -> Self::Future {
+    fn call(&mut self, addr: Addr) -> Self::Future {
         let req = {
             let target = match addr {
                 Addr::Name(ref name) => api::traffic_spec::Target::Authority(name.to_string()),

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -1,4 +1,4 @@
-use crate::{discover, Outbound};
+use crate::Outbound;
 use linkerd_app_core::{
     io, svc,
     transport::{self, addrs::*, metrics},
@@ -28,12 +28,6 @@ impl From<OrigDstAddr> for Accept {
 impl svc::Param<OrigDstAddr> for Accept {
     fn param(&self) -> OrigDstAddr {
         self.orig_dst
-    }
-}
-
-impl svc::Param<discover::TargetAddr> for Accept {
-    fn param(&self) -> discover::TargetAddr {
-        discover::TargetAddr((*self.orig_dst).into())
     }
 }
 


### PR DESCRIPTION
By avoiding a dedicated param value type, we can more flexibly instrument discovery!