### PR TITLE
stack: Add BoxCloneSyncService

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -71,12 +71,7 @@ impl Config {
         identity: identity::NewClient,
     ) -> svc::ArcNewService<
         (),
-        impl svc::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<RspBody>,
-                Error = ControlError,
-                Future = impl Send,
-            > + Clone,
+        svc::BoxCloneSyncService<http::Request<tonic::body::BoxBody>, http::Response<RspBody>>,
     > {
         let addr = self.addr;
 
@@ -135,6 +130,7 @@ impl Config {
             .push(svc::NewMapErr::layer_from_target::<ControlError, _>())
             .instrument(|c: &ControlAddr| info_span!("controller", addr = %c.addr))
             .push_map_target(move |()| addr.clone())
+            .push_on_service(svc::BoxCloneSyncService::layer())
             .push(svc::ArcNewService::layer())
             .into_inner()
     }

--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -34,7 +34,7 @@ pub type BoxHttp<B = http::BoxBody> =
 pub type ArcNewHttp<T, B = http::BoxBody> = ArcNewService<T, BoxHttp<B>>;
 
 pub type BoxCloneHttp<B = http::BoxBody> =
-    BoxCloneService<http::Request<B>, http::Response<http::BoxBody>, Error>;
+    BoxCloneSyncService<http::Request<B>, http::Response<http::BoxBody>>;
 
 pub type ArcNewCloneHttp<T, B = http::BoxBody> = ArcNewService<T, BoxCloneHttp<B>>;
 
@@ -42,7 +42,7 @@ pub type BoxTcp<I> = BoxService<I, (), Error>;
 
 pub type ArcNewTcp<T, I> = ArcNewService<T, BoxTcp<I>>;
 
-pub type BoxCloneTcp<I> = BoxCloneService<I, (), Error>;
+pub type BoxCloneTcp<I> = BoxCloneSyncService<I, ()>;
 
 pub type ArcNewCloneTcp<T, I> = ArcNewService<T, BoxCloneTcp<I>>;
 
@@ -302,11 +302,25 @@ impl<S> Stack<S> {
         T: 'static,
         B: 'static,
         S: NewService<T, Service = Svc> + Send + Sync + 'static,
-        Svc: Service<http::Request<B>, Response = http::Response<http::BoxBody>, Error = Error>,
-        Svc: Clone + Send + 'static,
+        Svc: Service<http::Request<B>, Response = http::Response<http::BoxBody>>,
+        Svc: Clone + Send + Sync + 'static,
+        Svc::Error: Into<Error>,
         Svc::Future: Send,
     {
-        self.push_on_service(BoxCloneService::layer())
+        self.push_on_service(BoxCloneHttp::layer())
+            .push(ArcNewService::layer())
+    }
+
+    pub fn arc_new_clone_tcp<T, I, Svc>(self) -> Stack<ArcNewCloneTcp<T, I>>
+    where
+        T: 'static,
+        I: 'static,
+        S: NewService<T, Service = Svc> + Send + Sync + 'static,
+        Svc: Service<I, Response = ()> + Clone + Send + Sync + 'static,
+        Svc::Error: Into<Error>,
+        Svc::Future: Send,
+    {
+        self.push_on_service(BoxCloneTcp::layer())
             .push(ArcNewService::layer())
     }
 

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -74,7 +74,7 @@ impl<C> Inbound<C> {
             + Param<Remote<ClientAddr>>
             + Param<tls::ConditionalServerTls>
             + Param<policy::AllowPolicy>,
-        T: Clone + Send + Unpin + 'static,
+        T: Clone + Send + Sync + Unpin + 'static,
         P: profiles::GetProfile<Error = Error>,
         C: svc::MakeConnection<Http> + Clone + Send + Sync + Unpin + 'static,
         C::Connection: Send + Unpin,

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -43,6 +43,7 @@ impl<H> Inbound<H> {
         HSvc: svc::Service<http::Request<http::BoxBody>, Response = http::Response<http::BoxBody>>
             + Clone
             + Send
+            + Sync
             + Unpin
             + 'static,
         HSvc::Error: Into<Error>,

--- a/linkerd/app/outbound/src/http/logical/policy.rs
+++ b/linkerd/app/outbound/src/http/logical/policy.rs
@@ -51,18 +51,7 @@ where
     /// services.
     pub(super) fn layer<N, S>(
         route_backend_metrics: RouteBackendMetrics,
-    ) -> impl svc::Layer<
-        N,
-        Service = svc::ArcNewService<
-            Self,
-            impl svc::Service<
-                    http::Request<http::BoxBody>,
-                    Response = http::Response<http::BoxBody>,
-                    Error = Error,
-                    Future = impl Send,
-                > + Clone,
-        >,
-    > + Clone
+    ) -> impl svc::Layer<N, Service = svc::ArcNewCloneHttp<Self>> + Clone
     where
         // Inner stack.
         N: svc::NewService<Concrete<T>, Service = S>,
@@ -89,7 +78,7 @@ where
                 },
                 grpc.into_inner(),
             )
-            .push(svc::ArcNewService::layer())
+            .arc_new_clone_http()
             .into_inner()
         })
     }

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -85,18 +85,7 @@ where
     /// filters.
     pub(crate) fn layer<N, S>(
         metrics: RouteBackendMetrics,
-    ) -> impl svc::Layer<
-        N,
-        Service = svc::ArcNewService<
-            Self,
-            impl svc::Service<
-                    http::Request<http::BoxBody>,
-                    Response = http::Response<http::BoxBody>,
-                    Error = Error,
-                    Future = impl Send,
-                > + Clone,
-        >,
-    > + Clone
+    ) -> impl svc::Layer<N, Service = svc::ArcNewCloneHttp<Self>> + Clone
     where
         // Inner stack.
         N: svc::NewService<Concrete<T>, Service = S>,
