### PR TITLE
meshtls: use published `rustls-webpki` v0.101.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2465,7 +2465,8 @@ dependencies = [
 [[package]]
 name = "rustls-webpki"
 version = "0.101.5"
-source = "git+https://github.com/cpu/webpki?rev=702d57f444e3f7d743277524e832a2363290ec4d#702d57f444e3f7d743277524e832a2363290ec4d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,3 @@ debug = false
 
 [profile.release]
 lto = true
-
-[patch.crates-io]
-# remove this patch when https://github.com/rustls/webpki/pull/170 is published!
-rustls-webpki = { git = "https://github.com/cpu/webpki", rev = "702d57f444e3f7d743277524e832a2363290ec4d" }

--- a/deny.toml
+++ b/deny.toml
@@ -72,7 +72,3 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = [
-    # remove this when https://github.com/rustls/webpki/pull/170 is published!
-    "https://github.com/cpu/webpki",
-]


### PR DESCRIPTION
Now that [v0.101.5 of `rustls-webpki`][1] has been [published][2], we can now depend on the crate from crates.io. This allows us to remove the Git dependency on the branch preparing that release to be published, which allows us to remove the allowance for Git dependencies in the `cargo-deny` config.

[1]: https://github.com/rustls/webpki/releases/tag/v%2F0.101.5
[2]: https://crates.io/crates/rustls-webpki/0.101.5