### PR TITLE
chore(http): split params types into a dedicated http-h2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,6 +1471,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkerd-http-h2"
+version = "0.1.0"
+
+[[package]]
 name = "linkerd-http-metrics"
 version = "0.1.0"
 dependencies = [
@@ -1854,6 +1858,7 @@ dependencies = [
  "linkerd-error",
  "linkerd-http-box",
  "linkerd-http-classify",
+ "linkerd-http-h2",
  "linkerd-io",
  "linkerd-proxy-balance",
  "linkerd-stack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "linkerd/http/access-log",
     "linkerd/http/box",
     "linkerd/http/classify",
+    "linkerd/http/h2",
     "linkerd/http/metrics",
     "linkerd/http/retry",
     "linkerd/http/route",
@@ -77,6 +78,7 @@ members = [
     "opencensus-proto",
     "spiffe-proto",
     "tools",
+    "linkerd/http/h2",
 ]
 
 [profile.release]

--- a/linkerd/http/h2/Cargo.toml
+++ b/linkerd/http/h2/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "linkerd-http-h2"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "HTTP/2-specific configuration types"

--- a/linkerd/http/h2/src/lib.rs
+++ b/linkerd/http/h2/src/lib.rs
@@ -1,0 +1,47 @@
+use std::time::Duration;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ServerParams {
+    pub flow_control: Option<FlowControl>,
+    pub keep_alive: Option<KeepAlive>,
+    pub max_concurrent_streams: Option<u32>,
+
+    // Internals
+    pub max_frame_size: Option<u32>,
+    pub max_header_list_size: Option<u32>,
+    pub max_pending_accept_reset_streams: Option<usize>,
+    pub max_send_buf_size: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Hash)]
+pub struct ClientParams {
+    pub flow_control: Option<FlowControl>,
+    pub keep_alive: Option<ClientKeepAlive>,
+
+    // Internals
+    pub max_concurrent_reset_streams: Option<usize>,
+    pub max_frame_size: Option<u32>,
+    pub max_send_buf_size: Option<usize>,
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct KeepAlive {
+    pub interval: Duration,
+    pub timeout: Duration,
+}
+
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
+pub struct ClientKeepAlive {
+    pub interval: Duration,
+    pub timeout: Duration,
+    pub while_idle: bool,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum FlowControl {
+    Adaptive,
+    Fixed {
+        initial_stream_window_size: u32,
+        initial_connection_window_size: u32,
+    },
+}

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -41,6 +41,7 @@ linkerd-detect = { path = "../../detect" }
 linkerd-duplex = { path = "../../duplex" }
 linkerd-error = { path = "../../error" }
 linkerd-http-box = { path = "../../http/box" }
+linkerd-http-h2 = { path = "../../http/h2" }
 linkerd-http-classify = { path = "../../http/classify" }
 linkerd-io = { path = "../../io" }
 linkerd-proxy-balance = { path = "../balance" }

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -1,6 +1,5 @@
 use crate::executor::TracingExecutor;
 use futures::prelude::*;
-pub use h2::{Error as H2Error, Reason};
 use hyper::{
     body::HttpBody,
     client::conn::{self, SendRequest},
@@ -11,56 +10,12 @@ use std::{
     marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
-    time::Duration,
 };
 use tracing::instrument::Instrument;
 use tracing::{debug, debug_span, trace_span};
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct ServerParams {
-    pub flow_control: Option<FlowControl>,
-    pub keep_alive: Option<KeepAlive>,
-    pub max_concurrent_streams: Option<u32>,
-
-    // Internals
-    pub max_frame_size: Option<u32>,
-    pub max_header_list_size: Option<u32>,
-    pub max_pending_accept_reset_streams: Option<usize>,
-    pub max_send_buf_size: Option<usize>,
-}
-
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct ClientParams {
-    pub flow_control: Option<FlowControl>,
-    pub keep_alive: Option<ClientKeepAlive>,
-
-    // Internals
-    pub max_concurrent_reset_streams: Option<usize>,
-    pub max_frame_size: Option<u32>,
-    pub max_send_buf_size: Option<usize>,
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct KeepAlive {
-    pub interval: Duration,
-    pub timeout: Duration,
-}
-
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
-pub struct ClientKeepAlive {
-    pub interval: Duration,
-    pub timeout: Duration,
-    pub while_idle: bool,
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum FlowControl {
-    Adaptive,
-    Fixed {
-        initial_stream_window_size: u32,
-        initial_connection_window_size: u32,
-    },
-}
+pub use h2::{Error as H2Error, Reason};
+pub use linkerd_http_h2::{ClientKeepAlive, ClientParams, FlowControl, KeepAlive, ServerParams};
 
 #[derive(Debug)]
 pub struct Connect<C, B> {


### PR DESCRIPTION
This sets up configuring ClientParams from the proxy-api-resolve crate, i.e. so that the proxy-api-resolve crate does not need to depend on the proxy-http crate.