### PR TITLE
Emit distinguishable version info

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,11 @@ jobs:
               exit 1
             fi
             ( echo publish=true
-              echo version="$ver"
+              echo version="${ver#v}"
             ) >> "$GITHUB_OUTPUT"
           else
             sha="${{ github.sha }}"
-            echo version="test-${sha:0:7}" >> "$GITHUB_OUTPUT"
+            echo version="0.0.0-test.${sha:0:7}" >> "$GITHUB_OUTPUT"
           fi
     outputs:
       publish: ${{ steps.meta.outputs.publish }}
@@ -60,13 +60,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     container: docker://ghcr.io/linkerd/dev:v40-rust-musl
+    env:
+      LINKERD2_PROXY_VENDOR: ${{ github.repository_owner }}
+      LINKERD2_PROXY_VERSION: ${{ needs.meta.outputs.version }}
     steps:
       - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
       - run: just fetch
       - run: just arch=${{ matrix.arch }} libc=${{ matrix.libc }} rustup
       - run: just arch=${{ matrix.arch }} libc=${{ matrix.libc }} profile=release build
-      - run: just arch=${{ matrix.arch }} libc=${{ matrix.libc }} profile=release package_version=${{ needs.meta.outputs.version }} package
+      - run: just arch=${{ matrix.arch }} libc=${{ matrix.libc }} profile=release package
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: ${{ matrix.arch }}-artifacts
@@ -84,6 +87,6 @@ jobs:
       - if: needs.meta.outputs.publish
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844
         with:
