### PR TITLE
identity: make spire client config fields pub

### DIFF
--- a/linkerd/app/src/spire.rs
+++ b/linkerd/app/src/spire.rs
@@ -11,8 +11,8 @@ const TONIC_DEFAULT_URI: &str = "http://[::]:50051";
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub(crate) socket_addr: Arc<String>,
-    pub(crate) backoff: ExponentialBackoff,
+    pub socket_addr: Arc<String>,
+    pub backoff: ExponentialBackoff,
 }
 
 // Connects to SPIRE workload API via Unix Domain Socket


### PR DESCRIPTION
Makes the fields of the spire::Config struct pub so we can construct client configs from other crates.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>