### PR TITLE
cargo-deny: Ignore private crates

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,8 @@ deny = []
 copyleft = "deny"
 allow-osi-fsf-free = "neither"
 default = "deny"
+# Ignore local workspace license values for unpublished crates.
+private = { ignore = true }
 confidence-threshold = 0.8
 exceptions = [
     { allow = [


### PR DESCRIPTION
There's no point in having to specify the license value on all our unpublished crates. This commit relaxes the license check for private crates.