### PR TITLE
refactor(http/prom): Simplify `record_response` middleware

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -173,8 +173,6 @@ impl<T> filters::Apply for Http<T> {
 }
 
 impl<T> metrics::MkStreamLabel for Http<T> {
-    type StatusLabels = metrics::labels::HttpRouteRsp;
-    type DurationLabels = metrics::labels::Route;
     type StreamLabel = metrics::LabelHttpRouteRsp;
 
     fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
@@ -227,8 +225,6 @@ impl<T> filters::Apply for Grpc<T> {
 }
 
 impl<T> metrics::MkStreamLabel for Grpc<T> {
-    type StatusLabels = metrics::labels::GrpcRouteRsp;
-    type DurationLabels = metrics::labels::Route;
     type StreamLabel = metrics::LabelGrpcRouteRsp;
 
     fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {

--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -175,7 +175,7 @@ impl<T> filters::Apply for Http<T> {
 impl<T> metrics::MkStreamLabel for Http<T> {
     type StreamLabel = metrics::LabelHttpRouteRsp;
 
-    fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
+    fn mk_stream_labeler(&self, _: &::http::request::Parts) -> Option<Self::StreamLabel> {
         let parent = self.params.parent_ref.clone();
         let route = self.params.route_ref.clone();
         Some(metrics::LabelHttpRsp::from(metrics::labels::Route::from((
@@ -227,7 +227,7 @@ impl<T> filters::Apply for Grpc<T> {
 impl<T> metrics::MkStreamLabel for Grpc<T> {
     type StreamLabel = metrics::LabelGrpcRouteRsp;
 
-    fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
+    fn mk_stream_labeler(&self, _: &::http::request::Parts) -> Option<Self::StreamLabel> {
         let parent = self.params.parent_ref.clone();
         let route = self.params.route_ref.clone();
         Some(metrics::LabelGrpcRsp::from(metrics::labels::Route::from((

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -1,5 +1,5 @@
 use super::{super::Concrete, filters};
-use crate::{BackendRef, ParentRef, RouteRef};
+use crate::{http::logical::policy::route, BackendRef, ParentRef, RouteRef};
 use linkerd_app_core::{proxy::http, svc, Error, Result};
 use linkerd_http_prom as http_prom;
 use linkerd_http_route as http_route;
@@ -148,14 +148,14 @@ impl<T> filters::Apply for Http<T> {
 }
 
 impl<T> http_prom::MkStreamLabel for Http<T> {
-    type StreamLabel = metrics::LabelHttpRouteBackendRsp;
+    type StreamLabel = route::metrics::LabelHttpRouteBackendRsp;
 
     fn mk_stream_labeler(&self, _: &::http::request::Parts) -> Option<Self::StreamLabel> {
         let parent = self.params.concrete.parent_ref.clone();
         let route = self.params.route_ref.clone();
         let backend = self.params.concrete.backend_ref.clone();
-        Some(metrics::LabelHttpRsp::from(
-            metrics::labels::RouteBackend::from((parent, route, backend)),
+        Some(route::metrics::LabelHttpRsp::from(
+            route::metrics::labels::RouteBackend::from((parent, route, backend)),
         ))
     }
 }
@@ -174,14 +174,14 @@ impl<T> filters::Apply for Grpc<T> {
 }
 
 impl<T> http_prom::MkStreamLabel for Grpc<T> {
-    type StreamLabel = metrics::LabelGrpcRouteBackendRsp;
+    type StreamLabel = route::metrics::LabelGrpcRouteBackendRsp;
 
     fn mk_stream_labeler(&self, _: &::http::request::Parts) -> Option<Self::StreamLabel> {
         let parent = self.params.concrete.parent_ref.clone();
         let route = self.params.route_ref.clone();
         let backend = self.params.concrete.backend_ref.clone();
-        Some(metrics::LabelGrpcRsp::from(
-            metrics::labels::RouteBackend::from((parent, route, backend)),
+        Some(route::metrics::LabelGrpcRsp::from(
+            route::metrics::labels::RouteBackend::from((parent, route, backend)),
         ))
     }
 }

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -148,8 +148,6 @@ impl<T> filters::Apply for Http<T> {
 }
 
 impl<T> metrics::MkStreamLabel for Http<T> {
-    type StatusLabels = metrics::labels::HttpRouteBackendRsp;
-    type DurationLabels = metrics::labels::RouteBackend;
     type StreamLabel = metrics::LabelHttpRouteBackendRsp;
 
     fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
@@ -176,8 +174,6 @@ impl<T> filters::Apply for Grpc<T> {
 }
 
 impl<T> metrics::MkStreamLabel for Grpc<T> {
-    type StatusLabels = metrics::labels::GrpcRouteBackendRsp;
-    type DurationLabels = metrics::labels::RouteBackend;
     type StreamLabel = metrics::LabelGrpcRouteBackendRsp;
 
     fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -1,7 +1,7 @@
 use super::{super::Concrete, filters};
 use crate::{BackendRef, ParentRef, RouteRef};
 use linkerd_app_core::{proxy::http, svc, Error, Result};
-use linkerd_http_prom::record_response::MkStreamLabel;
+use linkerd_http_prom as http_prom;
 use linkerd_http_route as http_route;
 use linkerd_proxy_client_policy as policy;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
@@ -21,7 +21,7 @@ pub(crate) type Http<T> =
 pub(crate) type Grpc<T> =
     MatchedBackend<T, http_route::grpc::r#match::RouteMatch, policy::grpc::Filter>;
 
-pub type Metrics<T> = metrics::RouteBackendMetrics<<T as MkStreamLabel>::StreamLabel>;
+pub type Metrics<T> = metrics::RouteBackendMetrics<<T as http_prom::MkStreamLabel>::StreamLabel>;
 
 /// Wraps errors with backend metadata.
 #[derive(Debug, thiserror::Error)]
@@ -68,7 +68,7 @@ where
     F: Clone + Send + Sync + 'static,
     // Assert that filters can be applied.
     Self: filters::Apply,
-    Self: metrics::MkStreamLabel,
+    Self: http_prom::MkStreamLabel,
 {
     /// Builds a stack that applies per-route-backend policy filters over an
     /// inner [`Concrete`] stack.
@@ -147,7 +147,7 @@ impl<T> filters::Apply for Http<T> {
     }
 }
 
-impl<T> metrics::MkStreamLabel for Http<T> {
+impl<T> http_prom::MkStreamLabel for Http<T> {
     type StreamLabel = metrics::LabelHttpRouteBackendRsp;
 
     fn mk_stream_labeler(&self, _: &::http::request::Parts) -> Option<Self::StreamLabel> {
@@ -173,7 +173,7 @@ impl<T> filters::Apply for Grpc<T> {
     }
 }
 
-impl<T> metrics::MkStreamLabel for Grpc<T> {
+impl<T> http_prom::MkStreamLabel for Grpc<T> {
     type StreamLabel = metrics::LabelGrpcRouteBackendRsp;
 
     fn mk_stream_labeler(&self, _: &::http::request::Parts) -> Option<Self::StreamLabel> {

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -150,7 +150,7 @@ impl<T> filters::Apply for Http<T> {
 impl<T> metrics::MkStreamLabel for Http<T> {
     type StreamLabel = metrics::LabelHttpRouteBackendRsp;
 
-    fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
+    fn mk_stream_labeler(&self, _: &::http::request::Parts) -> Option<Self::StreamLabel> {
         let parent = self.params.concrete.parent_ref.clone();
         let route = self.params.route_ref.clone();
         let backend = self.params.concrete.backend_ref.clone();
@@ -176,7 +176,7 @@ impl<T> filters::Apply for Grpc<T> {
 impl<T> metrics::MkStreamLabel for Grpc<T> {
     type StreamLabel = metrics::LabelGrpcRouteBackendRsp;
 
-    fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
+    fn mk_stream_labeler(&self, _: &::http::request::Parts) -> Option<Self::StreamLabel> {
         let parent = self.params.concrete.parent_ref.clone();
         let route = self.params.route_ref.clone();
         let backend = self.params.concrete.backend_ref.clone();

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -1,12 +1,11 @@
 use crate::{BackendRef, ParentRef, RouteRef};
 use linkerd_app_core::{metrics::prom, svc};
 use linkerd_http_prom::{
-    record_response::{self, NewResponseDuration, StreamLabel},
+    record_response::{self, MkStreamLabel, NewResponseDuration, StreamLabel},
     NewCountRequests, RequestCount, RequestCountFamilies,
 };
 
 pub use super::super::metrics::*;
-pub use linkerd_http_prom::record_response::MkStreamLabel;
 
 #[cfg(test)]
 mod tests;

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -7,7 +7,7 @@ use crate::{
 use linkerd_app_core::{metrics::prom, svc};
 use linkerd_http_prom::{
     count_reqs::{NewCountRequests, RequestCount, RequestCountFamilies},
-    record_response::{self, MkStreamLabel, NewResponseDuration, StreamLabel},
+    record_response::{self, MkStreamLabel, NewResponseDuration, ResponseMetrics, StreamLabel},
 };
 
 #[cfg(test)]
@@ -18,11 +18,6 @@ pub struct RouteBackendMetrics<L: StreamLabel> {
     requests: RequestCountFamilies<labels::RouteBackend>,
     responses: ResponseMetrics<L>,
 }
-
-type ResponseMetrics<L> = record_response::ResponseMetrics<
-    <L as StreamLabel>::DurationLabels,
-    <L as StreamLabel>::StatusLabels,
->;
 
 pub fn layer<T, N>(
     metrics: &RouteBackendMetrics<T::StreamLabel>,

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -1,11 +1,14 @@
-use crate::{BackendRef, ParentRef, RouteRef};
+use crate::{
+    http::logical::policy::route::metrics::{
+        labels, ExtractRecordDurationParams, NewRecordDuration,
+    },
+    BackendRef, ParentRef, RouteRef,
+};
 use linkerd_app_core::{metrics::prom, svc};
 use linkerd_http_prom::{
     record_response::{self, MkStreamLabel, NewResponseDuration, StreamLabel},
     NewCountRequests, RequestCount, RequestCountFamilies,
 };
-
-pub use super::super::metrics::*;
 
 #[cfg(test)]
 mod tests;

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 use linkerd_app_core::{metrics::prom, svc};
 use linkerd_http_prom::{
+    count_reqs::{NewCountRequests, RequestCount, RequestCountFamilies},
     record_response::{self, MkStreamLabel, NewResponseDuration, StreamLabel},
-    NewCountRequests, RequestCount, RequestCountFamilies,
 };
 
 #[cfg(test)]
@@ -77,7 +77,7 @@ impl<L: StreamLabel> RouteBackendMetrics<L> {
         p: ParentRef,
         r: RouteRef,
         b: BackendRef,
-    ) -> linkerd_http_prom::RequestCount {
+    ) -> RequestCount {
         self.requests.metrics(&labels::RouteBackend(p, r, b))
     }
 

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
@@ -1,10 +1,16 @@
 use super::{
     super::{Backend, Grpc, Http},
-    labels,
-    test_util::*,
-    LabelGrpcRouteBackendRsp, LabelHttpRouteBackendRsp, RouteBackendMetrics,
+    RouteBackendMetrics,
 };
-use crate::http::{concrete, logical::Concrete};
+use crate::http::{
+    concrete,
+    logical::{
+        policy::route::metrics::{
+            labels, test_util::*, LabelGrpcRouteBackendRsp, LabelHttpRouteBackendRsp,
+        },
+        Concrete,
+    },
+};
 use linkerd_app_core::{
     svc::{self, http::BoxBody, Layer, NewService},
     transport::{Remote, ServerAddr},

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
@@ -3,9 +3,7 @@ use linkerd_app_core::{
     metrics::prom::{self, EncodeLabelSetMut},
     svc,
 };
-use linkerd_http_prom::record_response::{self, StreamLabel};
-
-pub use linkerd_http_prom::record_response::MkStreamLabel;
+use linkerd_http_prom::record_response::{self, MkStreamLabel, StreamLabel};
 
 pub mod labels;
 #[cfg(test)]

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
@@ -29,18 +29,34 @@ pub type HttpRouteMetrics = RouteMetrics<LabelHttpRouteRsp, LabelHttpRouteBacken
 pub type GrpcRouteMetrics = RouteMetrics<LabelGrpcRouteRsp, LabelGrpcRouteBackendRsp>;
 
 /// Tracks HTTP streams to produce response labels.
+///
+/// Provides a [`StreamLabel`] implementation to label response streams on both logical routes and
+/// concrete backends.
 #[derive(Clone, Debug)]
 pub struct LabelHttpRsp<L> {
+    /// The parent set of labels to which this response stream belongs.
     parent: L,
+    /// The response's HTTP status code.
     status: Option<http::StatusCode>,
+    /// The category of error, if applicable.
+    ///
+    /// This is `None` when no error occured.
     error: Option<labels::Error>,
 }
 
 /// Tracks gRPC streams to produce response labels.
+///
+/// Provides a [`StreamLabel`] implementation to label response streams on both logical routes and
+/// concrete backends.
 #[derive(Clone, Debug)]
 pub struct LabelGrpcRsp<L> {
+    /// The parent set of labels to which this response stream belongs.
     parent: L,
+    /// The response's gRPC status code.
     status: Option<tonic::Code>,
+    /// The category of error, if applicable.
+    ///
+    /// This is `None` when no error occured.
     error: Option<labels::Error>,
 }
 

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
@@ -182,8 +182,8 @@ where
     type StatusLabels = labels::Rsp<P, labels::HttpRsp>;
     type DurationLabels = P;
 
-    fn init_response<B>(&mut self, rsp: &http::Response<B>) {
-        self.status = Some(rsp.status());
+    fn init_response(&mut self, rsp: &http::response::Parts) {
+        self.status = Some(rsp.status);
     }
 
     fn end_response(&mut self, res: Result<Option<&http::HeaderMap>, &linkerd_app_core::Error>) {
@@ -233,9 +233,9 @@ where
     type StatusLabels = labels::Rsp<P, labels::GrpcRsp>;
     type DurationLabels = P;
 
-    fn init_response<B>(&mut self, rsp: &http::Response<B>) {
+    fn init_response(&mut self, rsp: &http::response::Parts) {
         self.status = rsp
-            .headers()
+            .headers
             .get("grpc-status")
             .map(|v| tonic::Code::from_bytes(v.as_bytes()));
     }

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
@@ -3,18 +3,13 @@ use linkerd_app_core::{
     metrics::prom::{self, EncodeLabelSetMut},
     svc,
 };
-use linkerd_http_prom::record_response::{self, MkStreamLabel, StreamLabel};
+use linkerd_http_prom::record_response::{self, MkStreamLabel, RequestMetrics, StreamLabel};
 
 pub mod labels;
 #[cfg(test)]
 pub(super) mod test_util;
 #[cfg(test)]
 mod tests;
-
-pub type RequestMetrics<R> = record_response::RequestMetrics<
-    <R as StreamLabel>::DurationLabels,
-    <R as StreamLabel>::StatusLabels,
->;
 
 #[derive(Debug)]
 pub struct RouteMetrics<R: StreamLabel, B: StreamLabel> {
@@ -141,7 +136,7 @@ impl<R: StreamLabel, B: StreamLabel> RouteMetrics<R, B> {
         p: crate::ParentRef,
         r: crate::RouteRef,
         b: crate::BackendRef,
-    ) -> linkerd_http_prom::RequestCount {
+    ) -> linkerd_http_prom::count_reqs::RequestCount {
         self.backend.backend_request_count(p, r, b)
     }
 }

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
@@ -13,14 +13,6 @@ pub struct RouteBackend(pub ParentRef, pub RouteRef, pub BackendRef);
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Rsp<P, L>(pub P, pub L);
 
-pub type RouteRsp<L> = Rsp<Route, L>;
-pub type HttpRouteRsp = RouteRsp<HttpRsp>;
-pub type GrpcRouteRsp = RouteRsp<GrpcRsp>;
-
-pub type RouteBackendRsp<L> = Rsp<RouteBackend, L>;
-pub type HttpRouteBackendRsp = RouteBackendRsp<HttpRsp>;
-pub type GrpcRouteBackendRsp = RouteBackendRsp<GrpcRsp>;
-
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct HttpRsp {
     pub status: Option<http::StatusCode>,

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
@@ -1,30 +1,44 @@
 //! Prometheus label types.
+//!
+//! This submodule contains types that implement [`EncodeLabelSet`], [`EncodeLabelSetMut`], and
+//! [`EncodeLabelValue`]. These may be used to work with a labeled
+//! [`Family`][prometheus_client::metrics::family::Family] of metrics.
+//!
+//! Use [`Family::get_or_create()`][prometheus_client::metrics::family::Family::get_or_create]
+//! to retrieve, or create should it not exist, a metric with a given set of label values.
+
 use linkerd_app_core::{errors, metrics::prom::EncodeLabelSetMut, proxy::http, Error as BoxError};
 use prometheus_client::encoding::*;
 
 use crate::{BackendRef, ParentRef, RouteRef};
 
+/// Prometheus labels for a route resource, usually a service.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Route(pub ParentRef, pub RouteRef);
 
+/// Prometheus labels for a backend resource.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct RouteBackend(pub ParentRef, pub RouteRef, pub BackendRef);
 
+/// Prometheus labels for a route's response.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Rsp<P, L>(pub P, pub L);
 
+/// Prometheus labels for an HTTP response.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct HttpRsp {
     pub status: Option<http::StatusCode>,
     pub error: Option<Error>,
 }
 
+/// Prometheus labels for a gRPC response.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GrpcRsp {
     pub status: Option<tonic::Code>,
     pub error: Option<Error>,
 }
 
+/// Prometheus labels representing an error.
 #[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum Error {
     FailFast,
@@ -170,6 +184,7 @@ impl EncodeLabelSet for GrpcRsp {
 // === impl Error ===
 
 impl Error {
+    /// Returns an [`Error`] or a status code, given a boxed error.
     pub fn new_or_status(error: &BoxError) -> Result<Self, u16> {
         use super::super::super::errors as policy;
         use crate::http::h2::{H2Error, Reason};

--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -7,6 +7,7 @@ use linkerd_app_core::{
     classify, proxy::http, svc, transport::addrs::*, Addr, Error, NameAddr, Result,
 };
 use linkerd_distribute as distribute;
+use linkerd_http_prom as http_prom;
 use linkerd_http_route as http_route;
 use linkerd_proxy_client_policy as policy;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
@@ -65,8 +66,8 @@ where
     route::MatchedRoute<T, M::Summary, F, P>: route::filters::Apply
         + svc::Param<classify::Request>
         + svc::Param<route::extensions::Params>
-        + route::metrics::MkStreamLabel,
-    route::MatchedBackend<T, M::Summary, F>: route::filters::Apply + route::metrics::MkStreamLabel,
+        + http_prom::MkStreamLabel,
+    route::MatchedBackend<T, M::Summary, F>: route::filters::Apply + http_prom::MkStreamLabel,
 {
     /// Builds a stack that applies routes to distribute requests over a cached
     /// set of inner services so that.

--- a/linkerd/http/prom/src/lib.rs
+++ b/linkerd/http/prom/src/lib.rs
@@ -1,10 +1,7 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
-mod count_reqs;
+pub mod count_reqs;
 pub mod record_response;
 
-pub use self::{
-    count_reqs::{CountRequests, NewCountRequests, RequestCount, RequestCountFamilies},
-    record_response::{MkStreamLabel, StreamLabel},
-};
+pub use self::record_response::{MkStreamLabel, StreamLabel};

--- a/linkerd/http/prom/src/lib.rs
+++ b/linkerd/http/prom/src/lib.rs
@@ -4,4 +4,7 @@
 mod count_reqs;
 pub mod record_response;
 
-pub use self::count_reqs::{CountRequests, NewCountRequests, RequestCount, RequestCountFamilies};
+pub use self::{
+    count_reqs::{CountRequests, NewCountRequests, RequestCount, RequestCountFamilies},
+    record_response::{MkStreamLabel, StreamLabel},
+};

--- a/linkerd/http/prom/src/record_response.rs
+++ b/linkerd/http/prom/src/record_response.rs
@@ -72,7 +72,7 @@ pub struct RequestCancelled(());
 pub struct NewRecordResponse<L, X, M, N> {
     inner: N,
     extract: X,
-    _marker: std::marker::PhantomData<(L, M)>,
+    _marker: std::marker::PhantomData<fn() -> (L, M)>,
 }
 
 /// A Service that can record a request/response durations.

--- a/linkerd/http/prom/src/record_response.rs
+++ b/linkerd/http/prom/src/record_response.rs
@@ -32,27 +32,7 @@ pub use self::{
 /// This is specifically to support higher-cardinality status counters and
 /// lower-cardinality stream duration histograms.
 pub trait MkStreamLabel {
-    type DurationLabels: EncodeLabelSet
-        + Clone
-        + Eq
-        + std::fmt::Debug
-        + std::hash::Hash
-        + Send
-        + Sync
-        + 'static;
-    type StatusLabels: EncodeLabelSet
-        + Clone
-        + Eq
-        + std::fmt::Debug
-        + std::hash::Hash
-        + Send
-        + Sync
-        + 'static;
-
-    type StreamLabel: StreamLabel<
-        DurationLabels = Self::DurationLabels,
-        StatusLabels = Self::StatusLabels,
-    >;
+    type StreamLabel: StreamLabel;
 
     /// Returns None when the request should not be recorded.
     fn mk_stream_labeler<B>(&self, req: &http::Request<B>) -> Option<Self::StreamLabel>;

--- a/linkerd/http/prom/src/record_response.rs
+++ b/linkerd/http/prom/src/record_response.rs
@@ -1,7 +1,4 @@
-use http_body::Body;
 use linkerd_error::Error;
-use linkerd_http_box::BoxBody;
-use linkerd_metrics::prom::Counter;
 use linkerd_stack as svc;
 use prometheus_client::{
     encoding::EncodeLabelSet,
@@ -10,20 +7,16 @@ use prometheus_client::{
         histogram::Histogram,
     },
 };
-use std::{
-    future::Future,
-    pin::Pin,
-    sync::Arc,
-    task::{Context, Poll},
-};
-use tokio::{sync::oneshot, time};
+use std::sync::Arc;
 
 mod request;
 mod response;
+mod response_future;
 
 pub use self::{
     request::{NewRequestDuration, RecordRequestDuration, RequestMetrics},
     response::{NewResponseDuration, RecordResponseDuration, ResponseMetrics},
+    response_future::{ResponseFuture, ResponseState},
 };
 
 /// A strategy for labeling request/responses streams for status and duration
@@ -88,40 +81,6 @@ pub struct RecordResponse<L, M, S> {
     inner: S,
     labeler: L,
     metric: M,
-}
-
-#[pin_project::pin_project]
-pub struct ResponseFuture<L, F>
-where
-    L: StreamLabel,
-{
-    #[pin]
-    inner: F,
-    state: Option<ResponseState<L>>,
-}
-
-/// Notifies the response labeler when the response body is flushed.
-#[pin_project::pin_project(PinnedDrop)]
-struct ResponseBody<L: StreamLabel> {
-    #[pin]
-    inner: BoxBody,
-    state: Option<ResponseState<L>>,
-}
-
-/// Inner state used by [`ResponseFuture`] and [`ResponseBody`].
-///
-/// This is used to update Prometheus metrics across the response's lifecycle.
-///
-/// This is generic across an `L`-typed [`StreamLabel`], which bears responsibility for labelling
-/// responses according to their status code and duration.
-struct ResponseState<L: StreamLabel> {
-    labeler: L,
-    /// The family of [`Counter`]s tracking response status code.
-    statuses: Family<L::StatusLabels, Counter>,
-    /// The family of [`Histogram`]s tracking response durations.
-    duration: DurationFamily<L::DurationLabels>,
-    /// Receives a timestamp noting when the service received a request.
-    start: oneshot::Receiver<time::Instant>,
 }
 
 /// A family of labeled duration histograms.
@@ -189,128 +148,4 @@ where
             inner,
         }
     }
-}
-
-// === impl ResponseFuture ===
-
-impl<L, F> Future for ResponseFuture<L, F>
-where
-    L: StreamLabel,
-    F: Future<Output = Result<http::Response<BoxBody>, Error>>,
-{
-    /// A [`ResponseFuture`] produces the same response as its inner `F`-typed future.
-    type Output = F::Output;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-
-        // Poll the inner future, returning if it isn't ready yet.
-        let res = futures::ready!(this.inner.poll(cx)).map_err(Into::into);
-
-        // We got a response back! Take our state, and examine the output.
-        let mut state = this.state.take();
-        match res {
-            Ok(rsp) => {
-                let (head, inner) = rsp.into_parts();
-                if let Some(ResponseState { labeler, .. }) = state.as_mut() {
-                    labeler.init_response(&head);
-                }
-
-                // Call `end_stream` if the body is empty.
-                if inner.is_end_stream() {
-                    end_stream(&mut state, Ok(None));
-                }
-                Poll::Ready(Ok(http::Response::from_parts(
-                    head,
-                    BoxBody::new(ResponseBody { inner, state }),
-                )))
-            }
-            Err(error) => {
-                end_stream(&mut state, Err(&error));
-                Poll::Ready(Err(error))
-            }
-        }
-    }
-}
-
-// === impl ResponseBody ===
-
-impl<L> http_body::Body for ResponseBody<L>
-where
-    L: StreamLabel,
-{
-    type Data = <BoxBody as http_body::Body>::Data;
-    type Error = Error;
-
-    fn poll_data(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Self::Data, Error>>> {
-        let mut this = self.project();
-        let res =
-            futures::ready!(this.inner.as_mut().poll_data(cx)).map(|res| res.map_err(Into::into));
-        if let Some(Err(error)) = res.as_ref() {
-            end_stream(this.state, Err(error));
-        } else if (*this.inner).is_end_stream() {
-            end_stream(this.state, Ok(None));
-        }
-        Poll::Ready(res)
-    }
-
-    fn poll_trailers(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<Option<http::HeaderMap>, Error>> {
-        let this = self.project();
-        let res = futures::ready!(this.inner.poll_trailers(cx)).map_err(Into::into);
-        end_stream(this.state, res.as_ref().map(Option::as_ref));
-        Poll::Ready(res)
-    }
-
-    fn is_end_stream(&self) -> bool {
-        self.inner.is_end_stream()
-    }
-}
-
-#[pin_project::pinned_drop]
-impl<L> PinnedDrop for ResponseBody<L>
-where
-    L: StreamLabel,
-{
-    fn drop(self: Pin<&mut Self>) {
-        let this = self.project();
-        if this.state.is_some() {
-            end_stream(this.state, Err(&RequestCancelled(()).into()));
-        }
-    }
-}
-
-fn end_stream<L>(
-    state: &mut Option<ResponseState<L>>,
-    res: Result<Option<&http::HeaderMap>, &Error>,
-) where
-    L: StreamLabel,
-{
-    let Some(ResponseState {
-        duration,
-        statuses: total,
-        mut start,
-        mut labeler,
-    }) = state.take()
-    else {
-        return;
-    };
-
-    labeler.end_response(res);
-
-    total.get_or_create(&labeler.status_labels()).inc();
-
-    let elapsed = if let Ok(start) = start.try_recv() {
-        time::Instant::now().saturating_duration_since(start)
-    } else {
-        time::Duration::ZERO
-    };
-    duration
-        .get_or_create(&labeler.duration_labels())
-        .observe(elapsed.as_secs_f64());
 }

--- a/linkerd/http/prom/src/record_response.rs
+++ b/linkerd/http/prom/src/record_response.rs
@@ -79,7 +79,7 @@ pub struct RequestCancelled(());
 pub struct NewRecordResponse<L, X, M, N> {
     inner: N,
     extract: X,
-    _marker: std::marker::PhantomData<fn() -> (L, M)>,
+    _marker: std::marker::PhantomData<(L, M)>,
 }
 
 /// A Service that can record a request/response durations.

--- a/linkerd/http/prom/src/record_response/request.rs
+++ b/linkerd/http/prom/src/record_response/request.rs
@@ -22,23 +22,21 @@ pub struct RequestMetrics<DurL, StatL> {
     statuses: Family<StatL, Counter>,
 }
 
-pub type NewRequestDuration<L, X, N, ReqB, RespB> = super::NewRecordResponse<
+pub type NewRequestDuration<L, X, N> = super::NewRecordResponse<
     L,
     X,
     RequestMetrics<
-        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::DurationLabels,
-        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::StatusLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
     >,
     N,
-    ReqB,
-    RespB,
 >;
 
-pub type RecordRequestDuration<L, S, ReqB, RespB> = super::RecordResponse<
+pub type RecordRequestDuration<L, S> = super::RecordResponse<
     L,
     RequestMetrics<
-        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::DurationLabels,
-        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::StatusLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
     >,
     S,
 >;
@@ -104,15 +102,15 @@ impl<DurL, StatL> Clone for RequestMetrics<DurL, StatL> {
     }
 }
 
-impl<ReqB, L, S> svc::Service<http::Request<ReqB>> for RecordRequestDuration<L, S, ReqB, BoxBody>
+impl<ReqB, L, S> svc::Service<http::Request<ReqB>> for RecordRequestDuration<L, S>
 where
-    L: MkStreamLabel<ReqB, BoxBody>,
-    L::StreamLabel: StreamLabel<BoxBody>,
+    L: MkStreamLabel,
+    L::StreamLabel: StreamLabel,
     S: svc::Service<http::Request<ReqB>, Response = http::Response<BoxBody>, Error = Error>,
 {
     type Response = http::Response<BoxBody>;
     type Error = S::Error;
-    type Future = super::ResponseFuture<L::StreamLabel, S::Future, BoxBody>;
+    type Future = super::ResponseFuture<L::StreamLabel, S::Future>;
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {

--- a/linkerd/http/prom/src/record_response/request.rs
+++ b/linkerd/http/prom/src/record_response/request.rs
@@ -22,21 +22,23 @@ pub struct RequestMetrics<DurL, StatL> {
     statuses: Family<StatL, Counter>,
 }
 
-pub type NewRequestDuration<L, X, N> = super::NewRecordResponse<
+pub type NewRequestDuration<L, X, N, ReqB, RespB> = super::NewRecordResponse<
     L,
     X,
     RequestMetrics<
-        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
-        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::DurationLabels,
+        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::StatusLabels,
     >,
     N,
+    ReqB,
+    RespB,
 >;
 
-pub type RecordRequestDuration<L, S> = super::RecordResponse<
+pub type RecordRequestDuration<L, S, ReqB, RespB> = super::RecordResponse<
     L,
     RequestMetrics<
-        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
-        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::DurationLabels,
+        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::StatusLabels,
     >,
     S,
 >;
@@ -102,14 +104,15 @@ impl<DurL, StatL> Clone for RequestMetrics<DurL, StatL> {
     }
 }
 
-impl<ReqB, L, S> svc::Service<http::Request<ReqB>> for RecordRequestDuration<L, S>
+impl<ReqB, L, S> svc::Service<http::Request<ReqB>> for RecordRequestDuration<L, S, ReqB, BoxBody>
 where
-    L: MkStreamLabel,
+    L: MkStreamLabel<ReqB, BoxBody>,
+    L::StreamLabel: StreamLabel<BoxBody>,
     S: svc::Service<http::Request<ReqB>, Response = http::Response<BoxBody>, Error = Error>,
 {
     type Response = http::Response<BoxBody>;
     type Error = S::Error;
-    type Future = super::ResponseFuture<L::StreamLabel, S::Future>;
+    type Future = super::ResponseFuture<L::StreamLabel, S::Future, BoxBody>;
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {

--- a/linkerd/http/prom/src/record_response/request.rs
+++ b/linkerd/http/prom/src/record_response/request.rs
@@ -120,7 +120,8 @@ where
     }
 
     fn call(&mut self, req: http::Request<ReqB>) -> Self::Future {
-        let state = self.labeler.mk_stream_labeler(&req).map(|labeler| {
+        let (parts, body) = req.into_parts();
+        let state = self.labeler.mk_stream_labeler(&parts).map(|labeler| {
             let (tx, start) = oneshot::channel();
             tx.send(time::Instant::now()).unwrap();
             let RequestMetrics { statuses, duration } = self.metric.clone();
@@ -132,6 +133,7 @@ where
             }
         });
 
+        let req = http::Request::from_parts(parts, body);
         let inner = self.inner.call(req);
         super::ResponseFuture { state, inner }
     }

--- a/linkerd/http/prom/src/record_response/request.rs
+++ b/linkerd/http/prom/src/record_response/request.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use tokio::{sync::oneshot, time};
 
-use super::{DurationFamily, MkDurationHistogram, MkStreamLabel};
+use super::{DurationFamily, MkDurationHistogram, MkStreamLabel, StreamLabel};
 
 /// Metrics type that tracks completed requests.
 #[derive(Debug)]
@@ -25,13 +25,19 @@ pub struct RequestMetrics<DurL, StatL> {
 pub type NewRequestDuration<L, X, N> = super::NewRecordResponse<
     L,
     X,
-    RequestMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    RequestMetrics<
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+    >,
     N,
 >;
 
 pub type RecordRequestDuration<L, S> = super::RecordResponse<
     L,
-    RequestMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    RequestMetrics<
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+    >,
     S,
 >;
 

--- a/linkerd/http/prom/src/record_response/response.rs
+++ b/linkerd/http/prom/src/record_response/response.rs
@@ -23,23 +23,21 @@ pub struct ResponseMetrics<DurL, StatL> {
     statuses: Family<StatL, Counter>,
 }
 
-pub type NewResponseDuration<L, X, N, ReqB, RespB> = super::NewRecordResponse<
+pub type NewResponseDuration<L, X, N> = super::NewRecordResponse<
     L,
     X,
     ResponseMetrics<
-        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::DurationLabels,
-        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::StatusLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
     >,
     N,
-    ReqB,
-    RespB,
 >;
 
-pub type RecordResponseDuration<L, S, ReqB, RespB> = super::RecordResponse<
+pub type RecordResponseDuration<L, S> = super::RecordResponse<
     L,
     ResponseMetrics<
-        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::DurationLabels,
-        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::StatusLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
     >,
     S,
 >;
@@ -109,14 +107,14 @@ impl<DurL, StatL> Clone for ResponseMetrics<DurL, StatL> {
     }
 }
 
-impl<M, S> svc::Service<http::Request<BoxBody>> for RecordResponseDuration<M, S, BoxBody, BoxBody>
+impl<M, S> svc::Service<http::Request<BoxBody>> for RecordResponseDuration<M, S>
 where
-    M: MkStreamLabel<BoxBody, BoxBody>,
+    M: MkStreamLabel,
     S: svc::Service<http::Request<BoxBody>, Response = http::Response<BoxBody>, Error = Error>,
 {
     type Response = http::Response<BoxBody>;
     type Error = Error;
-    type Future = super::ResponseFuture<M::StreamLabel, S::Future, BoxBody>;
+    type Future = super::ResponseFuture<M::StreamLabel, S::Future>;
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {

--- a/linkerd/http/prom/src/record_response/response.rs
+++ b/linkerd/http/prom/src/record_response/response.rs
@@ -14,7 +14,7 @@ use std::{
 };
 use tokio::{sync::oneshot, time};
 
-use super::{DurationFamily, MkDurationHistogram, MkStreamLabel};
+use super::{DurationFamily, MkDurationHistogram, MkStreamLabel, StreamLabel};
 
 /// Metrics type that tracks completed responses.
 #[derive(Debug)]
@@ -26,13 +26,19 @@ pub struct ResponseMetrics<DurL, StatL> {
 pub type NewResponseDuration<L, X, N> = super::NewRecordResponse<
     L,
     X,
-    ResponseMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    ResponseMetrics<
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+    >,
     N,
 >;
 
 pub type RecordResponseDuration<L, S> = super::RecordResponse<
     L,
-    ResponseMetrics<<L as MkStreamLabel>::DurationLabels, <L as MkStreamLabel>::StatusLabels>,
+    ResponseMetrics<
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
+        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+    >,
     S,
 >;
 

--- a/linkerd/http/prom/src/record_response/response.rs
+++ b/linkerd/http/prom/src/record_response/response.rs
@@ -23,21 +23,23 @@ pub struct ResponseMetrics<DurL, StatL> {
     statuses: Family<StatL, Counter>,
 }
 
-pub type NewResponseDuration<L, X, N> = super::NewRecordResponse<
+pub type NewResponseDuration<L, X, N, ReqB, RespB> = super::NewRecordResponse<
     L,
     X,
     ResponseMetrics<
-        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
-        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::DurationLabels,
+        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::StatusLabels,
     >,
     N,
+    ReqB,
+    RespB,
 >;
 
-pub type RecordResponseDuration<L, S> = super::RecordResponse<
+pub type RecordResponseDuration<L, S, ReqB, RespB> = super::RecordResponse<
     L,
     ResponseMetrics<
-        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::DurationLabels,
-        <<L as MkStreamLabel>::StreamLabel as StreamLabel>::StatusLabels,
+        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::DurationLabels,
+        <<L as MkStreamLabel<ReqB, RespB>>::StreamLabel as StreamLabel<RespB>>::StatusLabels,
     >,
     S,
 >;
@@ -107,14 +109,14 @@ impl<DurL, StatL> Clone for ResponseMetrics<DurL, StatL> {
     }
 }
 
-impl<M, S> svc::Service<http::Request<BoxBody>> for RecordResponseDuration<M, S>
+impl<M, S> svc::Service<http::Request<BoxBody>> for RecordResponseDuration<M, S, BoxBody, BoxBody>
 where
-    M: MkStreamLabel,
+    M: MkStreamLabel<BoxBody, BoxBody>,
     S: svc::Service<http::Request<BoxBody>, Response = http::Response<BoxBody>, Error = Error>,
 {
     type Response = http::Response<BoxBody>;
     type Error = Error;
-    type Future = super::ResponseFuture<M::StreamLabel, S::Future>;
+    type Future = super::ResponseFuture<M::StreamLabel, S::Future, BoxBody>;
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {

--- a/linkerd/http/prom/src/record_response/response.rs
+++ b/linkerd/http/prom/src/record_response/response.rs
@@ -16,6 +16,7 @@ use tokio::{sync::oneshot, time};
 
 use super::{DurationFamily, MkDurationHistogram, MkStreamLabel};
 
+/// Metrics type that tracks completed responses.
 #[derive(Debug)]
 pub struct ResponseMetrics<DurL, StatL> {
     duration: DurationFamily<DurL>,

--- a/linkerd/http/prom/src/record_response/response_future.rs
+++ b/linkerd/http/prom/src/record_response/response_future.rs
@@ -1,0 +1,172 @@
+use super::{DurationFamily, StreamLabel};
+use http_body::Body;
+use linkerd_error::Error;
+use linkerd_http_box::BoxBody;
+use linkerd_metrics::prom::Counter;
+use prometheus_client::metrics::family::Family;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::{sync::oneshot, time};
+
+#[pin_project::pin_project]
+pub struct ResponseFuture<L, F>
+where
+    L: StreamLabel,
+{
+    #[pin]
+    pub(crate) inner: F,
+    pub(crate) state: Option<ResponseState<L>>,
+}
+
+/// Notifies the response labeler when the response body is flushed.
+#[pin_project::pin_project(PinnedDrop)]
+struct ResponseBody<L: StreamLabel> {
+    #[pin]
+    inner: BoxBody,
+    state: Option<ResponseState<L>>,
+}
+
+/// Inner state used by [`ResponseFuture`] and [`ResponseBody`].
+///
+/// This is used to update Prometheus metrics across the response's lifecycle.
+///
+/// This is generic across an `L`-typed [`StreamLabel`], which bears responsibility for labelling
+/// responses according to their status code and duration.
+//
+//  TODO(kate): this should not need to be public.
+pub struct ResponseState<L: StreamLabel> {
+    pub(super) labeler: L,
+    /// The family of [`Counter`]s tracking response status code.
+    pub(super) statuses: Family<L::StatusLabels, Counter>,
+    /// The family of [`Histogram`]s tracking response durations.
+    pub(super) duration: DurationFamily<L::DurationLabels>,
+    /// Receives a timestamp noting when the service received a request.
+    pub(super) start: oneshot::Receiver<time::Instant>,
+}
+
+// === impl ResponseFuture ===
+
+impl<L, F> Future for ResponseFuture<L, F>
+where
+    L: StreamLabel,
+    F: Future<Output = Result<http::Response<BoxBody>, Error>>,
+{
+    /// A [`ResponseFuture`] produces the same response as its inner `F`-typed future.
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        // Poll the inner future, returning if it isn't ready yet.
+        let res = futures::ready!(this.inner.poll(cx)).map_err(Into::into);
+
+        // We got a response back! Take our state, and examine the output.
+        let mut state = this.state.take();
+        match res {
+            Ok(rsp) => {
+                let (head, inner) = rsp.into_parts();
+                if let Some(ResponseState { labeler, .. }) = state.as_mut() {
+                    labeler.init_response(&head);
+                }
+
+                // Call `end_stream` if the body is empty.
+                if inner.is_end_stream() {
+                    end_stream(&mut state, Ok(None));
+                }
+                Poll::Ready(Ok(http::Response::from_parts(
+                    head,
+                    BoxBody::new(ResponseBody { inner, state }),
+                )))
+            }
+            Err(error) => {
+                end_stream(&mut state, Err(&error));
+                Poll::Ready(Err(error))
+            }
+        }
+    }
+}
+
+// === impl ResponseBody ===
+
+impl<L> http_body::Body for ResponseBody<L>
+where
+    L: StreamLabel,
+{
+    type Data = <BoxBody as http_body::Body>::Data;
+    type Error = Error;
+
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Error>>> {
+        let mut this = self.project();
+        let res =
+            futures::ready!(this.inner.as_mut().poll_data(cx)).map(|res| res.map_err(Into::into));
+        if let Some(Err(error)) = res.as_ref() {
+            end_stream(this.state, Err(error));
+        } else if (*this.inner).is_end_stream() {
+            end_stream(this.state, Ok(None));
+        }
+        Poll::Ready(res)
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<http::HeaderMap>, Error>> {
+        let this = self.project();
+        let res = futures::ready!(this.inner.poll_trailers(cx)).map_err(Into::into);
+        end_stream(this.state, res.as_ref().map(Option::as_ref));
+        Poll::Ready(res)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+}
+
+#[pin_project::pinned_drop]
+impl<L> PinnedDrop for ResponseBody<L>
+where
+    L: StreamLabel,
+{
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        if this.state.is_some() {
+            end_stream(this.state, Err(&super::RequestCancelled(()).into()));
+        }
+    }
+}
+
+fn end_stream<L>(
+    state: &mut Option<ResponseState<L>>,
+    res: Result<Option<&http::HeaderMap>, &Error>,
+) where
+    L: StreamLabel,
+{
+    let Some(ResponseState {
+        duration,
+        statuses: total,
+        mut start,
+        mut labeler,
+    }) = state.take()
+    else {
+        return;
+    };
+
+    labeler.end_response(res);
+
+    total.get_or_create(&labeler.status_labels()).inc();
+
+    let elapsed = if let Ok(start) = start.try_recv() {
+        time::Instant::now().saturating_duration_since(start)
+    } else {
+        time::Duration::ZERO
+    };
+    duration
+        .get_or_create(&labeler.duration_labels())
+        .observe(elapsed.as_secs_f64());
+}

--- a/linkerd/http/prom/src/record_response/response_future.rs
+++ b/linkerd/http/prom/src/record_response/response_future.rs
@@ -29,7 +29,7 @@ struct ResponseBody<L: StreamLabel> {
     state: Option<ResponseState<L>>,
 }
 
-/// Inner state used by [`ResponseFuture`] and [`ResponseBody`].
+/// Inner state used by [`ResponseFuture`].
 ///
 /// This is used to update Prometheus metrics across the response's lifecycle.
 ///


### PR DESCRIPTION
this branch makes a variety of small, non-breaking changes to the `linkerd-http-prom` crate, and the outbound proxy code related to route- and backend-level metrics.

this branch does _not_ make particularly significant breaking changes to the `StreamLabel` or `MkStreamLabel` traits. this branch is focused on minimizing the type complexity of these traits, and consequently in dependent code.

these changes are provided in distinct, atomic commits. readers are encourages to review this branch commit-by-commit. the primary changes that are worth highlighting, mentioned in comments below are:

* `StreamLabel` is now object-safe, making use of `dyn StreamLabel` possible. we now use `request::Parts` and `response::Parts` parameters in our trait methods. this means that we no longer need to be generic across request/response bodies, but retain the ability to inspect e.g. status codes.

* the `StreamLabel` interface includes associated types for the labels
used for metrics related to request/response duration, and counting
status codes. we do not however, actually need to separately define these associated
types in the `MkStreamLabel` contract. these types are removed.

* `ResponseMetrics` and `RequestMetrics` are generic over `L: StreamLabel`. these were previously generic over `DurationLabels` and `StatusLabels`, even though the same parent `L` was used in practice.

* documentation to various interfaces is added.