### PR TITLE
Box controller clients

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -33,18 +33,14 @@ pub type BoxHttp<B = http::BoxBody> =
 
 pub type ArcNewHttp<T, B = http::BoxBody> = ArcNewService<T, BoxHttp<B>>;
 
-pub type BoxCloneHttp<B = http::BoxBody> =
-    BoxCloneService<http::Request<B>, http::Response<http::BoxBody>, Error>;
+pub type BoxHttpClone<B = http::BoxBody> =
+    BoxServiceClone<http::Request<B>, http::Response<http::BoxBody>, Error>;
 
-pub type ArcNewCloneHttp<T, B = http::BoxBody> = ArcNewService<T, BoxCloneHttp<B>>;
+pub type ArcNewHttpClone<T, B = http::BoxBody> = ArcNewService<T, BoxHttpClone<B>>;
 
 pub type BoxTcp<I> = BoxService<I, (), Error>;
 
 pub type ArcNewTcp<T, I> = ArcNewService<T, BoxTcp<I>>;
-
-pub type BoxCloneTcp<I> = BoxCloneService<I, (), Error>;
-
-pub type ArcNewCloneTcp<T, I> = ArcNewService<T, BoxCloneTcp<I>>;
 
 #[derive(Clone, Debug)]
 pub struct Layers<L>(L);
@@ -297,16 +293,16 @@ impl<S> Stack<S> {
         self.arc_new_box()
     }
 
-    pub fn arc_new_clone_http<T, B, Svc>(self) -> Stack<ArcNewCloneHttp<T, B>>
+    pub fn arc_new_clone_http<T, B, Svc>(self) -> Stack<ArcNewHttpClone<T, B>>
     where
         T: 'static,
         B: 'static,
         S: NewService<T, Service = Svc> + Send + Sync + 'static,
         Svc: Service<http::Request<B>, Response = http::Response<http::BoxBody>, Error = Error>,
