### PR TITLE
policy: add TLS protocol type to client-policy crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,6 +1865,7 @@ dependencies = [
  "linkerd-http-route",
  "linkerd-proxy-api-resolve",
  "linkerd-proxy-core",
+ "linkerd-tls-route",
  "linkerd2-proxy-api",
  "maplit",
  "once_cell",

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = { version = "1", optional = true }
 linkerd-error = { path = "../../error" }
 linkerd-exp-backoff = { path = "../../exp-backoff" }
 linkerd-http-route = { path = "../../http/route" }
+linkerd-tls-route = { path = "../../tls/route" }
 linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }
 

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -7,6 +7,7 @@ use std::{borrow::Cow, fmt, hash::Hash, net::SocketAddr, num::NonZeroU16, sync::
 pub mod grpc;
 pub mod http;
 pub mod opaq;
+pub mod tls;
 
 pub use linkerd_http_route as route;
 pub use linkerd_proxy_api_resolve::Metadata as EndpointMetadata;
@@ -34,8 +35,7 @@ pub enum Protocol {
 
     Opaque(opaq::Opaque),
 
-    // TODO(ver) TLS-aware type
-    Tls(opaq::Opaque),
+    Tls(tls::Tls),
 }
 
 #[derive(Clone, Debug, Eq)]
@@ -497,7 +497,10 @@ pub mod proto {
                 | Protocol::Http2(http::Http2 { ref routes, .. }) => {
                     http::proto::fill_route_backends(routes, &mut backends);
                 }
-                Protocol::Opaque(ref p) | Protocol::Tls(ref p) => {
+                Protocol::Opaque(ref p) => {
+                    p.fill_backends(&mut backends);
+                }
+                Protocol::Tls(ref p) => {
                     p.fill_backends(&mut backends);
                 }
                 Protocol::Grpc(ref p) => {

--- a/linkerd/proxy/client-policy/src/tls.rs
+++ b/linkerd/proxy/client-policy/src/tls.rs
@@ -1,0 +1,55 @@
+use linkerd_tls_route as tls;
+use std::sync::Arc;
+
+pub use linkerd_tls_route::{find, sni, RouteMatch};
+
+pub type Policy = crate::RoutePolicy<Filter, ()>;
+pub type Route = tls::Route<Policy>;
+pub type Rule = tls::Rule<Policy>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Tls {
+    pub routes: Arc<[Route]>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Filter {}
+
+pub fn default(distribution: crate::RouteDistribution<Filter>) -> Route {
+    Route {
+        snis: vec![],
+        rules: vec![Rule {
+            matches: vec![],
+            policy: Policy {
+                meta: crate::Meta::new_default("default"),
+                filters: Arc::new([]),
+                params: (),
+                distribution,
+            },
+        }],
+    }
+}
+
+impl Default for Tls {
+    fn default() -> Self {
+        Self {
+            routes: Arc::new([]),
+        }
+    }
+}
+
+#[cfg(feature = "proto")]
+pub mod proto {
+    use super::*;
+    use crate::proto::BackendSet;
+
+    impl Tls {
+        pub fn fill_backends(&self, set: &mut BackendSet) {
+            for Route { ref rules, .. } in &*self.routes {
+                for Rule { ref policy, .. } in rules {
+                    policy.distribution.fill_backends(set);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
In preparation for adding Tls routing, this change updates our `client-policy` crate with a `Protocol::Tls` variant.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>