### PR TITLE
metrics: Support float values

### DIFF
--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -544,7 +544,7 @@ async fn grpc_response_class() {
             &classify::Class::Grpc(Err(tonic::Code::Unknown)),
         )
         .expect("response_total not found");
-    assert_eq!(response_total, 1.0);
+    assert_eq!(response_total, 1);
 
     drop((client, bg));
 }

--- a/linkerd/http-metrics/src/lib.rs
+++ b/linkerd/http-metrics/src/lib.rs
@@ -32,7 +32,7 @@ impl<T: Hash + Eq, C: Hash + Eq> Report<T, requests::Metrics<C>> {
         labels: &T,
         status: Option<http::StatusCode>,
         class: &C,
-    ) -> Option<f64> {
+    ) -> Option<u64> {
         let registry = self.registry.lock();
         let requests = registry.get(labels)?.lock();
         let status = requests.by_status().get(&status)?;

--- a/linkerd/http-metrics/src/requests.rs
+++ b/linkerd/http-metrics/src/requests.rs
@@ -32,7 +32,7 @@ pub struct StatusMetrics<C>
 where
     C: Hash + Eq,
 {
-    latency: Histogram<latency::Ms>,
+    latency: Histogram<u64>,
     by_class: HashMap<C, ClassMetrics>,
 }
 
@@ -110,7 +110,7 @@ where
 {
     fn default() -> Self {
         Self {
-            latency: Histogram::default(),
+            latency: Histogram::new(latency::MILLIS_BOUNDS),
             by_class: HashMap::default(),
         }
     }
@@ -125,7 +125,7 @@ impl<C: Hash + Eq> StatusMetrics<C> {
 
 #[cfg(feature = "test-util")]
 impl ClassMetrics {
-    pub fn total(&self) -> f64 {
+    pub fn total(&self) -> u64 {
         self.total.value()
     }
 }

--- a/linkerd/http-metrics/src/requests/report.rs
+++ b/linkerd/http-metrics/src/requests/report.rs
@@ -1,8 +1,6 @@
 use super::{ClassMetrics, Metrics, StatusMetrics};
 use crate::{Prefixed, Report};
-use linkerd_metrics::{
-    latency, Counter, FmtLabels, FmtMetric, FmtMetrics, Histogram, Metric, Store,
-};
+use linkerd_metrics::{Counter, FmtLabels, FmtMetric, FmtMetrics, Histogram, Metric, Store};
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash};
 use tokio::time::Instant;
@@ -30,9 +28,7 @@ where
         )
     }
 
-    fn response_latency_ms(
-        &self,
-    ) -> Metric<'_, Prefixed<'_, &'static str>, Histogram<latency::Ms>> {
+    fn response_latency_ms(&self) -> Metric<'_, Prefixed<'_, &'static str>, Histogram<u64>> {
         Metric::new(
             self.prefix_key("response_latency_ms"),
             "Elapsed times between a request's headers being received \

--- a/linkerd/http-metrics/src/requests/service.rs
+++ b/linkerd/http-metrics/src/requests/service.rs
@@ -3,7 +3,7 @@ use futures::{ready, TryFuture};
 use http_body::Body;
 use linkerd_error::Error;
 use linkerd_http_classify::{ClassifyEos, ClassifyResponse};
-use linkerd_metrics::NewMetrics;
+use linkerd_metrics::{latency, NewMetrics};
 use linkerd_stack::Proxy;
 use parking_lot::Mutex;
 use pin_project::{pin_project, pinned_drop};
@@ -351,7 +351,7 @@ where
             .or_insert_with(StatusMetrics::default);
 
         let elapsed = now.saturating_duration_since(*this.stream_open_at);
-        status_metrics.latency.add(elapsed);
+        status_metrics.latency.add(latency::millis_u64(elapsed));
 
         *this.latency_recorded = true;
     }

--- a/linkerd/metrics/src/counter.rs
+++ b/linkerd/metrics/src/counter.rs
@@ -1,9 +1,8 @@
-use super::{
+use crate::{
     prom::{FmtLabels, FmtMetric},
-    Factor,
+    value::{PromValue, Value},
 };
 use std::fmt::{self, Display};
-use std::sync::atomic::{AtomicU64, Ordering};
 
 /// A Prometheus counter is represented by a `Wrapping` unsigned 52-bit integer.
 ///
@@ -18,61 +17,70 @@ use std::sync::atomic::{AtomicU64, Ordering};
 /// [`irate()`]: https://prometheus.io/docs/prometheus/latest/querying/functions/#irate()
 /// [`resets()`]: https://prometheus.io/docs/prometheus/latest/querying/functions/#resets
 #[derive(Debug)]
-pub struct Counter<F = ()>(AtomicU64, std::marker::PhantomData<F>);
+pub struct Counter<T = u64>(Value<T>);
 
 // === impl Counter ===
 
-impl<F> Default for Counter<F> {
+impl<V> Default for Counter<V> {
     fn default() -> Self {
-        Self(AtomicU64::default(), std::marker::PhantomData)
+        Self(Value::default())
     }
 }
 
-impl<F> Counter<F> {
+impl<V> Counter<V> {
     pub fn new() -> Self {
         Self::default()
     }
+}
 
+impl From<u64> for Counter<u64> {
+    fn from(n: u64) -> Self {
+        Self(Value::from(n))
+    }
+}
+
+impl From<f64> for Counter<f64> {
+    fn from(n: f64) -> Self {
+        Self(Value::from(n))
+    }
+}
+
+impl Counter<u64> {
     pub fn incr(&self) {
         self.add(1)
     }
 
     pub fn add(&self, n: u64) {
-        self.0.fetch_add(n, Ordering::Release);
+        self.0.add(n)
+    }
+
+    pub fn value(&self) -> u64 {
+        self.0.value()
     }
 }
 
-impl<F: Factor> Counter<F> {
-    /// Return current counter value, wrapped to be safe for use with Prometheus.
+impl Counter<f64> {
+    pub fn incr(&self) {
+        self.add(1.0)
+    }
+
+    pub fn add(&self, value: f64) {
+        self.0.add(value);
+    }
+
     pub fn value(&self) -> f64 {
-        let n = self.0.load(Ordering::Acquire);
-        F::factor(n)
+        self.0.value()
     }
 }
 
-impl<F: Factor> From<&Counter<F>> for f64 {
-    fn from(counter: &Counter<F>) -> f64 {
-        counter.value()
-    }
-}
-
-impl<F> From<&Counter<F>> for u64 {
-    fn from(Counter(ref counter, _): &Counter<F>) -> u64 {
-        counter.load(Ordering::Acquire)
-    }
-}
-
-impl<F> From<u64> for Counter<F> {
-    fn from(value: u64) -> Self {
-        Counter(value.into(), std::marker::PhantomData)
-    }
-}
-
-impl<F: Factor> FmtMetric for Counter<F> {
+impl<T> FmtMetric for Counter<T>
+where
+    Value<T>: PromValue,
+{
     const KIND: &'static str = "counter";
 
     fn fmt_metric<N: Display>(&self, f: &mut fmt::Formatter<'_>, name: N) -> fmt::Result {
-        writeln!(f, "{} {}", name, self.value())
+        writeln!(f, "{} {}", name, self.0.prom_value())
     }
 
     fn fmt_metric_labeled<N, L>(
@@ -87,7 +95,17 @@ impl<F: Factor> FmtMetric for Counter<F> {
     {
         write!(f, "{}{{", name)?;
         labels.fmt_labels(f)?;
-        writeln!(f, "}} {}", self.value())
+        writeln!(f, "}} {}", self.0.prom_value())
+    }
+}
+
+impl<T> PromValue for Counter<T>
+where
+    Value<T>: PromValue,
+{
+    #[inline]
+    fn prom_value(&self) -> f64 {
+        self.0.prom_value()
     }
 }
 
@@ -95,70 +113,52 @@ impl<F: Factor> FmtMetric for Counter<F> {
 #[allow(clippy::float_cmp)]
 mod tests {
     use super::*;
-    use crate::{MicrosAsSeconds, MillisAsSeconds, MAX_PRECISE_UINT64};
+    use crate::value::MAX_PRECISE_UINT64;
 
     #[test]
     fn count_simple() {
-        let c = Counter::<()>::default();
-        assert_eq!(c.value(), 0.0);
+        let c = Counter::<u64>::default();
+        assert_eq!(c.prom_value(), 0.0);
         c.incr();
-        assert_eq!(c.value(), 1.0);
+        assert_eq!(c.prom_value(), 1.0);
         c.add(41);
-        assert_eq!(c.value(), 42.0);
+        assert_eq!(c.prom_value(), 42.0);
         c.add(0);
-        assert_eq!(c.value(), 42.0);
+        assert_eq!(c.prom_value(), 42.0);
     }
 
     #[test]
     fn count_wrapping() {
-        let c = Counter::<()>::from(MAX_PRECISE_UINT64 - 1);
-        assert_eq!(c.value(), (MAX_PRECISE_UINT64 - 1) as f64);
+        let c = Counter::<u64>::from(MAX_PRECISE_UINT64 - 1);
+        assert_eq!(c.prom_value(), (MAX_PRECISE_UINT64 - 1) as f64);
         c.incr();
-        assert_eq!(c.value(), MAX_PRECISE_UINT64 as f64);
+        assert_eq!(c.prom_value(), MAX_PRECISE_UINT64 as f64);
         c.incr();
-        assert_eq!(c.value(), 0.0);
+        assert_eq!(c.prom_value(), 0.0);
         c.incr();
-        assert_eq!(c.value(), 1.0);
+        assert_eq!(c.prom_value(), 1.0);
 
-        let max = Counter::<()>::from(MAX_PRECISE_UINT64);
-        assert_eq!(max.value(), MAX_PRECISE_UINT64 as f64);
+        let max = Counter::<u64>::from(MAX_PRECISE_UINT64);
+        assert_eq!(max.prom_value(), MAX_PRECISE_UINT64 as f64);
     }
 
     #[test]
-    fn millis_as_seconds() {
-        let c = Counter::<MillisAsSeconds>::from(1);
-        assert_eq!(c.value(), 0.001);
-
-        let c = Counter::<MillisAsSeconds>::from((MAX_PRECISE_UINT64 - 1) * 1000);
-        assert_eq!(c.value(), (MAX_PRECISE_UINT64 - 1) as f64);
-        c.add(1000);
-        assert_eq!(c.value(), MAX_PRECISE_UINT64 as f64);
-        c.add(1000);
-        assert_eq!(c.value(), 0.0);
-        c.add(1000);
-        assert_eq!(c.value(), 1.0);
-
-        let max = Counter::<MillisAsSeconds>::from(MAX_PRECISE_UINT64 * 1000);
-        assert_eq!(max.value(), MAX_PRECISE_UINT64 as f64);
+    fn f64_add() {
+        let c = Counter::<f64>::from(0.001);
+        assert_eq!(c.prom_value(), 0.001);
+        c.add(0.01);
+        assert_eq!(c.prom_value(), 0.011);
+        c.add(0.1);
+        assert_eq!(c.prom_value(), 0.111);
+        c.add(1.0);
+        assert_eq!(c.prom_value(), 1.111);
     }
 
     #[test]
-    fn micros_as_seconds() {
-        let c = Counter::<MicrosAsSeconds>::from(1);
-        assert_eq!(c.value(), 0.000_001);
-        c.add(110);
-        assert_eq!(c.value(), 0.000_111);
-
-        let c = Counter::<MicrosAsSeconds>::from((MAX_PRECISE_UINT64 - 1) * 1000);
-        assert_eq!(c.value(), (MAX_PRECISE_UINT64 - 1) as f64 * 0.001);
-        c.add(1_000);
-        assert_eq!(c.value(), MAX_PRECISE_UINT64 as f64 * 0.001);
-        c.add(1_000);
-        assert_eq!(c.value(), 0.0);
-        c.add(1);
-        assert_eq!(c.value(), 0.000_001);
-
-        let max = Counter::<MicrosAsSeconds>::from(MAX_PRECISE_UINT64 * 1000);
-        assert_eq!(max.value(), MAX_PRECISE_UINT64 as f64 * 0.001);
+    fn f64_overflow() {
+        let c = Counter::<f64>::from(std::f64::MAX);
+        assert_eq!(c.prom_value(), std::f64::MAX);
+        c.add(std::f64::MAX / 2.0);
+        assert_eq!(c.prom_value(), 0.0);
     }
 }

--- a/linkerd/metrics/src/histogram.rs
+++ b/linkerd/metrics/src/histogram.rs
@@ -94,7 +94,7 @@ impl<T> Histogram<T> {
     /// Assert the bucket containing `le` has a count of at least `at_least`.
     pub fn assert_bucket_at_least(&self, le: f64, at_least: u64) {
         for (bucket, count) in self {
-            if bucket >= Bucket::Le(le) {
+            if bucket >= le {
                 let count = count.value();
                 assert!(count >= at_least, "le={:?}; bucket={:?};", le, bucket);
                 break;
@@ -105,7 +105,7 @@ impl<T> Histogram<T> {
     /// Assert the bucket containing `le` has a count of exactly `exactly`.
     pub fn assert_bucket_exactly(&self, le: f64, exactly: u64) -> &Self {
         for (bucket, count) in self {
-            if bucket >= Bucket::Le(le) {
+            if bucket >= le {
                 let count = count.value();
                 assert_eq!(
                     count, exactly,
@@ -145,15 +145,13 @@ impl<T> Histogram<T> {
         // whose upper bound is >= `value`.
         let mut past_le = false;
         for (bucket, count) in self {
-            if let Bucket::Le(b) = bucket {
-                if b < value {
-                    continue;
-                }
+            if bucket < value {
+                continue;
+            }
 
-                if b >= value && !past_le {
-                    past_le = true;
-                    continue;
-                }
+            if bucket >= value && !past_le {
+                past_le = true;
+                continue;
             }
 
             if past_le {

--- a/linkerd/metrics/src/latency.rs
+++ b/linkerd/metrics/src/latency.rs
@@ -1,85 +1,11 @@
 use std::time::Duration;
 
-use super::histogram::{Bounds, Bucket, Histogram};
+/// The maximum value (inclusive) for each latency bucket in milliseconds.
+pub const MILLIS_BOUNDS: &[f64] = &[
+    1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 100.0, 200.0, 300.0, 400.0, 500.0,
+    1_000.0, 2_000.0, 3_000.0, 4_000.0, 5_000.0, 10_000.0, 20_000.0, 30_000.0, 40_000.0, 50_000.0,
+];
 
-/// The maximum value (inclusive) for each latency bucket in
-/// milliseconds.
-pub const BOUNDS: &Bounds = &Bounds(&[
-    Bucket::Le(1.0),
-    Bucket::Le(2.0),
-    Bucket::Le(3.0),
-    Bucket::Le(4.0),
-    Bucket::Le(5.0),
-    Bucket::Le(10.0),
-    Bucket::Le(20.0),
-    Bucket::Le(30.0),
-    Bucket::Le(40.0),
-    Bucket::Le(50.0),
-    Bucket::Le(100.0),
-    Bucket::Le(200.0),
-    Bucket::Le(300.0),
-    Bucket::Le(400.0),
-    Bucket::Le(500.0),
-    Bucket::Le(1_000.0),
-    Bucket::Le(2_000.0),
-    Bucket::Le(3_000.0),
-    Bucket::Le(4_000.0),
-    Bucket::Le(5_000.0),
-    Bucket::Le(10_000.0),
-    Bucket::Le(20_000.0),
-    Bucket::Le(30_000.0),
-    Bucket::Le(40_000.0),
-    Bucket::Le(50_000.0),
-    // A final upper bound.
-    Bucket::Inf,
-]);
-
-/// A duration in milliseconds.
-#[derive(Debug, Default, Clone)]
-pub struct Ms(Duration);
-
-/// A duration in microseconds.
-#[derive(Debug, Default, Clone)]
-pub struct Us(Duration);
-
-impl From<Us> for u64 {
-    fn from(Us(us): Us) -> u64 {
-        us.as_micros().try_into().unwrap_or_else(|_| {
-            // These measurements should never be long enough to overflow
-            tracing::warn!("Duration::as_micros would overflow u64");
-            u64::MAX
-        })
-    }
-}
-
-impl From<Duration> for Us {
-    fn from(d: Duration) -> Self {
-        Us(d)
-    }
-}
-
-impl Default for Histogram<Us> {
-    fn default() -> Self {
-        Histogram::new(BOUNDS)
-    }
-}
-
-impl From<Ms> for u64 {
-    fn from(Ms(ms): Ms) -> u64 {
-        ms.as_secs()
-            .saturating_mul(1_000)
-            .saturating_add(u64::from(ms.subsec_nanos()) / 1_000_000)
-    }
-}
-
-impl From<Duration> for Ms {
-    fn from(d: Duration) -> Self {
-        Ms(d)
-    }
-}
-
-impl Default for Histogram<Ms> {
-    fn default() -> Self {
-        Histogram::new(BOUNDS)
-    }
+pub fn millis_u64(dur: Duration) -> u64 {
+    crate::value::u128_to_u64(dur.as_millis())
 }

--- a/linkerd/stack/metrics/src/service.rs
+++ b/linkerd/stack/metrics/src/service.rs
@@ -116,27 +116,23 @@ mod tests {
         let b0 = TrackService::new(b, metrics.clone());
 
         drop(a1);
-        assert_eq!(metrics.drop_total.value(), 0.0, "Not dropped yet");
+        assert_eq!(metrics.drop_total.value(), 0, "Not dropped yet");
 
         drop(b0);
         assert_eq!(
             metrics.drop_total.value(),
-            1.0,
+            1,
             "Dropping distinct service is counted"
         );
 
         drop(a0);
         assert_eq!(
             metrics.drop_total.value(),
-            2.0,
+            2,
             "Dropping last service clone counted"
         );
 
-        assert_eq!(
-            metrics.create_total.value(),
-            0.0,
-            "No creates by the service"
-        );
+        assert_eq!(metrics.create_total.value(), 0, "No creates by the service");
     }
 
     #[cfg(test)]
@@ -166,17 +162,17 @@ mod tests {
 
         assert_eq!(
             metrics.ready_total.value(),
-            2.0,
+            2,
             "Both clones should be counted discretely"
         );
         assert_eq!(
             metrics.not_ready_total.value(),
-            2.0,
+            2,
             "Both clones should be counted discretely"
         );
         assert_eq!(
             metrics.poll_millis.value(),
-            2000.0,
+            2000,
             "Both clones should be counted discretely"
         );
     }


### PR DESCRIPTION
Prometheus natively handles all metric values as floats.

Becuase linkerd-metrics uses `AtomicU64` internally, float values have not been broadly supported. Some work towards supporting float values was added in 876ae02a, though this functionality is limited to scaling u64 values at render-time rather than tracking floats direclty. It is only used for process metrics currently.

This change updates the Gauge, Counter, and Histogram types to be generic over the stored representation--a u64 or f64. Counter and Gauge both use a common inner Value type: f64 values are encoded into the AtomicU64 storage.

This sets up to support new balancer metrics that report float values (e.g., load averages).