-        Svc: Clone + Send + 'static,
+        Svc: Clone + Send + Sync + 'static,
         Svc::Future: Send,
     {
-        self.push_on_service(BoxCloneService::layer())
+        self.push_on_service(BoxServiceClone::layer())
             .push(ArcNewService::layer())
     }
 

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -67,14 +67,14 @@ struct LogicalError {
 // === impl Inbound ===
 
 impl<C> Inbound<C> {
-    pub(crate) fn push_http_router<T, P>(self, profiles: P) -> Inbound<svc::ArcNewCloneHttp<T>>
+    pub(crate) fn push_http_router<T, P>(self, profiles: P) -> Inbound<svc::ArcNewHttpClone<T>>
     where
         T: Param<http::Version>
             + Param<Remote<ServerAddr>>
             + Param<Remote<ClientAddr>>
             + Param<tls::ConditionalServerTls>
             + Param<policy::AllowPolicy>,
-        T: Clone + Send + Unpin + 'static,
+        T: Clone + Send + Sync + Unpin + 'static,
         P: profiles::GetProfile<Error = Error>,
         C: svc::MakeConnection<Http> + Clone + Send + Sync + Unpin + 'static,
         C::Connection: Send + Unpin,

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -28,7 +28,7 @@ struct ServerError {
 impl<H> Inbound<H> {
     /// Prepares HTTP requests for inbound processing. Fails requests when the
     /// `HSvc`-typed inner service is not ready.
-    pub fn push_http_server<T, HSvc>(self) -> Inbound<svc::ArcNewCloneHttp<T>>
+    pub fn push_http_server<T, HSvc>(self) -> Inbound<svc::ArcNewHttpClone<T>>
     where
         // Connection target.
         T: Param<Version>
@@ -40,11 +40,8 @@ impl<H> Inbound<H> {
         T: Clone + Send + Sync + Unpin + 'static,
         // Inner HTTP stack.
         H: svc::NewService<T, Service = HSvc> + Clone + Send + Sync + Unpin + 'static,
-        HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
-            + Clone
-            + Send
-            + Unpin
-            + 'static,
+        HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>,
+        HSvc: Clone + Send + Sync + Unpin + 'static,
         HSvc::Error: Into<Error>,
         HSvc::Future: Send,
     {

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -78,7 +78,7 @@ impl<T> Outbound<svc::ArcNewHttp<concrete::Endpoint<logical::Concrete<Http<T>>>>
     /// Builds a stack that routes HTTP requests to endpoint stacks.
     ///
     /// Buffered concrete services are cached in and evicted when idle.
-    pub fn push_http_cached<R>(self, resolve: R) -> Outbound<svc::ArcNewCloneHttp<T>>
+    pub fn push_http_cached<R>(self, resolve: R) -> Outbound<svc::ArcNewHttpClone<T>>
     where
         // Logical HTTP target.
         T: svc::Param<http::Version>,

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -11,7 +11,7 @@ pub(crate) struct ServerRescue {
     emit_headers: bool,
 }
 
-impl<T> Outbound<svc::ArcNewCloneHttp<T>> {
+impl<T> Outbound<svc::ArcNewHttpClone<T>> {
     /// Builds a [`svc::NewService`] stack that prepares HTTP requests to be
     /// proxied.
     ///
@@ -19,7 +19,7 @@ impl<T> Outbound<svc::ArcNewCloneHttp<T>> {
     /// HTTP responses.
     ///
     /// Inner services must be available, otherwise load shedding is applied.
-    pub fn push_http_server(self) -> Outbound<svc::ArcNewCloneHttp<T>>
+    pub fn push_http_server(self) -> Outbound<svc::ArcNewHttpClone<T>>
     where
         // Target
         T: svc::Param<http::normalize_uri::DefaultAuthority> + 'static,

--- a/linkerd/app/outbound/src/protocol.rs
+++ b/linkerd/app/outbound/src/protocol.rs
@@ -28,7 +28,7 @@ impl<N> Outbound<N> {
     /// each connection.
     pub fn push_protocol<T, I, NSvc>(
         self,
-        http: svc::ArcNewCloneHttp<Http<T>>,
+        http: svc::ArcNewHttpClone<Http<T>>,
     ) -> Outbound<svc::ArcNewTcp<T, I>>
     where
         // Target type indicating whether detection should be skipped.

--- a/linkerd/stack/src/box_service.rs
+++ b/linkerd/stack/src/box_service.rs
@@ -1,37 +1,94 @@
-use std::marker::PhantomData;
+use futures::Future;
+use std::pin::Pin;
 pub use tower::util::BoxService;
 
-#[derive(Copy, Debug)]
-pub struct BoxServiceLayer<R> {
-    _p: PhantomData<fn(R)>,
+pub struct BoxServiceClone<Req, Rsp, E> {
+    inner: Box<
+        dyn sealed::CloneService<
+            Req,
+            Response = Rsp,
+            Error = E,
+            Future = Pin<Box<dyn Future<Output = Result<Rsp, E>> + Send + 'static>>,
+        >,
+    >,
 }
 
-impl<S, R> tower::Layer<S> for BoxServiceLayer<R>
-where
-    S: tower::Service<R> + Send + 'static,
-    S::Future: Send + 'static,
-    S::Error: Send + 'static,
-{
-    type Service = BoxService<R, S::Response, S::Error>;
-    fn layer(&self, s: S) -> Self::Service {
-        BoxService::new(s)
+impl<Req: 'static, Rsp: 'static, E: 'static> BoxServiceClone<Req, Rsp, E> {
+    pub fn new<S>(inner: S) -> Self
+    where
+        S: crate::Service<Req, Response = Rsp, Error = E>,
+        S: Clone + Send + Sync + 'static,
+        S::Future: Send + 'static,
+    {
+        Self {
+            inner: Box::new(crate::BoxFuture::new(inner)),
+        }
+    }
+
+    pub fn layer<S>() -> impl crate::layer::Layer<S, Service = Self> + Clone + Copy
+    where
+        S: crate::Service<Req, Response = Rsp, Error = E>,
+        S: Clone + Send + Sync + 'static,
+        S::Future: Send + 'static,
+    {
+        crate::layer::mk(Self::new)
     }
 }
 
-impl<R> BoxServiceLayer<R> {
-    pub fn new() -> Self {
-        Self { _p: PhantomData }
-    }
-}
-
-impl<R> Clone for BoxServiceLayer<R> {
+impl<Req: 'static, Rsp: 'static, E: 'static> Clone for BoxServiceClone<Req, Rsp, E> {
     fn clone(&self) -> Self {
-        Self::new()
+        BoxServiceClone {
+            inner: self.inner.clone_boxed(),
+        }
     }
 }
 
-impl<R> Default for BoxServiceLayer<R> {
-    fn default() -> Self {
-        Self::new()
+impl<Req, Rsp, E> crate::Service<Req> for BoxServiceClone<Req, Rsp, E>
+where
+    Req: 'static,
+    Rsp: 'static,
+    E: 'static,
+{
+    type Response = Rsp;
+    type Error = E;
+    type Future = Pin<Box<dyn Future<Output = Result<Rsp, E>> + Send + 'static>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> std::task::Poll<Result<(), E>> {
+        self.inner.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, req: Req) -> Self::Future {
+        self.inner.call(req)
+    }
+}
+
+mod sealed {
+    use crate::Service;
+
+    pub trait CloneService<Req>: Service<Req> + Send + Sync + 'static {
+        fn clone_boxed(
+            &self,
+        ) -> Box<
+            dyn CloneService<
+                Req,
+                Response = Self::Response,
+                Error = Self::Error,
+                Future = Self::Future,
+            >,
+        >;
+    }
+
+    impl<Req, S> CloneService<Req> for S
+    where
+        S: Service<Req> + Send + Sync + Clone + 'static,
+    {
+        fn clone_boxed(
+            &self,
+        ) -> Box<dyn CloneService<Req, Response = S::Response, Error = S::Error, Future = S::Future>>
+        {
+            Box::new(self.clone())
+        }
     }
 }

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -33,7 +33,7 @@ mod watch;
 pub use self::{
     arc_new_service::ArcNewService,
     box_future::BoxFuture,
-    box_service::{BoxService, BoxServiceLayer},
+    box_service::{BoxService, BoxServiceClone},
     connect::{MakeConnection, WithoutConnectionMetadata},
     either::{Either, NewEither},
     fail::Fail,
@@ -59,7 +59,7 @@ pub use self::{
 };
 pub use tower::{
     service_fn,
-    util::{self, future_service, BoxCloneService, FutureService, Oneshot, ServiceExt},
+    util::{self, future_service, FutureService, Oneshot, ServiceExt},
     Service,
 };
 


### PR DESCRIPTION
This change extends e62cc28ff by boxing the controller clients so their inner types signatures don't leak into the stacks that use them.

This change adds a new BoxServiceClone type to replace Tower's BoxCloneService. Our new type implements Sync so the Service can be used across threads.