### PR TITLE
outbound: handle `NotFound` client policies in ingress mode (#2431)

### DIFF
--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -1,18 +1,21 @@
 use crate::{http, opaq, policy, Config, Discovery, Outbound, ParentRef};
 use linkerd_app_core::{
     config::{ProxyConfig, ServerConfig},
-    detect, io, profiles,
+    detect, errors, io, profiles,
     proxy::{
         api_resolve::{ConcreteAddr, Metadata},
         core::Resolve,
+        http::balance,
     },
     svc::{self, ServiceExt},
     transport::addrs::*,
     Addr, Error, Infallible, NameAddr, Result,
 };
-use std::{fmt::Debug, hash::Hash};
+use once_cell::sync::Lazy;
+use std::{fmt::Debug, hash::Hash, sync::Arc};
 use thiserror::Error;
 use tokio::sync::watch;
+use tracing::Instrument;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct Http<T> {
@@ -79,20 +82,7 @@ impl Outbound<()> {
         // Endpoint resolver.
         R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
     {
-        let discover = svc::mk(move |DiscoverAddr(addr)| {
-            let profile = profiles
-                .clone()
-                .get_profile(profiles::LookupAddr(addr.clone()));
-            let policy = policies.get_policy(addr);
-            Box::pin(async move {
-                let (profile, policy) = tokio::join!(profile, policy);
-                let profile = profile.unwrap_or_else(|error| {
-                    tracing::warn!(%error, "Failed to resolve profile");
-                    None
-                });
-                Ok((profile, policy?))
-            })
-        });
+        let discover = self.ingress_resolver(profiles, policies);
 
         // The fallback stack is the same thing as the normal proxy stack, but
         // it doesn't include TCP metrics, since they are already instrumented
@@ -123,6 +113,128 @@ impl Outbound<()> {
         http.push_ingress(opaque)
             .push_tcp_instrument(|t: &T| tracing::info_span!("ingress", addr = %t.param()))
             .into_inner()
+    }
+
+    fn ingress_resolver(
+        &self,
+        profiles: impl profiles::GetProfile<Error = Error>,
+        policies: impl policy::GetPolicy,
+    ) -> impl svc::Service<
+        DiscoverAddr,
+        Error = Error,
+        Response = (Option<profiles::Receiver>, policy::Receiver),
+        Future = impl Send,
+    > + Clone
+           + Send
+           + Sync
+           + 'static {
+        let detect_timeout = self.config.proxy.detect_protocol_timeout;
+        let queue = {
+            let queue = self.config.tcp_connection_queue;
+            policy::Queue {
+                capacity: queue.capacity,
+                failfast_timeout: queue.failfast_timeout,
+            }
+        };
+        let load = {
+            let balance::EwmaConfig { decay, default_rtt } =
+                crate::http::logical::profile::DEFAULT_EWMA;
+            policy::Load::PeakEwma(policy::PeakEwma { decay, default_rtt })
+        };
+        svc::mk(move |DiscoverAddr(addr)| {
+            tracing::debug!(%addr, "Discover");
+
+            let profile = profiles
+                .clone()
+                .get_profile(profiles::LookupAddr(addr.clone()))
+                .instrument(tracing::debug_span!("profiles"));
+            let policy = policies
+                .get_policy(addr)
+                .instrument(tracing::debug_span!("policy"));
+
+            Box::pin(async move {
+                let (profile, policy) = tokio::join!(profile, policy);
+                tracing::debug!("Discovered");
+
+                let profile = profile.unwrap_or_else(|error| {
+                    tracing::warn!(%error, "Error resolving ServiceProfile");
+                    None
+                });
+
+                // If there was a policy resolution, return it with the profile so
+                // the stack can determine how to switch on them.
+                let policy_error = match policy {
+                    Ok(policy) => return Ok((profile, policy)),
+                    // XXX(ver) The policy controller may (for the time being) reject
+                    // our lookups, since it doesn't yet serve endpoint metadata for
+                    // forwarding.
+                    Err(error) if errors::has_grpc_status(&error, tonic::Code::NotFound) => {
+                        tracing::debug!("Policy not found");
+                        error
+                    }
+                    // Earlier versions of the Linkerd control plane (e.g.
+                    // 2.12.x) will return `Unimplemented` for requests to the
+                    // OutboundPolicy API. Log a warning and synthesize a policy
+                    // for backwards compatibility.
+                    Err(error) if errors::has_grpc_status(&error, tonic::Code::Unimplemented) => {
+                        tracing::warn!("Policy controller returned `Unimplemented`, the control plane may be out of date.");
+                        error
+                    }
+                    Err(error) => return Err(error),
+                };
+
+                // If there was a profile resolution, try to use it to synthesize a
+                // policy. Otherwise, return an error, as we have neither a
+                // policy nor a ServiceProfile and can't synthesize a policy.
+                let profile = match profile {
+                    Some(profile) => profile,
+                    None => return Err(policy_error),
+                };
+
+                let policy = crate::discover::spawn_synthesized_profile_policy(
+                    profile.clone().into(),
+                    move |profile: &profiles::Profile| {
+                        static ENDPOINT_META: Lazy<Arc<policy::Meta>> = Lazy::new(|| {
+                            Arc::new(policy::Meta::Default {
+                                name: "endpoint".into(),
+                            })
+                        });
+                        static PROFILE_META: Lazy<Arc<policy::Meta>> = Lazy::new(|| {
+                            Arc::new(policy::Meta::Default {
+                                name: "profile".into(),
+                            })
+                        });
+
+                        if let Some((addr, meta)) = profile.endpoint.clone() {
+                            return crate::discover::synthesize_forward_policy(
+                                &ENDPOINT_META,
+                                detect_timeout,
+                                queue,
+                                addr,
+                                meta,
+                            );
+                        }
+
+                        if let Some(ref logical) = profile.addr {
+                            return crate::discover::synthesize_balance_policy(
+                                &PROFILE_META,
+                                detect_timeout,
+                                queue,
+                                load,
+                                logical,
+                            );
+                        }
+
+                        // Return an empty policy so that a
+                        // `DiscoveryRejected` error is returned if
+                        // selecting the policy.
+                        policy::ClientPolicy::empty(detect_timeout)
+                    },
+                );
+
+                Ok((Some(profile), policy))
+            })
+        })
     }
 }
 

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -182,6 +182,37 @@ impl ClientPolicy {
             backends: BACKENDS.clone(),
         }
     }
+
+    pub fn empty(timeout: time::Duration) -> Self {
+        static META: Lazy<Arc<Meta>> = Lazy::new(|| {
+            Arc::new(Meta::Default {
+                name: "empty".into(),
+            })
+        });
+        static NO_HTTP_ROUTES: Lazy<Arc<[http::Route]>> = Lazy::new(|| Arc::new([]));
+        static NO_BACKENDS: Lazy<Arc<[Backend]>> = Lazy::new(|| Arc::new([]));
+
+        Self {
+            parent: META.clone(),
+            protocol: Protocol::Detect {
+                timeout,
+                http1: http::Http1 {
+                    routes: NO_HTTP_ROUTES.clone(),
+                    failure_accrual: Default::default(),
+                },
+                http2: http::Http2 {
+                    routes: NO_HTTP_ROUTES.clone(),
+                    failure_accrual: Default::default(),
+                },
+                opaque: opaq::Opaque {
+                    // TODO(eliza): eventually, can we configure the opaque
+                    // policy to fail conns?
+                    policy: None,
+                },
+            },
+            backends: NO_BACKENDS.clone(),
+        }
+    }
 }
 
 // === impl Meta ===


