### PR TITLE
ci: Fix check-each workflow

### DIFF
--- a/.github/list-crates.sh
+++ b/.github/list-crates.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-if [ $# -ne 1 ]; then
+if [ $# -eq 0 ]; then
     echo "Usage: $0 <changed-files>"
     exit 1
 fi
@@ -23,14 +23,14 @@ manifest_expr() {
 
     for file in "$@" ; do
         # If the workflow changes or root Cargo.toml changes, run checks for all crates in the repo.
-        if [[ "$file" = .github/* ]] || [ "$file" = "$PWD/Cargo.toml" ]; then
+        if [[ "$file" = .github/* ]] || [ "$file" = "Cargo.toml" ]; then
             expr="startswith(\"$PWD\")"
             break
         fi
 
         # Otherwise, only run checks for changes to subcrates (and not the top-level crate).
         m=$(find_manifest "$file")
-        if [ "$m" != "$PWD/Cargo.toml" ]; then
+        if [ "$m" != "Cargo.toml" ]; then
             expr="$expr or (. == \"$m\")"
         fi
     done
@@ -38,15 +38,9 @@ manifest_expr() {
     echo "$expr"
 }
 
-files=$1
-if [ -z "$files" ]; then
-    echo '[]'
-    exit 0
-fi
-
 # Get the crate names for all changed manifest directories.
 crates=$(cargo metadata --locked --format-version=1 \
-    | jq -cr "[.packages[] | select(.manifest_path | $(manifest_expr "$files")) | .name]")
+    | jq -cr "[.packages[] | select(.manifest_path | $(manifest_expr "$@")) | .name]")
 
 echo "crates=$crates" >> "$GITHUB_OUTPUT"
 echo "$crates" | jq .

--- a/.github/workflows/check-each.yml
+++ b/.github/workflows/check-each.yml
@@ -14,6 +14,7 @@ on:
       - "**/Cargo.toml"
       - "**/*.rs"
       - .github/workflows/check-each.yml
+      - .github/list-crates.sh
       - justfile
 
 env:
@@ -39,7 +40,7 @@ jobs:
             .github/workflows/check-each.yml
       - name: List changed crates
         id: changed-crates
-        run: ./.github/list-crates.sh '${{ steps.changed-files.outputs.all_changed_files }}'
+        run: ./.github/list-crates.sh ${{ steps.changed-files.outputs.all_changed_files }}
     outputs:
       crates: ${{ steps.changed-crates.outputs.crates }}
 


### PR DESCRIPTION
At some point, the check-each workflow broke (likely due to change in the action dependency we use to enumerate changed files).

This change fixes the script used to convert changed files to crate names so that the check-each workflows runs properly.