### PR TITLE
chore(http): allow http client configuration to vary by endpoint

### DIFF
--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -16,7 +16,7 @@ use tracing::{debug, trace};
 #[derive(Copy, Clone, Debug)]
 pub struct WasAbsoluteForm(pub(crate) ());
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct PoolSettings {
     pub max_idle: usize,
     pub idle_timeout: Duration,


### PR DESCRIPTION
Currently all HTTP client configuration is derived from the configuration loaded at startup.

We'd like to allow this configuration to vary by endpoint so that, for example, we can enable keepalives when communicating with other proxies. These keepalives allow load balancers to eagerly detect connections that are in a bad state (i.e. before attempting to write a request to that connection).

To setup this kind of per-endpoint configuration, this change modifies the HTTP client to extract its configuration from the per-endpoint target so that calling stacks can provide this configuration.

The inbound and outbound stacks continue to set these configurations based on process-wide defaults, but we now have obvious places where we can set these parameters based on discovery results.

There are no user-facing functional changes in this commit.