### PR TITLE
pool: Extract MockPool into a standalone crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkerd-pool-mock"
+version = "0.1.0"
+dependencies = [
+ "linkerd-error",
+ "linkerd-pool",
+ "linkerd-stack",
+ "parking_lot",
+ "thiserror",
+ "tokio",
+ "tower-test",
+ "tracing",
+]
+
+[[package]]
 name = "linkerd-pool-p2c"
 version = "0.1.0"
 dependencies = [
@@ -1718,6 +1732,7 @@ dependencies = [
  "linkerd-error",
  "linkerd-metrics",
  "linkerd-pool",
+ "linkerd-pool-mock",
  "linkerd-proxy-core",
  "linkerd-stack",
  "linkerd-tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "linkerd/metrics",
     "linkerd/opencensus",
     "linkerd/pool",
+    "linkerd/pool/mock",
     "linkerd/pool/p2c",
     "linkerd/proxy/api-resolve",
     "linkerd/proxy/balance",
@@ -81,4 +82,3 @@ members = [
 [profile.release]
 debug = 1
 lto = true
-

--- a/linkerd/pool/mock/Cargo.toml
+++ b/linkerd/pool/mock/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "linkerd-pool-mock"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+parking_lot = "0.12"
+thiserror = "1"
+tokio = { version = "1", features = ["sync", "time"] }
+tower-test = "0.4"
+tracing = "0.1"
+
+linkerd-error = { path = "../../error" }
+linkerd-pool = { path = ".." }
+linkerd-stack = { path = "../../stack" }

--- a/linkerd/pool/mock/src/lib.rs
+++ b/linkerd/pool/mock/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
+#![forbid(unsafe_code)]
+
 use linkerd_error::Error;
 use parking_lot::Mutex;
 use std::net::SocketAddr;
@@ -60,7 +63,7 @@ pub struct PoolError;
 #[error("mock resolution error")]
 pub struct ResolutionError;
 
-impl<T, Req, Rsp> crate::Pool<T, Req> for MockPool<T, Req, Rsp> {
+impl<T, Req, Rsp> linkerd_pool::Pool<T, Req> for MockPool<T, Req, Rsp> {
     fn reset_pool(&mut self, update: Vec<(SocketAddr, T)>) {
         let _ = self.tx.send(Change::Reset(update));
     }
@@ -90,7 +93,7 @@ impl<T, Req, Rsp> linkerd_stack::Service<Req> for MockPool<T, Req, Rsp> {
             return Poll::Ready(res);
         }
         // Drive the pool when the service isn't ready.
-        let _ = crate::Pool::poll_pool(self, cx)?;
+        let _ = linkerd_pool::Pool::poll_pool(self, cx)?;
         Poll::Pending
     }
 

--- a/linkerd/proxy/balance/queue/Cargo.toml
+++ b/linkerd/proxy/balance/queue/Cargo.toml
@@ -23,7 +23,9 @@ linkerd-pool = { path = "../../../pool" }
 linkerd-stack = { path = "../../../stack" }
 
 [dev-dependencies]
-linkerd-tracing = { path = "../../../tracing" }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-test = "0.4"
 tower-test = "0.4"
+
+linkerd-pool-mock = { path = "../../../pool/mock" }
+linkerd-tracing = { path = "../../../tracing" }

--- a/linkerd/proxy/balance/queue/src/tests.rs
+++ b/linkerd/proxy/balance/queue/src/tests.rs
@@ -2,13 +2,12 @@
 
 use crate::PoolQueue;
 use futures::prelude::*;
+use linkerd_pool_mock as mock;
 use linkerd_proxy_core::Update;
 use linkerd_stack::{Service, ServiceExt};
 use tokio::{sync::mpsc, time};
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_test::{assert_pending, assert_ready};
-
-mod mock;
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn processes_requests() {


### PR DESCRIPTION
This enables this to be reused in other crates.