### PR TITLE
ci: Compute coverage over all tests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,5 @@
 coverage:
-  # Disable the codecov status check until we start running it more regularly
-  # (so the comparisons are useful).
   status:
-    project:
+    project: default
+    patch:
       default: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  # Disable the codecov status check until we start running it more regularly
+  # (so the comparisons are useful).
+  status:
+    project:
+      default: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,13 +30,9 @@ jobs:
       # devcontainer.
       - run: rm -f /usr/local/bin/cargo-tarpaulin && cargo install cargo-tarpaulin
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-      # XXX(ver) AFAICT, Tarpaulin doesn't allow us to compose a report over multiple invocations,
-      # so we have to choose between getting coverage from unit tests and integration tests (since
-      # integration tests require --no-default-features to avoid flakiness). Currently the
-      # integration tests seem to cover more code, so we skip the unit tests for now :(.
-      #- run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --no-run
-      #- run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-app-integration --skip-clean --ignore-tests --no-fail-fast --out=Xml
-      - run: cargo tarpaulin --locked --packages=linkerd-app-integration --no-default-features --skip-clean --no-run
-      - run: cargo tarpaulin --locked --packages=linkerd-app-integration --no-default-features --skip-clean --ignore-tests --no-fail-fast --out=Xml
+      - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --no-run
+      - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --skip-clean --ignore-tests --no-fail-fast --out=Xml
+        # Some tests are especially flakey in coverage tests. That's fine. We
+        # only really care to measure how much of our codebase is covered.
         continue-on-error: true
       - uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,6 @@ env:
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -A deprecated -C debuginfo=2"
   RUSTUP_MAX_RETRIES: 10
-  CXX: "clang+-14"
 
 jobs:
   test:
@@ -26,6 +25,8 @@ jobs:
     container:
       image: docker://ghcr.io/linkerd/dev:v42-rust
       options: --security-opt seccomp=unconfined # 🤷
+    env:
+      CXX: "/usr/bin/clang++-14"
     steps:
       # XXX(ver) Workaround for a linking problem in the binary we store in the
       # devcontainer.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,6 +16,7 @@ env:
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -A deprecated -C debuginfo=2"
   RUSTUP_MAX_RETRIES: 10
+  CXX: "clang+-14"
 
 jobs:
   test:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,9 +45,6 @@ jobs:
             --package=linkerd-app-inbound \
             --package=linkerd-app-outbound \
             --package=linkerd-app-test
-      - run: |
-          just test-crate linkerd-app-integration --no-run \
-            --no-default-features --features=flakey-in-coverage
-      - run: |
-          just test-crate linkerd-app-integration \
-            --no-default-features --features=flakey-in-coverage
+      - run: just test-crate linkerd-app-integration --no-default-features --no-run
+      - run: just test-crate linkerd-app-integration --no-default-features
+

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -13,9 +13,8 @@ a dedicated crate to help the compiler cache dependencies properly.
 """
 
 [features]
-default = ["flakey-in-ci"]
-flakey-in-ci = ["flakey-in-coverage"]
-flakey-in-coverage = []
+default = []
+flakey = []
 
 [dependencies]
 bytes = "1"

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -508,7 +508,7 @@ where
 // Eventually, we can add some kind of mock timer system for simulating latency
 // more reliably, and re-enable this test.
 #[tokio::test]
-#[cfg_attr(not(feature = "flakey-in-ci"), ignore)]
+#[cfg_attr(not(feature = "flakey"), ignore)]
 async fn inbound_response_latency() {
     test_response_latency(Fixture::inbound_with_server).await
 }
@@ -518,7 +518,7 @@ async fn inbound_response_latency() {
 // Eventually, we can add some kind of mock timer system for simulating latency
 // more reliably, and re-enable this test.
 #[tokio::test]
-#[cfg_attr(not(feature = "flakey-in-ci"), ignore)]
+#[cfg_attr(not(feature = "flakey"), ignore)]
 async fn outbound_response_latency() {
     test_response_latency(Fixture::outbound_with_server).await
 }
@@ -1203,7 +1203,6 @@ mod transport {
         test_tcp_connect(TcpFixture::outbound()).await;
     }
 
-    #[cfg_attr(not(feature = "flakey-in-coverage"), ignore)]
     #[tokio::test]
     async fn outbound_tcp_accept() {
         test_tcp_accept(TcpFixture::outbound()).await;
@@ -1229,7 +1228,6 @@ mod transport {
         test_read_bytes_total(TcpFixture::outbound()).await
     }
 
-    #[cfg_attr(not(feature = "flakey-in-coverage"), ignore)]
     #[tokio::test]
     async fn outbound_tcp_open_connections() {
         test_tcp_open_conns(TcpFixture::outbound()).await

--- a/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
+++ b/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
@@ -231,7 +231,6 @@ async fn inbound_multi() {
 }
 
 /// Tests that TLS detect failure metrics are collected for the direct stack.
-#[cfg_attr(not(feature = "flakey-in-coverage"), ignore)]
 #[tokio::test]
 async fn inbound_direct_multi() {
     let _trace = trace_init();
@@ -315,7 +314,6 @@ async fn inbound_invalid_ip() {
 
 /// Tests that the detect metric is not incremented when TLS is successfully
 /// detected by the direct stack.
-#[cfg_attr(not(feature = "flakey-in-coverage"), ignore)]
 #[tokio::test]
 async fn inbound_direct_success() {
     let _trace = trace_init();


### PR DESCRIPTION
Our coverage workflow only measures the coverage of integration tests, ignoring all of our unit tests and component tests. This is caused by our inclusion of tests that don't run in CI in the default integration test configuration.

In order to run coverage over all tests, we disable two flakey tests from the default integration test configuration. The tests that are flakey only in coverage are simply enabled. Instead, we'll tolerate test failures in our coverage reports. We'll trust that our tests are actually executed successfully outside of the coverage run.