@@ -131,7 +120,7 @@ where
                         })
                     }
                 }))
-                .push(svc::ArcNewService::layer())
+                .arc_new_clone_http()
                 .into_inner()
         })
     }

--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -71,18 +71,7 @@ where
     /// set of inner services so that.
     pub(super) fn layer<N, S>(
         route_backend_metrics: RouteBackendMetrics,
-    ) -> impl svc::Layer<
-        N,
-        Service = svc::ArcNewService<
-            Self,
-            impl svc::Service<
-                    http::Request<http::BoxBody>,
-                    Response = http::Response<http::BoxBody>,
-                    Error = Error,
-                    Future = impl Send,
-                > + Clone,
-        >,
-    > + Clone
+    ) -> impl svc::Layer<N, Service = svc::ArcNewCloneHttp<Self>> + Clone
     where
         // Inner stack.
         N: svc::NewService<Concrete<T>, Service = S>,
@@ -105,7 +94,7 @@ where
                 // `SelectRoute` impl.
                 .push_on_service(route::MatchedRoute::layer(route_backend_metrics.clone()))
                 .push(svc::NewOneshotRoute::<Self, (), _>::layer_cached())
-                .push(svc::ArcNewService::layer())
+                .arc_new_clone_http()
                 .into_inner()
         })
     }

--- a/linkerd/app/outbound/src/opaq.rs
+++ b/linkerd/app/outbound/src/opaq.rs
@@ -26,15 +26,7 @@ impl<C> Outbound<C> {
     ///
     /// This stack uses caching so that a router/load-balancer may be reused
     /// across multiple connections.
-    pub fn push_opaq_cached<T, I, R>(
-        self,
-        resolve: R,
-    ) -> Outbound<
-        svc::ArcNewService<
-            T,
-            impl svc::Service<I, Response = (), Error = Error, Future = impl Send> + Clone,
-        >,
-    >
+    pub fn push_opaq_cached<T, I, R>(self, resolve: R) -> Outbound<svc::ArcNewCloneTcp<T, I>>
     where
         // Opaque target
         T: svc::Param<Logical>,
@@ -58,7 +50,7 @@ impl<C> Outbound<C> {
                     // Use a dedicated target type to configure parameters for
                     // the opaque stack. It also helps narrow the cache key.
                     .push_map_target(|t: T| Opaq(t.param()))
-                    .push(svc::ArcNewService::layer())
+                    .arc_new_clone_tcp()
             })
     }
 }

