### PR TITLE
proxy-http: Simplify TracingExecutor

### DIFF
--- a/linkerd/app/integration/src/client.rs
+++ b/linkerd/app/integration/src/client.rs
@@ -1,5 +1,5 @@
 use super::*;
-use linkerd_app_core::proxy::http::trace;
+use linkerd_app_core::proxy::http::TracingExecutor;
 use parking_lot::Mutex;
 use std::io;
 use tokio::net::TcpStream;
@@ -252,7 +252,7 @@ fn run(
     let work = async move {
         let client = hyper::Client::builder()
             .http2_only(http2_only)
-            .executor(trace::Executor::new())
+            .executor(TracingExecutor)
             .build::<Conn, hyper::Body>(conn);
         tracing::trace!("client task started");
         let mut rx = rx;

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub use linkerd2_proxy_api::destination as pb;
 use linkerd2_proxy_api::net;
-use linkerd_app_core::proxy::http::trace;
+use linkerd_app_core::proxy::http::TracingExecutor;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
 use std::net::IpAddr;
@@ -372,7 +372,7 @@ where
                 let _ = listening_tx.send(());
             }
 
-            let mut http = hyper::server::conn::Http::new().with_executor(trace::Executor::new());
+            let mut http = hyper::server::conn::Http::new().with_executor(TracingExecutor);
             http.http2_only(true);
             loop {
                 let (sock, addr) = listener.accept().await?;

--- a/linkerd/app/integration/src/server.rs
+++ b/linkerd/app/integration/src/server.rs
@@ -1,5 +1,5 @@
+use super::app_core::svc::http::TracingExecutor;
 use super::*;
-use linkerd_app_core::proxy::http::trace;
 use std::{
     io,
     sync::atomic::{AtomicUsize, Ordering},
@@ -194,8 +194,7 @@ impl Server {
             async move {
                 tracing::info!("support server running");
                 let mut new_svc = NewSvc(Arc::new(self.routes));
-                let mut http =
-                    hyper::server::conn::Http::new().with_executor(trace::Executor::new());
+                let mut http = hyper::server::conn::Http::new().with_executor(TracingExecutor);
                 match self.version {
                     Run::Http1 => http.http1_only(true),
                     Run::Http2 => http.http2_only(true),

--- a/linkerd/proxy/http/src/executor.rs
+++ b/linkerd/proxy/http/src/executor.rs
@@ -2,15 +2,9 @@ use std::future::Future;
 use tracing::instrument::Instrument;
 
 #[derive(Clone, Debug, Default)]
-pub struct Executor(());
+pub struct TracingExecutor;
 
-impl Executor {
-    pub fn new() -> Self {
-        Self(())
-    }
-}
-
-impl<F> hyper::rt::Executor<F> for Executor
+impl<F> hyper::rt::Executor<F> for TracingExecutor
 where
     F: Future + Send + 'static,
     F::Output: Send + 'static,

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -1,4 +1,4 @@
-use crate::trace;
+use crate::executor::TracingExecutor;
 use futures::prelude::*;
 pub use h2::{Error as H2Error, Reason};
 use hyper::{
@@ -95,10 +95,10 @@ where
                 let (io, _meta) = connect.err_into::<Error>().await?;
                 let mut builder = conn::Builder::new();
                 builder
+                    .executor(TracingExecutor)
                     .http2_only(true)
                     .http2_initial_stream_window_size(initial_stream_window_size)
-                    .http2_initial_connection_window_size(initial_connection_window_size)
-                    .executor(trace::Executor::new());
+                    .http2_initial_connection_window_size(initial_connection_window_size);
 
                 // Configure HTTP/2 PING frames
                 if let Some(timeout) = keepalive_timeout {

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -9,6 +9,7 @@ pub mod classify;
 pub mod client;
 pub mod client_handle;
 pub mod detect;
+mod executor;
 mod glue;
 pub mod h1;
 pub mod h2;
@@ -21,7 +22,6 @@ mod retain;
 mod server;
 pub mod strip_header;
 pub mod timeout;
-pub mod trace;
 pub mod upgrade;
 pub mod version;
 
@@ -33,6 +33,7 @@ pub use self::{
     },
     client_handle::{ClientHandle, SetClientHandle},
     detect::DetectHttp,
+    executor::TracingExecutor,
     header_from_target::NewHeaderFromTarget,
     normalize_uri::{MarkAbsoluteForm, NewNormalizeUri},
     override_authority::{AuthorityOverride, NewOverrideAuthority},

--- a/linkerd/proxy/tap/src/accept.rs
+++ b/linkerd/proxy/tap/src/accept.rs
@@ -5,7 +5,7 @@ use linkerd_conditional::Conditional;
 use linkerd_error::Error;
 use linkerd_io as io;
 use linkerd_meshtls as meshtls;
-use linkerd_proxy_http::trace;
+use linkerd_proxy_http::TracingExecutor;
 use linkerd_tls as tls;
 use std::{
     collections::HashSet,
@@ -46,7 +46,7 @@ impl AcceptPermittedClients {
         let svc = TapServer::new(tap);
         Box::pin(async move {
             hyper::server::conn::Http::new()
-                .with_executor(trace::Executor::new())
+                .with_executor(TracingExecutor)
                 .http2_only(true)
                 .serve_connection(io, svc)
                 .await


### PR DESCRIPTION
The proxy::http::trace module was a bit of a misnomer, as it has nothing to do with "tracing" per-se, and much more to do with being a hyper executor.

This change renames the module and hides it form public export for clarity. It also simplifies instantiation of the executor.