### PR TITLE
feat(inbound): Log traffic with the 'audit' policy

### DIFF
--- a/linkerd/app/inbound/src/policy/defaults.rs
+++ b/linkerd/app/inbound/src/policy/defaults.rs
@@ -36,6 +36,15 @@ pub fn cluster_unauthenticated(
     )
 }
 
+pub fn audit(timeout: Duration) -> ServerPolicy {
+    mk(
+        "audit",
+        all_nets(),
+        Authentication::Unauthenticated,
+        timeout,
+    )
+}
+
 pub fn all_mtls_unauthenticated(timeout: Duration) -> ServerPolicy {
     mk(
         "all-tls-unauthenticated",

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -203,7 +203,7 @@ impl<T, N> HttpPolicyService<T, N> {
             .find(|a| super::is_authorized(a, self.connection.client, &self.connection.tls))
         {
             Some(authz) => {
-                if authz.meta.name() == "audit" {
+                if authz.meta.is_audit() {
                     tracing::info!(
                         server.group = %labels.server.0.group(),
                         server.kind = %labels.server.0.kind(),

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -202,7 +202,25 @@ impl<T, N> HttpPolicyService<T, N> {
             .iter()
             .find(|a| super::is_authorized(a, self.connection.client, &self.connection.tls))
         {
-            Some(authz) => authz,
+            Some(authz) => {
+                if authz.meta.name() == "audit" {
+                    tracing::info!(
+                        server.group = %labels.server.0.group(),
+                        server.kind = %labels.server.0.kind(),
+                        server.name = %labels.server.0.name(),
+                        route.group = %labels.route.group(),
+                        route.kind = %labels.route.kind(),
+                        route.name = %labels.route.name(),
+                        client.tls = ?self.connection.tls,
+                        client.ip = %self.connection.client.ip(),
+                        authz.group = %authz.meta.group(),
+                        authz.kind = %authz.meta.kind(),
+                        authz.name = %authz.meta.name(),
+                        "Request allowed",
+                    );
+                }
+                authz
+            }
             None => {
                 tracing::info!(
                     server.group = %labels.server.0.group(),

--- a/linkerd/app/inbound/src/policy/tcp.rs
+++ b/linkerd/app/inbound/src/policy/tcp.rs
@@ -194,7 +194,7 @@ fn check_authorized(
     {
         for authz in &**authzs {
             if super::is_authorized(authz, client_addr, tls) {
-                if authz.meta.name() == "audit" {
+                if authz.meta.is_audit() {
                     tracing::info!(
                         server.group = %server.meta.group(),
                         server.kind = %server.meta.kind(),

--- a/linkerd/app/inbound/src/policy/tcp.rs
+++ b/linkerd/app/inbound/src/policy/tcp.rs
@@ -194,6 +194,19 @@ fn check_authorized(
     {
         for authz in &**authzs {
             if super::is_authorized(authz, client_addr, tls) {
+                if authz.meta.name() == "audit" {
+                    tracing::info!(
+                        server.group = %server.meta.group(),
+                        server.kind = %server.meta.kind(),
+                        server.name = %server.meta.name(),
+                        client.tls = ?tls,
+                        client.ip = %client_addr.ip(),
+                        authz.group = %authz.meta.group(),
+                        authz.kind = %authz.meta.kind(),
+                        authz.name = %authz.meta.name(),
+                        "Request allowed",
+                    );
+                }
                 return Ok(ServerPermit::new(dst, server, authz));
             }
         }

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -1008,7 +1008,7 @@ fn parse_default_policy(
         "all-authenticated" => {
             Ok(inbound::policy::defaults::all_authenticated(detect_timeout).into())
         }
-        "all-unauthenticated" => {
+        "all-unauthenticated" | "audit" => {
             Ok(inbound::policy::defaults::all_unauthenticated(detect_timeout).into())
         }
 

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -1008,7 +1008,7 @@ fn parse_default_policy(
         "all-authenticated" => {
             Ok(inbound::policy::defaults::all_authenticated(detect_timeout).into())
         }
-        "all-unauthenticated" | "audit" => {
+        "all-unauthenticated" => {
             Ok(inbound::policy::defaults::all_unauthenticated(detect_timeout).into())
         }
 
@@ -1024,6 +1024,8 @@ fn parse_default_policy(
             detect_timeout,
         )
         .into()),
+
+        "audit" => Ok(inbound::policy::defaults::audit(detect_timeout).into()),
 
         name => Err(ParseError::InvalidPortPolicy(name.to_string())),
     }

--- a/linkerd/proxy/server-policy/src/meta.rs
+++ b/linkerd/proxy/server-policy/src/meta.rs
@@ -39,6 +39,10 @@ impl Meta {
             Self::Resource { group, .. } => group,
         }
     }
+
+    pub fn is_audit(&self) -> bool {
+        self.kind() == "default" && self.name() == "audit"
+    }
 }
 
 impl std::cmp::PartialEq for Meta {

--- a/linkerd/proxy/server-policy/src/meta.rs
+++ b/linkerd/proxy/server-policy/src/meta.rs
@@ -41,7 +41,7 @@ impl Meta {
     }
 
     pub fn is_audit(&self) -> bool {
-        self.kind() == "default" && self.name() == "audit"
+        matches!(self, Self::Default { name } if name == "audit")
     }
 }
 


### PR DESCRIPTION
Audit mode is triggered by the policy controller, which will create an authorization named "audit" allowing traffic for the given target. When the proxy processes an authorization with such name it will log it at INFO.

Also, add "audit" to the possible values for
`LINKERD2_PROXY_INBOUND_DEFAULT_POLICY`, whose effect is the same as "all-unauthenticated".

Please check linkerd/website#1805 for how this is supposed to work from the user's perspective.