### PR TITLE
identity: support DER encoded trust roots

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -1303,7 +1303,7 @@ pub fn parse_tls_params<S: Strings>(strings: &S) -> Result<identity::TlsParams, 
             let params = identity::TlsParams {
                 id: server_id,
                 server_name,
-                trust_anchors_pem,
+                roots: identity::Roots::Pem(trust_anchors_pem),
             };
             Ok(params)
         }

--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -1,6 +1,6 @@
 use crate::spire;
 
-pub use linkerd_app_core::identity::{client, Id};
+pub use linkerd_app_core::identity::{client, Id, Roots};
 use linkerd_app_core::{
     control, dns,
     identity::{
@@ -35,7 +35,7 @@ pub enum Config {
 pub struct TlsParams {
     pub id: Id,
     pub server_name: dns::Name,
-    pub trust_anchors_pem: String,
+    pub roots: Roots,
 }
 
 pub struct Identity {
@@ -137,8 +137,7 @@ fn watch(
     watch::Receiver<bool>,
 )> {
     let (tx, ready) = watch::channel(false);
-    let (store, receiver) =
-        Mode::default().watch(tls.id, tls.server_name, &tls.trust_anchors_pem)?;
+    let (store, receiver) = Mode::default().watch(tls.id, tls.server_name, &tls.roots)?;
     let cred = WithCertMetrics::new(metrics, NotifyReady { store, tx });
     Ok((cred, receiver, ready))
 }

--- a/linkerd/app/src/spire.rs
+++ b/linkerd/app/src/spire.rs
@@ -11,8 +11,8 @@ const TONIC_DEFAULT_URI: &str = "http://[::]:50051";
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub(crate) socket_addr: Arc<String>,
-    pub(crate) backoff: ExponentialBackoff,
+    pub socket_addr: Arc<String>,
+    pub backoff: ExponentialBackoff,
 }
 
 // Connects to SPIRE workload API via Unix Domain Socket

--- a/linkerd/identity/src/lib.rs
+++ b/linkerd/identity/src/lib.rs
@@ -12,6 +12,13 @@ pub use self::{
     metrics::{CertMetrics, WithCertMetrics},
 };
 
+/// A set of x509 trust root certificates in either PEM or DER format.
+#[derive(Clone, Debug)]
+pub enum Roots {
+    Pem(String),
+    Der(Vec<self::DerX509>),
+}
+
 /// An endpoint identity descriptor used for authentication.
 ///
 /// Practically speaking, this could be:

--- a/linkerd/meshtls/boring/src/tests.rs
+++ b/linkerd/meshtls/boring/src/tests.rs
@@ -1,15 +1,16 @@
-use linkerd_identity::{Credentials, DerX509};
+use linkerd_identity::{Credentials, DerX509, Roots};
 use linkerd_tls_test_util::*;
 use std::time::{Duration, SystemTime};
 
 fn load(ent: &Entity) -> crate::creds::Store {
-    let roots_pem = std::str::from_utf8(ent.trust_anchors).expect("valid PEM");
-    let (store, _) = crate::creds::watch(
-        ent.name.parse().unwrap(),
-        ent.name.parse().unwrap(),
-        roots_pem,
-    )
-    .expect("credentials must be readable");
+    let roots = Roots::Pem(
+        std::str::from_utf8(ent.trust_anchors)
+            .expect("valid PEM")
+            .into(),
+    );
+    let (store, _) =
+        crate::creds::watch(ent.name.parse().unwrap(), ent.name.parse().unwrap(), &roots)
+            .expect("credentials must be readable");
     store
 }
 

--- a/linkerd/meshtls/rustls/src/creds.rs
+++ b/linkerd/meshtls/rustls/src/creds.rs
@@ -3,6 +3,7 @@ mod store;
 pub(crate) mod verify;
 
 pub use self::{receiver::Receiver, store::Store};
+use id::DerX509;
 use linkerd_dns_name as dns;
 use linkerd_error::Result;
 use linkerd_identity as id;
@@ -24,21 +25,26 @@ pub struct InvalidTrustRoots(());
 pub fn watch(
     local_id: id::Id,
     server_name: dns::Name,
-    roots_pem: &str,
+    roots: &id::Roots,
 ) -> Result<(Store, Receiver)> {
-    let mut roots = rustls::RootCertStore::empty();
-    let certs = match rustls_pemfile::certs(&mut std::io::Cursor::new(roots_pem)) {
-        Err(error) => {
-            warn!(%error, "invalid trust anchors file");
-            return Err(error.into());
+    let certs = match roots {
+        id::Roots::Pem(roots_pem) => {
+            match rustls_pemfile::certs(&mut std::io::Cursor::new(roots_pem)) {
+                Err(error) => {
+                    warn!(%error, "invalid trust anchors file");
+                    return Err(error.into());
+                }
+                Ok(certs) if certs.is_empty() => {
+                    warn!("no valid certs in trust anchors file");
+                    return Err("no trust roots in PEM file".into());
+                }
+                Ok(certs) => certs,
+            }
         }
-        Ok(certs) if certs.is_empty() => {
-            warn!("no valid certs in trust anchors file");
-            return Err("no trust roots in PEM file".into());
-        }
-        Ok(certs) => certs,
+        id::Roots::Der(roots_der) => roots_der.iter().map(DerX509::to_vec).collect(),
     };
 
+    let mut roots = rustls::RootCertStore::empty();
     let (added, skipped) = roots.add_parsable_certificates(&certs[..]);
     if skipped != 0 {
         warn!("Skipped {} invalid trust anchors", skipped);
@@ -90,10 +96,12 @@ pub fn watch(
 
 #[cfg(feature = "test-util")]
 pub fn for_test(ent: &linkerd_tls_test_util::Entity) -> (Store, Receiver) {
+    let roots_pem = std::str::from_utf8(ent.trust_anchors).expect("roots must be PEM");
+    let roots = id::Roots::Pem(roots_pem.into());
     watch(
         ent.name.parse().expect("id must be valid"),
         ent.name.parse().expect("name must be valid"),
-        std::str::from_utf8(ent.trust_anchors).expect("roots must be PEM"),
+        &roots,
     )
     .expect("credentials must be valid")
 }

--- a/linkerd/meshtls/rustls/src/tests.rs
+++ b/linkerd/meshtls/rustls/src/tests.rs
@@ -1,15 +1,16 @@
-use linkerd_identity::{Credentials, DerX509};
+use linkerd_identity::{Credentials, DerX509, Roots};
 use linkerd_tls_test_util::*;
 use std::time::{Duration, SystemTime};
 
 fn load(ent: &Entity) -> crate::creds::Store {
-    let roots_pem = std::str::from_utf8(ent.trust_anchors).expect("valid PEM");
-    let (store, _) = crate::creds::watch(
-        ent.name.parse().unwrap(),
-        ent.name.parse().unwrap(),
-        roots_pem,
-    )
-    .expect("credentials must be readable");
+    let roots = Roots::Pem(
+        std::str::from_utf8(ent.trust_anchors)
+            .expect("valid PEM")
+            .into(),
+    );
+    let (store, _) =
+        crate::creds::watch(ent.name.parse().unwrap(), ent.name.parse().unwrap(), &roots)
+            .expect("credentials must be readable");
     store
 }
 

--- a/linkerd/meshtls/src/lib.rs
+++ b/linkerd/meshtls/src/lib.rs
@@ -85,12 +85,12 @@ impl Mode {
         self,
         local_id: id::Id,
         server_name: dns::Name,
-        roots_pem: &str,
+        roots: &id::Roots,
     ) -> Result<(creds::Store, creds::Receiver)> {
         match self {
             #[cfg(feature = "boring")]
             Self::Boring => {
-                let (store, receiver) = boring::creds::watch(local_id, server_name, roots_pem)?;
+                let (store, receiver) = boring::creds::watch(local_id, server_name, roots)?;
                 Ok((
                     creds::Store::Boring(store),
                     creds::Receiver::Boring(receiver),
@@ -99,7 +99,7 @@ impl Mode {
 
             #[cfg(feature = "rustls")]
             Self::Rustls => {
-                let (store, receiver) = rustls::creds::watch(local_id, server_name, roots_pem)?;
+                let (store, receiver) = rustls::creds::watch(local_id, server_name, roots)?;
                 Ok((
                     creds::Store::Rustls(store),
                     creds::Receiver::Rustls(receiver),
@@ -107,7 +107,7 @@ impl Mode {
             }
 
             #[cfg(not(feature = "__has_any_tls_impls"))]
-            _ => no_tls!(local_id, server_name, roots_pem),
+            _ => no_tls!(local_id, server_name, roots),
         }
     }
 }

--- a/linkerd/meshtls/tests/boring.rs
+++ b/linkerd/meshtls/tests/boring.rs
@@ -7,8 +7,33 @@ mod util;
 use linkerd_meshtls::Mode;
 
 #[test]
-fn fails_processing_cert_when_wrong_id_configured() {
-    util::fails_processing_cert_when_wrong_id_configured(Mode::Boring);
+fn can_construct_store_der_roots() {
+    util::can_construct_store(Mode::Boring, util::RootsFormat::Der);
+}
+
+#[test]
+fn can_construct_store_pem_roots() {
+    util::can_construct_store(Mode::Boring, util::RootsFormat::Pem);
+}
+
+#[test]
+fn fails_processing_cert_when_wrong_id_configured_der_roots() {
+    util::fails_processing_cert_when_wrong_id_configured(Mode::Boring, util::RootsFormat::Der);
+}
+
+#[test]
+fn fails_processing_cert_when_wrong_id_configured_pem_roots() {
+    util::fails_processing_cert_when_wrong_id_configured(Mode::Boring, util::RootsFormat::Pem);
+}
+
+#[test]
+fn fails_to_construct_store_for_empty_der_roots() {
+    util::fails_to_construct_store_for_empty_roots(Mode::Boring, util::RootsFormat::Der);
+}
+
+#[test]
+fn fails_to_construct_store_for_empty_pem_roots() {
+    util::fails_to_construct_store_for_empty_roots(Mode::Boring, util::RootsFormat::Pem);
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/linkerd/meshtls/tests/rustls.rs
+++ b/linkerd/meshtls/tests/rustls.rs
@@ -7,8 +7,33 @@ mod util;
 use linkerd_meshtls::Mode;
 
 #[test]
-fn fails_processing_cert_when_wrong_id_configured() {
-    util::fails_processing_cert_when_wrong_id_configured(Mode::Rustls);
+fn can_construct_store_der_roots() {
+    util::can_construct_store(Mode::Rustls, util::RootsFormat::Der);
+}
+
+#[test]
+fn can_construct_store_pem_roots() {
+    util::can_construct_store(Mode::Rustls, util::RootsFormat::Pem);
+}
+
+#[test]
+fn fails_processing_cert_when_wrong_id_configured_der_roots() {
+    util::fails_processing_cert_when_wrong_id_configured(Mode::Rustls, util::RootsFormat::Der);
+}
+
+#[test]
+fn fails_processing_cert_when_wrong_id_configured_pem_roots() {
+    util::fails_processing_cert_when_wrong_id_configured(Mode::Rustls, util::RootsFormat::Pem);
+}
+
+#[test]
+fn fails_to_construct_store_for_empty_der_roots() {
+    util::fails_to_construct_store_for_empty_roots(Mode::Rustls, util::RootsFormat::Der);
+}
+
+#[test]
+fn fails_to_construct_store_for_empty_pem_roots() {
+    util::fails_to_construct_store_for_empty_roots(Mode::Rustls, util::RootsFormat::Pem);
 }
 
 #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
Currently, our TlsParam struct assumes roots are provided in PEM encoding.
This PR augments the API to allow for passing roots in DER format. 

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>