### PR DESCRIPTION
When the outbound proxy resolves an outbound policy from the policy controller's `OutboundPolicies` API, the policy controller may return an error with the `grpc-status` code `NotFound` in order to indicate that the destination is not a ClusterIP service. When this occurs, the proxy will fall back to either using a ServiceProfile, if the ServiceProfile contains non-trivial configuration, or synthesizing a default client policy from the ServiceProfile.

However, when the outbound proxy is configured to run in ingress mode, the fallback behavior does not occur. Instead, the ingress mode proxy treats any error returned by the policy controller's `OutboundPolicies` API as fatal. This means that when an ingress controller performs its own load-balancing and opens a connection to a pod IP directly, the ingress mode proxy will fail any requests on that connection. This is a bug, and is the cause of the issues described in linkerd/linkerd2#10908.

This branch fixes this by changing the ingress mode proxy to handle `NotFound` errors returned by the policy controller. I've added similar logic for synthesizing default policies from a discovered ServiceProfile, or using the profile if it's non-trivial. Unfortunately, we can't just reuse the existing `Outbound::resolver` method, as ingress discovery may be performed for an original destination address *or* for a DNS name, and it's necessary to construct fallback policies in either case. Instead, I've added a new function with similar behavior that's ingress-specific.

I've manually tested this change against the repro steps[^1] described in linkerd/linkerd2#10908, and verified that the proxy 503s on 2.13.4, and that it once again routes correctly after applying this change.

Fixes linkerd/linkerd2#10908.

[^1]: As described in the first comment, using Contour and podinfo.