### PR TITLE
outbound: Report per-route-backend request count metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,6 +1032,7 @@ dependencies = [
 name = "linkerd-app-outbound"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bytes",
  "futures",
  "http",
@@ -1882,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.8.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#afd13fc7d5a592acd31b4ba822f854e5590e9600"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=main#afca924a6df2434196e85a265ffb7c15a547a8fa"
 dependencies = [
  "h2",
  "http",

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -76,7 +76,7 @@ impl Config {
         policy: impl inbound::policy::GetPolicy,
         identity: identity::Server,
         report: R,
-        metrics: inbound::Metrics,
+        metrics: inbound::InboundMetrics,
         trace: trace::Handle,
         drain: drain::Watch,
         shutdown: mpsc::UnboundedSender<()>,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -17,7 +17,7 @@ mod server;
 #[cfg(any(test, feature = "test-util", fuzzing))]
 pub mod test_util;
 
-pub use self::{metrics::Metrics, policy::DefaultPolicy};
+pub use self::{metrics::InboundMetrics, policy::DefaultPolicy};
 use linkerd_app_core::{
     config::{ConnectConfig, ProxyConfig, QueueConfig},
     drain,
@@ -63,7 +63,7 @@ pub struct Inbound<S> {
 
 #[derive(Clone)]
 struct Runtime {
-    metrics: Metrics,
+    metrics: InboundMetrics,
     identity: identity::creds::Receiver,
     tap: tap::Registry,
     span_sink: OpenCensusSink,
@@ -150,7 +150,7 @@ impl<S> Inbound<S> {
 impl Inbound<()> {
     pub fn new(config: Config, runtime: ProxyRuntime) -> Self {
         let runtime = Runtime {
-            metrics: Metrics::new(runtime.metrics),
+            metrics: InboundMetrics::new(runtime.metrics),
             identity: runtime.identity,
             tap: runtime.tap,
             span_sink: runtime.span_sink,
@@ -170,7 +170,7 @@ impl Inbound<()> {
         (this, drain)
     }
 
-    pub fn metrics(&self) -> Metrics {
+    pub fn metrics(&self) -> InboundMetrics {
         self.runtime.metrics.clone()
     }
 

--- a/linkerd/app/inbound/src/metrics.rs
+++ b/linkerd/app/inbound/src/metrics.rs
@@ -15,7 +15,7 @@ pub use linkerd_app_core::metrics::*;
 
 /// Holds outbound proxy metrics.
 #[derive(Clone, Debug)]
-pub struct Metrics {
+pub struct InboundMetrics {
     pub http_authz: authz::HttpAuthzMetrics,
     pub http_errors: error::HttpErrorMetrics,
 
@@ -27,7 +27,7 @@ pub struct Metrics {
     pub proxy: Proxy,
 }
 
-impl Metrics {
+impl InboundMetrics {
     pub(crate) fn new(proxy: Proxy) -> Self {
         Self {
             http_authz: authz::HttpAuthzMetrics::default(),
@@ -39,7 +39,7 @@ impl Metrics {
     }
 }
 
-impl FmtMetrics for Metrics {
+impl FmtMetrics for InboundMetrics {
     fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.http_authz.fmt_metrics(f)?;
         self.http_errors.fmt_metrics(f)?;

--- a/linkerd/app/integration/src/policy.rs
+++ b/linkerd/app/integration/src/policy.rs
@@ -111,6 +111,9 @@ pub fn outbound_default(dst: impl ToString) -> outbound::OutboundPolicy {
     let dst = dst.to_string();
     let route = outbound_default_http_route(dst.clone());
     outbound::OutboundPolicy {
+        metadata: Some(api::meta::Metadata {
+            kind: Some(api::meta::metadata::Kind::Default("default".to_string())),
+        }),
         protocol: Some(outbound::ProxyProtocol {
             kind: Some(proxy_protocol::Kind::Detect(proxy_protocol::Detect {
                 timeout: Some(Duration::from_secs(10).try_into().unwrap()),

--- a/linkerd/app/integration/src/tests/client_policy.rs
+++ b/linkerd/app/integration/src/tests/client_policy.rs
@@ -51,6 +51,9 @@ async fn empty_http1_route() {
         .outbound(
             srv.addr,
             outbound::OutboundPolicy {
+                metadata: Some(api::meta::Metadata {
+                    kind: Some(api::meta::metadata::Kind::Default("test".to_string())),
+                }),
                 protocol: Some(outbound::ProxyProtocol {
                     kind: Some(proxy_protocol::Kind::Detect(proxy_protocol::Detect {
                         timeout: Some(Duration::from_secs(10).try_into().unwrap()),
@@ -137,6 +140,9 @@ async fn empty_http2_route() {
         .outbound(
             srv.addr,
             outbound::OutboundPolicy {
+                metadata: Some(api::meta::Metadata {
+                    kind: Some(api::meta::metadata::Kind::Default("test".to_string())),
+                }),
                 protocol: Some(outbound::ProxyProtocol {
                     kind: Some(proxy_protocol::Kind::Detect(proxy_protocol::Detect {
                         timeout: Some(Duration::from_secs(10).try_into().unwrap()),
@@ -250,6 +256,9 @@ async fn header_based_routing() {
         .outbound(
             srv.addr,
             outbound::OutboundPolicy {
+                metadata: Some(api::meta::Metadata {
+                    kind: Some(api::meta::metadata::Kind::Default("test".to_string())),
+                }),
                 protocol: Some(outbound::ProxyProtocol {
                     kind: Some(proxy_protocol::Kind::Detect(proxy_protocol::Detect {
                         timeout: Some(Duration::from_secs(10).try_into().unwrap()),
@@ -427,6 +436,9 @@ async fn path_based_routing() {
         .outbound(
             srv.addr,
             outbound::OutboundPolicy {
+                metadata: Some(api::meta::Metadata {
+                    kind: Some(api::meta::metadata::Kind::Default("test".to_string())),
+                }),
                 protocol: Some(outbound::ProxyProtocol {
                     kind: Some(proxy_protocol::Kind::Detect(proxy_protocol::Detect {
                         timeout: Some(Duration::from_secs(10).try_into().unwrap()),

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -16,6 +16,7 @@ test-subscriber = []
 test-util = ["linkerd-app-test", "linkerd-meshtls-rustls/test-util"]
 
 [dependencies]
+ahash = "0.8"
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -248,6 +248,7 @@ pub fn synthesize_forward_policy(
     };
 
     ClientPolicy {
+        parent: meta.clone(),
         protocol: detect,
         backends: Arc::new([backend]),
     }

--- a/linkerd/app/outbound/src/http/logical/policy.rs
+++ b/linkerd/app/outbound/src/http/logical/policy.rs
@@ -8,7 +8,7 @@ mod router;
 mod tests;
 
 pub use self::{
-    route::errors,
+    route::{backend::RouteBackendMetrics, errors},
     router::{GrpcParams, HttpParams},
 };
 pub use linkerd_proxy_client_policy::{ClientPolicy, FailureAccrual};
@@ -45,11 +45,17 @@ where
     // Parent target type.
     T: Debug + Eq + Hash,
     T: Clone + Send + Sync + 'static,
+    route::backend::ExtractMetrics:
+        svc::ExtractParam<route::backend::RequestCount, route::backend::Http<T>>,
+    // route::backend::ExtractMetrics:
+    //     svc::ExtractParam<route::backend::RequestCount, route::backend::Grpc<T>>,
 {
     /// Builds a stack that dynamically updates and applies HTTP or gRPC policy
     /// routing configurations to route requests over cached inner backend
     /// services.
-    pub(super) fn layer<N, S>() -> impl svc::Layer<
+    pub(super) fn layer<N, S>(
+        route_backend_metrics: RouteBackendMetrics,
+    ) -> impl svc::Layer<
         N,
         Service = svc::ArcNewService<
             Self,
@@ -73,9 +79,10 @@ where
         S: Clone + Send + Sync + 'static,
         S::Future: Send,
     {
-        svc::layer::mk(|inner: N| {
-            let http = svc::stack(inner.clone()).push(router::Http::layer());
-            let grpc = svc::stack(inner).push(router::Grpc::layer());
+        svc::layer::mk(move |inner: N| {
+            let http =
+                svc::stack(inner.clone()).push(router::Http::layer(route_backend_metrics.clone()));
+            let grpc = svc::stack(inner).push(router::Grpc::layer(route_backend_metrics.clone()));
 
             http.push_switch(
                 |pp: Policy<T>| {

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -4,8 +4,17 @@ use linkerd_http_route as http_route;
 use linkerd_proxy_client_policy as policy;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
 
+mod count_reqs;
+mod metrics;
+
+pub use self::{
+    count_reqs::RequestCount,
+    metrics::{RouteBackendMeta, RouteBackendMetrics},
+};
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub(crate) struct Backend<T, F> {
+    pub(crate) meta: RouteBackendMeta,
     pub(crate) concrete: Concrete<T>,
     pub(crate) filters: Arc<[F]>,
 }
@@ -16,11 +25,17 @@ pub(crate) type Http<T> =
 pub(crate) type Grpc<T> =
     MatchedBackend<T, http_route::grpc::r#match::RouteMatch, policy::grpc::Filter>;
 
+#[derive(Clone, Debug)]
+pub struct ExtractMetrics {
+    metrics: RouteBackendMetrics,
+}
+
 // === impl Backend ===
 
 impl<T: Clone, F> Clone for Backend<T, F> {
     fn clone(&self) -> Self {
         Self {
+            meta: self.meta.clone(),
             filters: self.filters.clone(),
             concrete: self.concrete.clone(),
         }
@@ -51,13 +66,16 @@ where
     F: Clone + Send + Sync + 'static,
     // Assert that filters can be applied.
     Self: filters::Apply,
+    ExtractMetrics: svc::ExtractParam<RequestCount, Self>,
 {
     /// Builds a stack that applies per-route-backend policy filters over an
     /// inner [`Concrete`] stack.
     ///
     /// This [`MatchedBackend`] must implement [`filters::Apply`] to apply these
     /// filters.
-    pub(crate) fn layer<N, S>() -> impl svc::Layer<
+    pub(crate) fn layer<N, S>(
+        metrics: RouteBackendMetrics,
+    ) -> impl svc::Layer<
         N,
         Service = svc::ArcNewService<
             Self,
@@ -81,15 +99,18 @@ where
         S: Clone + Send + Sync + 'static,
         S::Future: Send,
     {
-        svc::layer::mk(|inner| {
+        svc::layer::mk(move |inner| {
             svc::stack(inner)
                 .push_map_target(
-                    |MatchedBackend {
+                    |Self {
                          params: Backend { concrete, .. },
                          ..
                      }| concrete,
                 )
                 .push(filters::NewApplyFilters::<Self, _, _>::layer())
+                .push(count_reqs::NewCountRequests::layer_via(ExtractMetrics {
+                    metrics: metrics.clone(),
+                }))
                 .push(svc::ArcNewService::layer())
                 .into_inner()
         })
@@ -107,5 +128,17 @@ impl<T> filters::Apply for Grpc<T> {
     #[inline]
     fn apply<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
         filters::apply_grpc(&self.r#match, &self.params.filters, req)
+    }
+}
+
+impl<T> svc::ExtractParam<RequestCount, Http<T>> for ExtractMetrics {
+    fn extract_param(&self, params: &Http<T>) -> RequestCount {
+        RequestCount(self.metrics.http_requests_total(params.params.meta.clone()))
+    }
+}
+
+impl<T> svc::ExtractParam<RequestCount, Grpc<T>> for ExtractMetrics {
+    fn extract_param(&self, params: &Grpc<T>) -> RequestCount {
+        RequestCount(self.metrics.grpc_requests_total(params.params.meta.clone()))
     }
 }

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/count_reqs.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/count_reqs.rs
@@ -1,0 +1,73 @@
+use linkerd_app_core::{metrics::Counter, svc};
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct RequestCount(pub Arc<Counter>);
+
+#[derive(Clone, Debug)]
+pub struct NewCountRequests<X, N> {
+    inner: N,
+    extract: X,
+}
+
+#[derive(Clone, Debug)]
+pub struct CountRequests<S> {
+    inner: S,
+    requests: Arc<Counter>,
+}
+
+// === impl NewCountRequests ===
+
+impl<X: Clone, N> NewCountRequests<X, N> {
+    pub fn new(extract: X, inner: N) -> Self {
+        Self { extract, inner }
+    }
+
+    pub fn layer_via(extract: X) -> impl svc::Layer<N, Service = Self> + Clone {
+        svc::layer::mk(move |inner| Self::new(extract.clone(), inner))
+    }
+}
+
+impl<T, X, N> svc::NewService<T> for NewCountRequests<X, N>
+where
+    X: svc::ExtractParam<RequestCount, T>,
+    N: svc::NewService<T>,
+{
+    type Service = CountRequests<N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let RequestCount(counter) = self.extract.extract_param(&target);
+        let inner = self.inner.new_service(target);
+        CountRequests::new(counter, inner)
+    }
+}
+
+// === impl CountRequests ===
+
+impl<S> CountRequests<S> {
+    fn new(requests: Arc<Counter>, inner: S) -> Self {
+        Self { requests, inner }
+    }
+}
+
+impl<B, S> svc::Service<http::Request<B>> for CountRequests<S>
+where
+    S: svc::Service<http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        self.requests.incr();
+        self.inner.call(req)
+    }
+}

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -1,0 +1,86 @@
+use ahash::AHashMap;
+use linkerd_app_core::metrics::{metrics, Counter, FmtLabels, FmtMetrics};
+use linkerd_proxy_client_policy as policy;
+use parking_lot::Mutex;
+use std::{fmt::Write, sync::Arc};
+
+metrics! {
+    outbound_http_route_backend_requests_total: Counter {
+        "The total number of outbound requests dispatched to a HTTP route backend"
+    },
+    outbound_grpc_route_backend_requests_total: Counter {
+        "The total number of outbound requests dispatched to a gRPC route backend"
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct RouteBackendMeta {
+    pub parent: Arc<policy::Meta>,
+    pub route: Arc<policy::Meta>,
+    pub backend: Arc<policy::Meta>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RouteBackendMetrics {
+    http: Arc<Mutex<AHashMap<RouteBackendMeta, Arc<Counter>>>>,
+    grpc: Arc<Mutex<AHashMap<RouteBackendMeta, Arc<Counter>>>>,
+}
+
+// === impl RouteBackendMetrics ===
+
+impl RouteBackendMetrics {
+    pub fn http_requests_total(&self, meta: RouteBackendMeta) -> Arc<Counter> {
+        self.http.lock().entry(meta).or_default().clone()
+    }
+
+    pub fn grpc_requests_total(&self, meta: RouteBackendMeta) -> Arc<Counter> {
+        self.grpc.lock().entry(meta).or_default().clone()
+    }
+}
+
+impl FmtMetrics for RouteBackendMetrics {
+    fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let http = self.http.lock();
+        if !http.is_empty() {
+            outbound_http_route_backend_requests_total.fmt_help(f)?;
+            outbound_http_route_backend_requests_total.fmt_scopes(f, http.iter(), |c| c)?;
+        }
+        drop(http);
+
+        let grpc = self.grpc.lock();
+        if !grpc.is_empty() {
+            outbound_grpc_route_backend_requests_total.fmt_help(f)?;
+            outbound_grpc_route_backend_requests_total.fmt_scopes(f, grpc.iter(), |c| c)?;
+        }
+        drop(grpc);
+
+        Ok(())
+    }
+}
+
+impl FmtLabels for RouteBackendMeta {
+    fn fmt_labels(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Self::write_meta("parent", &self.parent, f)?;
+        f.write_char(',')?;
+
+        Self::write_meta("route", &self.route, f)?;
+        f.write_char(',')?;
+
+        Self::write_meta("backend", &self.backend, f)?;
+        Ok(())
+    }
+}
+
+impl RouteBackendMeta {
+    fn write_meta(
+        scope: &str,
+        meta: &policy::Meta,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "{scope}_group=\"{}\"", meta.group())?;
+        write!(f, ",{scope}_kind=\"{}\"", meta.kind())?;
+        write!(f, ",{scope}_namespace=\"{}\"", meta.namespace())?;
+        write!(f, ",{scope}_name=\"{}\"", meta.name())?;
+        Ok(())
+    }
+}

--- a/linkerd/app/outbound/src/http/logical/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/tests.rs
@@ -33,6 +33,7 @@ async fn routes() {
     let (_route_tx, routes) =
         watch::channel(Routes::Policy(policy::Params::Http(policy::HttpParams {
             addr: dest.into(),
+            meta: client_policy::Meta::new_default("parent"),
             backends: Arc::new([backend.clone()]),
             routes: Arc::new([default_route(backend)]),
             failure_accrual: client_policy::FailureAccrual::None,
@@ -90,6 +91,7 @@ async fn consecutive_failures_accrue() {
     let (_route_tx, routes) =
         watch::channel(Routes::Policy(policy::Params::Http(policy::HttpParams {
             addr: dest.into(),
+            meta: client_policy::Meta::new_default("parent"),
             backends: Arc::new([backend.clone()]),
             routes: Arc::new([default_route(backend)]),
             failure_accrual: client_policy::FailureAccrual::ConsecutiveFailures {

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -424,6 +424,7 @@ fn policy_routes(
             Some(http::Routes::Policy(http::policy::Params::Http(
                 http::policy::HttpParams {
                     addr,
+                    meta: policy.parent.clone(),
                     backends: policy.backends.clone(),
                     routes,
                     failure_accrual,
@@ -439,6 +440,7 @@ fn policy_routes(
         }) => Some(http::Routes::Policy(http::policy::Params::Http(
             http::policy::HttpParams {
                 addr,
+                meta: policy.parent.clone(),
                 backends: policy.backends.clone(),
                 routes: routes.clone(),
                 failure_accrual,
@@ -450,6 +452,7 @@ fn policy_routes(
         }) => Some(http::Routes::Policy(http::policy::Params::Http(
             http::policy::HttpParams {
                 addr,
+                meta: policy.parent.clone(),
                 backends: policy.backends.clone(),
                 routes: routes.clone(),
                 failure_accrual,
@@ -461,6 +464,7 @@ fn policy_routes(
         }) => Some(http::Routes::Policy(http::policy::Params::Grpc(
             http::policy::GrpcParams {
                 addr,
+                meta: policy.parent.clone(),
                 backends: policy.backends.clone(),
                 routes: routes.clone(),
                 failure_accrual,

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -46,7 +46,7 @@ pub mod test_util;
 
 pub use self::{
     discover::{spawn_synthesized_profile_policy, synthesize_forward_policy, Discovery},
-    metrics::Metrics,
+    metrics::OutboundMetrics,
 };
 
 #[derive(Clone, Debug)]
@@ -91,7 +91,7 @@ pub struct Outbound<S> {
 
 #[derive(Clone, Debug)]
 struct Runtime {
-    metrics: Metrics,
+    metrics: OutboundMetrics,
     identity: identity::NewClient,
     tap: tap::Registry,
     span_sink: OpenCensusSink,
@@ -105,7 +105,7 @@ pub type ConnectMeta = tls::ConnectMeta<Local<ClientAddr>>;
 impl Outbound<()> {
     pub fn new(config: Config, runtime: ProxyRuntime) -> Self {
         let runtime = Runtime {
-            metrics: Metrics::new(runtime.metrics),
+            metrics: OutboundMetrics::new(runtime.metrics),
             identity: runtime.identity.new_client(),
             tap: runtime.tap,
             span_sink: runtime.span_sink,
@@ -156,7 +156,7 @@ impl<S> Outbound<S> {
         &mut self.config
     }
 
-    pub fn metrics(&self) -> Metrics {
+    pub fn metrics(&self) -> OutboundMetrics {
         self.runtime.metrics.clone()
     }
 

--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -8,33 +8,39 @@
 //! to be updated frequently or in a performance-critical area. We should probably look to use
 //! `DashMap` as we migrate other metrics registries.
 
+use crate::http::policy::RouteBackendMetrics;
+
 pub(crate) mod error;
 
 pub use linkerd_app_core::metrics::*;
 
 /// Holds outbound proxy metrics.
 #[derive(Clone, Debug)]
-pub struct Metrics {
+pub struct OutboundMetrics {
     pub(crate) http_errors: error::Http,
     pub(crate) tcp_errors: error::Tcp,
+
+    pub(crate) http_route_backends: RouteBackendMetrics,
 
     /// Holds metrics that are common to both inbound and outbound proxies. These metrics are
     /// reported separately
     pub(crate) proxy: Proxy,
 }
 
-impl Metrics {
+impl OutboundMetrics {
     pub(crate) fn new(proxy: Proxy) -> Self {
         Self {
+            proxy,
             http_errors: error::Http::default(),
             tcp_errors: error::Tcp::default(),
-            proxy,
+            http_route_backends: RouteBackendMetrics::default(),
         }
     }
 }
 
-impl FmtMetrics for Metrics {
+impl FmtMetrics for OutboundMetrics {
     fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.http_route_backends.fmt_metrics(f)?;
         self.http_errors.fmt_metrics(f)?;
         self.tcp_errors.fmt_metrics(f)?;
 

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -236,6 +236,7 @@ impl HttpSidecar {
                 return Some(http::Routes::Policy(http::policy::Params::Grpc(
                     http::policy::GrpcParams {
                         addr: orig_dst.into(),
+                        meta: policy.parent.clone(),
                         backends: policy.backends.clone(),
                         routes: routes.clone(),
                         failure_accrual,
@@ -253,6 +254,7 @@ impl HttpSidecar {
         Some(http::Routes::Policy(http::policy::Params::Http(
             http::policy::HttpParams {
                 addr: orig_dst.into(),
+                meta: policy.parent.clone(),
                 routes,
                 backends: policy.backends.clone(),
                 failure_accrual,

--- a/linkerd/app/test/src/resolver/client_policy.rs
+++ b/linkerd/app/test/src/resolver/client_policy.rs
@@ -38,6 +38,8 @@ impl ClientPolicies {
     pub fn policy_default(self, addr: impl Into<Addr>) -> Self {
         let addr = addr.into();
 
+        let parent = Meta::new_default(addr.to_string());
+
         let backend = {
             let dispatcher = match addr {
                 Addr::Name(ref addr) => {
@@ -102,8 +104,9 @@ impl ClientPolicies {
             },
         };
         let policy = ClientPolicy {
-            backends: Arc::new([backend]),
+            parent,
             protocol,
+            backends: Arc::new([backend]),
         };
         self.policy(addr, policy)
     }


### PR DESCRIPTION
When performing policy-based routing, proxies may dispatch requests through per-route backend configurations. In order to illustrate how routing rules apply and how backend distributions are being honored, this change adds two new metrics:

* `outbound_http_route_backend_requests_total`; and
* `outbound_grpc_route_backend_requests_total`

Each of these metrics includes labels that identify a routes parent (i.e. a Service), the route resource being used, and the backend resource being used.

This implementation does NOT implement any form of metrics eviction for these new metrics. This is tolerable for the short term as the cardinality of services and routes is generally much less than the cardinality of individual endpoints (where we do require timeout/eviction for metrics).