### PR TITLE
cargo: Remove cyclic meshtls dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1601,7 +1601,6 @@ dependencies = [
  "linkerd-error",
  "linkerd-identity",
  "linkerd-io",
- "linkerd-meshtls",
  "linkerd-meshtls-verifier",
  "linkerd-stack",
  "linkerd-tls",

--- a/linkerd/meshtls/rustls/Cargo.toml
+++ b/linkerd/meshtls/rustls/Cargo.toml
@@ -30,5 +30,3 @@ linkerd-meshtls-verifier = { path = "../verifier" }
 
 [dev-dependencies]
 linkerd-tls-test-util = { path = "../../tls/test-util" }
-linkerd-meshtls = { path = "../../meshtls" }
-


### PR DESCRIPTION
The meshtls-rustls crate has an unneeded cyclic dependency onto meshtls. This change removes this unused dependency.