### PR TITLE
ci: Update release workflow to use a PAT

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,13 +165,16 @@ jobs:
       contents: write
     steps:
       - name: Configure git
+        env:
+          GITHUB_USERNAME: ${{ vars.LINKERD2_PROXY_GITHUB_USERNAME || 'github-actions[bot]' }}
         run: |
           git config --global --add safe.directory "$PWD" # actions/runner#2033
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global user.name "$GITHUB_USERNAME"
+          git config --global user.email "$GITHUB_USERNAME"@users.noreply.github.com
       # Tag the release.
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
         with:
+          token: ${{ secrets.LINKERD2_PROXY_GITHUB_TOKEN || github.token }}
           ref: ${{ needs.meta.outputs.ref }}
       - run: git tag -a -m 'v${{ needs.meta.outputs.version }}' '${{ needs.meta.outputs.tag }}'
       # Fetch the artifacts.


### PR DESCRIPTION
The proxy release workflow now pushes tags. When pushing a tag, we can be in the position of modifying GitHub workflows, and so we need 'workflows: write' permissons. These permisson cannot be granted to github-actions[bot].

This change updates the release worfklow to use Actions metadata to configure GitHub authentication.