### PR TITLE
config:add spire client config

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -818,7 +818,9 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             Some(socket) => match &tls.id {
                 // TODO: perform stricter SPIFFE ID validation following:
                 // https://github.com/spiffe/spiffe/blob/27b59b81ba8c56885ac5d4be73b35b9b3305fd7a/standards/SPIFFE-ID.md
-                identity::Id::Uri(uri) if uri.scheme() == SPIFFE_ID_URI_SCHEME => {
+                identity::Id::Uri(uri)
+                    if uri.scheme().eq_ignore_ascii_case(SPIFFE_ID_URI_SCHEME) =>
+                {
                     identity::Config::Spire {
                         tls,
                         client: spire::Config {


### PR DESCRIPTION
This change allows the proxy to be configured to use SPIRE
as it is credentials provider. There are three additional ENV
vars introduced: 

- `LINKERD2_PROXY_IDENTITY_SERVER_ID` - Configures the TLS Id of the proxy inbound server.
- `LINKERD2_PROXY_IDENTITY_SERVER_NAME` - Configures the server name of this proxy.
- `ENV_IDENTITY_SPIRE_SOCKET` - If this config is set, then the proxy will use Spire as the identity provider

For backward compatibility reasons if `ENV_IDENTITY_IDENTITY_LOCAL_NAME` is set both
tls id and server_name will be sourced from its value. If however it is not set, both `LINKERD2_PROXY_IDENTITY_SERVER_ID` and `LINKERD2_PROXY_IDENTITY_SERVER_NAME` are required. 

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>

