### PR TITLE
fix(http): Set logging contexts on HTTP/1 clients

### DIFF
--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -1,6 +1,7 @@
 use crate::{
     glue::HyperConnect,
     upgrade::{Http11Upgrade, HttpConnect},
+    TracingExecutor,
 };
 use futures::prelude::*;
 use http::{
@@ -96,6 +97,7 @@ where
             hyper::Client::builder()
                 .pool_max_idle_per_host(0)
                 .set_host(use_absolute_form)
+                .executor(TracingExecutor)
                 .build(HyperConnect::new(
                     self.connect.clone(),
                     self.target.clone(),
@@ -122,6 +124,7 @@ where
                         .pool_max_idle_per_host(self.pool.max_idle)
                         .pool_idle_timeout(self.pool.idle_timeout)
                         .set_host(use_absolute_form)
+                        .executor(TracingExecutor)
                         .build(HyperConnect::new(
                             self.connect.clone(),
                             self.target.clone(),


### PR DESCRIPTION
HTTP/1 clients do not preserve the calling trace context, so Hyper client debug logs are emitted without context metadata.

This change updates the HTTP/1 client to use an executor that preserves the tracing context.