### PR TITLE
chore(app): move helpers into submodules

### DIFF
--- a/linkerd/app/src/env/control.rs
+++ b/linkerd/app/src/env/control.rs
@@ -1,0 +1,81 @@
+use super::{parse, parse_duration_opt, EnvError, Strings};
+use std::time::Duration;
+use tracing::error;
+
+pub use linkerd_tonic_stream::ReceiveLimits;
+
+pub(super) fn mk_receive_limits(env: &dyn Strings) -> Result<ReceiveLimits, EnvError> {
+    const ENV_INIT: &str = "LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT";
+    const ENV_IDLE: &str = "LINKERD2_PROXY_CONTROL_STREAM_IDLE_TIMEOUT";
+    const ENV_LIFE: &str = "LINKERD2_PROXY_CONTROL_STREAM_LIFETIME";
+
+    let initial = parse(env, ENV_INIT, parse_duration_opt)?.flatten();
+    let idle = parse(env, ENV_IDLE, parse_duration_opt)?.flatten();
+    let lifetime = parse(env, ENV_LIFE, parse_duration_opt)?.flatten();
+
+    if initial.unwrap_or(Duration::ZERO) > idle.unwrap_or(Duration::MAX) {
+        error!("{ENV_INIT} must be less than {ENV_IDLE}");
+        return Err(EnvError::InvalidEnvVar);
+    }
+    if initial.unwrap_or(Duration::ZERO) > lifetime.unwrap_or(Duration::MAX) {
+        error!("{ENV_INIT} must be less than {ENV_LIFE}");
+        return Err(EnvError::InvalidEnvVar);
+    }
+    if idle.unwrap_or(Duration::ZERO) > lifetime.unwrap_or(Duration::MAX) {
+        error!("{ENV_IDLE} must be less than {ENV_LIFE}");
+        return Err(EnvError::InvalidEnvVar);
+    }
+
+    Ok(ReceiveLimits {
+        initial,
+        idle,
+        lifetime,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn control_stream_limits() {
+        impl Strings for HashMap<&'static str, &'static str> {
+            fn get(&self, key: &str) -> Result<Option<String>, EnvError> {
+                Ok(self.get(key).map(ToString::to_string))
+            }
+        }
+
+        let mut env = HashMap::default();
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT", "1s");
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_IDLE_TIMEOUT", "2s");
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_LIFETIME", "3s");
+        let limits = mk_receive_limits(&env).unwrap();
+        assert_eq!(limits.initial, Some(Duration::from_secs(1)));
+        assert_eq!(limits.idle, Some(Duration::from_secs(2)));
+        assert_eq!(limits.lifetime, Some(Duration::from_secs(3)));
+
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT", "");
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_IDLE_TIMEOUT", "");
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_LIFETIME", "");
+        let limits = mk_receive_limits(&env).unwrap();
+        assert_eq!(limits.initial, None);
+        assert_eq!(limits.idle, None);
+        assert_eq!(limits.lifetime, None);
+
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT", "3s");
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_IDLE_TIMEOUT", "1s");
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_LIFETIME", "");
+        assert!(mk_receive_limits(&env).is_err());
+
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT", "3s");
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_IDLE_TIMEOUT", "");
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_LIFETIME", "1s");
+        assert!(mk_receive_limits(&env).is_err());
+
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_INITIAL_TIMEOUT", "");
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_IDLE_TIMEOUT", "3s");
+        env.insert("LINKERD2_PROXY_CONTROL_STREAM_LIFETIME", "1s");
+        assert!(mk_receive_limits(&env).is_err());
+    }
+}

--- a/linkerd/app/src/env/opencensus.rs
+++ b/linkerd/app/src/env/opencensus.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+pub(super) fn read_trace_attributes(path: &std::path::Path) -> HashMap<String, String> {
+    match std::fs::read_to_string(path) {
+        Ok(attrs) => parse_attrs(&attrs),
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                path = %path.display(),
+                "Failed to read trace attributes",
+            );
+            HashMap::new()
+        }
+    }
+}
+
+fn parse_attrs(attrs: &str) -> HashMap<String, String> {
+    attrs
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(2, '=');
+            parts.next().and_then(move |key| {
+                parts.next().map(move |val|
+            // Trim double quotes in value, present by default when attached through k8s downwardAPI
+            (key.to_string(), val.trim_matches('"').to_string()))
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+#[test]
+fn parse_attrs_different_values() {
+    let attrs = "\
+        cluster=\"test-cluster1\"\n\
+        rack=\"rack-22\"\n\
+        zone=us-est-coast\n\
+        linkerd.io/control-plane-component=\"controller\"\n\
+        linkerd.io/proxy-deployment=\"linkerd-controller\"\n\
+        workload=\n\
+        kind=\"\"\n\
+        key1=\"=\"\n\
+        key2==value2\n\
+        key3\n\
+        =key4\n\
+        ";
+
+    let expected = [
+        ("cluster".to_string(), "test-cluster1".to_string()),
+        ("rack".to_string(), "rack-22".to_string()),
+        ("zone".to_string(), "us-est-coast".to_string()),
+        (
+            "linkerd.io/control-plane-component".to_string(),
+            "controller".to_string(),
+        ),
+        (
+            "linkerd.io/proxy-deployment".to_string(),
+            "linkerd-controller".to_string(),
+        ),
+        ("workload".to_string(), "".to_string()),
+        ("kind".to_string(), "".to_string()),
+        ("key1".to_string(), "=".to_string()),
+        ("key2".to_string(), "=value2".to_string()),
+        ("".to_string(), "key4".to_string()),
+    ]
+    .iter()
+    .cloned()
+    .collect();
+
+    assert_eq!(parse_attrs(attrs), expected);
+}

--- a/linkerd/app/src/env/types.rs
+++ b/linkerd/app/src/env/types.rs
@@ -1,0 +1,361 @@
+use super::ParseError;
+use linkerd_app_core::{dns, identity, Addr, IpNet};
+use rangemap::RangeInclusiveSet;
+use std::{
+    collections::HashSet,
+    net::{IpAddr, SocketAddr},
+    str::FromStr,
+    time::Duration,
+};
+use tracing::error;
+
+pub(crate) fn parse_dns_name(s: &str) -> Result<dns::Name, ParseError> {
+    s.parse().map_err(|_| {
+        error!("Not a valid identity name: {s}");
+        ParseError::NameError
+    })
+}
+
+pub(crate) fn parse_identity(s: &str) -> Result<identity::Id, ParseError> {
+    s.parse().map_err(|_| {
+        error!("Not a valid identity name: {s}");
+        ParseError::NameError
+    })
+}
+
+pub(super) fn parse_bool(s: &str) -> Result<bool, ParseError> {
+    s.parse().map_err(Into::into)
+}
+
+pub(super) fn parse_number<T>(s: &str) -> Result<T, ParseError>
+where
+    T: FromStr,
+    ParseError: From<T::Err>,
+{
+    s.parse().map_err(Into::into)
+}
+
+pub(super) fn parse_duration_opt(s: &str) -> Result<Option<Duration>, ParseError> {
+    if s.is_empty() {
+        return Ok(None);
+    }
+    parse_duration(s).map(Some)
+}
+
+pub(super) fn parse_duration(s: &str) -> Result<Duration, ParseError> {
+    use regex::Regex;
+
+    let re = Regex::new(r"^\s*(\d+)(ms|s|m|h|d)?\s*$").expect("duration regex");
+
+    let cap = re.captures(s).ok_or(ParseError::NotADuration)?;
+
+    let magnitude = parse_number(&cap[1])?;
+    match cap.get(2).map(|m| m.as_str()) {
+        None if magnitude == 0 => Ok(Duration::from_secs(0)),
+        Some("ms") => Ok(Duration::from_millis(magnitude)),
+        Some("s") => Ok(Duration::from_secs(magnitude)),
+        Some("m") => Ok(Duration::from_secs(magnitude * 60)),
+        Some("h") => Ok(Duration::from_secs(magnitude * 60 * 60)),
+        Some("d") => Ok(Duration::from_secs(magnitude * 60 * 60 * 24)),
+        _ => Err(ParseError::NotADuration),
+    }
+}
+
+pub(super) fn parse_socket_addr(s: &str) -> Result<SocketAddr, ParseError> {
+    match parse_addr(s)? {
+        Addr::Socket(a) => Ok(a),
+        _ => {
+            error!("Expected IP:PORT; found: {s}");
+            Err(ParseError::HostIsNotAnIpAddress)
+        }
+    }
+}
+
+pub(super) fn parse_socket_addrs(s: &str) -> Result<Vec<SocketAddr>, ParseError> {
+    let addrs: Vec<&str> = s.split(',').collect();
+    if addrs.len() > 2 {
+        return Err(ParseError::TooManyAddrs);
+    }
+    addrs.iter().map(|s| parse_socket_addr(s)).collect()
+}
+
+pub(super) fn parse_ip_set(s: &str) -> Result<HashSet<IpAddr>, ParseError> {
+    s.split(',')
+        .map(|s| s.parse::<IpAddr>().map_err(Into::into))
+        .collect()
+}
+
+pub(super) fn parse_addr(s: &str) -> Result<Addr, ParseError> {
+    Addr::from_str(s).map_err(|e| {
+        error!("Not a valid address: {s}");
+        ParseError::AddrError(e)
+    })
+}
+
+pub(super) fn parse_port_range_set(s: &str) -> Result<RangeInclusiveSet<u16>, ParseError> {
+    let mut set = RangeInclusiveSet::new();
+    if !s.is_empty() {
+        for part in s.split(',') {
+            let part = part.trim();
+            // Ignore empty list entries
+            if part.is_empty() {
+                continue;
+            }
+
+            let mut parts = part.splitn(2, '-');
+            let low = parts
+                .next()
+                .ok_or_else(|| {
+                    error!("Not a valid port range: {part}");
+                    ParseError::NotAPortRange
+                })?
+                .trim();
+            let low = parse_number::<u16>(low)?;
+            if let Some(high) = parts.next() {
+                let high = high.trim();
+                let high = parse_number::<u16>(high).map_err(|e| {
+                    error!("Not a valid port range: {part}");
+                    e
+                })?;
+                if high < low {
+                    error!("Not a valid port range: {part}; {high} is greater than {low}");
+                    return Err(ParseError::NotAPortRange);
+                }
+                set.insert(low..=high);
+            } else {
+                set.insert(low..=low);
+            }
+        }
+    }
+    Ok(set)
+}
+
+pub(super) fn parse_dns_suffixes(list: &str) -> Result<HashSet<dns::Suffix>, ParseError> {
+    let mut suffixes = HashSet::new();
+    for item in list.split(',') {
+        let item = item.trim();
+        if !item.is_empty() {
+            let sfx = parse_dns_suffix(item)?;
+            suffixes.insert(sfx);
+        }
+    }
+
+    Ok(suffixes)
+}
+
+pub(super) fn parse_dns_suffix(s: &str) -> Result<dns::Suffix, ParseError> {
+    if s == "." {
+        return Ok(dns::Suffix::Root);
+    }
+
+    dns::Suffix::from_str(s).map_err(|_| ParseError::NotADomainSuffix)
+}
+
+pub(super) fn parse_networks(list: &str) -> Result<HashSet<IpNet>, ParseError> {
+    let mut nets = HashSet::new();
+    for input in list.split(',') {
+        let input = input.trim();
+        if !input.is_empty() {
+            let net = IpNet::from_str(input).map_err(|error| {
+                error!(%input, %error, "Invalid network");
+                ParseError::NotANetwork
+            })?;
+            nets.insert(net);
+        }
+    }
+    Ok(nets)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_unit<F: Fn(u64) -> Duration>(unit: &str, to_duration: F) {
+        for v in &[0, 1, 23, 456_789] {
+            let d = to_duration(*v);
+            let text = format!("{}{}", v, unit);
+            assert_eq!(parse_duration(&text), Ok(d), "text=\"{}\"", text);
+
+            let text = format!(" {}{}\t", v, unit);
+            assert_eq!(parse_duration(&text), Ok(d), "text=\"{}\"", text);
+        }
+    }
+
+    #[test]
+    fn parse_duration_unit_ms() {
+        test_unit("ms", Duration::from_millis);
+    }
+
+    #[test]
+    fn parse_duration_unit_s() {
+        test_unit("s", Duration::from_secs);
+    }
+
+    #[test]
+    fn parse_duration_unit_m() {
+        test_unit("m", |v| Duration::from_secs(v * 60));
+    }
+
+    #[test]
+    fn parse_duration_unit_h() {
+        test_unit("h", |v| Duration::from_secs(v * 60 * 60));
+    }
+
+    #[test]
+    fn parse_duration_unit_d() {
+        test_unit("d", |v| Duration::from_secs(v * 60 * 60 * 24));
+    }
+
+    #[test]
+    fn parse_duration_floats_invalid() {
+        assert_eq!(parse_duration(".123h"), Err(ParseError::NotADuration));
+        assert_eq!(parse_duration("1.23h"), Err(ParseError::NotADuration));
+    }
+
+    #[test]
+    fn parse_duration_space_before_unit_invalid() {
+        assert_eq!(parse_duration("1 ms"), Err(ParseError::NotADuration));
+    }
+
+    #[test]
+    fn parse_duration_overflows_invalid() {
+        assert!(matches!(
+            parse_duration("123456789012345678901234567890ms"),
+            Err(ParseError::NotAnInteger(_))
+        ));
+    }
+
+    #[test]
+    fn parse_duration_invalid_unit() {
+        assert_eq!(parse_duration("12moons"), Err(ParseError::NotADuration));
+        assert_eq!(parse_duration("12y"), Err(ParseError::NotADuration));
+    }
+
+    #[test]
+    fn parse_duration_zero_without_unit() {
+        assert_eq!(parse_duration("0"), Ok(Duration::from_secs(0)));
+    }
+
+    #[test]
+    fn parse_duration_number_without_unit_is_invalid() {
+        assert_eq!(parse_duration("1"), Err(ParseError::NotADuration));
+    }
+
+    #[test]
+    fn dns_suffixes() {
+        fn p(s: &str) -> Result<Vec<String>, ParseError> {
+            let mut sfxs = parse_dns_suffixes(s)?
+                .into_iter()
+                .map(|s| format!("{}", s))
+                .collect::<Vec<_>>();
+            sfxs.sort();
+            Ok(sfxs)
+        }
+
+        assert_eq!(p(""), Ok(vec![]), "empty string");
+        assert_eq!(p(",,,"), Ok(vec![]), "empty list components are ignored");
+        assert_eq!(p("."), Ok(vec![".".to_owned()]), "root is valid");
+        assert_eq!(
+            p("a.b.c"),
+            Ok(vec!["a.b.c".to_owned()]),
+            "a name without trailing dot"
+        );
+        assert_eq!(
+            p("a.b.c."),
+            Ok(vec!["a.b.c.".to_owned()]),
+            "a name with a trailing dot"
+        );
+        assert_eq!(
+            p(" a.b.c. , d.e.f. "),
+            Ok(vec!["a.b.c.".to_owned(), "d.e.f.".to_owned()]),
+            "whitespace is ignored"
+        );
+        assert_eq!(
+            p("a .b.c"),
+            Err(ParseError::NotADomainSuffix),
+            "whitespace not allowed within a name"
+        );
+        assert_eq!(
+            p("mUlti.CasE.nAmE"),
+            Ok(vec!["multi.case.name".to_owned()]),
+            "names are coerced to lowercase"
+        );
+    }
+
+    #[test]
+    fn ip_sets() {
+        let ips = &[
+            IpAddr::from([127, 0, 0, 1]),
+            IpAddr::from([10, 0, 2, 42]),
+            IpAddr::from([192, 168, 0, 69]),
+        ];
+        assert_eq!(
+            parse_ip_set("127.0.0.1"),
+            Ok(ips[..1].iter().cloned().collect())
+        );
+        assert_eq!(
+            parse_ip_set("127.0.0.1,10.0.2.42"),
+            Ok(ips[..2].iter().cloned().collect())
+        );
+        assert_eq!(
+            parse_ip_set("127.0.0.1,10.0.2.42,192.168.0.69"),
+            Ok(ips[..3].iter().cloned().collect())
+        );
+        assert!(parse_ip_set("blaah").is_err());
+        assert!(parse_ip_set("10.4.0.555").is_err());
+        assert!(parse_ip_set("10.4.0.3,foobar,192.168.0.69").is_err());
+        assert!(parse_ip_set("10.0.1.1/24").is_err());
+    }
+
+    #[test]
+    fn ranges() {
+        fn set(
+            ranges: impl IntoIterator<Item = std::ops::RangeInclusive<u16>>,
+        ) -> Result<RangeInclusiveSet<u16>, ParseError> {
+            Ok(ranges.into_iter().collect())
+        }
+
+        assert_eq!(dbg!(parse_port_range_set("1-65535")), set([1..=65535]));
+        assert_eq!(
+            dbg!(parse_port_range_set("1-2,42-420")),
+            set([1..=2, 42..=420])
+        );
+        assert_eq!(
+            dbg!(parse_port_range_set("1-2,42,80-420")),
+            set([1..=2, 42..=42, 80..=420])
+        );
+        assert_eq!(
+            dbg!(parse_port_range_set("1,20,30,40")),
+            set([1..=1, 20..=20, 30..=30, 40..=40])
+        );
+        assert_eq!(
+            dbg!(parse_port_range_set("40,30,20,1")),
+            set([1..=1, 20..=20, 30..=30, 40..=40])
+        );
+        // ignores empty list entries
+        assert_eq!(dbg!(parse_port_range_set("1,,,,2")), set([1..=1, 2..=2]));
+        // ignores rando whitespace
+        assert_eq!(
+            dbg!(parse_port_range_set("1, 2,\t3- 5")),
+            set([1..=1, 2..=2, 3..=5])
+        );
+        assert_eq!(dbg!(parse_port_range_set("1, , 2,")), set([1..=1, 2..=2]));
+
+        // non-numeric strings
+        assert!(dbg!(parse_port_range_set("asdf")).is_err());
+        assert!(dbg!(parse_port_range_set("80, 443, http")).is_err());
+        assert!(dbg!(parse_port_range_set("80,http-443")).is_err());
+
+        // backwards ranges
+        assert!(dbg!(parse_port_range_set("80-79")).is_err());
+        assert!(dbg!(parse_port_range_set("1,2,5-2")).is_err());
+
+        // malformed (half-open) ranges
+        assert!(dbg!(parse_port_range_set("-1")).is_err());
+        assert!(dbg!(parse_port_range_set("1,2-,50")).is_err());
+
+        // not a u16
+        assert!(dbg!(parse_port_range_set("69420")).is_err());
+        assert!(dbg!(parse_port_range_set("1-69420")).is_err());
+    }
+}


### PR DESCRIPTION
The app::env module is large and unwieldy. Before we add additional utilities, making the module larger, this change splits out about 30% of the file into sub-modules.

There are no functional changes in this commit.