### PR TITLE
v2.210.4

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -244,7 +244,7 @@ const DEFAULT_INBOUND_CONNECT_TIMEOUT: Duration = Duration::from_millis(300);
 const DEFAULT_INBOUND_CONNECT_BACKOFF: ExponentialBackoff =
     ExponentialBackoff::new_unchecked(Duration::from_millis(100), Duration::from_millis(500), 0.1);
 
-const DEFAULT_OUTBOUND_TCP_QUEUE_CAPACITY: usize = 10;
+const DEFAULT_OUTBOUND_TCP_QUEUE_CAPACITY: usize = 10_000;
 const DEFAULT_OUTBOUND_TCP_FAILFAST_TIMEOUT: Duration = Duration::from_secs(3);
 const DEFAULT_OUTBOUND_HTTP_QUEUE_CAPACITY: usize = 10_000;
 const DEFAULT_OUTBOUND_HTTP_FAILFAST_TIMEOUT: Duration = Duration::from_secs(3);


### PR DESCRIPTION
This branch cherry-picks https://github.com/linkerd/linkerd2-proxy/pull/2521[)](https://github.com/linkerd/linkerd2-proxy/commit/115a8c92dc08556dd31a23d8cecf96e9093b707d) to `release/v2.210`