### PR TITLE
feat(outbound): Add HTTP and gRPC route retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,12 +1522,15 @@ dependencies = [
  "http-body",
  "hyper",
  "linkerd-error",
+ "linkerd-exp-backoff",
  "linkerd-http-box",
+ "linkerd-metrics",
  "linkerd-stack",
  "linkerd-tracing",
  "parking_lot",
  "thiserror",
  "tokio",
+ "tower",
  "tracing",
 ]
 

--- a/linkerd/app/outbound/src/http/logical/policy/route/extensions.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/extensions.rs
@@ -1,11 +1,18 @@
+use super::retry::RetryPolicy;
 use linkerd_app_core::{proxy::http, svc};
 use linkerd_proxy_client_policy as policy;
 use std::task::{Context, Poll};
 
 #[derive(Clone, Debug)]
 pub struct Params {
+    pub retry: Option<RetryPolicy>,
     pub timeouts: policy::http::Timeouts,
 }
+
+// A request extension that marks the number of times a request has been
+// attempted.
+#[derive(Clone, Debug)]
+pub struct Attempt(pub std::num::NonZeroU16);
 
 #[derive(Clone, Debug)]
 pub struct NewSetExtensions<N> {
@@ -56,8 +63,18 @@ where
     }
 
     fn call(&mut self, mut req: http::Request<B>) -> Self::Future {
-        let timeouts = self.configure_timeouts();
-        tracing::debug!(?timeouts, "Setting extensions");
+        let retry = self.configure_retry();
+
+        // Ensure that we get response headers within the retry timeout. Note
+        // that this may be cleared super::retry::RetryPolicy::set_extensions.
+        let mut timeouts = self.configure_timeouts();
+        timeouts.response_headers = retry.as_ref().and_then(|r| r.timeout);
+
+        tracing::debug!(?retry, ?timeouts, "Initializing route extensions");
+        if let Some(retry) = retry {
+            let _prior = req.extensions_mut().insert(retry);
+            debug_assert!(_prior.is_none(), "RetryPolicy must only be configured once");
+        }
 
         let _prior = req.extensions_mut().insert(timeouts);
         debug_assert!(
@@ -65,11 +82,18 @@ where
             "StreamTimeouts must only be configured once"
         );
 
+        let _prior = req.extensions_mut().insert(Attempt(1.try_into().unwrap()));
+        debug_assert!(_prior.is_none(), "Attempts must only be configured once");
+
         self.inner.call(req)
     }
 }
 
 impl<S> SetExtensions<S> {
+    fn configure_retry(&self) -> Option<RetryPolicy> {
+        self.params.retry.clone()
+    }
+
     fn configure_timeouts(&self) -> http::StreamTimeouts {
         http::StreamTimeouts {
             response_headers: None,

--- a/linkerd/app/outbound/src/http/logical/policy/route/retry.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/retry.rs
@@ -1,0 +1,163 @@
+use super::{extensions, metrics::labels::Route as RouteLabels};
+use futures::future::{Either, Ready};
+use linkerd_app_core::{
+    cause_ref, classify,
+    exp_backoff::ExponentialBackoff,
+    is_caused_by,
+    proxy::http::{self, stream_timeouts::ResponseTimeoutError},
+    svc::{self, http::h2},
+    Error, Result,
+};
+use linkerd_http_retry::{self as retry, peek_trailers::PeekTrailersBody};
+use linkerd_proxy_client_policy as policy;
+use tokio::time;
+
+// A request extension that marks that a request is a retry.
+#[derive(Copy, Clone, Debug)]
+pub struct IsRetry(());
+
+pub type NewHttpRetry<N> = retry::NewHttpRetry<RetryPolicy, RouteLabels, N>;
+
+#[derive(Clone, Debug)]
+pub struct RetryPolicy {
+    pub timeout: Option<time::Duration>,
+    pub retryable_http_statuses: Option<policy::http::StatusRanges>,
+    pub retryable_grpc_statuses: Option<policy::grpc::Codes>,
+
+    pub max_retries: usize,
+    pub max_request_bytes: usize,
+    pub backoff: Option<ExponentialBackoff>,
+}
+
+pub type RouteRetryMetrics = retry::MetricFamilies<RouteLabels>;
+
+// === impl RetryPolicy ===
+
+impl svc::Param<retry::Params> for RetryPolicy {
+    fn param(&self) -> retry::Params {
+        retry::Params {
+            max_retries: self.max_retries,
+            max_request_bytes: self.max_request_bytes,
+            backoff: self.backoff,
+        }
+    }
+}
+
+impl retry::Policy for RetryPolicy {
+    type Future = Either<time::Sleep, Ready<()>>;
+
+    fn is_retryable(&self, res: Result<&::http::Response<PeekTrailersBody>, &Error>) -> bool {
+        let rsp = match res {
+            Ok(rsp) => rsp,
+            Err(error) => {
+                let retryable = Self::retryable_error(error);
+                tracing::debug!(retryable, %error);
+                return retryable;
+            }
+        };
+
+        if let Some(codes) = self.retryable_grpc_statuses.as_ref() {
+            let grpc_status = Self::grpc_status(rsp);
+            let retryable = grpc_status.map_or(false, |c| codes.contains(c));
+            tracing::debug!(retryable, grpc.status = ?grpc_status);
+            if retryable {
+                return true;
+            }
+        }
+
+        if let Some(statuses) = self.retryable_http_statuses.as_ref() {
+            let retryable = statuses.contains(rsp.status());
+            tracing::debug!(retryable, http.status = %rsp.status());
+            if retryable {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    fn set_extensions(&self, dst: &mut ::http::Extensions, src: &::http::Extensions) {
+        let attempt = if let Some(extensions::Attempt(n)) = src.get::<extensions::Attempt>() {
+            n.saturating_add(1)
+        } else {
+            // There was an already a first attmept (the original extensions).
+            2.try_into().unwrap()
+        };
+        dst.insert(extensions::Attempt(attempt));
+
+        let retries_remain = u16::from(attempt) as usize <= self.max_retries;
+        if retries_remain {
+            dst.insert(self.clone());
+        }
+
+        if let Some(mut timeouts) = src.get::<http::StreamTimeouts>().cloned() {
+            // If retries are exhausted, remove the response headers timeout,
+            // since we're not blocked on making a decision on a retry decision.
+            // This may give the request additional time to be satisfied.
+            if !retries_remain {
+                timeouts.response_headers = None;
+            }
+            dst.insert(timeouts);
+        }
+
+        // The HTTP server sets a ClientHandle with the client's address and a means
+        // to close the server-side connection.
+        if let Some(client_handle) = src.get::<http::ClientHandle>().cloned() {
+            dst.insert(client_handle);
+        }
+
+        // The legacy response classifier is set for the endpoint stack to use.
+        // This informs endpoint-level behavior (failure accrual, etc.).
+        // TODO(ver): This should ultimately be eliminated in favor of
+        // failure-accrual specific configuration. The endpoint metrics should
+        // be migrated, ultimately...
+        if let Some(classify) = src.get::<classify::Response>().cloned() {
+            dst.insert(classify);
+        }
+    }
+}
+
+impl RetryPolicy {
+    fn grpc_status(rsp: &http::Response<PeekTrailersBody>) -> Option<tonic::Code> {
+        if let Some(header) = rsp.headers().get("grpc-status") {
+            return Some(header.to_str().ok()?.parse::<i32>().ok()?.into());
+        }
+
+        let Some(trailer) = rsp.body().peek_trailers() else {
+            tracing::debug!("No trailers");
+            return None;
+        };
+        let status = trailer.get("grpc-status")?;
+        Some(status.to_str().ok()?.parse::<i32>().ok()?.into())
+    }
+
+    fn retryable_error(error: &Error) -> bool {
+        // While LoadShed errors are not retryable, FailFast errors are, since
+        // retrying may put us in another backend that is available.
+        if is_caused_by::<svc::LoadShedError>(&**error) {
+            return false;
+        }
+        if is_caused_by::<svc::FailFastError>(&**error) {
+            return true;
+        }
+
+        if matches!(
+            cause_ref::<ResponseTimeoutError>(&**error),
+            Some(ResponseTimeoutError::Headers(_))
+        ) {
+            return true;
+        }
+
+        // HTTP/2 errors
+        if let Some(h2e) = cause_ref::<h2::H2Error>(&**error) {
+            if matches!(h2e.reason(), Some(h2::Reason::REFUSED_STREAM)) {
+                return true;
+            }
+        }
+
+        // TODO(ver) connection errors require changes to the endpoint stack so
+        // that they can be inspected. here.
+
+        false
+    }
+}

--- a/linkerd/app/outbound/src/http/logical/tests/retries.rs
+++ b/linkerd/app/outbound/src/http/logical/tests/retries.rs
@@ -1,0 +1,505 @@
+use super::{
+    super::{policy, Outbound, ParentRef, Routes},
+    default_backend, http_get, mk_grpc_rsp, mk_rsp, send_req, serve_delayed, serve_req,
+    HttpConnect, Request, Response, Target,
+};
+use crate::test_util::*;
+use hyper::body::HttpBody;
+use linkerd_app_core::{
+    errors,
+    proxy::http::{self, StatusCode},
+    svc::{self, http::stream_timeouts::StreamDeadlineError, NewService},
+    trace, NameAddr,
+};
+use linkerd_proxy_client_policy::{
+    self as client_policy,
+    grpc::{Codes, RouteParams as GrpcParams},
+    http::{RouteParams as HttpParams, Timeouts},
+};
+use std::{collections::BTreeSet, net::SocketAddr, sync::Arc, time::Duration};
+use tokio::{sync::watch, time};
+use tonic::Code;
+use tracing::{info, Instrument};
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn http_5xx() {
+    let _trace = trace::test::trace_init();
+
+    const TIMEOUT: Duration = Duration::from_secs(2);
+    let (svc, mut handle) = mock_http(HttpParams {
+        timeouts: Timeouts {
+            request: Some(TIMEOUT),
+            ..Default::default()
+        },
+        retry: Some(client_policy::http::Retry {
+            max_retries: 1,
+            status_ranges: Default::default(),
+            max_request_bytes: 1000,
+            timeout: None,
+            backoff: None,
+        }),
+    });
+
+    info!("Sending a request that will initially fail and then succeed");
+    tokio::spawn(
+        async move {
+            handle.allow(2);
+            info!("Failing the first request");
+            serve_req(&mut handle, mk_rsp(StatusCode::INTERNAL_SERVER_ERROR, "")).await;
+            info!("Serving the second request");
+            serve_req(&mut handle, mk_rsp(StatusCode::NO_CONTENT, "")).await;
+            handle
+        }
+        .in_current_span(),
+    );
+
+    info!("Verifying that we see the successful response");
+    let rsp = time::timeout(TIMEOUT, send_req(svc.clone(), http_get()))
+        .await
+        .expect("response");
+    assert_eq!(rsp.expect("response").status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn http_5xx_limits() {
+    let _trace = trace::test::trace_init();
+
+    const TIMEOUT: Duration = Duration::from_secs(2);
+    let (svc, mut handle) = mock_http(HttpParams {
+        timeouts: Timeouts {
+            request: Some(TIMEOUT),
+            ..Default::default()
+        },
+        retry: Some(client_policy::http::Retry {
+            max_retries: 2,
+            status_ranges: Default::default(),
+            max_request_bytes: 1000,
+            timeout: None,
+            backoff: None,
+        }),
+    });
+
+    info!("Sending a request that will initially fail and then succeed");
+    tokio::spawn(
+        async move {
+            handle.allow(3);
+            info!("Failing the first request");
+            serve_req(&mut handle, mk_rsp(StatusCode::INTERNAL_SERVER_ERROR, "")).await;
+            info!("Failing the second request");
+            serve_req(&mut handle, mk_rsp(StatusCode::INTERNAL_SERVER_ERROR, "")).await;
+            info!("Failing the third request");
+            serve_req(&mut handle, mk_rsp(StatusCode::GATEWAY_TIMEOUT, "")).await;
+            info!("Prepping the fourth request (shouldn't be served)");
+            serve_req(&mut handle, mk_rsp(StatusCode::NO_CONTENT, "")).await;
+            handle
+        }
+        .in_current_span(),
+    );
+
+    info!("Verifying that the response fails with the expected error");
+    let rsp = time::timeout(TIMEOUT, send_req(svc.clone(), http_get()))
+        .await
+        .expect("response");
+    assert_eq!(rsp.expect("response").status(), StatusCode::GATEWAY_TIMEOUT);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn http_timeout() {
+    let _trace = trace::test::trace_init();
+
+    const TIMEOUT: Duration = Duration::from_secs(2);
+    let (svc, mut handle) = mock_http(HttpParams {
+        timeouts: Timeouts {
+            request: Some(TIMEOUT),
+            ..Default::default()
+        },
+        retry: Some(client_policy::http::Retry {
+            max_retries: 1,
+            status_ranges: Default::default(),
+            max_request_bytes: 1000,
+            timeout: Some(TIMEOUT / 4),
+            backoff: None,
+        }),
+    });
+
+    info!("Sending a request that will initially timeout and then succeed");
+    tokio::spawn(
+        async move {
+            handle.allow(2);
+
+            info!("Delaying the first request");
+            serve_delayed(
+                TIMEOUT / 2,
+                &mut handle,
+                Ok(mk_rsp(StatusCode::NOT_FOUND, "")),
+            )
+            .await;
+
+            info!("Serving the second request");
+            serve_req(&mut handle, mk_rsp(StatusCode::NO_CONTENT, "")).await;
+
+            handle
+        }
+        .in_current_span(),
+    );
+
+    info!("Verifying that the response fails with the expected error");
+    let rsp = time::timeout(TIMEOUT, send_req(svc.clone(), http_get()))
+        .await
+        .expect("response");
+    assert_eq!(rsp.expect("response").status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn http_timeout_on_limit() {
+    let _trace = trace::test::trace_init();
+
+    const TIMEOUT: Duration = Duration::from_secs(2);
+    let (svc, mut handle) = mock_http(HttpParams {
+        timeouts: Timeouts {
+            request: Some(TIMEOUT),
+            ..Default::default()
+        },
+        retry: Some(client_policy::http::Retry {
+            max_retries: 1,
+            status_ranges: Default::default(),
+            max_request_bytes: 1000,
+            timeout: Some(TIMEOUT / 4),
+            backoff: None,
+        }),
+    });
+
+    info!("Testing that a retry timeout does not apply when max retries is reached");
+    tokio::spawn(
+        async move {
+            handle.allow(2);
+
+            info!("Delaying the first request");
+            serve_delayed(
+                TIMEOUT / 3,
+                &mut handle,
+                Ok(mk_rsp(StatusCode::NOT_FOUND, "")),
+            )
+            .await;
+
+            info!("Delaying the second request");
+            serve_delayed(
+                TIMEOUT / 3,
+                &mut handle,
+                Ok(mk_rsp(StatusCode::NO_CONTENT, "")),
+            )
+            .await;
+
+            handle
+        }
+        .in_current_span(),
+    );
+
+    info!("Verifying that the initial request was retried");
+    let rsp = time::timeout(TIMEOUT, send_req(svc.clone(), http_get()))
+        .await
+        .expect("response");
+    assert_eq!(rsp.expect("response").status(), StatusCode::NO_CONTENT);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn http_timeout_with_request_timeout() {
+    let _trace = trace::test::trace_init();
+
+    const TIMEOUT: Duration = Duration::from_millis(100);
+    let (svc, mut handle) = mock_http(HttpParams {
+        timeouts: Timeouts {
+            request: Some(TIMEOUT * 5),
+            ..Default::default()
+        },
+        retry: Some(client_policy::http::Retry {
+            max_retries: 2,
+            status_ranges: Default::default(),
+            max_request_bytes: 1000,
+            timeout: Some(TIMEOUT),
+            backoff: None,
+        }),
+    });
+
+    info!("Sending a request that will initially timeout and then succeed");
+    tokio::spawn(
+        async move {
+            handle.allow(6);
+
+            info!("Delaying the first request");
+            serve_delayed(
+                TIMEOUT * 2,
+                &mut handle,
+                Ok(mk_rsp(StatusCode::IM_A_TEAPOT, "")),
+            )
+            .await;
+
+            info!("Delaying the second request");
+            serve_delayed(
+                TIMEOUT * 2,
+                &mut handle,
+                Ok(mk_rsp(StatusCode::IM_A_TEAPOT, "")),
+            )
+            .await;
+
+            info!("Delaying the third request");
+            serve_req(&mut handle, mk_rsp(StatusCode::NO_CONTENT, "")).await;
+
+            info!("Delaying the fourth request");
+            serve_delayed(
+                TIMEOUT * 2,
+                &mut handle,
+                Ok(mk_rsp(StatusCode::IM_A_TEAPOT, "")),
+            )
+            .await;
+
+            info!("Delaying the fifth request");
+            serve_delayed(
+                TIMEOUT * 2,
+                &mut handle,
+                Ok(mk_rsp(StatusCode::IM_A_TEAPOT, "")),
+            )
+            .await;
+
+            info!("Delaying the sixth request");
+            serve_delayed(
+                TIMEOUT * 5,
+                &mut handle,
+                Ok(mk_rsp(StatusCode::NO_CONTENT, "")),
+            )
+            .await;
+
+            handle
+        }
+        .in_current_span(),
+    );
+
+    info!("Verifying that the response succeeds despite retry timeouts");
+    let rsp = time::timeout(TIMEOUT * 10, send_req(svc.clone(), http_get()))
+        .await
+        .expect("response timed out")
+        .expect("response ok");
+    assert_eq!(rsp.status(), StatusCode::NO_CONTENT);
+
+    info!("Verifying that retried requests fail with a request timeout");
+    let error = time::timeout(TIMEOUT * 10, send_req(svc.clone(), http_get()))
+        .await
+        .expect("response timed out")
+        .expect_err("response should timeout");
+    assert!(errors::is_caused_by::<StreamDeadlineError>(&*error));
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn grpc_internal() {
+    let _trace = trace::test::with_default_filter("linkerd=debug");
+
+    const TIMEOUT: Duration = Duration::from_millis(100);
+    let (svc, mut handle) = mock_grpc(GrpcParams {
+        timeouts: Timeouts {
+            request: Some(TIMEOUT),
+            ..Default::default()
+        },
+        retry: Some(client_policy::grpc::Retry {
+            max_retries: 1,
+            codes: Codes(
+                Some(Code::Internal as u16)
+                    .into_iter()
+                    .collect::<BTreeSet<_>>()
+                    .into(),
+            ),
+            max_request_bytes: 1000,
+            timeout: None,
+            backoff: None,
+        }),
+    });
+
+    info!("Sending a request that will initially fail and then succeed");
+    tokio::spawn(
+        async move {
+            handle.allow(2);
+            info!("Failing the first request");
+            serve_req(&mut handle, mk_grpc_rsp(tonic::Code::Internal)).await;
+            info!("Serving the second request");
+            serve_req(&mut handle, mk_grpc_rsp(tonic::Code::Ok)).await;
+            handle
+        }
+        .in_current_span(),
+    );
+
+    info!("Verifying that we see the successful response");
+    let mut rsp = time::timeout(
+        TIMEOUT * 10,
+        send_req(
+            svc.clone(),
+            http::Request::post("/svc/method")
+                .body(Default::default())
+                .unwrap(),
+        ),
+    )
+    .await
+    .expect("response")
+    .expect("response ok");
+    assert_eq!(rsp.status(), StatusCode::OK);
+    while rsp.body_mut().data().await.is_some() {}
+    let trailers = rsp.body_mut().trailers().await;
+    assert_eq!(
+        trailers
+            .expect("trailers")
+            .expect("trailers")
+            .get("grpc-status")
+            .expect("grpc-status")
+            .to_str()
+            .unwrap(),
+        "0"
+    );
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn grpc_timeout() {
+    let _trace = trace::test::with_default_filter("linkerd=debug");
+
+    const TIMEOUT: Duration = Duration::from_millis(100);
+    let (svc, mut handle) = mock_grpc(GrpcParams {
+        timeouts: Timeouts {
+            request: Some(TIMEOUT * 5),
+            ..Default::default()
+        },
+        retry: Some(client_policy::grpc::Retry {
+            max_retries: 1,
+            timeout: Some(TIMEOUT),
+            codes: Codes(Default::default()),
+            max_request_bytes: 1000,
+            backoff: None,
+        }),
+    });
+
+    info!("Sending a request that will initially fail and then succeed");
+    tokio::spawn(
+        async move {
+            handle.allow(2);
+            info!("Delaying the first request");
+            serve_delayed(
+                TIMEOUT * 2,
+                &mut handle,
+                Ok(mk_grpc_rsp(tonic::Code::NotFound)),
+            )
+            .await;
+            info!("Serving the second request");
+            serve_req(&mut handle, mk_grpc_rsp(tonic::Code::Ok)).await;
+            handle
+        }
+        .in_current_span(),
+    );
+
+    info!("Verifying that we see the successful response");
+    let mut rsp = time::timeout(
+        TIMEOUT * 10,
+        send_req(
+            svc.clone(),
+            http::Request::post("/svc/method")
+                .body(Default::default())
+                .unwrap(),
+        ),
+    )
+    .await
+    .expect("response")
+    .expect("response ok");
+    assert_eq!(rsp.status(), StatusCode::OK);
+    while rsp.body_mut().data().await.is_some() {}
+    let trailers = rsp.body_mut().trailers().await;
+    assert_eq!(
+        trailers
+            .expect("trailers")
+            .expect("trailers")
+            .get("grpc-status")
+            .expect("grpc-status")
+            .to_str()
+            .unwrap(),
+        "0"
+    );
+}
+
+// === Utils ===
+
+type Handle = tower_test::mock::Handle<Request, Response>;
+
+fn mock_http(params: HttpParams) -> (svc::BoxCloneHttp, Handle) {
+    let dest: NameAddr = "example.com:1234".parse::<NameAddr>().unwrap();
+    let backend = default_backend(&dest);
+    let route = mk_route(backend.clone(), params);
+    mock(
+        dest.clone(),
+        policy::Params::Http(policy::HttpParams {
+            addr: dest.into(),
+            meta: ParentRef(client_policy::Meta::new_default("parent")),
+            backends: Arc::new([backend]),
+            routes: Arc::new([route]),
+            failure_accrual: client_policy::FailureAccrual::None,
+        }),
+    )
+}
+
+fn mock_grpc(params: GrpcParams) -> (svc::BoxCloneHttp, Handle) {
+    let dest: NameAddr = "example.com:1234".parse::<NameAddr>().unwrap();
+    let backend = default_backend(&dest);
+    let route = mk_route(backend.clone(), params);
+    mock(
+        dest.clone(),
+        policy::Params::Grpc(policy::GrpcParams {
+            addr: dest.into(),
+            meta: ParentRef(client_policy::Meta::new_default("parent")),
+            backends: Arc::new([backend]),
+            routes: Arc::new([route]),
+            failure_accrual: client_policy::FailureAccrual::None,
+        }),
+    )
+}
+
+fn mock(dest: NameAddr, params: policy::Params) -> (svc::BoxCloneHttp, Handle) {
+    let addr = SocketAddr::new([192, 0, 2, 41].into(), 1234);
+
+    let (inner, handle) = tower_test::mock::pair();
+    let connect = HttpConnect::default().service(addr, inner);
+    let resolve = support::resolver().endpoint_exists(dest.clone(), addr, Default::default());
+    let (rt, _shutdown) = runtime();
+    let stack = Outbound::new(default_config(), rt, &mut Default::default())
+        .with_stack(svc::ArcNewService::new(connect))
+        .push_http_cached(resolve)
+        .into_inner();
+
+    let (tx, routes) = watch::channel(Routes::Policy(params));
+    tokio::spawn(async move {
+        tx.closed().await;
+    });
+
+    let svc = stack.new_service(Target {
+        num: 1,
+        version: http::Version::H2,
+        routes,
+    });
+
+    (svc, handle)
+}
+
+fn mk_route<M: Default, F, P>(
+    backend: client_policy::Backend,
+    params: P,
+) -> client_policy::route::Route<M, client_policy::RoutePolicy<F, P>> {
+    use client_policy::*;
+
+    route::Route {
+        hosts: vec![],
+        rules: vec![route::Rule {
+            matches: vec![M::default()],
+            policy: RoutePolicy {
+                meta: Meta::new_default("route"),
+                filters: [].into(),
+                distribution: RouteDistribution::FirstAvailable(Arc::new([RouteBackend {
+                    filters: [].into(),
+                    backend,
+                }])),
+                params,
+            },
+        }],
+    }
+}

--- a/linkerd/app/outbound/src/http/logical/tests/timeouts.rs
+++ b/linkerd/app/outbound/src/http/logical/tests/timeouts.rs
@@ -332,21 +332,22 @@ fn mock(timeouts: Timeouts) -> (svc::BoxCloneHttp, Handle) {
 
 fn mk_route(backend: client_policy::Backend, timeouts: Timeouts) -> client_policy::http::Route {
     use client_policy::{
-        http::{self, Filter, Policy, Route, Rule},
+        http::{self, Policy, Route, Rule},
         Meta, RouteBackend, RouteDistribution,
     };
-    use once_cell::sync::Lazy;
-    static NO_FILTERS: Lazy<Arc<[Filter]>> = Lazy::new(|| Arc::new([]));
     Route {
         hosts: vec![],
         rules: vec![Rule {
             matches: vec![http::r#match::MatchRequest::default()],
             policy: Policy {
                 meta: Meta::new_default("timeout-route"),
-                filters: NO_FILTERS.clone(),
-                params: http::RouteParams { timeouts },
+                filters: [].into(),
+                params: http::RouteParams {
+                    timeouts,
+                    ..Default::default()
+                },
                 distribution: RouteDistribution::FirstAvailable(Arc::new([RouteBackend {
-                    filters: NO_FILTERS.clone(),
+                    filters: [].into(),
                     backend,
                 }])),
             },

--- a/linkerd/app/outbound/src/http/retry.rs
+++ b/linkerd/app/outbound/src/http/retry.rs
@@ -89,7 +89,7 @@ where
                 let is_failure = classify::Request::from(self.response_classes.clone())
                     .classify(req)
                     .start(rsp)
-                    .eos(rsp.body().trailers())
+                    .eos(rsp.body().peek_trailers())
                     .is_failure();
                 // did the body exceed the maximum length limit?
                 let exceeded_max_len = req.body().is_capped();

--- a/linkerd/http/box/src/response.rs
+++ b/linkerd/http/box/src/response.rs
@@ -10,8 +10,12 @@ use std::task::{Context, Poll};
 pub struct BoxResponse<S>(S);
 
 impl<S> BoxResponse<S> {
+    pub fn new(inner: S) -> Self {
+        Self(inner)
+    }
+
     pub fn layer() -> impl layer::Layer<S, Service = Self> + Copy {
-        layer::mk(Self)
+        layer::mk(Self::new)
     }
 
     /// Constructs a boxing layer that erases the inner response type with [`EraseResponse`].

--- a/linkerd/http/retry/Cargo.toml
+++ b/linkerd/http/retry/Cargo.toml
@@ -12,11 +12,15 @@ futures = { version = "0.3", default-features = false }
 http-body = "0.4"
 http = "0.2"
 parking_lot = "0.12"
+tokio = { version = "1", features = ["macros", "rt"] }
+tower = { version = "0.4", features = ["retry"] }
 tracing = "0.1"
 thiserror = "1"
 
 linkerd-http-box = { path = "../box" }
 linkerd-error = { path = "../../error" }
+linkerd-exp-backoff = { path = "../../exp-backoff" }
+linkerd-metrics = { path = "../../metrics" }
 linkerd-stack = { path = "../../stack" }
 
 [dev-dependencies]

--- a/linkerd/http/retry/src/lib.rs
+++ b/linkerd/http/retry/src/lib.rs
@@ -5,3 +5,333 @@ pub mod peek_trailers;
 pub mod replay;
 
 pub use self::{peek_trailers::PeekTrailersBody, replay::ReplayBody};
+pub use tower::retry::budget::Budget;
+
+use futures::{future, prelude::*};
+use linkerd_error::{Error, Result};
+use linkerd_exp_backoff::ExponentialBackoff;
+use linkerd_http_box::BoxBody;
+use linkerd_metrics::prom;
+use linkerd_stack::{layer, NewService, Param, Service};
+use std::{
+    future::Future,
+    hash::Hash,
+    marker::PhantomData,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::ServiceExt;
+use tracing::{debug, trace};
+
+/// A HTTP retry strategy.
+pub trait Policy: Clone + Sized {
+    type Future: Future<Output = ()> + Send + 'static;
+
+    /// Determines if a response should be retried.
+    fn is_retryable(&self, result: Result<&http::Response<PeekTrailersBody>, &Error>) -> bool;
+
+    /// Prepare headers for the next request.
+    fn set_headers(&self, dst: &mut http::HeaderMap, orig: &http::HeaderMap) {
+        *dst = orig.clone();
+    }
+
+    /// Prepare extensions for the next request.
+    fn set_extensions(&self, _dst: &mut http::Extensions, _orig: &http::Extensions) {}
+}
+
+#[derive(Clone, Debug)]
+pub struct Params {
+    pub max_retries: usize,
+    pub max_request_bytes: usize,
+    pub backoff: Option<ExponentialBackoff>,
+}
+
+#[derive(Clone, Debug)]
+pub struct NewHttpRetry<P, L: Clone, N> {
+    inner: N,
+    metrics: MetricFamilies<L>,
+    _marker: PhantomData<fn() -> P>,
+}
+
+/// A Retry middleware that attempts to extract a `P` typed request extension to
+/// instrument retries. When the request extension is not set, requests are not
+/// retried.
+#[derive(Clone, Debug)]
+pub struct HttpRetry<P, S> {
+    inner: S,
+    metrics: Metrics,
+    _marker: PhantomData<fn() -> P>,
+}
+
+#[derive(Clone, Debug)]
+pub struct MetricFamilies<L: Clone> {
+    limit_exceeded: prom::Family<L, prom::Counter>,
+    overflow: prom::Family<L, prom::Counter>,
+    requests: prom::Family<L, prom::Counter>,
+    successes: prom::Family<L, prom::Counter>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct Metrics {
+    requests: prom::Counter,
+    successes: prom::Counter,
+    limit_exceeded: prom::Counter,
+    overflow: prom::Counter,
+}
+
+// === impl NewHttpRetry ===
+
+impl<P, L: Clone, N> NewHttpRetry<P, L, N> {
+    pub fn layer(metrics: MetricFamilies<L>) -> impl layer::Layer<N, Service = Self> + Clone {
+        layer::mk(move |inner| Self {
+            inner,
+            metrics: metrics.clone(),
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<T, P, L, N> NewService<T> for NewHttpRetry<P, L, N>
+where
+    T: Param<L>,
+    P: Policy,
+    L: Clone + std::fmt::Debug + Hash + Eq + Send + Sync + prom::encoding::EncodeLabelSet + 'static,
+    N: NewService<T>,
+{
+    type Service = HttpRetry<P, N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let labels: L = target.param();
+        let metrics = self.metrics.metrics(&labels);
+        HttpRetry {
+            inner: self.inner.new_service(target),
+            metrics,
+            _marker: PhantomData,
+        }
+    }
+}
+
+// === impl MetricFamilies ===
+
+impl<L> Default for MetricFamilies<L>
+where
+    L: Clone + std::fmt::Debug + Hash + Eq + Send + Sync + prom::encoding::EncodeLabelSet + 'static,
+{
+    fn default() -> Self {
+        Self {
+            limit_exceeded: prom::Family::default(),
+            overflow: prom::Family::default(),
+            requests: prom::Family::default(),
+            successes: prom::Family::default(),
+        }
+    }
+}
+
+impl<L> MetricFamilies<L>
+where
+    L: Clone + std::fmt::Debug + Hash + Eq + Send + Sync + prom::encoding::EncodeLabelSet + 'static,
+{
+    pub fn register(registry: &mut prom::Registry) -> Self {
+        let limit_exceeded = prom::Family::default();
+        registry.register(
+            "limit_exceeded",
+            "Retryable requests not sent due to retry limits",
+            limit_exceeded.clone(),
+        );
+
+        let overflow = prom::Family::default();
+        registry.register(
+            "overflow",
+            "Retryable requests not sent due to circuit breakers",
+            overflow.clone(),
+        );
+
+        let requests = prom::Family::default();
+        registry.register("requests", "Retry requests emitted", requests.clone());
+
+        let successes = prom::Family::default();
+        registry.register(
+            "successes",
+            "Successful responses to retry requests",
+            successes.clone(),
+        );
+        Self {
+            limit_exceeded,
+            overflow,
+            requests,
+            successes,
+        }
+    }
+
+    fn metrics(&self, labels: &L) -> Metrics {
+        let requests = (*self.requests.get_or_create(labels)).clone();
+        let successes = (*self.successes.get_or_create(labels)).clone();
+        let limit_exceeded = (*self.limit_exceeded.get_or_create(labels)).clone();
+        let overflow = (*self.overflow.get_or_create(labels)).clone();
+        Metrics {
+            requests,
+            successes,
+            limit_exceeded,
+            overflow,
+        }
+    }
+}
+
+// === impl HttpRetry ===
+
+impl<P, N> HttpRetry<P, N> {
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Copy {
+        layer::mk(|inner| Self {
+            inner,
+            metrics: Metrics::default(),
+            _marker: PhantomData,
+        })
+    }
+}
+
+impl<P, S> Service<http::Request<BoxBody>> for HttpRetry<P, S>
+where
+    P: Policy,
+    P: Param<Params>,
+    P: Clone + Send + Sync + std::fmt::Debug + 'static,
+    S: Service<http::Request<BoxBody>, Response = http::Response<BoxBody>, Error = Error>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = http::Response<BoxBody>;
+    type Error = Error;
+    type Future = future::Either<
+        <S as Service<http::Request<BoxBody>>>::Future,
+        Pin<Box<dyn Future<Output = Result<http::Response<BoxBody>>> + Send + 'static>>,
+    >;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: http::Request<BoxBody>) -> Self::Future {
+        // Retries are configured from request extensions so that they can be
+        // configured from both policy and request headers.
+        let Some(policy) = req.extensions_mut().remove::<P>() else {
+            // If there is no policy, there is no need to retry. This avoids
+            // buffering logic in the default case.
+            trace!(retryable = false, "Request lacks a retry policy");
+            return future::Either::Left(self.inner.call(req));
+        };
+
+        let params = policy.param();
+
+        // Since this request is retryable, we need to setup the request body to
+        // be buffered/cloneable. If the request body is too large to be cloned,
+        // the retry policy is ignored.
+        let req = {
+            let (head, body) = req.into_parts();
+            match ReplayBody::try_new(body, params.max_request_bytes) {
+                Ok(body) => http::Request::from_parts(head, body),
+                Err(body) => {
+                    debug!(retryable = false, "Request body is too large to be retried");
+                    return future::Either::Left(
+                        self.inner.call(http::Request::from_parts(head, body)),
+                    );
+                }
+            }
+        };
+        debug!(retryable = true, policy = ?policy);
+
+        // Take the inner service, replacing it with a clone. This allows the
+        // readiness from poll_ready to be preserved.
+        //
+        // Retry::poll_ready is just a pass-through to the inner service, so we
+        // can rely on the fact that we've taken the ready inner service handle.
+        let pending = self.inner.clone();
+        let svc = std::mem::replace(&mut self.inner, pending);
+        let call = send_req_with_retries(svc, req, policy, self.metrics.clone(), params);
+        future::Either::Right(Box::pin(call))
+    }
+}
+
+async fn send_req_with_retries(
+    // `svc` must be made ready before calling this function.
+    mut svc: impl Service<http::Request<BoxBody>, Response = http::Response<BoxBody>, Error = Error>,
+    request: http::Request<ReplayBody>,
+    policy: impl Policy,
+    metrics: Metrics,
+    params: Params,
+) -> Result<http::Response<BoxBody>> {
+    // Initial request.
+    let mut backup = mk_backup(&request, &policy);
+    let mut result = send_req(&mut svc, request).await;
+    if !policy.is_retryable(result.as_ref()) {
+        tracing::trace!("Success on first attempt");
+        return result.map(|rsp| rsp.map(BoxBody::new));
+    }
+    if backup.body().is_capped() {
+        return result.map(|rsp| rsp.map(BoxBody::new));
+    }
+
+    // The response was retryable, so continue trying to dispatch backup
+    // requests.
+    let mut backoff = params.backoff.map(|b| b.stream());
+    for n in 1..=params.max_retries {
+        if let Some(backoff) = backoff.as_mut() {
+            backoff.next().await;
+        }
+
+        // The service must be buffered to be cloneable; so if it's not ready,
+        // then a circuit breaker is active and requests will be load shed.
+        let Some(svc) = svc.ready().now_or_never().transpose()? else {
+            tracing::debug!("Retry overflow; service is not ready");
+            metrics.overflow.inc();
+            return result.map(|rsp| rsp.map(BoxBody::new));
+        };
+
+        tracing::debug!(retry.attempt = n);
+        let request = backup;
+        backup = mk_backup(&request, &policy);
+        metrics.requests.inc();
+        result = send_req(svc, request).await;
+        if !policy.is_retryable(result.as_ref()) {
+            if result.is_ok() {
+                metrics.successes.inc();
+            }
+            tracing::debug!("Retry success");
+            return result.map(|rsp| rsp.map(BoxBody::new));
+        }
+        if backup.body().is_capped() {
+            return result.map(|rsp| rsp.map(BoxBody::new));
+        }
+    }
+
+    // The result is retryable but we've run out of attempts.
+    tracing::debug!("Retry limit exceeded");
+    metrics.limit_exceeded.inc();
+    result.map(|rsp| rsp.map(BoxBody::new))
+}
+
+// Make the request and wait for the response. We proactively poll the
+// response body for its next frame to convert the response into a
+async fn send_req(
+    svc: &mut impl Service<http::Request<BoxBody>, Response = http::Response<BoxBody>, Error = Error>,
+    req: http::Request<ReplayBody>,
+) -> Result<http::Response<PeekTrailersBody>> {
+    svc.call(req.map(BoxBody::new))
+        .and_then(|rsp| async move {
+            tracing::debug!("Peeking at the response trailers");
+            let rsp = PeekTrailersBody::map_response(rsp).await;
+            Ok(rsp)
+        })
+        .await
+}
+
+fn mk_backup(orig: &http::Request<ReplayBody>, policy: &impl Policy) -> http::Request<ReplayBody> {
+    let mut dst = http::Request::new(orig.body().clone());
+    *dst.method_mut() = orig.method().clone();
+    *dst.uri_mut() = orig.uri().clone();
+    *dst.version_mut() = orig.version();
+    policy.set_headers(dst.headers_mut(), orig.headers());
+    policy.set_extensions(dst.extensions_mut(), orig.extensions());
+    dst
+}

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -1,6 +1,7 @@
 use crate::FailureAccrual;
+use linkerd_exp_backoff::ExponentialBackoff;
 use linkerd_http_route::{grpc, http};
-use std::sync::Arc;
+use std::{sync::Arc, time};
 
 pub use linkerd_http_route::grpc::{filter, find, r#match, RouteMatch};
 
@@ -11,6 +12,7 @@ pub type Rule = grpc::Rule<Policy>;
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct RouteParams {
     pub timeouts: crate::http::Timeouts,
+    pub retry: Option<Retry>,
 }
 
 // TODO HTTP2 settings
@@ -28,6 +30,15 @@ pub enum Filter {
     InjectFailure(filter::InjectFailure),
     RequestHeaders(http::filter::ModifyHeader),
     InternalError(&'static str),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Retry {
+    pub max_retries: usize,
+    pub max_request_bytes: usize,
+    pub codes: Codes,
+    pub timeout: Option<time::Duration>,
+    pub backoff: Option<ExponentialBackoff>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -1,4 +1,5 @@
 use crate::FailureAccrual;
+use linkerd_exp_backoff::ExponentialBackoff;
 use linkerd_http_route::http;
 use std::{ops::RangeInclusive, sync::Arc, time};
 
@@ -11,6 +12,7 @@ pub type Rule = http::Rule<Policy>;
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct RouteParams {
     pub timeouts: Timeouts,
+    pub retry: Option<Retry>,
 }
 
 // TODO: keepalive settings, etc.
@@ -38,6 +40,15 @@ pub enum Filter {
     RequestHeaders(filter::ModifyHeader),
     ResponseHeaders(filter::ModifyHeader),
     InternalError(&'static str),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Retry {
+    pub max_retries: u16,
+    pub max_request_bytes: usize,
+    pub status_ranges: StatusRanges,
+    pub timeout: Option<time::Duration>,
+    pub backoff: Option<ExponentialBackoff>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
This change updates the HTTP router to support retry policies that interact with the recently introduced timeout policies.

Retry policies can match responses by HTTP status code ranges or by individual GRPC response codes. Retry policies also include a max-retries limit and an optional retry timeout. When a retry timeout is configured, the router configures the endpoint-level stream timeout with a response header timeout that ensures initial response headers are received so that a retry decision may be made before returning the response to the server.

Routes are updated to include several retry-related metrics:

    # HELP outbound_http_route_retry_limit_exceeded Retryable requests not sent due to retry limits.
    # TYPE outbound_http_route_retry_limit_exceeded counter
    outbound_http_route_retry_limit_exceeded_total{parent...,route...} 0
    # HELP outbound_http_route_retry_overflow Retryable requests not sent due to circuit breakers.
    # TYPE outbound_http_route_retry_overflow counter
    outbound_http_route_retry_overflow_total{parent...,route...} 0
    # HELP outbound_http_route_retry_requests Retry requests emitted.
    # TYPE outbound_http_route_retry_requests counter
    outbound_http_route_retry_requests_total{parent...,route...} 0
    # HELP outbound_http_route_retry_successes Successful responses to retry requests.
    # TYPE outbound_http_route_retry_successes counter
    outbound_http_route_retry_successes_total{parent...,route...} 0