### PR TITLE
ci: Fix semver check in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           if [[ "$ref" == refs/tags/release/* ]]; then
             ver="${ref##refs/tags/release/}"
             # Semver-ish
-            if echo "$ver" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+)?(\+[0-9A-Za-z-]+)?$' ; then
+            if ! echo "$ver" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+)?(\+[0-9A-Za-z-]+)?$' ; then
               echo "Invalid version: $ver" >&2
               exit 1
             fi


### PR DESCRIPTION
The semver check was inverted. This commit fixes it.