### PR TITLE
app: Rename Metrics types as InboundMetrics and OutboundMetrics

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -76,7 +76,7 @@ impl Config {
         policy: impl inbound::policy::GetPolicy,
         identity: identity::Server,
         report: R,
-        metrics: inbound::Metrics,
+        metrics: inbound::InboundMetrics,
         trace: trace::Handle,
         drain: drain::Watch,
         shutdown: mpsc::UnboundedSender<()>,

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -17,7 +17,7 @@ mod server;
 #[cfg(any(test, feature = "test-util", fuzzing))]
 pub mod test_util;
 
-pub use self::{metrics::Metrics, policy::DefaultPolicy};
+pub use self::{metrics::InboundMetrics, policy::DefaultPolicy};
 use linkerd_app_core::{
     config::{ConnectConfig, ProxyConfig, QueueConfig},
     drain,
@@ -63,7 +63,7 @@ pub struct Inbound<S> {
 
 #[derive(Clone)]
 struct Runtime {
-    metrics: Metrics,
+    metrics: InboundMetrics,
     identity: identity::creds::Receiver,
     tap: tap::Registry,
     span_sink: OpenCensusSink,
@@ -150,7 +150,7 @@ impl<S> Inbound<S> {
 impl Inbound<()> {
     pub fn new(config: Config, runtime: ProxyRuntime) -> Self {
         let runtime = Runtime {
-            metrics: Metrics::new(runtime.metrics),
+            metrics: InboundMetrics::new(runtime.metrics),
             identity: runtime.identity,
             tap: runtime.tap,
             span_sink: runtime.span_sink,
@@ -170,7 +170,7 @@ impl Inbound<()> {
         (this, drain)
     }
 
-    pub fn metrics(&self) -> Metrics {
+    pub fn metrics(&self) -> InboundMetrics {
         self.runtime.metrics.clone()
     }
 

--- a/linkerd/app/inbound/src/metrics.rs
+++ b/linkerd/app/inbound/src/metrics.rs
@@ -15,7 +15,7 @@ pub use linkerd_app_core::metrics::*;
 
 /// Holds outbound proxy metrics.
 #[derive(Clone, Debug)]
-pub struct Metrics {
+pub struct InboundMetrics {
     pub http_authz: authz::HttpAuthzMetrics,
     pub http_errors: error::HttpErrorMetrics,
 
@@ -27,7 +27,7 @@ pub struct Metrics {
     pub proxy: Proxy,
 }
 
-impl Metrics {
+impl InboundMetrics {
     pub(crate) fn new(proxy: Proxy) -> Self {
         Self {
             http_authz: authz::HttpAuthzMetrics::default(),
@@ -39,7 +39,7 @@ impl Metrics {
     }
 }
 
-impl FmtMetrics for Metrics {
+impl FmtMetrics for InboundMetrics {
     fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.http_authz.fmt_metrics(f)?;
         self.http_errors.fmt_metrics(f)?;

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -46,7 +46,7 @@ pub mod test_util;
 
 pub use self::{
     discover::{spawn_synthesized_profile_policy, synthesize_forward_policy, Discovery},
-    metrics::Metrics,
+    metrics::OutboundMetrics,
 };
 
 #[derive(Clone, Debug)]
@@ -91,7 +91,7 @@ pub struct Outbound<S> {
 
 #[derive(Clone, Debug)]
 struct Runtime {
-    metrics: Metrics,
+    metrics: OutboundMetrics,
     identity: identity::NewClient,
     tap: tap::Registry,
     span_sink: OpenCensusSink,
@@ -105,7 +105,7 @@ pub type ConnectMeta = tls::ConnectMeta<Local<ClientAddr>>;
 impl Outbound<()> {
     pub fn new(config: Config, runtime: ProxyRuntime) -> Self {
         let runtime = Runtime {
-            metrics: Metrics::new(runtime.metrics),
+            metrics: OutboundMetrics::new(runtime.metrics),
             identity: runtime.identity.new_client(),
             tap: runtime.tap,
             span_sink: runtime.span_sink,
@@ -156,7 +156,7 @@ impl<S> Outbound<S> {
         &mut self.config
     }
 
-    pub fn metrics(&self) -> Metrics {
+    pub fn metrics(&self) -> OutboundMetrics {
         self.runtime.metrics.clone()
     }
 

--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -14,7 +14,7 @@ pub use linkerd_app_core::metrics::*;
 
 /// Holds outbound proxy metrics.
 #[derive(Clone, Debug)]
-pub struct Metrics {
+pub struct OutboundMetrics {
     pub(crate) http_errors: error::Http,
     pub(crate) tcp_errors: error::Tcp,
 
@@ -23,7 +23,7 @@ pub struct Metrics {
     pub(crate) proxy: Proxy,
 }
 
-impl Metrics {
+impl OutboundMetrics {
     pub(crate) fn new(proxy: Proxy) -> Self {
         Self {
             http_errors: error::Http::default(),
@@ -33,7 +33,7 @@ impl Metrics {
     }
 }
 
-impl FmtMetrics for Metrics {
+impl FmtMetrics for OutboundMetrics {
     fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.http_errors.fmt_metrics(f)?;
         self.tcp_errors.fmt_metrics(f)?;


### PR DESCRIPTION
This helps avoid a bug with rust-analyzer and is generally clearer.