### PR TITLE
outbound: Update route backend metrics implementation

### DIFF
--- a/linkerd/app/gateway/src/http.rs
+++ b/linkerd/app/gateway/src/http.rs
@@ -89,7 +89,7 @@ impl Gateway {
             .outbound
             .clone()
             .with_stack(inner)
-            .push_http_cached(registry, resolve)
+            .push_http_cached(outbound::http::HttpMetrics::register(registry), resolve)
             .into_stack()
             // Discard `T` and its associated client-specific metadata.
             .push_map_target(Target::discard_parent)

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -5,7 +5,7 @@ use super::{balance::EwmaConfig, client, handle_proxy_error_headers};
 use crate::{http, stack_labels, BackendRef, Outbound, ParentRef};
 use linkerd_app_core::{
     config::QueueConfig,
-    metrics::{prefix_labels, prom, EndpointLabels, OutboundEndpointLabels},
+    metrics::{prefix_labels, EndpointLabels, OutboundEndpointLabels},
     profiles,
     proxy::{
         api_resolve::{ConcreteAddr, Metadata, ProtocolHint},
@@ -21,6 +21,8 @@ use std::{fmt::Debug, net::SocketAddr, sync::Arc};
 use tracing::info_span;
 
 mod balance;
+
+pub use self::balance::BalancerMetrics;
 
 /// Parameter configuring dispatcher behavior.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -60,7 +62,7 @@ impl<N> Outbound<N> {
     /// services.
     pub fn push_http_concrete<T, NSvc, R>(
         self,
-        registry: &mut prom::Registry,
+        balancer_metrics: balance::BalancerMetrics,
         resolve: R,
     ) -> Outbound<svc::ArcNewCloneHttp<T>>
     where
@@ -106,7 +108,7 @@ impl<N> Outbound<N> {
                 .push(balance::Balance::layer(
                     config,
                     rt,
-                    registry.sub_registry_with_prefix("balancer"),
+                    balancer_metrics,
                     resolve,
                 ))
                 .check_new_clone()

--- a/linkerd/app/outbound/src/http/concrete/balance.rs
+++ b/linkerd/app/outbound/src/http/concrete/balance.rs
@@ -1,13 +1,12 @@
 use super::Endpoint;
 use crate::{
     http::{self, balance, breaker},
-    metrics::BalancerMetricsParams,
+    metrics::{BalancerMetricsParams, ConcreteLabels},
     stack_labels, BackendRef, ParentRef,
 };
 use linkerd_app_core::{
     classify,
     config::QueueConfig,
-    metrics::prom,
     proxy::{
         api_resolve::{ConcreteAddr, Metadata},
         core::Resolve,
@@ -37,6 +36,8 @@ pub struct BalanceError {
     #[source]
     source: Error,
 }
+
+pub type BalancerMetrics = BalancerMetricsParams<ConcreteLabels>;
 
 // === impl Balance ===
 
@@ -81,7 +82,7 @@ where
     pub(super) fn layer<N, NSvc, R>(
         config: &crate::Config,
         rt: &crate::Runtime,
-        registry: &mut prom::Registry,
+        metrics: BalancerMetrics,
         resolve: R,
     ) -> impl svc::Layer<N, Service = svc::ArcNewCloneHttp<Self>> + Clone
     where
@@ -99,13 +100,11 @@ where
         // TODO(ver) Configure queues from the target (i.e. from discovery).
         let http_queue = config.http_request_queue;
         let inbound_ips = config.inbound_ips.clone();
-        let metrics = rt.metrics.clone();
+        let stack_metrics = rt.metrics.proxy.stack.clone();
 
         let resolve = svc::stack(resolve.into_service())
             .push_map_target(|t: Self| ConcreteAddr(t.addr))
             .into_inner();
-
-        let metrics_params = BalancerMetricsParams::register(registry);
 
         svc::layer::mk(move |inner: N| {
             let endpoint = svc::stack(inner)
@@ -139,7 +138,7 @@ where
                     }),
                 )
                 .push_on_service(svc::OnServiceLayer::new(
-                    metrics.proxy.stack.layer(stack_labels("http", "endpoint")),
+                    stack_metrics.layer(stack_labels("http", "endpoint")),
                 ))
                 .push_on_service(svc::NewInstrumentLayer::new(
                     |(addr, _): &(SocketAddr, _)| info_span!("endpoint", %addr),
@@ -149,12 +148,9 @@ where
                 .push(svc::ArcNewService::layer());
 
             endpoint
-                .push(http::NewBalance::layer(
-                    resolve.clone(),
-                    metrics_params.clone(),
-                ))
+                .push(http::NewBalance::layer(resolve.clone(), metrics.clone()))
                 .push_on_service(http::BoxResponse::layer())
-                .push_on_service(metrics.proxy.stack.layer(stack_labels("http", "balance")))
+                .push_on_service(stack_metrics.layer(stack_labels("http", "balance")))
                 .push(svc::NewMapErr::layer_from_target::<BalanceError, _>())
                 .instrument(|t: &Self| {
                     let BackendRef(meta) = t.parent.param();

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -1,109 +1,61 @@
 use crate::{BackendRef, ParentRef, RouteRef};
-use ahash::AHashMap;
-use linkerd_app_core::metrics::{metrics, Counter, FmtLabels, FmtMetrics};
-use linkerd_proxy_client_policy as policy;
-use parking_lot::Mutex;
-use std::{fmt::Write, sync::Arc};
-
-metrics! {
-    outbound_http_route_backend_requests_total: Counter {
-        "The total number of outbound requests dispatched to a HTTP route backend"
-    },
-    outbound_grpc_route_backend_requests_total: Counter {
-        "The total number of outbound requests dispatched to a gRPC route backend"
-    }
-}
+use linkerd_app_core::{
+    metrics::prom::{self, encoding::*, EncodeLabelSetMut},
+    svc,
+};
 
 #[derive(Clone, Debug, Default)]
 pub struct RouteBackendMetrics {
-    http: Arc<Mutex<AHashMap<Labels, Arc<Counter>>>>,
-    grpc: Arc<Mutex<AHashMap<Labels, Arc<Counter>>>>,
+    metrics: super::count_reqs::RequestCountFamilies<RouteBackendLabels>,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-struct Labels(ParentRef, RouteRef, BackendRef);
+struct RouteBackendLabels(ParentRef, RouteRef, BackendRef);
 
 // === impl RouteBackendMetrics ===
 
 impl RouteBackendMetrics {
-    pub fn http_requests_total(&self, pr: ParentRef, rr: RouteRef, br: BackendRef) -> Arc<Counter> {
-        self.http
-            .lock()
-            .entry(Labels(pr, rr, br))
-            .or_default()
-            .clone()
+    pub fn register(reg: &mut prom::Registry) -> Self {
+        Self {
+            metrics: super::count_reqs::RequestCountFamilies::register(reg),
+        }
     }
 
-    pub fn grpc_requests_total(&self, pr: ParentRef, rr: RouteRef, br: BackendRef) -> Arc<Counter> {
-        self.grpc
-            .lock()
-            .entry(Labels(pr, rr, br))
-            .or_default()
-            .clone()
+    #[cfg(test)]
+    pub(crate) fn request_count(
+        &self,
+        p: ParentRef,
+        r: RouteRef,
+        b: BackendRef,
+    ) -> super::count_reqs::RequestCount {
+        self.metrics.metrics(&RouteBackendLabels(p, r, b))
     }
 }
 
-impl FmtMetrics for RouteBackendMetrics {
-    fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let http = self.http.lock();
-        if !http.is_empty() {
-            outbound_http_route_backend_requests_total.fmt_help(f)?;
-            outbound_http_route_backend_requests_total.fmt_scopes(f, http.iter(), |c| c)?;
-        }
-        drop(http);
-
-        let grpc = self.grpc.lock();
-        if !grpc.is_empty() {
-            outbound_grpc_route_backend_requests_total.fmt_help(f)?;
-            outbound_grpc_route_backend_requests_total.fmt_scopes(f, grpc.iter(), |c| c)?;
-        }
-        drop(grpc);
-
-        Ok(())
+impl<T> svc::ExtractParam<super::count_reqs::RequestCount, T> for RouteBackendMetrics
+where
+    T: svc::Param<ParentRef> + svc::Param<RouteRef> + svc::Param<BackendRef>,
+{
+    fn extract_param(&self, t: &T) -> super::count_reqs::RequestCount {
+        self.metrics
+            .metrics(&RouteBackendLabels(t.param(), t.param(), t.param()))
     }
 }
 
-impl FmtLabels for Labels {
-    fn fmt_labels(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Labels(parent, route, backend) = self;
+// === impl RouteBackendLabels ===
 
-        Self::write_extended_meta("parent", parent, f)?;
-        f.write_char(',')?;
-        Self::write_basic_meta("route", route, f)?;
-        f.write_char(',')?;
-        Self::write_extended_meta("backend", backend, f)?;
-
+impl EncodeLabelSetMut for RouteBackendLabels {
+    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        let Self(parent, route, backend) = self;
+        parent.encode_label_set(enc)?;
+        route.encode_label_set(enc)?;
+        backend.encode_label_set(enc)?;
         Ok(())
     }
 }
 
-impl Labels {
-    fn write_basic_meta(
-        scope: &str,
-        meta: &policy::Meta,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        write!(f, "{scope}_group=\"{}\"", meta.group())?;
-        write!(f, ",{scope}_kind=\"{}\"", meta.kind())?;
-        write!(f, ",{scope}_namespace=\"{}\"", meta.namespace())?;
-        write!(f, ",{scope}_name=\"{}\"", meta.name())?;
-
-        Ok(())
-    }
-
-    fn write_extended_meta(
-        scope: &str,
-        meta: &policy::Meta,
-        f: &mut std::fmt::Formatter<'_>,
-    ) -> std::fmt::Result {
-        Self::write_basic_meta(scope, meta, f)?;
-
-        match meta.port() {
-            Some(port) => write!(f, ",{scope}_port=\"{port}\"")?,
-            None => write!(f, ",{scope}_port=\"\"")?,
-        }
-        write!(f, ",{scope}_section_name=\"{}\"", meta.section())?;
-
-        Ok(())
+impl EncodeLabelSet for RouteBackendLabels {
+    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(&mut enc)
     }
 }

--- a/linkerd/app/outbound/src/http/logical/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/tests.rs
@@ -30,7 +30,7 @@ async fn routes() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(svc::ArcNewService::new(connect))
-        .push_http_cached(&mut Default::default(), resolve)
+        .push_http_cached(Default::default(), resolve)
         .into_inner();
 
     let backend = default_backend(&dest);
@@ -73,7 +73,7 @@ async fn consecutive_failures_accrue() {
     let cfg = default_config();
     let stack = Outbound::new(cfg.clone(), rt)
         .with_stack(svc::ArcNewService::new(connect))
-        .push_http_cached(&mut Default::default(), resolve)
+        .push_http_cached(Default::default(), resolve)
         .into_inner();
 
     let backend = default_backend(&dest);
@@ -236,7 +236,7 @@ async fn balancer_doesnt_select_tripped_breakers() {
     let cfg = default_config();
     let stack = Outbound::new(cfg.clone(), rt)
         .with_stack(svc::ArcNewService::new(connect))
-        .push_http_cached(&mut Default::default(), resolve)
+        .push_http_cached(Default::default(), resolve)
         .into_inner();
 
     let backend = default_backend(&dest);
@@ -324,7 +324,7 @@ async fn route_request_timeout() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(svc::ArcNewService::new(connect))
-        .push_http_cached(&mut Default::default(), resolve)
+        .push_http_cached(Default::default(), resolve)
         .into_inner();
 
     let (_route_tx, routes) = {
@@ -387,7 +387,7 @@ async fn backend_request_timeout() {
     let (rt, _shutdown) = runtime();
     let stack = Outbound::new(default_config(), rt)
         .with_stack(svc::ArcNewService::new(connect))
-        .push_http_cached(&mut Default::default(), resolve)
+        .push_http_cached(Default::default(), resolve)
         .into_inner();
 
     let (_route_tx, routes) = {

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -70,7 +70,7 @@ impl Outbound<()> {
     /// fails, we revert to using the normal IP-based discovery
     pub fn mk_ingress<T, I, R>(
         &self,
-        registry: &mut prom::registry::Registry,
+        registry: &mut prom::Registry,
         profiles: impl profiles::GetProfile<Error = Error>,
         policies: impl policy::GetPolicy,
         resolve: R,
@@ -108,7 +108,7 @@ impl Outbound<()> {
             .to_tcp_connect()
             .push_tcp_endpoint()
             .push_http_tcp_client()
-            .push_http_cached(registry, resolve)
+            .push_http_cached(http::HttpMetrics::register(registry), resolve)
             .push_http_server()
             .map_stack(|_, _, stk| {
                 stk.check_new_service::<Http<Logical>, _>()

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -63,7 +63,7 @@ impl Outbound<()> {
             .to_tcp_connect()
             .push_tcp_endpoint()
             .push_http_tcp_client()
-            .push_http_cached(registry.sub_registry_with_prefix("http"), resolve)
+            .push_http_cached(http::HttpMetrics::register(registry), resolve)
             .push_http_server()
             .into_stack()
             .push_map_target(HttpSidecar::from)

--- a/linkerd/pool/p2c/src/lib.rs
+++ b/linkerd/pool/p2c/src/lib.rs
@@ -277,6 +277,19 @@ where
 
 // === impl P2cMetricFamilies ===
 
+impl<L> Default for P2cMetricFamilies<L>
+where
+    L: prom::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone,
+{
+    fn default() -> Self {
+        Self {
+            endpoints: prom::Family::default(),
+            updates: prom::Family::default(),
+        }
+    }
+}
+
 impl<L> P2cMetricFamilies<L>
 where
     L: prom::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,

--- a/linkerd/proxy/balance/gauge-endpoints/src/lib.rs
+++ b/linkerd/proxy/balance/gauge-endpoints/src/lib.rs
@@ -46,6 +46,16 @@ enum StateLabel {
     pending,
 }
 
+impl<L> Default for EndpointsGaugesFamilies<L>
+where
+    L: prometheus_client::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone,
+{
+    fn default() -> Self {
+        Self(Family::default())
+    }
+}
+
 impl<L> EndpointsGaugesFamilies<L>
 where
     L: prometheus_client::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,

--- a/linkerd/proxy/balance/queue/src/failfast.rs
+++ b/linkerd/proxy/balance/queue/src/failfast.rs
@@ -108,6 +108,24 @@ impl Failfast {
     }
 }
 
+// === impl GateMetricFamilies ===
+
+impl<L> Default for GateMetricFamilies<L>
+where
+    L: prom::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone,
+{
+    fn default() -> Self {
+        Self {
+            open: prom::Family::default(),
+            shut: prom::Family::default(),
+            open_time: prom::Family::default(),
+            shut_time: prom::Family::default(),
+            timeout: prom::Family::default(),
+        }
+    }
+}
+
 impl<L> GateMetricFamilies<L>
 where
     L: prom::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,

--- a/linkerd/proxy/balance/queue/src/lib.rs
+++ b/linkerd/proxy/balance/queue/src/lib.rs
@@ -43,6 +43,26 @@ pub struct QueueMetrics {
 
 // === impl QueueMetricsFamilies ===
 
+impl<L> Default for QueueMetricFamilies<L>
+where
+    L: prom::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone,
+{
+    fn default() -> Self {
+        Self {
+            length: prom::Family::default(),
+            requests: prom::Family::default(),
+            latency: prom::Family::new_with_constructor(|| {
+                // We mostly want to get a broad sense of overhead and not incur the
+                // costs of higher fidelity histograms, so we use a constrained set
+                // of buckets.
+                prom::Histogram::new([0.0005, 0.005, 0.05, 0.5, 1.0, 3.0].iter().copied())
+            }),
+            gate: GateMetricFamilies::default(),
+        }
+    }
+}
+
 impl<L> QueueMetricFamilies<L>
 where
     L: prom::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,

--- a/linkerd/proxy/balance/src/lib.rs
+++ b/linkerd/proxy/balance/src/lib.rs
@@ -213,3 +213,17 @@ where
         }
     }
 }
+
+impl<L> Default for MetricFamilies<L>
+where
+    L: prom::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone,
+{
+    fn default() -> Self {
+        Self {
+            p2c: P2cMetricFamilies::default(),
+            queue: QueueMetricFamilies::default(),
+            endpoints: EndpointsGaugesFamilies::default(),
+        }
+    }
+}


### PR DESCRIPTION
To help setup for adding neew route metrics to the outbound proxy, this change wires up route metrics registry infrastructure, porting the route backend metrics implementation to use prometheus-client instead of Linkerd's legacy metrics.

No functional changes.