### PR TITLE
Group opentelemetry dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,10 @@ updates:
       - dependency-name: "wasm-bindgen"
       - dependency-name: "web-sys"
       - dependency-name: "windows*"
+    groups:
+      opentelemetry:
+        patterns:
+          - "opentelemetry*"
 
   - package-ecosystem: cargo
     directory: /linkerd/addr/fuzz


### PR DESCRIPTION
OpenTelemetry packages should always be updated in lockstep with each other. This tells dependabot to group dependency updates into a single PR: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups