### PR TITLE
docs(http/prom): Fix broken doc links

### DIFF
--- a/linkerd/http/prom/src/count_reqs.rs
+++ b/linkerd/http/prom/src/count_reqs.rs
@@ -44,10 +44,10 @@ impl<X: Clone, N> NewCountRequests<X, N> {
         Self { extract, inner }
     }
 
-    /// Returns a [`Layer`] that counts requests.
+    /// Returns a [`Layer<S>`][svc::layer::Layer] that counts requests.
     ///
-    /// This uses an `X`-typed [`ExtractParam`] implementation to extract [`RequestCount`] from a
-    /// `T`-typed target.
+    /// This uses an `X`-typed [`ExtractParam<P, T>`][svc::ExtractParam] implementation to extract
+    /// [`RequestCount`] from a `T`-typed target.
     pub fn layer_via(extract: X) -> impl svc::layer::Layer<N, Service = Self> + Clone {
         svc::layer::mk(move |inner| Self::new(extract.clone(), inner))
     }


### PR DESCRIPTION
<https://github.com/linkerd/linkerd2-proxy/pull/3228/files>

this fixes some links, added in #3228, because i observed github actions warning about these in a different pr. pardon me! 😅