### PR TITLE
feat(outbound): Configure HTTP/2 client overrides from discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,6 +1730,7 @@ dependencies = [
  "http-body",
  "linkerd-addr",
  "linkerd-error",
+ "linkerd-http-h2",
  "linkerd-identity",
  "linkerd-proxy-core",
  "linkerd-stack",

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -122,6 +122,7 @@ impl<N> Outbound<N> {
                             }
                             Dispatch::Forward(addr, metadata) => svc::Either::A(svc::Either::B({
                                 let is_local = inbound_ips.contains(&addr.ip());
+                                let http2 = http2.override_from(metadata.http2_client_params());
                                 Endpoint {
                                     is_local,
                                     addr,
@@ -129,9 +130,8 @@ impl<N> Outbound<N> {
                                     parent,
                                     queue,
                                     close_server_connection_on_remote_proxy_error: true,
-                                    // TODO(ver) read these from metadata.
                                     http1,
-                                    http2: http2.clone(),
+                                    http2,
                                 }
                             })),
                             Dispatch::Fail { message } => svc::Either::B(message),

--- a/linkerd/app/outbound/src/http/concrete/balance.rs
+++ b/linkerd/app/outbound/src/http/concrete/balance.rs
@@ -118,6 +118,7 @@ where
                     move |((addr, metadata), target): ((SocketAddr, Metadata), Self)| {
                         tracing::trace!(%addr, ?metadata, ?target, "Resolved endpoint");
                         let is_local = inbound_ips.contains(&addr.ip());
+                        let http2 = http2.override_from(metadata.http2_client_params());
                         Endpoint {
                             addr: Remote(ServerAddr(addr)),
                             metadata,
@@ -130,7 +131,7 @@ where
                             close_server_connection_on_remote_proxy_error: false,
                             // TODO(ver) Configure from metadata.
                             http1,
-                            http2: http2.clone(),
+                            http2,
                         }
                     }
                 })

--- a/linkerd/http/h2/src/lib.rs
+++ b/linkerd/http/h2/src/lib.rs
@@ -45,3 +45,19 @@ pub enum FlowControl {
         initial_connection_window_size: u32,
     },
 }
+
+// === impl ClientParams ===
+
+impl ClientParams {
+    pub fn override_from(&self, overrides: &Self) -> Self {
+        Self {
+            flow_control: overrides.flow_control.or(self.flow_control),
+            keep_alive: overrides.keep_alive.or(self.keep_alive),
+            max_concurrent_reset_streams: overrides
+                .max_concurrent_reset_streams
+                .or(self.max_concurrent_reset_streams),
+            max_frame_size: overrides.max_frame_size.or(self.max_frame_size),
+            max_send_buf_size: overrides.max_send_buf_size.or(self.max_send_buf_size),
+        }
+    }
+}

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -11,10 +11,11 @@ Implements the Resolve trait using the proxy's gRPC API
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
+linkerd2-proxy-api = { version = "0.13", features = ["destination"] }
 linkerd-addr = { path = "../../addr" }
 linkerd-error = { path = "../../error" }
-linkerd2-proxy-api = { version = "0.13", features = ["destination"] }
 linkerd-proxy-core = { path = "../core" }
+linkerd-http-h2 = { path = "../../http/h2" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tonic-stream = { path = "../../tonic-stream" }
 linkerd-tls = { path = "../../tls" }

--- a/linkerd/proxy/api-resolve/src/metadata.rs
+++ b/linkerd/proxy/api-resolve/src/metadata.rs
@@ -1,4 +1,5 @@
 use http::uri::Authority;
+use linkerd_http_h2::ClientParams as HTTP2ClientParams;
 use linkerd_tls::client::ClientTls;
 use std::collections::BTreeMap;
 
@@ -24,6 +25,8 @@ pub struct Metadata {
 
     /// Used to override the the authority if needed
     authority_override: Option<Authority>,
+
+    http2: HTTP2ClientParams,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -49,6 +52,7 @@ impl Default for Metadata {
             authority_override: None,
             tagged_transport_port: None,
             protocol_hint: ProtocolHint::Unknown,
+            http2: HTTP2ClientParams::default(),
         }
     }
 }
@@ -61,6 +65,7 @@ impl Metadata {
         identity: Option<ClientTls>,
         authority_override: Option<Authority>,
         weight: u32,
+        http2: HTTP2ClientParams,
     ) -> Self {
         Self {
             labels: labels.into_iter().collect::<BTreeMap<_, _>>().into(),
@@ -69,6 +74,7 @@ impl Metadata {
             identity,
             authority_override,
             weight,
+            http2,
         }
     }
 
@@ -95,5 +101,9 @@ impl Metadata {
 
     pub fn authority_override(&self) -> Option<&Authority> {
         self.authority_override.as_ref()
+    }
+
+    pub fn http2_client_params(&self) -> &HTTP2ClientParams {
+        &self.http2
     }
 }


### PR DESCRIPTION
This commit updates the outbound proxy to read HTTP/2 client parameters from
Destination responses and to use these values to override the process-wide
defaults.