### PR TITLE
outbound: Report HTTP balancer endpoint gauges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1438,6 +1438,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "linkerd-error",
+ "linkerd-metrics",
  "linkerd-proxy-core",
  "linkerd-stack",
  "pin-project",

--- a/linkerd/app/outbound/src/http/breaker.rs
+++ b/linkerd/app/outbound/src/http/breaker.rs
@@ -1,8 +1,10 @@
-mod consecutive_failures;
-use consecutive_failures::ConsecutiveFailures;
 use linkerd_app_core::{classify, proxy::http::classify::gate, svc};
 use linkerd_proxy_client_policy::FailureAccrual;
 use tracing::{trace_span, Instrument};
+
+mod consecutive_failures;
+
+use self::consecutive_failures::ConsecutiveFailures;
 
 /// Params configuring a circuit breaker stack.
 #[derive(Copy, Clone, Debug)]

--- a/linkerd/app/outbound/src/http/concrete/metrics.rs
+++ b/linkerd/app/outbound/src/http/concrete/metrics.rs
@@ -1,0 +1,85 @@
+use crate::{BackendRef, ParentRef};
+use ahash::AHashMap;
+use linkerd_app_core::{
+    metrics::{metrics, FmtLabels, FmtMetrics, Gauge},
+    svc::http::balance,
+};
+use parking_lot::Mutex;
+use std::{fmt::Write, sync::Arc};
+
+metrics! {
+    outbound_http_balancer_endpoints: Gauge {
+        "The number of endpoints currently in a HTTP request balancer"
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct BalancerMetrics {
+    balancers: Arc<Mutex<AHashMap<Labels, balance::EndpointsGauges>>>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct Labels(ParentRef, BackendRef);
+
+struct Ready<'l>(&'l Labels);
+struct Pending<'l>(&'l Labels);
+
+// === impl RouteBackendMetrics ===
+
+impl BalancerMetrics {
+    pub(super) fn http_endpoints(&self, pr: ParentRef, br: BackendRef) -> balance::EndpointsGauges {
+        self.balancers
+            .lock()
+            .entry(Labels(pr, br))
+            .or_default()
+            .clone()
+    }
+}
+
+impl FmtMetrics for BalancerMetrics {
+    fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let balancers = self.balancers.lock();
+        if !balancers.is_empty() {
+            outbound_http_balancer_endpoints.fmt_help(f)?;
+            outbound_http_balancer_endpoints.fmt_scopes(
+                f,
+                balancers.iter().map(|(l, e)| (Pending(l), e)),
+                |c| &c.pending,
+            )?;
+            outbound_http_balancer_endpoints.fmt_scopes(
+                f,
+                balancers.iter().map(|(l, e)| (Ready(l), e)),
+                |c| &c.ready,
+            )?;
+        }
+        drop(balancers);
+
+        Ok(())
+    }
+}
+
+impl FmtLabels for Labels {
+    fn fmt_labels(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Labels(parent, backend) = self;
+
+        crate::metrics::write_service_meta_labels("parent", parent, f)?;
+        f.write_char(',')?;
+        crate::metrics::write_service_meta_labels("backend", backend, f)?;
+
+        Ok(())
+    }
+}
+
+impl<'l> FmtLabels for Ready<'l> {
+    fn fmt_labels(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt_labels(f)?;
+        write!(f, ",endpoint_state=\"ready\"")
+    }
+}
+
+impl<'l> FmtLabels for Pending<'l> {
+    fn fmt_labels(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt_labels(f)?;
+        write!(f, ",endpoint_state=\"pending\"")
+    }
+}

