### PR TITLE
Render grpc_status metric label as number

### DIFF
--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -422,7 +422,7 @@ impl FmtLabels for Class {
                 "classification=\"{}\",grpc_status=\"{}\",error=\"\"",
                 class(res.is_ok()),
                 match res {
-                    Ok(code) | Err(code) => Into::<i32>::into(*code),
+                    Ok(code) | Err(code) => <i32>::from(*code),
                 }
             ),
 

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -422,7 +422,7 @@ impl FmtLabels for Class {
                 "classification=\"{}\",grpc_status=\"{}\",error=\"\"",
                 class(res.is_ok()),
                 match res {
-                    Ok(code) | Err(code) => code,
+                    Ok(code) | Err(code) => Into::<i32>::into(*code),
                 }
             ),
 


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/11449

The `grpc_status` metric label is rendered as a long form, human readable string value in the proxy metrics.  For example:

```
response_total{direction="outbound", [...], classification="failure",grpc_status="Unknown error",error=""} 1
```

This is because of the Display impl for Code.  We explicitly convert to an i32 so this renders as a number instead:

```
response_total{direction="outbound", [...] ,classification="failure",grpc_status="2",error=""} 1
```