### PR TITLE
docs(integration): Document test environment interfaces

### DIFF
--- a/linkerd/app/integration/src/test_env.rs
+++ b/linkerd/app/integration/src/test_env.rs
@@ -1,6 +1,7 @@
 use linkerd_app::env::{EnvError, Strings};
 use std::collections::HashMap;
 
+/// An implementation of [`Strings`] that wraps for use in tests.
 #[derive(Clone, Default)]
 pub struct TestEnv {
     values: HashMap<&'static str, String>,
@@ -9,18 +10,22 @@ pub struct TestEnv {
 // === impl TestEnv ===
 
 impl TestEnv {
+    /// Puts a new key-value pair in the test environment.
     pub fn put(&mut self, key: &'static str, value: String) {
         self.values.insert(key, value);
     }
 
+    /// Returns true if this environment contains the given key.
     pub fn contains_key(&self, key: &'static str) -> bool {
         self.values.contains_key(key)
     }
 
+    /// Removes a new key-value pair from the test environment.
     pub fn remove(&mut self, key: &'static str) {
         self.values.remove(key);
     }
 
+    /// Extends this test environment using the other given [`TestEnv`].
     pub fn extend(&mut self, other: TestEnv) {
         self.values.extend(other.values);
     }


### PR DESCRIPTION
this is a documentation pass, fleshing out information about how the `TestEnv` interfaces work.