### PR TITLE
ci: Add a confirmation job to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
 
   package:
-    needs: [meta]
+    needs: meta
     if: needs.meta.outputs.changed == 'true'
 
     strategy:
@@ -108,3 +108,18 @@ jobs:
           name: v${{ needs.meta.outputs.version }}
           files: artifacts/**/*
           generate_release_notes: true
+
+  release-ok:
+    needs: publish
+    if: always()
+    timeout-minutes: 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Results
+        run: |
+          echo 'needs.publish.result: ${{ needs.publish.result }}'
+
+      - name: Verify jobs
+        # All jobs must succeed or be skipped.
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
This job can be required on all changes.