### PR TITLE
Add suport for response header filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,8 +1894,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597facef5c3f12aece4d18a5e3dbba88288837b0b5d8276681d063e4c9b98a14"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=f1598b46c179f5a981bfca7b660dc89903b18ab7#f1598b46c179f5a981bfca7b660dc89903b18ab7"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,8 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.10.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=f1598b46c179f5a981bfca7b660dc89903b18ab7#f1598b46c179f5a981bfca7b660dc89903b18ab7"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2348745f909668e6de2dbd175eeeac374887ffb33989a0e09766f1807b27cdfe"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,4 +85,3 @@ lto = true
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.22" }
 boring = { git = "https://github.com/cloudflare/boring" }
 tokio-boring = { git = "https://github.com/cloudflare/boring" }
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "f1598b46c179f5a981bfca7b660dc89903b18ab7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,4 @@ lto = true
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.22" }
 boring = { git = "https://github.com/cloudflare/boring" }
 tokio-boring = { git = "https://github.com/cloudflare/boring" }
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api", rev = "f1598b46c179f5a981bfca7b660dc89903b18ab7" }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -29,7 +29,7 @@ linkerd-meshtls = { path = "../../meshtls", optional = true }
 linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true }
 linkerd-proxy-client-policy = { path = "../../proxy/client-policy" }
 linkerd-tonic-watch = { path = "../../tonic-watch" }
