### PR TITLE
ci: Fix fuzzer listing

### DIFF
--- a/.github/fuzzers-list.sh
+++ b/.github/fuzzers-list.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 ## Lists the fuzzers that should be run given a set of changed files.
 
 # Find the nearest fuzzer crate, or nothing.
 find_fuzz_dir() {
     d=${1%/*}
-    if [ "$d" = . ]; then
+    if ! [[ "$d" =~ / ]]; then
         return
     elif [ -d "$d" ] && [[ "$d" = */fuzz ]]; then
         echo "$d"

--- a/.github/list-crates.sh
+++ b/.github/list-crates.sh
@@ -3,8 +3,8 @@
 set -eu
 
 if [ $# -eq 0 ]; then
-    echo "Usage: $0 <changed-files>"
-    exit 1
+    echo '[]'
+    exit 0
 fi
 
 # Find the nearest Cargo.toml (except the root).

--- a/justfile
+++ b/justfile
@@ -159,14 +159,10 @@ fuzzers:
         echo "fuzzers must be run with nightly" >&2
         exit 1
     fi
-
-    for dir in $(find . -type d -name fuzz); do
-        echo "cd $dir && {{ _cargo }} fuzz build"
-        (
-            cd $dir
-            @{{ _cargo }} fuzz build \
-                {{ if profile == "release" { "--release" } else { "" } }}
-        )
+    for dir in $(find ./linkerd -type d -name fuzz); do
+        echo "cd $dir && cargo +nightly fuzz build"
+        ( cd $dir ; cargo +nightly fuzz build \
+                {{ if profile == "release" { "--release" } else { "" } }} )
     done
 
 export DOCKER_BUILDX_CACHE_DIR := env_var_or_default('DOCKER_BUILDX_CACHE_DIR', '')


### PR DESCRIPTION
The fuzzer tests in CI were broken in CI by a change to the file-listing
action. This change fixes CI for fuzzer changes.

It does not actually fix the fuzzer suites.