### PR TITLE
ci: Skip ARM builds during non-release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,12 +49,16 @@ jobs:
             fi
             ( echo publish=true
               echo version="${ver#v}"
+              echo archs='["amd64", "arm64", "arm"]'
             ) >> "$GITHUB_OUTPUT"
           else
             sha="${{ github.sha }}"
-            echo version="0.0.0-test.${sha:0:7}" >> "$GITHUB_OUTPUT"
+            ( echo version="0.0.0-test.${sha:0:7}"
+              echo archs='["amd64"]'
+            ) >> "$GITHUB_OUTPUT"
           fi
     outputs:
+      archs: ${{ steps.meta.outputs.archs }}
       publish: ${{ steps.meta.outputs.publish }}
       version: ${{ steps.meta.outputs.version }}
 
@@ -62,7 +66,7 @@ jobs:
     needs: [meta]
     strategy:
       matrix:
-        arch: [amd64, arm64, arm]
+        arch: ${{ fromJson(needs.meta.outputs.archs) }}
         libc: [gnu] # musl
 
     # If we're not actually building on a release tag, don't short-circuit on


### PR DESCRIPTION
We run release builds during CI to ensure that compilation doesn't regress. We exercise this against all platforms. This chews up CI resources.

This change updates the release workflow to skip ARM builds during non-release CI.