### PR TITLE
identity: change Credentials trait to allow dynamically setting roots

### DIFF
--- a/linkerd/identity/src/credentials.rs
+++ b/linkerd/identity/src/credentials.rs
@@ -1,6 +1,13 @@
 use linkerd_error::Result;
 use std::{ops::Deref, time::SystemTime};
 
+/// Contains roots certificates in PEM or DER formats.
+#[derive(Clone, Debug)]
+pub enum Roots {
+    Der(Vec<DerX509>),
+    Pem(String),
+}
+
 /// Publishes certificates to be used by TLS implementations.
 pub trait Credentials {
     /// Set the certificate returned by the identity service.
@@ -12,6 +19,7 @@ pub trait Credentials {
         chain: Vec<DerX509>,
         key: Vec<u8>,
         expiry: SystemTime,
+        roots: Roots,
     ) -> Result<()>;
 }
 

--- a/linkerd/identity/src/lib.rs
+++ b/linkerd/identity/src/lib.rs
@@ -8,7 +8,7 @@ use linkerd_error::{Error, Result};
 use std::str::FromStr;
 
 pub use self::{
-    credentials::{Credentials, DerX509},
+    credentials::{Credentials, DerX509, Roots},
     metrics::{CertMetrics, WithCertMetrics},
 };
 

