### PR TITLE
gateway: discover client policies from the policy controller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.11"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
+checksum = "8582122b8edba2af43eaf6b80dbfd33f421b5a0eb3a3113d21bc096ac5b44faf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -113,6 +113,7 @@ dependencies = [
  "serde",
  "sync_wrapper",
  "tower",
+ "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -603,6 +604,12 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -2409,9 +2416,9 @@ checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "scopeguard"
@@ -2772,6 +2779,25 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -3187,9 +3213,9 @@ checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,9 +91,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8582122b8edba2af43eaf6b80dbfd33f421b5a0eb3a3113d21bc096ac5b44faf"
+checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -113,7 +113,6 @@ dependencies = [
  "serde",
  "sync_wrapper",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
@@ -604,12 +603,6 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -2172,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
 dependencies = [
  "unicode-ident",
 ]
@@ -2417,9 +2410,9 @@ checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "scopeguard"
@@ -2780,25 +2773,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -3214,15 +3188,15 @@ checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winreg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,6 +960,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
+ "tonic",
  "tower",
  "tower-test",
  "tracing",

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -14,6 +14,7 @@ linkerd-app-inbound = { path = "../inbound" }
 linkerd-app-outbound = { path = "../outbound" }
 thiserror = "1"
 tokio = { version = "1", features = ["sync"] }
+tonic = { version = "0.8", default-features = false }
 tower = { version = "0.4", default-features = false }
 tracing = "0.1"
 

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -13,7 +13,7 @@ use linkerd_app_core::{
     Error, NameMatch,
 };
 use linkerd_app_inbound::{self as inbound, GatewayAddr, Inbound};
-use linkerd_app_outbound::Outbound;
+use linkerd_app_outbound::{self as outbound, Outbound};
 use std::fmt::Debug;
 
 mod http;
@@ -44,7 +44,12 @@ impl Gateway {
 
     /// Builds a gateway to the outbound stack, to be passed to the inbound
     /// stack.
-    pub fn stack<T, I, R, D>(self, resolve: R, disco: D) -> svc::Stack<svc::ArcNewTcp<T, I>>
+    pub fn stack<T, I, R>(
+        self,
+        resolve: R,
+        profiles: impl profiles::GetProfile<Error = Error>,
+        policies: impl outbound::policy::GetPolicy,
+    ) -> svc::Stack<svc::ArcNewTcp<T, I>>
     where
         // Target describing an inbound gateway connection.
         T: svc::Param<GatewayAddr>,
@@ -60,8 +65,6 @@ impl Gateway {
         I: Debug + Send + Sync + Unpin + 'static,
         // Endpoint resolution.
         R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
-        // Discovery
-        D: profiles::GetProfile<Error = Error>,
     {
         let opaq = {
             let resolve = resolve.clone();
@@ -83,6 +86,6 @@ impl Gateway {
                 .into_inner()
         };
 
-        self.server(disco, opaq, http)
+        self.server(profiles, policies, opaq, http)
     }
 }

--- a/linkerd/app/gateway/src/server.rs
+++ b/linkerd/app/gateway/src/server.rs
@@ -2,7 +2,7 @@ use crate::Gateway;
 use futures::FutureExt;
 use linkerd_app_core::{
     errors, io, profiles, proxy::http, svc, tls, transport::addrs::*,
-    transport_header::SessionProtocol, Addr, Error, NameMatch,
+    transport_header::SessionProtocol, Addr, Error,
 };
 use linkerd_app_inbound::{self as inbound, GatewayAddr, GatewayDomainInvalid};
 use linkerd_app_outbound::{self as outbound};
@@ -109,7 +109,7 @@ impl Gateway {
                         Err(e) => return Err(e),
                     };
 
-                    Ok((profile?, policy))
+                    Ok((profile?, Some(policy)))
                 });
                 future::Either::Right(f)
             })

