### PR TITLE
reuse `sleep` future in `ConsecutiveFailureGate`

### DIFF
--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -18,7 +18,6 @@ use linkerd_app_core::{
 };
 use std::{fmt::Debug, net::SocketAddr, sync::Arc};
 use tokio::{sync::Semaphore, time};
-use tokio_util::sync::ReusableBoxFuture;
 use tracing::info_span;
 
 /// Parameter configuring dispatcher behavior.


### PR DESCRIPTION
This is a suggestion for PR #2334. This change allows the `sleep` future
to be reused for every backoff without reallocating. The previous code
attempts to use the same allocation for sleeps using a
`ReusableBoxFuture`, but it doesn't actually achieve this, since when
the sleep is replaced with a differently-sized `pending` future, the
`ReusableBoxFuture` will reallocate. See here for details:
https://github.com/linkerd/linkerd2-proxy/pull/2334#discussion_r1139294331