### PR TITLE
chore(gitignore): ignore npm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+node_modules/**
+package-lock.json
+package.json
 target
 **/target
 **/corpus


### PR DESCRIPTION
the devcontainers cli is installed via npm. this means that some npm related artifacts (a package.json, package.lock, and a node_modules directory) may be present if starting, building, or attaching to containers outside of vs code.

this commit adds these npm artifacts to the gitignore.

see <https://github.com/devcontainers/cli>.