### PR TITLE
chore(proxy-http): Move utilities out of h1 module

### DIFF
--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -77,9 +77,9 @@ pub fn http_request_authority_addr<B>(req: &http::Request<B>) -> Result<Addr, ad
 }
 
 pub fn http_request_host_addr<B>(req: &http::Request<B>) -> Result<Addr, addr::Error> {
-    use crate::proxy::http::h1;
+    use crate::proxy::http;
 
-    h1::authority_from_host(req)
+    http::authority_from_header(req, http::header::HOST)
         .ok_or(addr::Error::InvalidHost)
         .and_then(|a| Addr::from_authority_and_default_port(&a, DEFAULT_PORT))
 }

--- a/linkerd/proxy/http/src/glue.rs
+++ b/linkerd/proxy/http/src/glue.rs
@@ -1,4 +1,4 @@
-use crate::{upgrade::Http11Upgrade, HasH2Reason};
+use crate::upgrade::Http11Upgrade;
 use bytes::Bytes;
 use futures::TryFuture;
 use hyper::body::HttpBody;
@@ -177,14 +177,6 @@ where
             transport,
             absolute_form: *this.absolute_form,
         }))
-    }
-}
-
-// === impl Error ===
-
-impl HasH2Reason for hyper::Error {
-    fn h2_reason(&self) -> Option<h2::Reason> {
-        (self as &(dyn std::error::Error + 'static)).h2_reason()
     }
 }
 

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -79,6 +79,12 @@ impl HasH2Reason for ::h2::Error {
     }
 }
 
+impl HasH2Reason for ::hyper::Error {
+    fn h2_reason(&self) -> Option<h2::Reason> {
+        (self as &(dyn std::error::Error + 'static)).h2_reason()
+    }
+}
+
 /// Returns an Authority from the value of `header`.
 pub fn authority_from_header<B, K>(req: &http::Request<B>, header: K) -> Option<Authority>
 where
@@ -86,4 +92,46 @@ where
 {
     let v = req.headers().get(header)?;
     v.to_str().ok()?.parse().ok()
+}
+
+fn set_authority(uri: &mut uri::Uri, auth: uri::Authority) {
+    let mut parts = uri::Parts::from(std::mem::take(uri));
+
+    parts.authority = Some(auth);
+
+    // If this was an origin-form target (path only),
+    // then we can't *only* set the authority, as that's
+    // an illegal target (such as `example.com/docs`).
+    //
+    // But don't set a scheme if this was authority-form (CONNECT),
+    // since that would change its meaning (like `https://example.com`).
+    if parts.path_and_query.is_some() {
+        parts.scheme = Some(http::uri::Scheme::HTTP);
+    }
+
+    let new = http::uri::Uri::from_parts(parts).expect("absolute uri");
+
+    *uri = new;
+}
+
+fn strip_connection_headers(headers: &mut http::HeaderMap) {
+    if let Some(val) = headers.remove(header::CONNECTION) {
+        if let Ok(conn_header) = val.to_str() {
+            // A `Connection` header may have a comma-separated list of
+            // names of other headers that are meant for only this specific
+            // connection.
+            //
+            // Iterate these names and remove them as headers.
+            for name in conn_header.split(',') {
+                let name = name.trim();
+                headers.remove(name);
+            }
+        }
+    }
+
+    // Additionally, strip these "connection-level" headers always, since
+    // they are otherwise illegal if upgraded to HTTP2.
+    headers.remove(header::UPGRADE);
+    headers.remove("proxy-connection");
+    headers.remove("keep-alive");
 }

--- a/linkerd/proxy/http/src/normalize_uri.rs
+++ b/linkerd/proxy/http/src/normalize_uri.rs
@@ -115,14 +115,15 @@ where
             if req.extensions().get::<h1::WasAbsoluteForm>().is_none()
                 && req.uri().authority().is_none()
             {
-                let authority = match h1::authority_from_host(&req).or_else(|| self.default.clone())
+                let authority = match crate::authority_from_header(&req, http::header::HOST)
+                    .or_else(|| self.default.clone())
                 {
                     Some(a) => a,
                     None => return future::Either::Right(future::err(NoAuthority(()).into())),
                 };
 
                 trace!(%authority, "Normalizing URI");
-                h1::set_authority(req.uri_mut(), authority);
+                crate::set_authority(req.uri_mut(), authority);
             }
         }
 

--- a/linkerd/proxy/http/src/override_authority.rs
+++ b/linkerd/proxy/http/src/override_authority.rs
@@ -1,4 +1,3 @@
-use super::h1;
 use http::{header::AsHeaderName, uri::Authority};
 use linkerd_stack::{layer, NewService, Param};
 use std::{
@@ -85,7 +84,7 @@ where
             }
 
             debug!(%authority, "Overriding");
-            h1::set_authority(req.uri_mut(), authority);
+            crate::set_authority(req.uri_mut(), authority);
         }
 
         self.inner.call(req)


### PR DESCRIPTION
Various utility functions are defined in the h1 module that are not strictly HTTP/1-specific.

In preparation for additional reorganization of the http module, this change moves utility functions: