### PR TITLE
outbound: Add a request_duration histogram for route backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,9 +1499,12 @@ dependencies = [
 name = "linkerd-http-prom"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "http",
  "linkerd-stack",
+ "pin-project",
  "prometheus-client",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1278,6 +1278,7 @@ dependencies = [
  "linkerd-app-test",
  "linkerd-distribute",
  "linkerd-http-classify",
+ "linkerd-http-prom",
  "linkerd-http-retry",
  "linkerd-http-route",
  "linkerd-identity",
@@ -1492,6 +1493,15 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "linkerd-http-prom"
+version = "0.1.0"
+dependencies = [
+ "http",
+ "linkerd-stack",
+ "prometheus-client",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "linkerd/http/classify",
     "linkerd/http/h2",
     "linkerd/http/metrics",
+    "linkerd/http/prom",
     "linkerd/http/retry",
     "linkerd/http/route",
     "linkerd/identity",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -35,6 +35,7 @@ linkerd-app-core = { path = "../core" }
 linkerd-app-test = { path = "../test", optional = true }
 linkerd-distribute = { path = "../../distribute" }
 linkerd-http-classify = { path = "../../http/classify" }
+linkerd-http-prom = { path = "../../http/prom" }
 linkerd-http-retry = { path = "../../http/retry" }
 linkerd-http-route = { path = "../../http/route" }
 linkerd-identity = { path = "../../identity" }
@@ -48,6 +49,11 @@ linkerd-tonic-watch = { path = "../../tonic-watch" }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["http1", "http2"] }
+parking_lot = "0.12"
+tokio = { version = "1", features = ["macros", "sync", "time"] }
+tokio-test = "0.4"
+tower-test = "0.4"
+
 linkerd-app-test = { path = "../test", features = ["client-policy"] }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 linkerd-meshtls = { path = "../../meshtls", features = ["rustls"] }
@@ -56,7 +62,3 @@ linkerd-meshtls-rustls = { path = "../../meshtls/rustls", features = [
 ] }
 linkerd-stack = { path = "../../stack", features = ["test-util"] }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }
-parking_lot = "0.12"
-tokio = { version = "1", features = ["macros", "sync", "time"] }
-tokio-test = "0.4"
-tower-test = "0.4"

--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -76,13 +76,13 @@ impl RouteMetrics {
     }
 
     #[cfg(test)]
-    pub(crate) fn request_count(
+    pub(crate) fn backend_metrics(
         &self,
         p: crate::ParentRef,
         r: RouteRef,
         b: crate::BackendRef,
-    ) -> backend::RequestCount {
-        self.backend.request_count(p, r, b)
+    ) -> backend::BackendHttpMetrics {
+        self.backend.get(p, r, b)
     }
 }
 

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -5,11 +5,9 @@ use linkerd_http_route as http_route;
 use linkerd_proxy_client_policy as policy;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
 
-mod count_reqs;
 mod metrics;
 
-pub use self::count_reqs::RequestCount;
-pub use self::metrics::RouteBackendMetrics;
+pub use self::metrics::{RequestCount, RouteBackendMetrics};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub(crate) struct Backend<T, F> {
@@ -103,7 +101,7 @@ where
                 )
                 .push(filters::NewApplyFilters::<Self, _, _>::layer())
                 .push(http::NewTimeout::layer())
-                .push(count_reqs::NewCountRequests::layer_via(metrics.clone()))
+                .push(metrics::NewCountRequests::layer_via(metrics.clone()))
                 .push(svc::NewMapErr::layer_with(|t: &Self| {
                     let backend = t.params.concrete.backend_ref.clone();
                     move |source| {

--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -64,8 +64,10 @@ where
     >,
     route::MatchedRoute<T, M::Summary, F, E>: route::filters::Apply + svc::Param<classify::Request>,
     route::MatchedBackend<T, M::Summary, F>: route::filters::Apply,
-    route::backend::RouteBackendMetrics:
-        svc::ExtractParam<route::backend::RequestCount, route::MatchedBackend<T, M::Summary, F>>,
+    route::backend::RouteBackendMetrics: svc::ExtractParam<
+        route::backend::BackendHttpMetrics,
+        route::MatchedBackend<T, M::Summary, F>,
+    >,
 {
     /// Builds a stack that applies routes to distribute requests over a cached
     /// set of inner services so that.

--- a/linkerd/app/outbound/src/http/logical/policy/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/tests.rs
@@ -130,18 +130,18 @@ async fn header_based_route() {
         .layer(inner)
         .new_service(Policy::from((routes, ())));
 
-    let default_reqs = metrics.request_count(
+    let default_reqs = metrics.backend_metrics(
         parent_ref.clone(),
         default_route_ref.clone(),
         default_backend_ref.clone(),
     );
-    let special_reqs = metrics.request_count(
+    let special_reqs = metrics.backend_metrics(
         parent_ref.clone(),
         special_route_ref.clone(),
         special_backend_ref.clone(),
     );
-    assert_eq!(default_reqs.get(), 0);
-    assert_eq!(special_reqs.get(), 0);
+    assert_eq!(default_reqs.requests_total().get(), 0);
+    assert_eq!(special_reqs.requests_total().get(), 0);
 
     default.allow(1);
     special.allow(1);
@@ -155,8 +155,8 @@ async fn header_based_route() {
         _ = time::sleep(time::Duration::from_secs(1)) => panic!("timed out"),
         reqrsp = default.next_request() => reqrsp.expect("request"),
     };
-    assert_eq!(default_reqs.get(), 1);
-    assert_eq!(special_reqs.get(), 0);
+    assert_eq!(default_reqs.requests_total().get(), 1);
+    assert_eq!(special_reqs.requests_total().get(), 0);
 
     default.allow(1);
     special.allow(1);
@@ -171,8 +171,8 @@ async fn header_based_route() {
         _ = time::sleep(time::Duration::from_secs(1)) => panic!("timed out"),
         reqrsp = special.next_request() => reqrsp.expect("request"),
     };
-    assert_eq!(default_reqs.get(), 1);
-    assert_eq!(special_reqs.get(), 1);
+    assert_eq!(default_reqs.requests_total().get(), 1);
+    assert_eq!(special_reqs.requests_total().get(), 1);
 
     // Hold the router to prevent inner services from being dropped.
     drop(router);

--- a/linkerd/http/prom/Cargo.toml
+++ b/linkerd/http/prom/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "linkerd-http-prom"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "Apache-2.0"
+
+[features]
+test-util = []
+
+[dependencies]
+http = "0.2"
+prometheus-client = "0.22"
+
+linkerd-stack = { path = "../../stack" }

--- a/linkerd/http/prom/Cargo.toml
+++ b/linkerd/http/prom/Cargo.toml
@@ -9,7 +9,10 @@ license = "Apache-2.0"
 test-util = []
 
 [dependencies]
+futures = { version = "0.3", default-features = false }
 http = "0.2"
+pin-project = "1"
 prometheus-client = "0.22"
+tokio = { version = "1", features = ["time"] }
 
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/http/prom/src/count_reqs.rs
+++ b/linkerd/http/prom/src/count_reqs.rs
@@ -1,11 +1,16 @@
-use linkerd_app_core::{metrics::prom, svc};
+use linkerd_stack as svc;
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::{counter::Counter, family::Family},
+    registry::Registry,
+};
 use std::task::{Context, Poll};
 
 #[derive(Clone, Debug)]
-pub struct RequestCountFamilies<L: Clone>(prom::Family<L, prom::Counter>);
+pub struct RequestCountFamilies<L: Clone>(Family<L, Counter>);
 
 #[derive(Clone, Debug)]
-pub struct RequestCount(prom::Counter);
+pub struct RequestCount(Counter);
 
 #[derive(Clone, Debug)]
 pub struct NewCountRequests<X, N> {
@@ -16,16 +21,16 @@ pub struct NewCountRequests<X, N> {
 #[derive(Clone, Debug)]
 pub struct CountRequests<S> {
     inner: S,
-    requests: prom::Counter,
+    requests: Counter,
 }
 
 impl<L> RequestCountFamilies<L>
 where
-    L: prom::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
     L: Eq + Clone + Send + Sync + 'static,
 {
-    pub fn register(registry: &mut prom::Registry) -> Self {
-        let requests = prom::Family::default();
+    pub fn register(registry: &mut Registry) -> Self {
+        let requests = Family::default();
         registry.register(
             "requests",
             "The total number of requests dispatched",
@@ -46,7 +51,7 @@ impl<X: Clone, N> NewCountRequests<X, N> {
         Self { extract, inner }
     }
 
-    pub fn layer_via(extract: X) -> impl svc::Layer<N, Service = Self> + Clone {
+    pub fn layer_via(extract: X) -> impl svc::layer::Layer<N, Service = Self> + Clone {
         svc::layer::mk(move |inner| Self::new(extract.clone(), inner))
     }
 }
@@ -68,7 +73,7 @@ where
 // === impl CountRequests ===
 
 impl<S> CountRequests<S> {
-    fn new(requests: prom::Counter, inner: S) -> Self {
+    fn new(requests: Counter, inner: S) -> Self {
         Self { requests, inner }
     }
 }
@@ -94,16 +99,15 @@ where
 
 impl<L> Default for RequestCountFamilies<L>
 where
-    L: prom::encoding::EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
     L: Eq + Clone + Send + Sync + 'static,
 {
     fn default() -> Self {
-        Self(prom::Family::default())
+        Self(Family::default())
     }
 }
 
 impl RequestCount {
-    #[cfg(test)]
     pub fn get(&self) -> u64 {
         self.0.get()
     }

--- a/linkerd/http/prom/src/count_rsps.rs
+++ b/linkerd/http/prom/src/count_rsps.rs
@@ -1,0 +1,210 @@
+use linkerd_stack as svc;
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::{
+        family::{Family, MetricConstructor},
+        histogram::Histogram,
+    },
+    registry::{Registry, Unit},
+};
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::time;
+
+#[derive(Clone, Debug)]
+pub struct ResponseMetricsFamilies<L, H> {
+    // errors: Family<L, Counter>,
+    request_durations: RequestDurationsFamily<L, H>,
+}
+
+type RequestDurationsFamily<L, H> = Family<Labels<L>, Histogram, H>;
+
+#[derive(Clone, Debug)]
+pub struct ResponseMetrics<L, H> {
+    labels: L,
+    // errors: Counter,
+    request_durations: Family<Labels<L>, Histogram, H>,
+}
+
+#[derive(Clone, Debug)]
+pub struct NewResponseMetrics<X, L, H, N> {
+    inner: N,
+    extract: X,
+    _marker: std::marker::PhantomData<fn() -> (L, H)>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ResponseMetricsService<L, H, S> {
+    inner: S,
+    metrics: ResponseMetrics<L, H>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct Labels<L> {
+    status_code: u16,
+    common: L,
+}
+
+// Define the ResponseFuture type
+#[pin_project::pin_project]
+pub struct ResponseFuture<L, H, F> {
+    #[pin]
+    future: F,
+    t0: time::Instant,
+    metrics: ResponseMetrics<L, H>,
+}
+
+// === impl ResponseMetricsFamilies ===
+
+impl<L, H> Default for ResponseMetricsFamilies<L, H>
+where
+    L: EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone,
+    H: Default,
+{
+    fn default() -> Self {
+        Self {
+            request_durations: Family::new_with_constructor(H::default()),
+        }
+    }
+}
+
+impl<L, H> ResponseMetricsFamilies<L, H>
+where
+    L: EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone + Send + Sync + 'static,
+    H: MetricConstructor<Histogram> + Clone + Send + Sync + 'static,
+{
+    pub fn register(registry: &mut Registry, mk_histo: H) -> Self
+where {
+        let request_durations = RequestDurationsFamily::new_with_constructor(mk_histo);
+        registry.register_with_unit(
+            "request_duration",
+            "The durations between sending an HTTP request and receiving response headers",
+            Unit::Seconds,
+            request_durations.clone(),
+        );
+
+        Self { request_durations }
+    }
+
+    pub fn metrics(&self, labels: &L) -> ResponseMetrics<L, H> {
+        ResponseMetrics {
+            labels: labels.clone(),
+            request_durations: self.request_durations.clone(),
+        }
+    }
+}
+
+// === impl NewCountResponses ===
+
+impl<X: Clone, L, H, N> NewResponseMetrics<X, L, H, N> {
+    pub fn new(extract: X, inner: N) -> Self {
+        Self {
+            extract,
+            inner,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn layer_via(extract: X) -> impl svc::layer::Layer<N, Service = Self> + Clone {
+        svc::layer::mk(move |inner| Self::new(extract.clone(), inner))
+    }
+}
+
+impl<T, X, L, H, N> svc::NewService<T> for NewResponseMetrics<X, L, H, N>
+where
+    X: svc::ExtractParam<ResponseMetrics<L, H>, T>,
+    L: EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone + Send + Sync + 'static,
+    N: svc::NewService<T>,
+{
+    type Service = ResponseMetricsService<L, H, N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let rc = self.extract.extract_param(&target);
+        let inner = self.inner.new_service(target);
+        ResponseMetricsService::new(rc, inner)
+    }
+}
+
+// === impl CountResponses ===
+
+impl<L, H, S> ResponseMetricsService<L, H, S> {
+    pub(crate) fn new(metrics: ResponseMetrics<L, H>, inner: S) -> Self {
+        Self { metrics, inner }
+    }
+}
+
+impl<B, L, H, RspB, S> svc::Service<http::Request<B>> for ResponseMetricsService<L, H, S>
+where
+    L: EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone + Send + Sync + 'static,
+    H: MetricConstructor<Histogram> + Clone + Send + Sync + 'static,
+    S: svc::Service<http::Request<B>, Response = http::Response<RspB>>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = ResponseFuture<L, H, S::Future>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<B>) -> Self::Future {
+        ResponseFuture {
+            t0: time::Instant::now(),
+            metrics: self.metrics.clone(),
+            future: self.inner.call(req),
+        }
+    }
+}
+
+// === impl Labels ===
+
+impl<L> prometheus_client::encoding::EncodeLabelSet for Labels<L>
+where
+    L: EncodeLabelSet,
+{
+    fn encode(
+        &self,
+        mut enc: prometheus_client::encoding::LabelSetEncoder<'_>,
+    ) -> std::fmt::Result {
+        use prometheus_client::encoding::EncodeLabel;
+        ("status_code", self.status_code).encode(enc.encode_label())?;
+        self.common.encode(enc)?;
+        Ok(())
+    }
+}
+
+// === impl ResponseFuture ===
+
+impl<B, E, L, H, F> Future for ResponseFuture<L, H, F>
+where
+    L: EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone + Send + Sync + 'static,
+    H: MetricConstructor<Histogram> + Clone + Send + Sync + 'static,
+    F: Future<Output = Result<http::Response<B>, E>>,
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let res = futures::ready!(this.future.poll(cx));
+        let status_code = res.as_ref().map(|rsp| rsp.status().as_u16()).unwrap_or(0);
+        let labels = Labels {
+            status_code,
+            common: this.metrics.labels.clone(),
+        };
+        let elapsed = time::Instant::now().saturating_duration_since(*this.t0);
+        this.metrics
+            .request_durations
+            .get_or_create(&labels)
+            .observe(elapsed.as_secs_f64());
+        Poll::Ready(res)
+    }
+}

--- a/linkerd/http/prom/src/lib.rs
+++ b/linkerd/http/prom/src/lib.rs
@@ -1,0 +1,3 @@
+mod count_reqs;
+
+pub use self::count_reqs::{CountRequests, NewCountRequests, RequestCount, RequestCountFamilies};

--- a/linkerd/http/prom/src/lib.rs
+++ b/linkerd/http/prom/src/lib.rs
@@ -1,3 +1,117 @@
-mod count_reqs;
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
+#![forbid(unsafe_code)]
 
-pub use self::count_reqs::{CountRequests, NewCountRequests, RequestCount, RequestCountFamilies};
+use linkerd_stack::{layer, ExtractParam, NewService};
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::{family::MetricConstructor, histogram::Histogram},
+};
+
+mod count_reqs;
+mod count_rsps;
+
+pub use self::{
+    count_reqs::{CountRequests, NewCountRequests, RequestCount, RequestCountFamilies},
+    count_rsps::{
+        NewResponseMetrics, ResponseMetrics, ResponseMetricsFamilies, ResponseMetricsService,
+    },
+};
+
+#[derive(Clone, Debug)]
+pub struct HttpMetricsFamiles<L, H> {
+    request: RequestCountFamilies<L>,
+    response: ResponseMetricsFamilies<L, H>,
+}
+
+#[derive(Clone, Debug)]
+pub struct HttpMetrics<L, H> {
+    request: RequestCount,
+    response: ResponseMetrics<L, H>,
+}
+
+// === NewHttpMetrics ===
+
+#[derive(Clone, Debug)]
+pub struct NewHttpMetrics<X, L, H, N> {
+    inner: N,
+    extract: X,
+    _marker: std::marker::PhantomData<fn() -> (L, H)>,
+}
+
+impl<X: Clone, L, H, N> NewHttpMetrics<X, L, H, N> {
+    pub fn layer_via(extract: X) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self {
+            inner,
+            extract: extract.clone(),
+            _marker: std::marker::PhantomData,
+        })
+    }
+}
+
+impl<T, X, L, H, N> NewService<T> for NewHttpMetrics<X, L, H, N>
+where
+    X: ExtractParam<HttpMetrics<L, H>, T>,
+    X: Clone + Send + Sync + 'static,
+    L: EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone + Send + Sync + 'static,
+    N: NewService<T>,
+{
+    type Service = CountRequests<ResponseMetricsService<L, H, N::Service>>;
+
+    #[inline]
+    fn new_service(&self, target: T) -> Self::Service {
+        let HttpMetrics { request, response } = self.extract.extract_param(&target);
+        CountRequests::new(
+            request,
+            ResponseMetricsService::new(response, self.inner.new_service(target)),
+        )
+    }
+}
+
+// === HttpMetricsFamilies ===
+
+impl<L, H> Default for HttpMetricsFamiles<L, H>
+where
+    L: EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone,
+    H: Default,
+{
+    fn default() -> Self {
+        Self {
+            request: RequestCountFamilies::default(),
+            response: ResponseMetricsFamilies::default(),
+        }
+    }
+}
+
+impl<L, H> HttpMetricsFamiles<L, H>
+where
+    L: EncodeLabelSet + std::fmt::Debug + std::hash::Hash,
+    L: Eq + Clone + Send + Sync + 'static,
+    H: MetricConstructor<Histogram> + Clone + Send + Sync + 'static,
+{
+    pub fn register(reg: &mut prometheus_client::registry::Registry, mk_histo: H) -> Self {
+        let request = RequestCountFamilies::register(reg);
+        let response = ResponseMetricsFamilies::register(reg, mk_histo);
+        Self { request, response }
+    }
+
+    pub fn metrics(&self, labels: &L) -> HttpMetrics<L, H> {
+        HttpMetrics {
+            request: self.request.metrics(labels),
+            response: self.response.metrics(labels),
+        }
+    }
+}
+
+// === HttpMetrics ===
+
+impl<L, H> HttpMetrics<L, H> {
+    pub fn requests_total(&self) -> &RequestCount {
+        &self.request
+    }
+
+    pub fn response(&self) -> &ResponseMetrics<L, H> {
+        &self.response
+    }
+}


### PR DESCRIPTION
a105b7984 - Extract the request counting middleware to an http-prom crate

02184874f - outbound: Add a request_duration histogram for route backends
The outbound proxy reports a counter,
outbound_http_route_backend_requests_total, that illustrates how requests are
dispatched over a logical service's backends.

This change augments these metrics with "request duration" histograms. This
terminology is consistent with that of the prometheus Go client library.

    # HELP outbound_http_route_backend_request_duration_seconds The durations between sending an HTTP request and receiving response headers.
    # TYPE outbound_http_route_backend_request_duration_seconds histogram
    # UNIT outbound_http_route_backend_request_duration_seconds seconds
    outbound_http_route_backend_request_duration_seconds_sum{status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 0.07080217000000001
    outbound_http_route_backend_request_duration_seconds_count{status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 54
    outbound_http_route_backend_request_duration_seconds_bucket{le="0.025",status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 54
    outbound_http_route_backend_request_duration_seconds_bucket{le="0.05",status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 54
    outbound_http_route_backend_request_duration_seconds_bucket{le="0.1",status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 54
    outbound_http_route_backend_request_duration_seconds_bucket{le="0.25",status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 54
    outbound_http_route_backend_request_duration_seconds_bucket{le="0.5",status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 54
    outbound_http_route_backend_request_duration_seconds_bucket{le="1.0",status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 54
    outbound_http_route_backend_request_duration_seconds_bucket{le="2.5",status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 54
    outbound_http_route_backend_request_duration_seconds_bucket{le="5.0",status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 54
    outbound_http_route_backend_request_duration_seconds_bucket{le="+Inf",status_code="200",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 54


A constrained histogram is used to balance the tradeoff between accuracy and
cost.

Additionally, a basic counter is added to track errors emitted from backends.
Given the current proxy configuration, these can only indicate load shedding
errors:

    # HELP outbound_http_route_backend_request_errors The total number of errors encountered while waiting for a response.
    # TYPE outbound_http_route_backend_request_errors counter
    outbound_http_route_backend_request_errors_total{parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name="",route_group="",route_kind="default",route_namespace="",route_name="http",backend_group="core",backend_kind="Service",backend_namespace="emojivoto",backend_name="emoji-svc",backend_port="8080",backend_section_name=""} 0