--- a/linkerd/identity/src/metrics.rs
+++ b/linkerd/identity/src/metrics.rs
@@ -1,4 +1,4 @@
-use crate::{Credentials, DerX509};
+use crate::{Credentials, DerX509, Roots};
 use linkerd_error::Result;
 use linkerd_metrics::prom;
 use std::{
@@ -89,8 +89,9 @@ where
         chain: Vec<DerX509>,
         key: Vec<u8>,
         expiry: SystemTime,
+        roots: Roots,
     ) -> Result<()> {
-        if let Err(err) = self.inner.set_certificate(leaf, chain, key, expiry) {
+        if let Err(err) = self.inner.set_certificate(leaf, chain, key, expiry, roots) {
             self.metrics.errors.inc();
             return Err(err);
         }
@@ -132,6 +133,7 @@ mod tests {
             _chain: Vec<DerX509>,
             _key: Vec<u8>,
             _expiry: SystemTime,
+            _roots: Roots,
         ) -> Result<()> {
             self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             self.1.map_err(|()| "boop".into())
@@ -155,8 +157,10 @@ mod tests {
         let chain = vec![leaf.clone()];
         let key = vec![0, 1, 2, 3, 4];
         let expiry = SystemTime::now() + Duration::from_secs(60 * 60 * 24); // 1 day from now
+        let roots =
+            Roots::Pem("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----".into());
         assert!(with_cert_metrics
-            .set_certificate(leaf, chain, key, expiry)
+            .set_certificate(leaf, chain, key, expiry, roots)
             .is_ok());
 
         assert_eq!(with_cert_metrics.metrics.refreshes.get(), 1);
@@ -192,8 +196,10 @@ mod tests {
         let chain = vec![leaf.clone()];
         let key = vec![0, 1, 2, 3, 4];
         let expiry = SystemTime::now() + Duration::from_secs(60 * 60 * 24); // 1 day from now
+        let roots =
+            Roots::Pem("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----".into());
         assert!(with_cert_metrics
-            .set_certificate(leaf, chain, key, expiry)
+            .set_certificate(leaf, chain, key, expiry, roots)
             .is_err());
 
         assert_eq!(with_cert_metrics.metrics.refreshes.get(), 0);

--- a/linkerd/meshtls/boring/src/creds/store.rs
+++ b/linkerd/meshtls/boring/src/creds/store.rs
@@ -28,6 +28,7 @@ impl id::Credentials for Store {
         intermediates: Vec<id::DerX509>,
         key_pkcs8: Vec<u8>,
         _expiry: std::time::SystemTime,
+        _roots: id::Roots,
     ) -> Result<()> {
         let leaf = X509::from_der(&leaf_der)?;
 

--- a/linkerd/meshtls/boring/src/tests.rs
+++ b/linkerd/meshtls/boring/src/tests.rs
@@ -1,50 +1,57 @@
-use linkerd_identity::{Credentials, DerX509};
+use linkerd_identity::{Credentials, DerX509, Roots};
 use linkerd_tls_test_util::*;
 use std::time::{Duration, SystemTime};
 
-fn load(ent: &Entity) -> crate::creds::Store {
+fn load(ent: &Entity) -> (crate::creds::Store, Roots) {
     let roots_pem = std::str::from_utf8(ent.trust_anchors).expect("valid PEM");
+    let roots = Roots::Pem(roots_pem.into());
     let (store, _) = crate::creds::watch(
         ent.name.parse().unwrap(),
         ent.name.parse().unwrap(),
-        roots_pem,
+        roots.clone(),
     )
     .expect("credentials must be readable");
-    store
+    (store, roots)
 }
 
 #[test]
 fn can_construct_client_and_server_config_from_valid_settings() {
-    assert!(load(&FOO_NS1)
+    let (mut store, roots) = load(&FOO_NS1);
+    assert!(store
         .set_certificate(
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            roots
         )
         .is_ok());
 }
 
 #[test]
 fn recognize_ca_did_not_issue_cert() {
-    assert!(load(&FOO_NS1_CA2)
+    let (mut store, roots) = load(&FOO_NS1_CA2);
+    assert!(store
         .set_certificate(
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            roots
         )
         .is_err());
 }
 
 #[test]
 fn recognize_cert_is_not_valid_for_identity() {
-    assert!(load(&BAR_NS1)
+    let (mut store, roots) = load(&BAR_NS1);
+    assert!(store
         .set_certificate(
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            roots
         )
         .is_err());
 }

--- a/linkerd/meshtls/rustls/src/creds/store.rs
+++ b/linkerd/meshtls/rustls/src/creds/store.rs
@@ -136,6 +136,7 @@ impl id::Credentials for Store {
         intermediates: Vec<id::DerX509>,
         key: Vec<u8>,
         _expiry: std::time::SystemTime,
+        _roots: id::Roots,
     ) -> Result<()> {
         let mut chain = Vec::with_capacity(intermediates.len() + 1);
         chain.push(rustls::Certificate(leaf));

--- a/linkerd/meshtls/rustls/src/tests.rs
+++ b/linkerd/meshtls/rustls/src/tests.rs
@@ -1,50 +1,57 @@
-use linkerd_identity::{Credentials, DerX509};
+use linkerd_identity::{Credentials, DerX509, Roots};
 use linkerd_tls_test_util::*;
 use std::time::{Duration, SystemTime};
 
-fn load(ent: &Entity) -> crate::creds::Store {
+fn load(ent: &Entity) -> (crate::creds::Store, Roots) {
     let roots_pem = std::str::from_utf8(ent.trust_anchors).expect("valid PEM");
+    let roots = Roots::Pem(roots_pem.into());
     let (store, _) = crate::creds::watch(
         ent.name.parse().unwrap(),
         ent.name.parse().unwrap(),
-        roots_pem,
+        roots.clone(),
     )
     .expect("credentials must be readable");
-    store
+    (store, roots)
 }
 
 #[test]
 fn can_construct_client_and_server_config_from_valid_settings() {
-    assert!(load(&FOO_NS1)
+    let (mut store, roots) = load(&FOO_NS1);
+    assert!(store
         .set_certificate(
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            roots
         )
         .is_ok());
 }
 
 #[test]
 fn recognize_ca_did_not_issue_cert() {
-    assert!(load(&FOO_NS1_CA2)
+    let (mut store, roots) = load(&FOO_NS1_CA2);
+    assert!(store
         .set_certificate(
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            roots
         )
         .is_err());
 }
 
 #[test]
 fn recognize_cert_is_not_valid_for_identity() {
-    assert!(load(&BAR_NS1)
+    let (mut store, roots) = load(&BAR_NS1);
+    assert!(store
         .set_certificate(
             DerX509(FOO_NS1.crt.to_vec()),
             vec![],
             FOO_NS1.key.to_vec(),
-            SystemTime::now() + Duration::from_secs(1000)
+            SystemTime::now() + Duration::from_secs(1000),
+            roots
         )
         .is_err());
 }

--- a/linkerd/meshtls/src/creds.rs
+++ b/linkerd/meshtls/src/creds.rs
@@ -3,7 +3,7 @@ use std::time::SystemTime;
 use crate::{NewClient, Server};
 use linkerd_dns_name as dns;
 use linkerd_error::Result;
-use linkerd_identity::{Credentials, DerX509, Id};
+use linkerd_identity::{Credentials, DerX509, Id, Roots};
 
 #[cfg(feature = "boring")]
 pub use crate::boring;
@@ -41,13 +41,14 @@ impl Credentials for Store {
         chain: Vec<DerX509>,
         key: Vec<u8>,
         exp: SystemTime,
+        roots: Roots,
     ) -> Result<()> {
         match self {
             #[cfg(feature = "boring")]
-            Self::Boring(store) => store.set_certificate(leaf, chain, key, exp),
+            Self::Boring(store) => store.set_certificate(leaf, chain, key, exp, roots),
 
             #[cfg(feature = "rustls")]
-            Self::Rustls(store) => store.set_certificate(leaf, chain, key, exp),
+            Self::Rustls(store) => store.set_certificate(leaf, chain, key, exp, roots),
 
             #[cfg(not(feature = "__has_any_tls_impls"))]
             _ => crate::no_tls!(leaf, chain, key, exp),

--- a/linkerd/meshtls/src/lib.rs
+++ b/linkerd/meshtls/src/lib.rs
@@ -85,12 +85,12 @@ impl Mode {
         self,
         local_id: id::Id,
         server_name: dns::Name,
-        roots_pem: &str,
+        roots: id::Roots,
     ) -> Result<(creds::Store, creds::Receiver)> {
         match self {
             #[cfg(feature = "boring")]
             Self::Boring => {
-                let (store, receiver) = boring::creds::watch(local_id, server_name, roots_pem)?;
+                let (store, receiver) = boring::creds::watch(local_id, server_name, roots)?;
                 Ok((
                     creds::Store::Boring(store),
                     creds::Receiver::Boring(receiver),
@@ -99,7 +99,7 @@ impl Mode {
 
             #[cfg(feature = "rustls")]
             Self::Rustls => {
-                let (store, receiver) = rustls::creds::watch(local_id, server_name, roots_pem)?;
+                let (store, receiver) = rustls::creds::watch(local_id, server_name, roots)?;
                 Ok((
                     creds::Store::Rustls(store),
                     creds::Receiver::Rustls(receiver),
@@ -107,7 +107,7 @@ impl Mode {
             }
 
             #[cfg(not(feature = "__has_any_tls_impls"))]
-            _ => no_tls!(local_id, server_name, roots_pem),
+            _ => no_tls!(local_id, server_name, roots),
         }
     }
 }

--- a/linkerd/proxy/spire-client/src/lib.rs
+++ b/linkerd/proxy/spire-client/src/lib.rs
@@ -5,8 +5,7 @@ mod api;
 
 pub use api::{Api, SvidUpdate};
 use linkerd_error::Error;
-use linkerd_identity::Credentials;
-use linkerd_identity::Id;
+use linkerd_identity::{Credentials, Id};
 use std::fmt::{Debug, Display};
 use tokio::sync::watch;
 use tower::{util::ServiceExt, Service};
@@ -61,7 +60,7 @@ mod tests {
     use super::*;
     use crate::api::Svid;
     use linkerd_error::Result;
-    use linkerd_identity::DerX509;
+    use linkerd_identity::{DerX509, Roots};
     use rcgen::{Certificate, CertificateParams, SanType, SerialNumber};
     use std::time::SystemTime;
 
@@ -78,6 +77,7 @@ mod tests {
                     .serialize_der()
                     .expect("should serialize"),
             ),
+            Vec::default(),
             Vec::default(),
             Vec::default(),
         )
@@ -131,6 +131,7 @@ mod tests {
             _: Vec<DerX509>,
             _: Vec<u8>,
             _: SystemTime,
+            _: Roots,
         ) -> Result<()> {
             let (_, cert) = x509_parser::parse_x509_certificate(&leaf.0).unwrap();
             let serial = SerialNumber::from_slice(&cert.serial.to_bytes_be());
@@ -199,6 +200,7 @@ mod tests {
         let invalid_svid = Svid::new(
             spiffe_id.clone(),
             DerX509(Vec::default()),
+            Vec::default(),
             Vec::default(),
             Vec::default(),
         );


### PR DESCRIPTION
The SPIFFE API allows provisioning trust roots. To enable that functionality, this PR changes the `Credentials` interface and adds a `Roots` parameter. The roots can be encoded in either PEM or DER.

For now, this is a nonfunctional change as the roots that are provided via the changes API are not used.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>