### PR TITLE
Implement setting TCP_USER_TIMEOUT option for TCP sockets

### DIFF
--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -2,7 +2,7 @@ pub use crate::exp_backoff::ExponentialBackoff;
 use crate::{
     proxy::http::{self, h1, h2},
     svc::{queue, CloneParam, ExtractParam, Param},
-    transport::{DualListenAddr, Keepalive, ListenAddr},
+    transport::{DualListenAddr, Keepalive, UserTimeout, ListenAddr},
 };
 use std::time::Duration;
 
@@ -10,6 +10,7 @@ use std::time::Duration;
 pub struct ServerConfig {
     pub addr: DualListenAddr,
     pub keepalive: Keepalive,
+    pub user_timeout: UserTimeout,
     pub http2: h2::ServerParams,
 }
 
@@ -18,6 +19,7 @@ pub struct ConnectConfig {
     pub backoff: ExponentialBackoff,
     pub timeout: Duration,
     pub keepalive: Keepalive,
+    pub user_timeout: UserTimeout,
     pub http1: h1::PoolSettings,
     pub http2: h2::ClientParams,
 }
@@ -82,5 +84,11 @@ impl Param<ListenAddr> for ServerConfig {
 impl Param<Keepalive> for ServerConfig {
     fn param(&self) -> Keepalive {
         self.keepalive
+    }
+}
+
+impl Param<UserTimeout> for ServerConfig {
+    fn param(&self) -> UserTimeout {
+        self.user_timeout
     }
 }

--- a/linkerd/app/core/src/config.rs
+++ b/linkerd/app/core/src/config.rs
@@ -2,7 +2,7 @@ pub use crate::exp_backoff::ExponentialBackoff;
 use crate::{
     proxy::http::{self, h1, h2},
     svc::{queue, CloneParam, ExtractParam, Param},
-    transport::{DualListenAddr, Keepalive, UserTimeout, ListenAddr},
+    transport::{DualListenAddr, Keepalive, ListenAddr, UserTimeout},
 };
 use std::time::Duration;
 

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -124,17 +124,16 @@ impl Config {
             }
         };
 
-        let client =
-            svc::stack(ConnectTcp::new(
-                self.connect.keepalive,
-                self.connect.user_timeout,
-            ))
-            .push(tls::Client::layer(identity))
-            .push_connect_timeout(self.connect.timeout)
-            .push_map_target(|(_version, target)| target)
-            .push(self::client::layer(self.connect.http2))
-            .push_on_service(svc::MapErr::layer_boxed())
-            .into_new_service();
+        let client = svc::stack(ConnectTcp::new(
+            self.connect.keepalive,
+            self.connect.user_timeout,
+        ))
+        .push(tls::Client::layer(identity))
+        .push_connect_timeout(self.connect.timeout)
+        .push_map_target(|(_version, target)| target)
+        .push(self::client::layer(self.connect.http2))
+        .push_on_service(svc::MapErr::layer_boxed())
+        .into_new_service();
 
         let endpoint = client
             // Ensure that connection is driven independently of the load

--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -124,7 +124,11 @@ impl Config {
             }
         };
 
