### PR TITLE
Add environment variables to configure HTTP/2 keepalive timeout and interval configuration from environment variables

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -374,8 +374,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let inbound_keepalive_interval = parse(strings, ENV_INBOUND_HTTP2_KEEPALIVE_INTERVAL, parse_duration);
     let outbound_keepalive_interval = parse(strings, ENV_OUTBOUND_HTTP2_KEEPALIVE_INTERVAL, parse_duration);
 
-    let inbound_keepalive_timeout = parse(strings, ENV_INBOUND_HTTP2_KEEPALIVE_TIMEOUT, parse_duration);
-    let outbound_keepalive_timeout = parse(strings, ENV_OUTBOUND_HTTP2_KEEPALIVE_TIMEOUT, parse_duration);
+    let inbound_keepalive_timeout =
+        parse(strings, ENV_INBOUND_HTTP2_KEEPALIVE_TIMEOUT, parse_duration)?.or(inbound_connect_keepalive.clone()?);
+    let outbound_keepalive_timeout
+        = parse(strings, ENV_OUTBOUND_HTTP2_KEEPALIVE_TIMEOUT, parse_duration)?.or(outbound_connect_keepalive.clone()?);
 
     let shutdown_grace_period = parse(strings, ENV_SHUTDOWN_GRACE_PERIOD, parse_duration);
 
@@ -482,7 +484,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         let keepalive = Keepalive(outbound_accept_keepalive?);
         let h2_settings = h2::Settings {
             keepalive_interval: outbound_keepalive_interval?,
-            keepalive_timeout: outbound_keepalive_timeout?,
+            keepalive_timeout: outbound_keepalive_timeout,
             ..h2_settings
         };
         let server = ServerConfig {
@@ -568,7 +570,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         let keepalive = Keepalive(inbound_accept_keepalive?);
         let h2_settings = h2::Settings {
             keepalive_interval: inbound_keepalive_interval?,
-            keepalive_timeout: inbound_keepalive_timeout?,
+            keepalive_timeout: inbound_keepalive_timeout,
             ..h2_settings
         };
         let server = ServerConfig {

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -771,11 +771,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         server: ServerConfig {
             addr: ListenAddr(admin_listener_addr),
             keepalive: inbound.proxy.server.keepalive,
-            h2_settings: h2::Settings {
-                keepalive_interval: inbound.proxy.server.h2_settings.keepalive_interval,
-                keepalive_timeout: inbound.proxy.server.h2_settings.keepalive_timeout,
-                ..h2_settings
-            },
+            h2_settings,
         },
 
         // TODO(ver) Currently we always enable profiling when the pprof feature
@@ -834,11 +830,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             config: ServerConfig {
                 addr: ListenAddr(addr),
                 keepalive: inbound.proxy.server.keepalive,
-                h2_settings: h2::Settings {
-                    keepalive_interval: inbound.proxy.server.h2_settings.keepalive_interval,
-                    keepalive_timeout: inbound.proxy.server.h2_settings.keepalive_timeout,
-                    ..h2_settings
-                },
+                h2_settings,
             },
         })
         .unwrap_or(super::tap::Config::Disabled);

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -21,6 +21,7 @@ pub struct Settings {
     pub initial_stream_window_size: Option<u32>,
     pub initial_connection_window_size: Option<u32>,
     pub keepalive_timeout: Option<Duration>,
+    pub keepalive_interval: Option<Duration>,
 }
 
 #[derive(Debug)]
@@ -83,6 +84,7 @@ where
             initial_connection_window_size,
             initial_stream_window_size,
             keepalive_timeout,
+            keepalive_interval,
         } = self.h2_settings;
 
         let connect = self
@@ -104,9 +106,14 @@ where
                 if let Some(timeout) = keepalive_timeout {
                     // XXX(eliza): is this a reasonable interval between
                     // PING frames?
-                    let interval = timeout / 4;
                     builder
                         .http2_keep_alive_timeout(timeout)
+                        // set default interval
+                        .http2_keep_alive_interval(timeout / 4)
+                        .http2_keep_alive_while_idle(true);
+                }
+                if let Some(interval) = keepalive_interval {
+                    builder
                         .http2_keep_alive_interval(interval)
                         .http2_keep_alive_while_idle(true);
                 }

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -70,8 +70,13 @@ where
             .http2_initial_connection_window_size(h2.initial_connection_window_size);
         // Configure HTTP/2 PING frames
         if let Some(timeout) = h2.keepalive_timeout {
-            srv.http2_keep_alive_timeout(timeout)
+            srv
+                .http2_keep_alive_timeout(timeout)
+                // set default interval
                 .http2_keep_alive_interval(timeout / 4);
+        }
+        if let Some(interval) = h2.keepalive_interval {
+            srv.http2_keep_alive_interval(interval);
         }
 
         debug!(?version, "Creating HTTP service");


### PR DESCRIPTION
Add environment variables to configure HTTP/2 keepalive timeout and interval

Problem
There is no way to configure timeout and interval via environment variables.

Solution
Configure keepalive timeout and interval for inbound/outbound by `LINKERD2_PROXY_{INBOUND,OUTBOUND}_HTTP2_KEEPALIVE_{TIMEOUT,INTERVAL}`

Fixes https://github.com/linkerd/linkerd2/issues/12269