### PR TITLE
outbound: determine protocol based on `OutboundPolicy`

### DIFF
--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -141,10 +141,10 @@ impl Controller {
         tx
     }
 
-    pub fn profile_tx(&self, dest: impl Into<String>) -> ProfileSender {
+    pub fn profile_tx(&self, dest: impl ToString) -> ProfileSender {
         let (tx, rx) = mpsc::unbounded_channel();
         let rx = UnboundedReceiverStream::new(rx);
-        let mut path = dest.into();
+        let mut path = dest.to_string();
         if !path.contains(':') {
             path.push_str(":80");
         };

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -197,27 +197,14 @@ async fn loop_inbound_http1() {
     assert_eq!(rsp.status(), http::StatusCode::FORBIDDEN);
 }
 
-async fn test_server_speaks_first(env: TestEnv) {
+async fn test_inbound_server_speaks_first(env: TestEnv) {
     const TIMEOUT: Duration = Duration::from_secs(5);
 
     let _trace = trace_init();
 
-    let msg1 = "custom tcp server starts";
-    let msg2 = "custom tcp client second";
-
-    let (tx, mut rx) = mpsc::channel(1);
+    let (tx, rx) = mpsc::channel(1);
     let srv = server::tcp()
-        .accept_fut(move |mut sock| {
-            async move {
-                sock.write_all(msg1.as_bytes()).await?;
-                let mut vec = vec![0; 512];
-                let n = sock.read(&mut vec).await?;
-                assert_eq!(s(&vec[..n]), msg2);
-                tx.send(()).await.unwrap();
-                Ok::<(), io::Error>(())
-            }
-            .map(|res| res.expect("TCP server must not fail"))
-        })
+        .accept_fut(move |sock| serve_server_first(sock, tx))
         .run()
         .await;
 
@@ -227,30 +214,93 @@ async fn test_server_speaks_first(env: TestEnv) {
         .run_with_test_env(env)
         .await;
 
-    let client = client::tcp(proxy.inbound);
-
-    let tcp_client = client.connect().await;
-
-    assert_eq!(s(&tcp_client.read_timeout(TIMEOUT).await), msg1);
-    tcp_client.write(msg2).await;
-    timeout(TIMEOUT, rx.recv()).await.unwrap();
-
-    // TCP client must close first
-    tcp_client.shutdown().await;
+    server_first_client(proxy.inbound, rx).await;
 
     // ensure panics from the server are propagated
     proxy.join_servers().await;
 }
 
 #[tokio::test]
-async fn tcp_server_first() {
-    test_server_speaks_first(TestEnv::default()).await;
+async fn inbound_tcp_server_first() {
+    test_inbound_server_speaks_first(TestEnv::default()).await;
+}
+
+/// Tests that the outbound proxy does not attempt to perform protocol detection
+/// when the policy controller returns an `OutboundPolicy` indicating that the
+/// destination is opaque.
+#[tokio::test]
+async fn outbound_opaque_tcp_server_first() {
+    let _trace = trace_init();
+
+    let (tx, rx) = mpsc::channel(1);
+    let srv = server::tcp()
+        .accept_fut(move |sock| serve_server_first(sock, tx))
+        .run()
+        .await;
+    let name = format!("opaque.test.svc.cluster.local:{}", srv.addr.port());
+    let dstctl = controller::new();
+    let profile = dstctl.profile_tx(srv.addr);
+    profile.send(controller::pb::DestinationProfile {
+        fully_qualified_name: name.clone(),
+        ..Default::default()
+    });
+    let dest = dstctl.destination_tx(name.clone());
+    dest.send_addr(srv.addr);
+    let policy = controller::policy().outbound(srv.addr, policy::outbound::OutboundPolicy {
+            protocol: Some(policy::outbound::ProxyProtocol {
+                kind: Some(policy::outbound::proxy_protocol::Kind::Opaque(policy::outbound::proxy_protocol::Opaque {
+                    routes: vec![policy::outbound_default_opaque_route(name.clone())]
+                })),
+            }),
+            ..policy::outbound_default(name)
+    });
+    let proxy = proxy::new()
+        .controller(dstctl.run().await)
+        .policy(policy.run().await)
+        .outbound(srv)
+        .run()
+        .await;
+
+    server_first_client(proxy.outbound, rx).await;
+
+    // ensure panics from the server are propagated
+    proxy.join_servers().await;
+}
+
+const SERVER_FIRST_MSG1: &str = "custom tcp server starts";
+const SERVER_FIRST_MSG2: &str = "custom tcp client second";
+
+async fn serve_server_first(mut sock: tokio::net::TcpStream, tx: mpsc::Sender<()>) {
+    async move {
+        sock.write_all(SERVER_FIRST_MSG1.as_bytes()).await?;
+        let mut vec = vec![0; 512];
+        let n = sock.read(&mut vec).await?;
+        assert_eq!(s(&vec[..n]), SERVER_FIRST_MSG2);
+        tx.send(()).await.unwrap();
+        Ok::<_, std::io::Error>(())
+    }
+    .map(|res| res.expect("TCP server must not fail"))
+    .await
+}
+
+async fn server_first_client(addr: SocketAddr, mut rx: mpsc::Receiver<()>) {
+    const TIMEOUT: Duration = Duration::from_secs(5);
+    let client = client::tcp(addr);
+
+    let tcp_client = client.connect().await;
+
+    assert_eq!(s(&tcp_client.read_timeout(TIMEOUT).await), SERVER_FIRST_MSG1);
+    tcp_client.write(SERVER_FIRST_MSG2).await;
+    timeout(TIMEOUT, rx.recv()).await.unwrap();
+
+    // TCP client must close first
+    tcp_client.shutdown().await;
 }
 
 // FIXME(ver) this test doesn't actually test TLS functionality.
 #[ignore]
 #[tokio::test]
-async fn tcp_server_first_tls() {
+async fn inbound_tcp_server_first_tls() {
     use std::path::PathBuf;
 
     let (_cert, _key, _trust_anchors) = {
@@ -289,7 +339,7 @@ async fn tcp_server_first_tls() {
     //    "foo.deployment.ns1.linkerd-managed.linkerd.svc.cluster.local".to_string(),
     //);
 
-    test_server_speaks_first(env).await
+    test_inbound_server_speaks_first(env).await
 }
 
 #[tokio::test]

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -246,14 +246,19 @@ async fn outbound_opaque_tcp_server_first() {
     });
     let dest = dstctl.destination_tx(name.clone());
     dest.send_addr(srv.addr);
-    let policy = controller::policy().outbound(srv.addr, policy::outbound::OutboundPolicy {
+    let policy = controller::policy().outbound(
+        srv.addr,
+        policy::outbound::OutboundPolicy {
             protocol: Some(policy::outbound::ProxyProtocol {
-                kind: Some(policy::outbound::proxy_protocol::Kind::Opaque(policy::outbound::proxy_protocol::Opaque {
-                    routes: vec![policy::outbound_default_opaque_route(name.clone())]
-                })),
+                kind: Some(policy::outbound::proxy_protocol::Kind::Opaque(
+                    policy::outbound::proxy_protocol::Opaque {
+                        routes: vec![policy::outbound_default_opaque_route(name.clone())],
+                    },
+                )),
             }),
             ..policy::outbound_default(name)
-    });
+        },
+    );
     let proxy = proxy::new()
         .controller(dstctl.run().await)
         .policy(policy.run().await)
@@ -289,7 +294,10 @@ async fn server_first_client(addr: SocketAddr, mut rx: mpsc::Receiver<()>) {
 
     let tcp_client = client.connect().await;
 
-    assert_eq!(s(&tcp_client.read_timeout(TIMEOUT).await), SERVER_FIRST_MSG1);
+    assert_eq!(
+        s(&tcp_client.read_timeout(TIMEOUT).await),
+        SERVER_FIRST_MSG1
+    );
     tcp_client.write(SERVER_FIRST_MSG2).await;
     timeout(TIMEOUT, rx.recv()).await.unwrap();
 

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -126,7 +126,12 @@ impl svc::Param<Protocol> for Sidecar {
             }
         }
 
-        Protocol::Detect
+        match self.policy.borrow().protocol {
+            policy::Protocol::Http1(_) => Protocol::Http1,
+            policy::Protocol::Http2(_) | policy::Protocol::Grpc(_) => Protocol::Http2,
+            policy::Protocol::Opaque(_) | policy::Protocol::Tls(_) => Protocol::Opaque,
+            policy::Protocol::Detect { .. } => Protocol::Detect,
+        }
     }
 }
 


### PR DESCRIPTION
Currently, the outbound proxy determines whether or not to perform
protocol detection based on the presence of the `opaque_protocol` field
on the resolved `ServiceProfile` from the Destination controller.
However, the `OutboundPolicy` resolved from the policy controller also
contains a `proxy_protocol` field that indicates what protocol should be
used for this destination. While the proxy uses the HTTPRoutes from the
`OutboundPolicy`'s `proxy_protocol`, it does _not_ take into account the
`proxy_protocol` when determining whether or not to perform protocol
detection. This can result in the outbound proxy performing protocol
detection on connections to destinations that have been marked as
opaque.

This branch modifies the outbound proxy to use the `proxy_protocol` from
the `OutboundPolicy`, as well as the `opaque_protocol` field from the
`ServiceProfile`, when determining whether or not to perform protocol
detection. In addition, I've added an integration test, which fails before
making the changes on this branch.

Fixes https://github.com/linkerd/linkerd2/issues/10745