### PR TITLE
set default `trust_dns` log level to `ERROR`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG PROXY_FEATURES=""
 RUN apt-get update && \
     apt-get install -y time && \
     if [[ "$PROXY_FEATURES" =~ .*meshtls-boring.* ]] ; then \
-    apt-get install -y golang ; \
+      apt-get install -y golang ; \
     fi && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG PROXY_FEATURES=""
 RUN apt-get update && \
     apt-get install -y time && \
     if [[ "$PROXY_FEATURES" =~ .*meshtls-boring.* ]] ; then \
-      apt-get install -y golang ; \
+    apt-get install -y golang ; \
     fi && \
     rm -rf /var/lib/apt/lists/*
 
@@ -41,5 +41,5 @@ RUN --mount=type=cache,id=target,target=target \
 FROM $RUNTIME_IMAGE as runtime
 WORKDIR /linkerd
 COPY --from=build /out/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy
-ENV LINKERD2_PROXY_LOG=warn,linkerd=info
+ENV LINKERD2_PROXY_LOG=warn,linkerd=info,trust_dns=error
 # Inherits the ENTRYPOINT from the runtime image.

--- a/linkerd/tracing/src/lib.rs
+++ b/linkerd/tracing/src/lib.rs
@@ -26,7 +26,7 @@ const ENV_LOG_LEVEL: &str = "LINKERD2_PROXY_LOG";
 const ENV_LOG_FORMAT: &str = "LINKERD2_PROXY_LOG_FORMAT";
 const ENV_ACCESS_LOG: &str = "LINKERD2_PROXY_ACCESS_LOG";
 
-const DEFAULT_LOG_LEVEL: &str = "warn,linkerd=info";
+const DEFAULT_LOG_LEVEL: &str = "warn,linkerd=info,trust_dns=error";
 const DEFAULT_LOG_FORMAT: &str = "PLAIN";
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
Since upstream has yet to release a version with PR bluejekyll/trust-dns#1881, this commit changes the proxy's default log level to silence warnings from `trust_dns_proto` that are generally spurious.

See linkerd/linkerd2#10123 for details.