### PR TITLE
ci: Update release workflow to use arbitrary references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s extglob
-          if [[ '${{ github.event_name }}' == "pull_request" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
             echo version="0.0.0-test.${GITHUB_SHA:0:7}"
             echo archs='["amd64"]'
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       package: ${{ github.event_name == 'workflow_dispatch' || steps.changed.outputs.any_changed == 'true' }}
       profile: ${{ inputs.profile || 'release' }}
+      publish: ${{ inputs.publish == 'true' }}
       ref: ${{ inputs.ref || github.ref }}
       tag: "${{ inputs.tag-prefix || 'release/' }}v${{ steps.meta.outputs.version }}"
       prerelease: ${{ inputs.prerelease }}
@@ -114,6 +115,7 @@ jobs:
           echo 'needs.meta.outputs.version: ${{ needs.meta.outputs.version }}'
           echo 'needs.meta.outputs.package: ${{ needs.meta.outputs.package }}'
           echo 'needs.meta.outputs.profile: ${{ needs.meta.outputs.profile }}'
+          echo 'needs.meta.outputs.publish: ${{ needs.meta.outputs.publish }}'
           echo 'needs.meta.outputs.ref: ${{ needs.meta.outputs.ref }}'
           echo 'needs.meta.outputs.prerelease: ${{ needs.meta.outputs.prerelease }}'
           echo 'needs.meta.outputs.draft: ${{ needs.meta.outputs.draft }}'
@@ -129,7 +131,7 @@ jobs:
 
     # If we're not actually building on a release tag, don't short-circuit on
     # errors. This helps us know whether a failure is platform-specific.
-    continue-on-error: ${{ inputs.publish != 'true' }}
+    continue-on-error: ${{ needs.meta.outputs.publish != 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     container: docker://ghcr.io/linkerd/dev:v43-rust-musl
@@ -177,9 +179,9 @@ jobs:
           path: artifacts
       - run: du -h artifacts/**/*
       # Publish the release.
-      - if: inputs.publish == 'true'
+      - if: needs.meta.outputs.publish == 'true'
         run: git push origin '${{ needs.meta.outputs.tag }}'
-      - if: inputs.publish == 'true'
+      - if: needs.meta.outputs.publish == 'true'
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         with:
           name: v${{ needs.meta.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,16 @@ on:
         required: false
         type: string
         default: ""
+      prerelease:
+        description: "Is this a prerelease?"
+        required: false
+        type: boolean
+        default: false
+      draft:
+        description: "Is this a draft?"
+        required: false
+        type: boolean
+        default: false
 
 env:
   CARGO_INCREMENTAL: 0
@@ -83,6 +93,9 @@ jobs:
       package: ${{ github.event_name == 'workflow_dispatch' || steps.changed.outputs.any_changed == 'true' }}
       profile: ${{ inputs.profile || 'release' }}
       ref: ${{ inputs.ref || github.ref }}
+      tag: "${{ inputs.tag-prefix || 'release/' }}v${{ steps.meta.outputs.version }}"
+      prerelease: ${{ inputs.prerelease }}
+      draft: ${{ inputs.draft }}
 
   info:
     needs: meta
@@ -102,6 +115,8 @@ jobs:
           echo 'needs.meta.outputs.package: ${{ needs.meta.outputs.package }}'
           echo 'needs.meta.outputs.profile: ${{ needs.meta.outputs.profile }}'
           echo 'needs.meta.outputs.ref: ${{ needs.meta.outputs.ref }}'
+          echo 'needs.meta.outputs.prerelease: ${{ needs.meta.outputs.prerelease }}'
+          echo 'needs.meta.outputs.draft: ${{ needs.meta.outputs.draft }}'
 
   package:
     needs: meta
@@ -145,8 +160,6 @@ jobs:
     timeout-minutes: 5
     permissions:
       contents: write
-    env:
-      TAG: "${{ inputs.tag-prefix }}v${{ needs.meta.outputs.version }}"
     steps:
       - name: Configure git
         run: |
@@ -157,7 +170,7 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
         with:
           ref: ${{ needs.meta.outputs.ref }}
-      - run: git tag -a -m "v${{ needs.meta.outputs.version }}" "$TAG"
+      - run: git tag -a -m 'v${{ needs.meta.outputs.version }}' '${{ needs.meta.outputs.tag }}'
       # Fetch the artifacts.
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
         with:
@@ -165,14 +178,16 @@ jobs:
       - run: du -h artifacts/**/*
       # Publish the release.
       - if: inputs.publish == 'true'
-        run: git push origin "$TAG"
+        run: git push origin '${{ needs.meta.outputs.tag }}'
       - if: inputs.publish == 'true'
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         with:
           name: v${{ needs.meta.outputs.version }}
-          tag_name: ${{ env.TAG }}
+          tag_name: ${{ needs.meta.outputs.tag }}
           files: artifacts/**/*
           generate_release_notes: true
+          prerelease: ${{ needs.meta.outputs.prerelease }}
+          draft: ${{ needs.meta.outputs.draft }}
 
   release-ok:
     needs: publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       package: ${{ github.event_name == 'workflow_dispatch' || steps.changed.outputs.any_changed == 'true' }}
       profile: ${{ inputs.profile || 'release' }}
-      publish: ${{ inputs.publish == 'true' }}
+      publish: ${{ inputs.publish }}
       ref: ${{ inputs.ref || github.ref }}
       tag: "${{ inputs.tag-prefix || 'release/' }}v${{ steps.meta.outputs.version }}"
       prerelease: ${{ inputs.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,11 @@ on:
         required: false
         type: boolean
         default: false
+      ref:
+        description: "Reference of the commit to release (default: github.ref)"
+        required: false
+        type: string
+        default: ""
 
 env:
   CARGO_INCREMENTAL: 0
@@ -43,14 +48,13 @@ jobs:
     steps:
       - id: meta
         env:
-          SHA: ${{ github.sha }}
           VERSION: ${{ inputs.version }}
         shell: bash
         run: |
           set -euo pipefail
           shopt -s extglob
           if [[ '${{ github.event_name }}' == "pull_request" ]]; then
-            echo version="0.0.0-test.${SHA:0:7}"
+            echo version="0.0.0-test.${GITHUB_SHA:0:7}"
             echo archs='["amd64"]'
             exit 0
           fi >> "$GITHUB_OUTPUT"
@@ -78,6 +82,7 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       package: ${{ github.event_name == 'workflow_dispatch' || steps.changed.outputs.any_changed == 'true' }}
       profile: ${{ inputs.profile || 'release' }}
+      ref: ${{ inputs.ref || github.ref }}
 
   info:
     needs: meta
@@ -91,10 +96,12 @@ jobs:
           echo 'inputs.tag-prefix: ${{ inputs.tag-prefix }}'
           echo 'inputs.profile: ${{ inputs.profile }}'
           echo 'inputs.publish: ${{ inputs.publish }}'
+          echo 'inputs.ref: ${{ inputs.ref }}'
           echo 'needs.meta.outputs.archs: ${{ needs.meta.outputs.archs }}'
           echo 'needs.meta.outputs.version: ${{ needs.meta.outputs.version }}'
           echo 'needs.meta.outputs.package: ${{ needs.meta.outputs.package }}'
           echo 'needs.meta.outputs.profile: ${{ needs.meta.outputs.profile }}'
+          echo 'needs.meta.outputs.ref: ${{ needs.meta.outputs.ref }}'
 
   package:
     needs: meta
@@ -118,6 +125,8 @@ jobs:
       - name: Configure git
         run: git config --global --add safe.directory "$PWD" # actions/runner#2033
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          ref: ${{ needs.meta.outputs.ref }}
       - uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84
         with:
           key: ${{ matrix.libc }}
@@ -146,6 +155,8 @@ jobs:
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
       # Tag the release.
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+        with:
+          ref: ${{ needs.meta.outputs.ref }}
       - run: git tag -a -m "v${{ needs.meta.outputs.version }}" "$TAG"
       # Fetch the artifacts.
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427


### PR DESCRIPTION
This allows unnamed references to be released, which is necessary now that the release workflow produces tag references.