### PR TITLE
Swap trust-dns-resolver dependency with hickory-resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,6 +755,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091a6fbccf4860009355e3efc52ff4acf37a63489aad7435372d44ceeb6fbbcf"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna 0.4.0",
+ "ipnet",
+ "once_cell",
+ "rand",
+ "thiserror",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b8f021164e6a984c9030023544c57789c51760065cd510572fedcfb04164e8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,12 +1372,12 @@ name = "linkerd-dns"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "hickory-resolver",
  "linkerd-dns-name",
  "linkerd-error",
  "thiserror",
  "tokio",
  "tracing",
- "trust-dns-resolver",
 ]
 
 [[package]]
@@ -3496,52 +3541,6 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "trust-dns-proto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119112651c157f4488931a01e586aa459736e9d6046d3bd9105ffb69352d374"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna 0.4.0",
- "ipnet",
- "once_cell",
- "rand",
- "smallvec",
- "thiserror",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "trust-dns-resolver"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3e6c3aff1718b3c73e395d1f35202ba2ffa847c6a62eea0db8fb4cfe30be6"
-dependencies = [
- "cfg-if",
- "futures-util",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand",
- "resolv-conf",
- "smallvec",
- "thiserror",
- "tokio",
- "tracing",
- "trust-dns-proto",
 ]
 
 [[package]]

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -12,5 +12,5 @@ linkerd-dns-name = { path = "./name" }
 linkerd-error = { path = "../error" }
 thiserror = "1"
 tracing = "0.1"
-trust-dns-resolver = "0.23.2"
+hickory-resolver = "0.24.0"
 tokio = { version = "1", features = ["rt", "sync", "time"] }

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -1,16 +1,16 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
+pub use hickory_resolver::config::ResolverOpts;
+use hickory_resolver::{
+    config::ResolverConfig, error, proto::rr::rdata, system_conf, AsyncResolver, TokioAsyncResolver,
+};
 use linkerd_dns_name::NameRef;
 pub use linkerd_dns_name::{InvalidName, Name, Suffix};
 use std::{fmt, net};
 use thiserror::Error;
 use tokio::time::{self, Instant};
 use tracing::{debug, trace};
-pub use trust_dns_resolver::config::ResolverOpts;
-use trust_dns_resolver::{
-    config::ResolverConfig, error, proto::rr::rdata, system_conf, AsyncResolver, TokioAsyncResolver,
-};
 
 #[derive(Clone)]
 pub struct Resolver {
@@ -127,7 +127,7 @@ impl Resolver {
     }
 
     // XXX We need to convert the SRV records to an IP addr manually,
-    // because of: https://github.com/bluejekyll/trust-dns/issues/872
+    // because of: https://github.com/hickory-dns/hickory-dns/issues/872
     // Here we rely in on the fact that the first label of the SRV
     // record's target will be the ip of the pod delimited by dashes
     // instead of dots. We can alternatively do another lookup


### PR DESCRIPTION
The trust-dns-resolver library has been rebranded as hickory-resolver as per this [post](https://bluejekyll.github.io/blog/posts/announcing-hickory-dns/).

In order to continue receiving updates, we swap the dependency and upgrade to v0.24.0