### PR TITLE
configure failure accrual from the `OutboundPolicy` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,7 +1882,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.8.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#9efe50fd769cf8fbba4f0eedf95fa8ca896d7355"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#afd13fc7d5a592acd31b4ba822f854e5590e9600"
 dependencies = [
  "h2",
  "http",

--- a/linkerd/app/integration/src/policy.rs
+++ b/linkerd/app/integration/src/policy.rs
@@ -116,11 +116,11 @@ pub fn outbound_default(dst: impl ToString) -> outbound::OutboundPolicy {
                 timeout: Some(Duration::from_secs(10).try_into().unwrap()),
                 http1: Some(proxy_protocol::Http1 {
                     routes: vec![route.clone()],
-                    breaker: None,
+                    failure_accrual: None,
                 }),
                 http2: Some(proxy_protocol::Http2 {
                     routes: vec![route],
-                    breaker: None,
+                    failure_accrual: None,
                 }),
                 opaque: Some(proxy_protocol::Opaque {
                     routes: vec![outbound_default_opaque_route(dst)],

--- a/linkerd/app/integration/src/policy.rs
+++ b/linkerd/app/integration/src/policy.rs
@@ -116,9 +116,11 @@ pub fn outbound_default(dst: impl ToString) -> outbound::OutboundPolicy {
                 timeout: Some(Duration::from_secs(10).try_into().unwrap()),
                 http1: Some(proxy_protocol::Http1 {
                     routes: vec![route.clone()],
+                    breaker: None,
                 }),
                 http2: Some(proxy_protocol::Http2 {
                     routes: vec![route],
+                    breaker: None,
                 }),
                 opaque: Some(proxy_protocol::Opaque {
                     routes: vec![outbound_default_opaque_route(dst)],
@@ -146,6 +148,7 @@ pub fn outbound_default_http_route(dst: impl ToString) -> outbound::HttpRoute {
             }],
             filters: Vec::new(),
             backends: Some(http_first_available(std::iter::once(backend(dst)))),
+            failure_policy: None,
         }],
     }
 }

--- a/linkerd/app/integration/src/policy.rs
+++ b/linkerd/app/integration/src/policy.rs
@@ -148,7 +148,6 @@ pub fn outbound_default_http_route(dst: impl ToString) -> outbound::HttpRoute {
             }],
             filters: Vec::new(),
             backends: Some(http_first_available(std::iter::once(backend(dst)))),
-            failure_policy: None,
         }],
     }
 }

--- a/linkerd/app/integration/src/tests/client_policy.rs
+++ b/linkerd/app/integration/src/tests/client_policy.rs
@@ -60,11 +60,11 @@ async fn empty_http1_route() {
                                 hosts: Vec::new(),
                                 rules: Vec::new(),
                             }],
