### PR TITLE
gate: Support admitting a limited number of requests

### DIFF
--- a/linkerd/stack/src/failfast.rs
+++ b/linkerd/stack/src/failfast.rs
@@ -88,7 +88,7 @@ impl<S> FailFast<S> {
         layer::mk(move |inner| {
             let (tx, rx) = gate::channel();
             let inner = inner_layer.layer(Self::new(timeout, Some(tx), inner));
-            gate::Gate::new(inner, rx)
+            gate::Gate::new(rx, inner)
         })
     }
 

--- a/linkerd/stack/src/gate.rs
+++ b/linkerd/stack/src/gate.rs
@@ -44,7 +44,7 @@ pub fn channel() -> (Tx, Rx) {
     (Tx(Arc::new(tx)), Rx(rx))
 }
 
-struct Permit(Option<OwnedSemaphorePermit>);
+pub struct Permit(Option<OwnedSemaphorePermit>);
 
 // === impl Rx ===
 

--- a/linkerd/stack/src/gate.rs
+++ b/linkerd/stack/src/gate.rs
@@ -186,7 +186,6 @@ impl<S> Gate<S> {
         S: Service<Req>,
     {
         if !self.acquiring {
-            let mut rx = self.rx.clone();
             match self.rx.state() {
                 State::Open => return Poll::Ready(None),
                 State::Shut => {}
@@ -201,6 +200,7 @@ impl<S> Gate<S> {
             }
 
             self.acquiring = true;
+            let mut rx = self.rx.clone();
             self.acquire.set(async move { rx.acquire().await });
         }
 
@@ -227,6 +227,7 @@ impl Permit {
         drop(self.0.take());
     }
 }
+
 impl Drop for Permit {
     fn drop(&mut self) {
         // Permits are forgotten so the `Tx` controller can decide when to allow

--- a/linkerd/stack/src/gate.rs
+++ b/linkerd/stack/src/gate.rs
@@ -1,7 +1,6 @@
 use crate::Service;
 use futures::{ready, FutureExt};
 use std::{
-    arch::x86_64::_addcarry_u64,
     sync::Arc,
     task::{Context, Poll},
 };

--- a/linkerd/stack/src/gate.rs
+++ b/linkerd/stack/src/gate.rs
@@ -1,81 +1,96 @@
 use crate::Service;
 use futures::{ready, FutureExt};
 use std::{
-    sync::{atomic::AtomicBool, Arc},
+    sync::Arc,
     task::{Context, Poll},
 };
-use tokio::sync::Notify;
+use tokio::sync::{watch, OwnedSemaphorePermit, Semaphore, TryAcquireError};
 use tokio_util::sync::ReusableBoxFuture;
-use tracing::{debug, trace};
+use tracing::debug;
 
 /// A middleware that alters its readiness state according to a gate channel.
 pub struct Gate<S> {
     inner: S,
     rx: Rx,
-    is_waiting: bool,
-    waiting: ReusableBoxFuture<'static, ()>,
+    acquire: ReusableBoxFuture<'static, Permit>,
+    permit: Poll<Permit>,
 }
 
 /// Observes gate state changes.
 #[derive(Clone, Debug)]
-pub struct Rx(Arc<Shared>, Arc<()>);
+pub struct Rx(watch::Receiver<State>);
 
 /// Changes the gate state.
 #[derive(Clone, Debug)]
-pub struct Tx(Arc<Shared>);
+pub struct Tx(Arc<watch::Sender<State>>);
 
-#[derive(Debug)]
-struct Shared {
-    open: AtomicBool,
-    notify: Notify,
-    closed: Notify,
+#[derive(Clone, Debug)]
+pub enum State {
+    /// The gate is open and unlimited.
+    Open,
+
+    /// The gate is limited by the provided semaphore. Permits are forgotten as
+    /// requests are processed so that this semaphore can specify a limit on the
+    /// number of requests to be admitted by the [`Gate`].
+    Limited(Arc<Semaphore>),
+
+    /// The gate is shut and no requests are to be admitted.
+    Shut,
 }
 
 /// Creates a new gate channel.
 pub fn channel() -> (Tx, Rx) {
-    let shared = Arc::new(Shared {
-        open: AtomicBool::new(true),
-        notify: Notify::new(),
-        closed: Notify::new(),
-    });
-    (Tx(shared.clone()), Rx(shared, Arc::new(())))
+    let (tx, rx) = watch::channel(State::Open);
+    (Tx(Arc::new(tx)), Rx(rx))
 }
+
+struct Permit(Option<OwnedSemaphorePermit>);
 
 // === impl Rx ===
 
 impl Rx {
     /// Indicates whether the gate is open.
-    pub fn is_open(&self) -> bool {
-        self.0.open.load(std::sync::atomic::Ordering::Acquire)
+    pub fn state(&self) -> State {
+        self.0.borrow().clone()
     }
 
-    /// Indicates whether the gate is closed.
-    #[inline]
+    pub fn is_open(&self) -> bool {
+        matches!(self.state(), State::Open)
+    }
+
+    pub fn is_limited(&self) -> bool {
+        matches!(self.state(), State::Limited(_))
+    }
+
     pub fn is_shut(&self) -> bool {
-        !self.is_open()
+        matches!(self.state(), State::Shut)
     }
 
     /// Waits for the gate state to change.
-    pub async fn changed(&self) -> bool {
-        self.0.notify.notified().await;
-        self.is_open()
+    pub async fn changed(&mut self) -> Result<(), watch::error::RecvError> {
+        self.0.changed().await
     }
 
     /// Waits for the gate state to change to be open.
-    pub async fn opened(&self) {
-        if self.is_open() {
-            return;
-        }
+    pub async fn acquire(&mut self) -> Permit {
+        loop {
+            let state = self.0.borrow_and_update().clone();
+            match state {
+                State::Open => return Permit(None),
+                State::Limited(sem) => match sem.acquire_owned().await {
+                    Ok(permit) => return Permit(Some(permit)),
+                    Err(_) => {
+                        debug!("Gate closed");
+                        return Permit(None);
+                    }
+                },
+                State::Shut => {}
+            }
 
-        while !self.changed().await {}
-    }
-}
-
-impl Drop for Rx {
-    fn drop(&mut self) {
-        let Rx(_, handle) = self;
-        if Arc::strong_count(handle) == 1 {
-            self.0.closed.notify_waiters();
+            if let Err(e) = self.0.changed().await {
+                debug!("Gate closed: {:?}", e);
+                futures::future::pending::<()>().await;
+            }
         }
     }
 }
@@ -84,27 +99,28 @@ impl Drop for Rx {
 
 impl Tx {
     /// Returns when all associated `Rx` clones are dropped.
-    pub async fn closed(&self) {
-        self.0.closed.notified().await;
+    pub async fn lost(&self) {
+        self.0.closed().await
     }
 
     /// Opens the gate.
     pub fn open(&self) {
-        if !self.0.open.swap(true, std::sync::atomic::Ordering::Release) {
+        if self.0.send(State::Open).is_ok() {
             debug!("Gate opened");
-            self.0.notify.notify_waiters();
+        }
+    }
+
+    /// Opens the gate.
+    pub fn limit(&self, sem: Arc<Semaphore>) {
+        if self.0.send(State::Limited(sem)).is_ok() {
+            debug!("Gate limited");
         }
     }
 
     /// Closes the gate.
     pub fn shut(&self) {
-        if self
-            .0
-            .open
-            .swap(false, std::sync::atomic::Ordering::Release)
-        {
+        if self.0.send(State::Shut).is_ok() {
             debug!("Gate shut");
-            self.0.notify.notify_waiters();
         }
     }
 }
@@ -114,15 +130,15 @@ impl Tx {
 impl<S> Gate<S> {
     pub fn channel(inner: S) -> (Tx, Self) {
         let (tx, rx) = channel();
-        (tx, Self::new(inner, rx))
+        (tx, Self::new(rx, inner))
     }
 
-    pub fn new(inner: S, rx: Rx) -> Self {
+    pub fn new(rx: Rx, inner: S) -> Self {
         Self {
             inner,
             rx,
-            is_waiting: false,
-            waiting: ReusableBoxFuture::new(futures::future::pending()),
+            permit: Poll::Pending,
+            acquire: ReusableBoxFuture::new(futures::future::pending()),
         }
     }
 }
@@ -132,7 +148,7 @@ where
     S: Clone,
 {
     fn clone(&self) -> Self {
-        Self::new(self.inner.clone(), self.rx.clone())
+        Self::new(self.rx.clone(), self.inner.clone())
     }
 }
 
@@ -145,117 +161,188 @@ where
     type Future = S::Future;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // If the gate is shut, wait for it to open by storing a future that
-        // will complete when it opens. This ensures that waiters are notified.
-        while self.rx.is_shut() {
-            trace!(gate.open = false);
-            if !self.is_waiting {
-                let rx = self.rx.clone();
-                self.waiting.set(async move { rx.opened().await });
-                self.is_waiting = true;
+        match self.rx.state() {
+            State::Open => {
+                self.permit = Poll::Ready(Permit(None));
+                self.inner.poll_ready(cx)
             }
-            ready!(self.waiting.poll_unpin(cx));
+
+            State::Shut => self.poll_acquire(cx),
+
+            State::Limited(sem) => match sem.try_acquire_owned() {
+                Ok(permit) => {
+                    self.permit = Poll::Ready(Permit(Some(permit)));
+                    self.inner.poll_ready(cx)
+                }
+
+                Err(TryAcquireError::NoPermits) => self.poll_acquire(cx),
+
+                Err(TryAcquireError::Closed) => {
+                    tracing::warn!("Gate closed");
+                    Poll::Pending
+                }
+            },
         }
-
-        debug_assert!(self.rx.is_open());
-        self.is_waiting = false;
-        trace!(gate.open = true);
-
-        // When the gate is open, poll the inner service.
-        self.inner.poll_ready(cx)
     }
 
     #[inline]
     fn call(&mut self, req: Req) -> Self::Future {
+        self.permit = match std::mem::replace(&mut self.permit, Poll::Pending) {
+            Poll::Pending => panic!("poll_ready must be called first"),
+            Poll::Ready(..) => Poll::Pending,
+        };
+
         self.inner.call(req)
+    }
+}
+
+impl<S> Gate<S> {
+    fn poll_acquire<Req>(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>>
+    where
+        S: Service<Req>,
+    {
+        let mut rx = self.rx.clone();
+        self.acquire.set(async move { rx.acquire().await });
+        let permit = ready!(self.acquire.poll_unpin(cx));
+        self.permit = Poll::Ready(permit);
+        self.inner.poll_ready(cx)
+    }
+}
+
+// === impl Permit ===
+
+impl Drop for Permit {
+    fn drop(&mut self) {
+        // Permits are forgotten so the `Tx` controller can decide when to allow
+        // more requests.
+        if let Some(p) = self.0.take() {
+            p.forget();
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio_test::{assert_pending, assert_ready, task};
 
     #[tokio::test]
     async fn gate() {
         let (tx, rx) = channel();
         let (mut gate, mut handle) =
-            tower_test::mock::spawn_with::<(), (), _, _>(move |inner| Gate::new(inner, rx.clone()));
+            tower_test::mock::spawn_with::<(), (), _, _>(move |inner| Gate::new(rx.clone(), inner));
 
         handle.allow(1);
         tx.shut();
-        assert!(gate.poll_ready().is_pending());
+        assert_pending!(gate.poll_ready());
 
         tx.open();
-        assert!(gate.poll_ready().is_ready());
+        assert_ready!(gate.poll_ready()).expect("ok");
     }
 
     #[tokio::test]
     async fn gate_polls_inner() {
         let (tx, rx) = channel();
         let (mut gate, mut handle) =
-            tower_test::mock::spawn_with::<(), (), _, _>(move |inner| Gate::new(inner, rx.clone()));
+            tower_test::mock::spawn_with::<(), (), _, _>(move |inner| Gate::new(rx.clone(), inner));
 
         handle.allow(0);
-        assert!(gate.poll_ready().is_pending());
+        assert_pending!(gate.poll_ready());
 
         tx.shut();
-        assert!(gate.poll_ready().is_pending());
+        assert_pending!(gate.poll_ready());
 
         tx.open();
-        assert!(gate.poll_ready().is_pending());
+        assert_pending!(gate.poll_ready());
 
         handle.allow(1);
-        assert!(gate.poll_ready().is_ready());
+        assert_ready!(gate.poll_ready()).expect("ok");
     }
 
     #[tokio::test]
     async fn notifies_on_open() {
         let (tx, rx) = channel();
         let (mut gate, mut handle) =
-            tower_test::mock::spawn_with::<(), (), _, _>(move |inner| Gate::new(inner, rx.clone()));
+            tower_test::mock::spawn_with::<(), (), _, _>(move |inner| Gate::new(rx.clone(), inner));
 
         // Start with a shut gate on an available inner service.
         handle.allow(1);
         tx.shut();
 
         // Wait for the gated service to become ready.
-        assert!(gate.poll_ready().is_pending());
+        assert_pending!(gate.poll_ready());
 
         // Open the gate and verify that the readiness future fires.
         tx.open();
-        assert!(gate.poll_ready().is_ready());
+        assert_ready!(gate.poll_ready()).expect("ok");
     }
 
     #[tokio::test]
     async fn channel_closes() {
         let (tx, rx) = channel();
-        let mut closed = tokio_test::task::spawn(tx.closed());
-        assert!(closed.poll().is_pending());
+        let mut closed = task::spawn(tx.lost());
+        assert_pending!(closed.poll());
         drop(rx);
-        assert!(closed.poll().is_ready());
+        assert_ready!(closed.poll());
     }
 
     #[tokio::test]
     async fn channel_closes_after_clones() {
         let (tx, rx0) = channel();
-        let mut closed = tokio_test::task::spawn(tx.closed());
+        let mut closed = task::spawn(tx.lost());
         let rx1 = rx0.clone();
-        assert!(closed.poll().is_pending());
+        assert_pending!(closed.poll());
         drop(rx0);
-        assert!(closed.poll().is_pending());
+        assert_pending!(closed.poll());
         drop(rx1);
-        assert!(closed.poll().is_ready());
+        assert_ready!(closed.poll());
     }
 
     #[tokio::test]
     async fn channel_closes_after_clones_reordered() {
         let (tx, rx0) = channel();
-        let mut closed = tokio_test::task::spawn(tx.closed());
+        let mut closed = task::spawn(tx.lost());
         let rx1 = rx0.clone();
-        assert!(closed.poll().is_pending());
+        assert_pending!(closed.poll());
         drop(rx1);
-        assert!(closed.poll().is_pending());
+        assert_pending!(closed.poll());
         drop(rx0);
-        assert!(closed.poll().is_ready());
+        assert_ready!(closed.poll());
+    }
+
+    #[tokio::test]
+    async fn limits() {
+        let (tx, rx) = channel();
+        let (mut gate, mut handle) =
+            tower_test::mock::spawn_with::<(), (), _, _>(move |inner| Gate::new(rx.clone(), inner));
+
+        handle.allow(2);
+        let sem = Arc::new(Semaphore::new(0));
+        tx.limit(sem.clone());
+
+        assert_pending!(gate.poll_ready());
+        sem.add_permits(1);
+        assert_ready!(gate.poll_ready()).expect("ok");
+        assert_eq!(sem.available_permits(), 0);
+        let rsp = handle
+            .next_request()
+            .map(|tx| tx.unwrap().1.send_response(()));
+        let (res, _) = tokio::join!(gate.call(()), rsp);
+        res.expect("ok");
+
+        assert_pending!(gate.poll_ready());
+        sem.add_permits(1);
+        assert_ready!(gate.poll_ready()).expect("ok");
+        assert_eq!(sem.available_permits(), 0);
+        let rsp = handle
+            .next_request()
+            .map(|tx| tx.unwrap().1.send_response(()));
+        let (res, _) = tokio::join!(gate.call(()), rsp);
+        res.expect("ok");
+
+        assert_pending!(gate.poll_ready());
+        sem.add_permits(1);
+        assert_pending!(gate.poll_ready());
+        assert_eq!(sem.available_permits(), 0);
     }
 }

--- a/linkerd/stack/src/gate.rs
+++ b/linkerd/stack/src/gate.rs
@@ -48,11 +48,12 @@ pub fn channel() -> (Tx, Rx) {
 // === impl Rx ===
 
 impl Rx {
-    /// Indicates whether the gate is open.
+    /// Returns a clone of the current state.
     pub fn state(&self) -> State {
         self.0.borrow().clone()
     }
 
+    /// Indicates whether the gate is open.
     pub fn is_open(&self) -> bool {
         matches!(self.state(), State::Open)
     }


### PR DESCRIPTION
To implement circuit breakers, we want to use the gate to control whether or not a service is available to callers. When a service is coming out of a failed state, we may want to admit a limited number of requests through before going back to an unfettered state.

To support this, this change updates the `Gate` service to be backed by a `tokio::sync::watch` channel so that each side of the gate channel can communicate state updates.

`gate::Tx::closed` is renamed to `gate::Tx::lost` to avoid ambiguity.