-linkerd2-proxy-api = { version = "0.10", features = ["inbound"] }
+linkerd2-proxy-api = { version = "0.11", features = ["inbound"] }
 once_cell = "1"
 parking_lot = "0.12"
 rangemap = "1"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -34,7 +34,7 @@ ipnet = "2"
 linkerd-app = { path = "..", features = ["allow-loopback"] }
 linkerd-app-core = { path = "../core" }
 linkerd-metrics = { path = "../../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { version = "0.10", features = [
+linkerd2-proxy-api = { version = "0.11", features = [
     "destination",
     "arbitrary",
 ] }

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -20,7 +20,7 @@ ahash = "0.8"
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { version = "0.10", features = ["outbound"] }
+linkerd2-proxy-api = { version = "0.11", features = ["outbound"] }
 linkerd-app-core = { path = "../core" }
 linkerd-app-test = { path = "../test", optional = true }
 linkerd-distribute = { path = "../../distribute" }

--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -153,8 +153,13 @@ impl<T, M, F, E> svc::Param<http::timeout::ResponseTimeout> for MatchedRoute<T, 
 
 impl<T> filters::Apply for Http<T> {
     #[inline]
-    fn apply<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
-        filters::apply_http(&self.r#match, &self.params.filters, req)
+    fn apply_request<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
+        filters::apply_http_request(&self.r#match, &self.params.filters, req)
+    }
+
+    #[inline]
+    fn apply_response<B>(&self, rsp: &mut ::http::Response<B>) -> Result<()> {
+        filters::apply_http_response(&self.params.filters, rsp)
     }
 }
 
@@ -168,8 +173,13 @@ impl<T> svc::Param<classify::Request> for Http<T> {
 
 impl<T> filters::Apply for Grpc<T> {
     #[inline]
-    fn apply<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
-        filters::apply_grpc(&self.r#match, &self.params.filters, req)
+    fn apply_request<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
+        filters::apply_grpc_request(&self.r#match, &self.params.filters, req)
+    }
+
+    #[inline]
+    fn apply_response<B>(&self, rsp: &mut ::http::Response<B>) -> Result<()> {
+        filters::apply_grpc_response(&self.params.filters, rsp)
     }
 }
 

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -145,15 +145,24 @@ impl<T, M, F> svc::Param<http::ResponseTimeout> for MatchedBackend<T, M, F> {
 
 impl<T> filters::Apply for Http<T> {
     #[inline]
-    fn apply<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
-        filters::apply_http(&self.r#match, &self.params.filters, req)
+    fn apply_request<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
+        filters::apply_http_request(&self.r#match, &self.params.filters, req)
+    }
+
+    #[inline]
+    fn apply_response<B>(&self, rsp: &mut ::http::Response<B>) -> Result<()> {
+        filters::apply_http_response(&self.params.filters, rsp)
     }
 }
 
 impl<T> filters::Apply for Grpc<T> {
     #[inline]
-    fn apply<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
-        filters::apply_grpc(&self.r#match, &self.params.filters, req)
+    fn apply_request<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
+        filters::apply_grpc_request(&self.r#match, &self.params.filters, req)
+    }
+
+    fn apply_response<B>(&self, rsp: &mut ::http::Response<B>) -> Result<()> {
+        filters::apply_grpc_response(&self.params.filters, rsp)
     }
 }
 

--- a/linkerd/http-route/Cargo.toml
+++ b/linkerd/http-route/Cargo.toml
@@ -17,7 +17,7 @@ tracing = "0.1"
 url = "2"
 
 [dependencies.linkerd2-proxy-api]
-version = "0.10"
+version = "0.11"
 features = ["http-route", "grpc-route"]
 optional = true
 

--- a/linkerd/http-route/src/http/filter/modify_header.rs
+++ b/linkerd/http-route/src/http/filter/modify_header.rs
@@ -46,19 +46,6 @@ pub mod proto {
         type Error = InvalidModifyHeader;
 
         fn try_from(rhm: api::RequestHeaderModifier) -> Result<Self, Self::Error> {
-            fn to_pairs(
-                hs: Option<http_types::Headers>,
-            ) -> Result<Vec<(HeaderName, HeaderValue)>, InvalidModifyHeader> {
-                hs.into_iter()
-                    .flat_map(|a| a.headers.into_iter())
-                    .map(|h| {
-                        let name = h.name.parse::<HeaderName>()?;
-                        let value = HeaderValue::from_bytes(&h.value)?;
-                        Ok((name, value))
-                    })
-                    .collect()
-            }
-
             let add = to_pairs(rhm.add)?;
             let set = to_pairs(rhm.set)?;
             let remove = rhm
@@ -76,19 +63,6 @@ pub mod proto {
         type Error = InvalidModifyHeader;
 
         fn try_from(rhm: api::ResponseHeaderModifier) -> Result<Self, Self::Error> {
-            fn to_pairs(
-                hs: Option<http_types::Headers>,
-            ) -> Result<Vec<(HeaderName, HeaderValue)>, InvalidModifyHeader> {
-                hs.into_iter()
-                    .flat_map(|a| a.headers.into_iter())
-                    .map(|h| {
-                        let name = h.name.parse::<HeaderName>()?;
-                        let value = HeaderValue::from_bytes(&h.value)?;
-                        Ok((name, value))
-                    })
-                    .collect()
-            }
-
             let add = to_pairs(rhm.add)?;
             let set = to_pairs(rhm.set)?;
             let remove = rhm
@@ -98,5 +72,18 @@ pub mod proto {
                 .collect::<Result<Vec<HeaderName>, http::header::InvalidHeaderName>>()?;
             Ok(ModifyHeader { add, set, remove })
         }
+    }
+
+    fn to_pairs(
+        hs: Option<http_types::Headers>,
+    ) -> Result<Vec<(HeaderName, HeaderValue)>, InvalidModifyHeader> {
+        hs.into_iter()
+            .flat_map(|a| a.headers.into_iter())
+            .map(|h| {
+                let name = h.name.parse::<HeaderName>()?;
+                let value = HeaderValue::from_bytes(&h.value)?;
+                Ok((name, value))
+            })
+            .collect()
     }
 }

--- a/linkerd/http-route/src/http/filter/modify_header.rs
+++ b/linkerd/http-route/src/http/filter/modify_header.rs
@@ -69,4 +69,34 @@ pub mod proto {
             Ok(ModifyHeader { add, set, remove })
         }
     }
+
+    // === impl ModifyResponseHeader ===
+
+    impl TryFrom<api::ResponseHeaderModifier> for ModifyHeader {
+        type Error = InvalidModifyHeader;
+
+        fn try_from(rhm: api::ResponseHeaderModifier) -> Result<Self, Self::Error> {
+            fn to_pairs(
+                hs: Option<http_types::Headers>,
+            ) -> Result<Vec<(HeaderName, HeaderValue)>, InvalidModifyHeader> {
+                hs.into_iter()
+                    .flat_map(|a| a.headers.into_iter())
+                    .map(|h| {
+                        let name = h.name.parse::<HeaderName>()?;
+                        let value = HeaderValue::from_bytes(&h.value)?;
+                        Ok((name, value))
+                    })
+                    .collect()
+            }
+
+            let add = to_pairs(rhm.add)?;
+            let set = to_pairs(rhm.set)?;
+            let remove = rhm
+                .remove
+                .into_iter()
+                .map(|n| n.parse())
+                .collect::<Result<Vec<HeaderName>, http::header::InvalidHeaderName>>()?;
+            Ok(ModifyHeader { add, set, remove })
+        }
+    }
 }

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -14,7 +14,7 @@ async-stream = "0.3"
 futures = { version = "0.3", default-features = false }
 linkerd-addr = { path = "../../addr" }
 linkerd-error = { path = "../../error" }
-linkerd2-proxy-api = { version = "0.10", features = ["destination"] }
+linkerd2-proxy-api = { version = "0.11", features = ["destination"] }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -18,7 +18,7 @@ proto = [
 ahash = "0.8"
 ipnet = "2"
 http = "0.2"
-linkerd2-proxy-api = { version = "0.10", optional = true, features = [
+linkerd2-proxy-api = { version = "0.11", optional = true, features = [
     "outbound",
 ] }
 linkerd-error = { path = "../../error" }

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -31,6 +31,7 @@ pub enum Filter {
     InjectFailure(filter::InjectFailure),
     Redirect(filter::RedirectRequest),
     RequestHeaders(filter::ModifyHeader),
+    ResponseHeaders(filter::ModifyHeader),
     InternalError(&'static str),
 }
 
@@ -320,6 +321,9 @@ pub mod proto {
                 Kind::FailureInjector(filter) => Ok(Filter::InjectFailure(filter.try_into()?)),
                 Kind::RequestHeaderModifier(filter) => {
                     Ok(Filter::RequestHeaders(filter.try_into()?))
+                }
+                Kind::ResponseHeaderModifier(filter) => {
+                    Ok(Filter::ResponseHeaders(filter.try_into()?))
                 }
                 Kind::Redirect(filter) => Ok(Filter::Redirect(filter.try_into()?)),
             }

--- a/linkerd/proxy/identity-client/Cargo.toml
+++ b/linkerd/proxy/identity-client/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { version = "0.10", features = ["identity"] }
+linkerd2-proxy-api = { version = "0.11", features = ["identity"] }
 linkerd-error = { path = "../../error" }
 linkerd-identity = { path = "../../identity" }
 linkerd-metrics = { path = "../../metrics" }

--- a/linkerd/proxy/server-policy/Cargo.toml
+++ b/linkerd/proxy/server-policy/Cargo.toml
@@ -17,7 +17,7 @@ prost-types = { version = "0.11", optional = true }
 thiserror = "1"
 
 [dependencies.linkerd2-proxy-api]
-version = "0.10"
+version = "0.11"
 features = ["inbound"]
 optional = true
 

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -11,7 +11,7 @@ http = "0.2"
 hyper = { version = "0.14", features = ["http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.7"
-linkerd2-proxy-api = { version = "0.10", features = ["tap"] }
+linkerd2-proxy-api = { version = "0.11", features = ["tap"] }
 linkerd-conditional = { path = "../../conditional" }
 linkerd-error = { path = "../../error" }
 linkerd-meshtls = { path = "../../meshtls" }
@@ -30,5 +30,5 @@ tracing = "0.1"
 pin-project = "1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { version = "0.10", features = ["arbitrary"] }
+linkerd2-proxy-api = { version = "0.11", features = ["arbitrary"] }
 quickcheck = { version = "1", default-features = false }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -21,7 +21,7 @@ linkerd-http-box = { path = "../http-box" }
 linkerd-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd-stack = { path = "../stack" }
 linkerd-tonic-watch = { path = "../tonic-watch" }
-linkerd2-proxy-api = { version = "0.10", features = ["destination"] }
+linkerd2-proxy-api = { version = "0.11", features = ["destination"] }
 once_cell = "1.17"
 prost-types = "0.11"
 regex = "1"
@@ -33,5 +33,5 @@ thiserror = "1"
 tracing = "0.1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { version = "0.10", features = ["arbitrary"] }
+linkerd2-proxy-api = { version = "0.11", features = ["arbitrary"] }
 quickcheck = { version = "1", default-features = false }


### PR DESCRIPTION
Add support for the response header modifier, which was added to the proxy API in https://github.com/linkerd/linkerd2-proxy-api/pull/251