### PR TITLE
use `rustls-webpki` instead of `linkerd/webpki`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,7 +2465,7 @@ dependencies = [
 [[package]]
 name = "rustls-webpki"
 version = "0.101.5"
-source = "git+https://github.com/cpu/webpki?branch=cpu-0.101.5-prep#702d57f444e3f7d743277524e832a2363290ec4d"
+source = "git+https://github.com/cpu/webpki?rev=702d57f444e3f7d743277524e832a2363290ec4d#702d57f444e3f7d743277524e832a2363290ec4d"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,9 +2464,8 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+version = "0.101.5"
+source = "git+https://github.com/cpu/webpki?branch=cpu-0.101.5-prep#702d57f444e3f7d743277524e832a2363290ec4d"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,11 +1408,11 @@ dependencies = [
  "linkerd-tls-test-util",
  "ring",
  "rustls-pemfile",
+ "rustls-webpki",
  "thiserror",
  "tokio",
  "tokio-rustls",
  "tracing",
- "webpki",
 ]
 
 [[package]]
@@ -2463,6 +2463,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-webpki"
+version = "0.101.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,8 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.22.0"
-source = "git+https://github.com/linkerd/webpki?branch=cert-dns-names-0.22#a26def03ec88d3b69542ccd2f0073369ecedc4f9"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0e74f82d49d545ad128049b7e88f6576df2da6b02e9ce565c6f533be576957e"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,3 +80,6 @@ debug = false
 
 [profile.release]
 lto = true
+
+[patch.crates-io]
+rustls-webpki = { git = "https://github.com/cpu/webpki", branch = "cpu-0.101.5-prep" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,4 +82,5 @@ debug = false
 lto = true
 
 [patch.crates-io]
-rustls-webpki = { git = "https://github.com/cpu/webpki", branch = "cpu-0.101.5-prep" }
+# remove this patch when https://github.com/rustls/webpki/pull/170 is published!
+rustls-webpki = { git = "https://github.com/cpu/webpki", rev = "702d57f444e3f7d743277524e832a2363290ec4d" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,3 @@ debug = false
 
 [profile.release]
 lto = true
-
-[patch.crates-io]
-webpki = { git = "https://github.com/linkerd/webpki", branch = "cert-dns-names-0.22" }

--- a/deny.toml
+++ b/deny.toml
@@ -72,8 +72,7 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-
-[sources.allow-org]
-github = [
-    "linkerd",
+allow-git = [
+    # remove this when https://github.com/rustls/webpki/pull/170 is published!
+    "https://github.com/cpu/webpki",
 ]

--- a/linkerd/meshtls/rustls/Cargo.toml
+++ b/linkerd/meshtls/rustls/Cargo.toml
@@ -19,11 +19,11 @@ linkerd-tls = { path = "../../tls" }
 linkerd-tls-test-util = { path = "../../tls/test-util", optional = true }
 ring = { version = "0.16", features = ["std"] }
 rustls-pemfile = "1.0"
+rustls-webpki = { version = "0.101.4", features = [ "std"] }
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 tokio-rustls = { version = "0.23", features = ["dangerous_configuration"] }
 tracing = "0.1"
-webpki = "0.22"
 
 [dev-dependencies]
 linkerd-tls-test-util = { path = "../../tls/test-util" }

--- a/linkerd/meshtls/rustls/Cargo.toml
+++ b/linkerd/meshtls/rustls/Cargo.toml
@@ -19,7 +19,7 @@ linkerd-tls = { path = "../../tls" }
 linkerd-tls-test-util = { path = "../../tls/test-util", optional = true }
 ring = { version = "0.16", features = ["std"] }
 rustls-pemfile = "1.0"
-rustls-webpki = { version = "0.101.4", features = [ "std"] }
+rustls-webpki = { version = "0.101.5", features = [ "std"] }
 thiserror = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 tokio-rustls = { version = "0.23", features = ["dangerous_configuration"] }

--- a/linkerd/meshtls/rustls/src/server.rs
+++ b/linkerd/meshtls/rustls/src/server.rs
@@ -130,12 +130,7 @@ fn client_identity<I>(tls: &tokio_rustls::server::TlsStream<I>) -> Option<Client
     let certs = session.peer_certificates()?;
     let c = certs.first().map(Certificate::as_ref)?;
     let end_cert = webpki::EndEntityCert::try_from(c).ok()?;
-    let mut dns_names = end_cert
-        .dns_names()
-        .map_err(|err| println!("error: {err:?}"))
-        .ok()?;
-
-    let name: &str = dbg!(dns_names.next().map(Into::into))?;
+    let name: &str = end_cert.dns_names().ok()?.next().map(Into::into)?;
     if name == "*" {
         // Wildcards can perhaps be handled in a future path...
         return None;

--- a/linkerd/meshtls/rustls/src/server.rs
+++ b/linkerd/meshtls/rustls/src/server.rs
@@ -130,9 +130,12 @@ fn client_identity<I>(tls: &tokio_rustls::server::TlsStream<I>) -> Option<Client
     let certs = session.peer_certificates()?;
     let c = certs.first().map(Certificate::as_ref)?;
     let end_cert = webpki::EndEntityCert::try_from(c).ok()?;
-    let mut dns_names = end_cert.dns_names().ok()?;
+    let mut dns_names = end_cert
+        .dns_names()
+        .map_err(|err| println!("error: {err:?}"))
+        .ok()?;
 
-    let name: &str = dns_names.next()?.into();
+    let name: &str = dbg!(dns_names.next().map(Into::into))?;
     if name == "*" {
         // Wildcards can perhaps be handled in a future path...
         return None;

--- a/linkerd/meshtls/rustls/src/server.rs
+++ b/linkerd/meshtls/rustls/src/server.rs
@@ -130,18 +130,15 @@ fn client_identity<I>(tls: &tokio_rustls::server::TlsStream<I>) -> Option<Client
     let certs = session.peer_certificates()?;
     let c = certs.first().map(Certificate::as_ref)?;
     let end_cert = webpki::EndEntityCert::try_from(c).ok()?;
-    let dns_names = end_cert.dns_names().ok()?;
+    let mut dns_names = end_cert.dns_names().ok()?;
 
-    match dns_names.first()? {
-        webpki::GeneralDnsNameRef::DnsName(n) => {
-            let s: &str = (*n).into();
-            s.parse().ok().map(ClientId)
-        }
-        webpki::GeneralDnsNameRef::Wildcard(_) => {
-            // Wildcards can perhaps be handled in a future path...
-            None
-        }
+    let name: &str = dns_names.next()?.into();
+    if name == "*" {
+        // Wildcards can perhaps be handled in a future path...
+        return None;
     }
+
+    name.parse().ok().map(ClientId)
 }
 
 // === impl ServerIo ===


### PR DESCRIPTION
This commit changes the `linkerd-meshtls-rustls` crate to use the upstream `rustls-webpki` crate, maintained by Rustls, rather than our fork of `briansmith/webpki` from GitHub. Since `rustls-webpki` includes the change which was the initial motivation for the `linkerd/webpki` fork (rustls/webpki#42), we can now depend on upstream.