### PR TITLE
outbound: Emit INFO-level logs on failure accrual changes

### DIFF
--- a/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
+++ b/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
@@ -33,7 +33,7 @@ impl ConsecutiveFailures {
                 return;
             }
 
-            tracing::info!("Consecutive failure-accrual breaker tripped");
+            tracing::info!("Consecutive failure-accrual breaker closed");
             if self.closed().await.is_err() {
                 return;
             }

--- a/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
+++ b/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
@@ -33,9 +33,12 @@ impl ConsecutiveFailures {
                 return;
             }
 
+            tracing::info!("Consecutive failure-accrual breaker tripped");
             if self.closed().await.is_err() {
                 return;
             }
+
+            tracing::info!("Consecutive failure-accrual breaker reopened");
         }
     }
 


### PR DESCRIPTION
There are no explicit indications of failure accrual related behavior.

This change adds INFO-level logs when a failure accrual breaker is
tripped or reeopened. These log messages are scoped within the
'endpoint' log context so that log lines include endpoint and balancer
addresses.

    INFO balance{addr=logical.test.svc.cluster.local:666}:endpoint{addr=192.0.2.41:666}:consecutive_failures: linkerd_app_outbound::http::breaker::consecutive_failures: Consecutive failure-accrual breaker closed
    INFO balance{addr=logical.test.svc.cluster.local:666}:endpoint{addr=192.0.2.41:666}:consecutive_failures: linkerd_app_outbound::http::breaker::consecutive_failures: Consecutive failure-accrual breaker reopened