### PR TITLE
split tls id and name

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -34,7 +34,7 @@ struct NonHttpClient(Remote<ClientAddr>);
 
 #[derive(Debug, Error)]
 #[error("Unexpected TLS connection to {} from {}", self.0, self.1)]
-struct UnexpectedSni(tls::ServerId, Remote<ClientAddr>);
+struct UnexpectedSni(tls::ServerName, Remote<ClientAddr>);
 
 #[derive(Clone, Debug)]
 struct Tcp {

--- a/linkerd/app/gateway/src/http.rs
+++ b/linkerd/app/gateway/src/http.rs
@@ -105,7 +105,7 @@ impl Gateway {
             .push_map_target(Target::discard_parent)
             // Add headers to prevent loops.
             .push(NewHttpGateway::layer(identity::LocalId(
-                self.inbound.identity().name().clone(),
+                self.inbound.identity().tls_name().clone(),
             )))
             .push_on_service(svc::LoadShed::layer())
             .lift_new()

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -396,8 +396,8 @@ impl svc::Param<http::normalize_uri::DefaultAuthority> for Http {
     }
 }
 
-impl svc::Param<Option<identity::Name>> for Http {
-    fn param(&self) -> Option<identity::Name> {
+impl svc::Param<Option<identity::TlsName>> for Http {
+    fn param(&self) -> Option<identity::TlsName> {
         self.tls
             .status
             .value()

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -374,9 +374,10 @@ impl<T> svc::Param<tls::ConditionalClientTls> for Endpoint<T> {
         self.metadata
             .identity()
             .cloned()
-            .map(move |server_id| {
+            .map(move |(server_id, server_name)| {
                 tls::ConditionalClientTls::Some(tls::ClientTls {
                     server_id,
+                    server_name,
                     alpn: if use_transport_header {
                         use linkerd_app_core::transport_header::PROTOCOL;
                         Some(tls::client::AlpnProtocols(vec![PROTOCOL.into()]))

--- a/linkerd/app/outbound/src/http/require_id_header.rs
+++ b/linkerd/app/outbound/src/http/require_id_header.rs
@@ -57,7 +57,7 @@ type ResponseFuture<F, T, E> =
 
 impl<S> RequireIdentity<S> {
     #[inline]
-    fn extract_id<B>(req: &mut http::Request<B>) -> Option<identity::Name> {
+    fn extract_id<B>(req: &mut http::Request<B>) -> Option<identity::TlsName> {
         let v = req.headers_mut().remove(HEADER_NAME)?;
         v.to_str().ok()?.parse().ok()
     }

--- a/linkerd/app/outbound/src/opaq/concrete.rs
+++ b/linkerd/app/outbound/src/opaq/concrete.rs
@@ -283,9 +283,10 @@ impl<T> svc::Param<tls::ConditionalClientTls> for Endpoint<T> {
         self.metadata
             .identity()
             .cloned()
-            .map(move |server_id| {
+            .map(move |(server_id, server_name)| {
                 tls::ConditionalClientTls::Some(tls::ClientTls {
                     server_id,
+                    server_name,
                     alpn: if use_transport_header {
                         use linkerd_app_core::transport_header::PROTOCOL;
                         Some(tls::client::AlpnProtocols(vec![PROTOCOL.into()]))

--- a/linkerd/app/outbound/src/tcp/tagged_transport.rs
+++ b/linkerd/app/outbound/src/tcp/tagged_transport.rs
@@ -154,17 +154,18 @@ mod test {
     struct Endpoint {
         port_override: Option<u16>,
         authority: Option<http::uri::Authority>,
-        server_id: Option<tls::ServerId>,
+        identity: Option<(tls::ServerId, tls::ServerName)>,
         proto: Option<SessionProtocol>,
     }
 
     impl svc::Param<tls::ConditionalClientTls> for Endpoint {
         fn param(&self) -> tls::ConditionalClientTls {
-            self.server_id
+            self.identity
                 .clone()
-                .map(|server_id| {
+                .map(|(server_id, server_name)| {
                     tls::ConditionalClientTls::Some(tls::ClientTls {
                         server_id,
+                        server_name,
                         alpn: Some(tls::client::AlpnProtocols(vec![
                             transport_header::PROTOCOL.into()
                         ])),
@@ -261,8 +262,9 @@ mod test {
 
         let e = Endpoint {
             port_override: Some(4143),
-            server_id: Some(tls::ServerId(
-                identity::Name::from_str("server.id").unwrap(),
+            identity: Some((
+                tls::ServerId(identity::TlsName::from_str("server.id").unwrap()),
+                tls::ServerName(identity::Name::from_str("server.id").unwrap()),
             )),
             authority: None,
             proto: None,
@@ -285,8 +287,9 @@ mod test {
 
         let e = Endpoint {
             port_override: Some(4143),
-            server_id: Some(tls::ServerId(
-                identity::Name::from_str("server.id").unwrap(),
+            identity: Some((
+                tls::ServerId(identity::TlsName::from_str("server.id").unwrap()),
+                tls::ServerName(identity::Name::from_str("server.id").unwrap()),
             )),
             authority: Some(http::uri::Authority::from_str("foo.bar.example.com:5555").unwrap()),
             proto: None,
@@ -309,8 +312,9 @@ mod test {
 
         let e = Endpoint {
             port_override: Some(4143),
-            server_id: Some(tls::ServerId(
-                identity::Name::from_str("server.id").unwrap(),
+            identity: Some((
+                tls::ServerId(identity::TlsName::from_str("server.id").unwrap()),
+                tls::ServerName(identity::Name::from_str("server.id").unwrap()),
             )),
             authority: None,
             proto: None,
@@ -333,8 +337,9 @@ mod test {
 
         let e = Endpoint {
             port_override: Some(4143),
-            server_id: Some(tls::ServerId(
-                identity::Name::from_str("server.id").unwrap(),
+            identity: Some((
+                tls::ServerId(identity::TlsName::from_str("server.id").unwrap()),
+                tls::ServerName(identity::Name::from_str("server.id").unwrap()),
             )),
             authority: None,
             proto: Some(SessionProtocol::Http1),
@@ -357,8 +362,9 @@ mod test {
 
         let e = Endpoint {
             port_override: Some(4143),
-            server_id: Some(tls::ServerId(
-                identity::Name::from_str("server.id").unwrap(),
+            identity: Some((
+                tls::ServerId(identity::TlsName::from_str("server.id").unwrap()),
+                tls::ServerName(identity::Name::from_str("server.id").unwrap()),
             )),
             authority: Some(http::uri::Authority::from_str("foo.bar.example.com:5555").unwrap()),
             proto: Some(SessionProtocol::Http1),
@@ -381,8 +387,9 @@ mod test {
 
         let e = Endpoint {
             port_override: Some(4143),
-            server_id: Some(tls::ServerId(
-                identity::Name::from_str("server.id").unwrap(),
+            identity: Some((
+                tls::ServerId(identity::TlsName::from_str("server.id").unwrap()),
+                tls::ServerName(identity::Name::from_str("server.id").unwrap()),
             )),
             authority: None,
             proto: Some(SessionProtocol::Http1),

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -311,8 +311,8 @@ impl App {
         &self.dst
     }
 
-    pub fn local_identity(&self) -> identity::Name {
-        self.identity.receiver().name().clone()
+    pub fn local_identity(&self) -> identity::TlsName {
+        self.identity.receiver().tls_name().clone()
     }
 
     pub fn identity_addr(&self) -> ControlAddr {
@@ -364,7 +364,7 @@ impl App {
 
                         // Kick off the identity so that the process can become ready.
                         let local = identity.receiver();
-                        let local_id = local.name().clone();
+                        let local_id = local.tls_name().clone();
                         let ready = identity.ready();
                         tokio::spawn(
                             identity

--- a/linkerd/http-access-log/src/lib.rs
+++ b/linkerd/http-access-log/src/lib.rs
@@ -28,7 +28,7 @@ pub struct NewAccessLog<N> {
 pub struct AccessLogContext<S> {
     inner: S,
     client_addr: SocketAddr,
-    client_id: Option<identity::Name>,
+    client_id: Option<identity::TlsName>,
 }
 
 struct ResponseFutureInner {

--- a/linkerd/identity/src/credentials.rs
+++ b/linkerd/identity/src/credentials.rs
@@ -1,11 +1,11 @@
-use crate::Name;
+use crate::TlsName;
 use linkerd_error::Result;
 use std::{ops::Deref, time::SystemTime};
 
 /// Publishes certificates to be used by TLS implementations.
 pub trait Credentials {
-    /// Get the authoritative DNS-like name used in the certificate.
-    fn dns_name(&self) -> &Name;
+    /// Get the tls name used in the certificate's SAN.
+    fn tls_name(&self) -> &TlsName;
 
     /// Generate a CSR to to be sent to the identity service.
     fn gen_certificate_signing_request(&mut self) -> DerX509;

--- a/linkerd/identity/src/lib.rs
+++ b/linkerd/identity/src/lib.rs
@@ -4,10 +4,13 @@
 mod credentials;
 mod local;
 mod name;
+mod tls_name;
 
 pub use self::{
     credentials::{Credentials, DerX509},
     local::LocalId,
+    local::LocalName,
     name::Name,
+    tls_name::TlsName,
 };
 pub use linkerd_dns_name::InvalidName;

--- a/linkerd/identity/src/local.rs
+++ b/linkerd/identity/src/local.rs
@@ -1,22 +1,27 @@
 use crate::Name;
+use crate::TlsName;
 use std::{fmt, ops::Deref};
 
 /// A newtype for local server identities.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-pub struct LocalId(pub Name);
+pub struct LocalId(pub TlsName);
+
+/// A newtype for local server names.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct LocalName(pub Name);
 
 // === impl LocalId ===
 
-impl From<Name> for LocalId {
-    fn from(n: Name) -> Self {
+impl From<TlsName> for LocalId {
+    fn from(n: TlsName) -> Self {
         Self(n)
     }
 }
 
 impl Deref for LocalId {
-    type Target = Name;
+    type Target = TlsName;
 
-    fn deref(&self) -> &Name {
+    fn deref(&self) -> &TlsName {
         &self.0
     }
 }
@@ -27,8 +32,24 @@ impl fmt::Display for LocalId {
     }
 }
 
-impl From<LocalId> for Name {
-    fn from(LocalId(name): LocalId) -> Name {
+impl From<LocalId> for TlsName {
+    fn from(LocalId(name): LocalId) -> TlsName {
         name
+    }
+}
+
+// === impl LocalName ===
+
+impl Deref for LocalName {
+    type Target = Name;
+
+    fn deref(&self) -> &Name {
+        &self.0
+    }
+}
+
+impl fmt::Display for LocalName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/linkerd/identity/src/tls_name.rs
+++ b/linkerd/identity/src/tls_name.rs
@@ -1,19 +1,19 @@
 use linkerd_dns_name::InvalidName;
 use std::{fmt, ops::Deref, str::FromStr, sync::Arc};
 
-/// An endpoint's DNS like name.
+/// An endpoint's identity.
 #[derive(Clone, Eq, PartialEq, Hash)]
-pub struct Name(Arc<linkerd_dns_name::Name>);
+pub struct TlsName(pub Arc<linkerd_dns_name::Name>);
 
 // === impl Name ===
 
-impl From<linkerd_dns_name::Name> for Name {
+impl From<linkerd_dns_name::Name> for TlsName {
     fn from(n: linkerd_dns_name::Name) -> Self {
-        Name(Arc::new(n))
+        TlsName(Arc::new(n))
     }
 }
 
-impl FromStr for Name {
+impl FromStr for TlsName {
     type Err = InvalidName;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -21,11 +21,11 @@ impl FromStr for Name {
             return Err(InvalidName); // SNI hostnames are implicitly absolute.
         }
 
-        linkerd_dns_name::Name::from_str(s).map(|n| Name(Arc::new(n)))
+        linkerd_dns_name::Name::from_str(s).map(|n| TlsName(Arc::new(n)))
     }
 }
 
-impl Deref for Name {
+impl Deref for TlsName {
     type Target = linkerd_dns_name::Name;
 
     fn deref(&self) -> &Self::Target {
@@ -33,13 +33,13 @@ impl Deref for Name {
     }
 }
 
-impl fmt::Debug for Name {
+impl fmt::Debug for TlsName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::Debug::fmt(&self.0, f)
     }
 }
 
-impl fmt::Display for Name {
+impl fmt::Display for TlsName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::Display::fmt(&self.0, f)
     }

--- a/linkerd/meshtls/boring/src/creds.rs
+++ b/linkerd/meshtls/boring/src/creds.rs
@@ -13,7 +13,8 @@ use std::sync::Arc;
 use tokio::sync::watch;
 
 pub fn watch(
-    identity: id::Name,
+    name: id::Name,
+    tls_name: id::TlsName,
     roots_pem: &str,
     key_pkcs8: &[u8],
     csr: &[u8],
@@ -25,8 +26,8 @@ pub fn watch(
     };
 
     let (tx, rx) = watch::channel(Creds::from(creds.clone()));
-    let rx = Receiver::new(identity.clone(), rx);
-    let store = Store::new(creds, csr, identity, tx);
+    let rx = Receiver::new(name, tls_name.clone(), rx);
+    let store = Store::new(creds, csr, tls_name, tx);
 
     Ok((store, rx))
 }

--- a/linkerd/meshtls/boring/src/creds/receiver.rs
+++ b/linkerd/meshtls/boring/src/creds/receiver.rs
@@ -1,21 +1,22 @@
 use super::CredsRx;
 use crate::{NewClient, Server};
-use linkerd_identity::Name;
+use linkerd_identity::{Name, TlsName};
 
 #[derive(Clone)]
 pub struct Receiver {
     name: Name,
+    tls_name: TlsName,
     rx: CredsRx,
 }
 
 impl Receiver {
-    pub(crate) fn new(name: Name, rx: CredsRx) -> Self {
-        Self { name, rx }
+    pub(crate) fn new(name: Name, tls_name: TlsName, rx: CredsRx) -> Self {
+        Self { tls_name, name, rx }
     }
 
-    /// Returns the local identity.
-    pub fn name(&self) -> &Name {
-        &self.name
+    /// Returns the local identity name.
+    pub fn tls_name(&self) -> &TlsName {
+        &self.tls_name
     }
 
     /// Returns a `NewClient` that can be used to establish TLS on client connections.
@@ -33,6 +34,7 @@ impl std::fmt::Debug for Receiver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Receiver")
             .field("name", &self.name)
+            .field("tls_name", &self.tls_name)
             .finish()
     }
 }

--- a/linkerd/meshtls/boring/src/creds/store.rs
+++ b/linkerd/meshtls/boring/src/creds/store.rs
@@ -7,18 +7,23 @@ use std::sync::Arc;
 pub struct Store {
     creds: Arc<BaseCreds>,
     csr: Vec<u8>,
-    name: id::Name,
+    tls_name: id::TlsName,
     tx: CredsTx,
 }
 
 // === impl Store ===
 
 impl Store {
-    pub(super) fn new(creds: Arc<BaseCreds>, csr: &[u8], name: id::Name, tx: CredsTx) -> Self {
+    pub(super) fn new(
+        creds: Arc<BaseCreds>,
+        csr: &[u8],
+        tls_name: id::TlsName,
+        tx: CredsTx,
+    ) -> Self {
         Self {
             creds,
             csr: csr.into(),
-            name,
+            tls_name,
             tx,
         }
     }
@@ -27,7 +32,7 @@ impl Store {
         for san in cert.subject_alt_names().into_iter().flatten() {
             if let Some(n) = san.dnsname() {
                 if let Ok(name) = n.parse::<linkerd_dns_name::Name>() {
-                    if name == *self.name {
+                    if name == *self.tls_name {
                         return true;
                     }
                 }
@@ -40,8 +45,8 @@ impl Store {
 
 impl id::Credentials for Store {
     /// Returns the proxy's identity.
-    fn dns_name(&self) -> &id::Name {
-        &self.name
+    fn tls_name(&self) -> &id::TlsName {
+        &self.tls_name
     }
 
     /// Returns the CSR that was configured at proxy startup.

--- a/linkerd/meshtls/boring/src/server.rs
+++ b/linkerd/meshtls/boring/src/server.rs
@@ -2,7 +2,7 @@ use crate::creds::CredsRx;
 use linkerd_identity::Name;
 use linkerd_io as io;
 use linkerd_stack::{Param, Service};
-use linkerd_tls::{ClientId, LocalId, NegotiatedProtocol, ServerTls};
+use linkerd_tls::{ClientId, LocalName, NegotiatedProtocol, ServerTls};
 use std::{future::Future, pin::Pin, sync::Arc, task::Context};
 use tracing::debug;
 
@@ -41,9 +41,9 @@ impl Server {
     }
 }
 
-impl Param<LocalId> for Server {
-    fn param(&self) -> LocalId {
-        LocalId(self.name.clone())
+impl Param<LocalName> for Server {
+    fn param(&self) -> LocalName {
+        LocalName(self.name.clone())
     }
 }
 

--- a/linkerd/meshtls/boring/src/tests.rs
+++ b/linkerd/meshtls/boring/src/tests.rs
@@ -6,6 +6,7 @@ fn load(ent: &Entity) -> crate::creds::Store {
     let roots_pem = std::str::from_utf8(ent.trust_anchors).expect("valid PEM");
     let (store, _) = crate::creds::watch(
         ent.name.parse().unwrap(),
+        ent.tls_name.parse().unwrap(),
         roots_pem,
         ent.key,
         b"fake CSR data",

--- a/linkerd/meshtls/rustls/src/client.rs
+++ b/linkerd/meshtls/rustls/src/client.rs
@@ -15,7 +15,7 @@ pub struct NewClient {
 /// A `Service` that initiates client-side TLS connections.
 #[derive(Clone)]
 pub struct Connect {
-    server_id: rustls::ServerName,
+    server_name: rustls::ServerName,
     config: Arc<ClientConfig>,
 }
 
@@ -68,10 +68,13 @@ impl Connect {
             }
         };
 
-        let server_id = rustls::ServerName::try_from(client_tls.server_id.as_str())
-            .expect("identity must be a valid DNS name");
+        let server_name = rustls::ServerName::try_from(client_tls.server_name.as_str())
+            .expect("server name must be a valid DNS name");
 
-        Self { server_id, config }
+        Self {
+            server_name,
+            config,
+        }
     }
 }
 
@@ -90,7 +93,7 @@ where
     fn call(&mut self, io: I) -> Self::Future {
         tokio_rustls::TlsConnector::from(self.config.clone())
             // XXX(eliza): it's a bummer that the server name has to be cloned here...
-            .connect(self.server_id.clone(), io)
+            .connect(self.server_name.clone(), io)
             .map_ok(ClientIo)
     }
 }

--- a/linkerd/meshtls/rustls/src/creds.rs
+++ b/linkerd/meshtls/rustls/src/creds.rs
@@ -20,7 +20,8 @@ pub struct InvalidKey(KeyRejected);
 pub struct InvalidTrustRoots(());
 
 pub fn watch(
-    identity: id::Name,
+    name: id::Name,
+    tls_name: id::TlsName,
     roots_pem: &str,
     key_pkcs8: &[u8],
     csr: &[u8],
@@ -80,13 +81,13 @@ pub fn watch(
         watch::channel(store::server_config(roots.clone(), empty_resolver))
     };
 
-    let rx = Receiver::new(identity.clone(), client_rx, server_rx);
+    let rx = Receiver::new(name, tls_name.clone(), client_rx, server_rx);
     let store = Store::new(
         roots,
         server_cert_verifier,
         key,
         csr,
-        identity,
+        tls_name,
         client_tx,
         server_tx,
     );
@@ -97,6 +98,7 @@ pub fn watch(
 #[cfg(feature = "test-util")]
 pub fn for_test(ent: &linkerd_tls_test_util::Entity) -> (Store, Receiver) {
     watch(
+        ent.name.parse().expect("name must be valid"),
         ent.name.parse().expect("name must be valid"),
         std::str::from_utf8(ent.trust_anchors).expect("roots must be PEM"),
         ent.key,

--- a/linkerd/meshtls/rustls/src/creds/receiver.rs
+++ b/linkerd/meshtls/rustls/src/creds/receiver.rs
@@ -1,5 +1,5 @@
 use crate::{NewClient, Server};
-use linkerd_identity::Name;
+use linkerd_identity::{Name, TlsName};
 use std::sync::Arc;
 use tokio::sync::watch;
 use tokio_rustls::rustls;
@@ -8,6 +8,7 @@ use tokio_rustls::rustls;
 #[derive(Clone)]
 pub struct Receiver {
     name: Name,
+    tls_name: TlsName,
     client_rx: watch::Receiver<Arc<rustls::ClientConfig>>,
     server_rx: watch::Receiver<Arc<rustls::ServerConfig>>,
 }
@@ -17,19 +18,21 @@ pub struct Receiver {
 impl Receiver {
     pub(super) fn new(
         name: Name,
+        tls_name: TlsName,
         client_rx: watch::Receiver<Arc<rustls::ClientConfig>>,
         server_rx: watch::Receiver<Arc<rustls::ServerConfig>>,
     ) -> Self {
         Self {
             name,
+            tls_name,
             client_rx,
             server_rx,
         }
     }
 
     /// Returns the local identity.
-    pub fn name(&self) -> &Name {
-        &self.name
+    pub fn tls_name(&self) -> &TlsName {
+        &self.tls_name
     }
 
     /// Returns a `NewClient` that can be used to establish TLS on client connections.
@@ -47,6 +50,7 @@ impl std::fmt::Debug for Receiver {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Receiver")
             .field("name", &self.name)
+            .field("tls_name", &self.name)
             .finish()
     }
 }
@@ -86,6 +90,7 @@ mod tests {
         let (_, client_rx) = watch::channel(Arc::new(empty_client_config()));
         let receiver = Receiver {
             name: "example".parse().unwrap(),
+            tls_name: "example".parse().unwrap(),
             server_rx,
             client_rx,
         };
@@ -109,6 +114,7 @@ mod tests {
         let (_, client_rx) = watch::channel(Arc::new(empty_client_config()));
         let receiver = Receiver {
             name: "example".parse().unwrap(),
+            tls_name: "example".parse().unwrap(),
             server_rx,
             client_rx,
         };

--- a/linkerd/meshtls/rustls/src/creds/store.rs
+++ b/linkerd/meshtls/rustls/src/creds/store.rs
@@ -12,7 +12,7 @@ pub struct Store {
     server_cert_verifier: Arc<dyn rustls::client::ServerCertVerifier>,
     key: Arc<EcdsaKeyPair>,
     csr: Arc<[u8]>,
-    name: id::Name,
+    tls_name: id::TlsName,
     client_tx: watch::Sender<Arc<rustls::ClientConfig>>,
     server_tx: watch::Sender<Arc<rustls::ServerConfig>>,
 }
@@ -75,7 +75,7 @@ impl Store {
         server_cert_verifier: Arc<dyn rustls::client::ServerCertVerifier>,
         key: EcdsaKeyPair,
         csr: &[u8],
-        name: id::Name,
+        tls_name: id::TlsName,
         client_tx: watch::Sender<Arc<rustls::ClientConfig>>,
         server_tx: watch::Sender<Arc<rustls::ServerConfig>>,
     ) -> Self {
@@ -84,7 +84,7 @@ impl Store {
             key: Arc::new(key),
             server_cert_verifier,
             csr: csr.into(),
-            name,
+            tls_name,
             client_tx,
             server_tx,
         }
@@ -105,7 +105,7 @@ impl Store {
     /// Ensures the certificate is valid for the services we terminate for TLS. This assumes that
     /// server cert validation does the same or more validation than client cert validation.
     fn validate(&self, certs: &[rustls::Certificate]) -> Result<()> {
-        let name = rustls::ServerName::try_from(self.name.as_str())
+        let name = rustls::ServerName::try_from(self.tls_name.as_str())
             .expect("server name must be a valid DNS name");
         static NO_OCSP: &[u8] = &[];
         let end_entity = &certs[0];
@@ -120,6 +120,7 @@ impl Store {
             NO_OCSP,
             now,
         )?;
+        //// ... ///
         debug!("Certified");
         Ok(())
     }
@@ -127,8 +128,8 @@ impl Store {
 
 impl id::Credentials for Store {
     /// Returns the proxy's identity.
-    fn dns_name(&self) -> &id::Name {
-        &self.name
+    fn tls_name(&self) -> &id::TlsName {
+        &self.tls_name
     }
 
     /// Returns the CSR that was configured at proxy startup.

--- a/linkerd/meshtls/rustls/src/server.rs
+++ b/linkerd/meshtls/rustls/src/server.rs
@@ -1,5 +1,5 @@
 use futures::prelude::*;
-use linkerd_identity::{LocalId, Name};
+use linkerd_identity::{LocalName, Name};
 use linkerd_io as io;
 use linkerd_stack::{Param, Service};
 use linkerd_tls::{ClientId, NegotiatedProtocol, NegotiatedProtocolRef, ServerTls};
@@ -82,9 +82,9 @@ impl Server {
     }
 }
 
-impl Param<LocalId> for Server {
-    fn param(&self) -> LocalId {
-        LocalId(self.name.clone())
+impl Param<LocalName> for Server {
+    fn param(&self) -> LocalName {
+        LocalName(self.name.clone())
     }
 }
 

--- a/linkerd/meshtls/rustls/src/tests.rs
+++ b/linkerd/meshtls/rustls/src/tests.rs
@@ -6,6 +6,7 @@ fn load(ent: &Entity) -> crate::creds::Store {
     let roots_pem = std::str::from_utf8(ent.trust_anchors).expect("valid PEM");
     let (store, _) = crate::creds::watch(
         ent.name.parse().unwrap(),
+        ent.tls_name.parse().unwrap(),
         roots_pem,
         ent.key,
         b"fake CSR data",

--- a/linkerd/meshtls/src/creds.rs
+++ b/linkerd/meshtls/src/creds.rs
@@ -1,6 +1,6 @@
 use crate::{NewClient, Server};
 use linkerd_error::Result;
-use linkerd_identity::{Credentials, DerX509, Name};
+use linkerd_identity::{Credentials, DerX509, TlsName};
 
 #[cfg(feature = "boring")]
 pub use crate::boring;
@@ -32,13 +32,13 @@ pub enum Receiver {
 // === impl Store ===
 
 impl Credentials for Store {
-    fn dns_name(&self) -> &Name {
+    fn tls_name(&self) -> &TlsName {
         match self {
             #[cfg(feature = "boring")]
-            Self::Boring(store) => store.dns_name(),
+            Self::Boring(store) => store.tls_name(),
 
             #[cfg(feature = "rustls")]
-            Self::Rustls(store) => store.dns_name(),
+            Self::Rustls(store) => store.tls_name(),
             #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }
@@ -91,13 +91,13 @@ impl From<rustls::creds::Receiver> for Receiver {
 }
 
 impl Receiver {
-    pub fn name(&self) -> &Name {
+    pub fn tls_name(&self) -> &TlsName {
         match self {
             #[cfg(feature = "boring")]
-            Self::Boring(receiver) => receiver.name(),
+            Self::Boring(receiver) => receiver.tls_name(),
 
             #[cfg(feature = "rustls")]
-            Self::Rustls(receiver) => receiver.name(),
+            Self::Rustls(receiver) => receiver.tls_name(),
             #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(),
         }

--- a/linkerd/meshtls/src/lib.rs
+++ b/linkerd/meshtls/src/lib.rs
@@ -21,7 +21,7 @@ pub use self::{
     server::{Server, ServerIo, TerminateFuture},
 };
 use linkerd_error::{Error, Result};
-use linkerd_identity::Name;
+use linkerd_identity::{Name, TlsName};
 use std::str::FromStr;
 
 #[cfg(feature = "boring")]
@@ -82,7 +82,8 @@ impl Default for Mode {
 impl Mode {
     pub fn watch(
         self,
-        identity: Name,
+        name: Name,
+        tls_name: TlsName,
         roots_pem: &str,
         key_pkcs8: &[u8],
         csr: &[u8],
@@ -90,7 +91,8 @@ impl Mode {
         match self {
             #[cfg(feature = "boring")]
             Self::Boring => {
-                let (store, receiver) = boring::creds::watch(identity, roots_pem, key_pkcs8, csr)?;
+                let (store, receiver) =
+                    boring::creds::watch(name, tls_name, roots_pem, key_pkcs8, csr)?;
                 Ok((
                     creds::Store::Boring(store),
                     creds::Receiver::Boring(receiver),
@@ -99,7 +101,8 @@ impl Mode {
 
             #[cfg(feature = "rustls")]
             Self::Rustls => {
-                let (store, receiver) = rustls::creds::watch(identity, roots_pem, key_pkcs8, csr)?;
+                let (store, receiver) =
+                    rustls::creds::watch(name, tls_name, roots_pem, key_pkcs8, csr)?;
                 Ok((
                     creds::Store::Rustls(store),
                     creds::Receiver::Rustls(receiver),
@@ -107,7 +110,7 @@ impl Mode {
             }
 
             #[cfg(not(feature = "__has_any_tls_impls"))]
-            _ => no_tls!(identity, roots_pem, key_pkcs8, csr),
+            _ => no_tls!(name, tls_name, roots_pem, key_pkcs8, csr),
         }
     }
 }

--- a/linkerd/meshtls/src/server.rs
+++ b/linkerd/meshtls/src/server.rs
@@ -1,5 +1,5 @@
 use linkerd_error::Result;
-use linkerd_identity::LocalId;
+use linkerd_identity::LocalName;
 use linkerd_io as io;
 use linkerd_stack::{Param, Service};
 use linkerd_tls::ServerTls;
@@ -57,9 +57,9 @@ pub enum ServerIo<I> {
 
 // === impl Server ===
 
-impl Param<LocalId> for Server {
+impl Param<LocalName> for Server {
     #[inline]
-    fn param(&self) -> LocalId {
+    fn param(&self) -> LocalName {
         match self {
             #[cfg(feature = "boring")]
             Self::Boring(srv) => srv.param(),

--- a/linkerd/proxy/api-resolve/src/metadata.rs
+++ b/linkerd/proxy/api-resolve/src/metadata.rs
@@ -1,5 +1,5 @@
 use http::uri::Authority;
-use linkerd_tls::client::ServerId;
+use linkerd_tls::client::{ServerId, ServerName};
 use std::collections::BTreeMap;
 
 /// Endpoint labels are lexigraphically ordered by key.
@@ -18,7 +18,7 @@ pub struct Metadata {
     tagged_transport_port: Option<u16>,
 
     /// How to verify TLS for the endpoint.
-    identity: Option<ServerId>,
+    identity: Option<(ServerId, ServerName)>,
 
     /// Used to override the the authority if needed
     authority_override: Option<Authority>,
@@ -55,7 +55,7 @@ impl Metadata {
         labels: impl IntoIterator<Item = (String, String)>,
         protocol_hint: ProtocolHint,
         tagged_transport_port: Option<u16>,
-        identity: Option<ServerId>,
+        identity: Option<(ServerId, ServerName)>,
         authority_override: Option<Authority>,
     ) -> Self {
         Self {
@@ -76,7 +76,7 @@ impl Metadata {
         self.protocol_hint
     }
 
-    pub fn identity(&self) -> Option<&ServerId> {
+    pub fn identity(&self) -> Option<&(ServerId, ServerName)> {
         self.identity.as_ref()
     }
 

--- a/linkerd/proxy/identity-client/src/certify.rs
+++ b/linkerd/proxy/identity-client/src/certify.rs
@@ -95,7 +95,7 @@ where
 {
     let req = tonic::Request::new(api::CertifyRequest {
         token: token.load()?,
-        identity: credentials.dns_name().to_string(),
+        identity: credentials.tls_name().to_string(),
         certificate_signing_request: credentials.gen_certificate_signing_request().to_vec(),
     });
 

--- a/linkerd/tls/src/lib.rs
+++ b/linkerd/tls/src/lib.rs
@@ -4,10 +4,12 @@
 pub mod client;
 pub mod server;
 
-pub use linkerd_identity::LocalId;
+pub use linkerd_identity::{LocalId, LocalName};
 
 pub use self::{
-    client::{Client, ClientTls, ConditionalClientTls, ConnectMeta, NoClientTls, ServerId},
+    client::{
+        Client, ClientTls, ConditionalClientTls, ConnectMeta, NoClientTls, ServerId, ServerName,
+    },
     server::{ClientId, ConditionalServerTls, NewDetectTls, NoServerTls, ServerTls},
 };
 

--- a/linkerd/tls/test-util/src/lib.rs
+++ b/linkerd/tls/test-util/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub struct Entity {
     pub name: &'static str,
+    pub tls_name: &'static str,
     pub trust_anchors: &'static [u8],
     pub crt: &'static [u8],
     pub key: &'static [u8],
@@ -10,6 +11,7 @@ pub struct Entity {
 
 pub static DEFAULT_DEFAULT: Entity = Entity {
     name: "default.default.serviceaccount.identity.linkerd.cluster.local",
+    tls_name: "default.default.serviceaccount.identity.linkerd.cluster.local",
     trust_anchors: include_bytes!("testdata/ca1.pem"),
     crt: include_bytes!("testdata/default-default-ca1/crt.der"),
     key: include_bytes!("testdata/default-default-ca1/key.p8"),
@@ -17,6 +19,7 @@ pub static DEFAULT_DEFAULT: Entity = Entity {
 
 pub static FOO_NS1: Entity = Entity {
     name: "foo.ns1.serviceaccount.identity.linkerd.cluster.local",
+    tls_name: "foo.ns1.serviceaccount.identity.linkerd.cluster.local",
     trust_anchors: include_bytes!("testdata/ca1.pem"),
     crt: include_bytes!("testdata/foo-ns1-ca1/crt.der"),
     key: include_bytes!("testdata/foo-ns1-ca1/key.p8"),
@@ -24,6 +27,7 @@ pub static FOO_NS1: Entity = Entity {
 
 pub static FOO_NS1_CA2: Entity = Entity {
     name: "foo.ns1.serviceaccount.identity.linkerd.cluster.local",
+    tls_name: "foo.ns1.serviceaccount.identity.linkerd.cluster.local",
     trust_anchors: include_bytes!("testdata/ca2.pem"),
     crt: include_bytes!("testdata/foo-ns1-ca2/crt.der"),
     key: include_bytes!("testdata/foo-ns1-ca2/key.p8"),
@@ -31,6 +35,7 @@ pub static FOO_NS1_CA2: Entity = Entity {
 
 pub static BAR_NS1: Entity = Entity {
     name: "bar.ns1.serviceaccount.identity.linkerd.cluster.local",
+    tls_name: "bar.ns1.serviceaccount.identity.linkerd.cluster.local",
     trust_anchors: include_bytes!("testdata/ca1.pem"),
     crt: include_bytes!("testdata/bar-ns1-ca1/crt.der"),
     key: include_bytes!("testdata/bar-ns1-ca1/key.p8"),


### PR DESCRIPTION
This change attempts to split the concept of a server name(SNI) and Tls identity(the identity of a peer as prescribed by its leaf TLS cert)