### PR TITLE
outbound: Report per-route-backend request count metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,6 +1032,7 @@ dependencies = [
 name = "linkerd-app-outbound"
 version = "0.1.0"
 dependencies = [
+ "ahash",
  "bytes",
  "futures",
  "http",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -16,6 +16,7 @@ test-subscriber = []
 test-util = ["linkerd-app-test", "linkerd-meshtls-rustls/test-util"]
 
 [dependencies]
+ahash = "0.8"
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -162,7 +162,8 @@ where
         S::Future: Send,
     {
         svc::layer::mk(move |concrete: N| {
-            let policy = svc::stack(concrete.clone()).push(policy::Policy::layer());
+            let policy = svc::stack(concrete.clone())
+                .push(policy::Policy::layer(metrics.http_route_backends.clone()));
             let profile =
                 svc::stack(concrete.clone()).push(profile::Params::layer(metrics.proxy.clone()));
             svc::stack(concrete)

--- a/linkerd/app/outbound/src/http/logical/policy.rs
+++ b/linkerd/app/outbound/src/http/logical/policy.rs
@@ -8,7 +8,7 @@ mod router;
 mod tests;
 
 pub use self::{
-    route::errors,
+    route::{backend::RouteBackendMetrics, errors},
     router::{GrpcParams, HttpParams},
 };
 pub use linkerd_proxy_client_policy::{ClientPolicy, FailureAccrual};
@@ -49,7 +49,9 @@ where
     /// Builds a stack that dynamically updates and applies HTTP or gRPC policy
     /// routing configurations to route requests over cached inner backend
     /// services.
-    pub(super) fn layer<N, S>() -> impl svc::Layer<
+    pub(super) fn layer<N, S>(
+        route_backend_metrics: RouteBackendMetrics,
+    ) -> impl svc::Layer<
         N,
         Service = svc::ArcNewService<
             Self,
@@ -74,8 +76,9 @@ where
         S::Future: Send,
     {
         svc::layer::mk(move |inner: N| {
-            let http = svc::stack(inner.clone()).push(router::Http::layer());
-            let grpc = svc::stack(inner).push(router::Grpc::layer());
+            let http =
+                svc::stack(inner.clone()).push(router::Http::layer(route_backend_metrics.clone()));
+            let grpc = svc::stack(inner).push(router::Grpc::layer(route_backend_metrics.clone()));
 
             http.push_switch(
                 |pp: Policy<T>| {

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -1,11 +1,18 @@
 use super::{super::Concrete, filters};
+use crate::RouteRef;
 use linkerd_app_core::{proxy::http, svc, Error, Result};
 use linkerd_http_route as http_route;
 use linkerd_proxy_client_policy as policy;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
 
+mod count_reqs;
+mod metrics;
+
+pub use self::{count_reqs::RequestCount, metrics::RouteBackendMetrics};
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub(crate) struct Backend<T, F> {
+    pub(crate) route_ref: RouteRef,
     pub(crate) concrete: Concrete<T>,
     pub(crate) filters: Arc<[F]>,
 }
@@ -16,11 +23,17 @@ pub(crate) type Http<T> =
 pub(crate) type Grpc<T> =
     MatchedBackend<T, http_route::grpc::r#match::RouteMatch, policy::grpc::Filter>;
 
+#[derive(Clone, Debug)]
+pub struct ExtractMetrics {
+    metrics: RouteBackendMetrics,
+}
+
 // === impl Backend ===
 
 impl<T: Clone, F> Clone for Backend<T, F> {
     fn clone(&self) -> Self {
         Self {
+            route_ref: self.route_ref.clone(),
             filters: self.filters.clone(),
             concrete: self.concrete.clone(),
         }
@@ -51,13 +64,16 @@ where
     F: Clone + Send + Sync + 'static,
     // Assert that filters can be applied.
     Self: filters::Apply,
+    ExtractMetrics: svc::ExtractParam<RequestCount, Self>,
 {
     /// Builds a stack that applies per-route-backend policy filters over an
     /// inner [`Concrete`] stack.
     ///
     /// This [`MatchedBackend`] must implement [`filters::Apply`] to apply these
     /// filters.
-    pub(crate) fn layer<N, S>() -> impl svc::Layer<
+    pub(crate) fn layer<N, S>(
+        metrics: RouteBackendMetrics,
+    ) -> impl svc::Layer<
         N,
         Service = svc::ArcNewService<
             Self,
@@ -90,6 +106,9 @@ where
                      }| concrete,
                 )
                 .push(filters::NewApplyFilters::<Self, _, _>::layer())
+                .push(count_reqs::NewCountRequests::layer_via(ExtractMetrics {
+                    metrics: metrics.clone(),
+                }))
                 .push(svc::ArcNewService::layer())
                 .into_inner()
         })
@@ -107,5 +126,25 @@ impl<T> filters::Apply for Grpc<T> {
     #[inline]
     fn apply<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
         filters::apply_grpc(&self.r#match, &self.params.filters, req)
+    }
+}
+
+impl<T> svc::ExtractParam<RequestCount, Http<T>> for ExtractMetrics {
+    fn extract_param(&self, params: &Http<T>) -> RequestCount {
+        RequestCount(self.metrics.http_requests_total(
+            params.params.concrete.parent_ref.clone(),
+            params.params.route_ref.clone(),
+            params.params.concrete.backend_ref.clone(),
+        ))
+    }
+}
+
+impl<T> svc::ExtractParam<RequestCount, Grpc<T>> for ExtractMetrics {
+    fn extract_param(&self, params: &Grpc<T>) -> RequestCount {
+        RequestCount(self.metrics.grpc_requests_total(
+            params.params.concrete.parent_ref.clone(),
+            params.params.route_ref.clone(),
+            params.params.concrete.backend_ref.clone(),
+        ))
     }
 }

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/count_reqs.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/count_reqs.rs
@@ -1,0 +1,73 @@
+use linkerd_app_core::{metrics::Counter, svc};
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct RequestCount(pub Arc<Counter>);
+
+#[derive(Clone, Debug)]
+pub struct NewCountRequests<X, N> {
+    inner: N,
+    extract: X,
+}
+
+#[derive(Clone, Debug)]
+pub struct CountRequests<S> {
+    inner: S,
+    requests: Arc<Counter>,
+}
+
+// === impl NewCountRequests ===
+
+impl<X: Clone, N> NewCountRequests<X, N> {
+    pub fn new(extract: X, inner: N) -> Self {
+        Self { extract, inner }
+    }
+
+    pub fn layer_via(extract: X) -> impl svc::Layer<N, Service = Self> + Clone {
+        svc::layer::mk(move |inner| Self::new(extract.clone(), inner))
+    }
+}
+
+impl<T, X, N> svc::NewService<T> for NewCountRequests<X, N>
+where
+    X: svc::ExtractParam<RequestCount, T>,
+    N: svc::NewService<T>,
+{
+    type Service = CountRequests<N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let RequestCount(counter) = self.extract.extract_param(&target);
+        let inner = self.inner.new_service(target);
+        CountRequests::new(counter, inner)
+    }
+}
+
+// === impl CountRequests ===
+
+impl<S> CountRequests<S> {
+    fn new(requests: Arc<Counter>, inner: S) -> Self {
+        Self { requests, inner }
+    }
+}
+
+impl<B, S> svc::Service<http::Request<B>> for CountRequests<S>
+where
+    S: svc::Service<http::Request<B>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        self.requests.incr();
+        self.inner.call(req)
+    }
+}

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -1,0 +1,110 @@
+use ahash::AHashMap;
+use linkerd_app_core::metrics::{metrics, Counter, FmtLabels, FmtMetrics};
+use linkerd_proxy_client_policy as policy;
+use parking_lot::Mutex;
+use std::{fmt::Write, sync::Arc};
+
+use crate::{BackendRef, ParentRef, RouteRef};
+
+metrics! {
+    outbound_http_route_backend_requests_total: Counter {
+        "The total number of outbound requests dispatched to a HTTP route backend"
+    },
+    outbound_grpc_route_backend_requests_total: Counter {
+        "The total number of outbound requests dispatched to a gRPC route backend"
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct RouteBackendMetrics {
+    http: Arc<Mutex<AHashMap<Labels, Arc<Counter>>>>,
+    grpc: Arc<Mutex<AHashMap<Labels, Arc<Counter>>>>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct Labels(ParentRef, RouteRef, BackendRef);
+
+// === impl RouteBackendMetrics ===
+
+impl RouteBackendMetrics {
+    pub fn http_requests_total(&self, pr: ParentRef, rr: RouteRef, br: BackendRef) -> Arc<Counter> {
+        self.http
+            .lock()
+            .entry(Labels(pr, rr, br))
+            .or_default()
+            .clone()
+    }
+
+    pub fn grpc_requests_total(&self, pr: ParentRef, rr: RouteRef, br: BackendRef) -> Arc<Counter> {
+        self.grpc
+            .lock()
+            .entry(Labels(pr, rr, br))
+            .or_default()
+            .clone()
+    }
+}
+
+impl FmtMetrics for RouteBackendMetrics {
+    fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let http = self.http.lock();
+        if !http.is_empty() {
+            outbound_http_route_backend_requests_total.fmt_help(f)?;
+            outbound_http_route_backend_requests_total.fmt_scopes(f, http.iter(), |c| c)?;
+        }
+        drop(http);
+
+        let grpc = self.grpc.lock();
+        if !grpc.is_empty() {
+            outbound_grpc_route_backend_requests_total.fmt_help(f)?;
+            outbound_grpc_route_backend_requests_total.fmt_scopes(f, grpc.iter(), |c| c)?;
+        }
+        drop(grpc);
+
+        Ok(())
+    }
+}
+
+impl FmtLabels for Labels {
+    fn fmt_labels(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Labels(parent, route, backend) = self;
+
+        Self::write_extended_meta("parent", parent, f)?;
+        f.write_char(',')?;
+        Self::write_basic_meta("route", route, f)?;
+        f.write_char(',')?;
+        Self::write_extended_meta("backend", backend, f)?;
+
+        Ok(())
+    }
+}
+
+impl Labels {
+    fn write_basic_meta(
+        scope: &str,
+        meta: &policy::Meta,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        write!(f, "{scope}_group=\"{}\"", meta.group())?;
+        write!(f, ",{scope}_kind=\"{}\"", meta.kind())?;
+        write!(f, ",{scope}_namespace=\"{}\"", meta.namespace())?;
+        write!(f, ",{scope}_name=\"{}\"", meta.name())?;
+
+        Ok(())
+    }
+
+    fn write_extended_meta(
+        scope: &str,
+        meta: &policy::Meta,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> std::fmt::Result {
+        Self::write_basic_meta(scope, meta, f)?;
+
+        match meta.port() {
+            Some(port) => write!(f, ",{scope}_port=\"{port}\"")?,
+            None => write!(f, ",{scope}_port=\"\"")?,
+        }
+        write!(f, ",{scope}_section_name=\"{}\"", meta.section())?;
+
+        Ok(())
+    }
+}

--- a/linkerd/app/outbound/src/http/logical/policy/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/tests.rs
@@ -4,27 +4,48 @@ use linkerd_app_core::{
     svc::NewService,
     svc::{Layer, ServiceExt},
     trace,
-    transport::addrs::*,
 };
 use linkerd_http_route as route;
 use linkerd_proxy_client_policy as policy;
-use std::{net::SocketAddr, sync::Arc};
+use std::{num::NonZeroU16, sync::Arc};
 use tokio::time;
 
 #[tokio::test(flavor = "current_thread")]
 async fn header_based_route() {
     let _trace = trace::test::trace_init();
 
-    let mk_backend = |name: &'static str, addr: SocketAddr| policy::Backend {
-        meta: policy::Meta::new_default(name),
+    let mk_backend = |name: &'static str| policy::Backend {
+        meta: Arc::new(policy::Meta::Resource {
+            group: "core".into(),
+            kind: "Service".into(),
+            namespace: "ns".into(),
+            name: name.into(),
+            port: NonZeroU16::new(8080),
+            section: None,
+        }),
         queue: policy::Queue {
             capacity: 10,
             failfast_timeout: time::Duration::from_secs(1),
         },
-        dispatcher: policy::BackendDispatcher::Forward(addr, Default::default()),
+        dispatcher: policy::BackendDispatcher::BalanceP2c(
+            policy::Load::PeakEwma(policy::PeakEwma {
+                decay: time::Duration::from_secs(10),
+                default_rtt: time::Duration::from_millis(300),
+            }),
+            policy::EndpointDiscovery::DestinationGet {
+                path: format!("{name}.ns.svc.cluster.local:8080"),
+            },
+        ),
     };
     let mk_policy = |name: &'static str, backend: policy::Backend| policy::RoutePolicy {
-        meta: policy::Meta::new_default(name),
+        meta: Arc::new(policy::Meta::Resource {
+            group: "policy.linkerd.io".into(),
+            kind: "HTTPRoute".into(),
+            namespace: "ns".into(),
+            name: name.into(),
+            port: None,
+            section: None,
+        }),
         filters: Arc::new([]),
         failure_policy: Default::default(),
         distribution: policy::RouteDistribution::FirstAvailable(Arc::new([policy::RouteBackend {
@@ -34,16 +55,20 @@ async fn header_based_route() {
     };
 
     // Stack that produces mock services.
-    let default_addr = ([127, 0, 0, 1], 18080).into();
-    let special_addr = ([127, 0, 0, 1], 28080).into();
     let (inner_default, mut default) = tower_test::mock::pair();
     let (inner_special, mut special) = tower_test::mock::pair();
     let inner = move |concrete: Concrete<()>| {
-        if let concrete::Dispatch::Forward(Remote(ServerAddr(addr)), ..) = concrete.target {
-            if addr == default_addr {
+        if let concrete::Dispatch::Balance(ref addr, ..) = concrete.target {
+            if addr
+                .name()
+                .eq_ignore_ascii_case("default.ns.svc.cluster.local")
+            {
                 return inner_default.clone();
             }
-            if addr == special_addr {
+            if addr
+                .name()
+                .eq_ignore_ascii_case("special.ns.svc.cluster.local")
+            {
                 return inner_special.clone();
             }
         }
@@ -52,11 +77,18 @@ async fn header_based_route() {
 
     // Routes that configure a special header-based route and a default route.
     let routes = Params::Http({
-        let default = mk_backend("default", default_addr);
-        let special = mk_backend("special", special_addr);
+        let default = mk_backend("default");
+        let special = mk_backend("special");
         router::HttpParams {
             addr: Addr::Socket(([127, 0, 0, 1], 8080).into()),
-            meta: ParentRef(policy::Meta::new_default("parent")),
+            meta: ParentRef(Arc::new(policy::Meta::Resource {
+                group: "core".into(),
+                kind: "Service".into(),
+                namespace: "ns".into(),
+                name: "papa".into(),
+                port: NonZeroU16::new(7979),
+                section: None,
+            })),
             routes: Arc::new([policy::http::Route {
                 hosts: Default::default(),
                 rules: vec![
@@ -81,7 +113,8 @@ async fn header_based_route() {
         }
     });
 
-    let router = Policy::layer()
+    let metrics = RouteBackendMetrics::default();
+    let router = Policy::layer(metrics.clone())
         .layer(inner)
         .new_service(Policy::from((routes, ())));
 
@@ -114,6 +147,20 @@ async fn header_based_route() {
 
     // Hold the router to prevent inner services from being dropped.
     drop(router);
+
+    let report = linkerd_app_core::metrics::FmtMetrics::as_display(&metrics).to_string();
+    let mut lines = report
+        .lines()
+        .filter(|l| !l.starts_with('#'))
+        .collect::<Vec<_>>();
+    lines.sort();
+    assert_eq!(
+        lines,
+        vec![
+            r#"outbound_http_route_backend_requests_total{parent_group="core",parent_kind="Service",parent_namespace="ns",parent_name="papa",parent_port="7979",parent_section_name="",route_group="policy.linkerd.io",route_kind="HTTPRoute",route_namespace="ns",route_name="default",backend_group="core",backend_kind="Service",backend_namespace="ns",backend_name="default",backend_port="8080",backend_section_name=""} 1"#,
+            r#"outbound_http_route_backend_requests_total{parent_group="core",parent_kind="Service",parent_namespace="ns",parent_name="papa",parent_port="7979",parent_section_name="",route_group="policy.linkerd.io",route_kind="HTTPRoute",route_namespace="ns",route_name="special",backend_group="core",backend_kind="Service",backend_namespace="ns",backend_name="special",backend_port="8080",backend_section_name=""} 1"#,
+        ]
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -175,7 +222,7 @@ async fn http_filter_request_headers() {
         }
     });
 
-    let router = Policy::layer()
+    let router = Policy::layer(Default::default())
         .layer(inner)
         .new_service(Policy::from((routes, ())));
 

--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -8,6 +8,8 @@
 //! to be updated frequently or in a performance-critical area. We should probably look to use
 //! `DashMap` as we migrate other metrics registries.
 
+use crate::http::policy::RouteBackendMetrics;
+
 pub(crate) mod error;
 
 pub use linkerd_app_core::metrics::*;
@@ -18,6 +20,8 @@ pub struct OutboundMetrics {
     pub(crate) http_errors: error::Http,
     pub(crate) tcp_errors: error::Tcp,
 
+    pub(crate) http_route_backends: RouteBackendMetrics,
+
     /// Holds metrics that are common to both inbound and outbound proxies. These metrics are
     /// reported separately
     pub(crate) proxy: Proxy,
@@ -26,15 +30,17 @@ pub struct OutboundMetrics {
 impl OutboundMetrics {
     pub(crate) fn new(proxy: Proxy) -> Self {
         Self {
+            proxy,
             http_errors: error::Http::default(),
             tcp_errors: error::Tcp::default(),
-            proxy,
+            http_route_backends: RouteBackendMetrics::default(),
         }
     }
 }
 
 impl FmtMetrics for OutboundMetrics {
     fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.http_route_backends.fmt_metrics(f)?;
         self.http_errors.fmt_metrics(f)?;
         self.tcp_errors.fmt_metrics(f)?;
 


### PR DESCRIPTION
When performing policy-based routing, proxies may dispatch requests through per-route backend configurations. In order to illustrate how routing rules apply and how backend distributions are being honored, this change adds two new metrics:

* `outbound_http_route_backend_requests_total`; and
* `outbound_grpc_route_backend_requests_total`

Each of these metrics includes labels that identify a routes parent (i.e. a Service), the route resource being used, and the backend resource being used.

This implementation does NOT implement any form of metrics eviction for these new metrics. This is tolerable for the short term as the cardinality of services and routes is generally much less than the cardinality of individual endpoints (where we do require timeout/eviction for metrics).