### PR TITLE
feat(outbound): Add response metrics to policy router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,7 @@ dependencies = [
  "linkerd-app-test",
  "linkerd-distribute",
  "linkerd-http-classify",
+ "linkerd-http-prom",
  "linkerd-http-retry",
  "linkerd-http-route",
  "linkerd-identity",
@@ -1491,6 +1492,24 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "linkerd-http-prom"
+version = "0.1.0"
+dependencies = [
+ "futures",
+ "http",
+ "http-body",
+ "linkerd-error",
+ "linkerd-http-box",
+ "linkerd-metrics",
+ "linkerd-stack",
+ "parking_lot",
+ "pin-project",
+ "prometheus-client",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "linkerd/http/classify",
     "linkerd/http/h2",
     "linkerd/http/metrics",
+    "linkerd/http/prom",
     "linkerd/http/retry",
     "linkerd/http/route",
     "linkerd/identity",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -35,6 +35,7 @@ linkerd-app-core = { path = "../core" }
 linkerd-app-test = { path = "../test", optional = true }
 linkerd-distribute = { path = "../../distribute" }
 linkerd-http-classify = { path = "../../http/classify" }
+linkerd-http-prom = { path = "../../http/prom" }
 linkerd-http-retry = { path = "../../http/retry" }
 linkerd-http-route = { path = "../../http/route" }
 linkerd-identity = { path = "../../identity" }
@@ -49,6 +50,7 @@ linkerd-tonic-watch = { path = "../../tonic-watch" }
 [dev-dependencies]
 hyper = { version = "0.14", features = ["http1", "http2"] }
 linkerd-app-test = { path = "../test", features = ["client-policy"] }
+linkerd-http-prom = { path = "../../http/prom", features = ["test-util"] }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 linkerd-meshtls = { path = "../../meshtls", features = ["rustls"] }
 linkerd-meshtls-rustls = { path = "../../meshtls/rustls", features = [

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -32,8 +32,8 @@ pub struct Http<T>(T);
 #[derive(Clone, Debug, Default)]
 pub struct HttpMetrics {
     balancer: concrete::BalancerMetrics,
-    http_route: policy::RouteMetrics,
-    grpc_route: policy::RouteMetrics,
+    http_route: policy::HttpRouteMetrics,
+    grpc_route: policy::GrpcRouteMetrics,
 }
 
 pub fn spawn_routes<T>(
@@ -132,12 +132,12 @@ where
 impl HttpMetrics {
     pub fn register(registry: &mut prom::Registry) -> Self {
         let http = registry.sub_registry_with_prefix("http");
-        let http_route = policy::RouteMetrics::register(http.sub_registry_with_prefix("route"));
+        let http_route = policy::HttpRouteMetrics::register(http.sub_registry_with_prefix("route"));
         let balancer =
             concrete::BalancerMetrics::register(http.sub_registry_with_prefix("balancer"));
 
         let grpc = registry.sub_registry_with_prefix("grpc");
-        let grpc_route = policy::RouteMetrics::register(grpc.sub_registry_with_prefix("route"));
+        let grpc_route = policy::GrpcRouteMetrics::register(grpc.sub_registry_with_prefix("route"));
 
         Self {
             balancer,

--- a/linkerd/app/outbound/src/http/logical/policy.rs
+++ b/linkerd/app/outbound/src/http/logical/policy.rs
@@ -8,7 +8,7 @@ mod router;
 mod tests;
 
 pub use self::{
-    route::{errors, RouteMetrics},
+    route::{errors, GrpcRouteMetrics, HttpRouteMetrics},
     router::{GrpcParams, HttpParams},
 };
 pub use linkerd_proxy_client_policy::{ClientPolicy, FailureAccrual};
@@ -50,8 +50,8 @@ where
     /// routing configurations to route requests over cached inner backend
     /// services.
     pub(super) fn layer<N, S>(
-        http_metrics: route::RouteMetrics,
-        grpc_metrics: route::RouteMetrics,
+        http_metrics: route::HttpRouteMetrics,
+        grpc_metrics: route::GrpcRouteMetrics,
     ) -> impl svc::Layer<N, Service = svc::ArcNewCloneHttp<Self>> + Clone
     where
         // Inner stack.

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -1,15 +1,12 @@
 use super::{super::Concrete, filters};
 use crate::{BackendRef, ParentRef, RouteRef};
 use linkerd_app_core::{proxy::http, svc, Error, Result};
+use linkerd_http_prom::record_response::MkStreamLabel;
 use linkerd_http_route as http_route;
 use linkerd_proxy_client_policy as policy;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
 
-mod count_reqs;
-mod metrics;
-
-pub use self::count_reqs::RequestCount;
-pub use self::metrics::RouteBackendMetrics;
+pub(super) mod metrics;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub(crate) struct Backend<T, F> {
@@ -24,6 +21,8 @@ pub(crate) type Http<T> =
     MatchedBackend<T, http_route::http::r#match::RequestMatch, policy::http::Filter>;
 pub(crate) type Grpc<T> =
     MatchedBackend<T, http_route::grpc::r#match::RouteMatch, policy::grpc::Filter>;
+
+pub type Metrics<T> = metrics::RouteBackendMetrics<<T as MkStreamLabel>::StreamLabel>;
 
 /// Wraps errors with backend metadata.
 #[derive(Debug, thiserror::Error)]
@@ -71,7 +70,7 @@ where
     F: Clone + Send + Sync + 'static,
     // Assert that filters can be applied.
     Self: filters::Apply,
-    RouteBackendMetrics: svc::ExtractParam<RequestCount, Self>,
+    Self: metrics::MkStreamLabel,
 {
     /// Builds a stack that applies per-route-backend policy filters over an
     /// inner [`Concrete`] stack.
@@ -79,7 +78,7 @@ where
     /// This [`MatchedBackend`] must implement [`filters::Apply`] to apply these
     /// filters.
     pub(crate) fn layer<N, S>(
-        metrics: RouteBackendMetrics,
+        metrics: Metrics<Self>,
     ) -> impl svc::Layer<N, Service = svc::ArcNewCloneHttp<Self>> + Clone
     where
         // Inner stack.
@@ -103,7 +102,7 @@ where
                 )
                 .push(filters::NewApplyFilters::<Self, _, _>::layer())
                 .push(http::NewTimeout::layer())
-                .push(count_reqs::NewCountRequests::layer_via(metrics.clone()))
+                .push(metrics::layer(&metrics))
                 .push(svc::NewMapErr::layer_with(|t: &Self| {
                     let backend = t.params.concrete.backend_ref.clone();
                     move |source| {
@@ -155,6 +154,21 @@ impl<T> filters::Apply for Http<T> {
     }
 }
 
+impl<T> metrics::MkStreamLabel for Http<T> {
+    type StatusLabels = metrics::labels::HttpRouteBackendRsp;
+    type DurationLabels = metrics::labels::RouteBackend;
+    type StreamLabel = metrics::LabelHttpRouteBackendRsp;
+
+    fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
+        let parent = self.params.concrete.parent_ref.clone();
+        let route = self.params.route_ref.clone();
+        let backend = self.params.concrete.backend_ref.clone();
+        Some(metrics::LabelHttpRsp::from(
+            metrics::labels::RouteBackend::from((parent, route, backend)),
+        ))
+    }
+}
+
 impl<T> filters::Apply for Grpc<T> {
     #[inline]
     fn apply_request<B>(&self, req: &mut ::http::Request<B>) -> Result<()> {
@@ -163,5 +177,20 @@ impl<T> filters::Apply for Grpc<T> {
 
     fn apply_response<B>(&self, rsp: &mut ::http::Response<B>) -> Result<()> {
         filters::apply_grpc_response(&self.params.filters, rsp)
+    }
+}
+
+impl<T> metrics::MkStreamLabel for Grpc<T> {
+    type StatusLabels = metrics::labels::GrpcRouteBackendRsp;
+    type DurationLabels = metrics::labels::RouteBackend;
+    type StreamLabel = metrics::LabelGrpcRouteBackendRsp;
+
+    fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
+        let parent = self.params.concrete.parent_ref.clone();
+        let route = self.params.route_ref.clone();
+        let backend = self.params.concrete.backend_ref.clone();
+        Some(metrics::LabelGrpcRsp::from(
+            metrics::labels::RouteBackend::from((parent, route, backend)),
+        ))
     }
 }

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -1,61 +1,122 @@
+#![allow(warnings)]
+
 use crate::{BackendRef, ParentRef, RouteRef};
+use futures::Stream;
 use linkerd_app_core::{
     metrics::prom::{self, encoding::*, EncodeLabelSetMut},
     svc,
 };
+use linkerd_http_prom::{
+    record_response::{self, NewResponseDuration, StreamLabel},
+    NewCountRequests, RequestCount, RequestCountFamilies,
+};
 
-#[derive(Clone, Debug, Default)]
-pub struct RouteBackendMetrics {
-    metrics: super::count_reqs::RequestCountFamilies<RouteBackendLabels>,
+pub use super::super::metrics::*;
+pub use linkerd_http_prom::record_response::MkStreamLabel;
+
+#[cfg(test)]
+mod tests;
+
+#[derive(Debug)]
+pub struct RouteBackendMetrics<L: StreamLabel> {
+    requests: RequestCountFamilies<labels::RouteBackend>,
+    responses: ResponseMetrics<L>,
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-struct RouteBackendLabels(ParentRef, RouteRef, BackendRef);
+type ResponseMetrics<L> = record_response::ResponseMetrics<
+    <L as StreamLabel>::DurationLabels,
+    <L as StreamLabel>::StatusLabels,
+>;
+
+pub fn layer<T, N>(
+    metrics: &RouteBackendMetrics<T::StreamLabel>,
+) -> impl svc::Layer<
+    N,
+    Service = NewCountRequests<
+        ExtractRequestCount,
+        NewResponseDuration<T, ExtractRecordDurationParams<ResponseMetrics<T::StreamLabel>>, N>,
+    >,
+> + Clone
+where
+    T: MkStreamLabel,
+    N: svc::NewService<T>,
+    NewCountRequests<
+        ExtractRequestCount,
+        NewResponseDuration<T, ExtractRecordDurationParams<ResponseMetrics<T::StreamLabel>>, N>,
+    >: svc::NewService<T>,
+    NewResponseDuration<T, ExtractRecordDurationParams<ResponseMetrics<T::StreamLabel>>, N>:
+        svc::NewService<T>,
+{
+    let RouteBackendMetrics {
+        requests,
+        responses,
+    } = metrics.clone();
+    svc::layer::mk(move |inner| {
+        use svc::Layer;
+        NewCountRequests::layer_via(ExtractRequestCount(requests.clone())).layer(
+            NewRecordDuration::layer_via(ExtractRecordDurationParams(responses.clone()))
+                .layer(inner),
+        )
+    })
+}
+
+#[derive(Clone, Debug)]
+pub struct ExtractRequestCount(RequestCountFamilies<labels::RouteBackend>);
 
 // === impl RouteBackendMetrics ===
 
-impl RouteBackendMetrics {
-    pub fn register(reg: &mut prom::Registry) -> Self {
+impl<L: StreamLabel> RouteBackendMetrics<L> {
+    pub fn register(reg: &mut prom::Registry, histo: impl IntoIterator<Item = f64>) -> Self {
+        let requests = RequestCountFamilies::register(reg);
+        let responses = record_response::ResponseMetrics::register(reg, histo);
         Self {
-            metrics: super::count_reqs::RequestCountFamilies::register(reg),
+            requests,
+            responses,
         }
     }
 
     #[cfg(test)]
-    pub(crate) fn request_count(
+    pub(crate) fn backend_request_count(
         &self,
         p: ParentRef,
         r: RouteRef,
         b: BackendRef,
-    ) -> super::count_reqs::RequestCount {
-        self.metrics.metrics(&RouteBackendLabels(p, r, b))
+    ) -> linkerd_http_prom::RequestCount {
+        self.requests.metrics(&labels::RouteBackend(p, r, b))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_statuses(&self, l: &L::StatusLabels) -> prom::Counter {
+        self.responses.get_statuses(l)
     }
 }
 
-impl<T> svc::ExtractParam<super::count_reqs::RequestCount, T> for RouteBackendMetrics
+impl<L: StreamLabel> Default for RouteBackendMetrics<L> {
+    fn default() -> Self {
+        Self {
+            requests: Default::default(),
+            responses: Default::default(),
+        }
+    }
+}
+
+impl<L: StreamLabel> Clone for RouteBackendMetrics<L> {
+    fn clone(&self) -> Self {
+        Self {
+            requests: self.requests.clone(),
+            responses: self.responses.clone(),
+        }
+    }
+}
+
+// === impl ExtractRequestCount ===
+
+impl<T> svc::ExtractParam<RequestCount, T> for ExtractRequestCount
 where
     T: svc::Param<ParentRef> + svc::Param<RouteRef> + svc::Param<BackendRef>,
 {
-    fn extract_param(&self, t: &T) -> super::count_reqs::RequestCount {
-        self.metrics
-            .metrics(&RouteBackendLabels(t.param(), t.param(), t.param()))
-    }
-}
-
-// === impl RouteBackendLabels ===
-
-impl EncodeLabelSetMut for RouteBackendLabels {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        let Self(parent, route, backend) = self;
-        parent.encode_label_set(enc)?;
-        route.encode_label_set(enc)?;
-        backend.encode_label_set(enc)?;
-        Ok(())
-    }
-}
-
-impl EncodeLabelSet for RouteBackendLabels {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn extract_param(&self, t: &T) -> RequestCount {
+        self.0
+            .metrics(&labels::RouteBackend(t.param(), t.param(), t.param()))
     }
 }

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
@@ -1,0 +1,394 @@
+use super::{
+    super::{Backend, Grpc, Http},
+    labels,
+    test_util::*,
+    LabelGrpcRouteBackendRsp, LabelHttpRouteBackendRsp, RouteBackendMetrics,
+};
+use crate::http::{concrete, logical::Concrete};
+use linkerd2_proxy_api::outbound::backend;
+use linkerd_app_core::{
+    metrics::prom::Counter,
+    svc::{self, http::BoxBody, Layer, NewService, Service, ServiceExt},
+    transport::{Remote, ServerAddr},
+};
+use linkerd_proxy_client_policy as policy;
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn http_request_statuses() {
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::RouteBackendMetrics::default();
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let backend_ref = crate::BackendRef(policy::Meta::new_default("backend"));
+    let (mut svc, mut handle) =
+        mock_http_route_backend_metrics(&metrics, &parent_ref, &route_ref, &backend_ref);
+
+    let route_backend =
+        labels::RouteBackend(parent_ref.clone(), route_ref.clone(), backend_ref.clone());
+
+    let requests =
+        metrics.backend_request_count(parent_ref.clone(), route_ref.clone(), backend_ref.clone());
+    assert_eq!(requests.get(), 0);
+
+    // Send one request and ensure it's counted.
+    let ok = metrics.get_statuses(&labels::Rsp(
+        route_backend.clone(),
+        labels::HttpRsp {
+            status: Some(http::StatusCode::OK),
+            error: None,
+        },
+    ));
+    send_assert_incremented(&ok, &mut handle, &mut svc, Default::default(), |tx| {
+        tx.send_response(
+            http::Response::builder()
+                .status(200)
+                .body(BoxBody::default())
+                .unwrap(),
+        )
+    })
+    .await;
+    assert_eq!(requests.get(), 1);
+
+    // Send another request and ensure it's counted with a different response
+    // status.
+    let no_content = metrics.get_statuses(&labels::Rsp(
+        route_backend.clone(),
+        labels::HttpRsp {
+            status: Some(http::StatusCode::NO_CONTENT),
+            error: None,
+        },
+    ));
+    send_assert_incremented(
+        &no_content,
+        &mut handle,
+        &mut svc,
+        Default::default(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .status(204)
+                    .body(BoxBody::default())
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+    assert_eq!(requests.get(), 2);
+
+    // Emit a response with an error and ensure it's counted.
+    let unknown = metrics.get_statuses(&labels::Rsp(
+        route_backend.clone(),
+        labels::HttpRsp {
+            status: None,
+            error: Some(labels::Error::Unknown),
+        },
+    ));
+    send_assert_incremented(&unknown, &mut handle, &mut svc, Default::default(), |tx| {
+        tx.send_error("a spooky ghost")
+    })
+    .await;
+    assert_eq!(requests.get(), 3);
+
+    // Emit a successful response with a body that fails and ensure that both
+    // the status and error are recorded.
+    let mixed = metrics.get_statuses(&labels::Rsp(
+        route_backend.clone(),
+        labels::HttpRsp {
+            status: Some(http::StatusCode::OK),
+            error: Some(labels::Error::Unknown),
+        },
+    ));
+    send_assert_incremented(&mixed, &mut handle, &mut svc, Default::default(), |tx| {
+        tx.send_response(
+            http::Response::builder()
+                .status(200)
+                .body(BoxBody::new(MockBody::new(async {
+                    Err("a spooky ghost".into())
+                })))
+                .unwrap(),
+        )
+    })
+    .await;
+    assert_eq!(requests.get(), 4);
+
+    assert_eq!(unknown.get(), 1);
+    assert_eq!(ok.get(), 1);
+    assert_eq!(no_content.get(), 1);
+    assert_eq!(mixed.get(), 1);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn grpc_request_statuses_ok() {
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::RouteBackendMetrics::default();
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let backend_ref = crate::BackendRef(policy::Meta::new_default("backend"));
+    let (mut svc, mut handle) =
+        mock_grpc_route_backend_metrics(&metrics, &parent_ref, &route_ref, &backend_ref);
+
+    let requests =
+        metrics.backend_request_count(parent_ref.clone(), route_ref.clone(), backend_ref.clone());
+    assert_eq!(requests.get(), 0);
+
+    let ok = metrics.get_statuses(&labels::Rsp(
+        labels::RouteBackend(parent_ref.clone(), route_ref.clone(), backend_ref.clone()),
+        labels::GrpcRsp {
+            status: Some(tonic::Code::Ok),
+            error: None,
+        },
+    ));
+    send_assert_incremented(
+        &ok,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .method("POST")
+            .uri("http://host/svc/method")
+            .body(Default::default())
+            .unwrap(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .body(BoxBody::new(MockBody::trailers(async move {
+                        let mut trailers = http::HeaderMap::new();
+                        trailers.insert("grpc-status", http::HeaderValue::from_static("0"));
+                        Ok(Some(trailers))
+                    })))
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+    assert_eq!(requests.get(), 1);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn grpc_request_statuses_not_found() {
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::RouteBackendMetrics::default();
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let backend_ref = crate::BackendRef(policy::Meta::new_default("backend"));
+    let (mut svc, mut handle) =
+        mock_grpc_route_backend_metrics(&metrics, &parent_ref, &route_ref, &backend_ref);
+
+    let not_found = metrics.get_statuses(&labels::Rsp(
+        labels::RouteBackend(parent_ref.clone(), route_ref.clone(), backend_ref.clone()),
+        labels::GrpcRsp {
+            status: Some(tonic::Code::NotFound),
+            error: None,
+        },
+    ));
+    send_assert_incremented(
+        &not_found,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .method("POST")
+            .uri("http://host/svc/method")
+            .body(Default::default())
+            .unwrap(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .body(BoxBody::new(MockBody::trailers(async move {
+                        let mut trailers = http::HeaderMap::new();
+                        trailers.insert("grpc-status", http::HeaderValue::from_static("5"));
+                        Ok(Some(trailers))
+                    })))
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn grpc_request_statuses_error_response() {
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::RouteBackendMetrics::default();
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let backend_ref = crate::BackendRef(policy::Meta::new_default("backend"));
+    let (mut svc, mut handle) =
+        mock_grpc_route_backend_metrics(&metrics, &parent_ref, &route_ref, &backend_ref);
+
+    let unknown = metrics.get_statuses(&labels::Rsp(
+        labels::RouteBackend(parent_ref.clone(), route_ref.clone(), backend_ref.clone()),
+        labels::GrpcRsp {
+            status: None,
+            error: Some(labels::Error::Unknown),
+        },
+    ));
+    send_assert_incremented(
+        &unknown,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .method("POST")
+            .uri("http://host/svc/method")
+            .body(Default::default())
+            .unwrap(),
+        |tx| tx.send_error("a spooky ghost"),
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn grpc_request_statuses_error_body() {
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::RouteBackendMetrics::default();
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let backend_ref = crate::BackendRef(policy::Meta::new_default("backend"));
+    let (mut svc, mut handle) =
+        mock_grpc_route_backend_metrics(&metrics, &parent_ref, &route_ref, &backend_ref);
+
+    let unknown = metrics.get_statuses(&labels::Rsp(
+        labels::RouteBackend(parent_ref.clone(), route_ref.clone(), backend_ref.clone()),
+        labels::GrpcRsp {
+            status: None,
+            error: Some(labels::Error::Unknown),
+        },
+    ));
+    send_assert_incremented(
+        &unknown,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .method("POST")
+            .uri("http://host/svc/method")
+            .body(Default::default())
+            .unwrap(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .body(BoxBody::new(MockBody::new(async {
+                        Err("a spooky ghost".into())
+                    })))
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+}
+
+// === Util ===
+
+fn mock_http_route_backend_metrics(
+    metrics: &RouteBackendMetrics<LabelHttpRouteBackendRsp>,
+    parent_ref: &crate::ParentRef,
+    route_ref: &crate::RouteRef,
+    backend_ref: &crate::BackendRef,
+) -> (svc::BoxHttp, Handle) {
+    let req = http::Request::builder().body(()).unwrap();
+    let (r#match, _) = policy::route::find(
+        &[policy::http::Route {
+            hosts: vec![],
+            rules: vec![policy::route::Rule {
+                matches: vec![policy::http::r#match::MatchRequest::default()],
+                policy: policy::http::Policy {
+                    meta: route_ref.0.clone(),
+                    filters: [].into(),
+                    request_timeout: None,
+                    failure_policy: Default::default(),
+                    distribution: policy::RouteDistribution::Empty,
+                },
+            }],
+        }],
+        &req,
+    )
+    .expect("find default route");
+
+    let (tx, handle) = tower_test::mock::pair::<http::Request<BoxBody>, http::Response<BoxBody>>();
+    let svc = super::layer(metrics)
+        .layer(move |_t: Http<()>| tx.clone())
+        .new_service(Http {
+            r#match,
+            params: Backend {
+                route_ref: route_ref.clone(),
+                request_timeout: None,
+                filters: [].into(),
+                concrete: Concrete {
+                    target: concrete::Dispatch::Forward(
+                        Remote(ServerAddr(std::net::SocketAddr::new(
+                            [0, 0, 0, 0].into(),
+                            8080,
+                        ))),
+                        Default::default(),
+                    ),
+                    authority: None,
+                    failure_accrual: Default::default(),
+                    parent: (),
+                    parent_ref: parent_ref.clone(),
+                    backend_ref: backend_ref.clone(),
+                },
+            },
+        });
+
+    (svc::BoxHttp::new(svc), handle)
+}
+
+fn mock_grpc_route_backend_metrics(
+    metrics: &RouteBackendMetrics<LabelGrpcRouteBackendRsp>,
+    parent_ref: &crate::ParentRef,
+    route_ref: &crate::RouteRef,
+    backend_ref: &crate::BackendRef,
+) -> (svc::BoxHttp, Handle) {
+    let req = http::Request::builder()
+        .method("POST")
+        .uri("http://host/svc/method")
+        .body(())
+        .unwrap();
+    let (r#match, _) = policy::route::find(
+        &[policy::grpc::Route {
+            hosts: vec![],
+            rules: vec![policy::route::Rule {
+                matches: vec![policy::grpc::r#match::MatchRoute::default()],
+                policy: policy::grpc::Policy {
+                    meta: route_ref.0.clone(),
+                    filters: [].into(),
+                    request_timeout: None,
+                    failure_policy: Default::default(),
+                    distribution: policy::RouteDistribution::Empty,
+                },
+            }],
+        }],
+        &req,
+    )
+    .expect("find default route");
+
+    let (tx, handle) = tower_test::mock::pair::<http::Request<BoxBody>, http::Response<BoxBody>>();
+    let svc = super::layer(metrics)
+        .layer(move |_t: Grpc<()>| tx.clone())
+        .new_service(Grpc {
+            r#match,
+            params: Backend {
+                route_ref: route_ref.clone(),
+                request_timeout: None,
+                filters: [].into(),
+                concrete: Concrete {
+                    target: concrete::Dispatch::Forward(
+                        Remote(ServerAddr(std::net::SocketAddr::new(
+                            [0, 0, 0, 0].into(),
+                            8080,
+                        ))),
+                        Default::default(),
+                    ),
+                    authority: None,
+                    failure_accrual: Default::default(),
+                    parent: (),
+                    parent_ref: parent_ref.clone(),
+                    backend_ref: backend_ref.clone(),
+                },
+            },
+        });
+
+    (svc::BoxHttp::new(svc), handle)
+}

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
@@ -1,0 +1,245 @@
+use super::backend::metrics as backend;
+use linkerd_app_core::{
+    metrics::prom::{self, EncodeLabelSetMut},
+    svc,
+};
+use linkerd_http_prom::record_response::{self, StreamLabel};
+
+pub use linkerd_http_prom::record_response::MkStreamLabel;
+
+pub mod labels;
+#[cfg(test)]
+pub(super) mod test_util;
+#[cfg(test)]
+mod tests;
+
+pub type RequestMetrics<R> = record_response::RequestMetrics<
+    <R as StreamLabel>::DurationLabels,
+    <R as StreamLabel>::StatusLabels,
+>;
+
+#[derive(Debug)]
+pub struct RouteMetrics<R: StreamLabel, B: StreamLabel> {
+    pub(super) requests: RequestMetrics<R>,
+    pub(super) backend: backend::RouteBackendMetrics<B>,
+}
+
+pub type HttpRouteMetrics = RouteMetrics<LabelHttpRouteRsp, LabelHttpRouteBackendRsp>;
+pub type GrpcRouteMetrics = RouteMetrics<LabelGrpcRouteRsp, LabelGrpcRouteBackendRsp>;
+
+/// Tracks HTTP streams to produce response labels.
+#[derive(Clone, Debug)]
+pub struct LabelHttpRsp<L> {
+    parent: L,
+    status: Option<http::StatusCode>,
+    error: Option<labels::Error>,
+}
+
+/// Tracks gRPC streams to produce response labels.
+#[derive(Clone, Debug)]
+pub struct LabelGrpcRsp<L> {
+    parent: L,
+    status: Option<tonic::Code>,
+    error: Option<labels::Error>,
+}
+
+pub type LabelHttpRouteRsp = LabelHttpRsp<labels::Route>;
+pub type LabelGrpcRouteRsp = LabelGrpcRsp<labels::Route>;
+
+pub type LabelHttpRouteBackendRsp = LabelHttpRsp<labels::RouteBackend>;
+pub type LabelGrpcRouteBackendRsp = LabelGrpcRsp<labels::RouteBackend>;
+
+pub type NewRecordDuration<T, M, N> =
+    record_response::NewRecordResponse<T, ExtractRecordDurationParams<M>, M, N>;
+
+#[derive(Clone, Debug)]
+pub struct ExtractRecordDurationParams<M>(pub M);
+
+pub fn layer<T, N>(
+    metrics: &RequestMetrics<T::StreamLabel>,
+) -> impl svc::Layer<N, Service = NewRecordDuration<T, RequestMetrics<T::StreamLabel>, N>> + Clone
+where
+    T: Clone + MkStreamLabel,
+{
+    NewRecordDuration::layer_via(ExtractRecordDurationParams(metrics.clone()))
+}
+
+// === impl RouteMetrics ===
+
+impl<R: StreamLabel, B: StreamLabel> RouteMetrics<R, B> {
+    // There are two histograms for which we need to register metrics: request
+    // durations, measured on routes, and response durations, measured on
+    // route-backends.
+    //
+    // Response duration is probably the more meaninful metric
+    // operationally--and it includes more backend metadata--so we opt to
+    // preserve higher fidelity for response durations (especially for lower
+    // values).
+    //
+    // We elide several buckets for request durations to be conservative about
+    // the costs of tracking these two largely overlapping histograms
+    const REQUEST_BUCKETS: &'static [f64] = &[0.05, 0.5, 1.0, 10.0];
+    const RESPONSE_BUCKETS: &'static [f64] = &[0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 10.0];
+}
+
+impl<R: StreamLabel, B: StreamLabel> Default for RouteMetrics<R, B> {
+    fn default() -> Self {
+        Self {
+            requests: Default::default(),
+            backend: Default::default(),
+        }
+    }
+}
+
+impl<R: StreamLabel, B: StreamLabel> Clone for RouteMetrics<R, B> {
+    fn clone(&self) -> Self {
+        Self {
+            requests: self.requests.clone(),
+            backend: self.backend.clone(),
+        }
+    }
+}
+
+impl<R: StreamLabel, B: StreamLabel> RouteMetrics<R, B> {
+    pub fn register(reg: &mut prom::Registry) -> Self {
+        let requests = RequestMetrics::<R>::register(reg, Self::REQUEST_BUCKETS.iter().copied());
+
+        let backend = backend::RouteBackendMetrics::register(
+            reg.sub_registry_with_prefix("backend"),
+            Self::RESPONSE_BUCKETS.iter().copied(),
+        );
+        Self { requests, backend }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn backend_request_count(
+        &self,
+        p: crate::ParentRef,
+        r: crate::RouteRef,
+        b: crate::BackendRef,
+    ) -> linkerd_http_prom::RequestCount {
+        self.backend.backend_request_count(p, r, b)
+    }
+}
+
+// === impl ExtractRequestDurationParams ===
+
+impl<T, M> svc::ExtractParam<record_response::Params<T, M>, T> for ExtractRecordDurationParams<M>
+where
+    T: Clone + MkStreamLabel,
+    M: Clone,
+{
+    fn extract_param(&self, target: &T) -> record_response::Params<T, M> {
+        record_response::Params {
+            labeler: target.clone(),
+            metric: self.0.clone(),
+        }
+    }
+}
+
+// === impl LabelHttpRsp ===
+
+impl<P> From<P> for LabelHttpRsp<P> {
+    fn from(parent: P) -> Self {
+        Self {
+            parent,
+            status: None,
+            error: None,
+        }
+    }
+}
+
+impl<P> StreamLabel for LabelHttpRsp<P>
+where
+    P: EncodeLabelSetMut + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+{
+    type StatusLabels = labels::Rsp<P, labels::HttpRsp>;
+    type DurationLabels = P;
+
+    fn init_response<B>(&mut self, rsp: &http::Response<B>) {
+        self.status = Some(rsp.status());
+    }
+
+    fn end_response(&mut self, res: Result<Option<&http::HeaderMap>, &linkerd_app_core::Error>) {
+        if let Err(e) = res {
+            match labels::Error::new_or_status(e) {
+                Ok(l) => self.error = Some(l),
+                Err(code) => match http::StatusCode::from_u16(code) {
+                    Ok(s) => self.status = Some(s),
+                    // This is kind of pathological, so mark it as an unkown error.
+                    Err(_) => self.error = Some(labels::Error::Unknown),
+                },
+            }
+        }
+    }
+
+    fn status_labels(&self) -> Self::StatusLabels {
+        labels::Rsp(
+            self.parent.clone(),
+            labels::HttpRsp {
+                status: self.status,
+                error: self.error,
+            },
+        )
+    }
+
+    fn duration_labels(&self) -> Self::DurationLabels {
+        self.parent.clone()
+    }
+}
+
+// === impl LabelGrpcRsp ===
+
+impl<P> From<P> for LabelGrpcRsp<P> {
+    fn from(parent: P) -> Self {
+        Self {
+            parent,
+            status: None,
+            error: None,
+        }
+    }
+}
+
+impl<P> StreamLabel for LabelGrpcRsp<P>
+where
+    P: EncodeLabelSetMut + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+{
+    type StatusLabels = labels::Rsp<P, labels::GrpcRsp>;
+    type DurationLabels = P;
+
+    fn init_response<B>(&mut self, rsp: &http::Response<B>) {
+        self.status = rsp
+            .headers()
+            .get("grpc-status")
+            .map(|v| tonic::Code::from_bytes(v.as_bytes()));
+    }
+
+    fn end_response(&mut self, res: Result<Option<&http::HeaderMap>, &linkerd_app_core::Error>) {
+        match res {
+            Ok(Some(trailers)) => {
+                self.status = trailers
+                    .get("grpc-status")
+                    .map(|v| tonic::Code::from_bytes(v.as_bytes()));
+            }
+            Ok(None) => {}
+            Err(e) => match labels::Error::new_or_status(e) {
+                Ok(l) => self.error = Some(l),
+                Err(code) => self.status = Some(tonic::Code::from_i32(i32::from(code))),
+            },
+        }
+    }
+
+    fn status_labels(&self) -> Self::StatusLabels {
+        labels::Rsp(
+            self.parent.clone(),
+            labels::GrpcRsp {
+                status: self.status,
+                error: self.error,
+            },
+        )
+    }
+
+    fn duration_labels(&self) -> Self::DurationLabels {
+        self.parent.clone()
+    }
+}

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
@@ -1,0 +1,241 @@
+//! Prometheus label types.
+use linkerd_app_core::{errors, metrics::prom::EncodeLabelSetMut, Error as BoxError};
+use prometheus_client::encoding::*;
+
+use crate::{BackendRef, ParentRef, RouteRef};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct Route(pub ParentRef, pub RouteRef);
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct RouteBackend(pub ParentRef, pub RouteRef, pub BackendRef);
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct Rsp<P, L>(pub P, pub L);
+
+pub type RouteRsp<L> = Rsp<Route, L>;
+pub type HttpRouteRsp = RouteRsp<HttpRsp>;
+pub type GrpcRouteRsp = RouteRsp<GrpcRsp>;
+
+pub type RouteBackendRsp<L> = Rsp<RouteBackend, L>;
+pub type HttpRouteBackendRsp = RouteBackendRsp<HttpRsp>;
+pub type GrpcRouteBackendRsp = RouteBackendRsp<GrpcRsp>;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct HttpRsp {
+    pub status: Option<http::StatusCode>,
+    pub error: Option<Error>,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct GrpcRsp {
+    pub status: Option<tonic::Code>,
+    pub error: Option<Error>,
+}
+
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
+pub enum Error {
+    FailFast,
+    LoadShed,
+    Timeout,
+    Cancel,
+    Refused,
+    EnhanceYourCalm,
+    Reset,
+    GoAway,
+    Io,
+    Unknown,
+}
+
+// === impl Route ===
+
+impl From<(ParentRef, RouteRef)> for Route {
+    fn from((parent, route): (ParentRef, RouteRef)) -> Self {
+        Self(parent, route)
+    }
+}
+
+impl EncodeLabelSetMut for Route {
+    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        let Self(parent, route) = self;
+        parent.encode_label_set(enc)?;
+        route.encode_label_set(enc)?;
+        Ok(())
+    }
+}
+
+impl EncodeLabelSet for Route {
+    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(&mut enc)
+    }
+}
+
+// === impl RouteBackend ===
+
+impl From<(ParentRef, RouteRef, BackendRef)> for RouteBackend {
+    fn from((parent, route, backend): (ParentRef, RouteRef, BackendRef)) -> Self {
+        Self(parent, route, backend)
+    }
+}
+
+impl EncodeLabelSetMut for RouteBackend {
+    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        let Self(parent, route, backend) = self;
+        parent.encode_label_set(enc)?;
+        route.encode_label_set(enc)?;
+        backend.encode_label_set(enc)?;
+        Ok(())
+    }
+}
+
+impl EncodeLabelSet for RouteBackend {
+    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(&mut enc)
+    }
+}
+
+// === impl Rsp ===
+
+impl<P: EncodeLabelSetMut, L: EncodeLabelSetMut> EncodeLabelSetMut for Rsp<P, L> {
+    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        let Self(route, rsp) = self;
+        route.encode_label_set(enc)?;
+        rsp.encode_label_set(enc)?;
+        Ok(())
+    }
+}
+
+impl<P: EncodeLabelSetMut, L: EncodeLabelSetMut> EncodeLabelSet for Rsp<P, L> {
+    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(&mut enc)
+    }
+}
+
+// === impl HttpRsp ===
+
+impl EncodeLabelSetMut for HttpRsp {
+    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        let Self { status, error } = self;
+
+        ("http_status", status.map(|c| c.as_u16())).encode(enc.encode_label())?;
+        ("error", *error).encode(enc.encode_label())?;
+
+        Ok(())
+    }
+}
+
+impl EncodeLabelSet for HttpRsp {
+    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(&mut enc)
+    }
+}
+
+// === impl GrpcRsp ===
+
+impl EncodeLabelSetMut for GrpcRsp {
+    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        let Self { status, error } = self;
+
+        (
+            "grpc_status",
+            match status.unwrap_or(tonic::Code::Unknown) {
+                tonic::Code::Ok => "OK",
+                tonic::Code::Cancelled => "CANCELLED",
+                tonic::Code::InvalidArgument => "INVALID_ARGUMENT",
+                tonic::Code::DeadlineExceeded => "DEADLINE_EXCEEDED",
+                tonic::Code::NotFound => "NOT_FOUND",
+                tonic::Code::AlreadyExists => "ALREADY_EXISTS",
+                tonic::Code::PermissionDenied => "PERMISSION_DENIED",
+                tonic::Code::ResourceExhausted => "RESOURCE_EXHAUSTED",
+                tonic::Code::FailedPrecondition => "FAILED_PRECONDITION",
+                tonic::Code::Aborted => "ABORTED",
+                tonic::Code::OutOfRange => "OUT_OF_RANGE",
+                tonic::Code::Unimplemented => "UNIMPLEMENTED",
+                tonic::Code::Internal => "INTERNAL",
+                tonic::Code::Unavailable => "UNAVAILABLE",
+                tonic::Code::DataLoss => "DATA_LOSS",
+                tonic::Code::Unauthenticated => "UNAUTHENTICATED",
+                _ => "UNKNOWN",
+            },
+        )
+            .encode(enc.encode_label())?;
+
+        ("error", *error).encode(enc.encode_label())?;
+
+        Ok(())
+    }
+}
+
+impl EncodeLabelSet for GrpcRsp {
+    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(&mut enc)
+    }
+}
+
+// === impl Error ===
+
+impl Error {
+    pub fn new_or_status(error: &BoxError) -> Result<Self, u16> {
+        use super::super::super::errors as policy;
+        use crate::http::h2::{H2Error, Reason};
+
+        // No available backend can be found for a request.
+        if errors::is_caused_by::<errors::FailFastError>(&**error) {
+            return Ok(Self::FailFast);
+        }
+        if errors::is_caused_by::<errors::LoadShedError>(&**error) {
+            return Ok(Self::LoadShed);
+        }
+
+        if let Some(policy::HttpRouteRedirect { status, .. }) = errors::cause_ref(&**error) {
+            return Err(status.as_u16());
+        }
+
+        // Policy-driven request failures.
+        if let Some(policy::HttpRouteInjectedFailure { status, .. }) = errors::cause_ref(&**error) {
+            return Err(status.as_u16());
+        }
+        if let Some(policy::GrpcRouteInjectedFailure { code, .. }) = errors::cause_ref(&**error) {
+            return Err(*code);
+        }
+
+        // HTTP/2 errors.
+        if let Some(h2e) = errors::cause_ref::<H2Error>(&**error) {
+            if h2e.is_reset() {
+                match h2e.reason() {
+                    Some(Reason::CANCEL) => return Ok(Self::Cancel),
+                    Some(Reason::REFUSED_STREAM) => return Ok(Self::Refused),
+                    Some(Reason::ENHANCE_YOUR_CALM) => return Ok(Self::EnhanceYourCalm),
+                    _ => return Ok(Self::Reset),
+                }
+            }
+            if h2e.is_go_away() {
+                return Ok(Self::GoAway);
+            }
+            if h2e.is_io() {
+                return Ok(Self::Io);
+            }
+        }
+
+        tracing::debug!(?error, "Unlabeled error");
+        Ok(Self::Unknown)
+    }
+}
+
+impl EncodeLabelValue for Error {
+    fn encode(&self, enc: &mut LabelValueEncoder<'_>) -> std::fmt::Result {
+        use std::fmt::Write;
+        match self {
+            Self::FailFast => enc.write_str("FAIL_FAST"),
+            Self::LoadShed => enc.write_str("LOAD_SHED"),
+            Self::Timeout => enc.write_str("TIMEOUT"),
+            Self::Cancel => enc.write_str("CANCEL"),
+            Self::Refused => enc.write_str("REFUSED"),
+            Self::EnhanceYourCalm => enc.write_str("ENHANCE_YOUR_CALM"),
+            Self::Reset => enc.write_str("RESET"),
+            Self::GoAway => enc.write_str("GO_AWAY"),
+            Self::Io => enc.write_str("IO"),
+            Self::Unknown => enc.write_str("UNKNOWN"),
+        }
+    }
+}

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/test_util.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/test_util.rs
@@ -1,0 +1,110 @@
+use hyper::body::HttpBody;
+use linkerd_app_core::{
+    metrics::prom::Counter,
+    svc::{self, http::BoxBody, Service, ServiceExt},
+};
+
+pub use self::mock_body::MockBody;
+
+pub async fn send_assert_incremented(
+    counter: &Counter,
+    handle: &mut Handle,
+    svc: &mut svc::BoxHttp,
+    req: http::Request<BoxBody>,
+    send: impl FnOnce(SendResponse),
+) {
+    handle.allow(1);
+    assert_eq!(counter.get(), 0);
+    svc.ready().await.expect("ready");
+    let mut call = svc.call(req);
+    let (_req, tx) = tokio::select! {
+        _ = (&mut call) => unreachable!(),
+        res = handle.next_request() => res.unwrap(),
+    };
+    assert_eq!(counter.get(), 0);
+    send(tx);
+    if let Ok(mut rsp) = call.await {
+        if !rsp.body().is_end_stream() {
+            assert_eq!(counter.get(), 0);
+            while let Some(Ok(_)) = rsp.body_mut().data().await {}
+            let _ = rsp.body_mut().trailers().await;
+        }
+    }
+    assert_eq!(counter.get(), 1);
+}
+
+pub type Handle = tower_test::mock::Handle<http::Request<BoxBody>, http::Response<BoxBody>>;
+pub type SendResponse = tower_test::mock::SendResponse<http::Response<BoxBody>>;
+
+mod mock_body {
+    use bytes::Bytes;
+    use hyper::body::HttpBody;
+    use linkerd_app_core::{Error, Result};
+    use std::{
+        future::Future,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    #[derive(Default)]
+    #[pin_project::pin_project]
+    pub struct MockBody {
+        #[pin]
+        data: Option<futures::future::BoxFuture<'static, Result<()>>>,
+        #[pin]
+        trailers: Option<futures::future::BoxFuture<'static, Result<Option<http::HeaderMap>>>>,
+    }
+
+    impl MockBody {
+        pub fn new(data: impl Future<Output = Result<()>> + Send + 'static) -> Self {
+            Self {
+                data: Some(Box::pin(data)),
+                trailers: None,
+            }
+        }
+
+        pub fn trailers(
+            trailers: impl Future<Output = Result<Option<http::HeaderMap>>> + Send + 'static,
+        ) -> Self {
+            Self {
+                data: None,
+                trailers: Some(Box::pin(trailers)),
+            }
+        }
+    }
+
+    impl HttpBody for MockBody {
+        type Data = Bytes;
+        type Error = Error;
+
+        fn poll_data(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+            let mut this = self.project();
+            if let Some(rx) = this.data.as_mut().as_pin_mut() {
+                let ready = futures::ready!(rx.poll(cx));
+                *this.data = None;
+                return Poll::Ready(ready.err().map(Err));
+            }
+            Poll::Ready(None)
+        }
+
+        fn poll_trailers(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<Option<hyper::HeaderMap>, Self::Error>> {
+            let mut this = self.project();
+            if let Some(rx) = this.trailers.as_mut().as_pin_mut() {
+                let ready = futures::ready!(rx.poll(cx));
+                *this.trailers = None;
+                return Poll::Ready(ready);
+            }
+            Poll::Ready(Ok(None))
+        }
+
+        fn is_end_stream(&self) -> bool {
+            self.data.is_none() && self.trailers.is_none()
+        }
+    }
+}

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
@@ -1,0 +1,345 @@
+use super::{
+    super::{Grpc, Http, Route},
+    labels,
+    test_util::*,
+    LabelGrpcRouteRsp, LabelHttpRouteRsp, RequestMetrics,
+};
+use linkerd_app_core::svc::{self, http::BoxBody, Layer, NewService};
+use linkerd_proxy_client_policy as policy;
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn http_request_statuses() {
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::HttpRouteMetrics::default().requests;
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let (mut svc, mut handle) = mock_http_route_metrics(&metrics, &parent_ref, &route_ref);
+
+    // Send one request and ensure it's counted.
+    let ok = metrics.get_statuses(&labels::Rsp(
+        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::HttpRsp {
+            status: Some(http::StatusCode::OK),
+            error: None,
+        },
+    ));
+    send_assert_incremented(&ok, &mut handle, &mut svc, Default::default(), |tx| {
+        tx.send_response(
+            http::Response::builder()
+                .status(200)
+                .body(BoxBody::default())
+                .unwrap(),
+        )
+    })
+    .await;
+
+    // Send another request and ensure it's counted with a different response
+    // status.
+    let no_content = metrics.get_statuses(&labels::Rsp(
+        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::HttpRsp {
+            status: Some(http::StatusCode::NO_CONTENT),
+            error: None,
+        },
+    ));
+    send_assert_incremented(
+        &no_content,
+        &mut handle,
+        &mut svc,
+        Default::default(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .status(204)
+                    .body(BoxBody::default())
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+
+    // Emit a response with an error and ensure it's counted.
+    let unknown = metrics.get_statuses(&labels::Rsp(
+        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::HttpRsp {
+            status: None,
+            error: Some(labels::Error::Unknown),
+        },
+    ));
+    send_assert_incremented(&unknown, &mut handle, &mut svc, Default::default(), |tx| {
+        tx.send_error("a spooky ghost")
+    })
+    .await;
+
+    // Emit a successful response with a body that fails and ensure that both
+    // the status and error are recorded.
+    let mixed = metrics.get_statuses(&labels::Rsp(
+        labels::Route(parent_ref, route_ref),
+        labels::HttpRsp {
+            status: Some(http::StatusCode::OK),
+            error: Some(labels::Error::Unknown),
+        },
+    ));
+    send_assert_incremented(&mixed, &mut handle, &mut svc, Default::default(), |tx| {
+        tx.send_response(
+            http::Response::builder()
+                .status(200)
+                .body(BoxBody::new(MockBody::new(async {
+                    Err("a spooky ghost".into())
+                })))
+                .unwrap(),
+        )
+    })
+    .await;
+
+    assert_eq!(unknown.get(), 1);
+    assert_eq!(ok.get(), 1);
+    assert_eq!(no_content.get(), 1);
+    assert_eq!(mixed.get(), 1);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn grpc_request_statuses_ok() {
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::GrpcRouteMetrics::default().requests;
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let (mut svc, mut handle) = mock_grpc_route_metrics(&metrics, &parent_ref, &route_ref);
+
+    // Send one request and ensure it's counted.
+    let ok = metrics.get_statuses(&labels::Rsp(
+        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::GrpcRsp {
+            status: Some(tonic::Code::Ok),
+            error: None,
+        },
+    ));
+    send_assert_incremented(
+        &ok,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .method("POST")
+            .uri("http://host/svc/method")
+            .body(Default::default())
+            .unwrap(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .body(BoxBody::new(MockBody::trailers(async move {
+                        let mut trailers = http::HeaderMap::new();
+                        trailers.insert("grpc-status", http::HeaderValue::from_static("0"));
+                        Ok(Some(trailers))
+                    })))
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn grpc_request_statuses_not_found() {
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::GrpcRouteMetrics::default().requests;
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let (mut svc, mut handle) = mock_grpc_route_metrics(&metrics, &parent_ref, &route_ref);
+
+    // Send another request and ensure it's counted with a different response
+    // status.
+    let not_found = metrics.get_statuses(&labels::Rsp(
+        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::GrpcRsp {
+            status: Some(tonic::Code::NotFound),
+            error: None,
+        },
+    ));
+    send_assert_incremented(
+        &not_found,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .method("POST")
+            .uri("http://host/svc/method")
+            .body(Default::default())
+            .unwrap(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .body(BoxBody::new(MockBody::trailers(async move {
+                        let mut trailers = http::HeaderMap::new();
+                        trailers.insert("grpc-status", http::HeaderValue::from_static("5"));
+                        Ok(Some(trailers))
+                    })))
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn grpc_request_statuses_error_response() {
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::GrpcRouteMetrics::default().requests;
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let (mut svc, mut handle) = mock_grpc_route_metrics(&metrics, &parent_ref, &route_ref);
+
+    let unknown = metrics.get_statuses(&labels::Rsp(
+        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::GrpcRsp {
+            status: None,
+            error: Some(labels::Error::Unknown),
+        },
+    ));
+    send_assert_incremented(
+        &unknown,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .method("POST")
+            .uri("http://host/svc/method")
+            .body(Default::default())
+            .unwrap(),
+        |tx| tx.send_error("a spooky ghost"),
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn grpc_request_statuses_error_body() {
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::GrpcRouteMetrics::default().requests;
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let (mut svc, mut handle) = mock_grpc_route_metrics(&metrics, &parent_ref, &route_ref);
+
+    let unknown = metrics.get_statuses(&labels::Rsp(
+        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::GrpcRsp {
+            status: None,
+            error: Some(labels::Error::Unknown),
+        },
+    ));
+    send_assert_incremented(
+        &unknown,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .method("POST")
+            .uri("http://host/svc/method")
+            .body(Default::default())
+            .unwrap(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .body(BoxBody::new(MockBody::new(async {
+                        Err("a spooky ghost".into())
+                    })))
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+}
+
+// === Utils ===
+
+pub fn mock_http_route_metrics(
+    metrics: &RequestMetrics<LabelHttpRouteRsp>,
+    parent_ref: &crate::ParentRef,
+    route_ref: &crate::RouteRef,
+) -> (svc::BoxHttp, Handle) {
+    let req = http::Request::builder().body(()).unwrap();
+    let (r#match, _) = policy::route::find(
+        &[policy::http::Route {
+            hosts: vec![],
+            rules: vec![policy::route::Rule {
+                matches: vec![policy::http::r#match::MatchRequest::default()],
+                policy: policy::http::Policy {
+                    meta: route_ref.0.clone(),
+                    filters: [].into(),
+                    request_timeout: None,
+                    failure_policy: Default::default(),
+                    distribution: policy::RouteDistribution::Empty,
+                },
+            }],
+        }],
+        &req,
+    )
+    .expect("find default route");
+
+    let (tx, handle) = tower_test::mock::pair::<http::Request<BoxBody>, http::Response<BoxBody>>();
+    let svc = super::layer(metrics)
+        .layer(move |_t: Http<()>| tx.clone())
+        .new_service(Http {
+            r#match,
+            params: Route {
+                parent: (),
+                addr: std::net::SocketAddr::new([0, 0, 0, 0].into(), 8080).into(),
+                parent_ref: parent_ref.clone(),
+                route_ref: route_ref.clone(),
+                failure_policy: Default::default(),
+                request_timeout: None,
+                filters: [].into(),
+                distribution: Default::default(),
+            },
+        });
+
+    (svc::BoxHttp::new(svc), handle)
+}
+
+pub fn mock_grpc_route_metrics(
+    metrics: &RequestMetrics<LabelGrpcRouteRsp>,
+    parent_ref: &crate::ParentRef,
+    route_ref: &crate::RouteRef,
+) -> (svc::BoxHttp, Handle) {
+    let req = http::Request::builder()
+        .method("POST")
+        .uri("http://host/svc/method")
+        .body(())
+        .unwrap();
+    let (r#match, _) = policy::route::find(
+        &[policy::grpc::Route {
+            hosts: vec![],
+            rules: vec![policy::route::Rule {
+                matches: vec![policy::grpc::r#match::MatchRoute::default()],
+                policy: policy::grpc::Policy {
+                    meta: route_ref.0.clone(),
+                    filters: [].into(),
+                    request_timeout: None,
+                    failure_policy: Default::default(),
+                    distribution: policy::RouteDistribution::Empty,
+                },
+            }],
+        }],
+        &req,
+    )
+    .expect("find default route");
+
+    let (tx, handle) = tower_test::mock::pair::<http::Request<BoxBody>, http::Response<BoxBody>>();
+    let svc = super::layer(metrics)
+        .layer(move |_t: Grpc<()>| tx.clone())
+        .new_service(Grpc {
+            r#match,
+            params: Route {
+                parent: (),
+                addr: std::net::SocketAddr::new([0, 0, 0, 0].into(), 8080).into(),
+                parent_ref: parent_ref.clone(),
+                route_ref: route_ref.clone(),
+                failure_policy: Default::default(),
+                request_timeout: None,
+                filters: [].into(),
+                distribution: Default::default(),
+            },
+        });
+
+    (svc::BoxHttp::new(svc), handle)
+}

--- a/linkerd/app/outbound/src/http/logical/policy/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/tests.rs
@@ -125,17 +125,17 @@ async fn header_based_route() {
         failure_accrual: Default::default(),
     });
 
-    let metrics = RouteMetrics::default();
+    let metrics = HttpRouteMetrics::default();
     let router = Policy::layer(metrics.clone(), Default::default())
         .layer(inner)
         .new_service(Policy::from((routes, ())));
 
-    let default_reqs = metrics.request_count(
+    let default_reqs = metrics.backend_request_count(
         parent_ref.clone(),
         default_route_ref.clone(),
         default_backend_ref.clone(),
     );
-    let special_reqs = metrics.request_count(
+    let special_reqs = metrics.backend_request_count(
         parent_ref.clone(),
         special_route_ref.clone(),
         special_backend_ref.clone(),

--- a/linkerd/http/prom/Cargo.toml
+++ b/linkerd/http/prom/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "linkerd-http-prom"
+version = "0.1.0"
+edition = "2021"
+publish = false
+license = "Apache-2.0"
+
+[features]
+test-util = []
+
+[dependencies]
+futures = { version = "0.3", default-features = false }
+http = "0.2"
+http-body = "0.4"
+parking_lot = "0.12"
+pin-project = "1"
+prometheus-client = "0.22"
+thiserror = "1"
+tokio = { version = "1", features = ["time"] }
+
+linkerd-error = { path = "../../error" }
+linkerd-http-box = { path = "../box" }
+linkerd-metrics = { path = "../../metrics" }
+linkerd-stack = { path = "../../stack" }

--- a/linkerd/http/prom/src/lib.rs
+++ b/linkerd/http/prom/src/lib.rs
@@ -1,0 +1,7 @@
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
+#![forbid(unsafe_code)]
+
+mod count_reqs;
+pub mod record_response;
+
+pub use self::count_reqs::{CountRequests, NewCountRequests, RequestCount, RequestCountFamilies};

--- a/linkerd/http/prom/src/record_response.rs
+++ b/linkerd/http/prom/src/record_response.rs
@@ -1,0 +1,328 @@
+use http_body::Body;
+use linkerd_error::Error;
+use linkerd_http_box::BoxBody;
+use linkerd_metrics::prom::Counter;
+use linkerd_stack as svc;
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::{
+        family::{Family, MetricConstructor},
+        histogram::Histogram,
+    },
+};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::{sync::oneshot, time};
+
+mod request;
+mod response;
+
+pub use self::{
+    request::{NewRequestDuration, RecordRequestDuration, RequestMetrics},
+    response::{NewResponseDuration, RecordResponseDuration, ResponseMetrics},
+};
+
+/// A strategy for labeling request/responses streams for status and duration
+/// metrics.
+///
+/// This is specifically to support higher-cardinality status counters and
+/// lower-cardinality stream duration histograms.
+pub trait MkStreamLabel {
+    type DurationLabels: EncodeLabelSet
+        + Clone
+        + Eq
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Send
+        + Sync
+        + 'static;
+    type StatusLabels: EncodeLabelSet
+        + Clone
+        + Eq
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Send
+        + Sync
+        + 'static;
+
+    type StreamLabel: StreamLabel<
+        DurationLabels = Self::DurationLabels,
+        StatusLabels = Self::StatusLabels,
+    >;
+
+    /// Returns None when the request should not be recorded.
+    fn mk_stream_labeler<B>(&self, req: &http::Request<B>) -> Option<Self::StreamLabel>;
+}
+
+pub trait StreamLabel: Send + 'static {
+    type DurationLabels: EncodeLabelSet
+        + Clone
+        + Eq
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Send
+        + Sync
+        + 'static;
+    type StatusLabels: EncodeLabelSet
+        + Clone
+        + Eq
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Send
+        + Sync
+        + 'static;
+
+    fn init_response<B>(&mut self, rsp: &http::Response<B>);
+    fn end_response(&mut self, trailers: Result<Option<&http::HeaderMap>, &Error>);
+
+    fn status_labels(&self) -> Self::StatusLabels;
+    fn duration_labels(&self) -> Self::DurationLabels;
+}
+
+/// A set of parameters that can be used to construct a `RecordResponse` layer.
+pub struct Params<L: MkStreamLabel, M> {
+    pub labeler: L,
+    pub metric: M,
+}
+
+#[derive(Clone, Debug, thiserror::Error)]
+#[error("request was cancelled before completion")]
+pub struct RequestCancelled(());
+
+/// Builds RecordResponse instances by extracing M-typed parameters from stack
+/// targets
+#[derive(Clone, Debug)]
+pub struct NewRecordResponse<L, X, M, N> {
+    inner: N,
+    extract: X,
+    _marker: std::marker::PhantomData<fn() -> (L, M)>,
+}
+
+/// A Service that can record a request/response durations.
+#[derive(Clone, Debug)]
+pub struct RecordResponse<L, M, S> {
+    inner: S,
+    labeler: L,
+    metric: M,
+}
+
+#[pin_project::pin_project]
+pub struct ResponseFuture<L, F>
+where
+    L: StreamLabel,
+{
+    #[pin]
+    inner: F,
+    state: Option<ResponseState<L>>,
+}
+
+/// Notifies the response labeler when the response body is flushed.
+#[pin_project::pin_project(PinnedDrop)]
+struct ResponseBody<L: StreamLabel> {
+    #[pin]
+    inner: BoxBody,
+    state: Option<ResponseState<L>>,
+}
+
+struct ResponseState<L: StreamLabel> {
+    labeler: L,
+    statuses: Family<L::StatusLabels, Counter>,
+    duration: DurationFamily<L::DurationLabels>,
+    start: oneshot::Receiver<time::Instant>,
+}
+
+type DurationFamily<L> = Family<L, Histogram, MkDurationHistogram>;
+
+#[derive(Clone, Debug)]
+struct MkDurationHistogram(Arc<[f64]>);
+
+// === impl MkDurationHistogram ===
+
+impl MetricConstructor<Histogram> for MkDurationHistogram {
+    fn new_metric(&self) -> Histogram {
+        Histogram::new(self.0.iter().copied())
+    }
+}
+
+// === impl NewRecordResponse ===
+
+impl<M, X, K, N> NewRecordResponse<M, X, K, N>
+where
+    M: MkStreamLabel,
+{
+    pub fn new(extract: X, inner: N) -> Self {
+        Self {
+            extract,
+            inner,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn layer_via(extract: X) -> impl svc::layer::Layer<N, Service = Self> + Clone
+    where
+        X: Clone,
+    {
+        svc::layer::mk(move |inner| Self::new(extract.clone(), inner))
+    }
+}
+
+impl<M, K, N> NewRecordResponse<M, (), K, N>
+where
+    M: MkStreamLabel,
+{
+    pub fn layer() -> impl svc::layer::Layer<N, Service = Self> + Clone {
+        Self::layer_via(())
+    }
+}
+
+impl<T, L, X, M, N> svc::NewService<T> for NewRecordResponse<L, X, M, N>
+where
+    L: MkStreamLabel,
+    X: svc::ExtractParam<Params<L, M>, T>,
+    N: svc::NewService<T>,
+{
+    type Service = RecordResponse<L, M, N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let Params { labeler, metric } = self.extract.extract_param(&target);
+        let inner = self.inner.new_service(target);
+        RecordResponse::new(labeler, metric, inner)
+    }
+}
+
+// === impl RecordResponse ===
+
+impl<L, M, S> RecordResponse<L, M, S>
+where
+    L: MkStreamLabel,
+{
+    pub(crate) fn new(labeler: L, metric: M, inner: S) -> Self {
+        Self {
+            inner,
+            labeler,
+            metric,
+        }
+    }
+}
+
+// === impl ResponseFuture ===
+
+impl<L, F> Future for ResponseFuture<L, F>
+where
+    L: StreamLabel,
+    F: Future<Output = Result<http::Response<BoxBody>, Error>>,
+{
+    type Output = Result<http::Response<BoxBody>, Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let res = futures::ready!(this.inner.poll(cx)).map_err(Into::into);
+        let mut state = this.state.take();
+        match res {
+            Ok(rsp) => {
+                if let Some(ResponseState { labeler, .. }) = state.as_mut() {
+                    labeler.init_response(&rsp);
+                }
+
+                let (head, inner) = rsp.into_parts();
+                if inner.is_end_stream() {
+                    end_stream(&mut state, Ok(None));
+                }
+                Poll::Ready(Ok(http::Response::from_parts(
+                    head,
+                    BoxBody::new(ResponseBody { inner, state }),
+                )))
+            }
+            Err(error) => {
+                end_stream(&mut state, Err(&error));
+                Poll::Ready(Err(error))
+            }
+        }
+    }
+}
+
+// === impl ResponseBody ===
+
+impl<L> http_body::Body for ResponseBody<L>
+where
+    L: StreamLabel,
+{
+    type Data = <BoxBody as http_body::Body>::Data;
+    type Error = Error;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Error>>> {
+        let mut this = self.project();
+        let res =
+            futures::ready!(this.inner.as_mut().poll_data(cx)).map(|res| res.map_err(Into::into));
+        if let Some(Err(error)) = res.as_ref() {
+            end_stream(this.state, Err(error));
+        } else if (*this.inner).is_end_stream() {
+            end_stream(this.state, Ok(None));
+        }
+        Poll::Ready(res)
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, Error>> {
+        let this = self.project();
+        let res = futures::ready!(this.inner.poll_trailers(cx)).map_err(Into::into);
+        end_stream(this.state, res.as_ref().map(Option::as_ref));
+        Poll::Ready(res)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+}
+
+#[pin_project::pinned_drop]
+impl<L> PinnedDrop for ResponseBody<L>
+where
+    L: StreamLabel,
+{
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        if this.state.is_some() {
+            end_stream(this.state, Err(&RequestCancelled(()).into()));
+        }
+    }
+}
+
+fn end_stream<L>(
+    state: &mut Option<ResponseState<L>>,
+    res: Result<Option<&http::HeaderMap>, &Error>,
+) where
+    L: StreamLabel,
+{
+    let Some(ResponseState {
+        duration,
+        statuses: total,
+        mut start,
+        mut labeler,
+    }) = state.take()
+    else {
+        return;
+    };
+
+    labeler.end_response(res);
+
+    total.get_or_create(&labeler.status_labels()).inc();
+
+    let elapsed = if let Ok(start) = start.try_recv() {
+        time::Instant::now().saturating_duration_since(start)
+    } else {
+        time::Duration::ZERO
+    };
+    duration
+        .get_or_create(&labeler.duration_labels())
+        .observe(elapsed.as_secs_f64());
+}

--- a/linkerd/http/prom/src/record_response/request.rs
+++ b/linkerd/http/prom/src/record_response/request.rs
@@ -1,0 +1,129 @@
+use linkerd_error::Error;
+use linkerd_http_box::BoxBody;
+use linkerd_metrics::prom::Counter;
+use linkerd_stack as svc;
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::family::Family,
+    registry::{Registry, Unit},
+};
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::{sync::oneshot, time};
+
+use super::{DurationFamily, MkDurationHistogram, MkStreamLabel};
+
+/// Metrics type that tracks completed requests.
+#[derive(Debug)]
+pub struct RequestMetrics<DurL, StatL> {
+    duration: DurationFamily<DurL>,
+    statuses: Family<StatL, Counter>,
+}
+
+pub type NewRequestDuration<L, X, N> = super::NewRecordResponse<
+    L,
+    X,
+    RequestMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    N,
+>;
+
+pub type RecordRequestDuration<L, S> = super::RecordResponse<
+    L,
+    RequestMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    S,
+>;
+
+// === impl RequestMetrics ===
+
+impl<DurL, StatL> RequestMetrics<DurL, StatL>
+where
+    DurL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+    StatL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+{
+    pub fn register(reg: &mut Registry, histo: impl IntoIterator<Item = f64>) -> Self {
+        let duration =
+            DurationFamily::new_with_constructor(MkDurationHistogram(histo.into_iter().collect()));
+        reg.register_with_unit(
+            "request_duration",
+            "The time between request initialization and response completion",
+            Unit::Seconds,
+            duration.clone(),
+        );
+
+        let statuses = Family::default();
+        reg.register(
+            "request_statuses",
+            "Completed request-response streams",
+            statuses.clone(),
+        );
+
+        Self { duration, statuses }
+    }
+}
+
+#[cfg(feature = "test-util")]
+impl<DurL, StatL> RequestMetrics<DurL, StatL>
+where
+    StatL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+    DurL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+{
+    pub fn get_statuses(&self, labels: &StatL) -> Counter {
+        (*self.statuses.get_or_create(labels)).clone()
+    }
+}
+
+impl<DurL, StatL> Default for RequestMetrics<DurL, StatL>
+where
+    StatL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+    DurL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self {
+            duration: DurationFamily::new_with_constructor(MkDurationHistogram(Arc::new([]))),
+            statuses: Default::default(),
+        }
+    }
+}
+
+impl<DurL, StatL> Clone for RequestMetrics<DurL, StatL> {
+    fn clone(&self) -> Self {
+        Self {
+            duration: self.duration.clone(),
+            statuses: self.statuses.clone(),
+        }
+    }
+}
+
+impl<ReqB, L, S> svc::Service<http::Request<ReqB>> for RecordRequestDuration<L, S>
+where
+    L: MkStreamLabel,
+    S: svc::Service<http::Request<ReqB>, Response = http::Response<BoxBody>, Error = Error>,
+{
+    type Response = http::Response<BoxBody>;
+    type Error = S::Error;
+    type Future = super::ResponseFuture<L::StreamLabel, S::Future>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: http::Request<ReqB>) -> Self::Future {
+        let state = self.labeler.mk_stream_labeler(&req).map(|labeler| {
+            let (tx, start) = oneshot::channel();
+            tx.send(time::Instant::now()).unwrap();
+            let RequestMetrics { statuses, duration } = self.metric.clone();
+            super::ResponseState {
+                labeler,
+                start,
+                duration,
+                statuses,
+            }
+        });
+
+        let inner = self.inner.call(req);
+        super::ResponseFuture { state, inner }
+    }
+}

--- a/linkerd/http/prom/src/record_response/response.rs
+++ b/linkerd/http/prom/src/record_response/response.rs
@@ -1,0 +1,192 @@
+use linkerd_error::Error;
+use linkerd_http_box::BoxBody;
+use linkerd_metrics::prom::Counter;
+use linkerd_stack as svc;
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::family::Family,
+    registry::{Registry, Unit},
+};
+use std::{
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio::{sync::oneshot, time};
+
+use super::{DurationFamily, MkDurationHistogram, MkStreamLabel};
+
+#[derive(Debug)]
+pub struct ResponseMetrics<DurL, StatL> {
+    duration: DurationFamily<DurL>,
+    statuses: Family<StatL, Counter>,
+}
+
+pub type NewResponseDuration<L, X, N> = super::NewRecordResponse<
+    L,
+    X,
+    ResponseMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    N,
+>;
+
+pub type RecordResponseDuration<L, S> = super::RecordResponse<
+    L,
+    ResponseMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    S,
+>;
+
+/// Notifies the response body when the request body is flushed.
+#[pin_project::pin_project(PinnedDrop)]
+struct RequestBody<B> {
+    #[pin]
+    inner: B,
+    flushed: Option<oneshot::Sender<time::Instant>>,
+}
+
+// === impl ResponseMetrics ===
+
+impl<DurL, StatL> ResponseMetrics<DurL, StatL>
+where
+    DurL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+    StatL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+{
+    pub fn register(reg: &mut Registry, histo: impl IntoIterator<Item = f64>) -> Self {
+        let duration =
+            DurationFamily::new_with_constructor(MkDurationHistogram(histo.into_iter().collect()));
+        reg.register_with_unit(
+            "response_duration",
+            "The time between request completion and response completion",
+            Unit::Seconds,
+            duration.clone(),
+        );
+
+        let statuses = Family::default();
+        reg.register("response_statuses", "Completed responses", statuses.clone());
+
+        Self { duration, statuses }
+    }
+}
+
+#[cfg(feature = "test-util")]
+impl<DurL, StatL> ResponseMetrics<DurL, StatL>
+where
+    StatL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+    DurL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+{
+    pub fn get_statuses(&self, labels: &StatL) -> Counter {
+        (*self.statuses.get_or_create(labels)).clone()
+    }
+}
+
+impl<DurL, StatL> Default for ResponseMetrics<DurL, StatL>
+where
+    StatL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+    DurL: EncodeLabelSet + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self {
+            duration: DurationFamily::new_with_constructor(MkDurationHistogram(Arc::new([]))),
+            statuses: Default::default(),
+        }
+    }
+}
+
+impl<DurL, StatL> Clone for ResponseMetrics<DurL, StatL> {
+    fn clone(&self) -> Self {
+        Self {
+            duration: self.duration.clone(),
+            statuses: self.statuses.clone(),
+        }
+    }
+}
+
+impl<M, S> svc::Service<http::Request<BoxBody>> for RecordResponseDuration<M, S>
+where
+    M: MkStreamLabel,
+    S: svc::Service<http::Request<BoxBody>, Response = http::Response<BoxBody>, Error = Error>,
+{
+    type Response = http::Response<BoxBody>;
+    type Error = Error;
+    type Future = super::ResponseFuture<M::StreamLabel, S::Future>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<BoxBody>) -> Self::Future {
+        // If there's a labeler, wrap the request body to record the time that
+        // the respond flushes.
+        let state = if let Some(labeler) = self.labeler.mk_stream_labeler(&req) {
+            let (tx, start) = oneshot::channel();
+            req = req.map(|inner| {
+                BoxBody::new(RequestBody {
+                    inner,
+                    flushed: Some(tx),
+                })
+            });
+            let ResponseMetrics { duration, statuses } = self.metric.clone();
+            Some(super::ResponseState {
+                labeler,
+                start,
+                duration,
+                statuses,
+            })
+        } else {
+            None
+        };
+
+        let inner = self.inner.call(req);
+        super::ResponseFuture { state, inner }
+    }
+}
+
+// === impl ResponseBody ===
+
+impl<B> http_body::Body for RequestBody<B>
+where
+    B: http_body::Body,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, B::Error>>> {
+        let mut this = self.project();
+        let res = futures::ready!(this.inner.as_mut().poll_data(cx));
+        if (*this.inner).is_end_stream() {
+            if let Some(tx) = this.flushed.take() {
+                let _ = tx.send(time::Instant::now());
+            }
+        }
+        Poll::Ready(res)
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, B::Error>> {
+        let this = self.project();
+        let res = futures::ready!(this.inner.poll_trailers(cx));
+        if let Some(tx) = this.flushed.take() {
+            let _ = tx.send(time::Instant::now());
+        }
+        Poll::Ready(res)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+}
+
+#[pin_project::pinned_drop]
+impl<B> PinnedDrop for RequestBody<B> {
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        if let Some(tx) = this.flushed.take() {
+            let _ = tx.send(time::Instant::now());
+        }
+    }
+}

--- a/linkerd/http/route/src/grpc/tests.rs
+++ b/linkerd/http/route/src/grpc/tests.rs
@@ -13,6 +13,25 @@ impl Default for Policy {
     }
 }
 
+#[test]
+fn default() {
+    let rts = vec![Route {
+        hosts: vec![],
+        rules: vec![Rule {
+            matches: vec![MatchRoute::default()],
+            policy: Policy::Expected,
+        }],
+    }];
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://foo.example.com/foo/bar")
+        .body(())
+        .unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}
+
 /// Given two equivalent routes, choose the explicit hostname match and not
 /// the wildcard.
 #[test]


### PR DESCRIPTION
The outbound policy router includes a requests counter that measures the number of requests dispatched to each route-backend; but this does not provide visibility into success rate or response time. Before introducing timeouts and retires on outbound routes, this change introduces visibility into per-route response metrics.

The route_request_statuses counters measure responses from the application's point of view. Once retries are introduced, this will provide visibility into the _effective_ success rate of each route.

    outbound_http_route_request_statuses_total{parent...,route...,http_status="200",error="TIMEOUT"} 0
    outbound_grpc_route_request_statuses_total{parent...,route...,grpc_status="NOT_FOUND",error="TIMEOUT"} 0

A coarse histogram is introduced at this scope to track the total duration of requests dispatched to each route, covering all retries and all response stream processing:

    outbound_http_route_request_duration_seconds_sum{parent...,route...} 0
    outbound_http_route_request_duration_seconds_count{parent...,route...} 0
    outbound_http_route_request_duration_seconds_bucket{le="0.05",parent...,route...} 0
    outbound_http_route_request_duration_seconds_bucket{le="0.5",parent...,route...} 0
    outbound_http_route_request_duration_seconds_bucket{le="1.0",parent...,route...} 0
    outbound_http_route_request_duration_seconds_bucket{le="10.0",parent...,route...} 0
    outbound_http_route_request_duration_seconds_bucket{le="+Inf",parent...,route...} 0

The route_backend_response_statuses counters measure the responses from individual backends. This reflects the _actual_ success rate of each route as served by the backend services.

    outbound_http_route_backend_response_statuses_total{parent...,route...,backend...,http_status="...",error="..."} 0
    outbound_grpc_route_backend_response_statuses_total{parent...,route...,backend...,grpc_status="...",error="..."} 0

A slightly more detailed histogram is introduced at this scope to track the time spend processing responses from each backend (i.e. after the request has been fully dispatched):

    outbound_http_route_backend_response_duration_seconds_sum{parent...,route...,backend...} 0
    outbound_http_route_backend_response_duration_seconds_count{parent...,route...,backend...} 0
    outbound_http_route_backend_response_duration_seconds_bucket{le="0.025",parent...,route...,backend...} 0
    outbound_http_route_backend_response_duration_seconds_bucket{le="0.05",parent...,route...,backend...} 0
    outbound_http_route_backend_response_duration_seconds_bucket{le="0.1",parent...,route...,backend...} 0
    outbound_http_route_backend_response_duration_seconds_bucket{le="0.25",parent...,route...,backend...} 0
    outbound_http_route_backend_response_duration_seconds_bucket{le="0.5",parent...,route...,backend...} 0
    outbound_http_route_backend_response_duration_seconds_bucket{le="1.0",parent...,route...,backend...} 0
    outbound_http_route_backend_response_duration_seconds_bucket{le="10.0",parent...,route...,backend...} 0
    outbound_http_route_backend_response_duration_seconds_bucket{le="+Inf",parent...,route...,backend...} 0

Note that duration histograms omit status code labels, as they needlessly inflate metrics cardinality. The histograms that we have introduced here are generally much more constrained, as we much choose broadly applicable buckets and want to avoid cardinality explosion when many routes are used.