### PR TITLE
inbound: determine default policies using the opaque ports env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -849,6 +849,7 @@ dependencies = [
  "linkerd-app-outbound",
  "linkerd-error",
  "linkerd-opencensus",
+ "rangemap",
  "regex",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b91535aa35fea1523ad1b86cb6b53c28e0ae566ba4a460f4457e936cad7c6f"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
  "bytes",
  "fnv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,6 +985,7 @@ dependencies = [
  "linkerd2-proxy-api",
  "once_cell",
  "parking_lot",
+ "rangemap",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -2299,6 +2300,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rangemap"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9283c6b06096b47afc7109834fdedab891175bb5241ee5d4f7d2546549f263"
 
 [[package]]
 name = "redox_syscall"

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -24,6 +24,7 @@ linkerd-app-inbound = { path = "./inbound" }
 linkerd-app-outbound = { path = "./outbound" }
 linkerd-error = { path = "../error" }
 linkerd-opencensus = { path = "../opencensus" }
+rangemap = "1"
 regex = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["rt"] }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -32,6 +32,7 @@ linkerd-tonic-watch = { path = "../../tonic-watch" }
 linkerd2-proxy-api = { version = "0.9", features = ["inbound"] }
 once_cell = "1"
 parking_lot = "0.12"
+rangemap = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["sync"] }
 tonic = { version = "0.8", default-features = false }

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -49,7 +49,7 @@ impl Config {
                 default,
                 ports,
                 cache_max_idle_age,
-                opaque_ports
+                opaque_ports,
             } => Store::spawn_fixed(default, cache_max_idle_age, ports, opaque_ports),
 
             Self::Discover {

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -46,7 +46,7 @@ impl Config {
                 default,
                 ports,
                 cache_max_idle_age,
-            } => Store::spawn_fixed(default, cache_max_idle_age, ports),
+            } => Store::spawn_fixed(default, cache_max_idle_age, ports, Default::default()),
 
             Self::Discover {
                 default,
@@ -63,7 +63,7 @@ impl Config {
                     };
                     Api::new(workload, detect_timeout, client).into_watch(backoff)
                 };
-                Store::spawn_discover(default, cache_max_idle_age, watch, ports)
+                Store::spawn_discover(default, cache_max_idle_age, watch, ports, Default::default())
             }
         }
     }

--- a/linkerd/app/inbound/src/policy/store.rs
+++ b/linkerd/app/inbound/src/policy/store.rs
@@ -122,6 +122,7 @@ impl<S> Store<S> {
                     Protocol::Detect { tcp_authorizations, .. } => {
                         Protocol::Opaque(tcp_authorizations)
                     }
+                    opaq @ Protocol::Opaque(_) => opaq,
                     _ => unreachable!("default policy must have been configured to detect prior to marking it opaque"),
                 };
                 DefaultPolicy::Allow(policy)

--- a/linkerd/app/inbound/src/policy/store.rs
+++ b/linkerd/app/inbound/src/policy/store.rs
@@ -42,7 +42,12 @@ impl<S> Store<S> {
     ) -> Self {
         let opaque_default_rx = Self::spawn_default(Self::make_opaque(default.clone()));
         let cache = {
-            let opaque_rxs = opaque_ports.iter().flat_map(|range| range.clone().into_iter().map(|port| (port, opaque_default_rx.clone())));
+            let opaque_rxs = opaque_ports.iter().flat_map(|range| {
+                range
+                    .clone()
+                    .into_iter()
+                    .map(|port| (port, opaque_default_rx.clone()))
+            });
             let rxs = ports.into_iter().map(|(p, s)| {
                 // When using a fixed policy, we don't need to watch for changes. It's
                 // safe to discard the sender, as the receiver will continue to let us
@@ -120,7 +125,7 @@ impl<S> Store<S> {
                     _ => unreachable!("default policy must have been configured to detect prior to marking it opaque"),
                 };
                 DefaultPolicy::Allow(policy)
-            },
+            }
             DefaultPolicy::Deny => DefaultPolicy::Deny,
         }
     }

--- a/linkerd/app/inbound/src/policy/tcp/tests.rs
+++ b/linkerd/app/inbound/src/policy/tcp/tests.rs
@@ -272,6 +272,11 @@ impl Store<MockSvc> {
         default: impl Into<DefaultPolicy>,
         ports: impl IntoIterator<Item = (u16, ServerPolicy)>,
     ) -> Self {
-        Self::spawn_fixed(default.into(), std::time::Duration::MAX, ports, Default::default())
+        Self::spawn_fixed(
+            default.into(),
+            std::time::Duration::MAX,
+            ports,
+            Default::default(),
+        )
     }
 }

