### PR TITLE
TLS routes draft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1159,6 +1159,7 @@ dependencies = [
  "linkerd-stack-tracing",
  "linkerd-system",
  "linkerd-tls",
+ "linkerd-tls-route",
  "linkerd-trace-context",
  "linkerd-tracing",
  "linkerd-transport-header",
@@ -1293,6 +1294,7 @@ dependencies = [
  "linkerd-proxy-client-policy",
  "linkerd-retry",
  "linkerd-stack",
+ "linkerd-tls-route",
  "linkerd-tonic-stream",
  "linkerd-tonic-watch",
  "linkerd-tracing",
@@ -1301,6 +1303,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "prometheus-client",
+ "rangemap",
  "thiserror",
  "tokio",
  "tokio-test",
@@ -1834,6 +1837,7 @@ dependencies = [
  "linkerd-http-route",
  "linkerd-proxy-api-resolve",
  "linkerd-proxy-core",
+ "linkerd-tls-route",
  "linkerd2-proxy-api",
  "maplit",
  "once_cell",
@@ -2184,6 +2188,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkerd-tls-route"
+version = "0.1.0"
+dependencies = [
+ "linkerd-dns",
+ "linkerd-tls",
+ "linkerd2-proxy-api",
+ "maplit",
+ "rand",
+ "regex",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "linkerd-tls-test-util"
 version = "0.1.0"
 
@@ -2301,8 +2319,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c72fb98d969e1e94e95d52a6fcdf4693764702c369e577934256e72fb5bc61"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api.git?branch=zd/tls-routes#9e72ed934daaadabaaeb99796844fec1b98492ff"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ members = [
     "linkerd/tonic-stream",
     "linkerd/tonic-watch",
     "linkerd/tls",
+    "linkerd/tls/route",
     "linkerd/tls/test-util",
     "linkerd/tracing",
     "linkerd/transport-header",
@@ -86,4 +87,5 @@ debug = 1
 lto = true
 
 [workspace.dependencies]
-linkerd2-proxy-api = "0.14.0"
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "zd/tls-routes" }
+

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -70,6 +70,7 @@ linkerd-tracing = { path = "../../tracing" }
 linkerd-transport-header = { path = "../../transport-header" }
 linkerd-transport-metrics = { path = "../../transport-metrics" }
 linkerd-tls = { path = "../../tls" }
+linkerd-tls-route = { path = "../../tls/route" }
 linkerd-trace-context = { path = "../../trace-context" }
 
 [dependencies.tower]

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -44,6 +44,7 @@ pub use linkerd_service_profiles as profiles;
 pub use linkerd_stack_metrics as stack_metrics;
 pub use linkerd_stack_tracing as stack_tracing;
 pub use linkerd_tls as tls;
+pub use linkerd_tls_route as tls_route;
 pub use linkerd_tracing as trace;
 pub use linkerd_transport_header as transport_header;
 

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -25,6 +25,7 @@ once_cell = "1"
 parking_lot = "0.12"
 pin-project = "1"
 prometheus-client = "0.22"
+rangemap = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["sync"] }
 tonic = { version = "0.10", default-features = false }
@@ -38,6 +39,7 @@ linkerd-http-classify = { path = "../../http/classify" }
 linkerd-http-prom = { path = "../../http/prom" }
 linkerd-http-retry = { path = "../../http/retry" }
 linkerd-http-route = { path = "../../http/route" }
+linkerd-tls-route = { path = "../../tls/route" }
 linkerd-identity = { path = "../../identity" }
 linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true }
 linkerd-proxy-client-policy = { path = "../../proxy/client-policy", features = [

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -71,7 +71,7 @@ impl<N> Outbound<N> {
         T: svc::Param<http::Version>,
         T: Clone + Send + Unpin + 'static,
         // Server-side socket
-        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
+        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + io::Peek + Send + Unpin + 'static,
         // Inner stack
         N: svc::NewService<T, Service = NSvc> + Clone + Send + Sync + Unpin + 'static,
         NSvc: svc::Service<

--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -37,6 +37,7 @@ pub struct OutboundMetrics {
 pub(crate) struct PromMetrics {
     pub(crate) http: crate::http::HttpMetrics,
     pub(crate) opaq: crate::opaq::OpaqMetrics,
+    pub(crate) tls: crate::tls::TlsMetrics,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -90,7 +91,9 @@ impl PromMetrics {
 
         let opaq = crate::opaq::OpaqMetrics::register(registry.sub_registry_with_prefix("tcp"));
 
-        Self { http, opaq }
+        let tls = crate::tls::TlsMetrics::register(registry.sub_registry_with_prefix("tls"));
+
+        Self { http, opaq, tls }
     }
 }
 

--- a/linkerd/app/outbound/src/protocol.rs
+++ b/linkerd/app/outbound/src/protocol.rs
@@ -15,6 +15,7 @@ pub enum Protocol {
     Http2,
     Detect,
     Opaque,
+    Tls,
 }
 
 // === impl Outbound ===
@@ -29,6 +30,7 @@ impl<N> Outbound<N> {
     pub fn push_protocol<T, I, NSvc>(
         self,
         http: svc::ArcNewCloneHttp<Http<T>>,
+        tls: svc::ArcNewCloneTcp<T, io::EitherIo<I, io::PrefixedIo<I>>>,
     ) -> Outbound<svc::ArcNewTcp<T, I>>
     where
         // Target type indicating whether detection should be skipped.
@@ -83,7 +85,14 @@ impl<N> Outbound<N> {
         http.map_stack(|_, _, http| {
             // First separate traffic that needs protocol detection. Then switch
             // between traffic that is known to be HTTP or opaque.
-            http.push_switch(Ok::<_, Infallible>, opaq.clone().into_inner())
+            let known = http.push_switch(
+                Ok::<_, Infallible>,
+                opaq.clone()
+                    .push_switch(Ok::<_, Infallible>, tls.clone())
+                    .into_inner(),
+            );
+
+            known
                 .push_on_service(svc::MapTargetLayer::new(io::EitherIo::Left))
                 .push_switch(
                     |parent: T| -> Result<_, Infallible> {
@@ -96,7 +105,12 @@ impl<N> Outbound<N> {
                                 version: http::Version::H2,
                                 parent,
                             }))),
-                            Protocol::Opaque => Ok(svc::Either::A(svc::Either::B(parent))),
+                            Protocol::Opaque => {
+                                Ok(svc::Either::A(svc::Either::B(svc::Either::A(parent))))
+                            }
+                            Protocol::Tls => {
+                                Ok(svc::Either::A(svc::Either::B(svc::Either::B(parent))))
+                            }
                             Protocol::Detect => Ok(svc::Either::B(parent)),
                         }
                     },

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -1,7 +1,7 @@
 use crate::{
     http, opaq, policy,
     protocol::{self, Protocol},
-    Discovery, Outbound, ParentRef,
+    tls, Discovery, Outbound, ParentRef,
 };
 use linkerd_app_core::{
     io, profiles,
@@ -32,6 +32,12 @@ struct HttpSidecar {
     routes: watch::Receiver<http::Routes>,
 }
 
+#[derive(Clone, Debug)]
+struct TlsSidecar {
+    orig_dst: OrigDstAddr,
+    routes: watch::Receiver<tls::Routes>,
+}
+
 // === impl Outbound ===
 
 impl Outbound<()> {
@@ -53,6 +59,12 @@ impl Outbound<()> {
         R::Resolution: Unpin,
     {
         let opaq = self.to_tcp_connect().push_opaq_cached(resolve.clone());
+        let tls = self
+            .to_tcp_connect()
+            .push_tls_cached(resolve.clone())
+            .into_stack()
+            .push_map_target(TlsSidecar::from)
+            .arc_new_clone_tcp();
 
         let http = self
             .to_tcp_connect()
@@ -64,7 +76,8 @@ impl Outbound<()> {
             .push_map_target(HttpSidecar::from)
             .arc_new_clone_http();
 
-        opaq.push_protocol(http.into_inner())
+        opaq.clone()
+            .push_protocol(http.into_inner(), tls.into_inner())
             // Use a dedicated target type to bind discovery results to the
             // outbound sidecar stack configuration.
             .map_stack(move |_, _, stk| stk.push_map_target(Sidecar::from))
@@ -131,7 +144,8 @@ impl svc::Param<Protocol> for Sidecar {
         match self.policy.borrow().protocol {
             policy::Protocol::Http1(_) => Protocol::Http1,
             policy::Protocol::Http2(_) | policy::Protocol::Grpc(_) => Protocol::Http2,
-            policy::Protocol::Opaque(_) | policy::Protocol::Tls(_) => Protocol::Opaque,
+            policy::Protocol::Opaque(_) => Protocol::Opaque,
+            policy::Protocol::Tls(_) => Protocol::Tls,
             policy::Protocol::Detect { .. } => Protocol::Detect,
         }
     }
@@ -324,5 +338,67 @@ impl std::hash::Hash for HttpSidecar {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.orig_dst.hash(state);
         self.version.hash(state);
+    }
+}
+
+// === impl TlsSidecar ===
+
+impl From<Sidecar> for TlsSidecar {
+    fn from(parent: Sidecar) -> Self {
+        let orig_dst = parent.orig_dst;
+        let mut policy = parent.policy.clone();
+
+        let init = Self::mk_policy_routes(orig_dst, &policy.borrow_and_update())
+            .expect("initial policy must be tls");
+        let routes = tls::spawn_routes(policy, init, move |policy: &policy::ClientPolicy| {
+            Self::mk_policy_routes(orig_dst, policy)
+        });
+        TlsSidecar { orig_dst, routes }
+    }
+}
+
+impl TlsSidecar {
+    fn mk_policy_routes(
+        OrigDstAddr(orig_dst): OrigDstAddr,
+        policy: &policy::ClientPolicy,
+    ) -> Option<tls::Routes> {
+        let parent_ref = ParentRef(policy.parent.clone());
+
+        let routes = match policy.protocol {
+            policy::Protocol::Tls(policy::tls::Tls { ref routes }) => routes.clone(),
+            _ => {
+                tracing::info!(
+                    "Ignoring a discovery update that changed a route from HTTP to opaque"
+                );
+                return None;
+            }
+        };
+
+        Some(tls::Routes {
+            addr: orig_dst.into(),
+            meta: parent_ref,
+            routes,
+            backends: policy.backends.clone(),
+        })
+    }
+}
+
+impl svc::Param<watch::Receiver<tls::Routes>> for TlsSidecar {
+    fn param(&self) -> watch::Receiver<tls::Routes> {
+        self.routes.clone()
+    }
+}
+
+impl std::cmp::PartialEq for TlsSidecar {
+    fn eq(&self, other: &Self) -> bool {
+        self.orig_dst == other.orig_dst
+    }
+}
+
+impl std::cmp::Eq for TlsSidecar {}
+
+impl std::hash::Hash for TlsSidecar {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.orig_dst.hash(state);
     }
 }

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -45,7 +45,14 @@ impl<N> Outbound<N> {
     where
         T: svc::Param<OrigDstAddr> + Clone + Send + 'static,
         G: svc::GetSpan<T> + Clone + Send + Sync + 'static,
-        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + std::fmt::Debug + Send + Unpin + 'static,
+        I: io::AsyncRead
+            + io::AsyncWrite
+            + io::PeerAddr
+            + io::Peek
+            + std::fmt::Debug
+            + Send
+            + Unpin
+            + 'static,
         N: svc::NewService<Accept, Service = NSvc> + Clone + Send + Sync + 'static,
         NSvc: svc::Service<metrics::SensorIo<I>, Response = (), Error = Error> + Send + 'static,
         NSvc::Future: Send,

--- a/linkerd/app/outbound/src/tls.rs
+++ b/linkerd/app/outbound/src/tls.rs
@@ -1,0 +1,133 @@
+use crate::{tcp, Outbound};
+use linkerd_app_core::{
+    io,
+    metrics::prom,
+    proxy::{
+        api_resolve::{ConcreteAddr, Metadata},
+        core::Resolve,
+    },
+    svc,
+    tls::ServerName,
+    transport::addrs::*,
+    Error,
+};
+use std::{fmt::Debug, hash::Hash};
+use tokio::sync::watch;
+
+mod concrete;
+mod detect;
+mod logical;
+
+pub use self::logical::{Concrete, Routes};
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct Tls<T> {
+    sni: ServerName,
+    parent: T,
+}
+
+pub fn spawn_routes<T>(
+    mut route_rx: watch::Receiver<T>,
+    init: Routes,
+    mut mk: impl FnMut(&T) -> Option<Routes> + Send + Sync + 'static,
+) -> watch::Receiver<Routes>
+where
+    T: Send + Sync + 'static,
+{
+    let (tx, rx) = watch::channel(init);
+
+    tokio::spawn(async move {
+        loop {
+            let res = tokio::select! {
+                biased;
+                _ = tx.closed() => return,
+                res = route_rx.changed() => res,
+            };
+
+            if res.is_err() {
+                // Drop the `tx` sender when the profile sender is
+                // dropped.
+                return;
+            }
+
+            if let Some(routes) = (mk)(&*route_rx.borrow_and_update()) {
+                if tx.send(routes).is_err() {
+                    // Drop the `tx` sender when all of its receivers are dropped.
+                    return;
+                }
+            }
+        }
+    });
+
+    rx
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TlsMetrics {
+    balance: concrete::BalancerMetrics,
+}
+
+// === impl Outbound ===
+
+impl<C> Outbound<C> {
+    /// Builds a stack that proxies tls connections.
+    ///
+    /// This stack uses caching so that a router/load-balancer may be reused
+    /// across multiple connections.
+    pub fn push_tls_cached<T, I, R>(self, resolve: R) -> Outbound<svc::ArcNewCloneTcp<T, I>>
+    where
+        // Tls target
+        T: Clone + Debug + PartialEq + Eq + Hash + Send + Sync + 'static,
+        T: svc::Param<watch::Receiver<Routes>>,
+        // Server-side connection
+        I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + io::Peek,
+        I: Debug + Send + Sync + Unpin + 'static,
+        // Endpoint discovery
+        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
+        R::Resolution: Unpin,
+        // TCP endpoint stack.
+        C: svc::MakeConnection<tcp::Connect, Metadata = Local<ClientAddr>, Error = io::Error>,
+        C: Clone + Send + Sync + Unpin + 'static,
+        C::Connection: Send + Unpin,
+        C::Future: Send + Unpin,
+    {
+        self.push_tcp_endpoint()
+            .push_tls_concrete(resolve)
+            .push_tls_logical()
+            .map_stack(|config, _rt, stk| {
+                stk.push_new_idle_cached(config.discovery_idle_timeout)
+                    // Use a dedicated target type to configure parameters for
+                    // the TLS stack. It also helps narrow the cache key.
+                    .push_map_target(|(sni, parent): (ServerName, T)| Tls { sni, parent })
+                    .push(detect::NewDetectSniServer::layer())
+                    .arc_new_clone_tcp()
+            })
+    }
+}
+
+// === impl Tls ===
+
+impl<T> svc::Param<ServerName> for Tls<T> {
+    fn param(&self) -> ServerName {
+        self.sni.clone()
+    }
+}
+
+impl<T> svc::Param<watch::Receiver<logical::Routes>> for Tls<T>
+where
+    T: svc::Param<watch::Receiver<logical::Routes>>,
+{
+    fn param(&self) -> watch::Receiver<logical::Routes> {
+        self.parent.param()
+    }
+}
+
+// === impl TlsMetrics ===
+
+impl TlsMetrics {
+    pub fn register(registry: &mut prom::Registry) -> Self {
+        let balance =
+            concrete::BalancerMetrics::register(registry.sub_registry_with_prefix("balancer"));
+        Self { balance }
+    }
+}

--- a/linkerd/app/outbound/src/tls/concrete.rs
+++ b/linkerd/app/outbound/src/tls/concrete.rs
@@ -1,0 +1,351 @@
+use crate::{metrics::BalancerMetricsParams, stack_labels, BackendRef, Outbound, ParentRef};
+use linkerd_app_core::{
+    config::QueueConfig,
+    drain, io,
+    metrics::{
+        self,
+        prom::{self, EncodeLabelSetMut},
+    },
+    proxy::{
+        api_resolve::{ConcreteAddr, Metadata},
+        core::Resolve,
+        http::AuthorityOverride,
+        tcp::{self, balance},
+    },
+    svc::{self, layer::Layer},
+    tls::{self, ServerName},
+    transport::{self, addrs::*},
+    transport_header::SessionProtocol,
+    Error, Infallible, NameAddr,
+};
+use std::{fmt::Debug, net::SocketAddr, sync::Arc};
+use tracing::info_span;
+
+/// Parameter configuring dispatcher behavior.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Dispatch {
+    Balance(NameAddr, balance::EwmaConfig),
+    Forward(Remote<ServerAddr>, Metadata),
+    Fail { message: Arc<str> },
+}
+
+/// Wraps errors encountered in this module.
+#[derive(Debug, thiserror::Error)]
+#[error("concrete service {addr}: {source}")]
+pub struct ConcreteError {
+    addr: NameAddr,
+    #[source]
+    source: Error,
+}
+
+/// Inner stack target type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Endpoint<T> {
+    addr: Remote<ServerAddr>,
+    is_local: bool,
+    metadata: Metadata,
+    parent: T,
+}
+
+pub type BalancerMetrics = BalancerMetricsParams<ConcreteLabels>;
+
+/// A target configuring a load balancer stack.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Balance<T> {
+    concrete: NameAddr,
+    ewma: balance::EwmaConfig,
+    queue: QueueConfig,
+    parent: T,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct ConcreteLabels {
+    concrete: Arc<str>,
+}
+
+impl prom::EncodeLabelSetMut for ConcreteLabels {
+    fn encode_label_set(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+        use prom::encoding::EncodeLabel;
+
+        ("concrete", &*self.concrete).encode(enc.encode_label())?;
+        Ok(())
+    }
+}
+
+impl prom::encoding::EncodeLabelSet for ConcreteLabels {
+    fn encode(&self, mut enc: prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(&mut enc)
+    }
+}
+
+impl<T> svc::ExtractParam<balance::Metrics, Balance<T>> for BalancerMetricsParams<ConcreteLabels> {
+    fn extract_param(&self, bal: &Balance<T>) -> balance::Metrics {
+        self.metrics(&ConcreteLabels {
+            concrete: bal.concrete.to_string().into(),
+        })
+    }
+}
+
+// === impl Outbound ===
+
+impl<C> Outbound<C> {
+    /// Builds a [`svc::NewService`] stack that builds buffered tls services
+    /// for `T`-typed concrete targets. Connections may be load balanced across
+    /// a discovered set of replicas or forwarded to a single endpoint,
+    /// depending on the value of the `Dispatch` parameter.
+    ///
+    /// When a balancer has no available inner services, it goes into
+    /// 'failfast'. While in failfast, buffered requests are failed and the
+    /// service becomes unavailable so callers may choose alternate concrete
+    /// services.
+    pub fn push_tls_concrete<T, I, R>(
+        self,
+        resolve: R,
+    ) -> Outbound<
+        svc::ArcNewService<
+            T,
+            impl svc::Service<I, Response = (), Error = Error, Future = impl Send> + Clone,
+        >,
+    >
+    where
+        // Logical target
+        T: svc::Param<Dispatch>,
+        T: Clone + Debug + Send + Sync + 'static,
+        T: svc::Param<ServerName>,
+        // Server-side socket.
+        I: io::AsyncRead + io::AsyncWrite + Debug + Send + Unpin + 'static,
+        // Endpoint resolution.
+        R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
+        R::Resolution: Unpin,
+        // Endpoint connector.
+        C: svc::MakeConnection<Endpoint<T>> + Clone + Send + 'static,
+        C::Connection: Send + Unpin,
+        C::Metadata: Send + Unpin,
+        C::Future: Send,
+        C: Send + Sync + 'static,
+    {
+        let resolve =
+            svc::MapTargetLayer::new(|t: Balance<T>| -> ConcreteAddr { ConcreteAddr(t.concrete) })
+                .layer(resolve.into_service());
+
+        self.map_stack(|config, rt, inner| {
+            let queue = config.tcp_connection_queue;
+
+            let connect = inner
+                .push(svc::stack::WithoutConnectionMetadata::layer())
+                .push_new_thunk();
+
+            let forward = connect
+                .clone()
+                .push_on_service(rt.metrics.proxy.stack.layer(stack_labels("tls", "forward")))
+                .instrument(|e: &Endpoint<T>| info_span!("forward", addr = %e.addr));
+
+            let endpoint = connect
+                .push_on_service(
+                    rt.metrics
+                        .proxy
+                        .stack
+                        .layer(stack_labels("tls", "endpoint")),
+                )
+                .instrument(|e: &Endpoint<T>| info_span!("endpoint", addr = %e.addr));
+
+            let inbound_ips = config.inbound_ips.clone();
+            let balance = endpoint
+                .push_map_target(
+                    move |((addr, metadata), target): ((SocketAddr, Metadata), Balance<T>)| {
+                        tracing::trace!(%addr, ?metadata, ?target, "Resolved endpoint");
+                        let is_local = inbound_ips.contains(&addr.ip());
+                        Endpoint {
+                            addr: Remote(ServerAddr(addr)),
+                            metadata,
+                            is_local,
+                            parent: target.parent,
+                        }
+                    },
+                )
+                .lift_new_with_target()
+                .push(tcp::NewBalance::layer(
+                    resolve,
+                    rt.metrics.prom.tls.balance.clone(),
+                ))
+                .push(svc::NewMapErr::layer_from_target::<ConcreteError, _>())
+                .push_on_service(rt.metrics.proxy.stack.layer(stack_labels("tls", "balance")))
+                .instrument(|t: &Balance<T>| info_span!("balance", addr = %t.concrete));
+
+            balance
+                .push_switch(
+                    move |parent: T| -> Result<_, Infallible> {
+                        Ok(match parent.param() {
+                            Dispatch::Balance(concrete, ewma) => svc::Either::A(Balance {
+                                concrete,
+                                ewma,
+                                queue,
+                                parent,
+                            }),
+                            Dispatch::Forward(addr, meta) => svc::Either::B(Endpoint {
+                                addr,
+                                is_local: false,
+                                metadata: meta,
+                                parent,
+                            }),
+                            Dispatch::Fail { .. } => unimplemented!(),
+                        })
+                    },
+                    forward.into_inner(),
+                )
+                .push_on_service(tcp::Forward::layer())
+                .push_on_service(drain::Retain::layer(rt.drain.clone()))
+                .push(svc::ArcNewService::layer())
+        })
+    }
+}
+
+// === impl ConcreteError ===
+
+impl<T> From<(&Balance<T>, Error)> for ConcreteError {
+    fn from((target, source): (&Balance<T>, Error)) -> Self {
+        Self {
+            addr: target.concrete.clone(),
+            source,
+        }
+    }
+}
+
+// === impl Balance ===
+
+impl<T> std::ops::Deref for Balance<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.parent
+    }
+}
+
+impl<T> svc::Param<balance::EwmaConfig> for Balance<T> {
+    fn param(&self) -> balance::EwmaConfig {
+        self.ewma
+    }
+}
+
+impl<T> svc::Param<svc::queue::Capacity> for Balance<T> {
+    fn param(&self) -> svc::queue::Capacity {
+        svc::queue::Capacity(self.queue.capacity)
+    }
+}
+
+impl<T> svc::Param<svc::queue::Timeout> for Balance<T> {
+    fn param(&self) -> svc::queue::Timeout {
+        svc::queue::Timeout(self.queue.failfast_timeout)
+    }
+}
+
+impl<T: svc::Param<ParentRef>> svc::Param<ParentRef> for Balance<T> {
+    fn param(&self) -> ParentRef {
+        self.parent.param()
+    }
+}
+
+impl<T: svc::Param<BackendRef>> svc::Param<BackendRef> for Balance<T> {
+    fn param(&self) -> BackendRef {
+        self.parent.param()
+    }
+}
+
+// === impl Endpoint ===
+
+impl<T> svc::Param<Remote<ServerAddr>> for Endpoint<T> {
+    fn param(&self) -> Remote<ServerAddr> {
+        self.addr
+    }
+}
+
+impl<T> svc::Param<Option<crate::tcp::tagged_transport::PortOverride>> for Endpoint<T> {
+    fn param(&self) -> Option<crate::tcp::tagged_transport::PortOverride> {
+        if self.is_local {
+            return None;
+        }
+        self.metadata
+            .tagged_transport_port()
+            .map(crate::tcp::tagged_transport::PortOverride)
+    }
+}
+
+impl<T> svc::Param<Option<AuthorityOverride>> for Endpoint<T> {
+    fn param(&self) -> Option<AuthorityOverride> {
+        if self.is_local {
+            return None;
+        }
+        self.metadata
+            .authority_override()
+            .cloned()
+            .map(AuthorityOverride)
+    }
+}
+
+impl<T> svc::Param<Option<SessionProtocol>> for Endpoint<T> {
+    fn param(&self) -> Option<SessionProtocol> {
+        None
+    }
+}
+
+impl<T> svc::Param<transport::labels::Key> for Endpoint<T>
+where
+    T: svc::Param<ServerName>,
+{
+    fn param(&self) -> transport::labels::Key {
+        transport::labels::Key::OutboundClient(self.param())
+    }
+}
+
+impl<T> svc::Param<metrics::OutboundEndpointLabels> for Endpoint<T>
+where
+    T: svc::Param<ServerName>,
+{
+    fn param(&self) -> metrics::OutboundEndpointLabels {
+        metrics::OutboundEndpointLabels {
+            authority: None,
+            labels: metrics::prefix_labels("dst", self.metadata.labels().iter()),
+            server_id: self.param(),
+            target_addr: self.addr.into(),
+        }
+    }
+}
+
+impl<T> svc::Param<metrics::EndpointLabels> for Endpoint<T>
+where
+    T: svc::Param<ServerName>,
+{
+    fn param(&self) -> metrics::EndpointLabels {
+        metrics::EndpointLabels::from(svc::Param::<metrics::OutboundEndpointLabels>::param(self))
+    }
+}
+
+impl<T> svc::Param<tls::ConditionalClientTls> for Endpoint<T> {
+    fn param(&self) -> tls::ConditionalClientTls {
+        if self.is_local {
+            return tls::ConditionalClientTls::None(tls::NoClientTls::Loopback);
+        }
+
+        // If we're transporting an opaque protocol OR we're communicating with
+        // a gateway, then set an ALPN value indicating support for a transport
+        // header.
+        let use_transport_header = self.metadata.tagged_transport_port().is_some()
+            || self.metadata.authority_override().is_some();
+        self.metadata
+            .identity()
+            .cloned()
+            .map(move |mut client_tls| {
+                client_tls.alpn = if use_transport_header {
+                    use linkerd_app_core::transport_header::PROTOCOL;
+                    Some(tls::client::AlpnProtocols(vec![PROTOCOL.into()]))
+                } else {
+                    None
+                };
+
+                tls::ConditionalClientTls::Some(client_tls)
+            })
+            .unwrap_or(tls::ConditionalClientTls::None(
+                tls::NoClientTls::NotProvidedByServiceDiscovery,
+            ))
+    }
+}

--- a/linkerd/app/outbound/src/tls/detect.rs
+++ b/linkerd/app/outbound/src/tls/detect.rs
@@ -1,0 +1,84 @@
+use linkerd_app_core::{
+    io,
+    svc::{self, layer, ServiceExt},
+    tls::{
+        server::{detect_sni, CouldNotDetectSNIError, DetectIo, ServerTlsTimeoutError},
+        ServerName,
+    },
+    Error, Result,
+};
+
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::time;
+
+#[derive(Clone, Debug, Default)]
+pub struct NewDetectSniServer<N> {
+    inner: N,
+    timeout: time::Duration,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct DetectSniServer<T, N> {
+    target: T,
+    inner: N,
+    timeout: time::Duration,
+}
+
+impl<N> NewDetectSniServer<N> {
+    pub fn layer() -> impl layer::Layer<N, Service = Self> + Copy {
+        let timeout = time::Duration::from_secs(10);
+        layer::mk(move |inner| Self { inner, timeout })
+    }
+}
+
+impl<T, N: Clone> svc::NewService<T> for NewDetectSniServer<N> {
+    type Service = DetectSniServer<T, N>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        DetectSniServer {
+            target,
+            timeout: self.timeout,
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T, I, N, S> svc::Service<I> for DetectSniServer<T, N>
+where
+    T: Clone + Send + Sync + 'static,
+    I: io::AsyncRead + io::Peek + io::AsyncWrite + Send + Sync + Unpin + 'static,
+    N: svc::NewService<(ServerName, T), Service = S> + Clone + Send + 'static,
+    S: svc::Service<DetectIo<I>> + Send,
+    S::Error: Into<Error>,
+    S::Future: Send,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<S::Response>> + Send + 'static>>;
+
+    #[inline]
+    fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, io: I) -> Self::Future {
+        let target = self.target.clone();
+        let new_accept = self.inner.clone();
+
+        // Detect the SNI from a ClientHello (or timeout).
+        let timeout = self.timeout;
+        let detect = time::timeout(timeout, detect_sni(io));
+        Box::pin(async move {
+            let (sni, io) = detect.await.map_err(|_| ServerTlsTimeoutError)??;
+            let sni = sni.ok_or(CouldNotDetectSNIError)?;
+
+            println!("detected SNI: {:?}", sni);
+            let svc = new_accept.new_service((sni, target));
+            svc.oneshot(io).await.map_err(Into::into)
+        })
+    }
+}

--- a/linkerd/app/outbound/src/tls/logical.rs
+++ b/linkerd/app/outbound/src/tls/logical.rs
@@ -1,0 +1,121 @@
+use super::concrete;
+use crate::{BackendRef, Outbound, ParentRef};
+use linkerd_app_core::{io, svc, tls::ServerName, Addr, Error};
+use linkerd_proxy_client_policy as client_policy;
+use std::{fmt::Debug, hash::Hash, sync::Arc};
+use tokio::sync::watch;
+
+pub mod route;
+pub mod router;
+
+/// Indicates the address used for logical routing.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct LogicalAddr(pub Addr);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Routes {
+    pub addr: Addr,
+    pub meta: ParentRef,
+    pub routes: Arc<[client_policy::tls::Route]>,
+    pub backends: Arc<[client_policy::Backend]>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Concrete<T> {
+    target: concrete::Dispatch,
+    parent: T,
+    parent_ref: ParentRef,
+    backend_ref: BackendRef,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("no route")]
+pub struct NoRoute;
+
+#[derive(Debug, thiserror::Error)]
+#[error("logical service {addr}: {source}")]
+pub struct LogicalError {
+    addr: Addr,
+    #[source]
+    source: Error,
+}
+
+impl<N> Outbound<N> {
+    /// Builds a `NewService` that produces a router service for each logical
+    /// target.
+    ///
+    /// The router uses discovery information (provided on the target) to
+    /// support per-request routing over a set of concrete inner services.
+    /// Only available inner services are used for routing. When there are no
+    /// available backends, requests are failed with a [`svc::stack::LoadShedError`].
+    pub fn push_tls_logical<T, I, NSvc>(self) -> Outbound<svc::ArcNewCloneTcp<T, I>>
+    where
+        // Logical target.
+        T: svc::Param<watch::Receiver<Routes>>,
+        T: svc::Param<ServerName>,
+        T: Eq + Hash + Clone + Debug + Send + Sync + 'static,
+        // Concrete stack.
+        I: io::AsyncRead + io::AsyncWrite + Debug + Send + Unpin + 'static,
+        // Concrete stack.
+        N: svc::NewService<Concrete<T>, Service = NSvc> + Clone + Send + Sync + 'static,
+        NSvc: svc::Service<I, Response = ()> + Clone + Send + Sync + 'static,
+        NSvc::Future: Send,
+        NSvc::Error: Into<Error>,
+    {
+        self.map_stack(|_config, _, concrete| {
+            concrete
+                .lift_new()
+                .push_on_service(svc::layer::mk(move |concrete: N| {
+                    svc::stack(concrete.clone())
+                        .push(router::Router::layer())
+                        .push(svc::NewMapErr::layer_from_target::<LogicalError, _>())
+                        .arc_new_clone_tcp()
+                        .into_inner()
+                }))
+                // Rebuild the inner router stack every time the watch changes.
+                .push(svc::NewSpawnWatch::<Routes, _>::layer_into::<
+                    router::Router<T>,
+                >())
+                .arc_new_clone_tcp()
+        })
+    }
+}
+
+// === impl LogicalError ===
+
+impl<T> From<(&router::Router<T>, Error)> for LogicalError
+where
+    T: Eq + Hash + Clone + Debug,
+{
+    fn from((target, source): (&router::Router<T>, Error)) -> Self {
+        let LogicalAddr(addr) = svc::Param::param(target);
+        Self { addr, source }
+    }
+}
+
+impl<T> svc::Param<concrete::Dispatch> for Concrete<T> {
+    fn param(&self) -> concrete::Dispatch {
+        self.target.clone()
+    }
+}
+
+impl<T> svc::Param<ServerName> for Concrete<T>
+where
+    T: svc::Param<ServerName>,
+{
+    fn param(&self) -> ServerName {
+        self.parent.param()
+    }
+}
+
+impl<T> svc::Param<ParentRef> for Concrete<T> {
+    fn param(&self) -> ParentRef {
+        self.parent_ref.clone()
+    }
+}
+
+impl<T> svc::Param<BackendRef> for Concrete<T> {
+    fn param(&self) -> BackendRef {
+        self.backend_ref.clone()
+    }
+}

--- a/linkerd/app/outbound/src/tls/logical/route.rs
+++ b/linkerd/app/outbound/src/tls/logical/route.rs
@@ -1,0 +1,99 @@
+use super::super::Concrete;
+use crate::RouteRef;
+use linkerd_app_core::{io, svc, Addr, Error};
+use linkerd_distribute as distribute;
+use linkerd_tls_route as tls_route;
+use std::{fmt::Debug, hash::Hash};
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub(crate) struct Backend<T> {
+    pub(crate) route_ref: RouteRef,
+    pub(crate) concrete: Concrete<T>,
+}
+
+// === impl Backend ===
+
+impl<T: Clone> Clone for Backend<T> {
+    fn clone(&self) -> Self {
+        Self {
+            route_ref: self.route_ref.clone(),
+            concrete: self.concrete.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct MatchedRoute<T> {
+    pub(super) r#match: tls_route::RouteMatch,
+    pub(super) params: Route<T>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct Route<T> {
+    pub(super) parent: T,
+    pub(super) addr: Addr,
+    pub(super) route_ref: RouteRef,
+    pub(super) distribution: BackendDistribution<T>,
+}
+
+pub(crate) type BackendDistribution<T> = distribute::Distribution<Backend<T>>;
+pub(crate) type NewDistribute<T, N> = distribute::NewDistribute<Backend<T>, (), N>;
+
+/// Wraps errors with route metadata.
+#[derive(Debug, thiserror::Error)]
+#[error("route {}: {source}", route.0)]
+struct RouteError {
+    route: RouteRef,
+    #[source]
+    source: Error,
+}
+
+// === impl MatchedRoute ===
+
+impl<T> MatchedRoute<T>
+where
+    // Parent target.
+    T: Debug + Eq + Hash,
+    T: Clone + Send + Sync + 'static,
+{
+    /// Builds a route stack that applies policy filters to requests and
+    /// distributes requests over each route's backends. These [`Concrete`]
+    /// backends are expected to be cached/shared by the inner stack.
+    pub(crate) fn layer<N, I, NSvc>(
+    ) -> impl svc::Layer<N, Service = svc::ArcNewCloneTcp<Self, I>> + Clone
+    where
+        I: io::AsyncRead + io::AsyncWrite + Debug + Send + Unpin + 'static,
+        // Inner stack.
+        N: svc::NewService<Concrete<T>, Service = NSvc> + Clone + Send + Sync + 'static,
+        NSvc: svc::Service<I, Response = ()> + Clone + Send + Sync + 'static,
+        NSvc::Future: Send,
+        NSvc::Error: Into<Error>,
+    {
+        svc::layer::mk(move |inner| {
+            svc::stack(inner)
+                .push_map_target(|t| t)
+                .push_map_target(|b: Backend<T>| b.concrete)
+                .lift_new()
+                .push(NewDistribute::layer())
+                // The router does not take the backend's availability into
+                // consideration, so we must eagerly fail requests to prevent
+                // leaking tasks onto the runtime.
+                .push_on_service(svc::LoadShed::layer())
+                .push(svc::NewMapErr::layer_with(|rt: &Self| {
+                    let route = rt.params.route_ref.clone();
+                    move |source| RouteError {
+                        route: route.clone(),
+                        source,
+                    }
+                }))
+                .arc_new_clone_tcp()
+                .into_inner()
+        })
+    }
+}
+
+impl<T: Clone> svc::Param<BackendDistribution<T>> for MatchedRoute<T> {
+    fn param(&self) -> BackendDistribution<T> {
+        self.params.distribution.clone()
+    }
+}

--- a/linkerd/app/outbound/src/tls/logical/router.rs
+++ b/linkerd/app/outbound/src/tls/logical/router.rs
@@ -1,0 +1,202 @@
+use super::{
+    super::{concrete, Concrete},
+    route, LogicalAddr, NoRoute,
+};
+use crate::{BackendRef, EndpointRef, RouteRef};
+use linkerd_app_core::{
+    io, proxy::http, svc, tls::ServerName, transport::addrs::*, Addr, Error, NameAddr, Result,
+};
+use linkerd_distribute as distribute;
+use linkerd_proxy_client_policy as policy;
+use linkerd_tls_route as tls_route;
+use std::{fmt::Debug, hash::Hash, sync::Arc};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Router<T: Clone + Debug + Eq + Hash> {
+    pub(super) parent: T,
+    pub(super) addr: Addr,
+    pub(super) routes: Arc<[tls_route::Route<route::Route<T>>]>,
+    pub(super) backends: distribute::Backends<Concrete<T>>,
+}
+
+type NewBackendCache<T, N, S> = distribute::NewBackendCache<Concrete<T>, (), N, S>;
+
+// === impl Router ===
+
+impl<T> Router<T>
+where
+    // Parent target type.
+    T: Eq + Hash + Clone + Debug + Send + Sync + 'static,
+    T: svc::Param<ServerName>,
+{
+    pub fn layer<N, I, NSvc>() -> impl svc::Layer<N, Service = svc::ArcNewCloneTcp<Self, I>> + Clone
+    where
+        I: io::AsyncRead + io::AsyncWrite + Debug + Send + Unpin + 'static,
+        // Concrete stack.
+        N: svc::NewService<Concrete<T>, Service = NSvc> + Clone + Send + Sync + 'static,
+        NSvc: svc::Service<I, Response = ()> + Clone + Send + Sync + 'static,
+        NSvc::Future: Send,
+        NSvc::Error: Into<Error>,
+    {
+        svc::layer::mk(move |inner| {
+            svc::stack(inner)
+                .lift_new()
+                // Each route builds over concrete backends. All of these
+                // backends are cached here and shared across routes.
+                .push(NewBackendCache::layer())
+                .push_on_service(route::MatchedRoute::layer())
+                .push(svc::NewOneshotRoute::<Self, (), _>::layer_cached())
+                .arc_new_clone_tcp()
+                .into_inner()
+        })
+    }
+}
+
+impl<T> From<(crate::tls::Routes, T)> for Router<T>
+where
+    T: Eq + Hash + Clone + Debug,
+{
+    fn from((rts, parent): (crate::tls::Routes, T)) -> Self {
+        let crate::tls::Routes {
+            addr,
+            meta: parent_ref,
+            routes,
+            backends,
+        } = rts;
+
+        let mk_concrete = {
+            let parent = parent.clone();
+            move |backend_ref: BackendRef, target: concrete::Dispatch| Concrete {
+                target,
+                parent: parent.clone(),
+                backend_ref,
+                parent_ref: parent_ref.clone(),
+            }
+        };
+
+        let mk_dispatch = move |bke: &policy::Backend| match bke.dispatcher {
+            policy::BackendDispatcher::BalanceP2c(
+                policy::Load::PeakEwma(policy::PeakEwma { decay, default_rtt }),
+                policy::EndpointDiscovery::DestinationGet { ref path },
+            ) => mk_concrete(
+                BackendRef(bke.meta.clone()),
+                concrete::Dispatch::Balance(
+                    path.parse::<NameAddr>()
+                        .expect("destination must be a nameaddr"),
+                    http::balance::EwmaConfig { decay, default_rtt },
+                ),
+            ),
+            policy::BackendDispatcher::Forward(addr, ref md) => mk_concrete(
+                EndpointRef::new(md, addr.port().try_into().expect("port must not be 0")).into(),
+                concrete::Dispatch::Forward(Remote(ServerAddr(addr)), md.clone()),
+            ),
+            policy::BackendDispatcher::Fail { ref message } => mk_concrete(
+                BackendRef(policy::Meta::new_default("fail")),
+                concrete::Dispatch::Fail {
+                    message: message.clone(),
+                },
+            ),
+        };
+
+        let mk_route_backend =
+            |route_ref: &RouteRef, rb: &policy::RouteBackend<policy::tls::Filter>| {
+                let concrete = mk_dispatch(&rb.backend);
+                route::Backend {
+                    route_ref: route_ref.clone(),
+                    concrete,
+                }
+            };
+
+        let mk_distribution =
+            |rr: &RouteRef, d: &policy::RouteDistribution<policy::tls::Filter>| match d {
+                policy::RouteDistribution::Empty => route::BackendDistribution::Empty,
+                policy::RouteDistribution::FirstAvailable(backends) => {
+                    route::BackendDistribution::first_available(
+                        backends.iter().map(|b| mk_route_backend(rr, b)),
+                    )
+                }
+                policy::RouteDistribution::RandomAvailable(backends) => {
+                    route::BackendDistribution::random_available(
+                        backends
+                            .iter()
+                            .map(|(rb, weight)| (mk_route_backend(rr, rb), *weight)),
+                    )
+                    .expect("distribution must be valid")
+                }
+            };
+
+        let mk_policy =
+            |policy::RoutePolicy::<policy::tls::Filter, ()> {
+                 meta, distribution, ..
+             }| {
+                let route_ref = RouteRef(meta);
+                let distribution = mk_distribution(&route_ref, &distribution);
+                route::Route {
+                    addr: addr.clone(),
+                    parent: parent.clone(),
+                    route_ref,
+                    distribution,
+                }
+            };
+
+        let routes = routes
+            .iter()
+            .map(|route| tls_route::Route {
+                snis: route.snis.clone(),
+                policy: mk_policy(route.policy.clone()),
+            })
+            .collect();
+
+        let backends = backends.iter().map(mk_dispatch).collect();
+
+        Self {
+            routes,
+            backends,
+            addr,
+            parent,
+        }
+    }
+}
+
+impl<T, I> svc::router::SelectRoute<I> for Router<T>
+where
+    T: Clone + Eq + Hash + Debug,
+    T: svc::Param<ServerName>,
+{
+    type Key = route::MatchedRoute<T>;
+    type Error = NoRoute;
+
+    fn select(&self, _: &I) -> Result<Self::Key, Self::Error> {
+        use linkerd_tls_route::SessionInfo;
+
+        let server_name: ServerName = self.parent.param();
+        tracing::trace!("Selecting TLS route for {:?}", server_name);
+        let si = SessionInfo { sni: server_name };
+        let (r#match, params) = policy::tls::find(&self.routes, si).ok_or(NoRoute)?;
+        tracing::debug!(meta = ?params.route_ref, "Selected route");
+        tracing::trace!(?r#match);
+
+        Ok(route::MatchedRoute {
+            r#match,
+            params: params.clone(),
+        })
+    }
+}
+
+impl<T> svc::Param<LogicalAddr> for Router<T>
+where
+    T: Eq + Hash + Clone + Debug,
+{
+    fn param(&self) -> LogicalAddr {
+        LogicalAddr(self.addr.clone())
+    }
+}
+
+impl<T> svc::Param<distribute::Backends<Concrete<T>>> for Router<T>
+where
+    T: Eq + Hash + Clone + Debug,
+{
+    fn param(&self) -> distribute::Backends<Concrete<T>> {
+        self.backends.clone()
+    }
+}

--- a/linkerd/app/src/env/types.rs
+++ b/linkerd/app/src/env/types.rs
@@ -1,5 +1,5 @@
 use super::ParseError;
-use linkerd_app_core::{dns, identity, Addr, IpNet};
+use linkerd_app_core::{dns, identity, tls_route, Addr, IpNet};
 use rangemap::RangeInclusiveSet;
 use std::{
     collections::HashSet,
@@ -128,6 +128,19 @@ pub(super) fn parse_port_range_set(s: &str) -> Result<RangeInclusiveSet<u16>, Pa
         }
     }
     Ok(set)
+}
+
+pub(super) fn parse_match_sni(list: &str) -> Result<HashSet<tls_route::MatchSni>, ParseError> {
+    let mut suffixes = HashSet::new();
+    for item in list.split(',') {
+        let item = item.trim();
+        if !item.is_empty() {
+            let sfx = tls_route::MatchSni::from_str(item)?;
+            suffixes.insert(sfx);
+        }
+    }
+
+    Ok(suffixes)
 }
 
 pub(super) fn parse_dns_suffixes(list: &str) -> Result<HashSet<dns::Suffix>, ParseError> {

--- a/linkerd/io/src/sensor.rs
+++ b/linkerd/io/src/sensor.rs
@@ -1,4 +1,4 @@
-use crate::{IoSlice, PeerAddr, Poll};
+use crate::{IoSlice, Peek, PeerAddr, Poll};
 use futures::ready;
 use linkerd_errno::Errno;
 use pin_project::pin_project;
@@ -80,5 +80,12 @@ impl<T: AsyncRead + AsyncWrite, S: Sensor> AsyncWrite for SensorIo<T, S> {
 impl<T: PeerAddr, S> PeerAddr for SensorIo<T, S> {
     fn peer_addr(&self) -> Result<std::net::SocketAddr> {
         self.io.peer_addr()
+    }
+}
+
+#[async_trait::async_trait]
+impl<I: Peek + Send + Sync, S: Sensor + Sync> Peek for SensorIo<I, S> {
+    async fn peek(&self, buf: &mut [u8]) -> Result<usize> {
+        self.io.peek(buf).await
     }
 }

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [features]
 proto = [
     "linkerd-http-route/proto",
+    "linkerd-tls-route/proto",
     "linkerd2-proxy-api",
     "prost-types",
     "thiserror",
@@ -26,6 +27,7 @@ thiserror = { version = "1", optional = true }
 linkerd-error = { path = "../../error" }
 linkerd-exp-backoff = { path = "../../exp-backoff" }
 linkerd-http-route = { path = "../../http/route" }
+linkerd-tls-route = { path = "../../tls/route" }
 linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }
 

--- a/linkerd/proxy/client-policy/src/tls.rs
+++ b/linkerd/proxy/client-policy/src/tls.rs
@@ -1,0 +1,198 @@
+use linkerd_tls_route as tls;
+use std::sync::Arc;
+
+pub use linkerd_tls_route::{find, sni, RouteMatch};
+
+pub type Policy = crate::RoutePolicy<Filter, ()>;
+pub type Route = tls::Route<Policy>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Tls {
+    pub routes: Arc<[Route]>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Filter {}
+
+pub fn default(distribution: crate::RouteDistribution<Filter>) -> Route {
+    Route {
+        snis: vec![],
+        policy: Policy {
+            meta: crate::Meta::new_default("default"),
+            filters: Arc::new([]),
+            params: (),
+            distribution,
+        },
+    }
+}
+
+impl Default for Tls {
+    fn default() -> Self {
+        Self {
+            routes: Arc::new([]),
+        }
+    }
+}
+
+#[cfg(feature = "proto")]
+pub mod proto {
+    use super::*;
+    use crate::{
+        proto::{BackendSet, InvalidBackend, InvalidDistribution, InvalidMeta},
+        Meta, RouteBackend, RouteDistribution,
+    };
+    use linkerd2_proxy_api::outbound::{self, tls_route};
+    use linkerd_tls_route::sni::proto::InvalidSniMatch;
+
+    use once_cell::sync::Lazy;
+    use std::sync::Arc;
+
+    pub(crate) static NO_FILTERS: Lazy<Arc<[Filter]>> = Lazy::new(|| Arc::new([]));
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidTlsRoute {
+        #[error("invalid sni match: {0}")]
+        SniMatch(#[from] InvalidSniMatch),
+
+        #[error("invalid route metadata: {0}")]
+        Meta(#[from] InvalidMeta),
+
+        #[error("invalid distribution: {0}")]
+        Distribution(#[from] InvalidDistribution),
+
+        /// Note: this restriction may be removed in the future, if a way of
+        /// actually matching rules for tls routes is added.
+        #[error("a tls route must have exactly one rule, but {0} were provided")]
+        OnlyOneRule(usize),
+
+        #[error("missing {0}")]
+        Missing(&'static str),
+    }
+
+    pub(crate) fn fill_route_backends(rts: &[Route], set: &mut BackendSet) {
+        for Route { ref policy, .. } in rts {
+            policy.distribution.fill_backends(set);
+        }
+    }
+
+    impl TryFrom<outbound::proxy_protocol::Tls> for Tls {
+        type Error = InvalidTlsRoute;
+        fn try_from(proto: outbound::proxy_protocol::Tls) -> Result<Self, Self::Error> {
+            let routes = proto
+                .routes
+                .into_iter()
+                .map(try_route)
+                .collect::<Result<Arc<[_]>, _>>()?;
+            Ok(Self { routes })
+        }
+    }
+
+    fn try_route(proto: outbound::TlsRoute) -> Result<Route, InvalidTlsRoute> {
+        let outbound::TlsRoute {
+            snis,
+            rules,
+            metadata,
+        } = proto;
+        let meta = Arc::new(
+            metadata
+                .ok_or(InvalidMeta("missing metadata"))?
+                .try_into()?,
+        );
+        let snis = snis
+            .into_iter()
+            .map(sni::MatchSni::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+
+        // Currently, TLS rules have no match expressions, so if there's
+        // more than one rule, we have no way of determining which one to
+        // use. Therefore, require that there's exactly one rule.
+        if rules.len() != 1 {
+            return Err(InvalidTlsRoute::OnlyOneRule(rules.len()));
+        }
+
+        let policy = rules
+            .into_iter()
+            .map(|rule| try_rule(&meta, rule))
+            .next()
+            .ok_or(InvalidTlsRoute::OnlyOneRule(0))??;
+
+        Ok(Route { snis, policy })
+    }
+
+    fn try_rule(
+        meta: &Arc<Meta>,
+        outbound::tls_route::Rule { backends, .. }: outbound::tls_route::Rule,
+    ) -> Result<Policy, InvalidTlsRoute> {
+        let distribution = backends
+            .ok_or(InvalidTlsRoute::Missing("distribution"))?
+            .try_into()?;
+
+        Ok(Policy {
+            meta: meta.clone(),
+            filters: NO_FILTERS.clone(),
+            distribution,
+            params: (),
+        })
+    }
+
+    impl TryFrom<tls_route::Distribution> for RouteDistribution<Filter> {
+        type Error = InvalidDistribution;
+        fn try_from(distribution: tls_route::Distribution) -> Result<Self, Self::Error> {
+            use tls_route::{distribution, WeightedRouteBackend};
+
+            Ok(
+                match distribution.kind.ok_or(InvalidDistribution::Missing)? {
+                    distribution::Kind::Empty(_) => RouteDistribution::Empty,
+                    distribution::Kind::RandomAvailable(distribution::RandomAvailable {
+                        backends,
+                    }) => {
+                        let backends = backends
+                            .into_iter()
+                            .map(|WeightedRouteBackend { weight, backend }| {
+                                let backend = backend
+                                    .ok_or(InvalidDistribution::MissingBackend)?
+                                    .try_into()?;
+                                Ok((backend, weight))
+                            })
+                            .collect::<Result<Arc<[_]>, InvalidDistribution>>()?;
+                        if backends.is_empty() {
+                            return Err(InvalidDistribution::Empty("RandomAvailable"));
+                        }
+                        RouteDistribution::RandomAvailable(backends)
+                    }
+                    distribution::Kind::FirstAvailable(distribution::FirstAvailable {
+                        backends,
+                    }) => {
+                        let backends = backends
+                            .into_iter()
+                            .map(RouteBackend::try_from)
+                            .collect::<Result<Arc<[_]>, InvalidBackend>>()?;
+                        if backends.is_empty() {
+                            return Err(InvalidDistribution::Empty("FirstAvailable"));
+                        }
+                        RouteDistribution::FirstAvailable(backends)
+                    }
+                },
+            )
+        }
+    }
+
+    impl TryFrom<tls_route::RouteBackend> for RouteBackend<Filter> {
+        type Error = InvalidBackend;
+        fn try_from(
+            tls_route::RouteBackend { backend }: tls_route::RouteBackend,
+        ) -> Result<Self, Self::Error> {
+            let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
+            RouteBackend::try_from_proto(backend, std::iter::empty::<()>())
+        }
+    }
+
+    // Necessary to satisfy `RouteBackend::try_from_proto` type constraints.
+    // TODO(eliza): if filters are added to tls routes, change this to a
+    // proper `TryFrom` impl...
+    impl From<()> for Filter {
+        fn from(_: ()) -> Self {
+            unreachable!("no filters can be configured on tls routes yet")
+        }
+    }
+}

--- a/linkerd/tls/route/Cargo.toml
+++ b/linkerd/tls/route/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "linkerd-tls-route"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[features]
+proto = ["linkerd2-proxy-api"]
+
+[dependencies]
+regex = "1"
+rand = "0.8"
+thiserror = "1"
+tracing = "0.1"
+linkerd-tls = { path = "../" }
+linkerd-dns = { path = "../../dns" }
+
+[dependencies.linkerd2-proxy-api]
+features = ["http-route", "grpc-route", "tls-route"]
+workspace = true
+optional = true
+
+[dev-dependencies]
+maplit = "1"

--- a/linkerd/tls/route/src/lib.rs
+++ b/linkerd/tls/route/src/lib.rs
@@ -1,0 +1,57 @@
+//! An TLS route matching library for Linkerd to support the TLSRoute
+//! Kubernetes Gateway API types.
+
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
+#![forbid(unsafe_code)]
+
+use linkerd_tls::ServerName;
+use tracing::trace;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct SessionInfo {
+    pub sni: ServerName,
+}
+
+pub mod sni;
+pub use self::sni::{InvalidSni, MatchSni, SniMatch};
+
+/// Groups routing rules under a common set of SNIs.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct Route<P> {
+    pub snis: Vec<MatchSni>,
+    pub policy: P,
+}
+
+/// Summarizes a matched route so that route matches may be compared/ordered. A
+/// greater match is preferred over a lesser match.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RouteMatch {
+    sni: SniMatch,
+}
+
+pub fn find<P>(routes: &[Route<P>], session_info: SessionInfo) -> Option<(RouteMatch, &P)> {
+    trace!(routes = ?routes.len(), "Finding matching route");
+
+    best(routes.iter().filter_map(|rt| {
+        trace!(snis = ?rt.snis);
+
+        let sni = if rt.snis.is_empty() {
+            None
+        } else {
+            trace!(%session_info.sni, "matching sni");
+            rt.snis
+                .iter()
+                .filter_map(|a| a.summarize_match(session_info.sni.clone()))
+                .max()
+        }?;
+
+        Some((RouteMatch { sni }, &rt.policy))
+    }))
+}
+
+#[inline]
+fn best<M: Ord, P>(matches: impl Iterator<Item = (M, P)>) -> Option<(M, P)> {
+    // This is roughly equivalent to `max_by(...)` but we want to ensure
+    // that the first match wins.
+    matches.reduce(|(m0, p0), (m1, p1)| if m0 >= m1 { (m0, p0) } else { (m1, p1) })
+}

--- a/linkerd/tls/route/src/sni.rs
+++ b/linkerd/tls/route/src/sni.rs
@@ -1,0 +1,119 @@
+use linkerd_dns as dns;
+use linkerd_tls::ServerName;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum MatchSni {
+    Exact(String),
+
+    /// Tokenized reverse list of DNS name suffix labels.
+    ///
+    /// For example: the match `*.example.com` is stored as `["com",
+    /// "example"]`.
+    Suffix(Vec<String>),
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum SniMatch {
+    Exact(usize),
+    Suffix(usize),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum InvalidSni {
+    #[error("invalid sni: {0}")]
+    Invalid(#[from] dns::InvalidName),
+}
+
+// === impl MatchSni ===
+
+impl std::str::FromStr for MatchSni {
+    type Err = InvalidSni;
+
+    fn from_str(sni: &str) -> Result<Self, Self::Err> {
+        if let Some(sni) = sni.strip_prefix("*.") {
+            return Ok(Self::Suffix(
+                sni.split('.').map(|s| s.to_string()).rev().collect(),
+            ));
+        }
+
+        Ok(Self::Exact(sni.to_string()))
+    }
+}
+
+impl MatchSni {
+    pub fn summarize_match(&self, sni: ServerName) -> Option<SniMatch> {
+        let mut sni = sni.as_str();
+
+        match self {
+            Self::Exact(h) => {
+                if !h.ends_with('.') {
+                    sni = sni.strip_suffix('.').unwrap_or(sni);
+                }
+                if h == sni {
+                    Some(SniMatch::Exact(h.len()))
+                } else {
+                    None
+                }
+            }
+
+            Self::Suffix(suffix) => {
+                if suffix.first().map(|s| &**s) != Some("") {
+                    sni = sni.strip_suffix('.').unwrap_or(sni);
+                }
+                let mut length = 0;
+                for sfx in suffix.iter() {
+                    sni = sni.strip_suffix(sfx)?;
+                    sni = sni.strip_suffix('.')?;
+                    length += sfx.len() + 1;
+                }
+
+                Some(SniMatch::Suffix(length))
+            }
+        }
+    }
+}
+
+// === impl SniMatch ===
+
+impl std::cmp::PartialOrd for SniMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for SniMatch {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match (self, other) {
+            (Self::Exact(l), Self::Exact(r)) => l.cmp(r),
+            (Self::Suffix(l), Self::Suffix(r)) => l.cmp(r),
+            (Self::Exact(_), Self::Suffix(_)) => Ordering::Greater,
+            (Self::Suffix(_), Self::Exact(_)) => Ordering::Less,
+        }
+    }
+}
+
+#[cfg(feature = "proto")]
+pub mod proto {
+    use super::*;
+    use linkerd2_proxy_api::tls_route as api;
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum InvalidSniMatch {
+        #[error("sni match must contain a match")]
+        Missing,
+    }
+
+    // === impl MatchSni ===
+
+    impl TryFrom<api::SniMatch> for MatchSni {
+        type Error = InvalidSniMatch;
+
+        fn try_from(hm: api::SniMatch) -> Result<Self, Self::Error> {
+            match hm.r#match.ok_or(InvalidSniMatch::Missing)? {
+                api::sni_match::Match::Exact(h) => Ok(MatchSni::Exact(h)),
+                api::sni_match::Match::Suffix(sfx) => Ok(MatchSni::Suffix(sfx.reverse_labels)),
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a draft of the TLS routing stack. At the moment there are no TLS-specific metrics. In order to test we rely on config provided upon linkerd installation that allows the proxy to build default TLS fallback policy. To test: 

1. Use the this linkerd branch: https://github.com/linkerd/linkerd2/tree/zd/tls-routes
2. Create a cluster
3. Install Linkerd with: 
```
linkerd install --set tlsHosts="*.org" --set tlsPorts="443"   | kubectl apply -f -
```
4. Build the proxy: `docker buildx build . -t proxy:tls`
5. Use the following client container pod:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: client
  annotations:
    linkerd.io/inject: enabled
    config.linkerd.io/proxy-log-level: debug
    config.linkerd.io/proxy-image: proxy
    config.linkerd.io/proxy-version: tls
  labels:
    app: client
spec:
  containers:
  - name: client
    image: radial/busyboxplus:curl
    command:
      - "sh"
      - "-c"
      - >
        while true; do
          sleep 3600;
        done
```
6. Exec into the pod `kubectl exec -c client --stdin --tty client  -- sh`
7. Convince yourself that you can hit a website that is in the allowed hosts:
```
[ root@client:/ ]$ curl https://httpbin.org:443/get
{
  "args": {},
  "headers": {
    "Accept": "*/*",
    "Host": "httpbin.org",
    "User-Agent": "curl/7.35.0",
    "X-Amzn-Trace-Id": "Root=1-66bb1f68-563591fa56339f4f7109ab20"
  },
  "origin": "51.116.126.217",
  "url": "https://httpbin.org/get"
}
```
8. Convince yourself that you cannot hit a website that is not in the allowed hosts:
```
[ root@client:/ ]$ curl https://google.com:443
curl: (35) Unknown SSL protocol error in connection to google.com:443
```