### PR TITLE
Update DEFAULT_OUTBOUND_TCP_QUEUE_CAPACITY to 10K

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -244,7 +244,7 @@ const DEFAULT_INBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
 const DEFAULT_INBOUND_CONNECT_BACKOFF: ExponentialBackoff =
     ExponentialBackoff::new_unchecked(Duration::from_millis(100), Duration::from_millis(500), 0.1);
 
-const DEFAULT_OUTBOUND_TCP_QUEUE_CAPACITY: usize = 10;
+const DEFAULT_OUTBOUND_TCP_QUEUE_CAPACITY: usize = 10_000;
 const DEFAULT_OUTBOUND_TCP_FAILFAST_TIMEOUT: Duration = Duration::from_secs(3);
 const DEFAULT_OUTBOUND_HTTP_QUEUE_CAPACITY: usize = 10_000;
 const DEFAULT_OUTBOUND_HTTP_FAILFAST_TIMEOUT: Duration = Duration::from_secs(3);


### PR DESCRIPTION
DEFAULT_OUTBOUND_TCP_QUEUE_CAPACITY was incorrectly set to 10 so that bursts of TCP connections could see EOF errors.

This change increases the value to match the HTTP queue capacity.