### PR TITLE
outbound: Report concrete authorities for policies

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy.rs
+++ b/linkerd/app/outbound/src/http/logical/policy.rs
@@ -227,12 +227,20 @@ where
         } = rts;
 
         let mk_concrete = {
-            let authority = addr.to_http_authority();
             let parent = parent.clone();
-            move |target: concrete::Dispatch| Concrete {
-                target,
-                authority: Some(authority.clone()),
-                parent: parent.clone(),
+            move |target: concrete::Dispatch| {
+                // XXX With policies we don't have a top-level authority name at
+                // the moment. So, instead, we use the concrete addr used for
+                // discovery for now.
+                let authority = match target {
+                    concrete::Dispatch::Balance(ref a, _) => Some(a.as_http_authority()),
+                    _ => None,
+                };
+                Concrete {
+                    target,
+                    authority,
+                    parent: parent.clone(),
+                }
             }
         };
 

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -276,10 +276,6 @@ impl svc::Param<http::Version> for HttpSidecar {
     }
 }
 
-// XXX Policy routes report their `OrigDstAddr` as a `LogicalAddr`, since the
-// API responses don't provide an DNS-style name in the response. Instead, they
-// include resource coordinates. Telemetry will eventually have to be updated to
-// support report this richer metadata.
 impl svc::Param<http::LogicalAddr> for HttpSidecar {
     fn param(&self) -> http::LogicalAddr {
         http::LogicalAddr(match *self.routes.borrow() {


### PR DESCRIPTION
The new policy router currently reports a numeric authority when using policy routes. In some cases, we have a named concrete address for the load balancer. In the vast majority of cases, this address is the same as the logical service's.

For now, let's use concrete addresses for telemetry. This will help minimize regressions while we figure how to move telemetry forward.