### PR TITLE
ci: Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      actions: write
       contents: write
     steps:
       - name: Configure git


### PR DESCRIPTION
The release workflow needs to be able to write actions.