### PR TITLE
outbound: Export balancer endpoints gauges

### DIFF
--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -45,6 +45,7 @@ impl OutboundMetrics {
 impl FmtMetrics for OutboundMetrics {
     fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.http_route_backends.fmt_metrics(f)?;
+        self.http_balancer.fmt_metrics(f)?;
         self.http_errors.fmt_metrics(f)?;
         self.tcp_errors.fmt_metrics(f)?;
 


### PR DESCRIPTION
d6f20a6 added a new `outbound_http_balancer_endpoints` gauge, but omitted it from metrics export. This change fixes this deficiency to ensure that this metric is rendered.