### PR TITLE
gateway: move discovery resolver into its own file

### DIFF
--- a/linkerd/app/gateway/src/discover.rs
+++ b/linkerd/app/gateway/src/discover.rs
@@ -1,0 +1,63 @@
+use crate::Gateway;
+use futures::TryFutureExt;
+use linkerd_app_core::{errors, profiles, svc, Error};
+use linkerd_app_inbound::{GatewayAddr, GatewayDomainInvalid};
+use linkerd_app_outbound::{self as outbound};
+use tokio::sync::watch;
+use tracing::Instrument;
+
+impl Gateway {
+    pub(crate) fn resolver(
+        &self,
+        profiles: impl profiles::GetProfile<Error = Error>,
+        policies: impl outbound::policy::GetPolicy,
+    ) -> impl svc::Service<
+        GatewayAddr,
+        Response = (
+            Option<profiles::Receiver>,
+            watch::Receiver<outbound::policy::ClientPolicy>,
+        ),
+        Error = Error,
+        Future = impl Send + Unpin,
+    > + Clone {
+        #[inline]
+        fn is_not_found(e: &Error) -> bool {
+            errors::cause_ref::<tonic::Status>(e.as_ref())
+                .map(|s| s.code() == tonic::Code::NotFound)
+                .unwrap_or(false)
+        }
+
+        use futures::future;
+
+        let allowlist = self.config.allow_discovery.clone();
+        svc::mk(move |GatewayAddr(addr)| {
+            tracing::debug!(%addr, "Discover");
+
+            if !allowlist.matches(addr.name()) {
+                tracing::debug!(%addr, "Address not in gateway discovery allowlist");
+                return future::Either::Left(future::err(GatewayDomainInvalid.into()));
+            }
+
+            let profile = profiles
+                .clone()
+                .get_profile(profiles::LookupAddr(addr.clone().into()))
+                .instrument(tracing::debug_span!("profiles"));
+
+            let policy = policies
+                .get_policy(addr.into())
+                .map_err(|e| {
+                    // If the policy controller returned `NotFound`, indicating
+                    // that it doesn't have a policy for this addr, then we
+                    // can't gateway this address.
+                    if is_not_found(&e) {
+                        GatewayDomainInvalid.into()
+                    } else {
+                        e
+                    }
+                })
+                .instrument(tracing::debug_span!("policy"));
+
+            future::Either::Right(future::try_join(profile, policy))
+        })
+    }
+}

--- a/linkerd/app/gateway/src/lib.rs
+++ b/linkerd/app/gateway/src/lib.rs
@@ -16,6 +16,7 @@ use linkerd_app_inbound::{self as inbound, GatewayAddr, Inbound};
 use linkerd_app_outbound::{self as outbound, Outbound};
 use std::fmt::Debug;
 
+mod discover;
 mod http;
 mod opaq;
 mod server;

--- a/linkerd/app/gateway/src/server.rs
+++ b/linkerd/app/gateway/src/server.rs
@@ -75,7 +75,7 @@ impl Gateway {
             )
             .into_inner();
 
-        let discover = self.discover(profiles, policies);
+        let discover = self.resolver(profiles, policies);
 
         self.outbound
             .with_stack(protocol)
@@ -83,60 +83,6 @@ impl Gateway {
             .into_stack()
             .push_on_service(svc::BoxService::layer())
             .push(svc::ArcNewService::layer())
-    }
-
-    fn discover(
-        &self,
-        profiles: impl profiles::GetProfile<Error = Error>,
-        policies: impl outbound::policy::GetPolicy,
-    ) -> impl svc::Service<
-        GatewayAddr,
-        Response = (
-            Option<profiles::Receiver>,
-            watch::Receiver<outbound::policy::ClientPolicy>,
-        ),
-        Error = Error,
-        Future = impl Send + Unpin,
-    > + Clone {
-        #[inline]
-        fn is_not_found(e: &Error) -> bool {
-            errors::cause_ref::<tonic::Status>(e.as_ref())
-                .map(|s| s.code() == tonic::Code::NotFound)
-                .unwrap_or(false)
-        }
-
-        use futures::future;
-
-        let allowlist = self.config.allow_discovery.clone();
-        svc::mk(move |GatewayAddr(addr)| {
-            tracing::debug!(%addr, "Discover");
-
-            if !allowlist.matches(addr.name()) {
-                tracing::debug!(%addr, "Address not in gateway discovery allowlist");
-                return future::Either::Left(future::err(GatewayDomainInvalid.into()));
-            }
-
-            let profile = profiles
-                .clone()
-                .get_profile(profiles::LookupAddr(addr.clone().into()))
-                .instrument(tracing::debug_span!("profiles"));
-
-            let policy = policies
-                .get_policy(addr.into())
-                .map_err(|e| {
-                    // If the policy controller returned `NotFound`, indicating
-                    // that it doesn't have a policy for this addr, then we
-                    // can't gateway this address.
-                    if is_not_found(&e) {
-                        GatewayDomainInvalid.into()
-                    } else {
-                        e
-                    }
-                })
-                .instrument(tracing::debug_span!("policy"));
-
-            future::Either::Right(future::try_join(profile, policy))
-        })
     }
 }
 

--- a/linkerd/app/gateway/src/server.rs
+++ b/linkerd/app/gateway/src/server.rs
@@ -1,14 +1,12 @@
 use crate::Gateway;
-use futures::TryFutureExt;
 use linkerd_app_core::{
-    errors, io, profiles, proxy::http, svc, tls, transport::addrs::*,
-    transport_header::SessionProtocol, Addr, Error,
+    io, profiles, proxy::http, svc, tls, transport::addrs::*, transport_header::SessionProtocol,
+    Addr, Error,
 };
 use linkerd_app_inbound::{self as inbound, GatewayAddr, GatewayDomainInvalid};
 use linkerd_app_outbound::{self as outbound};
 use std::fmt::Debug;
 use tokio::sync::watch;
-use tracing::Instrument;
 
 /// Target for HTTP stacks.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This branch moves the `Gateway::discover` method from `gateway/src/server.rs` into its own file. This is to prepare for future changes that will add more discovery-related logic to the gateway proxy, which made sense to put in its own module (see #2333 for details). In addition, I renamed the `Gateway::discover` method to `Gateway::resolver`, for consistency with the similar method on `Outbound`.

No functional changes.