### PR TITLE
Added environment variables to configure http2 ping timeout and interval

### DIFF
--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -21,6 +21,7 @@ pub struct Settings {
     pub initial_stream_window_size: Option<u32>,
     pub initial_connection_window_size: Option<u32>,
     pub keepalive_timeout: Option<Duration>,
+    pub keepalive_interval: Option<Duration>,
 }
 
 #[derive(Debug)]
@@ -83,6 +84,7 @@ where
             initial_connection_window_size,
             initial_stream_window_size,
             keepalive_timeout,
+            keepalive_interval,
         } = self.h2_settings;
 
         let connect = self
@@ -104,9 +106,14 @@ where
                 if let Some(timeout) = keepalive_timeout {
                     // XXX(eliza): is this a reasonable interval between
                     // PING frames?
-                    let interval = timeout / 4;
                     builder
                         .http2_keep_alive_timeout(timeout)
+                        // set default interval
+                        .http2_keep_alive_interval(timeout / 4)
+                        .http2_keep_alive_while_idle(true);
+                }
+                if let Some(interval) = keepalive_interval {
+                    builder
                         .http2_keep_alive_interval(interval)
                         .http2_keep_alive_while_idle(true);
                 }

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -70,8 +70,13 @@ where
             .http2_initial_connection_window_size(h2.initial_connection_window_size);
         // Configure HTTP/2 PING frames
         if let Some(timeout) = h2.keepalive_timeout {
-            srv.http2_keep_alive_timeout(timeout)
+            srv
+                .http2_keep_alive_timeout(timeout)
+                // set default interval
                 .http2_keep_alive_interval(timeout / 4);
+        }
+        if let Some(interval) = h2.keepalive_interval {
+            srv.http2_keep_alive_interval(interval);
         }
 
         debug!(?version, "Creating HTTP service");


### PR DESCRIPTION
Enabling HTTP/2 PING frames via environment variables for proxy container:
For inbound/outbound traffic keepalive timout can be configured by
`LINKERD2_PROXY_{INBOUND,OUTBOUND}_HTTP2_KEEPALIVE_{INTERVAL,TIMEOUT}`

Closes https://github.com/linkerd/linkerd2/issues/12269