### PR TITLE
outbound: implement `OutboundPolicies` route request timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5191a6b6a0d97519b4746c09a5e92cb9f586cb808d1828f6d7f9889e9ba24d"
+checksum = "597facef5c3f12aece4d18a5e3dbba88288837b0b5d8276681d063e4c9b98a14"
 dependencies = [
  "h2",
  "http",

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -29,7 +29,7 @@ linkerd-meshtls = { path = "../../meshtls", optional = true }
 linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true }
 linkerd-proxy-client-policy = { path = "../../proxy/client-policy" }
 linkerd-tonic-watch = { path = "../../tonic-watch" }
-linkerd2-proxy-api = { version = "0.9", features = ["inbound"] }
+linkerd2-proxy-api = { version = "0.10", features = ["inbound"] }
 once_cell = "1"
 parking_lot = "0.12"
 rangemap = "1"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -34,7 +34,7 @@ ipnet = "2"
 linkerd-app = { path = "..", features = ["allow-loopback"] }
 linkerd-app-core = { path = "../core" }
 linkerd-metrics = { path = "../../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { version = "0.9", features = [
+linkerd2-proxy-api = { version = "0.10", features = [
     "destination",
     "arbitrary",
 ] }

--- a/linkerd/app/integration/src/policy.rs
+++ b/linkerd/app/integration/src/policy.rs
@@ -151,6 +151,7 @@ pub fn outbound_default_http_route(dst: impl ToString) -> outbound::HttpRoute {
             }],
             filters: Vec::new(),
             backends: Some(http_first_available(std::iter::once(backend(dst)))),
+            request_timeout: None,
         }],
     }
 }
@@ -214,6 +215,7 @@ pub fn http_first_available(
                     .map(|backend| http_route::RouteBackend {
                         backend: Some(backend),
                         filters: Vec::new(),
+                        request_timeout: None,
                     })
                     .collect(),
             },

--- a/linkerd/app/integration/src/tests/client_policy.rs
+++ b/linkerd/app/integration/src/tests/client_policy.rs
@@ -223,6 +223,7 @@ async fn header_based_routing() {
             backends: Some(policy::http_first_available(std::iter::once(
                 policy::backend(dst),
             ))),
+            request_timeout: None,
         };
 
     let route = outbound::HttpRoute {
@@ -236,6 +237,7 @@ async fn header_based_routing() {
                 backends: Some(policy::http_first_available(std::iter::once(
                     policy::backend(&dst_world),
                 ))),
+                request_timeout: None,
             },
             // x-hello-city: sf | x-hello-city: san francisco
             mk_header_rule(
@@ -398,6 +400,8 @@ async fn path_based_routing() {
             backends: Some(policy::http_first_available(std::iter::once(
                 policy::backend(dst),
             ))),
+
+            request_timeout: None,
         };
 
     let route = outbound::HttpRoute {
@@ -411,6 +415,7 @@ async fn path_based_routing() {
                 backends: Some(policy::http_first_available(std::iter::once(
                     policy::backend(&dst_world),
                 ))),
+                request_timeout: None,
             },
             // /goodbye/*
             mk_path_rule(

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -20,7 +20,7 @@ ahash = "0.8"
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { version = "0.9", features = ["outbound"] }
+linkerd2-proxy-api = { version = "0.10", features = ["outbound"] }
 linkerd-app-core = { path = "../core" }
 linkerd-app-test = { path = "../test", optional = true }
 linkerd-distribute = { path = "../../distribute" }

--- a/linkerd/app/outbound/src/discover.rs
+++ b/linkerd/app/outbound/src/discover.rs
@@ -206,10 +206,12 @@ pub fn synthesize_forward_policy(
             meta: meta.clone(),
             filters: NO_OPAQ_FILTERS.clone(),
             failure_policy: Default::default(),
+            request_timeout: None,
             distribution: policy::RouteDistribution::FirstAvailable(Arc::new([
                 policy::RouteBackend {
                     filters: NO_OPAQ_FILTERS.clone(),
                     backend: backend.clone(),
+                    request_timeout: None,
                 },
             ])),
         }),
@@ -223,10 +225,12 @@ pub fn synthesize_forward_policy(
                 meta: meta.clone(),
                 filters: NO_HTTP_FILTERS.clone(),
                 failure_policy: Default::default(),
+                request_timeout: None,
                 distribution: policy::RouteDistribution::FirstAvailable(Arc::new([
                     policy::RouteBackend {
                         filters: NO_HTTP_FILTERS.clone(),
                         backend: backend.clone(),
+                        request_timeout: None,
                     },
                 ])),
             },

--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -110,10 +110,10 @@ where
                 // consideration, so we must eagerly fail requests to prevent
                 // leaking tasks onto the runtime.
                 .push_on_service(svc::LoadShed::layer())
-                // Sets an optional request timeout.
-                .push(http::NewTimeout::layer())
                 // TODO(ver) attach the `E` typed failure policy to requests.
                 .push(filters::NewApplyFilters::<Self, _, _>::layer())
+                // Sets an optional request timeout.
+                .push(http::NewTimeout::layer())
                 .push(classify::NewClassify::layer())
                 .push(svc::ArcNewService::layer())
                 .into_inner()

--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -204,6 +204,7 @@ where
                              filters,
                              distribution,
                              failure_policy,
+                             request_timeout,
                          }| {
             let route_ref = RouteRef(meta);
             let distribution = mk_distribution(&route_ref, &distribution);
@@ -214,6 +215,7 @@ where
                 filters,
                 failure_policy,
                 distribution,
+                request_timeout,
             }
         };
 

--- a/linkerd/app/outbound/src/http/logical/policy/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/tests.rs
@@ -48,9 +48,11 @@ async fn header_based_route() {
         }),
         filters: Arc::new([]),
         failure_policy: Default::default(),
