### PR TITLE
outbound: add `l5d-dst-canonical` to requests with ServiceProfiles

### DIFF
--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -68,11 +68,6 @@ enum RouterParams<T: Clone + Debug + Eq + Hash> {
 }
 
 // Only applies to requests with profiles.
-//
-// TODO Add l5d-dst-canonical header to requests.
-//
-// TODO(ver) move this into the endpoint stack so that we can only
-// set this on meshed connections.
 #[derive(Clone, Debug)]
 struct CanonicalDstHeader(NameAddr);
 


### PR DESCRIPTION
PR #2250 removed the `l5d-dst-canonical` header from ServiceProfile requests. This header is used by the inbound proxy for telemetry purposes, so removing it and not putting it back broke ServiceProfile route metrics. This commit adds a layer for setting this header to the service profile route stack.

We can also add the header for non-ServiceProfile requests if that's desirable...I'll have to look into whether it is. This commit should, at least, fix the existing ServiceProfile route metrics.