### PR TITLE
ci: Automate weekly proxy releases

### DIFF
--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -1,0 +1,78 @@
+name: Weekly proxy release
+
+on:
+  schedule:
+    # Wednesday at ~8:40PM Pacific
+    - cron: "40 3 * * 3"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  last-release:
+    if: github.repository == 'linkerd/linkerd2-proxy' # Don't run this in forks.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Latest release
+        id: latest
+        run: gh release view --json name,publishedAt | jq -r 'to_entries[] | (.key + "=" + .value)' >> "$GITHUB_OUTPUT"
+      - name: Check if release was in last 72 hours
+        id: recency
+        env:
+          PUBLISHED_AT: ${{ steps.latest.outputs.publishedAt }}
+        run: |
+          if [ "$(date -d "$PUBLISHED_AT" +%s)" -gt "$(date -d '72 hours ago' +%s)" ]; then
+            echo "Last release $PUBLISHED_AT is recent" >&2
+            echo "recent=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Last release $PUBLISHED_AT is not recent" >&2
+            echo "recent=false" >> "$GITHUB_OUTPUT"
+          fi
+    outputs:
+      version: ${{ steps.latest.outputs.name }}
+      published-at: ${{ steps.latest.outputs.publishedAt }}
+      recent: ${{ steps.recency.outputs.recent == 'true' }}
+
+  last-commit:
+    needs: last-release
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
+      - name: Check if the most recent commit is after the last release
+        id: recency
+        env:
+          PUBLISHED_AT: ${{ needs.last-release.outputs.published-at }}
+        run: |
+          if [ "$(git log -1 --format=%ct)" -gt "$(date -d "$PUBLISHED_AT" +%s)" ]; then
+            echo "HEAD after last release $PUBLISHED_AT" >&2
+            echo "after-release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "after-release=false" >> "$GITHUB_OUTPUT"
+          fi
+    outputs:
+      after-release: ${{ steps.recency.outputs.after-release == 'true' }}
+
+  trigger-release:
+    needs: [last-release, last-commit]
+    if: needs.last-release.outputs.recent == 'false' && needs.last-commit.outputs.after-release == 'true'
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    permissions:
+      actions: write
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+      LAST_VERSION: ${{ needs.last-release.outputs.version }}
+    steps:
+      - name: Get the latest minor version
+        run: |
+          m="$(echo "$LAST_VERSION" | cut -d. -f2)"
+          echo MINOR_VERSION="$((m+1))" >> "$GITHUB_ENV"
+      - run: gh workflow run release.yml -f publish=true -f version=v2."$MINOR_VERSION".0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,6 +163,9 @@ jobs:
     permissions:
       actions: write
       contents: write
+    env:
+      VERSION: v${{ needs.meta.outputs.version }}
+      TAG: ${{ needs.meta.outputs.tag }}
     steps:
       - name: Configure git
         env:
@@ -176,7 +179,7 @@ jobs:
         with:
           token: ${{ secrets.LINKERD2_PROXY_GITHUB_TOKEN || github.token }}
           ref: ${{ needs.meta.outputs.ref }}
-      - run: git tag -a -m 'v${{ needs.meta.outputs.version }}' '${{ needs.meta.outputs.tag }}'
+      - run: git tag -a -m "$VERSION" "$TAG"
       # Fetch the artifacts.
       - uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427
         with:
@@ -184,16 +187,22 @@ jobs:
       - run: du -h artifacts/**/*
       # Publish the release.
       - if: needs.meta.outputs.publish == 'true'
-        run: git push origin '${{ needs.meta.outputs.tag }}'
+        run: git push origin "$TAG"
       - if: needs.meta.outputs.publish == 'true'
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564
         with:
-          name: v${{ needs.meta.outputs.version }}
-          tag_name: ${{ needs.meta.outputs.tag }}
+          name: v${{ env.VERSION }}
+          tag_name: ${{ env.TAG }}
           files: artifacts/**/*
           generate_release_notes: true
           prerelease: ${{ needs.meta.outputs.prerelease }}
           draft: ${{ needs.meta.outputs.draft }}
+      - if: needs.meta.outputs.publish == 'true'
+        name: Trigger sync-proxy in linkerd2
+        run: gh workflow run sync-proxy.yml -f version="$VERSION"
+        env:
+          GH_REPO: ${{ vars.LINKERD2_REPO || 'linkerd/linkerd2' }}
+          GH_TOKEN: ${{ secrets.LINKERD2_GITHUB_TOKEN }}
 
   release-ok:
     needs: publish


### PR DESCRIPTION
This commit adds a release-weekly workflow that runs on Wednesday nights. If there hasn't been a proxy release earlier in the week and there are new commits on main, then a new release is triggered.