--- a/linkerd/app/gateway/src/server.rs
+++ b/linkerd/app/gateway/src/server.rs
@@ -80,7 +80,9 @@ impl Gateway {
             let allowlist = self.config.allow_discovery.clone().into();
             let mut profiles = profiles::WithAllowlist::new(profiles, allowlist);
             svc::mk(move |GatewayAddr(addr)| {
-                let profile = profiles.get_profile(profiles::LookupAddr(addr.into()));
+                let profile = profiles.get_profile(profiles::LookupAddr(addr.clone().into()));
+                // TODO(eliza): we should probably also add the allowlist to
+                // policy resolution...
                 let policy = policies.get_policy(addr.into());
                 Box::pin(async move {
                     let (profile, policy) = tokio::join!(profile, policy);
@@ -97,7 +99,7 @@ impl Gateway {
                         None
                     });
 
-                    Ok((profile, policy))
+                    Ok::<_, Box<dyn std::error::Error + Send + Sync + 'static>>((profile, policy))
                 })
             })
         };

--- a/linkerd/app/gateway/src/server.rs
+++ b/linkerd/app/gateway/src/server.rs
@@ -92,8 +92,6 @@ impl Gateway {
                     .get_profile(profiles::LookupAddr(addr.clone().into()))
                     .instrument(tracing::debug_span!("profiles"));
 
-                // TODO(eliza): we should probably also add the allowlist to
-                // policy resolution...
                 let policy = policies
                     .get_policy(addr.into())
                     .map_err(|e| {

--- a/linkerd/app/gateway/src/server.rs
+++ b/linkerd/app/gateway/src/server.rs
@@ -109,7 +109,7 @@ impl Gateway {
                         Err(e) => return Err(e),
                     };
 
-                    Ok((profile?, Some(policy)))
+                    Ok((profile?, policy))
                 });
                 future::Either::Right(f)
             })

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -21,8 +21,7 @@ mod tests;
 pub struct Discovery<T> {
     parent: T,
     profile: Option<profiles::Receiver>,
-    // TODO(ver) Policies should not be optional.
-    policy: Option<policy::Receiver>,
+    policy: policy::Receiver,
 }
 
 impl<N> Outbound<N> {
@@ -277,17 +276,7 @@ impl<T> From<((Option<profiles::Receiver>, policy::Receiver), T)> for Discovery<
         Self {
             parent,
             profile,
-            policy: Some(policy),
-        }
-    }
-}
-
-impl<T> From<(Option<profiles::Receiver>, T)> for Discovery<T> {
-    fn from((profile, parent): (Option<profiles::Receiver>, T)) -> Self {
-        Self {
-            parent,
-            profile,
-            policy: None,
+            policy,
         }
     }
 }
@@ -310,8 +299,8 @@ impl<T> svc::Param<Option<profiles::LogicalAddr>> for Discovery<T> {
     }
 }
 
-impl<T> svc::Param<Option<policy::Receiver>> for Discovery<T> {
-    fn param(&self) -> Option<policy::Receiver> {
+impl<T> svc::Param<policy::Receiver> for Discovery<T> {
+    fn param(&self) -> policy::Receiver {
         self.policy.clone()
     }
 }

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -282,12 +282,14 @@ impl<T> From<((Option<profiles::Receiver>, policy::Receiver), T)> for Discovery<
     }
 }
 