-                            breaker: None,
+                            failure_accrual: None,
                         }),
                         http2: Some(proxy_protocol::Http2 {
                             routes: vec![policy::outbound_default_http_route(&dst)],
-                            breaker: None,
+                            failure_accrual: None,
                         }),
                         opaque: Some(proxy_protocol::Opaque {
                             routes: vec![policy::outbound_default_opaque_route(&dst)],
@@ -142,7 +142,7 @@ async fn empty_http2_route() {
                         timeout: Some(Duration::from_secs(10).try_into().unwrap()),
                         http1: Some(proxy_protocol::Http1 {
                             routes: vec![policy::outbound_default_http_route(&dst)],
-                            breaker: None,
+                            failure_accrual: None,
                         }),
                         http2: Some(proxy_protocol::Http2 {
                             routes: vec![outbound::HttpRoute {
@@ -150,7 +150,7 @@ async fn empty_http2_route() {
                                 hosts: Vec::new(),
                                 rules: Vec::new(),
                             }],
-                            breaker: None,
+                            failure_accrual: None,
                         }),
                         opaque: Some(proxy_protocol::Opaque {
                             routes: vec![policy::outbound_default_opaque_route(&dst)],
@@ -255,11 +255,11 @@ async fn header_based_routing() {
                         timeout: Some(Duration::from_secs(10).try_into().unwrap()),
                         http1: Some(proxy_protocol::Http1 {
                             routes: vec![route.clone()],
-                            breaker: None,
+                            failure_accrual: None,
                         }),
                         http2: Some(proxy_protocol::Http2 {
                             routes: vec![route],
-                            breaker: None,
+                            failure_accrual: None,
                         }),
                         opaque: Some(proxy_protocol::Opaque {
                             routes: vec![policy::outbound_default_opaque_route(&dst_world)],
@@ -432,11 +432,11 @@ async fn path_based_routing() {
                         timeout: Some(Duration::from_secs(10).try_into().unwrap()),
                         http1: Some(proxy_protocol::Http1 {
                             routes: vec![route.clone()],
-                            breaker: None,
+                            failure_accrual: None,
                         }),
                         http2: Some(proxy_protocol::Http2 {
                             routes: vec![route],
-                            breaker: None,
+                            failure_accrual: None,
                         }),
                         opaque: Some(proxy_protocol::Opaque {
                             routes: vec![policy::outbound_default_opaque_route(&dst_world)],

--- a/linkerd/app/integration/src/tests/client_policy.rs
+++ b/linkerd/app/integration/src/tests/client_policy.rs
@@ -217,7 +217,6 @@ async fn header_based_routing() {
             backends: Some(policy::http_first_available(std::iter::once(
                 policy::backend(dst),
             ))),
-            failure_policy: None,
         };
 
     let route = outbound::HttpRoute {
@@ -231,7 +230,6 @@ async fn header_based_routing() {
                 backends: Some(policy::http_first_available(std::iter::once(
                     policy::backend(&dst_world),
                 ))),
-                failure_policy: None,
             },
             // x-hello-city: sf | x-hello-city: san francisco
             mk_header_rule(
@@ -391,7 +389,6 @@ async fn path_based_routing() {
             backends: Some(policy::http_first_available(std::iter::once(
                 policy::backend(dst),
             ))),
-            failure_policy: None,
         };
 
     let route = outbound::HttpRoute {
@@ -405,7 +402,6 @@ async fn path_based_routing() {
                 backends: Some(policy::http_first_available(std::iter::once(
                     policy::backend(&dst_world),
                 ))),
-                failure_policy: None,
             },
             // /goodbye/*
             mk_path_rule(

--- a/linkerd/app/integration/src/tests/client_policy.rs
+++ b/linkerd/app/integration/src/tests/client_policy.rs
@@ -60,9 +60,11 @@ async fn empty_http1_route() {
                                 hosts: Vec::new(),
                                 rules: Vec::new(),
                             }],
+                            breaker: None,
                         }),
                         http2: Some(proxy_protocol::Http2 {
                             routes: vec![policy::outbound_default_http_route(&dst)],
+                            breaker: None,
                         }),
                         opaque: Some(proxy_protocol::Opaque {
                             routes: vec![policy::outbound_default_opaque_route(&dst)],
@@ -140,6 +142,7 @@ async fn empty_http2_route() {
                         timeout: Some(Duration::from_secs(10).try_into().unwrap()),
                         http1: Some(proxy_protocol::Http1 {
                             routes: vec![policy::outbound_default_http_route(&dst)],
+                            breaker: None,
                         }),
                         http2: Some(proxy_protocol::Http2 {
                             routes: vec![outbound::HttpRoute {
@@ -147,6 +150,7 @@ async fn empty_http2_route() {
                                 hosts: Vec::new(),
                                 rules: Vec::new(),
                             }],
+                            breaker: None,
                         }),
                         opaque: Some(proxy_protocol::Opaque {
                             routes: vec![policy::outbound_default_opaque_route(&dst)],
@@ -213,6 +217,7 @@ async fn header_based_routing() {
             backends: Some(policy::http_first_available(std::iter::once(
                 policy::backend(dst),
             ))),
+            failure_policy: None,
         };
 
     let route = outbound::HttpRoute {
@@ -226,6 +231,7 @@ async fn header_based_routing() {
                 backends: Some(policy::http_first_available(std::iter::once(
                     policy::backend(&dst_world),
                 ))),
+                failure_policy: None,
             },
             // x-hello-city: sf | x-hello-city: san francisco
             mk_header_rule(
@@ -251,9 +257,11 @@ async fn header_based_routing() {
                         timeout: Some(Duration::from_secs(10).try_into().unwrap()),
                         http1: Some(proxy_protocol::Http1 {
                             routes: vec![route.clone()],
+                            breaker: None,
                         }),
                         http2: Some(proxy_protocol::Http2 {
                             routes: vec![route],
+                            breaker: None,
                         }),
                         opaque: Some(proxy_protocol::Opaque {
                             routes: vec![policy::outbound_default_opaque_route(&dst_world)],
@@ -383,6 +391,7 @@ async fn path_based_routing() {
             backends: Some(policy::http_first_available(std::iter::once(
                 policy::backend(dst),
             ))),
+            failure_policy: None,
         };
 
     let route = outbound::HttpRoute {
@@ -396,6 +405,7 @@ async fn path_based_routing() {
                 backends: Some(policy::http_first_available(std::iter::once(
                     policy::backend(&dst_world),
                 ))),
+                failure_policy: None,
             },
             // /goodbye/*
             mk_path_rule(
@@ -426,9 +436,11 @@ async fn path_based_routing() {
                         timeout: Some(Duration::from_secs(10).try_into().unwrap()),
                         http1: Some(proxy_protocol::Http1 {
                             routes: vec![route.clone()],
+                            breaker: None,
                         }),
                         http2: Some(proxy_protocol::Http2 {
                             routes: vec![route],
+                            breaker: None,
                         }),
                         opaque: Some(proxy_protocol::Opaque {
                             routes: vec![policy::outbound_default_opaque_route(&dst_world)],

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -149,13 +149,9 @@ pub mod proto {
                 .into_iter()
                 .map(try_route)
                 .collect::<Result<Arc<[_]>, _>>()?;
-            let failure_accrual = match proto.failure_accrual {
-                Some(accrual) => accrual.try_into()?,
-                None => FailureAccrual::None,
-            };
             Ok(Self {
                 routes,
-                failure_accrual,
+                failure_accrual: proto.failure_accrual.try_into()?,
             })
         }
     }

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -83,7 +83,9 @@ impl Default for Codes {
 pub mod proto {
     use super::*;
     use crate::{
-        proto::{BackendSet, InvalidBackend, InvalidBreaker, InvalidDistribution, InvalidMeta},
+        proto::{
+            BackendSet, InvalidBackend, InvalidDistribution, InvalidFailureAccrual, InvalidMeta,
+        },
         Meta, RouteBackend, RouteDistribution,
     };
     use linkerd2_proxy_api::outbound::{self, grpc_route};
@@ -120,8 +122,8 @@ pub mod proto {
         #[error("missing {0}")]
         Missing(&'static str),
 
-        #[error("invalid breaker: {0}")]
-        Breaker(#[from] InvalidBreaker),
+        #[error("invalid failure accrual policy: {0}")]
+        Breaker(#[from] InvalidFailureAccrual),
     }
 
     #[derive(Debug, thiserror::Error)]
@@ -147,7 +149,7 @@ pub mod proto {
                 .into_iter()
                 .map(try_route)
                 .collect::<Result<Arc<[_]>, _>>()?;
-            let failure_accrual = match proto.breaker {
+            let failure_accrual = match proto.failure_accrual {
                 Some(accrual) => accrual.try_into()?,
                 None => FailureAccrual::None,
             };

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -219,6 +219,11 @@ pub mod proto {
             .ok_or(InvalidGrpcRoute::Missing("distribution"))?
             .try_into()?;
 
+        let failure_policy = match failure_policy {
+            Some(policy) => policy.try_into()?,
+            None => Codes::default(),
+        };
+
         Ok(Rule {
             matches,
             policy: Policy {

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -120,9 +120,6 @@ pub mod proto {
         #[error("missing {0}")]
         Missing(&'static str),
 
-        #[error("invalid failure policy: {0}")]
-        FailurePolicy(#[from] InvalidFailurePolicy),
-
         #[error("invalid breaker: {0}")]
         Breaker(#[from] InvalidBreaker),
     }
@@ -218,11 +215,6 @@ pub mod proto {
         let distribution = backends
             .ok_or(InvalidGrpcRoute::Missing("distribution"))?
             .try_into()?;
-
-        let failure_policy = match failure_policy {
-            Some(policy) => policy.try_into()?,
-            None => Codes::default(),
-        };
 
         Ok(Rule {
             matches,

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -123,9 +123,6 @@ pub mod proto {
         #[error("invalid filter: {0}")]
         Filter(#[from] InvalidFilter),
 
-        #[error("invalid failure policy: {0}")]
-        FailurePolicy(#[from] InvalidFailurePolicy),
-
         #[error("invalid breaker: {0}")]
         Breaker(#[from] InvalidBreaker),
 

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -163,13 +163,9 @@ pub mod proto {
                 .into_iter()
                 .map(try_route)
                 .collect::<Result<Arc<[_]>, _>>()?;
-            let failure_accrual = match proto.failure_accrual {
-                Some(accrual) => accrual.try_into()?,
-                None => FailureAccrual::None,
-            };
             Ok(Self {
                 routes,
-                failure_accrual,
+                failure_accrual: proto.failure_accrual.try_into()?,
             })
         }
     }
@@ -182,13 +178,9 @@ pub mod proto {
                 .into_iter()
                 .map(try_route)
                 .collect::<Result<Arc<[_]>, _>>()?;
-            let failure_accrual = match proto.failure_accrual {
-                Some(accrual) => accrual.try_into()?,
-                None => FailureAccrual::None,
-            };
             Ok(Self {
                 routes,
-                failure_accrual,
+                failure_accrual: proto.failure_accrual.try_into()?,
             })
         }
     }

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -94,7 +94,9 @@ impl Default for StatusRanges {
 pub mod proto {
     use super::*;
     use crate::{
-        proto::{BackendSet, InvalidBackend, InvalidBreaker, InvalidDistribution, InvalidMeta},
+        proto::{
+            BackendSet, InvalidBackend, InvalidDistribution, InvalidFailureAccrual, InvalidMeta,
+        },
         Meta, RouteBackend, RouteDistribution,
     };
     use linkerd2_proxy_api::outbound::{self, http_route};
@@ -123,8 +125,8 @@ pub mod proto {
         #[error("invalid filter: {0}")]
         Filter(#[from] InvalidFilter),
 
-        #[error("invalid breaker: {0}")]
-        Breaker(#[from] InvalidBreaker),
+        #[error("invalid failure accrual policy: {0}")]
+        Breaker(#[from] InvalidFailureAccrual),
 
         #[error("missing {0}")]
         Missing(&'static str),
@@ -161,7 +163,7 @@ pub mod proto {
                 .into_iter()
                 .map(try_route)
                 .collect::<Result<Arc<[_]>, _>>()?;
-            let failure_accrual = match proto.breaker {
+            let failure_accrual = match proto.failure_accrual {
                 Some(accrual) => accrual.try_into()?,
                 None => FailureAccrual::None,
             };
@@ -180,7 +182,7 @@ pub mod proto {
                 .into_iter()
                 .map(try_route)
                 .collect::<Result<Arc<[_]>, _>>()?;
-            let failure_accrual = match proto.breaker {
+            let failure_accrual = match proto.failure_accrual {
                 Some(accrual) => accrual.try_into()?,
                 None => FailureAccrual::None,
             };

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -618,7 +618,6 @@ pub mod proto {
                     // TODO(eliza): if other failure accrual kinds are added
                     // that also use exponential backoffs, this could be factored out...
                     let outbound::ExponentialBackoff { min_backoff, max_backoff, jitter_ratio } =
-                        // TODO(eliza): should this be defaulted?
                         backoff.ok_or(InvalidFailureAccrual::Missing("consecutive failures backoff"))?;
                     let min = min_backoff
                         .ok_or(InvalidFailureAccrual::Missing("min_backoff"))?

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -624,20 +624,14 @@ pub mod proto {
                     } = backoff.ok_or(InvalidFailureAccrual::Missing(
                         "consecutive failures backoff",
                     ))?;
-                    let min = min_backoff
-                        .ok_or(InvalidFailureAccrual::Missing("min_backoff"))?
-                        .try_into()
-                        .map_err(|error| InvalidFailureAccrual::Duration {
-                            field: "max_backoff",
-                            error,
-                        })?;
-                    let max = max_backoff
-                        .ok_or(InvalidFailureAccrual::Missing("min_backoff"))?
-                        .try_into()
-                        .map_err(|error| InvalidFailureAccrual::Duration {
-                            field: "min_backoff",
-                            error,
-                        })?;
+
+                    let duration = |dur: Option<prost_types::Duration>, field: &'static str| {
+                        dur.ok_or(InvalidFailureAccrual::Missing(field))?
+                            .try_into()
+                            .map_err(|error| InvalidFailureAccrual::Duration { field, error })
+                    };
+                    let min = duration(min_backoff, "min_backoff")?;
+                    let max = duration(max_backoff, "max_backoff")?;
                     let backoff = linkerd_exp_backoff::ExponentialBackoff::try_new(
                         min,
                         max,

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -647,4 +647,13 @@ pub mod proto {
             }
         }
     }
+
+    impl TryFrom<Option<outbound::FailureAccrual>> for FailureAccrual {
+        type Error = InvalidFailureAccrual;
+        fn try_from(accrual: Option<outbound::FailureAccrual>) -> Result<Self, Self::Error> {
+            accrual
+                .map(Self::try_from)
+                .unwrap_or(Ok(FailureAccrual::None))
+        }
+    }
 }

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -628,14 +628,14 @@ pub mod proto {
                         .ok_or(InvalidFailureAccrual::Missing("min_backoff"))?
                         .try_into()
                         .map_err(|error| InvalidFailureAccrual::Duration {
-                            field: "exponential backoff min",
+                            field: "max_backoff",
                             error,
                         })?;
                     let max = max_backoff
                         .ok_or(InvalidFailureAccrual::Missing("min_backoff"))?
                         .try_into()
                         .map_err(|error| InvalidFailureAccrual::Duration {
-                            field: "exponential backoff min",
+                            field: "min_backoff",
                             error,
                         })?;
                     let backoff = linkerd_exp_backoff::ExponentialBackoff::try_new(

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -617,8 +617,13 @@ pub mod proto {
                 }) => {
                     // TODO(eliza): if other failure accrual kinds are added
                     // that also use exponential backoffs, this could be factored out...
-                    let outbound::ExponentialBackoff { min_backoff, max_backoff, jitter_ratio } =
-                        backoff.ok_or(InvalidFailureAccrual::Missing("consecutive failures backoff"))?;
+                    let outbound::ExponentialBackoff {
+                        min_backoff,
+                        max_backoff,
+                        jitter_ratio,
+                    } = backoff.ok_or(InvalidFailureAccrual::Missing(
+                        "consecutive failures backoff",
+                    ))?;
                     let min = min_backoff
                         .ok_or(InvalidFailureAccrual::Missing("min_backoff"))?
                         .try_into()


### PR DESCRIPTION
This branch updates the proxy to configure failure accrual policies from
the OutboundPolicy API. It updates the dependency on
`linkerd2-proxy-api` to include changes from
linkerd/linkerd2-proxy-api#223, which adds failure accrual configuration
to the `Protocol::Http1`, `Protocol::Http2`, and `Protocol::Grpc`
variants.

Currently, `ConsecutiveFailures` (added in #2357) is the only supported
failure accrual policy. If the proxy API does not configure a failure
accrual policy, failures are not accrued, and endpoints do not become
unavailable due to failure accrual.