### PR TITLE
proxy-http: Box request bodies

### DIFF
--- a/linkerd/app/admin/src/server.rs
+++ b/linkerd/app/admin/src/server.rs
@@ -196,7 +196,7 @@ impl<M> Admin<M> {
 impl<M, B> tower::Service<http::Request<B>> for Admin<M>
 where
     M: FmtMetrics,
-    B: HttpBody + Send + Sync + 'static,
+    B: HttpBody + Send + 'static,
     B::Error: Into<Error>,
     B::Data: Send,
 {

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -115,8 +115,7 @@ impl<H> Inbound<H> {
             let h2 = config.proxy.server.h2_settings;
             let drain = rt.drain.clone();
 
-            http.push_on_service(http::BoxRequest::layer())
-                .check_new_service::<T, http::Request<_>>()
+            http.check_new_service::<T, http::Request<http::BoxBody>>()
                 .unlift_new()
                 .check_new_new_service::<T, http::ClientHandle, http::Request<_>>()
                 .push(http::NewServeHttp::layer(move |t: &T| http::ServerParams {

--- a/linkerd/app/outbound/src/protocol.rs
+++ b/linkerd/app/outbound/src/protocol.rs
@@ -49,8 +49,7 @@ impl<N> Outbound<N> {
         let http = self.with_stack(http).map_stack(|config, rt, stk| {
             let h2 = config.proxy.server.h2_settings;
             let drain = rt.drain.clone();
-            stk.push_on_service(http::BoxRequest::layer())
-                .unlift_new()
+            stk.unlift_new()
                 .push(http::NewServeHttp::layer(move |t: &Http<T>| {
                     http::ServerParams {
                         version: t.version,

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -33,7 +33,6 @@ pub use self::{
     },
     client_handle::{ClientHandle, SetClientHandle},
     detect::DetectHttp,
-    glue::{HyperServerSvc, UpgradeBody},
     header_from_target::NewHeaderFromTarget,
     normalize_uri::{MarkAbsoluteForm, NewNormalizeUri},
     override_authority::{AuthorityOverride, NewOverrideAuthority},

--- a/linkerd/proxy/tap/src/accept.rs
+++ b/linkerd/proxy/tap/src/accept.rs
@@ -5,7 +5,7 @@ use linkerd_conditional::Conditional;
 use linkerd_error::Error;
 use linkerd_io as io;
 use linkerd_meshtls as meshtls;
-use linkerd_proxy_http::{trace, HyperServerSvc};
+use linkerd_proxy_http::trace;
 use linkerd_tls as tls;
 use std::{
     collections::HashSet,
@@ -48,7 +48,7 @@ impl AcceptPermittedClients {
             hyper::server::conn::Http::new()
                 .with_executor(trace::Executor::new())
                 .http2_only(true)
-                .serve_connection(io, HyperServerSvc::new(svc))
+                .serve_connection(io, svc)
                 .await
                 .map_err(Into::into)
         })


### PR DESCRIPTION
The proxy HTTP server emits requests with an UpgradeBody type (as required by the server module that sets up HTTP CONNECT handling). We also wrap HTTP/2 requests in this body even though we do not currently support CONNECT over HTTP/2. The inbound and outbound server stacks then Box the request body so that the UpgradeBody type is hidden.

This commit moves the Box-ing of the request body into the HTTP server to reduce boilerplate.

This change sets up for additional HTTP server changes. There are no functional changes.