### PR TITLE
ci: Use rust-cache in PR workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 concurrency:
-  group:  ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 env:
@@ -49,6 +49,7 @@ jobs:
       CXX: "/usr/bin/clang++-14"
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
       - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-transport-header --exclude=opencensus-proto --exclude=spire-proto --no-run
       - run: cargo tarpaulin --locked --workspace --exclude=linkerd2-proxy --exclude=linkerd-transport-header --exclude=opencensus-proto --exclude=spire-proto --skip-clean --ignore-tests --no-fail-fast --out=Xml
         # Some tests are especially flakey in coverage tests. That's fine. We

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ env:
   RUSTFLAGS: "-D warnings -D deprecated -C debuginfo=0"
 
 concurrency:
-  group:  ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
       - id: cargo
         uses: tj-actions/changed-files@77af4bed286740ef1a6387dc4e4e4dec39f96054
         with:
-          files_ignore: 'Cargo.toml'
+          files_ignore: "Cargo.toml"
           files: |
             **/Cargo.toml
       - id: cargo-crates
@@ -90,8 +90,9 @@ jobs:
       contents: read
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
       - run: just fetch
       - name: Run cargo deny check bans licenses sources
         uses: EmbarkStudios/cargo-deny-action@64015a69ee7ee08f6c56455089cdaf6ad974fd15
@@ -113,8 +114,9 @@ jobs:
       matrix:
         crate: ${{ fromJson(needs.meta.outputs.cargo_crates) }}
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
       - run: just fetch
       - run: just check-crate ${{ matrix.crate }}
 
@@ -167,7 +169,7 @@ jobs:
 
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
         if: needs.meta.outputs.is_dependabot == 'true' && needs.meta.outputs.any_changed == 'true'
-      - name: 'Merge dependabot changes'
+      - name: "Merge dependabot changes"
         if: needs.meta.outputs.is_dependabot == 'true' && needs.meta.outputs.any_changed == 'true'
         run: gh pr merge '${{ github.event.pull_request.number }}' --auto --squash
         env:


### PR DESCRIPTION
The Swatinem/rust-cache action attempts to cache dependencies for rust builds.

This PR adds it to the PR and Coverage workflows.