### PR TITLE
chore: allow `syn` v1 and v2 to coexist peacefully

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -52,7 +52,14 @@ highlight = "all"
 deny = [
     { name = "rustls", wrappers = ["tokio-rustls"] },
 ]
-skip = []
+skip = [
+    # The proc-macro ecosystem is in the middle of a migration from `syn` v1 to
+    # `syn` v2. Allow both versions to coexist peacefully for now.
+    #
+    # Since `syn` is used by proc-macros (executed at compile time), duplicate
+    # versions won't have an impact on the final binary size.
+    { name = "syn" },
+]
 skip-tree = [
     # Hasn't seen a new release since 2017. Pulls in an older version of nom.
     { name = "procinfo" },


### PR DESCRIPTION
The proc-macro ecosystem is in the middle of a migration from `syn` v1 to `syn` v2. Some crates (such as `tokio-macros`, `async-trait`, `tracing-attributes`, etc) have been updated to v2, while others haven't yet. This means that `cargo deny` will not currently permit us to update some of those crates to versions that depend on `syn` v2, because they will create a duplicate dependency.

Since `syn` is used by proc-macros (executed at compile time), duplicate versions won't have an impact on the final binary size. Therefore, it's fine to allow both v1 and v2 to coexist while the ecosystem is still being gradually migrated to the new version.