### PR TITLE
chore(app): Disallow warnings in policy router's backend metrics

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -1,11 +1,5 @@
-#![allow(warnings)]
-
 use crate::{BackendRef, ParentRef, RouteRef};
-use futures::Stream;
-use linkerd_app_core::{
-    metrics::prom::{self, encoding::*, EncodeLabelSetMut},
-    svc,
-};
+use linkerd_app_core::{metrics::prom, svc};
 use linkerd_http_prom::{
     record_response::{self, NewResponseDuration, StreamLabel},
     NewCountRequests, RequestCount, RequestCountFamilies,

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
@@ -5,10 +5,8 @@ use super::{
     LabelGrpcRouteBackendRsp, LabelHttpRouteBackendRsp, RouteBackendMetrics,
 };
 use crate::http::{concrete, logical::Concrete};
-use linkerd2_proxy_api::outbound::backend;
 use linkerd_app_core::{
-    metrics::prom::Counter,
-    svc::{self, http::BoxBody, Layer, NewService, Service, ServiceExt},
+    svc::{self, http::BoxBody, Layer, NewService},
     transport::{Remote, ServerAddr},
 };
 use linkerd_proxy_client_policy as policy;


### PR DESCRIPTION
a stray `#![allow(warnings)]` directive seems to have slipped in from an initial prototyping phase.

this commit removes this directive from
`/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs`, and addresses the newly unearthed warnings, related to unused imports.