### PR TITLE
fix(http): fix outbound HTTP metrics naming

### DIFF
--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -84,10 +84,13 @@ where
 
 impl PromMetrics {
     pub fn register(registry: &mut prom::Registry) -> Self {
-        Self {
-            http: crate::http::HttpMetrics::register(registry.sub_registry_with_prefix("http")),
-            opaq: crate::opaq::OpaqMetrics::register(registry.sub_registry_with_prefix("tcp")),
-        }
+        // NOTE: HTTP metrics are scoped internally, since this configures both
+        // HTTP and gRPC scopes.
+        let http = crate::http::HttpMetrics::register(registry);
+
+        let opaq = crate::opaq::OpaqMetrics::register(registry.sub_registry_with_prefix("tcp"));
+
+        Self { http, opaq }
     }
 }
 


### PR DESCRIPTION
31d7464ef introduced a naming regression, so that metrics that 'outbound_http_' became 'outbound_http_http_'. This change fixes this regression.