### PR TITLE
control: Configure controller client H2 settings

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -115,7 +115,7 @@ impl Config {
             .push(tls::Client::layer(identity))
             .push_connect_timeout(self.connect.timeout)
             .push_map_target(|(_version, target)| target)
-            .push(self::client::layer())
+            .push(self::client::layer(self.connect.h2_settings))
             .push_on_service(svc::MapErr::layer_boxed())
             .into_new_service();
 
@@ -353,10 +353,12 @@ mod client {
 
     // === impl Layer ===
 
-    pub fn layer<C, B>() -> impl svc::Layer<C, Service = http::h2::Connect<C, B>> + Copy
+    pub fn layer<C, B>(
+        settings: H2Settings,
+    ) -> impl svc::Layer<C, Service = http::h2::Connect<C, B>> + Copy
     where
         http::h2::Connect<C, B>: tower::Service<Target>,
     {
-        svc::layer::mk(|mk_conn| http::h2::Connect::new(mk_conn, H2Settings::default()))
+        svc::layer::mk(move |mk_conn| http::h2::Connect::new(mk_conn, settings))
     }
 }


### PR DESCRIPTION
The controller client is supposed to be configured with H2 settings derived from the environment, but it incorrectly uses defaults.

This change updates the controller client to be configured with the proper H2 client settings.