### PR TITLE
Fix Clippy warnings on nightly

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -2,6 +2,7 @@
 name: rust-beta
 
 on:
+  workflow_dispatch: {}
   pull_request:
     paths:
       - justfile

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,6 +2,7 @@
 name: rust-nightly
 
 on:
+  workflow_dispatch: {}
   pull_request:
     paths:
       - justfile

--- a/hyper-balance/src/lib.rs
+++ b/hyper-balance/src/lib.rs
@@ -418,7 +418,7 @@ mod tests {
         assert!(wk.upgrade().is_none());
     }
 
-    struct Handle(Arc<()>);
+    struct Handle(#[allow(dead_code)] Arc<()>);
     impl Handle {
         fn new() -> (Self, Weak<()>) {
             let strong = Arc::new(());

--- a/linkerd/app/admin/src/server.rs
+++ b/linkerd/app/admin/src/server.rs
@@ -294,7 +294,7 @@ mod tests {
     use super::*;
     use http::method::Method;
     use std::time::Duration;
-    use tokio::{sync::mpsc, time::timeout};
+    use tokio::time::timeout;
     use tower::util::ServiceExt;
 
     const TIMEOUT: Duration = Duration::from_secs(1);

--- a/linkerd/app/gateway/src/http/tests.rs
+++ b/linkerd/app/gateway/src/http/tests.rs
@@ -1,10 +1,8 @@
 use super::*;
 use linkerd_app_core::{
-    proxy::http,
     svc::{NewService, ServiceExt},
-    tls,
     trace::test::trace_init,
-    Error, NameAddr,
+    NameAddr,
 };
 use linkerd_app_inbound::GatewayLoop;
 use linkerd_proxy_server_policy as policy;

--- a/linkerd/app/inbound/src/accept.rs
+++ b/linkerd/app/inbound/src/accept.rs
@@ -113,10 +113,7 @@ mod tests {
         test_util,
     };
     use futures::future;
-    use linkerd_app_core::{
-        svc::{NewService, ServiceExt},
-        Error,
-    };
+    use linkerd_app_core::svc::{NewService, ServiceExt};
     use linkerd_proxy_server_policy::{Authentication, Authorization, Meta, ServerPolicy};
     use std::sync::Arc;
 

--- a/linkerd/app/inbound/src/detect/tests.rs
+++ b/linkerd/app/inbound/src/detect/tests.rs
@@ -4,9 +4,9 @@ use futures::future;
 use linkerd_app_core::{
     io::AsyncWriteExt,
     svc::{NewService, ServiceExt},
-    trace, Error,
+    trace,
 };
-use linkerd_proxy_server_policy::{Authentication, Authorization, Meta, Protocol, ServerPolicy};
+use linkerd_proxy_server_policy::{Authentication, Authorization, Meta, ServerPolicy};
 use std::sync::Arc;
 
 const HTTP1: &[u8] = b"GET / HTTP/1.1\r\nhost: example.com\r\n\r\n";

--- a/linkerd/app/inbound/src/policy/http/tests.rs
+++ b/linkerd/app/inbound/src/policy/http/tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::policy::{Authentication, Authorization, Meta, Protocol, ServerPolicy};
 use linkerd_app_core::{svc::Service, Infallible};
-use std::sync::Arc;
 
 macro_rules! conn {
     ($client:expr, $dst:expr) => {{

--- a/linkerd/app/inbound/src/policy/tcp/tests.rs
+++ b/linkerd/app/inbound/src/policy/tcp/tests.rs
@@ -1,10 +1,7 @@
 use super::*;
 use crate::policy::*;
-use linkerd_app_core::{proxy::http, Error};
-use linkerd_proxy_server_policy::{
-    authz::Suffix, Authentication, Authorization, Protocol, ServerPolicy,
-};
-use std::{collections::BTreeSet, sync::Arc};
+use linkerd_app_core::proxy::http;
+use std::collections::BTreeSet;
 
 #[derive(Clone)]
 pub(crate) struct MockSvc;

--- a/linkerd/app/integration/src/tests/identity.rs
+++ b/linkerd/app/integration/src/tests/identity.rs
@@ -1,10 +1,7 @@
 use crate::*;
 use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    time::{Duration, SystemTime},
+    sync::atomic::{AtomicBool, Ordering},
+    time::SystemTime,
 };
 
 #[tokio::test]

--- a/linkerd/app/integration/src/tests/profiles.rs
+++ b/linkerd/app/integration/src/tests/profiles.rs
@@ -588,7 +588,7 @@ mod http2 {
 
 mod grpc_retry {
     use super::*;
-    use http::header::{HeaderMap, HeaderName, HeaderValue};
+    use http::header::{HeaderName, HeaderValue};
     static GRPC_STATUS: HeaderName = HeaderName::from_static("grpc-status");
     static GRPC_STATUS_OK: HeaderValue = HeaderValue::from_static("0");
     static GRPC_STATUS_UNAVAILABLE: HeaderValue = HeaderValue::from_static("14");

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1,6 +1,5 @@
 use crate::*;
 use std::error::Error as _;
-use tokio::sync::mpsc;
 use tokio::time::timeout;
 
 #[tokio::test]

--- a/linkerd/app/outbound/src/discover/tests.rs
+++ b/linkerd/app/outbound/src/discover/tests.rs
@@ -3,14 +3,10 @@ use crate::test_util::*;
 use linkerd_app_core::{
     io,
     svc::{NewService, Service, ServiceExt},
-    transport::addrs::OrigDstAddr,
 };
-use std::{
-    net::SocketAddr,
-    sync::{
-        atomic::{AtomicUsize, Ordering},
-        Arc,
-    },
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
 };
 use tokio::time;
 

--- a/linkerd/app/outbound/src/http/handle_proxy_error_headers.rs
+++ b/linkerd/app/outbound/src/http/handle_proxy_error_headers.rs
@@ -157,11 +157,7 @@ fn update_response<B>(rsp: &mut http::Response<B>, closable: bool) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
-    use futures::future;
-    use linkerd_app_core::{
-        svc::{self, ServiceExt},
-        Infallible,
-    };
+    use linkerd_app_core::{svc::ServiceExt, Infallible};
     use linkerd_tracing::test;
     use tokio::time;
 

--- a/linkerd/app/outbound/src/http/logical/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/tests.rs
@@ -2,12 +2,12 @@ use super::*;
 use crate::test_util::*;
 use ::http::StatusCode;
 use linkerd_app_core::{
-    errors, exp_backoff::ExponentialBackoff, svc::NewService, svc::ServiceExt, trace, Error,
+    errors, exp_backoff::ExponentialBackoff, svc::NewService, svc::ServiceExt, trace,
 };
 use linkerd_proxy_client_policy as client_policy;
 use parking_lot::Mutex;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
-use tokio::{sync::watch, task, time};
+use tokio::{task, time};
 use tracing::Instrument;
 
 const AUTHORITY: &str = "logical.test.svc.cluster.local";

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -658,7 +658,7 @@ impl From<RequestTarget> for Addr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use svc::{NewService, ServiceExt};
+    use svc::NewService;
     use tokio::{io::AsyncReadExt, io::AsyncWriteExt, time};
     use tower_test::mock;
 

--- a/linkerd/app/outbound/src/opaq/logical/tests.rs
+++ b/linkerd/app/outbound/src/opaq/logical/tests.rs
@@ -3,9 +3,8 @@ use crate::test_util::*;
 use io::AsyncWriteExt;
 use linkerd_app_core::{
     errors::{self, FailFastError},
-    io::{self, AsyncReadExt},
-    profiles::{self, Profile},
-    svc::{self, NewService, ServiceExt},
+    io::AsyncReadExt,
+    svc::{NewService, ServiceExt},
 };
 use std::net::SocketAddr;
 use tokio::time;

--- a/linkerd/app/outbound/src/tcp/tagged_transport.rs
+++ b/linkerd/app/outbound/src/tcp/tagged_transport.rs
@@ -139,12 +139,10 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use futures::future;
     use linkerd_app_core::{
         io::{self, AsyncWriteExt},
-        tls,
         transport::{ClientAddr, Local},
-        transport_header::{self, TransportHeader},
+        transport_header,
     };
     use tower::util::{service_fn, ServiceExt};
 

--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -3,12 +3,11 @@ use crate::spire;
 pub use linkerd_app_core::identity::{client, Id};
 use linkerd_app_core::{
     control, dns,
-    exp_backoff::{ExponentialBackoff, ExponentialBackoffStream},
     identity::{
         client::linkerd::Certify, creds, CertMetrics, Credentials, DerX509, Mode, WithCertMetrics,
     },
     metrics::{prom, ControlHttp as ClientMetrics},
-    Error, Result,
+    Result,
 };
 use std::{future::Future, pin::Pin, time::SystemTime};
 use tokio::sync::watch;
@@ -46,9 +45,6 @@ pub struct Identity {
 }
 
 pub type Task = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
-
-#[derive(Clone, Debug)]
-struct Recover(ExponentialBackoff);
 
 /// Wraps a credential with a watch sender that notifies receivers when the store has been updated
 /// at least once.
@@ -175,15 +171,5 @@ impl Identity {
 
     pub fn run(self) -> Task {
         self.task
-    }
-}
-
-// === impl Recover ===
-
-impl<E: Into<Error>> linkerd_error::Recover<E> for Recover {
-    type Backoff = ExponentialBackoffStream;
-
-    fn recover(&self, _: E) -> Result<Self::Backoff, E> {
-        Ok(self.0.stream())
     }
 }

--- a/linkerd/http-retry/src/replay.rs
+++ b/linkerd/http-retry/src/replay.rs
@@ -275,7 +275,7 @@ where
             if !rest.is_end_stream() {
                 let res = futures::ready!(Pin::new(rest).poll_trailers(cx)).map(|tlrs| {
                     if state.trailers.is_none() {
-                        state.trailers = tlrs.clone();
+                        state.trailers.clone_from(&tlrs);
                     }
                     tlrs
                 });
@@ -503,7 +503,7 @@ impl<B> BodyState<B> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http::{HeaderMap, HeaderValue};
+    use http::HeaderValue;
 
     #[tokio::test]
     async fn replays_one_chunk() {

--- a/linkerd/idle-cache/src/lib.rs
+++ b/linkerd/idle-cache/src/lib.rs
@@ -116,10 +116,10 @@ where
         Self { inner, idle }
     }
 
-    pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<Cached<V>>
+    pub fn get<Q>(&self, key: &Q) -> Option<Cached<V>>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq + fmt::Debug,
+        Q: Hash + Eq + fmt::Debug + ?Sized,
         V: Clone,
     {
         let cache = self.inner.read();

--- a/linkerd/meshtls/rustls/src/server.rs
+++ b/linkerd/meshtls/rustls/src/server.rs
@@ -50,7 +50,7 @@ impl Server {
         let mut orig_rx = self.rx;
 
         let mut c = (**orig_rx.borrow_and_update()).clone();
-        c.alpn_protocols = alpn_protocols.clone();
+        c.alpn_protocols.clone_from(&alpn_protocols);
         let (tx, rx) = watch::channel(c.into());
 
         // Spawn a background task that watches the optional server configuration and publishes it
@@ -74,7 +74,7 @@ impl Server {
                 }
 
                 let mut c = (*orig_rx.borrow().clone()).clone();
-                c.alpn_protocols = alpn_protocols.clone();
+                c.alpn_protocols.clone_from(&alpn_protocols);
                 let _ = tx.send(c.into());
             }
         });

--- a/linkerd/meshtls/tests/util.rs
+++ b/linkerd/meshtls/tests/util.rs
@@ -11,7 +11,7 @@ use linkerd_meshtls as meshtls;
 use linkerd_proxy_transport::{
     addrs::*,
     listen::{Addrs, Bind, BindTcp},
-    ConnectTcp, Keepalive, ListenAddr,
+    ConnectTcp, Keepalive,
 };
 use linkerd_stack::{
     layer::Layer, service_fn, ExtractParam, InsertParam, NewService, Param, ServiceExt,
@@ -21,7 +21,6 @@ use linkerd_tls_test_util as test_util;
 use rcgen::{BasicConstraints, Certificate, CertificateParams, IsCa, SanType};
 use std::str::FromStr;
 use std::{
-    future::Future,
     net::SocketAddr,
     sync::mpsc,
     time::{Duration, SystemTime},

--- a/linkerd/proxy/api-resolve/src/pb.rs
+++ b/linkerd/proxy/api-resolve/src/pb.rs
@@ -148,7 +148,6 @@ pub(crate) fn to_sock_addr(pb: TcpAddress) -> Option<SocketAddr> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::api::destination::TlsIdentity;
     use linkerd2_proxy_api::destination::tls_identity::{
         DnsLikeIdentity, Strategy, UriLikeIdentity,
     };

--- a/linkerd/proxy/http/src/classify/channel.rs
+++ b/linkerd/proxy/http/src/classify/channel.rs
@@ -278,11 +278,8 @@ impl<C: ClassifyEos, B> PinnedDrop for ResponseBody<C, B> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::classify::ClassifyResponse;
-    use linkerd_error::Error;
     use linkerd_http_box::BoxBody;
-    use linkerd_http_classify::ClassifyEos;
-    use tokio::{sync::mpsc, time};
+    use tokio::time;
     use tokio_test::assert_ready;
     use tower_test::mock;
 

--- a/linkerd/proxy/spire-client/src/lib.rs
+++ b/linkerd/proxy/spire-client/src/lib.rs
@@ -61,10 +61,9 @@ mod tests {
     use super::*;
     use crate::api::Svid;
     use linkerd_error::Result;
-    use linkerd_identity::{Credentials, DerX509, Id};
+    use linkerd_identity::DerX509;
     use rcgen::{Certificate, CertificateParams, SanType, SerialNumber};
     use std::time::SystemTime;
-    use tokio::sync::watch;
 
     fn gen_svid(id: Id, subject_alt_names: Vec<SanType>, serial: SerialNumber) -> Svid {
         let mut params = CertificateParams::default();

--- a/linkerd/proxy/tap/src/grpc/match_.rs
+++ b/linkerd/proxy/tap/src/grpc/match_.rs
@@ -312,7 +312,6 @@ impl TryFrom<observe_request::r#match::Http> for HttpMatch {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ipnet::{Ipv4Net, Ipv6Net};
     use linkerd2_proxy_api::http_types;
     use quickcheck::*;
     use std::collections::HashMap;

--- a/linkerd/stack/src/failfast/test.rs
+++ b/linkerd/stack/src/failfast/test.rs
@@ -1,5 +1,4 @@
 use super::*;
-use std::time::Duration;
 use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok, task};
 use tower_test::mock::{self, Spawn};
 

--- a/linkerd/stack/src/lazy.rs
+++ b/linkerd/stack/src/lazy.rs
@@ -104,7 +104,6 @@ impl<T, N, S: Clone> Clone for Lazy<T, N, S> {
 mod tests {
     use super::*;
     use crate::layer::Layer;
-    use std::sync::Arc;
     use tokio_test::{assert_pending, assert_ready_ok};
     use tower::ServiceExt;
     use tower_test::mock;

--- a/linkerd/stack/src/watch.rs
+++ b/linkerd/stack/src/watch.rs
@@ -140,7 +140,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::NewService;
     use tokio::sync::watch;
     use tower::ServiceExt;
     use tower_test::mock;


### PR DESCRIPTION
Our nightly build is failing due to some dead code warnings that aren't being
triggered on stable.

This change runs `cargo +nightly clippy --fix` and then manually fixes the
remaining issues.
