### PR TITLE
feat(outbound): Discover timeouts and retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65678e4c506a7e5fdf1a664c629a9b658afa70e254dffcd24df72e937b2c0159"
+checksum = "26c72fb98d969e1e94e95d52a6fcdf4693764702c369e577934256e72fb5bc61"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,6 @@ members = [
 [profile.release]
 debug = 1
 lto = true
+
+[workspace.dependencies]
+linkerd2-proxy-api = "0.14.0"

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -30,7 +30,7 @@ linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true }
 linkerd-proxy-client-policy = { path = "../../proxy/client-policy" }
 linkerd-tonic-stream = { path = "../../tonic-stream" }
 linkerd-tonic-watch = { path = "../../tonic-watch" }
-linkerd2-proxy-api = { version = "0.13", features = ["inbound"] }
+linkerd2-proxy-api = { workspace = true, features = ["inbound"] }
 once_cell = "1"
 parking_lot = "0.12"
 rangemap = "1"

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -33,7 +33,7 @@ ipnet = "2"
 linkerd-app = { path = "..", features = ["allow-loopback"] }
 linkerd-app-core = { path = "../core" }
 linkerd-metrics = { path = "../../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { version = "0.13", features = [
+linkerd2-proxy-api = { workspace = true, features = [
     "destination",
     "arbitrary",
 ] }

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -20,7 +20,7 @@ ahash = "0.8"
 bytes = "1"
 http = "0.2"
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { version = "0.13", features = ["outbound"] }
+linkerd2-proxy-api = { workspace = true, features = ["outbound"] }
 once_cell = "1"
 parking_lot = "0.12"
 pin-project = "1"

--- a/linkerd/http/route/Cargo.toml
+++ b/linkerd/http/route/Cargo.toml
@@ -17,7 +17,7 @@ tracing = "0.1"
 url = "2"
 
 [dependencies.linkerd2-proxy-api]
-version = "0.13"
+workspace = true
 features = ["http-route", "grpc-route"]
 optional = true
 

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -11,7 +11,7 @@ Implements the Resolve trait using the proxy's gRPC API
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { version = "0.13", features = ["destination"] }
+linkerd2-proxy-api = { workspace = true, features = ["destination"] }
 linkerd-addr = { path = "../../addr" }
 linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -30,7 +30,7 @@ linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }
 
 [dependencies.linkerd2-proxy-api]
-version = "0.13"
+workspace = true
 optional = true
 features = ["outbound"]
 

--- a/linkerd/proxy/identity-client/Cargo.toml
+++ b/linkerd/proxy/identity-client/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-linkerd2-proxy-api = { version = "0.13", features = ["identity"] }
+linkerd2-proxy-api = { workspace = true, features = ["identity"] }
 linkerd-dns-name = { path = "../../dns/name" }
 linkerd-error = { path = "../../error" }
 linkerd-identity = { path = "../../identity" }

--- a/linkerd/proxy/server-policy/Cargo.toml
+++ b/linkerd/proxy/server-policy/Cargo.toml
@@ -18,7 +18,7 @@ thiserror = "1"
 linkerd-http-route = { path = "../../http/route" }
 
 [dependencies.linkerd2-proxy-api]
-version = "0.13"
+workspace = true
 features = ["inbound"]
 optional = true
 

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -11,7 +11,7 @@ http = "0.2"
 hyper = { version = "0.14", features = ["http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.7"
-linkerd2-proxy-api = { version = "0.13", features = ["tap"] }
+linkerd2-proxy-api = { workspace = true, features = ["tap"] }
 linkerd-conditional = { path = "../../conditional" }
 linkerd-error = { path = "../../error" }
 linkerd-meshtls = { path = "../../meshtls" }
@@ -30,5 +30,5 @@ tracing = "0.1"
 pin-project = "1"
 
 [dev-dependencies]
-linkerd2-proxy-api = { version = "0.13", features = ["arbitrary"] }
+linkerd2-proxy-api = { workspace = true, features = ["arbitrary"] }
 quickcheck = { version = "1", default-features = false }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
-linkerd2-proxy-api = { version = "0.13", features = ["destination"] }
+linkerd2-proxy-api = { workspace = true, features = ["destination"] }
 once_cell = "1.17"
 prost-types = "0.12"
 regex = "1"
@@ -35,5 +35,5 @@ linkerd-tonic-stream = { path = "../tonic-stream" }
 linkerd-tonic-watch = { path = "../tonic-watch" }
 
 [dev-dependencies]
-linkerd2-proxy-api = { version = "0.13", features = ["arbitrary"] }
+linkerd2-proxy-api = { workspace = true, features = ["arbitrary"] }
 quickcheck = { version = "1", default-features = false }


### PR DESCRIPTION
This change updates linkerd2-proxy-api to v0.14.0, which introduces per-route timeout and retry policies. These API responses are bound to the recently introduced outbound retry policies.

Support for the legacy request_timeout configuration (which in rare situations may be set by older control planes) is maintained, but is now deprecated in favor of the newer timeout policies.