### PR TITLE
ci: Configure integration test retries

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -103,6 +103,8 @@ jobs:
       - run: just doc
       - run: just test --exclude=linkerd2-proxy --no-run
       - run: just test --exclude=linkerd2-proxy
+        env:
+          NEXTEST_RETRIES: 3
 
   rust-crates:
     needs: meta


### PR DESCRIPTION
Some integration tests can fail in CI due to resource volatility.

This commit configures the PR workflow to use NEXTEST_RETRIES=3 to automatically retry flakey tests.