### PR TITLE
control: Avoid logging warnings on reconnect

### DIFF
--- a/linkerd/app/outbound/src/policy/api.rs
+++ b/linkerd/app/outbound/src/policy/api.rs
@@ -124,6 +124,13 @@ impl Recover<tonic::Status> for GrpcRecover {
             tonic::Code::InvalidArgument | tonic::Code::FailedPrecondition => Err(status),
             // Indicates no policy for this target
             tonic::Code::NotFound | tonic::Code::Unimplemented => Err(status),
+            tonic::Code::Ok => {
+                tracing::debug!(
+                    grpc.message = status.message(),
+                    "Completed; retrying with a backoff",
+                );
+                Ok(self.0.stream())
+            }
             code => {
                 tracing::warn!(
                     grpc.status = %code,

--- a/linkerd/app/src/dst.rs
+++ b/linkerd/app/src/dst.rs
@@ -97,19 +97,23 @@ impl Recover<tonic::Status> for BackoffUnlessInvalidArgument {
     type Backoff = ExponentialBackoffStream;
 
     fn recover(&self, status: tonic::Status) -> Result<Self::Backoff, tonic::Status> {
-        // Address is not resolvable
-        if status.code() == tonic::Code::InvalidArgument
-                    // Unexpected cluster state
-                    || status.code() == tonic::Code::FailedPrecondition
-        {
-            return Err(status);
+        match status.code() {
+            tonic::Code::InvalidArgument | tonic::Code::FailedPrecondition => Err(status),
+            tonic::Code::Ok => {
+                tracing::debug!(
+                    grpc.message = status.message(),
+                    "Completed; retrying with a backoff",
+                );
+                Ok(self.0.stream())
+            }
+            code => {
+                tracing::warn!(
+                    grpc.status = %code,
+                    grpc.message = status.message(),
+                    "Unexpected policy controller response; retrying with a backoff",
+                );
+                Ok(self.0.stream())
+            }
         }
-
-        tracing::warn!(
-            grpc.status = %status.code(),
-            grpc.message = status.message(),
-            "Unexpected destination controller response; retrying with a backoff",
-        );
-        Ok(self.0.stream())
     }
 }


### PR DESCRIPTION
When stream limits cause a graceful stream end, we should not log a warning.