### PR TITLE
control: Enforce timeouts on response stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,6 +1077,7 @@ dependencies = [
  "linkerd-app-outbound",
  "linkerd-error",
  "linkerd-opencensus",
+ "linkerd-tonic-stream",
  "rangemap",
  "regex",
  "thiserror",
@@ -1215,6 +1216,7 @@ dependencies = [
  "linkerd-meshtls-rustls",
  "linkerd-proxy-client-policy",
  "linkerd-proxy-server-policy",
+ "linkerd-tonic-stream",
  "linkerd-tonic-watch",
  "linkerd-tracing",
  "linkerd2-proxy-api",
@@ -1286,6 +1288,7 @@ dependencies = [
  "linkerd-proxy-client-policy",
  "linkerd-retry",
  "linkerd-stack",
+ "linkerd-tonic-stream",
  "linkerd-tonic-watch",
  "linkerd-tracing",
  "linkerd2-proxy-api",
@@ -1671,7 +1674,6 @@ dependencies = [
 name = "linkerd-proxy-api-resolve"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "futures",
  "http",
  "http-body",
@@ -1680,6 +1682,7 @@ dependencies = [
  "linkerd-proxy-core",
  "linkerd-stack",
  "linkerd-tls",
+ "linkerd-tonic-stream",
  "linkerd2-proxy-api",
  "pin-project",
  "prost",
@@ -1980,6 +1983,7 @@ dependencies = [
  "linkerd-http-box",
  "linkerd-proxy-api-resolve",
  "linkerd-stack",
+ "linkerd-tonic-stream",
  "linkerd-tonic-watch",
  "linkerd2-proxy-api",
  "once_cell",
@@ -2077,6 +2081,21 @@ dependencies = [
 [[package]]
 name = "linkerd-tls-test-util"
 version = "0.1.0"
+
+[[package]]
+name = "linkerd-tonic-stream"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "linkerd-stack",
+ "linkerd-tracing",
+ "pin-project",
+ "tokio",
+ "tokio-stream",
+ "tokio-test",
+ "tonic",
+ "tracing",
+]
 
 [[package]]
 name = "linkerd-tonic-watch"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ members = [
     "linkerd/stack/metrics",
     "linkerd/stack/tracing",
     "linkerd/system",
+    "linkerd/tonic-stream",
     "linkerd/tonic-watch",
     "linkerd/tls",
     "linkerd/tls/test-util",

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -25,6 +25,7 @@ linkerd-app-inbound = { path = "./inbound" }
 linkerd-app-outbound = { path = "./outbound" }
 linkerd-error = { path = "../error" }
 linkerd-opencensus = { path = "../opencensus" }
+linkerd-tonic-stream = { path = "../tonic-stream" }
 rangemap = "1"
 regex = "1"
 thiserror = "1"

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -28,6 +28,7 @@ linkerd-idle-cache = { path = "../../idle-cache" }
 linkerd-meshtls = { path = "../../meshtls", optional = true }
 linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true }
 linkerd-proxy-client-policy = { path = "../../proxy/client-policy" }
+linkerd-tonic-stream = { path = "../../tonic-stream" }
 linkerd-tonic-watch = { path = "../../tonic-watch" }
 linkerd2-proxy-api = { version = "0.12", features = ["inbound"] }
 once_cell = "1"

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -7,6 +7,7 @@ use linkerd_app_core::{
     transport::{self, addrs::*},
     Error,
 };
+use linkerd_tonic_stream::ReceiveLimits;
 use std::{fmt::Debug, sync::Arc};
 use tracing::debug_span;
 
@@ -23,6 +24,7 @@ impl Inbound<()> {
         workload: Arc<str>,
         client: C,
         backoff: ExponentialBackoff,
+        limits: ReceiveLimits,
     ) -> impl policy::GetPolicy + Clone + Send + Sync + 'static
     where
         C: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
@@ -31,7 +33,10 @@ impl Inbound<()> {
         C::ResponseBody: Default + Send + 'static,
         C::Future: Send,
     {
-        self.config.policy.clone().build(workload, client, backoff)
+        self.config
+            .policy
+            .clone()
+            .build(workload, client, backoff, limits)
     }
 
     pub fn mk<A, I, P>(

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -33,6 +33,7 @@ linkerd-proxy-client-policy = { path = "../../proxy/client-policy", features = [
     "proto",
 ] }
 linkerd-retry = { path = "../../retry" }
+linkerd-tonic-stream = { path = "../../tonic-stream" }
 linkerd-tonic-watch = { path = "../../tonic-watch" }
 once_cell = "1"
 parking_lot = "0.12"

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -25,6 +25,7 @@ use linkerd_app_core::{
     transport::addrs::*,
     AddrMatch, Error, ProxyRuntime,
 };
+use linkerd_tonic_stream::ReceiveLimits;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
@@ -141,6 +142,7 @@ impl Outbound<()> {
         workload: Arc<str>,
         client: C,
         backoff: ExponentialBackoff,
+        limits: ReceiveLimits,
     ) -> impl policy::GetPolicy
     where
         C: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
@@ -149,7 +151,7 @@ impl Outbound<()> {
         C::ResponseBody: Default + Send + 'static,
         C::Future: Send,
     {
-        policy::Api::new(workload, Duration::from_secs(10), client)
+        policy::Api::new(workload, limits, Duration::from_secs(10), client)
             .into_watch(backoff)
             .map_result(|response| match response {
                 Err(e) => Err(e.into()),

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -8,6 +8,7 @@ use linkerd_app_core::{
     transport::{Keepalive, ListenAddr},
     Addr, AddrMatch, Conditional, IpNet,
 };
+use linkerd_tonic_stream::ReceiveLimits;
 use rangemap::RangeInclusiveSet;
 use std::{
     collections::{HashMap, HashSet},
@@ -368,6 +369,8 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
     let metrics_retain_idle = parse(strings, ENV_METRICS_RETAIN_IDLE, parse_duration);
 
+    let control_receive_limits = mk_control_receive_limits(strings)?;
+
     // DNS
 
     let resolv_conf_path = strings.get(ENV_RESOLV_CONF);
@@ -666,6 +669,11 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         } else {
             outbound.http_request_queue.failfast_timeout
         };
+        let limits = addr
+            .addr
+            .is_loopback()
+            .then(ReceiveLimits::default)
+            .unwrap_or(control_receive_limits);
         super::dst::Config {
             context: dst_token?.unwrap_or_default(),
             control: ControlConfig {
@@ -676,6 +684,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                     failfast_timeout,
                 },
             },
+            limits,
         }
     };
 
@@ -692,6 +701,12 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             EnvError::InvalidEnvVar
         })?;
 
+        let limits = addr
+            .addr
+            .is_loopback()
+            .then(ReceiveLimits::default)
+            .unwrap_or(control_receive_limits);
+
         let control = {
             let connect = if addr.addr.is_loopback() {
                 inbound.proxy.connect.clone()
@@ -707,7 +722,12 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 },
             }
         };
-        policy::Config { control, workload }
+
+        policy::Config {
+            control,
+            workload,
+            limits,
+        }
     };
 
     let admin = super::admin::Config {
@@ -848,6 +868,35 @@ fn convert_attributes_string_to_map(attributes: String) -> HashMap<String, Strin
         .collect()
 }
 
+fn mk_control_receive_limits(env: &dyn Strings) -> Result<ReceiveLimits, EnvError> {
+    const ENV_INIT: &str = "LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT";
+    const ENV_IDLE: &str = "LINKERD2_PROXY_CONTROL_STREAM_IDLEL_TIMEOUT";
+    const ENV_LIFE: &str = "LINKERD2_PROXY_CONTROL_STREAM_LIFETIME";
+
+    let initial = parse(env, ENV_INIT, parse_duration_opt)?.flatten();
+    let idle = parse(env, ENV_IDLE, parse_duration_opt)?.flatten();
+    let lifetime = parse(env, ENV_LIFE, parse_duration_opt)?.flatten();
+
+    if initial.unwrap_or(Duration::ZERO) > idle.unwrap_or(Duration::MAX) {
+        error!("{ENV_INIT} must be less than {ENV_IDLE}");
+        return Err(EnvError::InvalidEnvVar);
+    }
+    if initial.unwrap_or(Duration::ZERO) > lifetime.unwrap_or(Duration::MAX) {
+        error!("{ENV_INIT} must be less than {ENV_LIFE}");
+        return Err(EnvError::InvalidEnvVar);
+    }
+    if idle.unwrap_or(Duration::ZERO) > lifetime.unwrap_or(Duration::MAX) {
+        error!("{ENV_IDLE} must be less than {ENV_LIFE}");
+        return Err(EnvError::InvalidEnvVar);
+    }
+
+    Ok(ReceiveLimits {
+        initial,
+        idle,
+        lifetime,
+    })
+}
+
 // === impl Env ===
 
 impl Strings for Env {
@@ -906,6 +955,13 @@ where
     ParseError: From<T::Err>,
 {
     s.parse().map_err(Into::into)
+}
+
+fn parse_duration_opt(s: &str) -> Result<Option<Duration>, ParseError> {
+    if s.is_empty() {
+        return Ok(None);
+    }
+    parse_duration(s).map(Some)
 }
 
 fn parse_duration(s: &str) -> Result<Duration, ParseError> {

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -870,7 +870,7 @@ fn convert_attributes_string_to_map(attributes: String) -> HashMap<String, Strin
 
 fn mk_control_receive_limits(env: &dyn Strings) -> Result<ReceiveLimits, EnvError> {
     const ENV_INIT: &str = "LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT";
-    const ENV_IDLE: &str = "LINKERD2_PROXY_CONTROL_STREAM_IDLEL_TIMEOUT";
+    const ENV_IDLE: &str = "LINKERD2_PROXY_CONTROL_STREAM_IDLE_TIMEOUT";
     const ENV_LIFE: &str = "LINKERD2_PROXY_CONTROL_STREAM_LIFETIME";
 
     let initial = parse(env, ENV_INIT, parse_duration_opt)?.flatten();

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -198,12 +198,14 @@ impl Config {
             policies.workload.clone(),
             policies.client.clone(),
             policies.backoff,
+            policies.limits,
         );
 
         let outbound_policies = outbound.build_policies(
             policies.workload.clone(),
             policies.client.clone(),
             policies.backoff,
+            policies.limits,
         );
 
         let dst_addr = dst.addr.clone();

--- a/linkerd/app/src/policy.rs
+++ b/linkerd/app/src/policy.rs
@@ -7,6 +7,7 @@ use linkerd_app_core::{
     svc::{self, NewService, ServiceExt},
     Error,
 };
+use linkerd_tonic_stream::ReceiveLimits;
 
 use std::sync::Arc;
 
@@ -14,6 +15,7 @@ use std::sync::Arc;
 pub struct Config {
     pub control: control::Config,
     pub workload: String,
+    pub limits: ReceiveLimits,
 }
 
 /// Handles to policy service clients.
@@ -28,6 +30,8 @@ pub struct Policy<S> {
     pub workload: Arc<str>,
 
     pub backoff: ExponentialBackoff,
+
+    pub limits: ReceiveLimits,
 }
 
 // === impl Config ===
@@ -64,6 +68,7 @@ impl Config {
             client,
             workload,
             backoff,
+            limits: self.limits,
         })
     }
 }

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -10,13 +10,13 @@ Implements the Resolve trait using the proxy's gRPC API
 """
 
 [dependencies]
-async-stream = "0.3"
 futures = { version = "0.3", default-features = false }
 linkerd-addr = { path = "../../addr" }
 linkerd-error = { path = "../../error" }
 linkerd2-proxy-api = { version = "0.12", features = ["destination"] }
 linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
+linkerd-tonic-stream = { path = "../../tonic-stream" }
 linkerd-tls = { path = "../../tls" }
 http = "0.2"
 http-body = "0.4"

--- a/linkerd/proxy/api-resolve/src/resolve.rs
+++ b/linkerd/proxy/api-resolve/src/resolve.rs
@@ -1,15 +1,10 @@
-use crate::{
-    api::destination as api,
-    core::resolve::{self, Update},
-    metadata::Metadata,
-    pb, ConcreteAddr,
-};
+use crate::{api::destination as api, core::resolve::Update, metadata::Metadata, pb, ConcreteAddr};
 use api::destination_client::DestinationClient;
-use async_stream::try_stream;
 use futures::prelude::*;
 use http_body::Body;
 use linkerd_error::Error;
 use linkerd_stack::Param;
+use linkerd_tonic_stream::{LimitReceiveFuture, ReceiveLimits};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tonic::{self as grpc, body::BoxBody, client::GrpcService};
@@ -18,8 +13,9 @@ use tracing::{debug, info, trace};
 
 #[derive(Clone)]
 pub struct Resolve<S> {
-    service: DestinationClient<S>,
+    client: DestinationClient<S>,
     context_token: String,
+    limits: ReceiveLimits,
 }
 
 // === impl Resolve ===
@@ -32,10 +28,11 @@ where
     <S::ResponseBody as Body>::Error: Into<Error> + Send,
     S::Future: Send,
 {
-    pub fn new(svc: S, context_token: String) -> Self {
+    pub fn new(svc: S, context_token: String, limits: ReceiveLimits) -> Self {
         Self {
-            service: DestinationClient::new(svc),
+            client: DestinationClient::new(svc),
             context_token,
+            limits,
         }
     }
 }
@@ -72,61 +69,56 @@ where
             context_token: self.context_token.clone(),
             ..Default::default()
         };
-        let mut client = self.service.clone();
+
+        let limits = self.limits;
+        let mut client = self.client.clone();
         Box::pin(async move {
-            // Wait for the server to respond once before returning a stream. This let's us eagerly
-            // detect errors (like InvalidArgument).
-            let rsp = client.get(grpc::Request::new(req)).await?;
+            let rsp = LimitReceiveFuture::new(limits, client.get(grpc::Request::new(req))).await?;
             trace!(metadata = ?rsp.metadata());
-            let stream: UpdatesStream = Box::pin(resolution(rsp.into_inner()));
-            Ok(stream)
+            Ok(rsp
+                .into_inner()
+                .try_filter_map(|up| futures::future::ok::<_, _>(mk_update(up)))
+                .boxed())
         })
     }
 }
 
-fn resolution(
-    mut stream: tonic::Streaming<api::Update>,
-) -> impl Stream<Item = Result<resolve::Update<Metadata>, grpc::Status>> {
-    try_stream! {
-        while let Some(update) = stream.next().await {
-            match update?.update {
-                Some(api::update::Update::Add(api::WeightedAddrSet {
-                    addrs,
-                    metric_labels,
-                })) => {
-                    let addr_metas = addrs
-                        .into_iter()
-                        .filter_map(|addr| pb::to_addr_meta(addr, &metric_labels))
-                        .collect::<Vec<_>>();
-                    if !addr_metas.is_empty() {
-                        debug!(endpoints = %addr_metas.len(), "Add");
-                        yield Update::Add(addr_metas);
-                    }
-                }
-
-                Some(api::update::Update::Remove(api::AddrSet { addrs })) => {
-                    let sock_addrs = addrs
-                        .into_iter()
-                        .filter_map(pb::to_sock_addr)
-                        .collect::<Vec<_>>();
-                    if !sock_addrs.is_empty() {
-                        debug!(endpoints = %sock_addrs.len(), "Remove");
-                        yield Update::Remove(sock_addrs);
-                    }
-                }
-
-                Some(api::update::Update::NoEndpoints(api::NoEndpoints { exists })) => {
-                    info!("No endpoints");
-                    let update = if exists {
-                        Update::Reset(Vec::new())
-                    } else {
-                        Update::DoesNotExist
-                    };
-                    yield update;
-                }
-
-                None => {} // continue
+fn mk_update(up: api::Update) -> Option<Update<Metadata>> {
+    match up.update? {
+        api::update::Update::Add(api::WeightedAddrSet {
+            addrs,
+            metric_labels,
+        }) => {
+            let addr_metas = addrs
+                .into_iter()
+                .filter_map(|addr| pb::to_addr_meta(addr, &metric_labels))
+                .collect::<Vec<_>>();
+            if !addr_metas.is_empty() {
+                debug!(endpoints = %addr_metas.len(), "Add");
+                return Some(Update::Add(addr_metas));
             }
         }
+
+        api::update::Update::Remove(api::AddrSet { addrs }) => {
+            let sock_addrs = addrs
+                .into_iter()
+                .filter_map(pb::to_sock_addr)
+                .collect::<Vec<_>>();
+            if !sock_addrs.is_empty() {
+                debug!(endpoints = %sock_addrs.len(), "Remove");
+                return Some(Update::Remove(sock_addrs));
+            }
+        }
+
+        api::update::Update::NoEndpoints(api::NoEndpoints { exists }) => {
+            info!("No endpoints");
+            return Some(if exists {
+                Update::Reset(Vec::new())
+            } else {
+                Update::DoesNotExist
+            });
+        }
     }
+
+    None
 }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -20,6 +20,7 @@ linkerd-error = { path = "../error" }
 linkerd-http-box = { path = "../http-box" }
 linkerd-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd-stack = { path = "../stack" }
+linkerd-tonic-stream = { path = "../tonic-stream" }
 linkerd-tonic-watch = { path = "../tonic-watch" }
 linkerd2-proxy-api = { version = "0.12", features = ["destination"] }
 once_cell = "1.17"

--- a/linkerd/service-profiles/src/client.rs
+++ b/linkerd/service-profiles/src/client.rs
@@ -4,6 +4,7 @@ use http_body::Body;
 use linkerd2_proxy_api::destination::{self as api, destination_client::DestinationClient};
 use linkerd_error::{Infallible, Recover};
 use linkerd_stack::{Param, Service};
+use linkerd_tonic_stream::{LimitReceiveFuture, ReceiveLimits};
 use linkerd_tonic_watch::StreamWatch;
 use std::{
     sync::Arc,
@@ -23,6 +24,7 @@ pub struct Client<R, S> {
 struct Inner<S> {
     client: DestinationClient<S>,
     context_token: Arc<str>,
+    limits: ReceiveLimits,
 }
 
 // === impl Client ===
@@ -38,9 +40,14 @@ where
     R: Recover<tonic::Status> + Send + Clone + 'static,
     R::Backoff: Unpin + Send,
 {
-    pub fn new(recover: R, inner: S, context_token: impl Into<Arc<str>>) -> Self {
+    pub fn new(
+        recover: R,
+        inner: S,
+        context_token: impl Into<Arc<str>>,
+        limits: ReceiveLimits,
+    ) -> Self {
         Self {
-            watch: StreamWatch::new(recover, Inner::new(context_token.into(), inner)),
+            watch: StreamWatch::new(recover, Inner::new(context_token.into(), limits, inner)),
         }
     }
 
@@ -48,8 +55,9 @@ where
         recover: R,
         inner: S,
         context_token: impl Into<Arc<str>>,
+        limits: ReceiveLimits,
     ) -> RecoverDefault<Self> {
-        RecoverDefault::new(Self::new(recover, inner, context_token))
+        RecoverDefault::new(Self::new(recover, inner, context_token, limits))
     }
 }
 
@@ -109,9 +117,10 @@ where
         Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send,
     S::Future: Send,
 {
-    fn new(context_token: Arc<str>, inner: S) -> Self {
+    fn new(context_token: Arc<str>, limits: ReceiveLimits, inner: S) -> Self {
         Self {
             context_token,
+            limits,
             client: DestinationClient::new(inner),
         }
     }
@@ -142,12 +151,15 @@ where
             ..Default::default()
         };
 
+        // TODO(ver): Record metrics on requests/errors/etc per addr.
         let mut client = self.client.clone();
+        let limits = self.limits;
+        let port = addr.port();
         Box::pin(async move {
-            let rsp = client.get_profile(req).await?;
-            Ok(rsp.map(|s| {
-                Box::pin(s.map_ok(move |p| proto::convert_profile(p, addr.port()))) as InnerStream
-            }))
+            // Limit the amount of time we spend waiting for the first
+            // profile update.
+            let rsp = LimitReceiveFuture::new(limits, client.get_profile(req)).await?;
+            Ok(rsp.map(move |rsp| rsp.map_ok(move |p| proto::convert_profile(p, port)).boxed()))
         })
     }
 }

--- a/linkerd/tonic-stream/Cargo.toml
+++ b/linkerd/tonic-stream/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "linkerd-tonic-stream"
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+futures = { version = "0.3", default-features = false }
+linkerd-stack = { path = "../stack" }
+pin-project = "1"
+tonic = { version = "0.10", default-features = false }
+tokio = { version = "1", features = ["time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros"] }
+tokio-test = "0.4"
+tokio-stream = { version = "0.1", features = ["sync"] }
+linkerd-tracing = { path = "../tracing" }

--- a/linkerd/tonic-stream/src/lib.rs
+++ b/linkerd/tonic-stream/src/lib.rs
@@ -1,0 +1,334 @@
+use futures::FutureExt;
+use linkerd_stack::{layer, ExtractParam, NewService, Service};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::time;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ReceiveLimits {
+    /// Bounds the amount of time until a gRPC stream's initial item is
+    /// received.
+    pub initial: Option<time::Duration>,
+
+    /// Bounds the amount of time between received gRPC stream items.
+    pub idle: Option<time::Duration>,
+
+    /// Bounds the total lifetime of a gRPC stream.
+    pub lifetime: Option<time::Duration>,
+}
+
+#[derive(Clone, Debug)]
+pub struct NewLimitReceive<P, N> {
+    inner: N,
+    params: P,
+}
+
+#[derive(Clone, Debug)]
+pub struct LimitReceive<S> {
+    inner: S,
+    limits: ReceiveLimits,
+}
+
+#[pin_project::pin_project]
+#[derive(Debug)]
+pub struct LimitReceiveFuture<F> {
+    #[pin]
+    inner: F,
+    limits: ReceiveLimits,
+    recv: Option<Pin<Box<time::Sleep>>>,
+}
+
+#[pin_project::pin_project]
+#[derive(Debug)]
+pub struct LimitReceiveStream<S> {
+    #[pin]
+    inner: S,
+
+    #[pin]
+    lifetime: time::Sleep,
+
+    recv: Pin<Box<time::Sleep>>,
+    recv_timeout: Option<time::Duration>,
+    recv_init: bool,
+}
+
+// === impl NewLimitReceive ===
+
+impl<P: Clone, N> NewLimitReceive<P, N> {
+    pub fn layer_via(params: P) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self {
+            inner,
+            params: params.clone(),
+        })
+    }
+}
+
+impl<T, P, N> NewService<T> for NewLimitReceive<P, N>
+where
+    N: NewService<T>,
+    P: ExtractParam<ReceiveLimits, T>,
+{
+    type Service = LimitReceive<N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let limits = self.params.extract_param(&target);
+        let inner = self.inner.new_service(target);
+        LimitReceive { inner, limits }
+    }
+}
+
+// === impl LimitReceive ===`
+
+impl<S> LimitReceive<S> {
+    pub fn new<Req, Rsp>(limits: ReceiveLimits, inner: S) -> Self
+    where
+        S: Service<tonic::Request<Req>, Response = tonic::Response<Rsp>, Error = tonic::Status>,
+    {
+        Self { inner, limits }
+    }
+}
+
+impl<Req, Rsp, S> Service<tonic::Request<Req>> for LimitReceive<S>
+where
+    S: Service<tonic::Request<Req>, Response = tonic::Response<Rsp>, Error = tonic::Status>,
+{
+    type Response = tonic::Response<LimitReceiveStream<Rsp>>;
+    type Error = tonic::Status;
+    type Future = LimitReceiveFuture<S::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: tonic::Request<Req>) -> Self::Future {
+        let inner = self.inner.call(req);
+        LimitReceiveFuture::new(self.limits, inner)
+    }
+}
+
+// === impl LimitReceiveFuture ===
+
+impl<S, F> LimitReceiveFuture<F>
+where
+    F: Future<Output = Result<tonic::Response<S>, tonic::Status>>,
+{
+    pub fn new(limits: ReceiveLimits, inner: F) -> Self {
+        let recv = Some(Box::pin(time::sleep(
+            limits
+                .initial
+                .or(limits.idle)
+                .unwrap_or(time::Duration::MAX),
+        )));
+        Self {
+            inner,
+            limits,
+            recv,
+        }
+    }
+}
+
+impl<S, F> Future for LimitReceiveFuture<F>
+where
+    F: Future<Output = Result<tonic::Response<S>, tonic::Status>>,
+{
+    type Output = Result<tonic::Response<LimitReceiveStream<S>>, tonic::Status>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        let rsp = if let Poll::Ready(res) = this.inner.poll(cx) {
+            res?
+        } else {
+            futures::ready!(this.recv.as_mut().unwrap().poll_unpin(cx));
+            return Poll::Ready(Err(tonic::Status::deadline_exceeded(
+                "initial item not received within timeout",
+            )));
+        };
+
+        let rsp = rsp.map(|inner| LimitReceiveStream {
+            inner,
+            recv: this.recv.take().unwrap(),
+            recv_timeout: this.limits.idle,
+            recv_init: true,
+            lifetime: time::sleep(this.limits.lifetime.unwrap_or(time::Duration::MAX)),
+        });
+        Poll::Ready(Ok(rsp))
+    }
+}
+
+// === impl ReceiveStream ===
+
+impl<S> futures::Stream for LimitReceiveStream<S>
+where
+    S: futures::TryStream<Error = tonic::Status>,
+{
+    type Item = Result<S::Ok, tonic::Status>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+
+        // If the lifetime has expired, end the stream.
+        if this.lifetime.poll(cx).is_ready() {
+            return Poll::Ready(None);
+        }
+
+        // Every time the inner stream yields an item, reset the receive
+        // timeout.
+        if let Poll::Ready(res) = this.inner.try_poll_next(cx) {
+            *this.recv_init = false;
+            if let Some(timeout) = this.recv_timeout {
+                if let Some(t) = time::Instant::now().checked_add(*timeout) {
+                    this.recv.as_mut().reset(t);
+                } else {
+                    tracing::error!("Receive timeout overflowed; ignoring")
+                }
+            }
+            return Poll::Ready(res);
+        }
+
+        // If the receive timeout has expired, end the stream.
+        if this.recv.poll_unpin(cx).is_ready() {
+            return Poll::Ready(this.recv_init.then(|| {
+                Err(tonic::Status::deadline_exceeded(
+                    "Initial update not received within timeout",
+                ))
+            }));
+        }
+
+        Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::prelude::*;
+    use linkerd_stack::ServiceExt;
+    use tokio_stream::wrappers::ReceiverStream;
+
+    /// Tests that the initial timeout bounds the response from the inner
+    /// service.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn init_timeout_response() {
+        let _trace = linkerd_tracing::test::trace_init();
+
+        let limits = ReceiveLimits {
+            initial: Some(time::Duration::from_millis(1)),
+            ..Default::default()
+        };
+        let svc = linkerd_stack::service_fn(|_: tonic::Request<()>| {
+            futures::future::pending::<
+                tonic::Result<tonic::Response<ReceiverStream<tonic::Result<()>>>>,
+            >()
+        });
+        let svc = LimitReceive::new(limits, svc);
+
+        let status = svc.oneshot(tonic::Request::new(())).await.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
+    }
+
+    /// Tests that the initial timeout bounds the first item received from the
+    /// inner response stream.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn init_timeout_recv() {
+        let _trace = linkerd_tracing::test::trace_init();
+
+        let limits = ReceiveLimits {
+            initial: Some(time::Duration::from_millis(1)),
+            ..Default::default()
+        };
+        let svc = linkerd_stack::service_fn(|_: tonic::Request<()>| {
+            futures::future::ok::<_, tonic::Status>(tonic::Response::new(
+                futures::stream::pending::<tonic::Result<()>>(),
+            ))
+        });
+        let svc = LimitReceive::new(limits, svc);
+
+        let rsp = svc
+            .oneshot(tonic::Request::new(()))
+            .await
+            .unwrap()
+            .into_inner();
+        tokio::pin!(rsp);
+        let status = rsp.try_next().await.unwrap_err();
+        assert_eq!(status.code(), tonic::Code::DeadlineExceeded);
+    }
+
+    /// Tests that the receive timeout bounds idleness after the initial update.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn recv_timeout() {
+        let _trace = linkerd_tracing::test::trace_init();
+
+        let limits = ReceiveLimits {
+            initial: Some(time::Duration::from_millis(1)),
+            idle: Some(time::Duration::from_millis(1)),
+            ..Default::default()
+        };
+        let (tx, rx) = tokio::sync::mpsc::channel::<tonic::Result<()>>(2);
+        let svc = {
+            let mut rx = Some(rx);
+            linkerd_stack::service_fn(move |_: tonic::Request<()>| {
+                futures::future::ok::<_, tonic::Status>(tonic::Response::new(ReceiverStream::new(
+                    rx.take().unwrap(),
+                )))
+            })
+        };
+        let svc = LimitReceive::new(limits, svc);
+
+        let rsp = svc
+            .oneshot(tonic::Request::new(()))
+            .await
+            .unwrap()
+            .into_inner();
+        tokio::pin!(rsp);
+
+        tx.send(Ok(())).await.unwrap();
+        assert!(rsp.try_next().await.is_ok());
+
+        let res = rsp.try_next().await.expect("stream should not error");
+        assert_eq!(res, None);
+    }
+
+    /// Tests that the lifetime bounds the total duration of the stream.
+    #[tokio::test(flavor = "current_thread", start_paused = true)]
+    async fn lifetime() {
+        let _trace = linkerd_tracing::test::trace_init();
+
+        let limits = ReceiveLimits {
+            lifetime: Some(time::Duration::from_millis(10)),
+            ..Default::default()
+        };
+        let (tx, rx) = tokio::sync::mpsc::channel::<tonic::Result<()>>(2);
+        let svc = {
+            let mut rx = Some(rx);
+            linkerd_stack::service_fn(move |_: tonic::Request<()>| {
+                futures::future::ok::<_, tonic::Status>(tonic::Response::new(ReceiverStream::new(
+                    rx.take().unwrap(),
+                )))
+            })
+        };
+        let svc = LimitReceive::new(limits, svc);
+
+        let rsp = svc
+            .oneshot(tonic::Request::new(()))
+            .await
+            .unwrap()
+            .into_inner();
+        tokio::pin!(rsp);
+
+        tx.send(Ok(())).await.unwrap();
+        time::sleep(time::Duration::from_millis(5)).await;
+        assert!(rsp.try_next().await.is_ok());
+
+        tx.send(Ok(())).await.unwrap();
+        time::sleep(time::Duration::from_millis(9)).await;
+        assert!(rsp.try_next().await.is_ok());
+
+        tx.send(Ok(())).await.unwrap();
+        time::sleep(time::Duration::from_millis(10)).await;
+        assert!(rsp.try_next().await.is_ok());
+    }
+}


### PR DESCRIPTION
When connecting to a control plane API, the API server can return an
HTTP response long before it returns the first stream response. To bound
this time, we now enforce timeouts so that failures may result in attempting
to use an alternate controller instances.

All controller response streams now use a generic gRPC middlware with
initial, idle, and lifetime timeouts. When an initial timeout is
encounterd, a DeadlineExceeded grpc status is synthesized. When the
other timeouts are encountered, the stream terminates gracefully.

These timeouts are configurable by the proxy injector. Timeouts are not
enabled without configuration:

* LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT
* LINKERD2_PROXY_CONTROL_STREAM_IDLE_TIMEOUT
* LINKERD2_PROXY_CONTROL_STREAM_LIFETIME

Each of these parameters is optional.