### PR TITLE
Properly set log level for hickory_resolver in proxy

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -81,7 +81,7 @@ skip = [
     # https://github.com/hawkw/matchers/pull/4
     { name = "regex-automata", version = "0.1" },
     { name = "regex-syntax", version = "0.6" },
-    # `trust-dns-proto`, depends on `idna` v0.2.3 while `url` depends on v0.5.0
+    # `trust-dns-proto`, depends on `idna` v0.4.0 while `url` depends on v0.5.0
     { name = "idna" },
     # Some dependencies still use indexmap v1.
     { name = "indexmap", version = "1" },

--- a/linkerd/app/core/src/dns.rs
+++ b/linkerd/app/core/src/dns.rs
@@ -24,7 +24,7 @@ impl Config {
 }
 
 impl ConfigureResolver for Config {
-    /// Modify a `trust-dns-resolver::config::ResolverOpts` to reflect
+    /// Modify a `hickory-resolver::config::ResolverOpts` to reflect
     /// the configured minimum and maximum DNS TTL values.
     fn configure_resolver(&self, opts: &mut ResolverOpts) {
         opts.positive_min_ttl = self.min_ttl;

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -64,7 +64,7 @@ impl Resolver {
     }
 
     pub fn new(config: ResolverConfig, mut opts: ResolverOpts) -> Self {
-        // Disable Trust-DNS's caching.
+        // Disable Hickory-resolver's caching.
         opts.cache_size = 0;
         // This function is synchronous, but needs to be called within the Tokio
         // 0.2 runtime context, since it gets a handle.

--- a/linkerd/tracing/src/lib.rs
+++ b/linkerd/tracing/src/lib.rs
@@ -26,7 +26,7 @@ const ENV_LOG_LEVEL: &str = "LINKERD2_PROXY_LOG";
 const ENV_LOG_FORMAT: &str = "LINKERD2_PROXY_LOG_FORMAT";
 const ENV_ACCESS_LOG: &str = "LINKERD2_PROXY_ACCESS_LOG";
 
-const DEFAULT_LOG_LEVEL: &str = "warn,linkerd=info,hickory_dns=error";
+const DEFAULT_LOG_LEVEL: &str = "warn,linkerd=info,hickory_resolver=error";
 const DEFAULT_LOG_FORMAT: &str = "PLAIN";
 
 #[derive(Debug, Default)]

--- a/linkerd/tracing/src/lib.rs
+++ b/linkerd/tracing/src/lib.rs
@@ -26,7 +26,7 @@ const ENV_LOG_LEVEL: &str = "LINKERD2_PROXY_LOG";
 const ENV_LOG_FORMAT: &str = "LINKERD2_PROXY_LOG_FORMAT";
 const ENV_ACCESS_LOG: &str = "LINKERD2_PROXY_ACCESS_LOG";
 
-const DEFAULT_LOG_LEVEL: &str = "warn,linkerd=info,hickory_resolver=error";
+const DEFAULT_LOG_LEVEL: &str = "warn,linkerd=info,hickory=error";
 const DEFAULT_LOG_FORMAT: &str = "PLAIN";
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
Followup to #2872 , where we swapped the trust-dns-resolver with the hickory-resolver dependency. We had mistakingly changed the default log level to `hickory_dns=error` when it should have been `hickory_resolver=error`.