-          name: ${{ needs.meta.outputs.version }}
+          name: v${{ needs.meta.outputs.version }}
           files: artifacts/**/*
           generate_release_notes: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,6 +938,7 @@ dependencies = [
  "pin-project",
  "quickcheck",
  "regex",
+ "semver 1.0.17",
  "serde_json",
  "thiserror",
  "tokio",
@@ -2396,7 +2397,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2470,6 +2471,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "semver-parser"

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,9 @@ RUN --mount=type=cache,id=cargo,target=/usr/local/cargo/registry \
     just fetch
 ARG TARGETARCH="amd64"
 ARG PROFILE="release"
-RUN --mount=type=cache,id=target,target=target \
-    --mount=type=cache,id=cargo,target=/usr/local/cargo/registry \
+ARG LINKERD2_PROXY_VERSION=""
+ARG LINKERD2_PROXY_VENDOR=""
+RUN --mount=type=cache,id=cargo,target=/usr/local/cargo/registry \
     just arch="$TARGETARCH" features="$PROXY_FEATURES" profile="$PROFILE" build && \
     mkdir -p /out && \
     mv $(just --evaluate profile="$PROFILE" _target_bin) /out/linkerd2-proxy

--- a/justfile
+++ b/justfile
@@ -15,8 +15,11 @@ toolchain := ""
 
 features := ""
 
+export LINKERD2_PROXY_VERSION := env_var_or_default("LINKERD2_PROXY_VERSION", "0.0.0-dev." + `git rev-parse --short HEAD`)
+export LINKERD2_PROXY_VENDOR := env_var_or_default("LINKERD2_PROXY_VENDOR", `whoami` + "@" + `hostname`)
+
 # The version name to use for packages.
-package_version := `git rev-parse --short HEAD`
+package_version := "v" + LINKERD2_PROXY_VERSION
 
 # Docker image name & tag.
 docker-repo := "localhost/linkerd/proxy"
@@ -175,6 +178,9 @@ docker *args='--output=type=docker': && _clean-cache
         --pull \
         --tag={{ docker-image }} \
         --build-arg PROFILE='{{ profile }}' \
+        --build-arg LINKERD2_PROXY_VENDOR='{{ LINKERD2_PROXY_VENDOR }}' \
+        --build-arg LINKERD2_PROXY_VERSION='{{ LINKERD2_PROXY_VERSION }}' \
+        --no-cache-filter=runtime \
         {{ if linkerd-tag == '' { '' } else { '--build-arg=RUNTIME_IMAGE=ghcr.io/linkerd/proxy:' + linkerd-tag } }} \
         {{ if features != "" { "--build-arg PROXY_FEATURES=" + features } else { "" } }} \
         {{ if DOCKER_BUILDX_CACHE_DIR == '' { '' } else { '--cache-from=type=local,src=' + DOCKER_BUILDX_CACHE_DIR + ' --cache-to=type=local,dest=' + DOCKER_BUILDX_CACHE_DIR } }} \

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -76,5 +76,8 @@ features = ["make", "spawn-ready", "timeout", "util", "limit"]
 [target.'cfg(target_os = "linux")'.dependencies]
 linkerd-system = { path = "../../system" }
 
+[build-dependencies]
+semver = "1"
+
 [dev-dependencies]
 quickcheck = { version = "1", default-features = false }

--- a/linkerd/app/core/build.rs
+++ b/linkerd/app/core/build.rs
@@ -1,5 +1,4 @@
 use std::process::Command;
-use std::string::String;
 
 fn set_env(name: &str, cmd: &mut Command) {
     let value = match cmd.output() {
@@ -12,21 +11,38 @@ fn set_env(name: &str, cmd: &mut Command) {
     println!("cargo:rustc-env={}={}", name, value);
 }
 
+fn version() -> String {
+    if let Ok(v) = std::env::var("LINKERD2_PROXY_VERSION") {
+        if !v.is_empty() {
+            if semver::Version::parse(&v).is_err() {
+                panic!("LINKERD2_PROXY_VERSION must be semver");
+            }
+            return v;
+        }
+    }
+
+    "0.0.0-dev".to_string()
+}
+
+fn vendor() -> String {
+    std::env::var("LINKERD2_PROXY_VENDOR").unwrap_or_default()
+}
+
 fn main() {
-    set_env(
-        "GIT_BRANCH",
-        Command::new("git").args(["rev-parse", "--abbrev-ref", "HEAD"]),
-    );
     set_env(
         "GIT_SHA",
         Command::new("git").args(["rev-parse", "--short", "HEAD"]),
     );
-    set_env(
-        "GIT_VERSION",
-        Command::new("git").args(["describe", "--always", "HEAD"]),
-    );
-    set_env("RUST_VERSION", Command::new("rustc").arg("--version"));
 
-    let profile = std::env::var("PROFILE").unwrap();
-    println!("cargo:rustc-env=PROFILE={}", profile);
+    // Capture the ISO 8601 formatted UTC time.
+    set_env(
+        "LINKERD2_PROXY_BUILD_DATE",
+        Command::new("date").args(["-u", "+%Y-%m-%dT%H:%M:%SZ"]),
+    );
+
+    println!("cargo:rustc-env=LINKERD2_PROXY_VERSION={}", version());
+    println!("cargo:rustc-env=LINKERD2_PROXY_VENDOR={}", vendor());
+
+    let profile = std::env::var("PROFILE").expect("PROFILE must be set");
+    println!("cargo:rustc-env=PROFILE={profile}");
 }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -149,7 +149,7 @@ impl Metrics {
     ) -> (Self, impl FmtMetrics + Clone + Send + 'static) {
         let process = telemetry::process::Report::new(start_time);
 
-        let build_info = telemetry::build_info::Report::new();
+        let build_info = telemetry::build_info::Report::default();
 
         let (control, control_report) = {
             let m = metrics::Requests::<ControlLabels, Class>::default();

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -12,7 +12,10 @@ compile_error!(
 );
 
 use linkerd_app::{
-    core::{telemetry::StartTime, transport::BindTcp},
+    core::{
+        telemetry::{build_info, StartTime},
+        transport::BindTcp,
+    },
     trace, Config,
 };
 use linkerd_signal as signal;
@@ -36,6 +39,15 @@ fn main() {
             std::process::exit(EX_USAGE);
         }
     };
+
+    info!(
+        "{profile} {version} ({sha}) by {vendor} on {date}",
+        date = build_info::DATE,
+        sha = build_info::GIT_SHA,
+        version = build_info::VERSION,
+        profile = build_info::PROFILE,
+        vendor = build_info::VENDOR,
+    );
 
     // Load configuration from the environment without binding ports.
     let config = match Config::try_from_env() {


### PR DESCRIPTION
The proxy currently emits very little useful version information.

This change updates the proxy to support new build-time environment variables that are used to report version information:

* LINKERD2_PROXY_BUILD_TIME
* LINKERD2_PROXY_VENDOR
* LINKERD2_PROXY_VERSION

Additionally, several pre-existing Git-oriented metadata have been removed, as they were generally redundant or uninformative. The Rustc version has also been removed (since it has no real user-facing value and can be easily determined by the version/tag).