### PR TITLE
client-policy: accept backends with empty `dispatcher` fields

### DIFF
--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -23,6 +23,7 @@ use tracing::info_span;
 pub enum Dispatch {
     Balance(NameAddr, balance::EwmaConfig),
     Forward(Remote<ServerAddr>, Metadata),
+    Null,
 }
 
 /// Wraps errors encountered in this module.
@@ -166,6 +167,7 @@ impl<N> Outbound<N> {
                                     close_server_connection_on_remote_proxy_error: true,
                                 }
                             }),
+                            Dispatch::Null => todo!("eliza: add a second switch here :("),
                         })
                     },
                     forward.into_inner(),

--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -145,7 +145,11 @@ where
             policy::BackendDispatcher::Forward(addr, ref metadata) => mk_concrete(
                 concrete::Dispatch::Forward(Remote(ServerAddr(addr)), metadata.clone()),
             ),
-            policy::BackendDispatcher::Null => mk_concrete(concrete::Dispatch::Null),
+            policy::BackendDispatcher::Fail { ref message } => {
+                mk_concrete(concrete::Dispatch::Fail {
+                    message: message.clone(),
+                })
+            }
         };
 
         let mk_route_backend = |rb: &policy::RouteBackend<F>| {

--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -145,6 +145,7 @@ where
             policy::BackendDispatcher::Forward(addr, ref metadata) => mk_concrete(
                 concrete::Dispatch::Forward(Remote(ServerAddr(addr)), metadata.clone()),
             ),
+            policy::BackendDispatcher::Null => mk_concrete(concrete::Dispatch::Null),
         };
 
         let mk_route_backend = |rb: &policy::RouteBackend<F>| {

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -161,6 +161,9 @@ impl errors::HttpRescue<Error> for ServerRescue {
         if errors::is_caused_by::<errors::LoadShedError>(&*error) {
             return Ok(errors::SyntheticHttpResponse::unavailable(error));
         }
+        if errors::is_caused_by::<super::concrete::NullDispatcher>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::bad_gateway(error));
+        }
 
         // No routes configured for a request.
         if errors::is_caused_by::<super::logical::NoRoute>(&*error) {

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -161,7 +161,7 @@ impl errors::HttpRescue<Error> for ServerRescue {
         if errors::is_caused_by::<errors::LoadShedError>(&*error) {
             return Ok(errors::SyntheticHttpResponse::unavailable(error));
         }
-        if errors::is_caused_by::<super::concrete::NullDispatcher>(&*error) {
+        if errors::is_caused_by::<super::concrete::DispatcherFailed>(&*error) {
             return Ok(errors::SyntheticHttpResponse::bad_gateway(error));
         }
 


### PR DESCRIPTION
When a `backendRef` in an HTTPRoute references a valid Service name
which doesn't currently exist in the cluster, the policy controller
constructs a synthesized backend with a `failureInjector` filter, so
that traffic sent to the invalid backend will fail with a descriptive
error message, and any other backends in the route will still work
normally. Because the backend doesn't exist, there is no reasonable
value for the policy controller to set as the backend's `dispatcher`
field in the OutboundPolicy proto.

Unfortunately, however, the proxy currently rejects any OutboundPolicy
which has a backend without a populated `dispatcher` field. This means
that when an OutboundPolicy has one backend that has no `dispatcher`,
the proxy will synthesize an invalid policy that fails all traffic,
rather than one that only fails traffic sent to that backend.

This branch changes the proxy so that backends without a `dispatcher`
are no longer rejected by the client policy protobuf conversion code.
Instead, a new `Dispatcher::Null` variant is used to represent a backend
which does not exist, so that a functional `ClientPolicy` can still be
constructed when one or more backends lack a dispatcher. When
constructing a stack for a `Concrete` target with a `Null` dispatcher,
the proxy builds a service that fails all requests. In practice, these
errors will not be observed when the policy controller returns a backend
for an invalid Service name, as the `failureInjector` filter's error
should be produced first, but constructing a service is necessary for
the stack to function correctly.

Closes linkerd/linkerd2#10620