### PR TITLE
fix(retry): Avoid panicking if responses come early

### DIFF
--- a/linkerd/http/retry/src/lib.rs
+++ b/linkerd/http/retry/src/lib.rs
@@ -268,8 +268,13 @@ async fn send_req_with_retries(
         tracing::trace!("Success on first attempt");
         return result.map(|rsp| rsp.map(BoxBody::new));
     }
-    if backup.body().is_capped() {
-        return result.map(|rsp| rsp.map(BoxBody::new));
+    match backup.body().is_capped() {
+        // The body completely fit into the retry buffer, so we can retry.
+        Some(false) => {}
+        // The body was either too large, or we received an early response
+        // before the request body was completed read. We cannot safely
+        // attempt to send this request again.
+        None | Some(true) => return result.map(|rsp| rsp.map(BoxBody::new)),
     }
 
     // The response was retryable, so continue trying to dispatch backup
@@ -300,8 +305,9 @@ async fn send_req_with_retries(
             tracing::debug!("Retry success");
             return result.map(|rsp| rsp.map(BoxBody::new));
         }
-        if backup.body().is_capped() {
-            return result.map(|rsp| rsp.map(BoxBody::new));
+        match backup.body().is_capped() {
+            Some(false) => {}
+            None | Some(true) => return result.map(|rsp| rsp.map(BoxBody::new)),
         }
     }
 


### PR DESCRIPTION
`linkerd-http-retry` and `linkerd-retry` provide generic `tower`
middleware to allow services to retry requests that fail.

part of this middleware hinges on a `ReplayBody<B>` that will lazily
buffer request bodies' data for use in subsequent attempts. if a request
fails, the retry middleware will attempt to send another request,
assuming the original body was able to completely fit into this buffer.

`ReplayBody<B>` makes a subtle assummption, most succinctly stated in
this excerpt of an internal method's documentation:

```rust
// linkerd/http/retry/src/replay.rs
impl<B: Body> ReplayBody<B> {
    /// This panics if another clone has currently acquired the state, based on
    /// the assumption that a retry body will not be polled until the previous
    /// request has been dropped.
        fn acquire_state<'a>(
        state: &'a mut Option<BodyState<B>>,
        shared: &Mutex<Option<BodyState<B>>>,
    ) -> &'a mut BodyState<B> {
        // ...
    }
}
```

this assumption is slightly at odds with the request/response lifecycle
permitted within the HTTP/2 specification. see RFC 9113 § 8.1, "_HTTP
Message Framing_" (emphasis added):

> An HTTP request/response exchange fully consumes a single stream. A
> request starts with the HEADERS frame that puts the stream into the
> "open" state. **The request ends with a frame with the END_STREAM flag
> set**, which causes the stream to become "half-closed (local)" for the
> client and "half-closed (remote)" for the server. A response stream
> starts with zero or more interim responses in HEADERS frames, followed
> by a HEADERS frame containing a final status code.
>
> An HTTP response is complete after the server sends -- or the client
> receives -- a frame with the END_STREAM flag set (including any
> CONTINUATION frames needed to complete a field block). **A server can
> send a complete response prior to the client sending an entire request
> if the response does not depend on any portion of the request that has
> not been sent and received.**

<https://www.rfc-editor.org/rfc/rfc9113.html#section-8.1-11>

because of this, a retry may panic when checking if the previous request
body was capped, if a server delivers a response before the request is
complete. this has been observed when retrying
[wire-grpc](https://github.com/square/wire) requests, manifesting in a
panic with this message:

```text
thread 'main' panicked at 'if our `state` was `None`, the shared state must be `Some`', /__w/linkerd2-proxy/linkerd2-proxy/linkerd/http-retry/src/replay.rs:152:22
```

this commit refactors `ReplayBody::is_capped()` so that it will no
longer panic if there is an outstanding body still being polled.
rather, it will return `Some(true)` or `Some(false)` if the previous
body was capped, or `None` if it has not finished streaming.

the related logic in the `linkerd-http-retry` library is updated to
refrain from attempting a retry if a response is received before the
request stream was completed.
