### PR TITLE
ci(release): Allow concurrent releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ env:
   RUSTUP_MAX_RETRIES: 10
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ inputs.ref || github.head_ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
It is sometimes necessary for multiple release workflows to run in parallel. The current configuration does not allow this. This commit changes the configuration so that the concurrency group varies by the target ref.