### PR TITLE
refactor(prom): Remove `MkStreamLabel`'s associated types

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -173,8 +173,6 @@ impl<T> filters::Apply for Http<T> {
 }
 
 impl<T> metrics::MkStreamLabel for Http<T> {
-    type StatusLabels = metrics::labels::HttpRouteRsp;
-    type DurationLabels = metrics::labels::Route;
     type StreamLabel = metrics::LabelHttpRouteRsp;
 
     fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
@@ -227,8 +225,6 @@ impl<T> filters::Apply for Grpc<T> {
 }
 
 impl<T> metrics::MkStreamLabel for Grpc<T> {
-    type StatusLabels = metrics::labels::GrpcRouteRsp;
-    type DurationLabels = metrics::labels::Route;
     type StreamLabel = metrics::LabelGrpcRouteRsp;
 
     fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -148,8 +148,6 @@ impl<T> filters::Apply for Http<T> {
 }
 
 impl<T> metrics::MkStreamLabel for Http<T> {
-    type StatusLabels = metrics::labels::HttpRouteBackendRsp;
-    type DurationLabels = metrics::labels::RouteBackend;
     type StreamLabel = metrics::LabelHttpRouteBackendRsp;
 
     fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
@@ -176,8 +174,6 @@ impl<T> filters::Apply for Grpc<T> {
 }
 
 impl<T> metrics::MkStreamLabel for Grpc<T> {
-    type StatusLabels = metrics::labels::GrpcRouteBackendRsp;
-    type DurationLabels = metrics::labels::RouteBackend;
     type StreamLabel = metrics::LabelGrpcRouteBackendRsp;
 
     fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
@@ -13,14 +13,6 @@ pub struct RouteBackend(pub ParentRef, pub RouteRef, pub BackendRef);
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Rsp<P, L>(pub P, pub L);
 
-pub type RouteRsp<L> = Rsp<Route, L>;
-pub type HttpRouteRsp = RouteRsp<HttpRsp>;
-pub type GrpcRouteRsp = RouteRsp<GrpcRsp>;
-
-pub type RouteBackendRsp<L> = Rsp<RouteBackend, L>;
-pub type HttpRouteBackendRsp = RouteBackendRsp<HttpRsp>;
-pub type GrpcRouteBackendRsp = RouteBackendRsp<GrpcRsp>;
-
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct HttpRsp {
     pub status: Option<http::StatusCode>,

--- a/linkerd/http/prom/src/record_response.rs
+++ b/linkerd/http/prom/src/record_response.rs
@@ -32,27 +32,7 @@ pub use self::{
 /// This is specifically to support higher-cardinality status counters and
 /// lower-cardinality stream duration histograms.
 pub trait MkStreamLabel {
-    type DurationLabels: EncodeLabelSet
-        + Clone
-        + Eq
-        + std::fmt::Debug
-        + std::hash::Hash
-        + Send
-        + Sync
-        + 'static;
-    type StatusLabels: EncodeLabelSet
-        + Clone
-        + Eq
-        + std::fmt::Debug
-        + std::hash::Hash
-        + Send
-        + Sync
-        + 'static;
-
-    type StreamLabel: StreamLabel<
-        DurationLabels = Self::DurationLabels,
-        StatusLabels = Self::StatusLabels,
-    >;
+    type StreamLabel: StreamLabel;
 
     /// Returns None when the request should not be recorded.
     fn mk_stream_labeler<B>(&self, req: &http::Request<B>) -> Option<Self::StreamLabel>;

--- a/linkerd/http/prom/src/record_response/request.rs
+++ b/linkerd/http/prom/src/record_response/request.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use tokio::{sync::oneshot, time};
 
-use super::{DurationFamily, MkDurationHistogram, MkStreamLabel};
+use super::{DurationFamily, MkDurationHistogram, MkStreamLabel, StreamLabel};
 
 /// Metrics type that tracks completed requests.
 #[derive(Debug)]
@@ -25,13 +25,19 @@ pub struct RequestMetrics<DurL, StatL> {
 pub type NewRequestDuration<L, X, N> = super::NewRecordResponse<
     L,
     X,
-    RequestMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    RequestMetrics<
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+    >,
     N,
 >;
 
 pub type RecordRequestDuration<L, S> = super::RecordResponse<
     L,
-    RequestMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    RequestMetrics<
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+    >,
     S,
 >;
 

--- a/linkerd/http/prom/src/record_response/response.rs
+++ b/linkerd/http/prom/src/record_response/response.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use tokio::{sync::oneshot, time};
 
-use super::{DurationFamily, MkDurationHistogram, MkStreamLabel};
+use super::{DurationFamily, MkDurationHistogram, MkStreamLabel, StreamLabel};
 
 #[derive(Debug)]
 pub struct ResponseMetrics<DurL, StatL> {
@@ -25,13 +25,19 @@ pub struct ResponseMetrics<DurL, StatL> {
 pub type NewResponseDuration<L, X, N> = super::NewRecordResponse<
     L,
     X,
-    ResponseMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    ResponseMetrics<
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+    >,
     N,
 >;
 
 pub type RecordResponseDuration<L, S> = super::RecordResponse<
     L,
-    ResponseMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    ResponseMetrics<
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+    >,
     S,
 >;
 


### PR DESCRIPTION
`MkStreamLabel` is, in short, a generic
`(&Request) -> Option<StreamLabel>` function. we use it to inspect a request, and potentially provide the caller with an object that can provide relevant labels.

the `StreamLabel` interface includes associated types for the labels used for metrics related to request/response duration, and counting status codes.

we do not however, actually need to separately define these associated types in the `MkStreamLabel` contract. instead, we can return a generic `StreamLabel` of some sort, and leave the responsibility of the (admittedly baroque) uniform function call access to our type aliases like `RecordResponseDuration` and `RecordRequestDuration`.

this is a small initial step towards simplifying code that must interact with the `MkStreamLabel` interface.