+        request_timeout: None,
         distribution: policy::RouteDistribution::FirstAvailable(Arc::new([policy::RouteBackend {
             filters: Arc::new([]),
             backend,
+            request_timeout: None,
         }])),
     };
 
@@ -197,6 +199,7 @@ async fn http_filter_request_headers() {
                     policy: policy::RoutePolicy {
                         meta: policy::Meta::new_default("turtles"),
                         failure_policy: Default::default(),
+                        request_timeout: None,
                         filters: Arc::new([policy::http::Filter::RequestHeaders(
                             policy::http::filter::ModifyHeader {
                                 add: vec![(PIZZA.clone(), TUBULAR.clone())],
@@ -212,6 +215,7 @@ async fn http_filter_request_headers() {
                                         ..Default::default()
                                     },
                                 )]),
+                                request_timeout: None,
                             },
                         ])),
                     },

--- a/linkerd/app/outbound/src/http/logical/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/tests.rs
@@ -336,8 +336,13 @@ async fn route_request_timeout() {
     let rsp = send_req(svc.clone(), http::Request::get("/"));
     tokio::time::sleep(REQUEST_TIMEOUT).await;
     let error = rsp.await.expect_err("request must fail with a timeout");
-    assert!(error.is::<LogicalError>(), "error must originate in the logical stack");
-    assert!(errors::is_caused_by::<http::timeout::ResponseTimeoutError>(error.as_ref()));
+    assert!(
+        error.is::<LogicalError>(),
+        "error must originate in the logical stack"
+    );
+    assert!(errors::is_caused_by::<http::timeout::ResponseTimeoutError>(
+        error.as_ref()
+    ));
 }
 
 #[derive(Clone, Debug)]

--- a/linkerd/app/test/src/resolver/client_policy.rs
+++ b/linkerd/app/test/src/resolver/client_policy.rs
@@ -73,9 +73,11 @@ impl ClientPolicies {
                     meta: Meta::new_default("default"),
                     filters: Arc::new([]),
                     failure_policy: Default::default(),
+                    request_timeout: None,
                     distribution: RouteDistribution::FirstAvailable(Arc::new([RouteBackend {
                         filters: Arc::new([]),
                         backend: backend.clone(),
+                        request_timeout: None,
                     }])),
                 },
             }],
@@ -96,9 +98,11 @@ impl ClientPolicies {
                     meta: Meta::new_default("default"),
                     filters: Arc::new([]),
                     failure_policy: Default::default(),
+                    request_timeout: None,
                     distribution: RouteDistribution::FirstAvailable(Arc::new([RouteBackend {
                         filters: Arc::new([]),
                         backend: backend.clone(),
+                        request_timeout: None,
                     }])),
                 }),
             },

--- a/linkerd/http-route/Cargo.toml
+++ b/linkerd/http-route/Cargo.toml
@@ -17,7 +17,7 @@ tracing = "0.1"
 url = "2"
 
 [dependencies.linkerd2-proxy-api]
-version = "0.9"
+version = "0.10"
 features = ["http-route", "grpc-route"]
 optional = true
 

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -14,7 +14,7 @@ async-stream = "0.3"
 futures = { version = "0.3", default-features = false }
 linkerd-addr = { path = "../../addr" }
 linkerd-error = { path = "../../error" }