-impl<T> From<(Option<profiles::Receiver>, T)> for Discovery<T> {
-    fn from((profile, parent): (Option<profiles::Receiver>, T)) -> Self {
+impl<T> From<((Option<profiles::Receiver>, Option<policy::Receiver>), T)> for Discovery<T> {
+    fn from(
+        ((profile, policy), parent): ((Option<profiles::Receiver>, Option<policy::Receiver>), T),
+    ) -> Self {
         Self {
             parent,
             profile,
-            policy: None,
+            policy,
         }
     }
 }

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -21,8 +21,7 @@ mod tests;
 pub struct Discovery<T> {
     parent: T,
     profile: Option<profiles::Receiver>,
-    // TODO(ver) Policies should not be optional.
-    policy: Option<policy::Receiver>,
+    policy: policy::Receiver,
 }
 
 impl<N> Outbound<N> {
@@ -277,18 +276,6 @@ impl<T> From<((Option<profiles::Receiver>, policy::Receiver), T)> for Discovery<
         Self {
             parent,
             profile,
-            policy: Some(policy),
-        }
-    }
-}
-
-impl<T> From<((Option<profiles::Receiver>, Option<policy::Receiver>), T)> for Discovery<T> {
-    fn from(
-        ((profile, policy), parent): ((Option<profiles::Receiver>, Option<policy::Receiver>), T),
-    ) -> Self {
-        Self {
-            parent,
-            profile,
             policy,
         }
     }
@@ -312,8 +299,8 @@ impl<T> svc::Param<Option<profiles::LogicalAddr>> for Discovery<T> {
     }
 }
 
-impl<T> svc::Param<Option<policy::Receiver>> for Discovery<T> {
-    fn param(&self) -> Option<policy::Receiver> {
+impl<T> svc::Param<policy::Receiver> for Discovery<T> {
+    fn param(&self) -> policy::Receiver {
         self.policy.clone()
     }
 }

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -21,7 +21,8 @@ mod tests;
 pub struct Discovery<T> {
     parent: T,
     profile: Option<profiles::Receiver>,
-    policy: policy::Receiver,
+    // TODO(ver) Policies should not be optional.
+    policy: Option<policy::Receiver>,
 }
 
 impl<N> Outbound<N> {
@@ -276,7 +277,17 @@ impl<T> From<((Option<profiles::Receiver>, policy::Receiver), T)> for Discovery<
         Self {
             parent,
             profile,
-            policy,
+            policy: Some(policy),
+        }
+    }
+}
+
+impl<T> From<(Option<profiles::Receiver>, T)> for Discovery<T> {
+    fn from((profile, parent): (Option<profiles::Receiver>, T)) -> Self {
+        Self {
+            parent,
+            profile,
+            policy: None,
         }
     }
 }
@@ -299,8 +310,8 @@ impl<T> svc::Param<Option<profiles::LogicalAddr>> for Discovery<T> {
     }
 }
 
-impl<T> svc::Param<policy::Receiver> for Discovery<T> {
-    fn param(&self) -> policy::Receiver {
+impl<T> svc::Param<Option<policy::Receiver>> for Discovery<T> {
+    fn param(&self) -> Option<policy::Receiver> {
         self.policy.clone()
     }
 }

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -165,4 +165,3 @@ impl errors::HttpRescue<Error> for ServerRescue {
         Ok(errors::SyntheticHttpResponse::unexpected_error())
     }
 }
- `

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -165,3 +165,4 @@ impl errors::HttpRescue<Error> for ServerRescue {
         Ok(errors::SyntheticHttpResponse::unexpected_error())
     }
 }
+ `

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -310,8 +310,7 @@ impl TryFrom<Discovery<Http<RequestTarget>>> for Http<Logical> {
         let version = parent.version;
         let profile =
             svc::Param::<Option<profiles::Receiver>>::param(&parent).map(watch::Receiver::from);
-        let mut policy =
-            svc::Param::<Option<policy::Receiver>>::param(&parent).expect("policies are required");
+        let mut policy = svc::Param::<policy::Receiver>::param(&parent);
 
         match (**parent).clone() {
             RequestTarget::Named(addr) => {

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -310,7 +310,8 @@ impl TryFrom<Discovery<Http<RequestTarget>>> for Http<Logical> {
         let version = parent.version;
         let profile =
             svc::Param::<Option<profiles::Receiver>>::param(&parent).map(watch::Receiver::from);
-        let mut policy = svc::Param::<policy::Receiver>::param(&parent);
+        let mut policy =
+            svc::Param::<Option<policy::Receiver>>::param(&parent).expect("policies are required");
 
         match (**parent).clone() {
             RequestTarget::Named(addr) => {

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -22,7 +22,8 @@ use tracing::info_span;
 struct Sidecar {
     orig_dst: OrigDstAddr,
     profile: Option<profiles::Receiver>,
-    policy: policy::Receiver,
+    // TODO(ver) Policies should not be optional.
+    policy: Option<policy::Receiver>,
 }
 
 #[derive(Clone, Debug)]
@@ -178,7 +179,7 @@ impl From<protocol::Http<Sidecar>> for HttpSidecar {
     fn from(parent: protocol::Http<Sidecar>) -> Self {
         let orig_dst = (*parent).orig_dst;
         let version = svc::Param::<http::Version>::param(&parent);
-        let mut policy = (*parent).policy.clone();
+        let mut policy = (*parent).policy.clone().expect("policies are required");
 
         if let Some(mut profile) = (*parent).profile.clone().map(watch::Receiver::from) {
             // Only use service profiles if there are novel routes/target

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -22,8 +22,7 @@ use tracing::info_span;
 struct Sidecar {
     orig_dst: OrigDstAddr,
     profile: Option<profiles::Receiver>,
-    // TODO(ver) Policies should not be optional.
-    policy: Option<policy::Receiver>,
+    policy: policy::Receiver,
 }
 
 #[derive(Clone, Debug)]
@@ -179,7 +178,7 @@ impl From<protocol::Http<Sidecar>> for HttpSidecar {
     fn from(parent: protocol::Http<Sidecar>) -> Self {
         let orig_dst = (*parent).orig_dst;
         let version = svc::Param::<http::Version>::param(&parent);
-        let mut policy = (*parent).policy.clone().expect("policies are required");
+        let mut policy = (*parent).policy.clone();
 
         if let Some(mut profile) = (*parent).profile.clone().map(watch::Receiver::from) {
             // Only use service profiles if there are novel routes/target

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -177,6 +177,12 @@ impl Config {
             policies.backoff,
         );
 
+        let outbound_policies = outbound.build_policies(
+            policies.workload.clone(),
+            policies.client.clone(),
+            policies.backoff,
+        );
+
         let admin = {
             let identity = identity.receiver().server();
             let metrics = inbound.metrics();
@@ -200,8 +206,11 @@ impl Config {
         };
 
         let dst_addr = dst.addr.clone();
-        let gateway = gateway::Gateway::new(gateway, inbound.clone(), outbound.clone())
-            .stack(dst.resolve.clone(), dst.profiles.clone());
+        let gateway = gateway::Gateway::new(gateway, inbound.clone(), outbound.clone()).stack(
+            dst.resolve.clone(),
+            dst.profiles.clone(),
+            outbound_policies.clone(),
+        );
 
         // Bind the proxy sockets eagerly (so they're reserved and known) but defer building the
         // stacks until the proxy starts running.
@@ -219,12 +228,6 @@ impl Config {
             let inbound_addr = inbound_addr;
             let profiles = dst.profiles;
             let resolve = dst.resolve;
-
-            let outbound_policies = outbound.build_policies(
-                policies.workload.clone(),
-                policies.client.clone(),
-                policies.backoff,
-            );
 
             Box::pin(async move {
                 Self::await_identity(identity_ready).await;


### PR DESCRIPTION
Depends on #2314.

Currently, the gateway stack does not resolve client policies, and only
uses service profiles for client-side policy discovery. This branch
updates the gateway proxy to also perform client policy discovery,
similarly to the outbound proxy.

Because all outbound stacks, including the one constructed by the
gateway, will now discover client policies, the client policy `Receiver`
in the `Discovery` type, which is currently an `Option`, can now be made
non-optional. This simplifies some code a little bit and removes some
`expect`s.