### PR TITLE
Configure response classifiers from ClientPolicy routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1463,6 +1463,7 @@ dependencies = [
  "prost-types",
  "quickcheck",
  "thiserror",
+ "tonic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -905,6 +905,7 @@ dependencies = [
  "linkerd-metrics",
  "linkerd-opencensus",
  "linkerd-proxy-api-resolve",
+ "linkerd-proxy-client-policy",
  "linkerd-proxy-core",
  "linkerd-proxy-dns-resolve",
  "linkerd-proxy-http",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -43,6 +43,7 @@ linkerd-proxy-identity-client = { path = "../../proxy/identity-client" }
 linkerd-proxy-http = { path = "../../proxy/http" }
 linkerd-proxy-resolve = { path = "../../proxy/resolve" }
 linkerd-proxy-dns-resolve = { path = "../../proxy/dns-resolve" }
+linkerd-proxy-client-policy = { path = "../../proxy/client-policy" }
 linkerd-proxy-server-policy = { path = "../../proxy/server-policy" }
 linkerd-proxy-tap = { path = "../../proxy/tap" }
 linkerd-proxy-tcp = { path = "../../proxy/tcp" }

--- a/linkerd/app/core/src/classify.rs
+++ b/linkerd/app/core/src/classify.rs
@@ -1,6 +1,7 @@
 use crate::profiles;
 use linkerd_error::Error;
 use linkerd_http_classify as classify;
+use linkerd_proxy_client_policy as client_policy;
 use linkerd_proxy_http::{HasH2Reason, ResponseTimeoutError};
 use std::borrow::Cow;
 use tonic as grpc;
@@ -12,53 +13,52 @@ pub type NewClassify<N, X = ()> = classify::NewClassify<Request, X, N>;
 pub enum Request {
     Default,
     Profile(profiles::http::ResponseClasses),
+    ClientPolicy(ClientPolicy),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Response {
-    Default,
-    Grpc,
+    Http(client_policy::http::StatusRanges),
+    Grpc(client_policy::grpc::Codes),
     Profile(profiles::http::ResponseClasses),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ClientPolicy {
+    Grpc(client_policy::grpc::Codes),
+    Http(client_policy::http::StatusRanges),
 }
 
 #[derive(Clone, Debug)]
 pub enum Eos {
-    Default(http::StatusCode),
-    Grpc(GrpcEos),
-    Profile(Class),
-    Error(&'static str),
+    Class(Class),
+    GrpcOpen(client_policy::grpc::Codes),
+    ProfileUnmatched(Class),
 }
 
-#[derive(Clone, Debug)]
-pub enum GrpcEos {
-    NoBody(Class),
-    Open,
-}
+pub type Result<T> = std::result::Result<T, T>;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum Class {
-    Default(SuccessOrFailure),
-    Grpc(SuccessOrFailure, u32),
-    Error(SuccessOrFailure, Cow<'static, str>),
+    Http(Result<http::StatusCode>),
+    Grpc(Result<grpc::Code>),
+    Error(Cow<'static, str>),
 }
-
-pub type SuccessOrFailure = Result<(), ()>;
 
 // === impl Request ===
 
 impl From<profiles::http::ResponseClasses> for Request {
     fn from(classes: profiles::http::ResponseClasses) -> Self {
-        if classes.is_empty() {
-            Request::Default
-        } else {
-            Request::Profile(classes)
+        if !classes.is_empty() {
+            return Self::Profile(classes);
         }
+        Self::Default
     }
 }
 
 impl Default for Request {
     fn default() -> Self {
-        Request::Default
+        Self::Default
     }
 }
 
@@ -69,20 +69,22 @@ impl classify::Classify for Request {
 
     fn classify<B>(&self, req: &http::Request<B>) -> Self::ClassifyResponse {
         match self {
-            Request::Profile(classes) => Response::Profile(classes.clone()),
-            Request::Default => {
+            Self::Profile(classes) => Response::Profile(classes.clone()),
+
+            Self::ClientPolicy(ClientPolicy::Http(policy)) => Response::Http(policy.clone()),
+            Self::ClientPolicy(ClientPolicy::Grpc(policy)) => Response::Grpc(policy.clone()),
+
+            Self::Default => {
                 let is_grpc = req
                     .headers()
                     .get(http::header::CONTENT_TYPE)
                     .and_then(|v| v.to_str().ok())
-                    .map(|ct| ct.starts_with("application/grpc+"))
+                    .map(|ct| ct.starts_with("application/grpc"))
                     .unwrap_or(false);
-
                 if is_grpc {
-                    Response::Grpc
-                } else {
-                    Response::Default
+                    return Response::Grpc(Default::default());
                 }
+                Response::default()
             }
         }
     }
@@ -92,9 +94,7 @@ impl classify::Classify for Request {
 
 impl Default for Response {
     fn default() -> Self {
-        // By default, simply perform HTTP classification. This only applies
-        // when no `insert` layer is present.
-        Response::Default
+        Self::Http(client_policy::http::StatusRanges::default())
     }
 }
 
@@ -105,8 +105,12 @@ impl Response {
     ) -> Option<Class> {
         for class in classes {
             if class.is_match(rsp) {
-                let result = if class.is_failure() { Err(()) } else { Ok(()) };
-                return Some(Class::Default(result));
+                let res = if class.is_failure() {
+                    Err(rsp.status())
+                } else {
+                    Ok(rsp.status())
+                };
+                return Some(Class::Http(res));
             }
         }
 
@@ -119,19 +123,36 @@ impl classify::ClassifyResponse for Response {
     type ClassifyEos = Eos;
 
     fn start<B>(self, rsp: &http::Response<B>) -> Eos {
+        let status = rsp.status();
         match self {
-            Response::Default => grpc_class(rsp.headers())
-                .map(|c| Eos::Grpc(GrpcEos::NoBody(c)))
-                .unwrap_or_else(|| Eos::Default(rsp.status())),
-            Response::Grpc => grpc_class(rsp.headers())
-                .map(|c| Eos::Grpc(GrpcEos::NoBody(c)))
-                .unwrap_or(Eos::Grpc(GrpcEos::Open)),
-            Response::Profile(ref classes) => Self::match_class(rsp, classes.as_ref())
-                .map(Eos::Profile)
+            Self::Http(statuses) => Eos::Class(Class::Http(if statuses.contains(status) {
+                Err(status)
+            } else {
+                Ok(status)
+            })),
+
+            Self::Grpc(codes) => grpc_code(rsp.headers())
+                .map(|c| Eos::Class(Class::Grpc(if codes.contains(c) { Err(c) } else { Ok(c) })))
+                .unwrap_or(Eos::GrpcOpen(codes)),
+
+            Self::Profile(ref classes) => Self::match_class(rsp, classes.as_ref())
+                .map(Eos::Class)
                 .unwrap_or_else(|| {
-                    grpc_class(rsp.headers())
-                        .map(|c| Eos::Grpc(GrpcEos::NoBody(c)))
-                        .unwrap_or_else(|| Eos::Default(rsp.status()))
+                    if let Some(code) = grpc_code(rsp.headers()) {
+                        let codes = client_policy::grpc::Codes::default();
+                        return Eos::Class(Class::Grpc(if codes.contains(code) {
+                            Err(code)
+                        } else {
+                            Ok(code)
+                        }));
+                    }
+
+                    let http = Class::Http(if status.is_server_error() {
+                        Err(status)
+                    } else {
+                        Ok(status)
+                    });
+                    Eos::ProfileUnmatched(http)
                 }),
         }
     }
@@ -142,8 +163,7 @@ impl classify::ClassifyResponse for Response {
         } else {
             h2_error(err).into()
         };
-
-        Class::Error(Err(()), msg)
+        Class::Error(msg)
     }
 }
 
@@ -152,43 +172,43 @@ impl classify::ClassifyResponse for Response {
 impl classify::ClassifyEos for Eos {
     type Class = Class;
 
-    fn eos(self, trailers: Option<&http::HeaderMap>) -> Self::Class {
+    fn eos(self, trailers: Option<&http::HeaderMap>) -> Class {
         match self {
-            Eos::Default(status) if status.is_server_error() => Class::Default(Err(())),
-            Eos::Default(_) => trailers
-                .and_then(grpc_class)
-                .unwrap_or(Class::Default(Ok(()))),
-            Eos::Grpc(GrpcEos::NoBody(class)) => class,
-            Eos::Grpc(GrpcEos::Open) => trailers
-                .and_then(grpc_class)
-                .unwrap_or(Class::Grpc(Ok(()), 0)),
-            Eos::Profile(class) => class,
-            Eos::Error(msg) => Class::Error(Err(()), msg.into()),
+            Self::Class(class) => class,
+            Self::GrpcOpen(codes) => {
+                let code = match trailers.and_then(grpc_code) {
+                    None => return Class::Grpc(Ok(grpc::Code::Unknown)),
+                    Some(code) => code,
+                };
+                if codes.contains(code) {
+                    return Class::Grpc(Err(code));
+                }
+                Class::Grpc(Ok(code))
+            }
+            Self::ProfileUnmatched(http_class) => {
+                if let Some(code) = trailers.and_then(grpc_code) {
+                    let codes = client_policy::grpc::Codes::default();
+                    return Class::Grpc(if codes.contains(code) {
+                        Err(code)
+                    } else {
+                        Ok(code)
+                    });
+                }
+                http_class
+            }
         }
     }
 
-    fn error(self, err: &Error) -> Self::Class {
-        Class::Error(Err(()), h2_error(err).into())
+    fn error(self, err: &Error) -> Class {
+        Class::Error(h2_error(err).into())
     }
 }
 
-fn grpc_class(headers: &http::HeaderMap) -> Option<Class> {
-    headers
-        .get("grpc-status")
+fn grpc_code(hdrs: &http::HeaderMap) -> Option<grpc::Code> {
+    hdrs.get("grpc-status")
         .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u32>().ok())
-        .map(|grpc_status| {
-            let ok = match grpc::Code::from_i32(grpc_status as i32) {
-                grpc::Code::Unknown
-                | grpc::Code::DeadlineExceeded
-                | grpc::Code::Internal
-                | grpc::Code::Unavailable
-                | grpc::Code::PermissionDenied
-                | grpc::Code::DataLoss => Err(()),
-                _ => Ok(()),
-            };
-            Class::Grpc(ok, grpc_status)
-        })
+        .and_then(|s| s.parse::<u16>().ok())
+        .map(|code| grpc::Code::from_i32(code as i32))
 }
 
 fn h2_error(err: &Error) -> String {
@@ -208,7 +228,7 @@ impl Class {
     pub fn is_failure(&self) -> bool {
         matches!(
             self,
-            Class::Default(Err(())) | Class::Grpc(Err(()), _) | Class::Error(Err(()), _)
+            Class::Http(Err(_)) | Class::Grpc(Err(_)) | Class::Error(_),
         )
     }
 }
@@ -222,8 +242,8 @@ mod tests {
     #[test]
     fn http_response_status_ok() {
         let rsp = Response::builder().status(StatusCode::OK).body(()).unwrap();
-        let class = super::Response::Default.start(&rsp).eos(None);
-        assert_eq!(class, Class::Default(Ok(())));
+        let class = super::Response::default().start(&rsp).eos(None);
+        assert_eq!(class, Class::Http(Ok(http::StatusCode::OK)));
     }
 
     #[test]
@@ -232,8 +252,8 @@ mod tests {
             .status(StatusCode::BAD_REQUEST)
             .body(())
             .unwrap();
-        let class = super::Response::Default.start(&rsp).eos(None);
-        assert_eq!(class, Class::Default(Ok(())));
+        let class = super::Response::default().start(&rsp).eos(None);
+        assert_eq!(class, Class::Http(Ok(StatusCode::BAD_REQUEST)));
     }
 
     #[test]
@@ -242,8 +262,8 @@ mod tests {
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body(())
             .unwrap();
-        let class = super::Response::Default.start(&rsp).eos(None);
-        assert_eq!(class, Class::Default(Err(())));
+        let class = super::Response::default().start(&rsp).eos(None);
+        assert_eq!(class, Class::Http(Err(StatusCode::INTERNAL_SERVER_ERROR)));
     }
 
     #[test]
@@ -253,8 +273,10 @@ mod tests {
             .status(StatusCode::OK)
             .body(())
             .unwrap();
-        let class = super::Response::Grpc.start(&rsp).eos(None);
-        assert_eq!(class, Class::Grpc(Ok(()), 0));
+        let class = super::Response::Grpc(Default::default())
+            .start(&rsp)
+            .eos(None);
+        assert_eq!(class, Class::Grpc(Ok(tonic::Code::Ok)));
     }
 
     #[test]
@@ -264,8 +286,10 @@ mod tests {
             .status(StatusCode::OK)
             .body(())
             .unwrap();
-        let class = super::Response::Grpc.start(&rsp).eos(None);
-        assert_eq!(class, Class::Grpc(Err(()), 2));
+        let class = super::Response::Grpc(Default::default())
+            .start(&rsp)
+            .eos(None);
+        assert_eq!(class, Class::Grpc(Err(tonic::Code::Unknown)));
     }
 
     #[test]
@@ -274,8 +298,10 @@ mod tests {
         let mut trailers = HeaderMap::new();
         trailers.insert("grpc-status", 0.into());
 
-        let class = super::Response::Grpc.start(&rsp).eos(Some(&trailers));
-        assert_eq!(class, Class::Grpc(Ok(()), 0));
+        let class = super::Response::Grpc(Default::default())
+            .start(&rsp)
+            .eos(Some(&trailers));
+        assert_eq!(class, Class::Grpc(Ok(tonic::Code::Ok)));
     }
 
     #[test]
@@ -284,16 +310,20 @@ mod tests {
         let mut trailers = HeaderMap::new();
         trailers.insert("grpc-status", 4.into());
 
-        let class = super::Response::Grpc.start(&rsp).eos(Some(&trailers));
-        assert_eq!(class, Class::Grpc(Err(()), 4));
+        let class = super::Response::Grpc(Default::default())
+            .start(&rsp)
+            .eos(Some(&trailers));
+        assert_eq!(class, Class::Grpc(Err(tonic::Code::DeadlineExceeded)));
     }
 
     #[test]
     fn grpc_response_trailer_missing() {
         let rsp = Response::builder().status(StatusCode::OK).body(()).unwrap();
         let trailers = HeaderMap::new();
-        let class = super::Response::Grpc.start(&rsp).eos(Some(&trailers));
-        assert_eq!(class, Class::Grpc(Ok(()), 0));
+        let class = super::Response::Grpc(Default::default())
+            .start(&rsp)
+            .eos(Some(&trailers));
+        assert_eq!(class, Class::Grpc(Ok(tonic::Code::Unknown)));
     }
 
     #[test]
@@ -305,6 +335,6 @@ mod tests {
         let class = super::Response::Profile(Default::default())
             .start(&rsp)
             .eos(Some(&trailers));
-        assert_eq!(class, Class::Grpc(Err(()), 4));
+        assert_eq!(class, Class::Grpc(Err(tonic::Code::DeadlineExceeded)));
     }
 }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -408,23 +408,27 @@ impl<'a> FmtLabels for Authority<'a> {
 
 impl FmtLabels for Class {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let class = |res: Result<(), ()>| res.map(|()| "success").unwrap_or("failure");
+        let class = |ok: bool| if ok { "success" } else { "failure" };
+
         match self {
-            Class::Default(res) => write!(
+            Class::Http(res) => write!(
                 f,
                 "classification=\"{}\",grpc_status=\"\",error=\"\"",
-                class(*res)
+                class(res.is_ok())
             ),
-            Class::Grpc(res, status) => write!(
+
+            Class::Grpc(res) => write!(
                 f,
                 "classification=\"{}\",grpc_status=\"{}\",error=\"\"",
-                class(*res),
-                status
+                class(res.is_ok()),
+                match res {
+                    Ok(code) | Err(code) => code,
+                }
             ),
-            Class::Error(res, msg) => write!(
+
+            Class::Error(msg) => write!(
                 f,
-                "classification=\"{}\",grpc_status=\"\",error=\"{}\"",
-                class(*res),
+                "classification=\"failure\",grpc_status=\"\",error=\"{}\"",
                 msg
             ),
         }

--- a/linkerd/app/integration/src/tests/profiles.rs
+++ b/linkerd/app/integration/src/tests/profiles.rs
@@ -624,10 +624,10 @@ mod grpc_retry {
             .await;
         let client = &test.client;
 
-        let res = client
-            .request(client.request_builder("/retry"))
-            .await
-            .unwrap();
+        let req = client
+            .request_builder("/retry")
+            .header(http::header::CONTENT_TYPE, "application/grpc");
+        let res = client.request(req).await.unwrap();
 
         assert_eq!(res.status(), 200);
         assert_eq!(res.headers().get(&GRPC_STATUS), Some(&GRPC_STATUS_OK));
@@ -672,10 +672,10 @@ mod grpc_retry {
             .await;
         let client = &test.client;
 
-        let res = client
-            .request(client.request_builder("/retry"))
-            .await
-            .unwrap();
+        let req = client
+            .request_builder("/retry")
+            .header(http::header::CONTENT_TYPE, "application/grpc");
+        let res = client.request(req).await.unwrap();
         assert_eq!(res.status(), 200);
         assert_eq!(res.headers().get(&GRPC_STATUS), None);
 

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -226,6 +226,7 @@ fn synthesize_forward_policy(
         policy: Some(policy::opaq::Policy {
             meta: meta.clone(),
             filters: NO_OPAQ_FILTERS.clone(),
+            failure_policy: Default::default(),
             distribution: policy::RouteDistribution::FirstAvailable(Arc::new([
                 policy::RouteBackend {
                     filters: NO_OPAQ_FILTERS.clone(),
@@ -242,6 +243,7 @@ fn synthesize_forward_policy(
             policy: policy::http::Policy {
                 meta: meta.clone(),
                 filters: NO_HTTP_FILTERS.clone(),
+                failure_policy: Default::default(),
                 distribution: policy::RouteDistribution::FirstAvailable(Arc::new([
                     policy::RouteBackend {
                         filters: NO_HTTP_FILTERS.clone(),

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -138,7 +138,6 @@ impl<N> Outbound<N> {
                 .push_on_service(http::BoxRequest::layer())
                 .push(tap::NewTapHttp::layer(rt.tap.clone()))
                 .push(
-                    // XXX(ver) we need to allow for policy-driven clasification here...
                     rt.metrics
                         .proxy
                         .http_endpoint

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -138,6 +138,7 @@ impl<N> Outbound<N> {
                 .push_on_service(http::BoxRequest::layer())
                 .push(tap::NewTapHttp::layer(rt.tap.clone()))
                 .push(
+                    // XXX(ver) we need to allow for policy-driven clasification here...
                     rt.metrics
                         .proxy
                         .http_endpoint

--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -104,6 +104,7 @@ where
                 // consideration, so we must eagerly fail requests to prevent
                 // leaking tasks onto the runtime.
                 .push_on_service(svc::LoadShed::layer())
+                // TODO(ver) attach the `E` typed failure policy to requests.
                 .push(filters::NewApplyFilters::<Self, _, _>::layer())
                 .push(svc::ArcNewService::layer())
                 .into_inner()

--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -1,5 +1,5 @@
 use super::super::Concrete;
-use linkerd_app_core::{proxy::http, svc, Addr, Error, Result};
+use linkerd_app_core::{classify, proxy::http, svc, Addr, Error, Result};
 use linkerd_distribute as distribute;
 use linkerd_http_route as http_route;
 use linkerd_proxy_client_policy as policy;
@@ -64,6 +64,7 @@ where
     E: Clone + Send + Sync + 'static,
     // Assert that filters can be applied.
     Self: filters::Apply,
+    Self: svc::Param<classify::Request>,
     MatchedBackend<T, M, F>: filters::Apply,
 {
     /// Builds a route stack that applies policy filters to requests and
@@ -106,6 +107,7 @@ where
                 .push_on_service(svc::LoadShed::layer())
                 // TODO(ver) attach the `E` typed failure policy to requests.
                 .push(filters::NewApplyFilters::<Self, _, _>::layer())
+                .push(classify::NewClassify::layer())
                 .push(svc::ArcNewService::layer())
                 .into_inner()
         })
@@ -125,9 +127,25 @@ impl<T> filters::Apply for Http<T> {
     }
 }
 
+impl<T> svc::Param<classify::Request> for Http<T> {
+    fn param(&self) -> classify::Request {
+        classify::Request::ClientPolicy(classify::ClientPolicy::Http(
+            self.params.failure_policy.clone(),
+        ))
+    }
+}
+
 impl<T> filters::Apply for Grpc<T> {
     #[inline]
     fn apply<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
         filters::apply_grpc(&self.r#match, &self.params.filters, req)
+    }
+}
+
+impl<T> svc::Param<classify::Request> for Grpc<T> {
+    fn param(&self) -> classify::Request {
+        classify::Request::ClientPolicy(classify::ClientPolicy::Grpc(
+            self.params.failure_policy.clone(),
+        ))
     }
 }

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -29,8 +29,10 @@ impl<T: Clone, F> Clone for Backend<T, F> {
 
 // === impl Matched ===
 
-impl<M, T, F> From<(Backend<T, F>, super::MatchedRoute<T, M, F>)> for MatchedBackend<T, M, F> {
-    fn from((params, route): (Backend<T, F>, super::MatchedRoute<T, M, F>)) -> Self {
+impl<M, T, F, E> From<(Backend<T, F>, super::MatchedRoute<T, M, F, E>)>
+    for MatchedBackend<T, M, F>
+{
+    fn from((params, route): (Backend<T, F>, super::MatchedRoute<T, M, F, E>)) -> Self {
         MatchedBackend {
             r#match: route.r#match,
             params,

--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -2,7 +2,7 @@ use super::{
     super::{concrete, Concrete, LogicalAddr, NoRoute},
     route,
 };
-use linkerd_app_core::{proxy::http, svc, transport::addrs::*, Addr, Error, Result};
+use linkerd_app_core::{classify, proxy::http, svc, transport::addrs::*, Addr, Error, Result};
 use linkerd_distribute as distribute;
 use linkerd_http_route as http_route;
 use linkerd_proxy_client_policy as policy;
@@ -57,7 +57,7 @@ where
         Key = route::MatchedRoute<T, M::Summary, F, E>,
         Error = NoRoute,
     >,
-    route::MatchedRoute<T, M::Summary, F, E>: route::filters::Apply,
+    route::MatchedRoute<T, M::Summary, F, E>: route::filters::Apply + svc::Param<classify::Request>,
     route::MatchedBackend<T, M::Summary, F>: route::filters::Apply,
 {
     /// Builds a stack that applies routes to distribute requests over a cached

--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -9,31 +9,35 @@ use linkerd_proxy_client_policy as policy;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Params<M, F> {
+pub struct Params<M, F, E> {
     pub addr: Addr,
-    pub routes: Arc<[http_route::Route<M, policy::RoutePolicy<F>>]>,
+    pub routes: Arc<[http_route::Route<M, policy::RoutePolicy<F, E>>]>,
     pub backends: Arc<[policy::Backend]>,
 }
 
-pub type HttpParams = Params<http_route::http::MatchRequest, policy::http::Filter>;
-pub type GrpcParams = Params<http_route::grpc::MatchRoute, policy::grpc::Filter>;
+pub type HttpParams =
+    Params<http_route::http::MatchRequest, policy::http::Filter, policy::http::StatusRanges>;
+pub type GrpcParams =
+    Params<http_route::grpc::MatchRoute, policy::grpc::Filter, policy::grpc::Codes>;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct Router<T: Clone + Debug + Eq + Hash, M, F> {
+pub(crate) struct Router<T: Clone + Debug + Eq + Hash, M, F, E> {
     pub(super) parent: T,
     pub(super) addr: Addr,
-    pub(super) routes: Arc<[http_route::Route<M, route::Route<T, F>>]>,
+    pub(super) routes: Arc<[http_route::Route<M, route::Route<T, F, E>>]>,
     pub(super) backends: distribute::Backends<Concrete<T>>,
 }
 
-pub(super) type Http<T> = Router<T, http_route::http::MatchRequest, policy::http::Filter>;
-pub(super) type Grpc<T> = Router<T, http_route::grpc::MatchRoute, policy::grpc::Filter>;
+pub(super) type Http<T> =
+    Router<T, http_route::http::MatchRequest, policy::http::Filter, policy::http::StatusRanges>;
+pub(super) type Grpc<T> =
+    Router<T, http_route::grpc::MatchRoute, policy::grpc::Filter, policy::grpc::Codes>;
 
 type NewBackendCache<T, N, S> = distribute::NewBackendCache<Concrete<T>, (), N, S>;
 
 // === impl Router ===
 
-impl<T, M, F> Router<T, M, F>
+impl<T, M, F, E> Router<T, M, F, E>
 where
     // Parent target type.
     T: Clone + Debug + Eq + Hash + Send + Sync + 'static,
@@ -44,14 +48,17 @@ where
     // Request filter.
     F: Debug + Eq + Hash,
     F: Clone + Send + Sync + 'static,
+    // Failure policy.
+    E: Debug + Eq + Hash,
+    E: Clone + Send + Sync + 'static,
     // Assert that we can route for the given match and filter types.
     Self: svc::router::SelectRoute<
         http::Request<http::BoxBody>,
-        Key = route::MatchedRoute<T, M::Summary, F>,
+        Key = route::MatchedRoute<T, M::Summary, F, E>,
         Error = NoRoute,
     >,
-    route::MatchedRoute<T, M::Summary, F>: route::filters::Apply,
-    route::backend::MatchedBackend<T, M::Summary, F>: route::filters::Apply,
+    route::MatchedRoute<T, M::Summary, F, E>: route::filters::Apply,
+    route::MatchedBackend<T, M::Summary, F>: route::filters::Apply,
 {
     /// Builds a stack that applies routes to distribute requests over a cached
     /// set of inner services so that.
@@ -95,13 +102,14 @@ where
     }
 }
 
-impl<T, M, F> From<(Params<M, F>, T)> for Router<T, M, F>
+impl<T, M, F, E> From<(Params<M, F, E>, T)> for Router<T, M, F, E>
 where
     T: Eq + Hash + Clone + Debug,
     M: Clone,
     F: Clone,
+    E: Clone,
 {
-    fn from((rts, parent): (Params<M, F>, T)) -> Self {
+    fn from((rts, parent): (Params<M, F, E>, T)) -> Self {
         let Params {
             addr,
             routes,
@@ -152,15 +160,17 @@ where
             }
         };
 
-        let mk_policy = |policy::RoutePolicy::<F> {
+        let mk_policy = |policy::RoutePolicy::<F, E> {
                              meta,
                              filters,
                              distribution,
+                             failure_policy,
                          }| route::Route {
             addr: addr.clone(),
             parent: parent.clone(),
             meta,
             filters,
+            failure_policy,
             distribution: mk_distribution(&distribution),
         };
 
@@ -232,7 +242,7 @@ where
     }
 }
 
-impl<T, M, F> svc::Param<LogicalAddr> for Router<T, M, F>
+impl<T, M, F, E> svc::Param<LogicalAddr> for Router<T, M, F, E>
 where
     T: Eq + Hash + Clone + Debug,
 {
@@ -241,7 +251,7 @@ where
     }
 }
 
-impl<T, M, F> svc::Param<distribute::Backends<Concrete<T>>> for Router<T, M, F>
+impl<T, M, F, E> svc::Param<distribute::Backends<Concrete<T>>> for Router<T, M, F, E>
 where
     T: Eq + Hash + Clone + Debug,
 {

--- a/linkerd/app/outbound/src/http/logical/policy/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/tests.rs
@@ -25,6 +25,7 @@ async fn header_based_route() {
     let mk_policy = |name: &'static str, backend: policy::Backend| policy::RoutePolicy {
         meta: policy::Meta::new_default(name),
         filters: Arc::new([]),
+        failure_policy: Default::default(),
         distribution: policy::RouteDistribution::FirstAvailable(Arc::new([policy::RouteBackend {
             filters: Arc::new([]),
             backend,
@@ -144,6 +145,7 @@ async fn http_filter_request_headers() {
                     matches: vec![route::http::MatchRequest::default()],
                     policy: policy::RoutePolicy {
                         meta: policy::Meta::new_default("turtles"),
+                        failure_policy: Default::default(),
                         filters: Arc::new([policy::http::Filter::RequestHeaders(
                             policy::http::filter::ModifyHeader {
                                 add: vec![(PIZZA.clone(), TUBULAR.clone())],

--- a/linkerd/app/test/src/resolver/client_policy.rs
+++ b/linkerd/app/test/src/resolver/client_policy.rs
@@ -70,6 +70,7 @@ impl ClientPolicies {
                 policy: http::Policy {
                     meta: Meta::new_default("default"),
                     filters: Arc::new([]),
+                    failure_policy: http::StatusRanges::default(),
                     distribution: RouteDistribution::FirstAvailable(Arc::new([RouteBackend {
                         filters: Arc::new([]),
                         backend: backend.clone(),
@@ -90,6 +91,7 @@ impl ClientPolicies {
                 policy: Some(opaq::Policy {
                     meta: Meta::new_default("default"),
                     filters: Arc::new([]),
+                    failure_policy: Default::default(),
                     distribution: RouteDistribution::FirstAvailable(Arc::new([RouteBackend {
                         filters: Arc::new([]),
                         backend: backend.clone(),

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -27,6 +27,7 @@ linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }
 once_cell = { version = "1" }
 prost-types = { version = "0.11", optional = true }
+tonic = { version = "0.8", default-features = false }
 thiserror = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 pub use linkerd_http_route::grpc::{filter, find, r#match, RouteMatch};
 
-pub type Policy = crate::RoutePolicy<Filter>;
+pub type Policy = crate::RoutePolicy<Filter, Codes>;
 pub type Route = grpc::Route<Policy>;
 pub type Rule = grpc::Rule<Policy>;
 
@@ -20,6 +20,9 @@ pub enum Filter {
     InternalError(&'static str),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Codes(pub std::collections::BTreeSet<u16>);
+
 pub fn default(distribution: crate::RouteDistribution<Filter>) -> Route {
     Route {
         hosts: vec![],
@@ -29,6 +32,7 @@ pub fn default(distribution: crate::RouteDistribution<Filter>) -> Route {
                 meta: crate::Meta::new_default("default"),
                 filters: Arc::new([]),
                 distribution,
+                failure_policy: Codes::default(),
             },
         }],
     }
@@ -39,6 +43,30 @@ impl Default for Grpc {
         Self {
             routes: Arc::new([]),
         }
+    }
+}
+
+impl Codes {
+    pub fn contains(&self, code: tonic::Code) -> bool {
+        self.0.contains(&(code as u16))
+    }
+}
+
+impl Default for Codes {
+    fn default() -> Self {
+        Self(
+            [
+                tonic::Code::DataLoss,
+                tonic::Code::DeadlineExceeded,
+                tonic::Code::Internal,
+                tonic::Code::PermissionDenied,
+                tonic::Code::Unavailable,
+                tonic::Code::Unknown,
+            ]
+            .into_iter()
+            .map(|c| c as u16)
+            .collect(),
+        )
     }
 }
 
@@ -176,6 +204,7 @@ pub mod proto {
                 meta: meta.clone(),
                 filters,
                 distribution,
+                failure_policy: Codes::default(),
             },
         })
     }

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -21,7 +21,7 @@ pub enum Filter {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Codes(pub std::collections::BTreeSet<u16>);
+pub struct Codes(pub Arc<std::collections::BTreeSet<u16>>);
 
 pub fn default(distribution: crate::RouteDistribution<Filter>) -> Route {
     Route {
@@ -54,19 +54,23 @@ impl Codes {
 
 impl Default for Codes {
     fn default() -> Self {
-        Self(
-            [
-                tonic::Code::DataLoss,
-                tonic::Code::DeadlineExceeded,
-                tonic::Code::Internal,
-                tonic::Code::PermissionDenied,
-                tonic::Code::Unavailable,
-                tonic::Code::Unknown,
-            ]
-            .into_iter()
-            .map(|c| c as u16)
-            .collect(),
-        )
+        use once_cell::sync::Lazy;
+        static CODES: Lazy<Arc<std::collections::BTreeSet<u16>>> = Lazy::new(|| {
+            Arc::new(
+                [
+                    tonic::Code::DataLoss,
+                    tonic::Code::DeadlineExceeded,
+                    tonic::Code::Internal,
+                    tonic::Code::PermissionDenied,
+                    tonic::Code::Unavailable,
+                    tonic::Code::Unknown,
+                ]
+                .into_iter()
+                .map(|c| c as u16)
+                .collect(),
+            )
+        });
+        Self(CODES.clone())
     }
 }
 

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -1,9 +1,9 @@
 use linkerd_http_route::http;
-use std::sync::Arc;
+use std::{ops::RangeInclusive, sync::Arc};
 
 pub use linkerd_http_route::http::{filter, find, r#match, RouteMatch};
 
-pub type Policy = crate::RoutePolicy<Filter>;
+pub type Policy = crate::RoutePolicy<Filter, StatusRanges>;
 pub type Route = http::Route<Policy>;
 pub type Rule = http::Rule<Policy>;
 
@@ -27,6 +27,9 @@ pub enum Filter {
     InternalError(&'static str),
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct StatusRanges(pub Arc<[RangeInclusive<u16>]>);
+
 pub fn default(distribution: crate::RouteDistribution<Filter>) -> Route {
     Route {
         hosts: vec![],
@@ -36,6 +39,7 @@ pub fn default(distribution: crate::RouteDistribution<Filter>) -> Route {
                 meta: crate::Meta::new_default("default"),
                 filters: Arc::new([]),
                 distribution,
+                failure_policy: StatusRanges::default(),
             },
         }],
     }
@@ -58,6 +62,20 @@ impl Default for Http2 {
         Self {
             routes: Arc::new([]),
         }
+    }
+}
+
+// === impl StatusRanges ===
+
+impl StatusRanges {
+    pub fn contains(&self, code: ::http::StatusCode) -> bool {
+        self.0.iter().any(|range| range.contains(&code.as_u16()))
+    }
+}
+
+impl Default for StatusRanges {
+    fn default() -> Self {
+        Self(Arc::new([500..=599]))
     }
 }
 
@@ -200,6 +218,7 @@ pub mod proto {
                 meta: meta.clone(),
                 filters,
                 distribution,
+                failure_policy: StatusRanges::default(),
             },
         })
     }

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -75,7 +75,9 @@ impl StatusRanges {
 
 impl Default for StatusRanges {
     fn default() -> Self {
-        Self(Arc::new([500..=599]))
+        use once_cell::sync::Lazy;
+        static STATUSES: Lazy<Arc<[RangeInclusive<u16>]>> = Lazy::new(|| Arc::new([500..=599]));
+        Self(STATUSES.clone())
     }
 }
 

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -52,10 +52,11 @@ pub enum Meta {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct RoutePolicy<T> {
+pub struct RoutePolicy<T, F> {
     pub meta: Arc<Meta>,
     pub filters: Arc<[T]>,
     pub distribution: RouteDistribution<T>,
+    pub failure_policy: F,
 }
 
 // TODO(ver) Weighted random WITHOUT availability awareness, as required by
@@ -133,6 +134,7 @@ impl ClientPolicy {
                         ))
                         .collect(),
                         distribution: RouteDistribution::Empty,
+                        failure_policy: http::StatusRanges::default(),
                     },
                 }],
             }])


### PR DESCRIPTION
* 408457ad Carve out space in the policy API for a "failure policy"
* 2e165e05 classify: Replace SuccessOrFailure with Result
* 6af16e29 Update classifier to reuse clientpolicy response status/code types
* 60a61d96 Configure request classification from client policy routes