### PR TITLE
Handle ipv6 wrapped ipv4 addresses in loopback check

### DIFF
--- a/linkerd/app/admin/src/server.rs
+++ b/linkerd/app/admin/src/server.rs
@@ -188,7 +188,16 @@ impl<M> Admin<M> {
     fn client_is_localhost<B>(req: &Request<B>) -> bool {
         req.extensions()
             .get::<ClientHandle>()
-            .map(|a| a.addr.ip().is_loopback())
+            .map(|a| match a.addr.ip() {
+                std::net::IpAddr::V4(v4) => v4.is_loopback(),
+                std::net::IpAddr::V6(v6) => {
+                    if let Some(v4) = v6.to_ipv4_mapped() {
+                        v4.is_loopback()
+                    } else {
+                        v6.is_loopback()
+                    }
+                }
+            })
             .unwrap_or(false)
     }
 }


### PR DESCRIPTION
The `IpAddr::is_loopback` function does not account for ipv4 mapped ipv6 addresses and returns false if the address is an ipv4 localhost mapped to ipv6.  This causes localhost-only admin endpoints to be unaccessible from localhost when ipv4 mapped ipv6 addresses are used.

We update the logic to check if the ipv6 address is ipv4 mapped and, if so, if the mapped ipv4 address is loopback.