### PR TITLE
Unwrap IPv4-mapped IPv6 addresses

### DIFF
--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -6,11 +6,7 @@ use futures::prelude::*;
 use linkerd_error::Result;
 use linkerd_io as io;
 use linkerd_stack::Param;
-use std::{
-    fmt,
-    net::{SocketAddr, SocketAddrV4},
-    pin::Pin,
-};
+use std::{fmt, net::SocketAddr, pin::Pin};
 use thiserror::Error;
 use tokio::net::TcpStream;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -93,7 +89,7 @@ where
             super::set_nodelay_or_warn(&tcp);
             let tcp = super::set_keepalive_or_warn(tcp, keepalive).map_err(KeepaliveError)?;
 
-            fn ipv4_mapped(orig: SocketAddr) -> SocketAddr {    
+            fn ipv4_mapped(orig: SocketAddr) -> SocketAddr {
                 if let SocketAddr::V6(v6) = orig {
                     if let Some(ip) = v6.ip().to_ipv4_mapped() {
                         return (ip, orig.port()).into();
@@ -101,7 +97,7 @@ where
                 }
                 orig
             }
-            
+
             let client_addr = tcp.peer_addr().map_err(PeerAddrError)?;
             let client = Remote(ClientAddr(ipv4_mapped(client_addr)));
             Ok((Addrs { server, client }, tcp))

--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -6,7 +6,11 @@ use futures::prelude::*;
 use linkerd_error::Result;
 use linkerd_io as io;
 use linkerd_stack::Param;
-use std::{fmt, pin::Pin};
+use std::{
+    fmt,
+    net::{SocketAddr, SocketAddrV4},
+    pin::Pin,
+};
 use thiserror::Error;
 use tokio::net::TcpStream;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -88,7 +92,16 @@ where
             let tcp = res.map_err(AcceptError)?;
             super::set_nodelay_or_warn(&tcp);
             let tcp = super::set_keepalive_or_warn(tcp, keepalive).map_err(KeepaliveError)?;
-            let client = Remote(ClientAddr(tcp.peer_addr().map_err(PeerAddrError)?));
+            let mut client_addr = tcp.peer_addr().map_err(PeerAddrError)?;
+
+            // unwrap IPv4-mapped IPv6 address
+            if let SocketAddr::V6(ipv6) = client_addr {
+                if let Some(ipv4) = ipv6.ip().to_ipv4_mapped() {
+                    client_addr = SocketAddr::V4(SocketAddrV4::new(ipv4, client_addr.port()));
+                }
+            }
+
+            let client = Remote(ClientAddr(client_addr));
             Ok((Addrs { server, client }, tcp))
         });
 


### PR DESCRIPTION
The policy logic doesn't account for IPv4-mapped IPv6 addresses when matching allowed IPs with client IPs, so this change "unwraps" these types of IPs, converting those sockets into `SocketAddr::V4` at the lowest level in `BindTcp`. This also allows us to simplify the logic introduced by 7338f6b2b27c40ef8748551bed3e89905322f151 into `BindWithOrigDst` as it no longer has to account for IPv4-mapped IPv6 addresses (it was detecting them but wasn't unwrapping them).

As an example, this is the error we were getting, when prometheus (at 10.42.0.11) attempted to scrape a pod, even when that IP was authorized:
```
[    69.592605s]  INFO ThreadId(02) daemon:admin{listen.addr=[::]:4191}: linkerd_app_inbound::policy::http: Request denied server.group=policy.linkerd.io server.kind=server server.name=smoke-test-proxy-admin route.group= route.kind=default route.name=default client.tls=Some(Established { client_id: Some(ClientId(Dns(Name("prometheus.linkerd-viz.serviceaccount.identity.linkerd.custom.domain")))), negotiated_protocol: None }) client.ip=::ffff:10.42.0.11
[    69.592664s]  INFO ThreadId(02) daemon:admin{listen.addr=[::]:4191}:rescue{client.addr=[::ffff:10.42.0.11]:55168}: linkerd_app_core::errors::respond: HTTP/2.0 request failed error=unauthorized request on route
```