### PR TITLE
dev: Disable nightly install for now

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,10 @@
 ARG DEV_VERSION
 
 FROM ghcr.io/linkerd/dev:${DEV_VERSION}
-RUN rustup toolchain install --profile=minimal nightly && \
-    cargo +nightly install cargo-fuzz
 RUN scurl https://run.linkerd.io/install-edge | sh && \
     mkdir -p "$HOME/bin" && ln -s "$HOME/.linkerd2/bin/linkerd" "$HOME/bin/linkerd"
+
+# XXX(ver) This doesn't currently work, because it puts
+# /usr/local/cargo/registry into a weird state with regard to permissions.
+#RUN rustup toolchain install --profile=minimal nightly
+#RUN cargo +nightly install cargo-fuzz


### PR DESCRIPTION
The devcontainer nightly install leaves cargo in a bad state due to permissions issues in the docker setup. Let's just disable nightly for now (it can always be added at runtime).