### PR TITLE
Pull identity initialization out of app building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +199,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "b64-ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1e8deebfdca687fcef6fe024fc92cf8183f203075ce4fda263ae6ea13a8dc3"
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +250,12 @@ dependencies = [
  "shlex",
  "syn",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -277,6 +304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +341,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +373,12 @@ checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "cpp_demangle"
@@ -398,7 +451,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-traits",
  "rusticata-macros",
 ]
@@ -864,6 +917,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "idna"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +1042,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1118,7 @@ dependencies = [
  "linkerd-error",
  "linkerd-opencensus",
  "linkerd-tonic-stream",
+ "pkix",
  "rangemap",
  "regex",
  "thiserror",
@@ -1532,6 +1618,7 @@ dependencies = [
  "linkerd-io",
  "linkerd-meshtls-boring",
  "linkerd-meshtls-rustls",
+ "linkerd-meshtls-verifier",
  "linkerd-proxy-transport",
  "linkerd-stack",
  "linkerd-tls",
@@ -2379,6 +2466,17 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
@@ -2549,6 +2647,22 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkix"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6e18f09ac3ee824fac9693352470dcb4b008d211a41f103fa4e80e91e2e6260"
+dependencies = [
+ "b64-ct",
+ "bit-vec",
+ "bitflags 1.3.2",
+ "chrono",
+ "lazy_static",
+ "num-bigint 0.2.6",
+ "num-integer",
+ "yasna 0.3.2",
+]
 
 [[package]]
 name = "powerfmt"
@@ -2774,7 +2888,7 @@ dependencies = [
  "pem",
  "ring",
  "time",
- "yasna",
+ "yasna 0.5.2",
 ]
 
 [[package]]
@@ -3026,7 +3140,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.4.4",
  "num-traits",
  "thiserror",
  "time",
@@ -3628,6 +3742,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,6 +3834,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3824,6 +4001,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror",
  "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
+dependencies = [
+ "bit-vec",
+ "num-bigint 0.2.6",
 ]
 
 [[package]]

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -34,3 +34,4 @@ tokio-stream = { version = "0.1", features = ["time", "sync"] }
 tonic = { version = "0.10", default-features = false, features = ["prost"] }
 tower = "0.4"
 tracing = "0.1"
+pkix = "0.2.3"

--- a/linkerd/app/src/identity/linkerd_config.rs
+++ b/linkerd/app/src/identity/linkerd_config.rs
@@ -1,0 +1,118 @@
+pub use linkerd_app_core::identity::{client, Id};
+use linkerd_app_core::{
+    control, dns,
+    identity::{
+        client::linkerd::Certify, creds, CertMetrics, Credentials, DerX509, Mode, WithCertMetrics,
+    },
+    metrics::{prom, ControlHttp as ClientMetrics},
+    Result,
+};
+use std::time::SystemTime;
+use tokio::sync::watch;
+use tracing::Instrument;
+
+/// Wraps a credential with a watch sender that notifies receivers when the store has been updated
+/// at least once.
+struct NotifyReady {
+    store: creds::Store,
+    tx: watch::Sender<bool>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub client: control::Config,
+    pub certify: client::linkerd::Config,
+    pub tls: super::TlsParams,
+}
+
+impl Config {
+    pub fn build(
+        self,
+        cert_metrics: CertMetrics,
+        dns: dns::Resolver,
+        client_metrics: ClientMetrics,
+        registry: &mut prom::Registry,
+    ) -> Result<super::Identity> {
+        let Self {
+            client,
+            certify,
+            tls,
+        } = self;
+        // TODO: move this validation into env.rs
+        let name = match (&tls.id, &tls.server_name) {
+            (Id::Dns(id), sni) if id == sni => id.clone(),
+            (_id, _sni) => {
+                return Err(super::TlsIdAndServerNameNotMatching(()).into());
+            }
+        };
+
+        let roots = DerX509(pkix::pem::pem_to_der(&tls.trust_anchors_pem, None).unwrap());
+        let certify = Certify::from(certify);
+        let (store, receiver, mut obtained_cert) = watch(tls, cert_metrics)?;
+        let (ready_tx, ready_rx) = watch::channel(None);
+
+        let task =
+            {
+                let addr = client.addr.clone();
+                let svc = client.build(
+                    dns,
+                    client_metrics,
+                    registry.sub_registry_with_prefix("control_identity"),
+                    receiver.new_client(),
+                );
+
+                Box::pin(async move {
+                    tokio::spawn(certify.run(name, roots, store, svc).instrument(
+                        tracing::info_span!("identity", server.addr = %addr).or_current(),
+                    ));
+
+                    // make sure to wait while a cert has been obtained
+                    while !*obtained_cert.borrow_and_update() {
+                        obtained_cert
+                            .changed()
+                            .await
+                            .expect("identity sender must be held");
+                    }
+
+                    let _ = ready_tx.send(Some(receiver));
+                })
+            };
+
+        Ok(super::Identity {
+            ready: ready_rx,
+            task,
+        })
+    }
+}
+
+fn watch(
+    tls: super::TlsParams,
+    metrics: CertMetrics,
+) -> Result<(
+    WithCertMetrics<NotifyReady>,
+    creds::Receiver,
+    watch::Receiver<bool>,
+)> {
+    let (tx, ready) = watch::channel(false);
+    let (store, receiver) =
+        Mode::default().watch(tls.id, tls.server_name, &tls.trust_anchors_pem)?;
+    let cred = WithCertMetrics::new(metrics, NotifyReady { store, tx });
+    Ok((cred, receiver, ready))
+}
+
+// === impl NotifyReady ===
+
+impl Credentials for NotifyReady {
+    fn set_certificate(
+        &mut self,
+        leaf: DerX509,
+        chain: Vec<DerX509>,
+        key: Vec<u8>,
+        exp: SystemTime,
+        roots: DerX509,
+    ) -> Result<()> {
+        self.store.set_certificate(leaf, chain, key, exp, roots)?;
+        let _ = self.tx.send(true);
+        Ok(())
+    }
+}

--- a/linkerd/app/src/identity/spire_config.rs
+++ b/linkerd/app/src/identity/spire_config.rs
@@ -1,0 +1,100 @@
+use crate::spire;
+
+pub use linkerd_app_core::identity::{client, Id};
+use linkerd_app_core::{
+    dns,
+    identity::{client_identity, creds, CertMetrics, Credentials, DerX509, Mode, WithCertMetrics},
+    Result,
+};
+use spire::client as spire_client;
+use std::time::SystemTime;
+use tokio::sync::watch;
+use tracing::Instrument;
+
+#[derive(Debug, thiserror::Error)]
+#[error("linkerd identity requires a TLS Id and server name to be the same")]
+pub struct TlsIdAndServerNameNotMatching(());
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub client: spire::Config,
+    pub server_name: dns::Name,
+}
+
+impl Config {
+    pub fn build(self, cert_metrics: CertMetrics) -> Result<super::Identity> {
+        let addr = self.client.socket_addr.clone();
+        let (store, ready_rx) = SpireInit::new(cert_metrics, self.server_name);
+        let task = Box::pin(
+            spire_client::run(store, spire::Client::from(self.client))
+                .instrument(tracing::info_span!("spire", server.addr = %addr).or_current()),
+        );
+
+        Ok(super::Identity {
+            ready: ready_rx,
+            task,
+        })
+    }
+}
+
+struct SpireInit {
+    store: Option<WithCertMetrics<creds::Store>>,
+    tx: watch::Sender<Option<creds::Receiver>>,
+    cert_metrics: CertMetrics,
+    server_name: dns::Name,
+}
+
+impl SpireInit {
+    fn new(
+        cert_metrics: CertMetrics,
+        server_name: dns::Name,
+    ) -> (Self, watch::Receiver<Option<creds::Receiver>>) {
+        let (tx, rx) = watch::channel(None);
+        let init = Self {
+            store: None,
+            tx,
+            cert_metrics,
+            server_name,
+        };
+
+        (init, rx)
+    }
+
+    fn make_tls_params(&self, roots: DerX509, leaf: DerX509) -> super::TlsParams {
+        let id = client_identity(&leaf).unwrap();
+        let trust_anchors_pem =
+            pkix::pem::der_to_pem(roots.0.as_slice(), pkix::pem::PEM_CERTIFICATE);
+
+        super::TlsParams {
+            id,
+            server_name: self.server_name.clone(),
+            trust_anchors_pem,
+        }
+    }
+}
+
+impl Credentials for SpireInit {
+    fn set_certificate(
+        &mut self,
+        leaf: DerX509,
+        chain: Vec<DerX509>,
+        key: Vec<u8>,
+        exp: SystemTime,
+        roots: DerX509,
+    ) -> Result<()> {
+        match &mut self.store {
+            Some(store) => store.set_certificate(leaf, chain, key, exp, roots),
+            None => {
+                let tls = self.make_tls_params(roots.clone(), leaf.clone());
+                let (store, receiver) =
+                    Mode::default().watch(tls.id, tls.server_name, &tls.trust_anchors_pem)?;
+                let mut store = WithCertMetrics::new(self.cert_metrics.clone(), store);
+
+                store.set_certificate(leaf, chain, key, exp, roots)?;
+                self.store = Some(store);
+                let _ = self.tx.send(Some(receiver));
+                Ok(())
+            }
+        }
+    }
+}

--- a/linkerd/app/src/spire.rs
+++ b/linkerd/app/src/spire.rs
@@ -11,8 +11,8 @@ const TONIC_DEFAULT_URI: &str = "http://[::]:50051";
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub(crate) socket_addr: Arc<String>,
-    pub(crate) backoff: ExponentialBackoff,
+    pub socket_addr: Arc<String>,
+    pub backoff: ExponentialBackoff,
 }
 
 // Connects to SPIRE workload API via Unix Domain Socket

