### PR TITLE
chore(app,outbound)!: Decouple metrics registry from stack building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,6 +2249,7 @@ dependencies = [
  "jemallocator",
  "linkerd-app",
  "linkerd-meshtls",
+ "linkerd-metrics",
  "linkerd-signal",
  "num_cpus",
  "tokio",

--- a/linkerd/app/gateway/src/http.rs
+++ b/linkerd/app/gateway/src/http.rs
@@ -1,7 +1,7 @@
 use super::Gateway;
 use inbound::{GatewayAddr, GatewayDomainInvalid};
 use linkerd_app_core::{
-    metrics::{prom, ServerLabel},
+    metrics::ServerLabel,
     profiles,
     proxy::{
         api_resolve::{ConcreteAddr, Metadata},
@@ -47,7 +47,6 @@ impl Gateway {
     /// outbound router.
     pub fn http<T, R>(
         &self,
-        registry: &mut prom::Registry,
         inner: svc::ArcNewHttp<
             outbound::http::concrete::Endpoint<
                 outbound::http::logical::Concrete<outbound::http::Http<Target>>,
@@ -86,7 +85,7 @@ impl Gateway {
             .outbound
             .clone()
             .with_stack(inner)
-            .push_http_cached(outbound::http::HttpMetrics::register(registry), resolve)
+            .push_http_cached(resolve)
             .into_stack()
             // Discard `T` and its associated client-specific metadata.
             .push_map_target(Target::discard_parent)

--- a/linkerd/app/gateway/src/http/tests.rs
+++ b/linkerd/app/gateway/src/http/tests.rs
@@ -160,7 +160,6 @@ async fn upgraded_request_remains_relative_form() {
         );
         gateway
             .http(
-                &mut Default::default(),
                 svc::ArcNewHttp::new(move |_: _| svc::BoxHttp::new(inner.clone())),
                 resolve,
             )

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -457,7 +457,14 @@ async fn run(proxy: Proxy, mut env: TestEnv, random_ports: bool) -> Listening {
                         let bind_adm = listen::BindTcp::default();
                         let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::unbounded_channel();
                         let main = config
-                            .build(bind_in, bind_out, bind_adm, shutdown_tx, trace_handle)
+                            .build(
+                                bind_in,
+                                bind_out,
+                                bind_adm,
+                                shutdown_tx,
+                                trace_handle,
+                                Default::default(),
+                            )
                             .await
                             .expect("config");
 

--- a/linkerd/app/outbound/src/discover/tests.rs
+++ b/linkerd/app/outbound/src/discover/tests.rs
@@ -37,7 +37,7 @@ async fn errors_propagate() {
 
     // Create a profile stack that uses the tracked inner stack.
     let (rt, _shutdown) = runtime();
-    let stack = Outbound::new(default_config(), rt)
+    let stack = Outbound::new(default_config(), rt, &mut Default::default())
         .with_stack(stack)
         .push_discover(discover)
         .into_inner();
@@ -107,7 +107,7 @@ async fn caches_profiles_until_idle() {
         cfg
     };
     let (rt, _shutdown) = runtime();
-    let stack = Outbound::new(cfg, rt)
+    let stack = Outbound::new(cfg, rt, &mut Default::default())
         .with_stack(stack)
         .push_discover(discover)
         .into_inner();

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -86,11 +86,7 @@ impl<T> Outbound<svc::ArcNewHttp<concrete::Endpoint<logical::Concrete<Http<T>>>>
     /// Builds a stack that routes HTTP requests to endpoint stacks.
     ///
     /// Buffered concrete services are cached in and evicted when idle.
-    pub fn push_http_cached<R>(
-        self,
-        metrics: HttpMetrics,
-        resolve: R,
-    ) -> Outbound<svc::ArcNewCloneHttp<T>>
+    pub fn push_http_cached<R>(self, resolve: R) -> Outbound<svc::ArcNewCloneHttp<T>>
     where
         // Logical HTTP target.
         T: svc::Param<http::Version>,
@@ -101,8 +97,8 @@ impl<T> Outbound<svc::ArcNewHttp<concrete::Endpoint<logical::Concrete<Http<T>>>>
         R::Resolution: Unpin,
     {
         self.push_http_endpoint()
-            .push_http_concrete(metrics.balancer, resolve)
-            .push_http_logical(metrics.http_route, metrics.grpc_route)
+            .push_http_concrete(resolve)
+            .push_http_logical()
             .map_stack(move |config, _, stk| {
                 stk.push_new_idle_cached(config.discovery_idle_timeout)
                     .push_map_target(Http)

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -60,11 +60,7 @@ impl<N> Outbound<N> {
     /// 'failfast'. While in failfast, buffered requests are failed and the
     /// service becomes unavailable so callers may choose alternate concrete
     /// services.
-    pub fn push_http_concrete<T, NSvc, R>(
-        self,
-        balancer_metrics: balance::BalancerMetrics,
-        resolve: R,
-    ) -> Outbound<svc::ArcNewCloneHttp<T>>
+    pub fn push_http_concrete<T, NSvc, R>(self, resolve: R) -> Outbound<svc::ArcNewCloneHttp<T>>
     where
         // Concrete target type.
         T: svc::Param<ParentRef>,
@@ -105,12 +101,7 @@ impl<N> Outbound<N> {
             });
 
             inner
-                .push(balance::Balance::layer(
-                    config,
-                    rt,
-                    balancer_metrics,
-                    resolve,
-                ))
+                .push(balance::Balance::layer(config, rt, resolve))
                 .check_new_clone()
                 .push_switch(Ok::<_, Infallible>, forward.into_inner())
                 .push_switch(

--- a/linkerd/app/outbound/src/http/endpoint/tests.rs
+++ b/linkerd/app/outbound/src/http/endpoint/tests.rs
@@ -23,7 +23,7 @@ async fn http11_forward() {
 
     // Build the outbound server
     let (rt, _shutdown) = runtime();
-    let stack = Outbound::new(default_config(), rt)
+    let stack = Outbound::new(default_config(), rt, &mut Default::default())
         .with_stack(connect)
         .push_http_tcp_client()
         .push_http_endpoint()
@@ -59,7 +59,7 @@ async fn http2_forward() {
 
     // Build the outbound server
     let (rt, _shutdown) = runtime();
-    let stack = Outbound::new(default_config(), rt)
+    let stack = Outbound::new(default_config(), rt, &mut Default::default())
         .with_stack(connect)
         .push_http_tcp_client()
         .push_http_endpoint::<http::BoxBody>()
@@ -97,7 +97,7 @@ async fn orig_proto_upgrade() {
 
     // Build the outbound server
     let (rt, _shutdown) = runtime();
-    let stack = Outbound::new(default_config(), rt)
+    let stack = Outbound::new(default_config(), rt, &mut Default::default())
         .with_stack(connect)
         .push_http_tcp_client()
         .push_http_endpoint::<http::BoxBody>()
@@ -147,7 +147,7 @@ async fn orig_proto_skipped_on_http_upgrade() {
     // Build the outbound server
     let (rt, _shutdown) = runtime();
     let drain = rt.drain.clone();
-    let stack = Outbound::new(default_config(), rt)
+    let stack = Outbound::new(default_config(), rt, &mut Default::default())
         .with_stack(connect)
         .push_http_tcp_client()
         .push_http_endpoint::<http::BoxBody>()
@@ -195,7 +195,7 @@ async fn orig_proto_http2_noop() {
 
     // Build the outbound server
     let (rt, _shutdown) = runtime();
-    let stack = Outbound::new(default_config(), rt)
+    let stack = Outbound::new(default_config(), rt, &mut Default::default())
         .with_stack(connect)
         .push_http_tcp_client()
         .push_http_endpoint::<http::BoxBody>()

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -81,11 +81,7 @@ impl<N> Outbound<N> {
     /// support per-request routing over a set of concrete inner services.
     /// Only available inner services are used for routing. When there are no
     /// available backends, requests are failed with a [`svc::stack::LoadShedError`].
-    pub fn push_http_logical<T, NSvc>(
-        self,
-        http_metrics: policy::RouteMetrics,
-        grpc_metrics: policy::RouteMetrics,
-    ) -> Outbound<svc::ArcNewCloneHttp<T>>
+    pub fn push_http_logical<T, NSvc>(self) -> Outbound<svc::ArcNewCloneHttp<T>>
     where
         // Logical target.
         T: svc::Param<watch::Receiver<Routes>>,
@@ -106,11 +102,7 @@ impl<N> Outbound<N> {
             concrete
                 // Share the concrete stack with each router stack.
                 .lift_new()
-                .push_on_service(RouterParams::layer(
-                    rt.metrics.clone(),
-                    http_metrics,
-                    grpc_metrics,
-                ))
+                .push_on_service(RouterParams::layer(rt.metrics.clone()))
                 // Rebuild the inner router stack every time the watch changes.
                 .push(svc::NewSpawnWatch::<Routes, _>::layer_into::<RouterParams<T>>())
                 .arc_new_clone_http()
@@ -126,8 +118,6 @@ where
 {
     fn layer<N, S>(
         metrics: OutboundMetrics,
-        http_metrics: policy::RouteMetrics,
-        grpc_metrics: policy::RouteMetrics,
     ) -> impl svc::Layer<N, Service = svc::ArcNewCloneHttp<RouterParams<T>>> + Clone
     where
         N: svc::NewService<Concrete<T>, Service = S>,
@@ -142,8 +132,8 @@ where
     {
         svc::layer::mk(move |concrete: N| {
             let policy = svc::stack(concrete.clone()).push(policy::Policy::layer(
-                http_metrics.clone(),
-                grpc_metrics.clone(),
+                metrics.prom.http.http_route.clone(),
+                metrics.prom.http.grpc_route.clone(),
             ));
             let profile =
                 svc::stack(concrete.clone()).push(profile::Params::layer(metrics.proxy.clone()));

--- a/linkerd/app/outbound/src/http/logical/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/tests.rs
@@ -28,9 +28,9 @@ async fn routes() {
     let connect = HttpConnect::default().service(addr, svc);
     let resolve = support::resolver().endpoint_exists(dest.clone(), addr, Default::default());
     let (rt, _shutdown) = runtime();
-    let stack = Outbound::new(default_config(), rt)
+    let stack = Outbound::new(default_config(), rt, &mut Default::default())
         .with_stack(svc::ArcNewService::new(connect))
-        .push_http_cached(Default::default(), resolve)
+        .push_http_cached(resolve)
         .into_inner();
 
     let backend = default_backend(&dest);
@@ -71,9 +71,9 @@ async fn consecutive_failures_accrue() {
     let resolve = support::resolver().endpoint_exists(dest.clone(), addr, Default::default());
     let (rt, _shutdown) = runtime();
     let cfg = default_config();
-    let stack = Outbound::new(cfg.clone(), rt)
+    let stack = Outbound::new(cfg.clone(), rt, &mut Default::default())
         .with_stack(svc::ArcNewService::new(connect))
-        .push_http_cached(Default::default(), resolve)
+        .push_http_cached(resolve)
         .into_inner();
 
     let backend = default_backend(&dest);
@@ -234,9 +234,9 @@ async fn balancer_doesnt_select_tripped_breakers() {
         .unwrap();
     let (rt, _shutdown) = runtime();
     let cfg = default_config();
-    let stack = Outbound::new(cfg.clone(), rt)
+    let stack = Outbound::new(cfg.clone(), rt, &mut Default::default())
         .with_stack(svc::ArcNewService::new(connect))
-        .push_http_cached(Default::default(), resolve)
+        .push_http_cached(resolve)
         .into_inner();
 
     let backend = default_backend(&dest);
@@ -322,9 +322,9 @@ async fn route_request_timeout() {
     let connect = HttpConnect::default().service(addr, svc);
     let resolve = support::resolver().endpoint_exists(dest.clone(), addr, Default::default());
     let (rt, _shutdown) = runtime();
-    let stack = Outbound::new(default_config(), rt)
+    let stack = Outbound::new(default_config(), rt, &mut Default::default())
         .with_stack(svc::ArcNewService::new(connect))
-        .push_http_cached(Default::default(), resolve)
+        .push_http_cached(resolve)
         .into_inner();
 
     let (_route_tx, routes) = {
@@ -385,9 +385,9 @@ async fn backend_request_timeout() {
     let connect = HttpConnect::default().service(addr, svc);
     let resolve = support::resolver().endpoint_exists(dest.clone(), addr, Default::default());
     let (rt, _shutdown) = runtime();
-    let stack = Outbound::new(default_config(), rt)
+    let stack = Outbound::new(default_config(), rt, &mut Default::default())
         .with_stack(svc::ArcNewService::new(connect))
-        .push_http_cached(Default::default(), resolve)
+        .push_http_cached(resolve)
         .into_inner();
 
     let (_route_tx, routes) = {

--- a/linkerd/app/src/dst.rs
+++ b/linkerd/app/src/dst.rs
@@ -1,8 +1,7 @@
 use linkerd_app_core::{
     control, dns,
     exp_backoff::{ExponentialBackoff, ExponentialBackoffStream},
-    identity,
-    metrics::{self, prom},
+    identity, metrics,
     profiles::{self, DiscoveryRejected},
     proxy::{api_resolve as api, http, resolve::recover},
     svc::{self, NewService, ServiceExt},
@@ -38,8 +37,8 @@ impl Config {
     pub fn build(
         self,
         dns: dns::Resolver,
-        metrics: metrics::ControlHttp,
-        registry: &mut prom::Registry,
+        legacy_metrics: metrics::ControlHttp,
+        control_metrics: control::Metrics,
         identity: identity::NewClient,
     ) -> Result<
         Dst<
@@ -56,7 +55,7 @@ impl Config {
         let backoff = BackoffUnlessInvalidArgument(self.control.connect.backoff);
         let svc = self
             .control
-            .build(dns, metrics, registry, identity)
+            .build(dns, legacy_metrics, control_metrics, identity)
             .new_service(())
             .map_err(Error::from);
 

--- a/linkerd/app/src/policy.rs
+++ b/linkerd/app/src/policy.rs
@@ -1,8 +1,7 @@
 use linkerd_app_core::{
     control, dns,
     exp_backoff::ExponentialBackoff,
-    identity,
-    metrics::{self, prom},
+    identity, metrics,
     proxy::http,
     svc::{self, NewService, ServiceExt},
     Error,
@@ -40,8 +39,8 @@ impl Config {
     pub fn build(
         self,
         dns: dns::Resolver,
-        metrics: metrics::ControlHttp,
-        registry: &mut prom::Registry,
+        legacy_metrics: metrics::ControlHttp,
+        control_metrics: control::Metrics,
         identity: identity::NewClient,
     ) -> Result<
         Policy<
@@ -59,7 +58,7 @@ impl Config {
         let backoff = self.control.connect.backoff;
         let client = self
             .control
-            .build(dns, metrics, registry, identity)
+            .build(dns, legacy_metrics, control_metrics, identity)
             .new_service(())
             .map_err(Error::from);
 

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -20,6 +20,7 @@ pprof = ["linkerd-app/pprof"]
 futures = { version = "0.3", default-features = false }
 num_cpus = { version = "1", optional = true }
 linkerd-app = { path = "../linkerd/app" }
+linkerd-metrics = { path = "../linkerd/metrics" }
 # We don't actually use code from this crate in `main`; it's here only so we can
 # control its feature flags.
 linkerd-meshtls = { path = "../linkerd/meshtls" }

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -42,6 +42,8 @@ fn main() {
         vendor = BUILD_INFO.vendor,
     );
 
+    let metrics = linkerd_metrics::prom::Registry::default();
+
     // Load configuration from the environment without binding ports.
     let config = match Config::try_from_env() {
         Ok(config) => config,
@@ -60,7 +62,7 @@ fn main() {
 
         let bind = BindTcp::with_orig_dst();
         let app = match config
-            .build(bind, bind, BindTcp::default(), shutdown_tx, trace)
+            .build(bind, bind, BindTcp::default(), shutdown_tx, trace, metrics)
             .await
         {
             Ok(app) => app,


### PR DESCRIPTION
As we introduced the newer prometheus-client metrics registry, we did so by allowing stacks to register metrics directly. This is incongruent with the existing legacy metrics registries, which are known by the Inbound and Outbound stack builders.

This leads to two problems:

1. We cannot build the admin server until all of the proxy stacks are built. This ordering dependency is unnecessary and cumbersome if we want to insert additional discovery work into the initialization process.
2. It is cumbersome to add new metrics to stacks, as the registry must be passed through the stack building process.

To fix this, this change introduces additional Metrics types so that these metrics may be registered along with the other stack metrics.

BREAKING CHANGE: Gateway-mode proxies now report Balancer metrics with the "outbound_" prefix instead of the "gateway_" prefix. This metrics scope was introduced very recently and is incongruent with our other metrics export. We have no known readers of these metrics, as they are only relevant to new load balancer behavior, and only on multicluster gateways. Unifying under the outbound_ prefix reduces noise in metrics in non-gateway use cases and makes it easier to query proxy data consistently.