### PR TITLE
Adding extra fields to access logging

### DIFF
--- a/linkerd/http-access-log/src/lib.rs
+++ b/linkerd/http-access-log/src/lib.rs
@@ -118,12 +118,18 @@ where
                 .unwrap_or_default()
         };
 
+        let path = match request.uri().path_and_query() {
+            Some(v) => v.as_str(),
+            _ => ""
+        };
+
         let span = span!(target: TRACE_TARGET, Level::INFO, "http",
             client.addr = %self.client_addr,
             client.id = self.client_id.as_ref().map(|n| n.as_str()).unwrap_or("-"),
             timestamp = %now(),
             method = request.method().as_str(),
             uri =  %request.uri(),
+            path,
             version = ?request.version(),
             trace_id = trace_id(),
             request_bytes = get_header(http::header::CONTENT_LENGTH),
@@ -133,7 +139,10 @@ where
             processing_ns = field::Empty,
             user_agent = get_header(http::header::USER_AGENT),
             host = get_header(http::header::HOST),
+            x_forwarded_for = get_header(http::header::HeaderName::from_static("x-forwarded-for")),
+            requested_server_name = get_header(http::header::HeaderName::from_static("x-envoy-decorator-operation")),
         );
+
 
         // The access log span is only enabled by the `tracing` subscriber if
         // access logs are being recorded. If it's disabled, we can skip


### PR DESCRIPTION
### Problem:
Observing network traffic with Linkerd is a step-backwards from Istio as fields like ‘x-forwarded-from’ are missing from the access logs. This makes it difficult to identify where a request comes from.

As partly described in Issue #9842 https://github.com/linkerd/linkerd2/issues/9842. 

Access logs also lack a path and query field and instead provide only the entire uri, again a QOL problem that makes it harder to adopt Linkerd.

### Solution:
Adding in three fields, 
```
x_forwarded_for
requested_server_name
path
```

The first two fields are extracted from the request headers using the pre-existing `get-header` method.

The path field is extracted from the `request.uri().path_and_query()` method and defaults to `""` if no path can be extracted from the uri.

### Validation:
Building and deploying the customised linkerd proxy with access logs enabled alongside a nginx container.

Sending network requests and validating that all pre-existing fields persist and the new ones function as intended. 

### Fixes:
Part fixes #9842

I agree to the DCO for all the commits in this PR.