--- a/linkerd/identity/src/credentials.rs
+++ b/linkerd/identity/src/credentials.rs
@@ -12,6 +12,7 @@ pub trait Credentials {
         chain: Vec<DerX509>,
         key: Vec<u8>,
         expiry: SystemTime,
+        roots: DerX509,
     ) -> Result<()>;
 }
 

--- a/linkerd/meshtls/Cargo.toml
+++ b/linkerd/meshtls/Cargo.toml
@@ -25,6 +25,7 @@ linkerd-meshtls-boring = { path = "boring", optional = true }
 linkerd-meshtls-rustls = { path = "rustls", optional = true }
 linkerd-stack = { path = "../stack" }
 linkerd-tls = { path = "../tls" }
+linkerd-meshtls-verifier = { path = "verifier" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }

--- a/linkerd/meshtls/boring/src/creds/store.rs
+++ b/linkerd/meshtls/boring/src/creds/store.rs
@@ -28,6 +28,7 @@ impl id::Credentials for Store {
         intermediates: Vec<id::DerX509>,
         key_pkcs8: Vec<u8>,
         _expiry: std::time::SystemTime,
+        _roots: id::DerX509,
     ) -> Result<()> {
         let leaf = X509::from_der(&leaf_der)?;
 

--- a/linkerd/meshtls/boring/src/tests.rs
+++ b/linkerd/meshtls/boring/src/tests.rs
@@ -20,7 +20,8 @@ fn can_construct_client_and_server_config_from_valid_settings() {
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            DerX509(FOO_NS1.trust_anchors.to_vec()),
         )
         .is_ok());
 }
