### PR TITLE
outbound: fix `Balance::Dispatch` "authority" labels

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -108,13 +108,22 @@ where
             backends,
         } = rts;
 
+        let parent = parent.clone();
         let mk_concrete = {
-            let authority = addr.to_http_authority();
             let parent = parent.clone();
-            move |target: concrete::Dispatch| Concrete {
-                target,
-                authority: Some(authority.clone()),
-                parent: parent.clone(),
+            move |target: concrete::Dispatch| {
+                // XXX With policies we don't have a top-level authority name at
+                // the moment. So, instead, we use the concrete addr used for
+                // discovery for now.
+                let authority = match target {
+                    concrete::Dispatch::Balance(ref a, _) => Some(a.as_http_authority()),
+                    _ => None,
+                };
+                Concrete {
+                    target,
+                    authority,
+                    parent: parent.clone(),
+                }
             }
         };
 

--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -108,7 +108,6 @@ where
             backends,
         } = rts;
 
-        let parent = parent.clone();
         let mk_concrete = {
             let parent = parent.clone();
             move |target: concrete::Dispatch| {


### PR DESCRIPTION
PR #2313 changed client policies with the load balancer dispatch type to report the load balancer's destination address as the "authority" label, rather than the numeric authority the policy was discovered for. However, this change was accidentally undone when merging PR #2260, which moved the code where the authority label is generated to a different file.

This PR changes it back, so that the discovered concrete destination address should still be reported as the "authority" metrics label.