--- a/linkerd/app/outbound/src/opaq/logical.rs
+++ b/linkerd/app/outbound/src/opaq/logical.rs
@@ -74,14 +74,7 @@ impl<N> Outbound<N> {
     /// services. Only available inner services are used for routing. When
     /// there are no available backends, requests are failed with a
     /// [`svc::stack::LoadShedError`].
-    pub fn push_opaq_logical<T, I, NSvc>(
-        self,
-    ) -> Outbound<
-        svc::ArcNewService<
-            T,
-            impl svc::Service<I, Response = (), Error = Error, Future = impl Send> + Clone,
-        >,
-    >
+    pub fn push_opaq_logical<T, I, NSvc>(self) -> Outbound<svc::ArcNewCloneTcp<T, I>>
     where
         // Opaque logical target.
         T: svc::Param<Logical>,
@@ -142,7 +135,7 @@ impl<N> Outbound<N> {
                     },
                     concrete.into_inner(),
                 )
-                .push(svc::ArcNewService::layer())
+                .arc_new_clone_tcp()
         })
     }
 }

--- a/linkerd/stack/src/box_future.rs
+++ b/linkerd/stack/src/box_future.rs
@@ -17,7 +17,7 @@ impl<T> BoxFuture<T> {
         Self(inner)
     }
 
-    pub fn layer() -> impl tower::Layer<T, Service = Self> {
+    pub fn layer() -> impl tower::Layer<T, Service = Self> + Copy {
         crate::layer::mk(Self::new)
     }
 }

--- a/linkerd/stack/src/box_service.rs
+++ b/linkerd/stack/src/box_service.rs
@@ -1,37 +1,97 @@
-use std::marker::PhantomData;
+use linkerd_error::{Error, Result};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
 pub use tower::util::BoxService;
 