@@ -32,7 +33,8 @@ fn recognize_ca_did_not_issue_cert() {
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            DerX509(FOO_NS1.trust_anchors.to_vec()),
         )
         .is_err());
 }
@@ -44,7 +46,8 @@ fn recognize_cert_is_not_valid_for_identity() {
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            DerX509(FOO_NS1.trust_anchors.to_vec()),
         )
         .is_err());
 }

--- a/linkerd/meshtls/rustls/src/creds/store.rs
+++ b/linkerd/meshtls/rustls/src/creds/store.rs
@@ -136,6 +136,7 @@ impl id::Credentials for Store {
         intermediates: Vec<id::DerX509>,
         key: Vec<u8>,
         _expiry: std::time::SystemTime,
+        _roots: id::DerX509,
     ) -> Result<()> {
         let mut chain = Vec::with_capacity(intermediates.len() + 1);
         chain.push(rustls::Certificate(leaf));

--- a/linkerd/meshtls/rustls/src/tests.rs
+++ b/linkerd/meshtls/rustls/src/tests.rs
@@ -20,7 +20,8 @@ fn can_construct_client_and_server_config_from_valid_settings() {
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            DerX509(FOO_NS1.trust_anchors.to_vec()),
         )
         .is_ok());
 }
@@ -32,7 +33,8 @@ fn recognize_ca_did_not_issue_cert() {
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            DerX509(FOO_NS1.trust_anchors.to_vec()),
         )
         .is_err());
 }
