### PR TITLE
Add wall clock gauge to proxy metrics

### DIFF
--- a/linkerd/identity/src/metrics.rs
+++ b/linkerd/identity/src/metrics.rs
@@ -37,14 +37,6 @@ impl CertMetrics {
             refresh_ts.clone(),
         );
 
-        let clock_time_ts = prom::Gauge::<f64, ClockMetric>::default();
-        registry.register_with_unit(
-            "clock_time",
-            "Current system time for this proxy",
-            prom::Unit::Seconds,
-            clock_time_ts,
-        );
-
         #[derive(Clone, Debug, PartialEq, Eq, Hash, prom::encoding::EncodeLabelSet)]
         struct RefreshLabelSet {
             result: RefreshResult,
@@ -77,44 +69,6 @@ impl CertMetrics {
             expiry_ts,
             refreshes,
             errors,
-        }
-    }
-}
-
-// Metric that always reports the current system time on a call to [`get`].
-#[derive(Copy, Clone, Debug, Default)]
-struct ClockMetric;
-
-impl prom::GaugeAtomic<f64> for ClockMetric {
-    fn inc(&self) -> f64 {
-        self.get()
-    }
-
-    fn inc_by(&self, _v: f64) -> f64 {
-        self.get()
-    }
-
-    fn dec(&self) -> f64 {
-        self.get()
-    }
-
-    fn dec_by(&self, _v: f64) -> f64 {
-        self.get()
-    }
-
-    fn set(&self, _v: f64) -> f64 {
-        self.get()
-    }
-
-    fn get(&self) -> f64 {
-        match SystemTime::now().duration_since(UNIX_EPOCH) {
-            Ok(elapsed) => elapsed.as_secs_f64().floor(),
-            Err(e) => {
-                tracing::warn!(
-                    "System time is before the UNIX epoch; reporting negative timestamp"
-                );
-                -e.duration().as_secs_f64().floor()
-            }
         }
     }
 }

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -36,7 +36,7 @@ pub mod prom {
         metrics::{
             counter::{ConstCounter, Counter},
             family::Family,
-            gauge::{ConstGauge, Gauge},
+            gauge::{Atomic as GaugeAtomic, ConstGauge, Gauge},
             histogram::Histogram,
             info::Info,
         },

--- a/linkerd/metrics/src/process.rs
+++ b/linkerd/metrics/src/process.rs
@@ -15,6 +15,14 @@ pub fn register(reg: &mut prom::Registry) {
         prom::ConstGauge::new(start_time_from_epoch.as_secs_f64()),
     );
 
+    let clock_time_ts = prom::Gauge::<f64, ClockMetric>::default();
+    reg.register_with_unit(
+        "clock_time",
+        "Current system time for this proxy",
+        prom::Unit::Seconds,
+        clock_time_ts,
+    );
+
     reg.register_collector(Box::new(ProcessCollector {
         start_time,
         #[cfg(target_os = "linux")]
@@ -53,6 +61,44 @@ impl prom::collector::Collector for ProcessCollector {
         self.system.encode(encoder)?;
 
         Ok(())
+    }
+}
+
+// Metric that always reports the current system time on a call to [`get`].
+#[derive(Copy, Clone, Debug, Default)]
+struct ClockMetric;
+
+impl prom::GaugeAtomic<f64> for ClockMetric {
+    fn inc(&self) -> f64 {
+        self.get()
+    }
+
+    fn inc_by(&self, _v: f64) -> f64 {
+        self.get()
+    }
+
+    fn dec(&self) -> f64 {
+        self.get()
+    }
+
+    fn dec_by(&self, _v: f64) -> f64 {
+        self.get()
+    }
+
+    fn set(&self, _v: f64) -> f64 {
+        self.get()
+    }
+
+    fn get(&self) -> f64 {
+        match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(elapsed) => elapsed.as_secs_f64().floor(),
+            Err(e) => {
+                tracing::warn!(
+                    "System time is before the UNIX epoch; reporting negative timestamp"
+                );
+                -e.duration().as_secs_f64().floor()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Currently, it's not possible to accurately calculate the time remaining before the proxy certificate expires, since the proxy didn't expose its view of what the time is. This exposes the wall clock time (rounded to the nearest second) as a gauge so downstream consumers can calculate the offsets for cert expiry, as well as any other offsets for timestamps we provide.

Example metrics output:
```
$ curl http://whoami.default:4191/metrics | grep process_clock_time
...
# HELP process_clock_time_seconds Current system time for this proxy.
# TYPE process_clock_time_seconds gauge
# UNIT process_clock_time_seconds seconds
process_clock_time_seconds 1725565062.0
```

Fixes [#12413](https://github.com/linkerd/linkerd2/issues/12413)