### PR TITLE
feat(tls-route): add TLS route matching crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,6 +2191,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkerd-tls-route"
+version = "0.1.0"
+dependencies = [
+ "linkerd-dns",
+ "linkerd-tls",
+ "rand",
+ "regex",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "linkerd-tls-test-util"
 version = "0.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ members = [
     "linkerd/tonic-stream",
     "linkerd/tonic-watch",
     "linkerd/tls",
+    "linkerd/tls/route",
     "linkerd/tls/test-util",
     "linkerd/tracing",
     "linkerd/transport-header",

--- a/linkerd/tls/route/Cargo.toml
+++ b/linkerd/tls/route/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "linkerd-tls-route"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+regex = "1"
+rand = "0.8"
+thiserror = "1"
+tracing = "0.1"
+linkerd-tls = { path = "../" }
+linkerd-dns = { path = "../../dns" }

--- a/linkerd/tls/route/src/lib.rs
+++ b/linkerd/tls/route/src/lib.rs
@@ -64,11 +64,14 @@ pub fn find<P>(routes: &[Route<P>], session_info: SessionInfo) -> Option<(RouteM
         let sni = if rt.snis.is_empty() {
             None
         } else {
-            trace!(%session_info.sni, "matching sni");
-            rt.snis
+            let session_sni = &session_info.sni;
+            trace!(%session_sni, "matching sni");
+            let sni_match = rt
+                .snis
                 .iter()
-                .filter_map(|a| a.summarize_match(&session_info.sni))
-                .max()
+                .filter_map(|a| a.summarize_match(session_sni))
+                .max()?;
+            Some(sni_match)
         };
 
         trace!(rules = %rt.rules.len());

--- a/linkerd/tls/route/src/lib.rs
+++ b/linkerd/tls/route/src/lib.rs
@@ -8,11 +8,6 @@ use linkerd_tls::ServerName;
 use r#match::SessionMatch;
 use tracing::trace;
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct SessionInfo {
-    pub sni: ServerName,
-}
-
 pub mod r#match;
 pub mod sni;
 #[cfg(test)]
@@ -51,6 +46,14 @@ pub struct Rule<P> {
 pub struct RouteMatch {
     sni: Option<SniMatch>,
     route: r#match::SessionMatch,
+}
+
+/// Provides metadata information about a TLS session. For now this contains
+/// only the SNI value but further down the line, we could add more metadata
+/// if want to support more advanced routing scenarios.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct SessionInfo {
+    pub sni: ServerName,
 }
 
 pub fn find<P>(routes: &[Route<P>], session_info: SessionInfo) -> Option<(RouteMatch, &P)> {

--- a/linkerd/tls/route/src/lib.rs
+++ b/linkerd/tls/route/src/lib.rs
@@ -1,0 +1,100 @@
+//! An TLS route matching library for Linkerd to support the TLSRoute
+//! Kubernetes Gateway API types.
+
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
+#![forbid(unsafe_code)]
+
+use linkerd_tls::ServerName;
+use r#match::SessionMatch;
+use tracing::trace;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct SessionInfo {
+    pub sni: ServerName,
+}
+
+pub mod r#match;
+pub mod sni;
+#[cfg(test)]
+mod tests;
+
+pub use self::sni::{InvalidSni, MatchSni, SniMatch};
+
+/// Groups routing rules under a common set of SNIs.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct Route<P> {
+    /// A list of SNIs that this route applies to, to be matched against,
+    ///
+    /// If at least one match is specified, any match may apply for rules to applied.
+    /// When no SNI matches are present, all SNIs match.
+    pub snis: Vec<MatchSni>,
+
+    /// Must not be empty.
+    pub rules: Vec<Rule<P>>,
+}
+
+/// Policies for a given set of route matches.
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct Rule<P> {
+    /// A list of session matchers, *any* of which may apply.
+    ///
+    /// The "best" match is used when comparing rules.
+    pub matches: Vec<r#match::MatchSession>,
+
+    /// The policy to apply to sessions matched by this rule.
+    pub policy: P,
+}
+
+/// Summarizes a matched route so that route matches may be compared/ordered. A
+/// greater match is preferred over a lesser match.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub struct RouteMatch {
+    sni: Option<SniMatch>,
+    route: r#match::SessionMatch,
+}
+
+pub fn find<P>(routes: &[Route<P>], session_info: SessionInfo) -> Option<(RouteMatch, &P)> {
+    trace!(routes = ?routes.len(), "Finding matching route");
+
+    best(routes.iter().filter_map(|rt| {
+        trace!(snis = ?rt.snis);
+        let sni = if rt.snis.is_empty() {
+            None
+        } else {
+            trace!(%session_info.sni, "matching sni");
+            rt.snis
+                .iter()
+                .filter_map(|a| a.summarize_match(&session_info.sni))
+                .max()
+        };
+
+        trace!(rules = %rt.rules.len());
+        let (route, policy) = best(rt.rules.iter().filter_map(|rule| {
+            // If there are no matches in the list, then the rule has an
+            // implicit default match.
+            if rule.matches.is_empty() {
+                trace!("implicit match");
+                return Some((SessionMatch::default(), &rule.policy));
+            }
+            // Find the best match to compare against other rules/routes
+            // (if any apply). The order/precedence of matches is not
+            // relevant.
+            let summary = rule
+                .matches
+                .iter()
+                .filter_map(|m| m.match_session(&session_info))
+                .max()?;
+            trace!("matches!");
+            Some((summary, &rule.policy))
+        }))?;
+
+        Some((RouteMatch { sni, route }, policy))
+    }))
+}
+
+#[inline]
+fn best<M: Ord, P>(matches: impl Iterator<Item = (M, P)>) -> Option<(M, P)> {
+    // This is roughly equivalent to `max_by(...)` but we want to ensure
+    // that the first match wins.
+    matches.reduce(|(m0, p0), (m1, p1)| if m0 >= m1 { (m0, p0) } else { (m1, p1) })
+}

--- a/linkerd/tls/route/src/match.rs
+++ b/linkerd/tls/route/src/match.rs
@@ -1,0 +1,50 @@
+use crate::{MatchSni, SessionInfo, SniMatch};
+
+/// Matches TLS sessions.
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct MatchSession {
+    pub sni: Option<MatchSni>,
+}
+
+/// Summarizes a matched TLS session.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct SessionMatch {
+    sni: SniMatch,
+}
+
+impl MatchSession {
+    pub(crate) fn match_session(&self, info: &SessionInfo) -> Option<SessionMatch> {
+        let mut summary = SessionMatch::default();
+
+        if let Some(match_sni) = &self.sni {
+            if let Some(sni) = match_sni.summarize_match(&info.sni) {
+                summary.sni = sni;
+            } else {
+                return None;
+            }
+        }
+        Some(summary)
+    }
+}
+
+// === impl SessionMatch ===
+
+impl Default for SessionMatch {
+    fn default() -> Self {
+        Self {
+            sni: SniMatch::Exact(0),
+        }
+    }
+}
+
+impl std::cmp::PartialOrd for SessionMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for SessionMatch {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.sni.cmp(&other.sni)
+    }
+}