@@ -44,7 +46,8 @@ fn recognize_cert_is_not_valid_for_identity() {
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            DerX509(FOO_NS1.trust_anchors.to_vec()),
         )
         .is_err());
 }

--- a/linkerd/meshtls/src/creds.rs
+++ b/linkerd/meshtls/src/creds.rs
@@ -41,13 +41,14 @@ impl Credentials for Store {
         chain: Vec<DerX509>,
         key: Vec<u8>,
         exp: SystemTime,
+        _roots: DerX509,
     ) -> Result<()> {
         match self {
             #[cfg(feature = "boring")]
-            Self::Boring(store) => store.set_certificate(leaf, chain, key, exp),
+            Self::Boring(store) => store.set_certificate(leaf, chain, key, exp, _roots),
 
             #[cfg(feature = "rustls")]
-            Self::Rustls(store) => store.set_certificate(leaf, chain, key, exp),
+            Self::Rustls(store) => store.set_certificate(leaf, chain, key, exp, _roots),
 
             #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(leaf, chain, key, exp),

--- a/linkerd/meshtls/src/lib.rs
+++ b/linkerd/meshtls/src/lib.rs
@@ -20,6 +20,8 @@ pub use self::{
     client::{ClientIo, Connect, ConnectFuture, NewClient},
     server::{Server, ServerIo, TerminateFuture},
 };
+pub use linkerd_meshtls_verifier::client_identity;
+
 use linkerd_dns_name as dns;
 use linkerd_error::{Error, Result};
 use linkerd_identity as id;

--- a/linkerd/meshtls/tests/util.rs
+++ b/linkerd/meshtls/tests/util.rs
@@ -57,7 +57,13 @@ pub fn fails_processing_cert_when_wrong_id_configured(mode: meshtls::Mode) {
         .expect("should construct");
 
     let err = store
-        .set_certificate(DerX509(cert), vec![], key, SystemTime::now())
+        .set_certificate(
+            DerX509(cert.clone()),
+            vec![],
+            key,
+            SystemTime::now(),
+            DerX509(cert),
+        )
         .expect_err("should error");
 
     assert_eq!(
@@ -177,6 +183,7 @@ fn load(
             vec![],
             ent.key.to_vec(),
             SystemTime::now() + Duration::from_secs(1000),
+            DerX509(ent.trust_anchors.to_vec()),
         )
         .expect("certificate must be valid");
 

--- a/linkerd/proxy/identity-client/src/certify.rs
+++ b/linkerd/proxy/identity-client/src/certify.rs
@@ -88,7 +88,7 @@ impl From<Config> for Certify {
 }
 
 impl Certify {
-    pub async fn run<C, N, S>(self, name: Name, mut credentials: C, new_client: N)
+    pub async fn run<C, N, S>(self, name: Name, roots: DerX509, mut credentials: C, new_client: N)
     where
         C: Credentials,
         N: NewService<(), Service = S>,
@@ -111,6 +111,7 @@ impl Certify {
                     client,
                     &name,
                     &mut credentials,
+                    roots.clone(),
                 )
                 .await
             };
@@ -151,6 +152,7 @@ async fn certify<C, S>(
     client: S,
     name: &Name,
     credentials: &mut C,
+    roots: DerX509,
 ) -> Result<SystemTime>
 where
     C: Credentials,
@@ -180,6 +182,7 @@ where
         intermediate_certificates.into_iter().map(DerX509).collect(),
         docs.key_pkcs8.clone(),
         expiry,
+        roots,
     )?;
 
     Ok(expiry)


### PR DESCRIPTION
The purpose of this change is to allow a SPIRE identity to obtained without prior knowledge of the TLS id or the roots. In addition to that, the change enables us to construct and initialize the identity before we construct the proxy App. In order to achieve that: 

- the identity config has been split into Spire and Linkerd structs
- metrics related components can be passed to the Config::build method
- the `Credentials` trait has been modified to accept roots in addition to the rest of the credentials
- when the app is constrcuted, it is assumed that identity has already been initialized.

TODO: 
- pull pkix pem parsing crate functionality into our codebase
- conage/fix proxy initialization tests