-        let client = svc::stack(ConnectTcp::new(self.connect.keepalive))
+        let client =
+            svc::stack(ConnectTcp::new(
+                self.connect.keepalive,
+                self.connect.user_timeout,
+            ))
             .push(tls::Client::layer(identity))
             .push_connect_timeout(self.connect.timeout)
             .push_map_target(|(_version, target)| target)

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -201,6 +201,7 @@ impl Inbound<()> {
             // forwarding and HTTP proxying).
             let ConnectConfig {
                 ref keepalive,
+                ref user_timeout,
                 ref timeout,
                 ..
             } = config.proxy.connect;
@@ -209,7 +210,7 @@ impl Inbound<()> {
             #[error("inbound connection must not target port {0}")]
             struct Loop(u16);
 
-            svc::stack(transport::ConnectTcp::new(*keepalive))
+            svc::stack(transport::ConnectTcp::new(*keepalive, *user_timeout))
                 // Limits the time we wait for a connection to be established.
                 .push_connect_timeout(*timeout)
                 // Prevent connections that would target the inbound proxy port from looping.

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -10,7 +10,7 @@ use linkerd_app_core::{
         http::{h1, h2},
         tap,
     },
-    transport::{DualListenAddr, Keepalive},
+    transport::{DualListenAddr, Keepalive, UserTimeout},
     ProxyRuntime,
 };
 pub use linkerd_app_test as support;
@@ -59,10 +59,12 @@ pub fn default_config() -> Config {
             server: config::ServerConfig {
                 addr: DualListenAddr(([0, 0, 0, 0], 0).into(), None),
                 keepalive: Keepalive(None),
+                user_timeout: UserTimeout(None),
                 http2: h2::ServerParams::default(),
             },
             connect: config::ConnectConfig {
                 keepalive: Keepalive(None),
+                user_timeout: UserTimeout(None),
                 timeout: Duration::from_secs(1),
                 backoff: exp_backoff::ExponentialBackoff::try_new(
                     Duration::from_millis(100),

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -1,7 +1,7 @@
 use super::*;
 use linkerd_app_core::{
     svc::Param,
-    transport::{listen, orig_dst, Keepalive, ListenAddr, Local, OrigDstAddr, ServerAddr},
+    transport::{listen, orig_dst, Keepalive, UserTimeout, ListenAddr, Local, OrigDstAddr, ServerAddr},
     Result,
 };
 use std::{collections::HashSet, thread};
@@ -68,7 +68,7 @@ struct MockDualOrigDst {
 
 impl<T> listen::Bind<T> for MockOrigDst
 where
-    T: Param<Keepalive> + Param<ListenAddr>,
+    T: Param<Keepalive> + Param<UserTimeout> + Param<ListenAddr>,
 {
     type Addrs = orig_dst::Addrs;
     type BoundAddrs = Local<ServerAddr>;
@@ -118,7 +118,7 @@ impl fmt::Debug for MockOrigDst {
 
 impl<T> listen::Bind<T> for MockDualOrigDst
 where
-    T: Param<Keepalive> + Param<ListenAddr>,
+    T: Param<Keepalive> + Param<UserTimeout> + Param<ListenAddr>,
 {
     type Addrs = orig_dst::Addrs;
     type BoundAddrs = (Local<ServerAddr>, Option<Local<ServerAddr>>);

--- a/linkerd/app/integration/src/proxy.rs
+++ b/linkerd/app/integration/src/proxy.rs
@@ -1,7 +1,9 @@
 use super::*;
 use linkerd_app_core::{
     svc::Param,
-    transport::{listen, orig_dst, Keepalive, UserTimeout, ListenAddr, Local, OrigDstAddr, ServerAddr},
+    transport::{
+        listen, orig_dst, Keepalive, ListenAddr, Local, OrigDstAddr, ServerAddr, UserTimeout,
+    },
     Result,
 };
 use std::{collections::HashSet, thread};

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -21,7 +21,10 @@ pub struct PreventLoopback<S>(S);
 
 impl Outbound<()> {
     pub fn to_tcp_connect(&self) -> Outbound<PreventLoopback<ConnectTcp>> {
-        let connect = PreventLoopback(ConnectTcp::new(self.config.proxy.connect.keepalive));
+        let connect = PreventLoopback(ConnectTcp::new(
+            self.config.proxy.connect.keepalive,
+            self.config.proxy.connect.user_timeout,
+        ));
         self.clone().with_stack(connect)
     }
 }

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -7,7 +7,7 @@ use linkerd_app_core::{
         http::{h1, h2},
         tap,
     },
-    transport::{DualListenAddr, Keepalive},
+    transport::{DualListenAddr, Keepalive, UserTimeout},
     IpMatch, IpNet, ProxyRuntime,
 };
 pub use linkerd_app_test as support;
@@ -26,10 +26,12 @@ pub(crate) fn default_config() -> Config {
             server: config::ServerConfig {
                 addr: DualListenAddr(([0, 0, 0, 0], 0).into(), None),
                 keepalive: Keepalive(None),
+                user_timeout: UserTimeout(None),
                 http2: h2::ServerParams::default(),
             },
             connect: config::ConnectConfig {
                 keepalive: Keepalive(None),
+                user_timeout: UserTimeout(None),
                 timeout: Duration::from_secs(1),
                 backoff: exp_backoff::ExponentialBackoff::try_new(
                     Duration::from_millis(100),

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -5,7 +5,7 @@ use linkerd_app_core::{
     control::{Config as ControlConfig, ControlAddr},
     proxy::http::{h1, h2},
     tls,
-    transport::{DualListenAddr, Keepalive, UserTimeout, ListenAddr},
+    transport::{DualListenAddr, Keepalive, ListenAddr, UserTimeout},
     AddrMatch, Conditional, IpNet,
 };
 use std::{
@@ -380,11 +380,15 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let inbound_connect_keepalive = parse(strings, ENV_INBOUND_CONNECT_KEEPALIVE, parse_duration);
     let outbound_connect_keepalive = parse(strings, ENV_OUTBOUND_CONNECT_KEEPALIVE, parse_duration);
 
-    let inbound_accept_user_timeout = parse(strings, ENV_INBOUND_ACCEPT_USER_TIMEOUT, parse_duration);
-    let outbound_accept_user_timeout = parse(strings, ENV_OUTBOUND_ACCEPT_USER_TIMEOUT, parse_duration);
+    let inbound_accept_user_timeout =
+        parse(strings, ENV_INBOUND_ACCEPT_USER_TIMEOUT, parse_duration);
+    let outbound_accept_user_timeout =
+        parse(strings, ENV_OUTBOUND_ACCEPT_USER_TIMEOUT, parse_duration);
 
-    let inbound_connect_user_timeout = parse(strings, ENV_INBOUND_CONNECT_USER_TIMEOUT, parse_duration);
-    let outbound_connect_user_timeout = parse(strings, ENV_OUTBOUND_CONNECT_USER_TIMEOUT, parse_duration);
+    let inbound_connect_user_timeout =
+        parse(strings, ENV_INBOUND_CONNECT_USER_TIMEOUT, parse_duration);
+    let outbound_connect_user_timeout =
+        parse(strings, ENV_OUTBOUND_CONNECT_USER_TIMEOUT, parse_duration);
 
     let shutdown_grace_period = parse(strings, ENV_SHUTDOWN_GRACE_PERIOD, parse_duration);
 

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -5,7 +5,7 @@ use linkerd_app_core::{
     control::{Config as ControlConfig, ControlAddr},
     proxy::http::{h1, h2},
     tls,
-    transport::{DualListenAddr, Keepalive, ListenAddr},
+    transport::{DualListenAddr, Keepalive, UserTimeout, ListenAddr},
     AddrMatch, Conditional, IpNet,
 };
 use std::{
@@ -128,6 +128,12 @@ const ENV_OUTBOUND_ACCEPT_KEEPALIVE: &str = "LINKERD2_PROXY_OUTBOUND_ACCEPT_KEEP
 
 const ENV_INBOUND_CONNECT_KEEPALIVE: &str = "LINKERD2_PROXY_INBOUND_CONNECT_KEEPALIVE";
 const ENV_OUTBOUND_CONNECT_KEEPALIVE: &str = "LINKERD2_PROXY_OUTBOUND_CONNECT_KEEPALIVE";
+
+const ENV_INBOUND_ACCEPT_USER_TIMEOUT: &str = "LINKERD2_PROXY_INBOUND_ACCEPT_USER_TIMEOUT";
+const ENV_OUTBOUND_ACCEPT_USER_TIMEOUT: &str = "LINKERD2_PROXY_OUTBOUND_ACCEPT_USER_TIMEOUT";
+
+const ENV_INBOUND_CONNECT_USER_TIMEOUT: &str = "LINKERD2_PROXY_INBOUND_CONNECT_USER_TIMEOUT";
+const ENV_OUTBOUND_CONNECT_USER_TIMEOUT: &str = "LINKERD2_PROXY_OUTBOUND_CONNECT_USER_TIMEOUT";
 
 const ENV_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: &str = "LINKERD2_PROXY_MAX_IDLE_CONNS_PER_ENDPOINT";
 const ENV_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: &str =
@@ -374,6 +380,12 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let inbound_connect_keepalive = parse(strings, ENV_INBOUND_CONNECT_KEEPALIVE, parse_duration);
     let outbound_connect_keepalive = parse(strings, ENV_OUTBOUND_CONNECT_KEEPALIVE, parse_duration);
 
+    let inbound_accept_user_timeout = parse(strings, ENV_INBOUND_ACCEPT_USER_TIMEOUT, parse_duration);
+    let outbound_accept_user_timeout = parse(strings, ENV_OUTBOUND_ACCEPT_USER_TIMEOUT, parse_duration);
+
+    let inbound_connect_user_timeout = parse(strings, ENV_INBOUND_CONNECT_USER_TIMEOUT, parse_duration);
+    let outbound_connect_user_timeout = parse(strings, ENV_OUTBOUND_CONNECT_USER_TIMEOUT, parse_duration);
+
     let shutdown_grace_period = parse(strings, ENV_SHUTDOWN_GRACE_PERIOD, parse_duration);
 
     let inbound_discovery_idle_timeout =
@@ -477,9 +489,11 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         };
 
         let keepalive = Keepalive(outbound_accept_keepalive?);
+        let user_timeout = UserTimeout(outbound_accept_user_timeout?);
         let server = ServerConfig {
             addr,
             keepalive,
+            user_timeout,
             http2: http2::parse_server(strings, "LINKERD2_PROXY_OUTBOUND_SERVER_HTTP2")?,
         };
         let discovery_idle_timeout =
@@ -487,6 +501,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         let max_idle =
             outbound_max_idle_per_endpoint?.unwrap_or(DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT);
         let keepalive = Keepalive(outbound_connect_keepalive?);
+        let user_timeout = UserTimeout(outbound_connect_user_timeout?);
         let connection_pool_timeout = parse(
             strings,
             ENV_OUTBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT,
@@ -495,6 +510,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
         let connect = ConnectConfig {
             keepalive,
+            user_timeout,
             timeout: outbound_connect_timeout?.unwrap_or(DEFAULT_OUTBOUND_CONNECT_TIMEOUT),
             backoff: parse_backoff(
                 strings,
@@ -565,9 +581,11 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             None,
         );
         let keepalive = Keepalive(inbound_accept_keepalive?);
+        let user_timeout = UserTimeout(inbound_accept_user_timeout?);
         let server = ServerConfig {
             addr,
             keepalive,
+            user_timeout,
             http2: http2::parse_server(strings, "LINKERD2_PROXY_INBOUND_SERVER_HTTP2")?,
         };
         let discovery_idle_timeout =
@@ -581,8 +599,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         )?
         .unwrap_or(DEFAULT_INBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT);
         let keepalive = Keepalive(inbound_connect_keepalive?);
+        let user_timeout = UserTimeout(inbound_connect_user_timeout?);
         let connect = ConnectConfig {
             keepalive,
+            user_timeout,
             timeout: inbound_connect_timeout?.unwrap_or(DEFAULT_INBOUND_CONNECT_TIMEOUT),
             backoff: parse_backoff(
                 strings,
@@ -769,6 +789,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         server: ServerConfig {
             addr: DualListenAddr(admin_listener_addr, None),
             keepalive: inbound.proxy.server.keepalive,
+            user_timeout: inbound.proxy.server.user_timeout,
             http2: inbound.proxy.server.http2.clone(),
         },
 
@@ -829,6 +850,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             config: ServerConfig {
                 addr: DualListenAddr(addr, None),
                 keepalive: inbound.proxy.server.keepalive,
+                user_timeout: inbound.proxy.server.user_timeout,
                 http2: inbound.proxy.server.http2.clone(),
             },
         })

--- a/linkerd/meshtls/tests/util.rs
+++ b/linkerd/meshtls/tests/util.rs
@@ -11,7 +11,7 @@ use linkerd_meshtls as meshtls;
 use linkerd_proxy_transport::{
     addrs::*,
     listen::{Addrs, Bind, BindTcp},
-    ConnectTcp, Keepalive,
+    ConnectTcp, Keepalive, UserTimeout,
 };
 use linkerd_stack::{
     layer::Layer, service_fn, ExtractParam, InsertParam, NewService, Param, ServiceExt,
@@ -283,7 +283,7 @@ where
         let tls = Some(client_server_id.clone());
         let client = async move {
             let conn = tls::Client::layer(client_tls)
-                .layer(ConnectTcp::new(Keepalive(None)))
+                .layer(ConnectTcp::new(Keepalive(None), UserTimeout(None)))
                 .oneshot(Target(server_addr.into(), client_server_id))
                 .await;
             match conn {
@@ -404,6 +404,11 @@ impl Param<ListenAddr> for Server {
 impl Param<Keepalive> for Server {
     fn param(&self) -> Keepalive {
         Keepalive(None)
+    }
+}
+impl Param<UserTimeout> for Server {
+    fn param(&self) -> UserTimeout {
+        UserTimeout(None)
     }
 }
 

--- a/linkerd/proxy/transport/src/connect.rs
+++ b/linkerd/proxy/transport/src/connect.rs
@@ -12,12 +12,15 @@ use tracing::debug;
 #[derive(Copy, Clone, Debug)]
 pub struct ConnectTcp {
     keepalive: Keepalive,
-    user_timeout: UserTimeout
+    user_timeout: UserTimeout,
 }
 
 impl ConnectTcp {
     pub fn new(keepalive: Keepalive, user_timeout: UserTimeout) -> Self {
-        Self { keepalive, user_timeout }
+        Self {
+            keepalive,
+            user_timeout,
+        }
     }
 }
 

--- a/linkerd/proxy/transport/src/connect.rs
+++ b/linkerd/proxy/transport/src/connect.rs
@@ -1,4 +1,4 @@
-use crate::{ClientAddr, Keepalive, Local, Remote, ServerAddr};
+use crate::{ClientAddr, Keepalive, Local, Remote, ServerAddr, UserTimeout};
 use linkerd_io as io;
 use linkerd_stack::{Param, Service};
 use std::{
@@ -12,11 +12,12 @@ use tracing::debug;
 #[derive(Copy, Clone, Debug)]
 pub struct ConnectTcp {
     keepalive: Keepalive,
+    user_timeout: UserTimeout
 }
 
 impl ConnectTcp {
-    pub fn new(keepalive: Keepalive) -> Self {
-        Self { keepalive }
+    pub fn new(keepalive: Keepalive, user_timeout: UserTimeout) -> Self {
+        Self { keepalive, user_timeout }
     }
 }
 
@@ -31,12 +32,14 @@ impl<T: Param<Remote<ServerAddr>>> Service<T> for ConnectTcp {
 
     fn call(&mut self, t: T) -> Self::Future {
         let Keepalive(keepalive) = self.keepalive;
+        let UserTimeout(user_timeout) = self.user_timeout;
         let Remote(ServerAddr(addr)) = t.param();
         debug!(server.addr = %addr, "Connecting");
         Box::pin(async move {
             let io = TcpStream::connect(&addr).await?;
             super::set_nodelay_or_warn(&io);
             let io = super::set_keepalive_or_warn(io, keepalive)?;
+            let io = super::set_user_timeout_or_warn(io, user_timeout)?;
             let local_addr = io.local_addr()?;
             debug!(
                 local.addr = %local_addr,

--- a/linkerd/proxy/transport/src/listen.rs
+++ b/linkerd/proxy/transport/src/listen.rs
@@ -93,7 +93,8 @@ where
             let tcp = res.map_err(AcceptError)?;
             super::set_nodelay_or_warn(&tcp);
             let tcp = super::set_keepalive_or_warn(tcp, keepalive).map_err(KeepaliveError)?;
-            let tcp = super::set_user_timeout_or_warn(tcp, user_timeout).map_err(UserTimeoutError)?;
+            let tcp =
+                super::set_user_timeout_or_warn(tcp, user_timeout).map_err(UserTimeoutError)?;
 
             fn ipv4_mapped(orig: SocketAddr) -> SocketAddr {
                 if let SocketAddr::V6(v6) = orig {

--- a/linkerd/proxy/transport/src/listen/dual_bind.rs
+++ b/linkerd/proxy/transport/src/listen/dual_bind.rs
@@ -1,4 +1,4 @@
-use crate::{addrs::DualListenAddr, listen::Bind, Keepalive, ListenAddr};
+use crate::{addrs::DualListenAddr, listen::Bind, Keepalive, ListenAddr, UserTimeout};
 use futures::Stream;
 use linkerd_error::Result;
 use linkerd_stack::Param;
@@ -26,7 +26,7 @@ impl<B> From<B> for DualBind<B> {
 
 impl<T, B> Bind<T> for DualBind<B>
 where
-    T: Param<DualListenAddr> + Param<Keepalive> + Clone,
+    T: Param<DualListenAddr> + Param<Keepalive> + Param<UserTimeout> + Clone,
     B: Bind<Listen<T>, Io = TcpStream> + Clone + 'static,
 {
     type Addrs = B::Addrs;
@@ -58,6 +58,12 @@ where
 
 impl<T: Param<Keepalive>> Param<Keepalive> for Listen<T> {
     fn param(&self) -> Keepalive {
+        self.parent.param()
+    }
+}
+
+impl<T: Param<UserTimeout>> Param<UserTimeout> for Listen<T> {
+    fn param(&self) -> UserTimeout {
         self.parent.param()
     }
 }


### PR DESCRIPTION
Implement setting TCP_USER_TIMEOUT option for TCP sockets

To ensure stable connection and exclude dangling connections set TCP_USER_TIMEOUT for each TCP socket for inbound, outbound and to control-plane traffic. UserTimeout configured in same way as Keepalive for ServerConfig and ConnectConfig. if setting UserTimeout failed - there will be warning to console

Fixes [#13023](https://github.com/linkerd/linkerd2/issues/13023)