-#[derive(Copy, Debug)]
-pub struct BoxServiceLayer<R> {
-    _p: PhantomData<fn(R)>,
+pub struct BoxCloneSyncService<Req, Rsp> {
+    inner: Box<dyn sealed::BoxCloneSyncService<Req, Rsp, Error = Error>>,
 }
 
-impl<S, R> tower::Layer<S> for BoxServiceLayer<R>
+impl<Req, Rsp> BoxCloneSyncService<Req, Rsp> {
+    pub fn new<S>(inner: S) -> Self
+    where
+        S: crate::Service<Req, Response = Rsp> + Send + Sync + Clone + 'static,
+        S::Error: Into<Error>,
+        S::Future: Send + 'static,
+    {
+        Self {
+            inner: Box::new(crate::BoxFuture::new(crate::MapErrBoxed::from(inner))),
+        }
+    }
+
+    pub fn layer<S>() -> impl crate::layer::Layer<S, Service = Self> + Copy
+    where
+        S: crate::Service<Req, Response = Rsp> + Send + Sync + Clone + 'static,
+        S::Error: Into<Error>,
+        S::Future: Send + 'static,
+    {
+        crate::layer::mk(Self::new)
+    }
+}
+
+impl<Req, Rsp> crate::Service<Req> for BoxCloneSyncService<Req, Rsp>
 where
-    S: tower::Service<R> + Send + 'static,
-    S::Future: Send + 'static,
-    S::Error: Send + 'static,
+    Req: Send + 'static,
 {
-    type Service = BoxService<R, S::Response, S::Error>;
-    fn layer(&self, s: S) -> Self::Service {
-        BoxService::new(s)
+    type Response = Rsp;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Rsp>> + Send>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    #[inline]
+    fn call(&mut self, req: Req) -> Self::Future {
+        self.inner.call(req)
     }
 }
 
-impl<R> BoxServiceLayer<R> {
-    pub fn new() -> Self {
-        Self { _p: PhantomData }
-    }
-}
-
-impl<R> Clone for BoxServiceLayer<R> {
+impl<Req, Rsp> Clone for BoxCloneSyncService<Req, Rsp> {
     fn clone(&self) -> Self {
-        Self::new()
+        Self {
+            inner: self.inner.box_clone_sync(),
+        }
     }
 }
 
-impl<R> Default for BoxServiceLayer<R> {
-    fn default() -> Self {
-        Self::new()
+mod sealed {
+    use crate::Service;
+    use linkerd_error::{Error, Result};
+    use std::{future::Future, pin::Pin};
+
+    pub trait BoxCloneSyncService<Req, Rsp>:
+        Service<
+            Req,
+            Response = Rsp,
+            Error = Error,
+            Future = Pin<Box<dyn Future<Output = Result<Rsp>> + Send>>,
+        > + Send
+        + Sync
+    {
+        fn box_clone_sync(&self) -> Box<dyn BoxCloneSyncService<Req, Rsp>>;
+    }
+
+    // Implement the trait for Box<dyn YourTrait>
+    impl<Req, Rsp, S> BoxCloneSyncService<Req, Rsp> for S
+    where
+        S: Service<
+                Req,
+                Error = Error,
+                Response = Rsp,
+                Future = Pin<Box<dyn Future<Output = Result<Rsp>> + Send>>,
+            > + Clone
+            + Send
+            + Sync
+            + 'static,
+    {
+        fn box_clone_sync(&self) -> Box<dyn BoxCloneSyncService<Req, Rsp>> {
+            Box::new(self.clone())
+        }
     }
 }

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -33,7 +33,7 @@ mod watch;
 pub use self::{
     arc_new_service::ArcNewService,
     box_future::BoxFuture,
-    box_service::{BoxService, BoxServiceLayer},
+    box_service::{BoxCloneSyncService, BoxService},
     connect::{MakeConnection, WithoutConnectionMetadata},
     either::{Either, NewEither},
     fail::Fail,
@@ -57,9 +57,11 @@ pub use self::{
     unwrap_or::UnwrapOr,
     watch::{NewSpawnWatch, SpawnWatch},
 };
+#[cfg(feature = "ready-cache")]
+pub use tower::ready_cache;
 pub use tower::{
     service_fn,
-    util::{self, future_service, BoxCloneService, FutureService, Oneshot, ServiceExt},
+    util::{self, future_service, FutureService, Oneshot, ServiceExt},
     Service,
 };
 

--- a/linkerd/stack/src/lib.rs
+++ b/linkerd/stack/src/lib.rs
@@ -57,8 +57,6 @@ pub use self::{
     unwrap_or::UnwrapOr,
     watch::{NewSpawnWatch, SpawnWatch},
 };
-#[cfg(feature = "ready-cache")]
-pub use tower::ready_cache;
 pub use tower::{
     service_fn,
     util::{self, future_service, FutureService, Oneshot, ServiceExt},


### PR DESCRIPTION
tower::util::BoxCloneService doesn't implement Sync, which is necessary when we may want to share these services across threads (which is entirely the point of making a service cloneable, really).

This change replicates BoxCloneService as BoxCloneSyncService and updates many of Linkerd's stacks to return this new type.

This continues on the work begun in #2510 and #2514.

---

Building proxy with full debug symbols:

```
:; RUSTFLAGS='-C debuginfo=2' just profile=release build              
```

Before:

```
:; du -h target/x86_64-unknown-linux-gnu/release/linkerd2-proxy{,.dbg}
20M     target/x86_64-unknown-linux-gnu/release/linkerd2-proxy
1.5G    target/x86_64-unknown-linux-gnu/release/linkerd2-proxy.dbg
```


After:

```
:; du -h target/x86_64-unknown-linux-gnu/release/linkerd2-proxy{,.dbg}
20M     target/x86_64-unknown-linux-gnu/release/linkerd2-proxy
904M    target/x86_64-unknown-linux-gnu/release/linkerd2-proxy.dbg
```

**Result:** >500MB saved for debug symbols.