### PR TITLE
update minimum `h2` dependency to v0.3.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
 dependencies = [
  "bytes",
  "fnv",

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -20,7 +20,7 @@ flakey-in-coverage = []
 [dependencies]
 bytes = "1"
 futures = { version = "0.3", default-features = false, features = ["executor"] }
-h2 = "0.3"
+h2 = "0.3.17"
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14", features = [

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -14,7 +14,7 @@ client-policy = ["linkerd-proxy-client-policy", "tonic", "linkerd-http-route"]
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-h2 = "0.3"
+h2 = "0.3.17"
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14", features = ["http1", "http2"] }

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1"
 bytes = "1"
 drain = "0.1"
 futures = { version = "0.3", default-features = false }
-h2 = "0.3"
+h2 = "0.3.17"
 http = "0.2"
 http-body = "0.4"
 httparse = "1"


### PR DESCRIPTION
This commit updates the minimum dependency on `h2` to v0.3.17. This release includes the following [changes]:

* Add `Error::is_library()` method to check if the originated inside `h2`.
* Add `max_pending_accept_reset_streams(usize)` option to client and server builders.
* Fix theoretical memory growth when receiving too many HEADERS and then RST_STREAM frames faster than an application can accept them off the queue. (CVE-2023-26964)

[changes]: https://github.com/hyperium/h2/releases/tag/v0.3.17