--- a/linkerd/tls/route/src/match.rs
+++ b/linkerd/tls/route/src/match.rs
@@ -1,39 +1,18 @@
-use crate::{MatchSni, SessionInfo, SniMatch};
+use std::cmp::Ordering;
 
-/// Matches TLS sessions.
+use crate::SessionInfo;
+
+/// Matches TLS sessions. For now, this is a placeholder
 #[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
-pub struct MatchSession {
-    pub sni: Option<MatchSni>,
-}
+pub struct MatchSession(());
 
-/// Summarizes a matched TLS session.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-pub struct SessionMatch {
-    sni: SniMatch,
-}
+/// Summarizes a matched TLS session. For now this is a placeholder
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Default)]
+pub struct SessionMatch(());
 
 impl MatchSession {
-    pub(crate) fn match_session(&self, info: &SessionInfo) -> Option<SessionMatch> {
-        let mut summary = SessionMatch::default();
-
-        if let Some(match_sni) = &self.sni {
-            if let Some(sni) = match_sni.summarize_match(&info.sni) {
-                summary.sni = sni;
-            } else {
-                return None;
-            }
-        }
-        Some(summary)
-    }
-}
-
-// === impl SessionMatch ===
-
-impl Default for SessionMatch {
-    fn default() -> Self {
-        Self {
-            sni: SniMatch::Exact(0),
-        }
+    pub(crate) fn match_session(&self, _: &SessionInfo) -> Option<SessionMatch> {
+        Some(SessionMatch::default())
     }
 }
 
@@ -44,7 +23,7 @@ impl std::cmp::PartialOrd for SessionMatch {
 }
 
 impl std::cmp::Ord for SessionMatch {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.sni.cmp(&other.sni)
+    fn cmp(&self, _: &Self) -> std::cmp::Ordering {
+        Ordering::Equal
     }
 }

--- a/linkerd/tls/route/src/sni.rs
+++ b/linkerd/tls/route/src/sni.rs
@@ -1,6 +1,13 @@
 use linkerd_dns as dns;
 use linkerd_tls::ServerName;
 
+/// Defines a way to match against SNI attributes of the TLS ClientHello
+/// message in a TLS handshake. The SNI value being matched is the equivalent
+/// of a hostname (as defined in RFC 1123) with 2 notable exceptions:
+///
+/// 1. IPs are not allowed in SNI names per RFC 6066.
+/// 2. A hostname may be prefixed with a wildcard label (`*.`). The wildcard
+///    label must appear by itself as the first label.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum MatchSni {
     Exact(String),

--- a/linkerd/tls/route/src/sni.rs
+++ b/linkerd/tls/route/src/sni.rs
@@ -1,0 +1,94 @@
+use linkerd_dns as dns;
+use linkerd_tls::ServerName;
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum MatchSni {
+    Exact(String),
+
+    /// Tokenized reverse list of DNS name suffix labels.
+    ///
+    /// For example: the match `*.example.com` is stored as `["com",
+    /// "example"]`.
+    Suffix(Vec<String>),
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum SniMatch {
+    Exact(usize),
+    Suffix(usize),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum InvalidSni {
+    #[error("invalid sni: {0}")]
+    Invalid(#[from] dns::InvalidName),
+}
+
+// === impl MatchSni ===
+
+impl std::str::FromStr for MatchSni {
+    type Err = InvalidSni;
+
+    fn from_str(sni: &str) -> Result<Self, Self::Err> {
+        if let Some(sni) = sni.strip_prefix("*.") {
+            return Ok(Self::Suffix(
+                sni.split('.').map(|s| s.to_string()).rev().collect(),
+            ));
+        }
+
+        Ok(Self::Exact(sni.to_string()))
+    }
+}
+
+impl MatchSni {
+    pub fn summarize_match(&self, sni: &ServerName) -> Option<SniMatch> {
+        let mut sni = sni.as_str();
+
+        match self {
+            Self::Exact(h) => {
+                if !h.ends_with('.') {
+                    sni = sni.strip_suffix('.').unwrap_or(sni);
+                }
+                if h == sni {
+                    Some(SniMatch::Exact(h.len()))
+                } else {
+                    None
+                }
+            }
+
+            Self::Suffix(suffix) => {
+                if suffix.first().map(|s| &**s) != Some("") {
+                    sni = sni.strip_suffix('.').unwrap_or(sni);
+                }
+                let mut length = 0;
+                for sfx in suffix.iter() {
+                    sni = sni.strip_suffix(sfx)?;
+                    sni = sni.strip_suffix('.')?;
+                    length += sfx.len() + 1;
+                }
+
+                Some(SniMatch::Suffix(length))
+            }
+        }
+    }
+}
+
+// === impl SniMatch ===
+
+impl std::cmp::PartialOrd for SniMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for SniMatch {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        use std::cmp::Ordering;
+        match (self, other) {
+            (Self::Exact(l), Self::Exact(r)) => l.cmp(r),
+            (Self::Suffix(l), Self::Suffix(r)) => l.cmp(r),
+            (Self::Exact(_), Self::Suffix(_)) => Ordering::Greater,
+            (Self::Suffix(_), Self::Exact(_)) => Ordering::Less,
+        }
+    }
+}

--- a/linkerd/tls/route/src/tests.rs
+++ b/linkerd/tls/route/src/tests.rs
@@ -69,3 +69,47 @@ fn first_identical_wins() {
     let (_, policy) = find(&rts, si).expect("must match");
     assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
 }
+
+#[test]
+fn no_match_suffix() {
+    let rts = vec![Route {
+        snis: vec!["*.test.example.com".parse().unwrap()],
+        rules: vec![Rule {
+            policy: Policy::Unexpected,
+            matches: vec![],
+        }],
+    }];
+
+    let si = SessionInfo {
+        sni: "test.example.com".parse().expect("must parse"),
+    };
+
+    assert!(find(&rts, si).is_none(), "should have no matches");
+}
+
+#[test]
+fn no_match_exact() {
+    let rts = vec![Route {
+        snis: vec!["test.example.com".parse().unwrap()],
+        rules: vec![Rule {
+            policy: Policy::Unexpected,
+            matches: vec![],
+        }],
+    }];
+
+    let si = SessionInfo {
+        sni: "fest.example.com".parse().expect("must parse"),
+    };
+
+    assert!(find(&rts, si).is_none(), "should have no matches");
+}
+
+#[test]
+fn no_routes_no_match() {
+    let rts: Vec<Route<Policy>> = Vec::default();
+    let si = SessionInfo {
+        sni: "fest.example.com".parse().expect("must parse"),
+    };
+
+    assert!(find(&rts, si).is_none(), "should have no matches");
+}

--- a/linkerd/tls/route/src/tests.rs
+++ b/linkerd/tls/route/src/tests.rs
@@ -1,0 +1,148 @@
+use super::{r#match::*, *};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Policy {
+    Expected,
+    Unexpected,
+}
+
+impl Default for Policy {
+    fn default() -> Self {
+        Self::Unexpected
+    }
+}
+
+/// Given two equivalent routes, choose the explicit sni match and not
+/// the wildcard.
+#[test]
+fn sni_precedence_routes() {
+    let rts = vec![
+        Route {
+            snis: vec!["*.example.com".parse().unwrap()],
+            rules: vec![Rule {
+                policy: Policy::Unexpected,
+                matches: vec![],
+            }],
+        },
+        Route {
+            snis: vec!["foo.example.com".parse().unwrap()],
+            rules: vec![Rule {
+                policy: Policy::Expected,
+                matches: vec![],
+            }],
+        },
+    ];
+
+    let si = SessionInfo {
+        sni: "foo.example.com".parse().expect("must parse"),
+    };
+
+    let (_, policy) = find(&rts, si).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}
+
+/// Given two equivalent rules, choose the explicit sni match and not
+/// the wildcard.
+#[test]
+fn sni_precedence_rules() {
+    let rts = vec![Route {
+        snis: vec!["*.com".parse().unwrap()],
+        rules: vec![
+            Rule {
+                policy: Policy::Expected,
+                matches: vec![MatchSession {
+                    sni: Some("foo.example.com".parse().unwrap()),
+                }],
+            },
+            Rule {
+                policy: Policy::Unexpected,
+                matches: vec![MatchSession {
+                    sni: Some("*.example.com".parse().unwrap()),
+                }],
+            },
+        ],
+    }];
+
+    let si = SessionInfo {
+        sni: "foo.example.com".parse().expect("must parse"),
+    };
+
+    let (_, policy) = find(&rts, si).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}
+
+#[test]
+fn choose_from_multiple_routes_and_rules() {
+    let rts = vec![
+        Route {
+            snis: vec!["*.com".parse().unwrap()],
+            rules: vec![
+                Rule {
+                    policy: Policy::Unexpected,
+                    matches: vec![MatchSession {
+                        sni: Some("foo.example.com".parse().unwrap()),
+                    }],
+                },
+                Rule {
+                    policy: Policy::Unexpected,
+                    matches: vec![MatchSession {
+                        sni: Some("*.example.com".parse().unwrap()),
+                    }],
+                },
+            ],
+        },
+        Route {
+            snis: vec!["*.io".parse().unwrap()],
+            rules: vec![
+                Rule {
+                    policy: Policy::Unexpected,
+                    matches: vec![MatchSession {
+                        sni: Some("*.github.io".parse().unwrap()),
+                    }],
+                },
+                Rule {
+                    policy: Policy::Expected,
+                    matches: vec![MatchSession {
+                        sni: Some("api.github.io".parse().unwrap()),
+                    }],
+                },
+            ],
+        },
+    ];
+
+    let si = SessionInfo {
+        sni: "api.github.io".parse().expect("must parse"),
+    };
+
+    let (_, policy) = find(&rts, si).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}
+
+#[test]
+fn first_identical_wins() {
+    let rts = vec![
+        Route {
+            rules: vec![
+                Rule {
+                    policy: Policy::Expected,
+                    ..Rule::default()
+                },
+                // Redundant rule.
+                Rule::default(),
+            ],
+            snis: vec![],
+        },
+        // Redundant route.
+        Route {
+            rules: vec![Rule::default()],
+            snis: vec![],
+        },
+    ];
+
+    let si = SessionInfo {
+        sni: "api.github.io".parse().expect("must parse"),
+    };
+
+    let (_, policy) = find(&rts, si).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+}


### PR DESCRIPTION
This PR includes a nonfunctional change that adds a TLS route-matching library.
The library works similarly to the http-route one but instead of relying on HTTP concepts
such as paths, headers, etc is specific to TLS ones (i.e. SNI).

At the moment the library is capable of matching routes based on SNIs.