### PR TITLE
build(deps): bump `h2` to v0.3.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
The DOS mitigation changes in `h2` v0.3.17 inadvertantly introduced a potential panic (hyperium/h2#674). Version 0.3.18 fixes this, so we should bump the proxy's dependency to avoid panics.