### PR TITLE
http: Parameterize NewServeHttp

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -123,7 +123,16 @@ impl Config {
 
         let tcp = http
             .unlift_new()
-            .push(http::NewServeHttp::layer(Default::default(), drain.clone()))
+            .push(http::NewServeHttp::layer({
+                let drain = drain.clone();
+                move |t: &Http| {
+                    http::ServerParams {
+                        version: t.version,
+                        h2: Default::default(),
+                        drain: drain.clone(),
+                    }
+                }
+            }))
             .push_filter(
                 |(http, tcp): (
                     Result<Option<http::Version>, detect::DetectTimeoutError<_>>,

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -38,7 +38,7 @@ pub use self::{
     normalize_uri::{MarkAbsoluteForm, NewNormalizeUri},
     override_authority::{AuthorityOverride, NewOverrideAuthority},
     retain::Retain,
-    server::{NewServeHttp, ServeHttp},
+    server::{NewServeHttp, Params as ServerParams, ServeHttp},
     strip_header::StripHeader,
     timeout::{NewTimeout, ResponseTimeout, ResponseTimeoutError},
     version::Version,


### PR DESCRIPTION
We plan to add defensive timeouts to the HTTP server to limit idle streams and connections. In preparation for this, we need to parameterize the server to accept these additonal configurations.

This change updates NewServeHttp to use an ExtractParam to build a Params struct for each server. In follow-up changes, the timeout configuration will be instrumented through this Params struct.

There are no functional changes in this commit.