### PR TITLE
add `ConsecutiveFailures` failure accrual policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,6 +1455,7 @@ dependencies = [
  "http",
  "ipnet",
  "linkerd-error",
+ "linkerd-exp-backoff",
  "linkerd-http-route",
  "linkerd-proxy-api-resolve",
  "linkerd-proxy-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,7 @@ dependencies = [
  "linkerd-meshtls-rustls",
  "linkerd-proxy-client-policy",
  "linkerd-retry",
+ "linkerd-stack",
  "linkerd-tonic-watch",
  "linkerd-tracing",
  "linkerd2-proxy-api",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -50,6 +50,7 @@ linkerd-meshtls = { path = "../../meshtls", features = ["rustls"] }
 linkerd-meshtls-rustls = { path = "../../meshtls/rustls", features = [
     "test-util",
 ] }
+linkerd-stack = { path = "../../stack", features = ["test-util"] }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }
 parking_lot = "0.12"
 tokio = { version = "1", features = ["macros", "sync", "time"] }

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -12,6 +12,7 @@ use linkerd_app_core::{
 use std::{fmt::Debug, hash::Hash};
 use tokio::sync::watch;
 
+mod breaker;
 pub mod concrete;
 mod endpoint;
 mod handle_proxy_error_headers;

--- a/linkerd/app/outbound/src/http/breaker.rs
+++ b/linkerd/app/outbound/src/http/breaker.rs
@@ -27,9 +27,13 @@ impl<T> svc::ExtractParam<gate::Params<classify::Class>, T> for Params {
                 max_failures,
                 backoff,
             } => {
-                tracing::trace!(max_failures, backoff = ?backoff, "Using consecutive-failures failure accrual policy.");
+                tracing::trace!(
+                    max_failures,
+                    backoff = ?backoff,
+                    "Using consecutive-failures failure accrual policy.",
+                );
 
-                // 1. If the configured number of consecutive failures are encountered,'
+                // 1. If the configured number of consecutive failures are encountered,
                 //    shut the gate.
                 // 2. After an ejection timeout, open the gate so that 1 request can be processed.
                 // 3. If that request succeeds, open the gate. If it fails, increase the

--- a/linkerd/app/outbound/src/http/breaker.rs
+++ b/linkerd/app/outbound/src/http/breaker.rs
@@ -1,0 +1,51 @@
+pub mod consecutive_failures;
+use linkerd_app_core::{classify, proxy::http::classify::gate, svc};
+use linkerd_proxy_client_policy::FailureAccrual;
+
+/// Params configuring a circuit breaker stack.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct Params {
+    pub(crate) accrual: FailureAccrual,
+    pub(crate) channel_capacity: usize,
+}
+
+impl<T> svc::ExtractParam<gate::Params<classify::Class>, T> for Params {
+    fn extract_param(&self, _: &T) -> gate::Params<classify::Class> {
+        // Create a channel so that we can receive response summaries and
+        // control the gate.
+        let (prms, gate, rsps) = gate::Params::channel(self.channel_capacity);
+
+        match self.accrual {
+            FailureAccrual::None => {
+                // No failure accrual for this target; construct a gate
+                // that will never close.
+                tracing::trace!("No failure accrual policy enabled.");
+                prms
+            }
+            FailureAccrual::ConsecutiveFailures {
+                max_failures,
+                backoff,
+            } => {
+                tracing::trace!(max_failures, backoff = ?backoff, "Using consecutive-failures failure accrual policy.");
+
+                // 1. If the configured number of consecutive failures are encountered,
+                //    shut the gate.
+                // 2. After an ejection timeout, open the gate so that 1 request can be processed.
+                // 3. If that request succeeds, open the gate. If it fails, increase the
+                //    ejection timeout and repeat.
+                let breaker = consecutive_failures::ConsecutiveFailures::new(
+                    consecutive_failures::Params {
+                        max_failures,
+                        backoff,
+                        channel_capacity: self.channel_capacity,
+                    },
+                    gate,
+                    rsps,
+                );
+                tokio::spawn(breaker.run());
+
+                prms
+            }
+        }
+    }
+}

--- a/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
+++ b/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
@@ -158,7 +158,7 @@ mod tests {
                 assert_eq!(sem.available_permits(), 1);
                 params
                     .gate
-                    .acquire()
+                    .acquire_for_test()
                     .await
                     .expect("permit should be acquired")
                     // The `Gate` service would forget this permit when called, so
@@ -194,7 +194,7 @@ mod tests {
                 assert_eq!(sem.available_permits(), 1);
                 params
                     .gate
-                    .acquire()
+                    .acquire_for_test()
                     .await
                     .expect("permit should be acquired")
                     // The `Gate` service would forget this permit when called, so

--- a/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
+++ b/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
@@ -1,0 +1,240 @@
+use futures::stream::StreamExt;
+use linkerd_app_core::{
+    classify, exp_backoff::ExponentialBackoff, proxy::http::classify::gate, svc,
+};
+use std::{fmt::Debug, sync::Arc};
+use tokio::sync::{mpsc, Semaphore};
+
+#[derive(Copy, Clone, Debug)]
+pub struct Params {
+    pub max_failures: usize,
+    pub channel_capacity: usize,
+    pub backoff: ExponentialBackoff,
+}
+
+pub struct ConsecutiveFailures {
+    params: Params,
+    gate: gate::Tx,
+    rsps: mpsc::Receiver<classify::Class>,
+    semaphore: Arc<Semaphore>,
+}
+
+// === impl Params ===
+
+impl<T> svc::ExtractParam<gate::Params<classify::Class>, T> for Params {
+    fn extract_param(&self, _: &T) -> gate::Params<classify::Class> {
+        // Create a channel so that we can receive response summaries and
+        // control the gate.
+        let (prms, gate, rsps) = gate::Params::channel(self.channel_capacity);
+
+        // 1. If the configured number of consecutive failures are encountered,
+        //    shut the gate.
+        // 2. After an ejection timeout, open the gate so that 1 request can be processed.
+        // 3. If that request succeeds, open the gate. If it fails, increase the
+        //    ejection timeout and repeat.
+        let breaker = ConsecutiveFailures::new(*self, gate, rsps);
+        tokio::spawn(breaker.run());
+
+        prms
+    }
+}
+
+// === impl ConsecutiveFailures ===
+
+impl ConsecutiveFailures {
+    pub fn new(params: Params, gate: gate::Tx, rsps: mpsc::Receiver<classify::Class>) -> Self {
+        Self {
+            params,
+            gate,
+            rsps,
+            semaphore: Arc::new(Semaphore::new(0)),
+        }
+    }
+
+    pub(super) async fn run(mut self) {
+        loop {
+            if self.open().await.is_err() {
+                return;
+            }
+
+            if self.closed().await.is_err() {
+                return;
+            }
+        }
+    }
+
+    /// Keep the breaker open until `max_failures` consecutive failures are
+    /// observed.
+    async fn open(&mut self) -> Result<(), ()> {
+        tracing::debug!("Open");
+        self.gate.open();
+        let mut failures = 0;
+        loop {
+            let class = tokio::select! {
+                rsp = self.rsps.recv() => rsp.ok_or(())?,
+                _ = self.gate.lost() => return Err(()),
+            };
+
+            tracing::trace!(?class, %failures, "Response");
+            if class.is_success() {
+                failures = 0;
+            } else {
+                failures += 1;
+                if failures == self.params.max_failures {
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    /// Keep the breaker closed for at least the initial backoff, and then,
+    /// once the timeout expires, go into probation to admit a single request
+    /// before reverting to the open state or continuing in the shut state.
+    async fn closed(&mut self) -> Result<(), ()> {
+        let mut backoff = self.params.backoff.stream();
+        loop {
+            // The breaker is shut now. Wait until we can open it again.
+            tracing::debug!(backoff = ?backoff.duration(), "Shut");
+            self.gate.shut();
+
+            loop {
+                tokio::select! {
+                    _ = backoff.next() => break,
+                    // Ignore responses while the breaker is shut.
+                    _ = self.rsps.recv() => continue,
+                    _ = self.gate.lost() => return Err(()),
+                }
+            }
+
+            let class = self.probation().await?;
+            tracing::trace!(?class, "Response");
+            if class.is_success() {
+                // Open!
+                return Ok(());
+            }
+        }
+    }
+
+    /// Wait for a response to determine whether the breaker should be opened.
+    async fn probation(&mut self) -> Result<classify::Class, ()> {
+        tracing::debug!("Probation");
+        self.semaphore.add_permits(1);
+        self.gate.limit(self.semaphore.clone());
+        tokio::select! {
+            rsp = self.rsps.recv() => rsp.ok_or(()),
+            _ = self.gate.lost() => Err(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::time;
+    use tokio_test::{assert_pending, task};
+
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn transitions() {
+        let _trace = linkerd_tracing::test::trace_init();
+
+        let (mut params, gate, rsps) = gate::Params::channel(1);
+        let send = |res: Result<http::StatusCode, http::StatusCode>| {
+            params
+                .responses
+                .try_send(classify::Class::Http(res))
+                .unwrap()
+        };
+
+        let prms = Params {
+            max_failures: 2,
+            channel_capacity: 1,
+            backoff: ExponentialBackoff::try_new(
+                time::Duration::from_secs(1),
+                time::Duration::from_secs(100),
+                // Don't jitter backoffs to ensure tests are deterministic.
+                0.0,
+            )
+            .expect("backoff params are valid"),
+        };
+        let breaker = ConsecutiveFailures::new(prms, gate, rsps);
+        let mut task = task::spawn(breaker.run());
+
+        // Start open and failing.
+        send(Err(http::StatusCode::BAD_GATEWAY));
+        assert_pending!(task.poll());
+        assert!(params.gate.is_open());
+
+        send(Err(http::StatusCode::BAD_GATEWAY));
+        assert_pending!(task.poll());
+        assert!(params.gate.is_shut());
+
+        // After two failures, the breaker is closed.
+        time::sleep(time::Duration::from_millis(500)).await;
+        assert_pending!(task.poll());
+        assert!(params.gate.is_shut());
+
+        // It remains closed until the init ejection backoff elapses. Then it's
+        // limited to a single request.
+        time::sleep(time::Duration::from_millis(500)).await;
+        assert_pending!(task.poll());
+
+        // hold the permit to prevent the breaker from opening
+        match params.gate.state() {
+            gate::State::Open => panic!("still open"),
+            gate::State::Shut => panic!("still shut"),
+            gate::State::Limited(sem) => {
+                assert_eq!(sem.available_permits(), 1);
+                params
+                    .gate
+                    .acquire()
+                    .await
+                    .expect("permit should be acquired")
+                    // The `Gate` service would forget this permit when called, so
+                    // we must do the same here explicitly.
+                    .forget();
+                assert_eq!(sem.available_permits(), 0);
+            }
+        };
+
+        // The first request in probation fails, so the breaker remains closed.
+        send(Err(http::StatusCode::BAD_GATEWAY));
+        assert_pending!(task.poll());
+        assert!(params.gate.is_shut());
+
+        // The breaker goes into closed for 2s now...
+        time::sleep(time::Duration::from_secs(1)).await;
+        assert_pending!(task.poll());
+        assert!(params.gate.is_shut());
+
+        // If some straggling responses are observed while the breaker is
+        // closed, they are ignored.
+        send(Ok(http::StatusCode::OK));
+        assert_pending!(task.poll());
+        assert!(params.gate.is_shut());
+        // After that timeout elapses, we go into probation again.
+        time::sleep(time::Duration::from_secs(1)).await;
+        assert_pending!(task.poll());
+
+        match params.gate.state() {
+            gate::State::Open => panic!("still open"),
+            gate::State::Shut => panic!("still shut"),
+            gate::State::Limited(sem) => {
+                assert_eq!(sem.available_permits(), 1);
+                params
+                    .gate
+                    .acquire()
+                    .await
+                    .expect("permit should be acquired")
+                    // The `Gate` service would forget this permit when called, so
+                    // we must do the same here explicitly.
+                    .forget();
+                assert_eq!(sem.available_permits(), 0);
+            }
+        }
+
+        // And then a single success takes us back into the open state!
+        send(Ok(http::StatusCode::OK));
+        assert_pending!(task.poll());
+        assert!(params.gate.is_open());
+    }
+}

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -22,6 +22,7 @@ linkerd2-proxy-api = { version = "0.8", optional = true, features = [
     "outbound",
 ] }
 linkerd-error = { path = "../../error" }
+linkerd-exp-backoff = { path = "../../exp-backoff" }
 linkerd-http-route = { path = "../../http-route" }
 linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -120,6 +120,15 @@ pub struct PeakEwma {
 pub enum FailureAccrual {
     /// Endpoints do not become unavailable due to observed failures.
     None,
+    /// Endpoints are marked as unavailable when `max_failures` consecutive
+    /// failures are observed.
+    ConsecutiveFailures {
+        /// The number of consecutive failures after which an endpoint becomes
+        /// unavailable.
+        max_failures: usize,
+        /// Backoff for probing the endpoint when it is in a failed state.
+        backoff: linkerd_exp_backoff::ExponentialBackoff,
+    },
 }
 
 // === impl ClientPolicy ===

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -9,6 +9,9 @@ description = """
 Utilities for composing Tower services.
 """
 
+[features]
+test-util = []
+
 [dependencies]
 futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }

--- a/linkerd/stack/src/gate.rs
+++ b/linkerd/stack/src/gate.rs
@@ -72,7 +72,15 @@ impl Rx {
     }
 
     /// Waits for the gate state to change to be open.
-    pub async fn acquire(&mut self) -> Option<OwnedSemaphorePermit> {
+    ///
+    /// This is intended for testing purposes.
+    #[cfg(feature = "test-util")]
+    pub async fn acquire_for_test(&mut self) -> Option<OwnedSemaphorePermit> {
+        self.acquire().await
+    }
+
+    /// Waits for the gate state to change to be open.
+    async fn acquire(&mut self) -> Option<OwnedSemaphorePermit> {
         loop {
             let state = self.0.borrow_and_update().clone();
             match state {

--- a/linkerd/stack/src/gate.rs
+++ b/linkerd/stack/src/gate.rs
@@ -72,7 +72,7 @@ impl Rx {
     }
 
     /// Waits for the gate state to change to be open.
-    async fn acquire(&mut self) -> Option<OwnedSemaphorePermit> {
+    pub async fn acquire(&mut self) -> Option<OwnedSemaphorePermit> {
         loop {
             let state = self.0.borrow_and_update().clone();
             match state {


### PR DESCRIPTION
Depends on https://github.com/linkerd/linkerd2-proxy/pull/2354.

This branch introduces a `ConsecutiveFailures` failure accrual policy
which marks an endpoint as unavailable if a given number of failures
occur in a row without any successes. Once the endpoint is marked as
failing, it is issued a single probe request after a delay. If the probe
succeeds, the endpoint transitions back to the available state.
Otherwise, it remains unavailable, with subsequent probe requests being
issued with an exponential backoff. The consecutive failures failure
accrual policy was initially implemented in PR #2334 by @olix0r.

A new `FailureAccrual::ConsecutiveFailures` variant is added in
`linkerd2-proxy-client-policy` for configuring the consecutive failures
failure accrual policy. The construction of circuit breakers in the
outbound stack is changed from a closure implementing `ExtractParam` to
a new `breaker::Params` type, so that the type returned can be the same
regardless of which failure accrual policy is constructed.