--- a/linkerd/app/outbound/src/http/concrete/tests.rs
+++ b/linkerd/app/outbound/src/http/concrete/tests.rs
@@ -15,7 +15,7 @@ async fn gauges_endpoints() {
     let (rt, _shutdown) = runtime();
     let outbound = Outbound::new(default_config(), rt);
 
-    let addr = format!("mysvc.myns.svc.cluster.local:80")
+    let addr = "mysvc.myns.svc.cluster.local:80"
         .parse::<NameAddr>()
         .unwrap();
     let ep0 = SocketAddr::new([192, 0, 2, 41].into(), 8080);

--- a/linkerd/app/outbound/src/http/concrete/tests.rs
+++ b/linkerd/app/outbound/src/http/concrete/tests.rs
@@ -1,0 +1,152 @@
+use super::*;
+use crate::test_util::*;
+use linkerd_app_core::{
+    svc::{http::balance::EwmaConfig, ServiceExt},
+    svc::{NewService, Service},
+    trace,
+};
+use linkerd_proxy_client_policy as policy;
+use std::{net::SocketAddr, num::NonZeroU16, sync::Arc};
+use tokio::time;
+
+#[tokio::test(flavor = "current_thread")]
+async fn gauges_endpoints() {
+    let _trace = trace::test::trace_init();
+    let (rt, _shutdown) = runtime();
+    let outbound = Outbound::new(default_config(), rt);
+
+    let addr = format!("mysvc.myns.svc.cluster.local:80")
+        .parse::<NameAddr>()
+        .unwrap();
+    let ep0 = SocketAddr::new([192, 0, 2, 41].into(), 8080);
+    let ep1 = SocketAddr::new([192, 0, 2, 42].into(), 8080);
+
+    let resolve = support::resolver::<Metadata>();
+    let mut resolve_tx = resolve.endpoint_tx(addr.clone());
+
+    let (svc0, mut handle0) = tower_test::mock::pair();
+    let (svc1, mut handle1) = tower_test::mock::pair();
+
+    let stk = move |ep: Endpoint<_>| {
+        if *ep.addr == ep0 {
+            return svc0.clone();
+        }
+        if *ep.addr == ep1 {
+            return svc1.clone();
+        }
+        panic!("unexpected endpoint: {:?}", ep)
+    };
+
+    let mut svc = svc::stack(stk)
+        .push(Balance::layer(&outbound.config, &outbound.runtime, resolve))
+        .into_inner()
+        .new_service(Balance {
+            addr,
+            parent: Target,
+            ewma: EwmaConfig {
+                default_rtt: time::Duration::from_millis(100),
+                decay: time::Duration::from_secs(10),
+            },
+        });
+
+    let ready = Arc::new(tokio::sync::Notify::new());
+    let _task = tokio::spawn({
+        let ready = ready.clone();
+        async move {
+            loop {
+                ready.notified().await;
+                svc.ready().await.unwrap();
+                svc.call(http::Request::default()).await.unwrap();
+            }
+        }
+    });
+
+    let gauge = outbound
+        .runtime
+        .metrics
+        .http_balancer
+        .http_endpoints(svc::Param::param(&Target), svc::Param::param(&Target));
+    assert_eq!(gauge.pending.value(), 0);
+    assert_eq!(gauge.ready.value(), 0);
+
+    // Begin with a single endpoint. When the balancer can process requests, the
+    // gauge is accurate.
+    resolve_tx.add(vec![(ep0, Metadata::default())]).unwrap();
+    handle0.allow(1);
+    ready.notify_one();
+    tokio::task::yield_now().await;
+    assert_eq!(gauge.pending.value(), 0);
+    assert_eq!(gauge.ready.value(), 1);
+    let (_, res) = handle0.next_request().await.unwrap();
+    res.send_response(http::Response::default());
+
+    // Add a second endpoint and ensure the gauge is updated.
+    resolve_tx.add(vec![(ep1, Metadata::default())]).unwrap();
+    handle0.allow(0);
+    handle1.allow(1);
+    ready.notify_one();
+    tokio::task::yield_now().await;
+    assert_eq!(gauge.pending.value(), 1);
+    assert_eq!(gauge.ready.value(), 1);
+    let (_, res) = handle1.next_request().await.unwrap();
+    res.send_response(http::Response::default());
+
+    // Remove the first endpoint.
+    resolve_tx.remove(vec![ep0]).unwrap();
+    handle1.allow(2);
+    ready.notify_one();
+    let (_, res) = handle1.next_request().await.unwrap();
+    res.send_response(http::Response::default());
+
+    // The inner endpoint isn't actually dropped until the balancer's subsequent poll.
+    ready.notify_one();
+    tokio::task::yield_now().await;
+    assert_eq!(gauge.pending.value(), 0);
+    assert_eq!(gauge.ready.value(), 1);
+    let (_, res) = handle1.next_request().await.unwrap();
+    res.send_response(http::Response::default());
+
+    // Dropping the remaining endpoint, the gauge is updated.
+    resolve_tx.remove(vec![ep1]).unwrap();
+    ready.notify_one();
+    tokio::task::yield_now().await;
+    assert_eq!(gauge.pending.value(), 0);
+    assert_eq!(gauge.ready.value(), 0);
+}
+
+#[derive(Clone, Debug)]
+struct Target;
+
+// === impl Target ===
+
+impl svc::Param<ParentRef> for Target {
+    fn param(&self) -> ParentRef {
+        ParentRef(Arc::new(policy::Meta::Resource {
+            group: "core".into(),
+            kind: "Service".into(),
+            namespace: "myns".into(),
+            name: "mysvc".into(),
+            port: NonZeroU16::new(80),
+            section: None,
+        }))
+    }
+}
+
+impl svc::Param<BackendRef> for Target {
+    fn param(&self) -> BackendRef {
+        BackendRef(Arc::new(policy::Meta::Resource {
+            group: "core".into(),
+            kind: "Service".into(),
+            namespace: "myns".into(),
+            name: "mysvc".into(),
+            port: NonZeroU16::new(80),
+            section: None,
+        }))
+    }
+}
+
+impl svc::Param<FailureAccrual> for Target {
+    fn param(&self) -> FailureAccrual {
+        FailureAccrual::default()
+    }
+}

--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -1,6 +1,5 @@
+use super::super::Concrete;
 use crate::RouteRef;
-
-use super::{super::Concrete, RouteBackendMetrics};
 use linkerd_app_core::{classify, proxy::http, svc, Addr, Error, Result};
 use linkerd_distribute as distribute;
 use linkerd_http_route as http_route;
@@ -74,7 +73,7 @@ where
     /// distributes requests over each route's backends. These [`Concrete`]
     /// backends are expected to be cached/shared by the inner stack.
     pub(crate) fn layer<N, S>(
-        backend_metrics: RouteBackendMetrics,
+        backend_metrics: backend::RouteBackendMetrics,
     ) -> impl svc::Layer<
         N,
         Service = svc::ArcNewService<

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -8,7 +8,8 @@ use std::{fmt::Debug, hash::Hash, sync::Arc};
 mod count_reqs;
 mod metrics;
 
-pub use self::{count_reqs::RequestCount, metrics::RouteBackendMetrics};
+pub use self::count_reqs::RequestCount;
+pub use self::metrics::RouteBackendMetrics;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub(crate) struct Backend<T, F> {

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -1,10 +1,9 @@
+use crate::{BackendRef, ParentRef, RouteRef};
 use ahash::AHashMap;
 use linkerd_app_core::metrics::{metrics, Counter, FmtLabels, FmtMetrics};
 use linkerd_proxy_client_policy as policy;
 use parking_lot::Mutex;
 use std::{fmt::Write, sync::Arc};
-
-use crate::{BackendRef, ParentRef, RouteRef};
 
 metrics! {
     outbound_http_route_backend_requests_total: Counter {

--- a/linkerd/proxy/balance/Cargo.toml
+++ b/linkerd/proxy/balance/Cargo.toml
@@ -10,7 +10,8 @@ futures = { version = "0.3", default-features = false }
 futures-util = "0.3"
 indexmap = "1"
 linkerd-error = { path = "../../error" }
-linkerd-proxy-core = { path = "../../proxy/core" }
+linkerd-metrics = { path = "../../metrics" }
+linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 pin-project = "1"
 rand = "0.8"

--- a/linkerd/proxy/balance/src/gauge_endpoints.rs
+++ b/linkerd/proxy/balance/src/gauge_endpoints.rs
@@ -12,7 +12,7 @@ pub struct EndpointsGauges {
     pub pending: Arc<Gauge>,
 }
 
-/// A [`NewService`] that builds [`NewGaugeBalancerEndpoint`]s with an
+/// A [`NewService`] that builds `NewGaugeBalancerEndpoint`s with an
 /// endpoint gauge.
 #[derive(Clone, Debug, Default)]
 pub struct NewGaugeEndpoints<X, N> {

--- a/linkerd/proxy/balance/src/gauge_endpoints.rs
+++ b/linkerd/proxy/balance/src/gauge_endpoints.rs
@@ -30,7 +30,6 @@ pub struct NewGaugeBalancerEndpoint<N> {
 
 /// A [`Service`] that decrements an endpoint gauge when dropped.
 #[derive(Debug)]
-
 pub struct GaugeBalancerEndpoint<S> {
     inner: S,
     gauge: EndpointsGauges,

--- a/linkerd/proxy/balance/src/gauge_endpoints.rs
+++ b/linkerd/proxy/balance/src/gauge_endpoints.rs
@@ -1,0 +1,130 @@
+use linkerd_metrics::Gauge;
+use linkerd_stack::{layer, ExtractParam, NewService, Service};
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+/// Parameter that provides a per-balancer endpoint gauge.
+#[derive(Clone, Debug, Default)]
+pub struct EndpointsGauges {
+    pub ready: Arc<Gauge>,
+    pub pending: Arc<Gauge>,
+}
+
+/// A [`NewService`] that builds [`NewGaugeBalancerEndpoint`]s with an
+/// endpoint gauge.
+#[derive(Clone, Debug, Default)]
+pub struct NewGaugeEndpoints<X, N> {
+    inner: N,
+    extract: X,
+}
+
+/// A [`NewService`] that builds [`GaugeBalancerEndpoint`]s with an
+/// endpoint gauge.
+#[derive(Clone, Debug, Default)]
+pub struct NewGaugeBalancerEndpoint<N> {
+    inner: N,
+    gauge: EndpointsGauges,
+}
+
+/// A [`Service`] that decrements an endpoint gauge when dropped.
+#[derive(Debug)]
+
+pub struct GaugeBalancerEndpoint<S> {
+    inner: S,
+    gauge: EndpointsGauges,
+    state: Poll<()>,
+}
+
+/// === impl NewGaugeBalancerEndpointSet ===
+
+impl<X: Clone, N> NewGaugeEndpoints<X, N> {
+    pub fn new(extract: X, inner: N) -> Self {
+        Self { extract, inner }
+    }
+
+    pub fn layer_via(extract: X) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self::new(extract.clone(), inner))
+    }
+}
+
+impl<N> NewGaugeEndpoints<(), N> {
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Clone {
+        Self::layer_via(())
+    }
+}
+
+impl<T, X, N> NewService<T> for NewGaugeEndpoints<X, N>
+where
+    X: ExtractParam<EndpointsGauges, T>,
+    N: NewService<T>,
+{
+    type Service = NewGaugeBalancerEndpoint<N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let gauge = self.extract.extract_param(&target);
+        let inner = self.inner.new_service(target);
+        NewGaugeBalancerEndpoint { inner, gauge }
+    }
+}
+
+/// === impl NewGaugeBalancerEndpoint ===
+
+impl<T, N> NewService<T> for NewGaugeBalancerEndpoint<N>
+where
+    N: NewService<T>,
+{
+    type Service = GaugeBalancerEndpoint<N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let gauge = self.gauge.clone();
+        let inner = self.inner.new_service(target);
+        gauge.pending.incr();
+        GaugeBalancerEndpoint {
+            inner,
+            gauge,
+            state: Poll::Pending,
+        }
+    }
+}
+
+/// === impl GaugeBalancerEndpoint ===
+
+impl<Req, S> Service<Req> for GaugeBalancerEndpoint<S>
+where
+    S: Service<Req>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let poll = self.inner.poll_ready(cx);
+        if self.state.is_ready() && poll.is_pending() {
+            self.gauge.pending.incr();
+            self.gauge.ready.decr();
+            self.state = Poll::Pending;
+        } else if self.state.is_pending() && poll.is_ready() {
+            self.gauge.pending.decr();
+            self.gauge.ready.incr();
+            self.state = Poll::Ready(());
+        }
+        poll
+    }
+
+    #[inline]
+    fn call(&mut self, req: Req) -> Self::Future {
+        self.inner.call(req)
+    }
+}
+
+impl<S> Drop for GaugeBalancerEndpoint<S> {
+    fn drop(&mut self) {
+        if self.state.is_pending() {
+            self.gauge.pending.decr();
+        } else {
+            self.gauge.ready.decr();
+        }
+    }
+}

--- a/linkerd/proxy/balance/src/lib.rs
+++ b/linkerd/proxy/balance/src/lib.rs
@@ -9,10 +9,12 @@ use tower::{
 };
 
 mod discover;
+mod gauge_endpoints;
 
+pub use self::gauge_endpoints::{EndpointsGauges, NewGaugeEndpoints};
 pub use tower::load::peak_ewma::Handle;
 
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EwmaConfig {
     pub default_rtt: Duration,
     pub decay: Duration,

--- a/linkerd/proxy/http/src/balance.rs
+++ b/linkerd/proxy/http/src/balance.rs
@@ -1,9 +1,7 @@
-use hyper_balance::{PendingUntilFirstData, PendingUntilFirstDataBody};
-use linkerd_proxy_balance as balance;
+pub use hyper_balance::{PendingUntilFirstData, PendingUntilFirstDataBody};
+pub use linkerd_proxy_balance::*;
 
-pub type Body<B> = PendingUntilFirstDataBody<balance::Handle, B>;
-
-pub type EwmaConfig = balance::EwmaConfig;
+pub type Body<B> = PendingUntilFirstDataBody<Handle, B>;
 
 pub type NewBalancePeakEwma<B, R, N> =
-    balance::NewBalancePeakEwma<PendingUntilFirstData, http::Request<B>, R, N>;
+    linkerd_proxy_balance::NewBalancePeakEwma<PendingUntilFirstData, http::Request<B>, R, N>;


### PR DESCRIPTION
It's not currently possible to know how many endpoints are in a balancer. This change adds an `outbound_http_balancer_endpoints` gauge that exposes the number of endpoints a balancer has by their current readiness status.

Note that in the concrete stack we do not currently differentiate between gRPC and HTTP backends, so all balancers are exposed under this single metric.