### PR TITLE
dev: v42

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "linkerd2-proxy",
-	"image": "ghcr.io/linkerd/dev:v40",
+	"image": "ghcr.io/linkerd/dev:v42",
 	"customizations": {
 		"vscode": {
 			"extensions": [

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: linkerd/dev/actions/setup-tools@v40

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v40
+      - uses: linkerd/dev/actions/setup-tools@v42
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: just action-lint
 
   devcontainer-versions:
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v40
+      - uses: linkerd/dev/actions/setup-tools@v42
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: just action-dev-check

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/check-all.yml
+++ b/.github/workflows/check-all.yml
@@ -22,7 +22,7 @@ jobs:
   check-all:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033

--- a/.github/workflows/check-each.yml
+++ b/.github/workflows/check-each.yml
@@ -26,7 +26,7 @@ jobs:
   list-changed-crates:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: docker://ghcr.io/linkerd/dev:v40-rust
+    container: docker://ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -47,7 +47,7 @@ jobs:
     needs: list-changed-crates
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     strategy:
       matrix:
         crate: ${{ fromJson(needs.list-changed-crates.outputs.crates) }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     container:
-      image: docker://ghcr.io/linkerd/dev:v40-rust
+      image: docker://ghcr.io/linkerd/dev:v42-rust
       options: --security-opt seccomp=unconfined # 🤷
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -46,7 +46,7 @@ jobs:
   deprecated:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -27,7 +27,7 @@ jobs:
   list-changed:
     timeout-minutes: 3
     runs-on: ubuntu-latest
-    container: docker://rust:1.73.0-bullseye
+    container: docker://rust:1.73.0
     steps:
       - run: apt update && apt install -y jo
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
@@ -48,7 +48,7 @@ jobs:
     needs: [list-changed]
     timeout-minutes: 40
     runs-on: ubuntu-latest
-    container: docker://rust:1.73.0-bullseye
+    container: docker://rust:1.73.0
     strategy:
       matrix:
         dir: ${{ fromJson(needs.list-changed.outputs.dirs) }}

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -27,7 +27,7 @@ jobs:
   list-changed:
     timeout-minutes: 3
     runs-on: ubuntu-latest
-    container: docker://rust:1.69.0-bullseye
+    container: docker://rust:1.73.0-bullseye
     steps:
       - run: apt update && apt install -y jo
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
@@ -48,7 +48,7 @@ jobs:
     needs: [list-changed]
     timeout-minutes: 40
     runs-on: ubuntu-latest
-    container: docker://rust:1.69.0-bullseye
+    container: docker://rust:1.73.0-bullseye
     strategy:
       matrix:
         dir: ${{ fromJson(needs.list-changed.outputs.dirs) }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     timeout-minutes: 20
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v40
+      - uses: linkerd/dev/actions/setup-tools@v42
 
       - name: Install linkerd CLI (edge)
         id: linkerd

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
   clippy:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -31,7 +31,7 @@ jobs:
   fmt:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -40,7 +40,7 @@ jobs:
   docs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     continue-on-error: ${{ !needs.meta.outputs.publish }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    container: docker://ghcr.io/linkerd/dev:v40-rust-musl
+    container: docker://ghcr.io/linkerd/dev:v42-rust-musl
     env:
       LINKERD2_PROXY_VENDOR: ${{ github.repository_owner }}
       LINKERD2_PROXY_VERSION: ${{ needs.meta.outputs.version }}

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,6 +15,6 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v40
+      - uses: linkerd/dev/actions/setup-tools@v42
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: just sh-lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
   meshtls:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -43,7 +43,7 @@ jobs:
   unit:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -37,7 +37,7 @@ jobs:
   workflows:
     runs-on: ubuntu-latest
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v40
+      - uses: linkerd/dev/actions/setup-tools@v42
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - shell: bash
         run: |

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   devcontainer:
     runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v40-rust
+    container: ghcr.io/linkerd/dev:v42-rust
     steps:
       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2214,9 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,11 @@
 
 ARG RUST_IMAGE=ghcr.io/linkerd/dev:v42-rust
 
+# Use an arbitrary ~recent edge release image to get the proxy
+# identity-initializing and linkerd-await wrappers.
+# Currently pinned to a build off of edge-23.11.1 + dev:v42
+ARG LINKERD2_IMAGE=ghcr.io/olix0r/l2-proxy:git-04283611
+
 # Build the proxy.
 FROM --platform=$BUILDPLATFORM $RUST_IMAGE as build
 
@@ -34,10 +39,6 @@ RUN --mount=type=cache,id=cargo,target=/usr/local/cargo/registry \
     mkdir -p /out && \
     mv $(just --evaluate profile="$PROFILE" _target_bin) /out/linkerd2-proxy
 
-# Use an arbitrary ~recent edge release image to get the proxy
-# identity-initializing and linkerd-await wrappers.
-# Currently pinned to a build off of edge-23.11.1 + dev:v42
-ARG LINKERD2_IMAGE=ghcr.io/olix0r/l2-proxy:git-04283611
 FROM $LINKERD2_IMAGE as linkerd2
 
 # Install the proxy binary into a base image that we can at least get a shell to

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,6 @@ FROM $LINKERD2_IMAGE as linkerd2
 # debug on.
 FROM docker.io/library/debian:bookworm-slim as runtime
 WORKDIR /linkerd
-COPY --from=linkerd2 /usr/lib/linkerd/linkerd-await /usr/lib/linkerd/linkerd-await
-COPY --from=linkerd2 /usr/lib/linkerd/linkerd2-network-validator /usr/lib/linkerd/linkerd2-network-validator
-COPY --from=linkerd2 /usr/lib/linkerd/linkerd2-proxy-identity /usr/lib/linkerd/linkerd2-proxy-identity
+COPY --from=linkerd2 /usr/lib/linkerd/* /usr/lib/linkerd/
 COPY --from=build /out/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy
 ENTRYPOINT ["/usr/lib/linkerd/linkerd2-proxy-identity"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ARG RUST_IMAGE=ghcr.io/linkerd/dev:v42-rust
 
 # Use an arbitrary ~recent edge release image to get the proxy
 # identity-initializing and linkerd-await wrappers.
-ARG RUNTIME_IMAGE=ghcr.io/linkerd/proxy:edge-22.12.1
+# Currently pinned to a build off of edge-23.11.1 + dev:v42
+ARG RUNTIME_IMAGE=ghcr.io/olix0r/l2-proxy:git-04283611
 
 # Build the proxy.
 FROM --platform=$BUILDPLATFORM $RUST_IMAGE as build

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,6 @@
 
 ARG RUST_IMAGE=ghcr.io/linkerd/dev:v42-rust
 
-# Use an arbitrary ~recent edge release image to get the proxy
-# identity-initializing and linkerd-await wrappers.
-# Currently pinned to a build off of edge-23.11.1 + dev:v42
-ARG RUNTIME_IMAGE=ghcr.io/olix0r/l2-proxy:git-04283611
-
 # Build the proxy.
 FROM --platform=$BUILDPLATFORM $RUST_IMAGE as build
 
@@ -39,9 +34,18 @@ RUN --mount=type=cache,id=cargo,target=/usr/local/cargo/registry \
     mkdir -p /out && \
     mv $(just --evaluate profile="$PROFILE" _target_bin) /out/linkerd2-proxy
 
-## Install the proxy binary into the base runtime image.
-FROM $RUNTIME_IMAGE as runtime
+# Use an arbitrary ~recent edge release image to get the proxy
+# identity-initializing and linkerd-await wrappers.
+# Currently pinned to a build off of edge-23.11.1 + dev:v42
+ARG LINKERD2_IMAGE=ghcr.io/olix0r/l2-proxy:git-04283611
+FROM $LINKERD2_IMAGE as linkerd2
+
+# Install the proxy binary into a base image that we can at least get a shell to
+# debug on.
+FROM docker.io/library/debian:bookworm-slim as runtime
 WORKDIR /linkerd
+COPY --from=linkerd2 /usr/lib/linkerd/linkerd-await /usr/lib/linkerd/linkerd-await
+COPY --from=linkerd2 /usr/lib/linkerd/linkerd2-network-validator /usr/lib/linkerd/linkerd2-network-validator
+COPY --from=linkerd2 /usr/lib/linkerd/linkerd2-proxy-identity /usr/lib/linkerd/linkerd2-proxy-identity
 COPY --from=build /out/linkerd2-proxy /usr/lib/linkerd/linkerd2-proxy
-ENV LINKERD2_PROXY_LOG=warn,linkerd=info,trust_dns=error
-# Inherits the ENTRYPOINT from the runtime image.
+ENTRYPOINT ["/usr/lib/linkerd/linkerd2-proxy-identity"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # This is intended **DEVELOPMENT ONLY**, i.e. so that proxy developers can
 # easily test the proxy in the context of the larger `linkerd2` project.
 
-ARG RUST_IMAGE=ghcr.io/linkerd/dev:v40-rust
+ARG RUST_IMAGE=ghcr.io/linkerd/dev:v42-rust
 
 # Use an arbitrary ~recent edge release image to get the proxy
 # identity-initializing and linkerd-await wrappers.

--- a/justfile
+++ b/justfile
@@ -57,6 +57,8 @@ _features := if features == "all" {
         "--no-default-features --features=" + features
     } else { "" }
 
+export CXX := 'clang++-14'
+
 #
 # Recipes
 #

--- a/justfile
+++ b/justfile
@@ -57,9 +57,6 @@ _features := if features == "all" {
         "--no-default-features --features=" + features
     } else { "" }
 
-# For dev:v40
-export CXX := 'clang++-14'
-
 #
 # Recipes
 #

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -1,9 +1,6 @@
 use super::set_identity_header::NewSetIdentityHeader;
 use crate::{policy, Inbound};
-pub use linkerd_app_core::proxy::http::{
-    normalize_uri, strip_header, uri, BoxBody, BoxResponse, DetectHttp, Request, Response, Retain,
-    Version,
-};
+pub use linkerd_app_core::proxy::http::{normalize_uri, Version};
 use linkerd_app_core::{
     config::{ProxyConfig, ServerConfig},
     errors, http_tracing, io,

--- a/linkerd/app/inbound/src/policy/http/tests.rs
+++ b/linkerd/app/inbound/src/policy/http/tests.rs
@@ -38,8 +38,9 @@ macro_rules! new_svc {
             connection: $conn,
             metrics: HttpAuthzMetrics::default(),
             inner: |(permit, _): (HttpRoutePermit, ())| {
+                let f = $rsp;
                 svc::mk(move |req: ::http::Request<hyper::Body>| {
-                    futures::future::ready($rsp(permit.clone(), req))
+                    futures::future::ready((f)(permit.clone(), req))
                 })
             },
         };

--- a/linkerd/app/inbound/src/policy/store.rs
+++ b/linkerd/app/inbound/src/policy/store.rs
@@ -1,9 +1,7 @@
 use super::{api, AllowPolicy, DefaultPolicy, GetPolicy};
 use linkerd_app_core::{proxy::http, transport::OrigDstAddr, Error};
 use linkerd_idle_cache::IdleCache;
-pub use linkerd_proxy_server_policy::{
-    authz::Suffix, Authentication, Authorization, Protocol, ServerPolicy,
-};
+pub use linkerd_proxy_server_policy::{Protocol, ServerPolicy};
 use rangemap::RangeInclusiveSet;
 use std::{
     collections::HashSet,

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -37,7 +37,6 @@ use socket2::Socket;
 pub use std::collections::HashMap;
 use std::fmt;
 pub use std::future::Future;
-use std::io;
 pub use std::net::SocketAddr;
 use std::pin::Pin;
 pub use std::sync::Arc;

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -47,7 +47,6 @@ use tokio::net::TcpListener;
 pub use tokio::sync::oneshot;
 pub use tonic as grpc;
 pub use tower::Service;
-pub use tracing::*;
 
 /// Environment variable for overriding the test patience.
 pub const ENV_TEST_PATIENCE_MS: &str = "RUST_TEST_PATIENCE_MS";

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![warn(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
+#![recursion_limit = "256"]
 
 mod test_env;
 

--- a/linkerd/app/integration/src/metrics.rs
+++ b/linkerd/app/integration/src/metrics.rs
@@ -253,7 +253,7 @@ impl Labels {
     /// the values from `other` overwrite the values in `self`.
     pub fn and(&self, other: Labels) -> Labels {
         let mut new_labels = self.0.clone();
-        new_labels.extend(other.0.into_iter());
+        new_labels.extend(other.0);
         Labels(new_labels)
     }
 

--- a/linkerd/app/outbound/src/protocol.rs
+++ b/linkerd/app/outbound/src/protocol.rs
@@ -1,5 +1,4 @@
 use crate::{http, Outbound};
-pub use linkerd_app_core::proxy::api_resolve::ConcreteAddr;
 use linkerd_app_core::{detect, io, svc, Error, Infallible};
 use std::{fmt::Debug, hash::Hash};
 

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -226,7 +226,6 @@ impl Config {
         // Build a task that initializes and runs the proxy stacks.
         let start_proxy = {
             let identity_ready = identity.ready();
-            let inbound_addr = inbound_addr;
             let profiles = dst.profiles;
             let resolve = dst.resolve;
 

--- a/linkerd/http-metrics/src/requests/service.rs
+++ b/linkerd/http-metrics/src/requests/service.rs
@@ -387,15 +387,9 @@ fn measure_class<C: Hash + Eq>(
 
     metrics.last_update = now;
 
-    let status_metrics = metrics
-        .by_status
-        .entry(status)
-        .or_default();
+    let status_metrics = metrics.by_status.entry(status).or_default();
 
-    let class_metrics = status_metrics
-        .by_class
-        .entry(class)
-        .or_default();
+    let class_metrics = status_metrics.by_class.entry(class).or_default();
 
     class_metrics.total.incr();
 }

--- a/linkerd/http-metrics/src/requests/service.rs
+++ b/linkerd/http-metrics/src/requests/service.rs
@@ -1,4 +1,4 @@
-use super::{ClassMetrics, Metrics, StatusMetrics};
+use super::{Metrics, StatusMetrics};
 use futures::{ready, TryFuture};
 use http_body::Body;
 use linkerd_error::Error;
@@ -390,12 +390,12 @@ fn measure_class<C: Hash + Eq>(
     let status_metrics = metrics
         .by_status
         .entry(status)
-        .or_insert_with(StatusMetrics::default);
+        .or_default();
 
     let class_metrics = status_metrics
         .by_class
         .entry(class)
-        .or_insert_with(ClassMetrics::default);
+        .or_default();
 
     class_metrics.total.incr();
 }

--- a/linkerd/http-route/src/http/match/path.rs
+++ b/linkerd/http-route/src/http/match/path.rs
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn path_regex() {
-        let m = MatchPath::Regex(r#"/foo/\d+"#.parse().unwrap());
+        let m = MatchPath::Regex(r"/foo/\d+".parse().unwrap());
         assert_eq!(
             m.match_length(&"/foo/4".parse().unwrap()),
             Some(PathMatch::Regex("/foo/4".len()))

--- a/linkerd/metrics/src/scopes.rs
+++ b/linkerd/metrics/src/scopes.rs
@@ -36,7 +36,7 @@ impl<L: FmtLabels + Hash + Eq, S> Scopes<L, S> {
 
 impl<L: FmtLabels + Hash + Eq, S: Default> Scopes<L, S> {
     pub fn get_or_default(&mut self, key: L) -> &mut S {
-        self.0.entry(key).or_insert_with(S::default)
+        self.0.entry(key).or_default()
     }
 }
 

--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -130,7 +130,7 @@ where
                 match tx.reserve().await {
                     Ok(tx) => {
                         let msg = ExportTraceServiceRequest {
-                            spans: accum.drain(..).collect(),
+                            spans: std::mem::take(accum),
                             node: node.take(),
                             ..Default::default()
                         };

--- a/linkerd/proxy/client-policy/src/opaq.rs
+++ b/linkerd/proxy/client-policy/src/opaq.rs
@@ -125,7 +125,7 @@ pub(crate) mod proto {
         Ok(Policy {
             meta: meta.clone(),
             filters: NO_FILTERS.clone(),
-            failure_policy: NonIoErrors::default(),
+            failure_policy: NonIoErrors,
             distribution,
             // Request timeouts are ignored on opaque routes.
             request_timeout: None,

--- a/linkerd/stack/metrics/src/lib.rs
+++ b/linkerd/stack/metrics/src/lib.rs
@@ -37,12 +37,7 @@ where
     L: Hash + Eq,
 {
     pub fn layer(&self, labels: L) -> TrackServiceLayer {
-        let metrics = self
-            .0
-            .lock()
-            .entry(labels)
-            .or_default()
-            .clone();
+        let metrics = self.0.lock().entry(labels).or_default().clone();
         TrackServiceLayer::new(metrics)
     }
 }

--- a/linkerd/stack/metrics/src/lib.rs
+++ b/linkerd/stack/metrics/src/lib.rs
@@ -41,7 +41,7 @@ where
             .0
             .lock()
             .entry(labels)
-            .or_insert_with(Default::default)
+            .or_default()
             .clone();
         TrackServiceLayer::new(metrics)
     }

--- a/linkerd/stack/src/fail.rs
+++ b/linkerd/stack/src/fail.rs
@@ -49,9 +49,7 @@ impl<U, E> Default for Fail<U, E> {
 
 impl<U, E> Clone for Fail<U, E> {
     fn clone(&self) -> Self {
-        Self {
-            _marker: self._marker,
-        }
+        *self
     }
 }
 

--- a/linkerd/stack/src/unwrap_or.rs
+++ b/linkerd/stack/src/unwrap_or.rs
@@ -42,7 +42,7 @@ impl<T, U: Default> Predicate<Option<T>> for UnwrapOr<U> {
 
 impl<U> Clone for UnwrapOr<U> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.73.0"


### PR DESCRIPTION
* Update dev to v42
* Update Rust to 1.73.0
  * Address new clippy & check warnings
* Update debian from bullseye to bookworm
* Update K3d to v5.6.0
  * Update CI from k3s 1.26 to 1.28
* Fix `just linkerd-install` to specify k8s context
* Update markdownlint-cli2 to 0.10.0
* Update Dockerfile to use a debian base image for easier debugging
* Update proc-macro2 to fix rust-nightly build failures