### PR TITLE
build(deps): update `rustix` to v0.36.16/v0.37.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,7 +2227,7 @@ dependencies = [
  "byteorder",
  "hex",
  "lazy_static",
- "rustix 0.36.14",
+ "rustix 0.36.16",
 ]
 
 [[package]]
@@ -2421,9 +2421,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.36.14"
+version = "0.36.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
+checksum = "6da3636faa25820d8648e0e31c5d519bbb01f72fdf57131f0f5f7da5fed36eab"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2435,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.4"
+version = "0.37.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c348b5dc624ecee40108aa2922fed8bad89d7fcc2b9f8cb18f632898ac4a37f9"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2621,7 +2621,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.4",
+ "rustix 0.37.7",
  "windows-sys 0.45.0",
 ]
 


### PR DESCRIPTION
This commit updates the proxy's dependency on `rustix` in order to resolve a potential memory exhaustion issue when using the `rustix::fs::Dir` iterator with the `linux-raw` backend. This issue is described in GHSA-c827-hfw6-qwvm.

We currently depend on both `rustix` v0.36 and v0.37 as transitive deps, so this branch updates the v0.36 dep from v0.36.14 to v0.36.16, and the v0.37 dependency from v0.37.4 to v0.37.7.

Unfortunately, we weren't able to get Dependabot to bump these deps for us, because it no longer supports the legacy (non-TOML) `rust-toolchain` file (see #2487 for details). Therefore, we have to do this bump manually.