-linkerd2-proxy-api = { version = "0.9", features = ["destination"] }
+linkerd2-proxy-api = { version = "0.10", features = ["destination"] }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -18,7 +18,7 @@ proto = [
 ahash = "0.8"
 ipnet = "2"
 http = "0.2"
-linkerd2-proxy-api = { version = "0.9", optional = true, features = [
+linkerd2-proxy-api = { version = "0.10", optional = true, features = [
     "outbound",
 ] }
 linkerd-error = { path = "../../error" }

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -279,7 +279,11 @@ pub mod proto {
     impl TryFrom<grpc_route::RouteBackend> for RouteBackend<Filter> {
         type Error = InvalidBackend;
         fn try_from(
-            grpc_route::RouteBackend { backend, filters, request_timeout }: grpc_route::RouteBackend,
+            grpc_route::RouteBackend {
+                backend,
+                filters,
+                request_timeout,
+            }: grpc_route::RouteBackend,
         ) -> Result<RouteBackend<Filter>, InvalidBackend> {
             let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
             RouteBackend::try_from_proto(backend, filters, request_timeout)

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -238,7 +238,9 @@ pub mod proto {
             .ok_or(InvalidHttpRoute::Missing("distribution"))?
             .try_into()?;
 
-        let request_timeout = request_timeout.map(std::time::Duration::try_from).transpose()?;
+        let request_timeout = request_timeout
+            .map(std::time::Duration::try_from)
+            .transpose()?;
 
         Ok(Rule {
             matches,
@@ -297,7 +299,11 @@ pub mod proto {
     impl TryFrom<http_route::RouteBackend> for RouteBackend<Filter> {
         type Error = InvalidBackend;
         fn try_from(
-            http_route::RouteBackend { backend, filters, request_timeout }: http_route::RouteBackend,
+            http_route::RouteBackend {
+                backend,
+                filters,
+                request_timeout,
+            }: http_route::RouteBackend,
         ) -> Result<Self, Self::Error> {
             let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
             RouteBackend::try_from_proto(backend, filters, request_timeout)

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -547,12 +547,20 @@ pub mod proto {
                 .map(T::try_from)
                 .collect::<Result<Arc<[_]>, _>>()
                 .map_err(|error| InvalidBackend::Filter(error.into()))?;
-            let request_timeout = request_timeout
-                .map(|d| d.try_into())
-                .transpose()
-                .map_err(|error| InvalidBackend::Duration { field: "backend request timeout", error })?;
+            let request_timeout =
+                request_timeout
+                    .map(|d| d.try_into())
+                    .transpose()
+                    .map_err(|error| InvalidBackend::Duration {
+                        field: "backend request timeout",
+                        error,
+                    })?;
 
-            Ok(RouteBackend { filters, backend, request_timeout })
+            Ok(RouteBackend {
+                filters,
+                backend,
+                request_timeout,
+            })
         }
     }
 

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -58,6 +58,17 @@ pub struct RoutePolicy<T, F> {
     pub meta: Arc<Meta>,
     pub filters: Arc<[T]>,
     pub distribution: RouteDistribution<T>,
+    /// Request timeout applied to HTTP and gRPC routes.
+    ///
+    /// Opaque routes are proxied as opaque TCP, and therefore, we have no
+    /// concept of a "request", so this field is ignored by opaque routes.
+    /// It's somewhat unfortunate that this field is part of the `RoutePolicy`
+    /// struct, which is used to represent routes for all protocols, rather than
+    /// as a filter, which are a generic type that depends on the protocol in
+    /// use. However, this can't be easily modeled as a filter using the current
+    /// design for filters, as filters synchronously modify a request or return
+    /// an error --- a filter cannot wrap the response future in order to add a
+    /// timeout.
     pub request_timeout: Option<time::Duration>,
 
     /// Configures what responses are classified as failures.

--- a/linkerd/proxy/client-policy/src/opaq.rs
+++ b/linkerd/proxy/client-policy/src/opaq.rs
@@ -127,8 +127,7 @@ pub(crate) mod proto {
             filters: NO_FILTERS.clone(),
             failure_policy: NonIoErrors::default(),
             distribution,
-            // XXX(eliza): maybe this shouldn't even be present on opaque
-            // routes...might have to turn it into a filter...
+            // Request timeouts are ignored on opaque routes.
             request_timeout: None,
         })
     }

--- a/linkerd/proxy/client-policy/src/opaq.rs
+++ b/linkerd/proxy/client-policy/src/opaq.rs
@@ -127,6 +127,9 @@ pub(crate) mod proto {
             filters: NO_FILTERS.clone(),
             failure_policy: NonIoErrors::default(),
             distribution,
+            // XXX(eliza): maybe this shouldn't even be present on opaque
+            // routes...might have to turn it into a filter...
+            request_timeout: None,
         })
     }
 
@@ -178,7 +181,7 @@ pub(crate) mod proto {
             opaque_route::RouteBackend { backend }: opaque_route::RouteBackend,
         ) -> Result<Self, Self::Error> {
             let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
-            RouteBackend::try_from_proto(backend, std::iter::empty::<()>())
+            RouteBackend::try_from_proto(backend, std::iter::empty::<()>(), None)
         }
     }
 

--- a/linkerd/proxy/identity-client/Cargo.toml
+++ b/linkerd/proxy/identity-client/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { version = "0.9", features = ["identity"] }
+linkerd2-proxy-api = { version = "0.10", features = ["identity"] }
 linkerd-error = { path = "../../error" }
 linkerd-identity = { path = "../../identity" }
 linkerd-metrics = { path = "../../metrics" }

--- a/linkerd/proxy/server-policy/Cargo.toml
+++ b/linkerd/proxy/server-policy/Cargo.toml
@@ -17,7 +17,7 @@ prost-types = { version = "0.11", optional = true }
 thiserror = "1"
 
 [dependencies.linkerd2-proxy-api]
-version = "0.9"
+version = "0.10"
 features = ["inbound"]
 optional = true
 

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -11,7 +11,7 @@ http = "0.2"
 hyper = { version = "0.14", features = ["http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.7"
-linkerd2-proxy-api = { version = "0.9", features = ["tap"] }
+linkerd2-proxy-api = { version = "0.10", features = ["tap"] }
 linkerd-conditional = { path = "../../conditional" }
 linkerd-error = { path = "../../error" }
 linkerd-meshtls = { path = "../../meshtls" }
@@ -30,5 +30,5 @@ tracing = "0.1"
 pin-project = "1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { version = "0.9", features = ["arbitrary"] }
+linkerd2-proxy-api = { version = "0.10", features = ["arbitrary"] }
 quickcheck = { version = "1", default-features = false }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -21,7 +21,7 @@ linkerd-http-box = { path = "../http-box" }
 linkerd-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd-stack = { path = "../stack" }
 linkerd-tonic-watch = { path = "../tonic-watch" }
-linkerd2-proxy-api = { version = "0.9", features = ["destination"] }
+linkerd2-proxy-api = { version = "0.10", features = ["destination"] }
 once_cell = "1.17"
 prost-types = "0.11"
 regex = "1"
@@ -33,5 +33,5 @@ thiserror = "1"
 tracing = "0.1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { version = "0.9", features = ["arbitrary"] }
+linkerd2-proxy-api = { version = "0.10", features = ["arbitrary"] }
 quickcheck = { version = "1", default-features = false }


### PR DESCRIPTION
The latest proxy-api release, v0.10.0, adds fields to the
`OutboundPolicies` API for configuring HTTP request timeouts, based on
the proposed changes to HTTPRoute in kubernetes-sigs/gateway-api#1997.

This branch updates the proxy-api dependency to v0.10.0 and adds the new
timeout configuration fields to the proxy's internal client policy
types. In addition, this branch adds a timeout middleware to the HTTP
client policy stack, so that the timeout described by the
`Rule.request_timeout` field is now applied.

Implementing the `RouteBackend.request_timeout` field with semantics as
close as possible to those described in GEP-1742 will be somewhat more
complex, and will be added in a separate PR. The reason for this
complexity is that, as described in GEP-1742, the
`timeouts.backendRequest` timeout is intended to bound only the time it
takes for the *backend* to respond to the request, rather than bounding
both time spent in the proxy and time spent in the backend (which isthe
intention behind the `timeouts.request` timeout). Therefore, the timeout
for `backendRequest` should be started as "close" to the actual backend
client as possible, ideally in the endpoint stack after the request has
already made it through the load balancer queue. Starting this timeout
in the logical stack like the route's `request_timeout` does would mean
that time spent in the proxy's queues is included in this timeout, which
seems not to be the intention. However, if we want these timeouts to
start in the endpoint stack, we can't configure them using the target
type, because a backend may be referenced with different timeouts by
different HTTPRoutes, and we would prefer not to create separate client
stacks based on those timeout values. Instead, we will need the request
to carry the configured timeout value as an extension, and a new timeout
middleware that applies timeouts from a request extension. This will be
implemented in a follow-up PR.