### PR TITLE
build: Use jemalloc on all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
       - .github/workflows/release.yml
       - justfile
       - Cargo.toml # For release build settings
+      - linkerd2-proxy/* # For top-level binary changes
   push:
     tags:
       - "release/*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,26 +795,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
-name = "jemalloc-sys"
-version = "0.5.3+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9bd5d616ea7ed58b571b2e209a65759664d7fb021a0819d7a790afc67e47ca1"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "jemallocator"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c2514137880c52b0b4822b563fadd38257c1f380858addb74a400889696ea6"
-dependencies = [
- "jemalloc-sys",
- "libc",
-]
-
-[[package]]
 name = "jobserver"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,11 +1923,11 @@ name = "linkerd2-proxy"
 version = "0.1.0"
 dependencies = [
  "futures",
- "jemallocator",
  "linkerd-app",
  "linkerd-meshtls",
  "linkerd-signal",
  "num_cpus",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
 ]
@@ -2725,6 +2705,26 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -26,5 +26,5 @@ linkerd-signal = { path = "../linkerd/signal" }
 tokio = { version = "1", features = ["rt", "time", "net"] }
 tracing = "0.1"
 
-[target.x86_64-unknown-linux-gnu.dependencies]
-jemallocator = { version = "0.5" }
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -22,9 +22,9 @@ use linkerd_signal as signal;
 use tokio::{sync::mpsc, time};
 pub use tracing::{debug, error, info, warn};
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64", target_env = "gnu"))]
+#[cfg(not(target_env = "msvc"))]
 #[global_allocator]
-static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod rt;
 


### PR DESCRIPTION
We've been using jemalloc on amd64 for a very long time. linkerd2#11430 reports that the proxy's allocation behavior has less desirable characteristics on arm64. To fix this, we adopt use of jemallocator on all platforms.

Additionally, we change our dependencies to use tikv-jemallocator. From the docs:

> This project is the successor of jemallocator.
>
> The project is also published as jemallocator for historical
> reasons. The two crates are the same except names. For new projects,
> it's recommended to use tikv-xxx versions instead.