### PR TITLE
add `NewClassifyGate` and `BroadcastClassification` middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -896,7 +896,6 @@ dependencies = [
  "linkerd-error",
  "linkerd-error-respond",
  "linkerd-exp-backoff",
- "linkerd-http-classify",
  "linkerd-http-metrics",
  "linkerd-identity",
  "linkerd-idle-cache",
@@ -1227,8 +1226,6 @@ version = "0.1.0"
 dependencies = [
  "http",
  "linkerd-error",
- "linkerd-stack",
- "tower",
 ]
 
 [[package]]
@@ -1513,6 +1510,7 @@ dependencies = [
  "linkerd-duplex",
  "linkerd-error",
  "linkerd-http-box",
+ "linkerd-http-classify",
  "linkerd-io",
  "linkerd-proxy-balance",
  "linkerd-stack",
@@ -1523,6 +1521,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tower",
+ "tower-test",
  "tracing",
  "try-lock",
 ]

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -29,7 +29,6 @@ linkerd-errno = { path = "../../errno" }
 linkerd-error = { path = "../../error" }
 linkerd-error-respond = { path = "../../error-respond" }
 linkerd-exp-backoff = { path = "../../exp-backoff" }
-linkerd-http-classify = { path = "../../http-classify" }
 linkerd-http-metrics = { path = "../../http-metrics" }
 linkerd-identity = { path = "../../identity" }
 linkerd-idle-cache = { path = "../../idle-cache" }

--- a/linkerd/app/core/src/classify.rs
+++ b/linkerd/app/core/src/classify.rs
@@ -1,13 +1,12 @@
 use crate::profiles;
 use linkerd_error::Error;
-use linkerd_http_classify as classify;
 use linkerd_proxy_client_policy as client_policy;
-use linkerd_proxy_http::{HasH2Reason, ResponseTimeoutError};
+use linkerd_proxy_http::{classify, HasH2Reason, ResponseTimeoutError};
 use std::borrow::Cow;
 use tonic as grpc;
 use tracing::trace;
 
-pub type NewClassify<N, X = ()> = classify::NewClassify<Request, X, N>;
+pub type NewClassify<N, X = ()> = classify::NewInsertClassifyResponse<Request, X, N>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Request {
@@ -225,6 +224,12 @@ fn h2_error(err: &Error) -> String {
 // === impl Class ===
 
 impl Class {
+    #[inline]
+    pub fn is_success(&self) -> bool {
+        !self.is_failure()
+    }
+
+    #[inline]
     pub fn is_failure(&self) -> bool {
         matches!(
             self,
@@ -237,7 +242,7 @@ impl Class {
 mod tests {
     use super::Class;
     use http::{HeaderMap, Response, StatusCode};
-    use linkerd_http_classify::{ClassifyEos, ClassifyResponse};
+    use linkerd_proxy_http::classify::{ClassifyEos, ClassifyResponse};
 
     #[test]
     fn http_response_status_ok() {

--- a/linkerd/http-classify/Cargo.toml
+++ b/linkerd/http-classify/Cargo.toml
@@ -9,5 +9,3 @@ publish = false
 [dependencies]
 http = "0.2"
 linkerd-error = { path = "../error" }
-linkerd-stack = { path = "../stack" }
-tower = { version = "0.4", default-features = false }

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -33,20 +33,22 @@ linkerd-detect = { path = "../../detect" }
 linkerd-duplex = { path = "../../duplex" }
 linkerd-error = { path = "../../error" }
 linkerd-http-box = { path = "../../http-box" }
+linkerd-http-classify = { path = "../../http-classify" }
 linkerd-io = { path = "../../io" }
 linkerd-proxy-balance = { path = "../balance" }
 linkerd-stack = { path = "../../stack" }
+pin-project = "1"
 rand = "0.8"
 thiserror = "1"
-tokio = { version = "1", features = ["time", "rt"] }
-tower = { version = "0.4.13", default-features = false }
+tokio = { version = "1", features = ["rt", "sync", "time"] }
+tower = { version = "0.4", default-features = false }
 tracing = "0.1"
 try-lock = "0.2"
-pin-project = "1"
 
 [target.'cfg(fuzzing)'.dependencies]
 tokio-test = "0.4"
 
 [dev-dependencies]
 tokio-test = "0.4"
+tower-test = "0.4"
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }

--- a/linkerd/proxy/http/src/classify.rs
+++ b/linkerd/proxy/http/src/classify.rs
@@ -1,0 +1,10 @@
+pub mod channel;
+pub mod gate;
+mod insert;
+
+pub use self::{
+    channel::{BroadcastClassification, NewBroadcastClassification, Tx},
+    gate::{NewClassifyGate, NewClassifyGateSet},
+    insert::{InsertClassifyResponse, NewInsertClassifyResponse},
+};
+pub use linkerd_http_classify::*;

--- a/linkerd/proxy/http/src/classify/channel.rs
+++ b/linkerd/proxy/http/src/classify/channel.rs
@@ -1,0 +1,335 @@
+use super::{ClassifyEos, ClassifyResponse};
+use futures::{prelude::*, ready};
+use linkerd_error::Error;
+use linkerd_stack::{layer, ExtractParam, NewService, Service};
+use pin_project::{pin_project, pinned_drop};
+use std::{
+    fmt::Debug,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::sync::mpsc;
+
+#[derive(Debug)]
+pub struct NewBroadcastClassification<C, X, N> {
+    inner: N,
+    extract: X,
+    _marker: PhantomData<fn() -> C>,
+}
+
+/// A HTTP `Service` that applies a [`super::Classify`] to each request and
+/// broadcasts the result to an [`Rx`] inserted to inner requests and outer
+/// responses..
+#[derive(Debug)]
+pub struct BroadcastClassification<C: ClassifyResponse, S> {
+    inner: S,
+    tx: mpsc::Sender<C::Class>,
+    _marker: PhantomData<fn() -> C>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Tx<C>(pub mpsc::Sender<C>);
+
+#[pin_project]
+pub struct ResponseFuture<C: ClassifyResponse, B, F> {
+    #[pin]
+    inner: F,
+    state: Option<State<C, C::Class>>,
+    _marker: PhantomData<fn() -> B>,
+}
+
+#[pin_project(PinnedDrop)]
+pub struct ResponseBody<C: ClassifyEos, B> {
+    #[pin]
+    inner: B,
+    state: Option<State<C, C::Class>>,
+}
+
+#[derive(Debug)]
+struct State<C, T> {
+    classify: C,
+    tx: mpsc::Sender<T>,
+}
+
+// === impl NewBroadcastClassification ===
+
+impl<C, X: Clone, N> NewBroadcastClassification<C, X, N> {
+    pub fn new(extract: X, inner: N) -> Self {
+        Self {
+            inner,
+            extract,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn layer_via(extract: X) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self::new(extract.clone(), inner))
+    }
+}
+
+impl<C, N> NewBroadcastClassification<C, (), N> {
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Clone {
+        Self::layer_via(())
+    }
+}
+
+impl<T, C, X, N> NewService<T> for NewBroadcastClassification<C, X, N>
+where
+    C: ClassifyResponse,
+    X: ExtractParam<Tx<C::Class>, T>,
+    N: NewService<T>,
+{
+    type Service = BroadcastClassification<C, N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let Tx(tx) = self.extract.extract_param(&target);
+        let inner = self.inner.new_service(target);
+        BroadcastClassification::new(tx, inner)
+    }
+}
+
+impl<C, X: Clone, N: Clone> Clone for NewBroadcastClassification<C, X, N> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            extract: self.extract.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+// === impl BroadcastClassification ===
+
+impl<C: ClassifyResponse, S> BroadcastClassification<C, S> {
+    pub fn new(tx: mpsc::Sender<C::Class>, inner: S) -> Self {
+        Self {
+            inner,
+            tx,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C, S, ReqB, RspB> Service<http::Request<ReqB>> for BroadcastClassification<C, S>
+where
+    C: ClassifyResponse + Debug,
+    C::Class: Debug,
+    S: Service<http::Request<ReqB>, Response = http::Response<RspB>, Error = Error>,
+{
+    type Response = http::Response<ResponseBody<C::ClassifyEos, RspB>>;
+    type Error = Error;
+    type Future = ResponseFuture<C, RspB, S::Future>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<ReqB>) -> Self::Future {
+        let tx = self.tx.clone();
+        let state = req
+            .extensions()
+            .get::<C>()
+            .cloned()
+            .map(|classify| State { classify, tx });
+        tracing::debug!(?state);
+
+        let inner = self.inner.call(req);
+        ResponseFuture {
+            inner,
+            state,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<C, S> Clone for BroadcastClassification<C, S>
+where
+    C: ClassifyResponse + Clone,
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            tx: self.tx.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+// === impl ResponseFuture ===
+
+impl<C, B, F> Future for ResponseFuture<C, B, F>
+where
+    C: ClassifyResponse,
+    F: TryFuture<Ok = http::Response<B>, Error = Error>,
+{
+    type Output = Result<http::Response<ResponseBody<C::ClassifyEos, B>>, Error>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        match ready!(this.inner.try_poll(cx)) {
+            Ok(rsp) => {
+                let state = this.state.take().map(|State { classify, tx }| {
+                    let classify = classify.start(&rsp);
+                    State { classify, tx }
+                });
+                Poll::Ready(Ok(rsp.map(|inner| ResponseBody { inner, state })))
+            }
+
+            Err(e) => {
+                if let Some(State { classify, tx }) = this.state.take() {
+                    let class = classify.error(&e);
+                    let _ = tx.try_send(class);
+                }
+                Poll::Ready(Err(e))
+            }
+        }
+    }
+}
+
+// === impl ResponseBody ===
+
+impl<C, B> hyper::body::HttpBody for ResponseBody<C, B>
+where
+    C: ClassifyEos + Unpin,
+    B: hyper::body::HttpBody<Error = Error>,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        let this = self.project();
+        match ready!(this.inner.poll_data(cx)) {
+            None => Poll::Ready(None),
+            Some(Ok(data)) => Poll::Ready(Some(Ok(data))),
+            Some(Err(e)) => {
+                if let Some(State { classify, tx }) = this.state.take() {
+                    let _ = tx.try_send(classify.error(&e));
+                }
+                Poll::Ready(Some(Err(e)))
+            }
+        }
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
+        let this = self.project();
+        match ready!(this.inner.poll_trailers(cx)) {
+            Ok(trls) => {
+                if let Some(State { classify, tx }) = this.state.take() {
+                    let _ = tx.try_send(classify.eos(trls.as_ref()));
+                }
+                Poll::Ready(Ok(trls))
+            }
+            Err(e) => {
+                if let Some(State { classify, tx }) = this.state.take() {
+                    let _ = tx.try_send(classify.error(&e));
+                }
+                Poll::Ready(Err(e))
+            }
+        }
+    }
+
+    #[inline]
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> http_body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+#[pinned_drop]
+impl<C: ClassifyEos, B> PinnedDrop for ResponseBody<C, B> {
+    fn drop(self: Pin<&mut Self>) {
+        tracing::debug!("dropping ResponseBody");
+        if let Some(State { classify, tx }) = self.project().state.take() {
+            tracing::debug!("sending EOS to classify");
+            let _ = tx.try_send(classify.eos(None));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::classify::ClassifyResponse;
+    use linkerd_error::Error;
+    use linkerd_http_box::BoxBody;
+    use linkerd_http_classify::ClassifyEos;
+    use tokio::{sync::mpsc, time};
+    use tokio_test::assert_ready;
+    use tower_test::mock;
+
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    struct TestClass;
+
+    impl ClassifyResponse for TestClass {
+        type Class = TestClass;
+        type ClassifyEos = TestClass;
+
+        fn start<B>(self, _: &http::Response<B>) -> TestClass {
+            TestClass
+        }
+
+        fn error(self, _: &Error) -> Self::Class {
+            TestClass
+        }
+    }
+
+    impl ClassifyEos for TestClass {
+        type Class = TestClass;
+
+        fn eos(self, _: Option<&http::HeaderMap>) -> Self::Class {
+            TestClass
+        }
+
+        fn error(self, _: &Error) -> Self::Class {
+            TestClass
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcasts() {
+        let _trace = linkerd_tracing::test::with_default_filter("linkerd=debug");
+
+        let (rsps_tx, mut rsps) = mpsc::channel(1);
+        let (inner, mut mock) = mock::pair::<http::Request<BoxBody>, http::Response<BoxBody>>();
+        let mut svc =
+            mock::Spawn::new(BroadcastClassification::<TestClass, _>::new(rsps_tx, inner));
+
+        mock.allow(1);
+        assert_ready!(svc.poll_ready()).expect("ok");
+
+        rsps.try_recv()
+            .expect_err("should not have received a response");
+        let req = http::Request::builder()
+            .extension(TestClass)
+            .body(BoxBody::default())
+            .unwrap();
+        let (rsp, _) = tokio::join! {
+            svc.call(req).map(|res| res.expect("must not fail")),
+            mock.next_request().map(|req| {
+                let (_, tx) = req.expect("request");
+                tx.send_response(http::Response::default());
+                tracing::debug!("sent response");
+            }),
+        };
+        // Consume the response body and trailers to drive classification.
+        drop(rsp);
+        time::timeout(time::Duration::from_secs(1), rsps.recv())
+            .await
+            .expect("should have received a response");
+    }
+}

--- a/linkerd/proxy/http/src/classify/gate.rs
+++ b/linkerd/proxy/http/src/classify/gate.rs
@@ -1,0 +1,136 @@
+// A `NewService` called `NewClassifyGate` that builds a
+// `BroadcastClassification` and a `Gate` so that the `gate::Tx` can be
+// controlled by the `BroadcastClassification`'s `Tx`.
+
+use crate::classify::{BroadcastClassification, ClassifyResponse};
+use linkerd_stack::{gate, layer, ExtractParam, Gate, NewService};
+use std::marker::PhantomData;
+use tokio::sync::mpsc;
+
+pub use linkerd_stack::gate::{Rx, State, Tx};
+
+#[derive(Clone, Debug)]
+pub struct Params<C> {
+    pub responses: mpsc::Sender<C>,
+    pub gate: gate::Rx,
+}
+
+pub struct NewClassifyGateSet<C, P, X, N> {
+    inner: N,
+    extract: X,
+    _marker: PhantomData<fn() -> (P, C)>,
+}
+
+pub struct NewClassifyGate<C, X, N> {
+    inner: N,
+    extract: X,
+    _marker: PhantomData<fn() -> C>,
+}
+
+// === impl NewClassifyGateSet ===
+
+impl<C, P, X: Clone, N> NewClassifyGateSet<C, P, X, N> {
+    pub fn new(extract: X, inner: N) -> Self {
+        Self {
+            inner,
+            extract,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn layer_via(extract: X) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self::new(extract.clone(), inner))
+    }
+}
+
+impl<C, P, N> NewClassifyGateSet<C, P, (), N> {
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Clone {
+        Self::layer_via(())
+    }
+}
+
+impl<T, C, P, X, N> NewService<T> for NewClassifyGateSet<C, P, X, N>
+where
+    P: Clone,
+    X: ExtractParam<P, T>,
+    N: NewService<T>,
+{
+    type Service = NewClassifyGate<C, P, N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let new_params = self.extract.extract_param(&target);
+        let inner = self.inner.new_service(target);
+        NewClassifyGate::new(new_params, inner)
+    }
+}
+
+impl<C, P, X: Clone, N: Clone> Clone for NewClassifyGateSet<C, P, X, N> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            extract: self.extract.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+// === impl NewClassifyGate ===
+
+impl<C, X: Clone, N> NewClassifyGate<C, X, N> {
+    pub fn new(extract: X, inner: N) -> Self {
+        Self {
+            inner,
+            extract,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn layer_via(extract: X) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self::new(extract.clone(), inner))
+    }
+}
+
+impl<C, N> NewClassifyGate<C, (), N> {
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Clone {
+        Self::layer_via(())
+    }
+}
+
+impl<T, C, X, N> NewService<T> for NewClassifyGate<C, X, N>
+where
+    C: ClassifyResponse,
+    X: ExtractParam<Params<C::Class>, T>,
+    N: NewService<T>,
+{
+    type Service = Gate<BroadcastClassification<C, N::Service>>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let Params { responses, gate } = self.extract.extract_param(&target);
+        let inner = self.inner.new_service(target);
+        Gate::new(gate, BroadcastClassification::new(responses, inner))
+    }
+}
+
+impl<C, X: Clone, N: Clone> Clone for NewClassifyGate<C, X, N> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            extract: self.extract.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+// === impl Params ===
+
+impl<C> Params<C> {
+    pub fn channel(capacity: usize) -> (Self, gate::Tx, mpsc::Receiver<C>) {
+        let (gate_tx, gate_rx) = gate::channel();
+        let (rsps_tx, rsps_rx) = mpsc::channel(capacity);
+        let prms = Self {
+            gate: gate_rx,
+            responses: rsps_tx,
+        };
+        (prms, gate_tx, rsps_rx)
+    }
+}

--- a/linkerd/proxy/http/src/classify/insert.rs
+++ b/linkerd/proxy/http/src/classify/insert.rs
@@ -1,0 +1,90 @@
+use linkerd_stack::{layer, ExtractParam, NewService, Proxy, Service};
+use std::{
+    marker::PhantomData,
+    task::{Context, Poll},
+};
+
+#[derive(Clone, Debug)]
+pub struct NewInsertClassifyResponse<C, X, N> {
+    inner: N,
+    extract: X,
+    _marker: PhantomData<fn() -> C>,
+}
+
+#[derive(Clone, Debug)]
+pub struct InsertClassifyResponse<C, P> {
+    classify: C,
+    inner: P,
+}
+
+impl<C, X: Clone, N> NewInsertClassifyResponse<C, X, N> {
+    pub fn layer_via(extract: X) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self {
+            inner,
+            extract: extract.clone(),
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<C, N> NewInsertClassifyResponse<C, (), N> {
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Clone {
+        Self::layer_via(())
+    }
+}
+
+impl<T, C, X, N> NewService<T> for NewInsertClassifyResponse<C, X, N>
+where
+    C: super::Classify,
+    X: ExtractParam<C, T>,
+    N: NewService<T>,
+{
+    type Service = InsertClassifyResponse<C, N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let classify = self.extract.extract_param(&target);
+        let inner = self.inner.new_service(target);
+        InsertClassifyResponse { classify, inner }
+    }
+}
+
+impl<C, P, S, B> Proxy<http::Request<B>, S> for InsertClassifyResponse<C, P>
+where
+    C: super::Classify,
+    P: Proxy<http::Request<B>, S>,
+    S: Service<P::Request>,
+{
+    type Request = P::Request;
+    type Response = P::Response;
+    type Error = P::Error;
+    type Future = P::Future;
+
+    fn proxy(&self, svc: &mut S, mut req: http::Request<B>) -> Self::Future {
+        let classify_rsp = self.classify.classify(&req);
+        let prior = req.extensions_mut().insert(classify_rsp);
+        debug_assert!(prior.is_none(), "classification extension already existed");
+        self.inner.proxy(svc, req)
+    }
+}
+
+impl<C, S, B> Service<http::Request<B>> for InsertClassifyResponse<C, S>
+where
+    C: super::Classify,
+    S: Service<http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
+        let classify_rsp = self.classify.classify(&req);
+        let prior = req.extensions_mut().insert(classify_rsp);
+        debug_assert!(prior.is_none(), "classification extension already existed");
+        self.inner.call(req)
+    }
+}

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -1,10 +1,11 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
-use http::header::AsHeaderName;
-use http::uri::Authority;
+
+use http::{header::AsHeaderName, uri::Authority};
 use linkerd_error::Error;
 
 pub mod balance;
+pub mod classify;
 pub mod client;
 pub mod client_handle;
 pub mod detect;
@@ -26,6 +27,10 @@ pub mod version;
 
 pub use self::{
     balance::NewBalancePeakEwma,
+    classify::{
+        Classify, ClassifyEos, ClassifyResponse, NewClassifyGate, NewClassifyGateSet,
+        NewInsertClassifyResponse,
+    },
     client_handle::{ClientHandle, SetClientHandle},
     detect::DetectHttp,
     glue::{HyperServerSvc, UpgradeBody},


### PR DESCRIPTION
This branch introduces middleware for opening and closing a `Gate` middleware based on HTTP response classification. The `BroadcastClassification` service applies an HTTP response classifier to each request, and sends the classification over a channel. The `NewClassifyGate` middleware constructs stacks containing `BroadcastClassification` and `Gate` middleware. In conjunction with a _failure accrual policy_, these middleware allow response classification results to determine whether a service stack is available, implementing _request-level HTTP circuit breaking_.

Failure accrual policies are determined by the `ExtractParam` implementation provided to the `NewClassifyGate` layer. This type must provide a `classify::gate::Params` type containing a `mpsc::Sender` for the response classification channel, and a `gate::Rx` that controls the opening and closing of the `Gate` middleware. This means that the `ExtractParam` implementation can spawn a task implementing an arbitrary policy for opening and closing the gate based on classifications received over the `mpsc::Receiver` end of the classification channel, based on the target type the stack is constructed for.

This branch does not implement any failure accrual policies, nor does it integrate the `NewClassifyGate` middleware with existing proxy stacks. It simply adds these middleware. Subsequent branches will add the circuit-breaking middleware to the proxy stack, implement failure accrual policies, and configure failure accrual from individual stack targets.

This change was factored out from PR #2334 in order to merge independently.