### PR TITLE
gate: Fix readiness deadlock

### DIFF
--- a/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
+++ b/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
@@ -1,14 +1,12 @@
 use futures::stream::StreamExt;
 use linkerd_app_core::{classify, exp_backoff::ExponentialBackoff, proxy::http::classify::gate};
-use std::sync::Arc;
-use tokio::sync::{mpsc, Semaphore};
+use tokio::sync::mpsc;
 
 pub struct ConsecutiveFailures {
     max_failures: usize,
     backoff: ExponentialBackoff,
     gate: gate::Tx,
     rsps: mpsc::Receiver<classify::Class>,
-    semaphore: Arc<Semaphore>,
 }
 
 impl ConsecutiveFailures {
@@ -23,7 +21,6 @@ impl ConsecutiveFailures {
             backoff,
             gate,
             rsps,
-            semaphore: Arc::new(Semaphore::new(0)),
         }
     }
 
@@ -46,7 +43,7 @@ impl ConsecutiveFailures {
     /// observed.
     async fn open(&mut self) -> Result<(), ()> {
         tracing::debug!("Open");
-        self.gate.open();
+        self.gate.open().map_err(|_| ())?;
         let mut failures = 0;
         loop {
             let class = tokio::select! {
@@ -74,7 +71,7 @@ impl ConsecutiveFailures {
         loop {
             // The breaker is shut now. Wait until we can open it again.
             tracing::debug!(backoff = ?backoff.duration(), "Shut");
-            self.gate.shut();
+            self.gate.shut().map_err(|_| ())?;
 
             loop {
                 tokio::select! {
@@ -97,8 +94,8 @@ impl ConsecutiveFailures {
     /// Wait for a response to determine whether the breaker should be opened.
     async fn probation(&mut self) -> Result<classify::Class, ()> {
         tracing::debug!("Probation");
-        self.semaphore.add_permits(1);
-        self.gate.limit(self.semaphore.clone());
+        let sem = self.gate.limit().map_err(|_| ())?;
+        sem.add_permits(1);
         tokio::select! {
             rsp = self.rsps.recv() => rsp.ok_or(()),
             _ = self.gate.lost() => Err(()),

--- a/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
+++ b/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
@@ -161,7 +161,7 @@ mod tests {
                 assert_eq!(sem.available_permits(), 1);
                 params
                     .gate
-                    .acquire_for_test()
+                    .opened_for_test()
                     .await
                     .expect("permit should be acquired")
                     // The `Gate` service would forget this permit when called, so
@@ -197,7 +197,7 @@ mod tests {
                 assert_eq!(sem.available_permits(), 1);
                 params
                     .gate
-                    .acquire_for_test()
+                    .opened_for_test()
                     .await
                     .expect("permit should be acquired")
                     // The `Gate` service would forget this permit when called, so

--- a/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
+++ b/linkerd/app/outbound/src/http/breaker/consecutive_failures.rs
@@ -94,8 +94,7 @@ impl ConsecutiveFailures {
     /// Wait for a response to determine whether the breaker should be opened.
     async fn probation(&mut self) -> Result<classify::Class, ()> {
         tracing::debug!("Probation");
-        let sem = self.gate.limit().map_err(|_| ())?;
-        sem.add_permits(1);
+        let _sem = self.gate.limit(1).map_err(|_| ())?;
         tokio::select! {
             rsp = self.rsps.recv() => rsp.ok_or(()),
             _ = self.gate.lost() => Err(()),

--- a/linkerd/stack/src/failfast.rs
+++ b/linkerd/stack/src/failfast.rs
@@ -169,7 +169,7 @@ where
 
                         warn!("Service entering failfast after {:?}", self.timeout);
                         if let Some(gate) = self.gate.as_ref() {
-                            gate.shut();
+                            let _ = gate.shut();
                         }
 
                         let gate = self.gate.clone();
@@ -179,7 +179,7 @@ where
                             // advertising readiness so that the failfast
                             // service can advance.
                             if let Some(gate) = gate {
-                                gate.open();
+                                let _ = gate.open();
                             }
                             match res {
                                 Ok(_) => {


### PR DESCRIPTION
The gate middleware controls a service's readiness so that it can exert backpressure. This is used, for instance, by the circuit breaker module so that an endpoint can go into an unavailable state after the breaker has been tripped and be marked available again as it recovers.

This change fixes a bug in that recovery scenario: when the gate is in a Limited state (i.e. when the circuit breaker puts an endpoint into Probation to test its availability), and caller (i.e. the balancer) is waiting for the endpoint to leave probation, the balancer may never be notified that the endpoint has left its probation state.

To fix this, we update the gate controller to definitively close its inner Semaphore when transitioning out of a limited state -- dropping the semaphore in the sender doesn't close it when it's being held by a receiver. This change motivates an update to the gate::Tx API so that it always produces a Semaphore when transitioning to the limited state (rather than take a shared semaphore as a caller).

This issue is somewhat masked by the balancer's polling behavior, where endpoint states are only advanced as requests are processed. It seems likely, however, that this scenario could be encountered in the wild when circuit breaking is enabled on a service.