### PR TITLE
build(deps): use published version of `boring`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
 dependencies = [
  "async-trait",
  "axum-core",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "http",
@@ -142,11 +142,11 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bindgen"
-version = "0.60.1"
+version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
+checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -157,6 +157,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "syn 2.0.12",
 ]
 
 [[package]]
@@ -166,26 +167,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "boring"
-version = "2.1.0"
+name = "bitflags"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c713ad6d8d7a681a43870ac37b89efd2a08015ceb4b256d82707509c1f0b6bb"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "boring"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9aa560ebe73bcf696f83e70c0c3840e20506dfa4b0531eb3394f591489030f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "boring-sys",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
 name = "boring-sys"
-version = "2.1.0"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7663d3069437a5ccdb2b5f4f481c8b80446daea10fa8503844e89ac65fcdc363"
+checksum = "7c911b5e71589a68226571982d3f67ef03034c6efddd1b5d7bbd02d54aeda579"
 dependencies = [
  "bindgen",
  "cmake",
+ "fs_extra",
+ "fslock",
 ]
 
 [[package]]
@@ -400,6 +409,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -2324,7 +2349,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534cfe58d6a18cc17120fbf4635d53d14691c1fe4d951064df9bd326178d7d5a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2333,7 +2358,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -2408,7 +2433,7 @@ version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -2676,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-boring"
-version = "2.1.5"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb059337235a89f03252c6285da8f0a6747a85bbd42e9ece70178d578054cba7"
+checksum = "deccebd21ed5c1afda79080d3de6f2a7383a122b68b1909b785376b95ba869e2"
 dependencies = [
  "boring",
  "boring-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,8 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 [[package]]
 name = "boring"
 version = "2.1.0"
-source = "git+https://github.com/cloudflare/boring#3059ba6e102599f8ae0a962223ca1e216bb61902"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c713ad6d8d7a681a43870ac37b89efd2a08015ceb4b256d82707509c1f0b6bb"
 dependencies = [
  "bitflags",
  "boring-sys",
@@ -180,7 +181,8 @@ dependencies = [
 [[package]]
 name = "boring-sys"
 version = "2.1.0"
-source = "git+https://github.com/cloudflare/boring#3059ba6e102599f8ae0a962223ca1e216bb61902"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7663d3069437a5ccdb2b5f4f481c8b80446daea10fa8503844e89ac65fcdc363"
 dependencies = [
  "bindgen",
  "cmake",
@@ -2675,7 +2677,8 @@ dependencies = [
 [[package]]
 name = "tokio-boring"
 version = "2.1.5"
-source = "git+https://github.com/cloudflare/boring#3059ba6e102599f8ae0a962223ca1e216bb61902"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb059337235a89f03252c6285da8f0a6747a85bbd42e9ece70178d578054cba7"
 dependencies = [
  "boring",
  "boring-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,5 +83,3 @@ lto = true
 
 [patch.crates-io]
 webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.22" }
-boring = { git = "https://github.com/cloudflare/boring" }
-tokio-boring = { git = "https://github.com/cloudflare/boring" }

--- a/deny.toml
+++ b/deny.toml
@@ -59,6 +59,9 @@ skip = [
     # Since `syn` is used by proc-macros (executed at compile time), duplicate
     # versions won't have an impact on the final binary size.
     { name = "syn" },
+    # `tonic` v0.6 depends on `bitflags` v1.x, while `boring-sys` depends on
+    # `bitflags` v2.x. Allow both versions to coexist peacefully for now.
+    { name = "bitflags", version = "1" },
 ]
 skip-tree = [
     # Hasn't seen a new release since 2017. Pulls in an older version of nom.

--- a/deny.toml
+++ b/deny.toml
@@ -69,7 +69,6 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = ["https://github.com/cloudflare/boring.git"]
 
 [sources.allow-org]
 github = [

--- a/linkerd/meshtls/boring/Cargo.toml
+++ b/linkerd/meshtls/boring/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-boring = "2"
+boring = "3"
 futures = { version = "0.3", default-features = false }
 hex = "0.4" # used for debug logging
 linkerd-error = { path = "../../error" }
@@ -17,7 +17,7 @@ linkerd-io = { path = "../../io" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }
 tokio = { version = "1", features = ["macros", "sync"] }
-tokio-boring = "2"
+tokio-boring = "3"
 tracing = "0.1"
 
 [features]


### PR DESCRIPTION
The `linkerd-meshtls-boring` crate currently uses a Git dependency on `boring` and `tokio-boring`. This is because, when this crate was initially introduced, the proxy required unreleased changes to these crates. Now, however, upstream has published all the changes we depended on (this happened ages ago), and we can depend on these libraries from crates.io.

This branch removes the Git deps and updates to v3.0.0 of `boring`/`tokio-boring`. I've also changed the `cargo-deny` settings to no longer allow Git deps on these crates, as we no longer depend on them from Git.