### PR TITLE
outbound: add missing `meta` field in test policy

### DIFF
--- a/linkerd/app/outbound/src/http/logical/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/tests.rs
@@ -231,6 +231,7 @@ async fn balancer_doesnt_select_tripped_breakers() {
     let (_route_tx, routes) =
         watch::channel(Routes::Policy(policy::Params::Http(policy::HttpParams {
             addr: dest.into(),
+            meta: ParentRef(client_policy::Meta::new_default("parent")),
             backends: Arc::new([backend.clone()]),
             routes: Arc::new([default_route(backend)]),
             failure_accrual: client_policy::FailureAccrual::ConsecutiveFailures {


### PR DESCRIPTION
Looks like we accidentally merged PR #2375 without a CI build against the latest state of `main`. In the meantime since #2375 was last built on CI, PR #2374 added an additional metadata field to `policy::HttpParams`, which the `HttpParams` constructed in the test added from #2375 doesn't populate. Therefore, merging this PR broke the build. Whoops!

This commit populates the `meta` field, fixing it.