### PR TITLE
chore(retry): Simplify retry types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,6 +1522,7 @@ dependencies = [
  "http-body",
  "hyper",
  "linkerd-error",
+ "linkerd-http-box",
  "linkerd-stack",
  "linkerd-tracing",
  "parking_lot",

--- a/linkerd/app/outbound/src/http/retry.rs
+++ b/linkerd/app/outbound/src/http/retry.rs
@@ -6,11 +6,11 @@ use linkerd_app_core::{
     profiles::{self, http::Route},
     proxy::http::{ClientHandle, EraseResponse, HttpBody},
     svc::{layer, Either, Param},
-    Error,
+    Error, Result,
 };
 use linkerd_http_classify::{Classify, ClassifyEos, ClassifyResponse};
 use linkerd_http_retry::{
-    with_trailers::{self, WithTrailers},
+    peek_trailers::{self, PeekTrailersBody},
     ReplayBody,
 };
 use linkerd_retry as retry;
@@ -19,11 +19,10 @@ use std::sync::Arc;
 pub fn layer<N>(
     metrics: metrics::HttpProfileRouteRetry,
 ) -> impl layer::Layer<N, Service = retry::NewRetry<NewRetryPolicy, N, EraseResponse<()>>> + Clone {
-    retry::layer(NewRetryPolicy::new(metrics))
-        // Because we wrap the response body type on retries, we must include a
-        // `Proxy` middleware for unifying the response body types of the retry
-        // and non-retry services.
-        .with_proxy(EraseResponse::new(()))
+    // Because we wrap the response body type on retries, we must include a
+    // `Proxy` middleware for unifying the response body types of the retry
+    // and non-retry services.
+    retry::NewRetry::layer(NewRetryPolicy::new(metrics), EraseResponse::new(()))
 }
 
 #[derive(Clone, Debug)]
@@ -68,19 +67,20 @@ where
 
 // === impl Retry ===
 
-impl<A, B, E> retry::Policy<http::Request<ReplayBody<A>>, http::Response<WithTrailers<B>>, E>
+impl<ReqB, RspB>
+    retry::Policy<http::Request<ReplayBody<ReqB>>, http::Response<PeekTrailersBody<RspB>>, Error>
     for RetryPolicy
 where
-    A: HttpBody + Unpin,
-    A::Error: Into<Error>,
-    B: HttpBody + Unpin,
+    ReqB: HttpBody + Unpin,
+    ReqB::Error: Into<Error>,
+    RspB: HttpBody + Unpin,
 {
     type Future = future::Ready<Self>;
 
     fn retry(
         &self,
-        req: &http::Request<ReplayBody<A>>,
-        result: Result<&http::Response<WithTrailers<B>>, &E>,
+        req: &http::Request<ReplayBody<ReqB>>,
+        result: Result<&http::Response<PeekTrailersBody<RspB>>, &Error>,
     ) -> Option<Self::Future> {
         let retryable = match result {
             Err(_) => false,
@@ -115,8 +115,8 @@ where
 
     fn clone_request(
         &self,
-        req: &http::Request<ReplayBody<A>>,
-    ) -> Option<http::Request<ReplayBody<A>>> {
+        req: &http::Request<ReplayBody<ReqB>>,
+    ) -> Option<http::Request<ReplayBody<ReqB>>> {
         // Since the body is already wrapped in a ReplayBody, it must not be obviously too large to
         // buffer/clone.
         let mut clone = http::Request::new(req.body().clone());
@@ -139,25 +139,27 @@ where
     }
 }
 
-impl<A, B, E> retry::PrepareRetry<http::Request<A>, http::Response<B>, E> for RetryPolicy
+impl<ReqB, RspB> retry::PrepareRetry<http::Request<ReqB>, http::Response<RspB>> for RetryPolicy
 where
-    A: HttpBody + Unpin,
-    A::Error: Into<Error>,
-    B: HttpBody + Unpin + Send + 'static,
-    B::Data: Unpin + Send,
-    B::Error: Unpin + Send,
+    ReqB: HttpBody + Unpin,
+    ReqB::Error: Into<Error>,
+    RspB: HttpBody + Unpin + Send + 'static,
+    RspB::Data: Unpin + Send,
+    RspB::Error: Unpin + Send,
 {
-    type RetryRequest = http::Request<ReplayBody<A>>;
-    type RetryResponse = http::Response<WithTrailers<B>>;
+    type RetryRequest = http::Request<ReplayBody<ReqB>>;
+    type RetryResponse = http::Response<PeekTrailersBody<RspB>>;
     type ResponseFuture = future::Map<
-        with_trailers::WithTrailersFuture<B>,
-        fn(http::Response<WithTrailers<B>>) -> Result<http::Response<WithTrailers<B>>, E>,
+        peek_trailers::WithPeekTrailersBody<RspB>,
+        fn(
+            http::Response<PeekTrailersBody<RspB>>,
+        ) -> Result<http::Response<PeekTrailersBody<RspB>>>,
     >;
 
     fn prepare_request(
-        &self,
-        req: http::Request<A>,
-    ) -> Either<Self::RetryRequest, http::Request<A>> {
+        self,
+        req: http::Request<ReqB>,
+    ) -> Either<(Self, Self::RetryRequest), http::Request<ReqB>> {
         let (head, body) = req.into_parts();
         let replay_body = match ReplayBody::try_new(body, MAX_BUFFERED_BYTES) {
             Ok(body) => body,
@@ -172,12 +174,12 @@ where
 
         // The body may still be too large to be buffered if the body's length was not known.
         // `ReplayBody` handles this gracefully.
-        Either::A(http::Request::from_parts(head, replay_body))
+        Either::A((self, http::Request::from_parts(head, replay_body)))
     }
 
     /// If the response is HTTP/2, return a future that checks for a `TRAILERS`
     /// frame immediately after the first frame of the response.
-    fn prepare_response(rsp: http::Response<B>) -> Self::ResponseFuture {
-        WithTrailers::map_response(rsp).map(Ok)
+    fn prepare_response(rsp: http::Response<RspB>) -> Self::ResponseFuture {
+        PeekTrailersBody::map_response(rsp).map(Ok)
     }
 }

--- a/linkerd/http/retry/Cargo.toml
+++ b/linkerd/http/retry/Cargo.toml
@@ -15,6 +15,7 @@ parking_lot = "0.12"
 tracing = "0.1"
 thiserror = "1"
 
+linkerd-http-box = { path = "../box" }
 linkerd-error = { path = "../../error" }
 linkerd-stack = { path = "../../stack" }
 

--- a/linkerd/http/retry/src/lib.rs
+++ b/linkerd/http/retry/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
+pub mod peek_trailers;
 pub mod replay;
-pub mod with_trailers;
 
-pub use self::{replay::ReplayBody, with_trailers::WithTrailers};
+pub use self::{peek_trailers::PeekTrailersBody, replay::ReplayBody};

--- a/linkerd/http/retry/src/replay.rs
+++ b/linkerd/http/retry/src/replay.rs
@@ -2,6 +2,7 @@ use bytes::{Buf, BufMut, Bytes, BytesMut};
 use http::HeaderMap;
 use http_body::{Body, SizeHint};
 use linkerd_error::Error;
+use linkerd_http_box::BoxBody;
 use parking_lot::Mutex;
 use std::{collections::VecDeque, io::IoSlice, pin::Pin, sync::Arc, task::Context, task::Poll};
 use thiserror::Error;
@@ -18,7 +19,7 @@ use thiserror::Error;
 /// The buffered data can then be used to retry the request if the original
 /// request fails.
 #[derive(Debug)]
-pub struct ReplayBody<B> {
+pub struct ReplayBody<B = BoxBody> {
     /// Buffered state owned by this body if it is actively being polled. If
     /// this body has been polled and no other body owned the state, this will
     /// be `Some`.


### PR DESCRIPTION
Before introducing a new retry middleware for policy-driven retries, this change updates the existing linkerd-http-retry crate (1) to use boxed Error types and (2) to default to use BoxBody types with ReplayBody and (the newly renamed) PeekTrailersBody.

No functional changes.