--- a/linkerd/app/inbound/src/policy/tcp/tests.rs
+++ b/linkerd/app/inbound/src/policy/tcp/tests.rs
@@ -272,6 +272,6 @@ impl Store<MockSvc> {
         default: impl Into<DefaultPolicy>,
         ports: impl IntoIterator<Item = (u16, ServerPolicy)>,
     ) -> Self {
-        Self::spawn_fixed(default.into(), std::time::Duration::MAX, ports)
+        Self::spawn_fixed(default.into(), std::time::Duration::MAX, ports, Default::default())
     }
 }

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -49,6 +49,7 @@ pub fn default_config() -> Config {
         }
         .into(),
         ports: Default::default(),
+        opaque_ports: Default::default(),
     };
 
     Config {

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -202,22 +202,9 @@ async fn test_server_speaks_first(env: TestEnv) {
 
     let _trace = trace_init();
 
-    let msg1 = "custom tcp server starts";
-    let msg2 = "custom tcp client second";
-
     let (tx, mut rx) = mpsc::channel(1);
     let srv = server::tcp()
-        .accept_fut(move |mut sock| {
-            async move {
-                sock.write_all(msg1.as_bytes()).await?;
-                let mut vec = vec![0; 512];
-                let n = sock.read(&mut vec).await?;
-                assert_eq!(s(&vec[..n]), msg2);
-                tx.send(()).await.unwrap();
-                Ok::<(), io::Error>(())
-            }
-            .map(|res| res.expect("TCP server must not fail"))
-        })
+        .accept_fut(move |sock| serve_server_first(sock, tx))
         .run()
         .await;
 
@@ -231,8 +218,8 @@ async fn test_server_speaks_first(env: TestEnv) {
 
     let tcp_client = client.connect().await;
 
-    assert_eq!(s(&tcp_client.read_timeout(TIMEOUT).await), msg1);
-    tcp_client.write(msg2).await;
+    assert_eq!(s(&tcp_client.read_timeout(TIMEOUT).await), SERVER_FIRST_MSG1);
+    tcp_client.write(SERVER_FIRST_MSG2).await;
     timeout(TIMEOUT, rx.recv()).await.unwrap();
 
     // TCP client must close first
@@ -242,9 +229,62 @@ async fn test_server_speaks_first(env: TestEnv) {
     proxy.join_servers().await;
 }
 
+
 #[tokio::test]
 async fn tcp_server_first() {
     test_server_speaks_first(TestEnv::default()).await;
+}
+
+/// Like `tcp_server_first`, but the opaque port configuration is not discovered
+/// from the policy controller before accepting the connection (i.e. the port is
+/// *not* in `LINKERD2_PROXY_INBOUND_PORTS`).
+#[tokio::test]
+async fn tcp_server_first_no_discovery() {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+
+    let _trace = trace_init();
+
+    let (tx, mut rx) = mpsc::channel(1);
+    let srv = server::tcp()
+        .accept_fut(move |sock| serve_server_first(sock, tx))
+        .run()
+        .await;
+
+    let mut env = TestEnv::default();
+    env.put(app::env::ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION, srv.addr.port().to_string());
+
+    let proxy = proxy::new()
+        .inbound(srv)
+        .run_with_test_env(env)
+        .await;
+
+    let client = client::tcp(proxy.inbound);
+
+    let tcp_client = client.connect().await;
+
+    assert_eq!(s(&tcp_client.read_timeout(TIMEOUT).await), SERVER_FIRST_MSG1);
+    tcp_client.write(SERVER_FIRST_MSG2).await;
+    timeout(TIMEOUT, rx.recv()).await.unwrap();
+
+    // TCP client must close first
+    tcp_client.shutdown().await;
+
+    // ensure panics from the server are propagated
+    proxy.join_servers().await;
+}
+
+const SERVER_FIRST_MSG1: &str = "custom tcp server starts";
+const SERVER_FIRST_MSG2: &str = "custom tcp client second";
+
+async fn serve_server_first(mut sock: tokio::net::TcpStream, tx: mpsc::Sender<()>) {
+    async move {
+        sock.write_all(SERVER_FIRST_MSG1.as_bytes()).await?;
+        let mut vec = vec![0; 512];
+        let n = sock.read(&mut vec).await?;
+        assert_eq!(s(&vec[..n]), SERVER_FIRST_MSG2);
+        tx.send(()).await.unwrap();
+        Ok::<_, std::io::Error>(())
+    }.map(|res| res.expect("TCP server must not fail")).await
 }
 
 // FIXME(ver) this test doesn't actually test TLS functionality.

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -218,7 +218,10 @@ async fn test_server_speaks_first(env: TestEnv) {
 
     let tcp_client = client.connect().await;
 
-    assert_eq!(s(&tcp_client.read_timeout(TIMEOUT).await), SERVER_FIRST_MSG1);
+    assert_eq!(
+        s(&tcp_client.read_timeout(TIMEOUT).await),
+        SERVER_FIRST_MSG1
+    );
     tcp_client.write(SERVER_FIRST_MSG2).await;
     timeout(TIMEOUT, rx.recv()).await.unwrap();
 
@@ -228,7 +231,6 @@ async fn test_server_speaks_first(env: TestEnv) {
     // ensure panics from the server are propagated
     proxy.join_servers().await;
 }
-
 
 #[tokio::test]
 async fn tcp_server_first() {
@@ -251,18 +253,21 @@ async fn tcp_server_first_no_discovery() {
         .await;
 
     let mut env = TestEnv::default();
-    env.put(app::env::ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION, srv.addr.port().to_string());
+    env.put(
+        app::env::ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION,
+        srv.addr.port().to_string(),
+    );
 
-    let proxy = proxy::new()
-        .inbound(srv)
-        .run_with_test_env(env)
-        .await;
+    let proxy = proxy::new().inbound(srv).run_with_test_env(env).await;
 
     let client = client::tcp(proxy.inbound);
 
     let tcp_client = client.connect().await;
 
-    assert_eq!(s(&tcp_client.read_timeout(TIMEOUT).await), SERVER_FIRST_MSG1);
+    assert_eq!(
+        s(&tcp_client.read_timeout(TIMEOUT).await),
+        SERVER_FIRST_MSG1
+    );
     tcp_client.write(SERVER_FIRST_MSG2).await;
     timeout(TIMEOUT, rx.recv()).await.unwrap();
 
@@ -284,7 +289,9 @@ async fn serve_server_first(mut sock: tokio::net::TcpStream, tx: mpsc::Sender<()
         assert_eq!(s(&vec[..n]), SERVER_FIRST_MSG2);
         tx.send(()).await.unwrap();
         Ok::<_, std::io::Error>(())
-    }.map(|res| res.expect("TCP server must not fail")).await
+    }
+    .map(|res| res.expect("TCP server must not fail"))
+    .await
 }
 
 // FIXME(ver) this test doesn't actually test TLS functionality.

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -593,8 +593,8 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
             // Load the the set of all known inbound ports to be discovered
             // eagerly during initialization.
-            let mut ports = match parse(strings, ENV_INBOUND_PORTS, parse_port_set)? {
-                Some(ports) => ports,
+            let mut ports = match parse(strings, ENV_INBOUND_PORTS, parse_port_range_set)? {
+                Some(ports) => ports.into_iter().flat_map(|range| range.into_iter()).collect::<HashSet<_>>(),
                 None => {
                     error!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
                     Default::default()
@@ -939,16 +939,6 @@ fn parse_addr(s: &str) -> Result<Addr, ParseError> {
         error!("Not a valid address: {}", s);
         ParseError::AddrError(e)
     })
-}
-
-fn parse_port_set(s: &str) -> Result<HashSet<u16>, ParseError> {
-    let mut set = HashSet::new();
-    if !s.is_empty() {
-        for num in s.split(',') {
-            set.insert(parse_number::<u16>(num)?);
-        }
-    }
-    Ok(set)
 }
 
 fn parse_port_range_set(s: &str) -> Result<RangeInclusiveSet<u16>, ParseError> {

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -594,7 +594,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             // Load the the set of all known inbound ports to be discovered
             // eagerly during initialization.
             let mut ports = match parse(strings, ENV_INBOUND_PORTS, parse_port_range_set)? {
-                Some(ports) => ports.into_iter().flat_map(|range| range.into_iter()).collect::<HashSet<_>>(),
+                Some(ports) => ports.into_iter().flatten().collect::<HashSet<_>>(),
                 None => {
                     error!("No inbound ports specified via {}", ENV_INBOUND_PORTS,);
                     Default::default()

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -611,13 +611,16 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             // Ensure that the admin server port is included in policy discovery.
             ports.insert(admin_listener_addr.port());
 
-
             // Determine any pre-configured opaque ports.
-            let opaque_ports = parse(strings, ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION, parse_port_range_set)?
-                // If the `INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` environment
-                // variable is not set, then there are no default opaque ports,
-                // and that's fine.
-                .unwrap_or_default();
+            let opaque_ports = parse(
+                strings,
+                ENV_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION,
+                parse_port_range_set,
+            )?
+            // If the `INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` environment
+            // variable is not set, then there are no default opaque ports,
+            // and that's fine.
+            .unwrap_or_default();
 
             inbound::policy::Config::Discover {
                 default,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -1470,6 +1470,10 @@ mod tests {
         assert!(dbg!(parse_port_range_set("80-79")).is_err());
         assert!(dbg!(parse_port_range_set("1,2,5-2")).is_err());
 
+        // malformed (half-open) ranges
+        assert!(dbg!(parse_port_range_set("-1")).is_err());
+        assert!(dbg!(parse_port_range_set("1,2-,50")).is_err());
+        
         // not a u16
         assert!(dbg!(parse_port_range_set("69420")).is_err());
         assert!(dbg!(parse_port_range_set("1-69420")).is_err());


### PR DESCRIPTION
The proxy injector populates an environment variable,
`LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION`, with a list
of all ports marked as opaque. Currently, however, _the proxy _does not
actually use this environment variable_. Instead, opaque ports are
discovered from the policy controller. The opaque ports environment
variable was used only when running in the "fixed" inbound policy mode,
where all inbound policies are determined from environment variables,
and no policy controller address is provided. This mode is no longer
supported, and the policy controller address is now required, so the
`LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` environment
variable is not currently used to discover inbound opaque ports.

There are two issues with the current state of things. One is that
inbound policy discovery is _non-blocking_: when an inbound proxy
receives a connection on a port that it has not previously discovered a
policy for, it uses the default policy until it has successfully
discovered a policy for that port from the policy controller. This means
that the proxy may perform protocol detection on the first connection to
an opaque port. This isn't great, as it may result in a protocol
detection timeout error on a port that the user had previously marked as
opaque. It would be preferable for the proxy to read the environment
variable, and use it to determine whether the default policy for a port
is opaque, so that ports marked as opaque disable protocol detection
even before the "actual" policy is discovered.

The other issue with the
`LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` environment
variable is that it is currently a list of _individual port numbers_,
while the proxy injector can accept annotations that specify _ranges_ of
opaque ports. This means that when a very large number of ports are
marked as opaque, the proxy manifest must contain a list of each
individual port number in those ranges, making it potentially quite
large. See linkerd/linkerd2#9803 for details on this issue.

This branch addresses both of these problems. The proxy is changed so
that it will once again read the
`LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` environment
variable, and use it to determine which ports should have opaque
policies by default. The parsing of the environment variable is changed
to support specifying ports as a list of ranges, rather than a list of
individual port numbers. Along with a proxy-injector change, this would
resolve the manifest size issue described in linkerd/linkerd2#9803.

This is implemented by changing the `inbound::policy::Store` type to
also include a set of port ranges that are marked as opaque. When the
`Store` handles a `get_policy` call for a port that is not already in
the cache, it starts a control plane watch for that port just as it did
previously. However, when determining the initial _default_ value for
the policy, before the control plane discovery provides one, it checks
whether the port is in a range that is marked as opaque, and, if it is,
uses an opaque default policy instead.

This approach was chosen rather than pre-populating the `Store` with
policies for all opaque ports to better handle the case where very large
ranges are marked as opaque and are used infrequently. If the `Store`
was pre-populated with default policies for all such ports, it would
essentially behave as though all ports in
`LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` were also in
`LINKERD2_PROXY_INBOUND_PORTS`, and the proxy would immediately start a
policy controller discovery watch for all opaque ports, which would be
kept open for the proxy's entire lifetime. In cases where the opaque
ports ranges include ~10,000s of ports, this causes significant
unnecessary load on the policy controller. Storing opaque port ranges
separately and using them to determine the default policy as needed
allows opaque port policies to be treated the same as non-default ports,
which are discovered as needed and can be evicted from the cache if they
are unused. If a port is in both
`LINKERD2_PROXY_INBOUND_PORTS_DISABLE_PROTOCOL_DETECTION` *and*
`LINKERD2_PROXY_INBOUND_PORTS`, the proxy will start discovery eagerly
and retain the port in the cache forever, but the default policy will be
opaque.

I've also added a test for the behavior of opaque ports where the port's
policy has not been discovered from the policy controller. That test
fails on `main`, as the proxy attempts protocol detection, but passes on
this branch.

In addition, I changed the parsing of the `LINKERD2_PROXY_INBOUND_PORTS`
environment variable to also accept ranges, because it seemed like a
nice thing to do while I was here. :)