### PR TITLE
Allow configuring proxy trace exporter service name

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -148,6 +148,7 @@ const ENV_OUTBOUND_DISABLE_INFORMATIONAL_HEADERS: &str =
 
 const ENV_TRACE_ATTRIBUTES_PATH: &str = "LINKERD2_PROXY_TRACE_ATTRIBUTES_PATH";
 const ENV_TRACE_PROTOCOL: &str = "LINKERD2_PROXY_TRACE_PROTOCOL";
+const ENV_TRACE_SERVICE_NAME: &str = "LINKERD2_PROXY_TRACE_SERVICE_NAME";
 
 /// Constrains which destination names may be used for profile/route discovery.
 ///
@@ -432,6 +433,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
 
     let trace_attributes_file_path = strings.get(ENV_TRACE_ATTRIBUTES_PATH);
     let trace_protocol = strings.get(ENV_TRACE_PROTOCOL);
+    let trace_service_name = strings.get(ENV_TRACE_SERVICE_NAME);
 
     let trace_collector_addr = parse_control_addr(strings, ENV_TRACE_COLLECTOR_SVC_BASE);
 
@@ -842,9 +844,12 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 .flatten()
                 .unwrap_or_default();
 
+            let trace_service_name = trace_service_name.ok().flatten();
+
             trace_collector::Config::Enabled(Box::new(trace_collector::EnabledConfig {
                 attributes,
                 hostname: hostname?,
+                service_name: trace_service_name,
                 control: ControlConfig {
                     addr,
                     connect,

--- a/linkerd/app/src/trace_collector.rs
+++ b/linkerd/app/src/trace_collector.rs
@@ -24,6 +24,7 @@ pub struct EnabledConfig {
     pub control: control::Config,
     pub attributes: HashMap<String, String>,
     pub hostname: Option<String>,
+    pub service_name: Option<String>,
     pub kind: CollectorProtocol,
 }
 
@@ -78,11 +79,15 @@ impl Config {
                     .control
                     .build(dns, client_metrics, control_metrics, identity)
                     .new_service(());
+                let svc_name = inner
+                    .service_name
+                    .unwrap_or_else(|| SERVICE_NAME.to_string());
 
                 let collector = match inner.kind {
                     CollectorProtocol::OpenCensus => oc_collector::create_collector(
                         addr.clone(),
                         inner.hostname,
+                        svc_name,
                         inner.attributes,
                         svc,
                         legacy_oc_metrics,
@@ -90,6 +95,7 @@ impl Config {
                     CollectorProtocol::OpenTelemetry => otel_collector::create_collector(
                         addr.clone(),
                         inner.hostname,
+                        svc_name,
                         inner.attributes,
                         svc,
                         legacy_otel_metrics,

--- a/linkerd/app/src/trace_collector/oc_collector.rs
+++ b/linkerd/app/src/trace_collector/oc_collector.rs
@@ -12,6 +12,7 @@ use tracing::Instrument;
 pub(super) fn create_collector<S>(
     addr: ControlAddr,
     hostname: Option<String>,
+    service_name: String,
     attributes: HashMap<String, String>,
     svc: S,
     legacy_metrics: metrics::Registry,
@@ -35,9 +36,7 @@ where
                 pid: std::process::id(),
                 start_timestamp: Some(SystemTime::now().into()),
             }),
-            service_info: Some(oc::ServiceInfo {
-                name: crate::trace_collector::SERVICE_NAME.to_string(),
-            }),
+            service_info: Some(oc::ServiceInfo { name: service_name }),
             attributes,
             ..oc::Node::default()
         };

--- a/linkerd/app/src/trace_collector/otel_collector.rs
+++ b/linkerd/app/src/trace_collector/otel_collector.rs
@@ -16,6 +16,7 @@ use tracing::Instrument;
 pub(super) fn create_collector<S>(
     addr: ControlAddr,
     hostname: Option<String>,
+    service_name: String,
     attributes: HashMap<String, String>,
     svc: S,
     legacy_metrics: metrics::Registry,
@@ -35,7 +36,7 @@ where
     resources
         .attributes
         .0
-        .push(crate::trace_collector::SERVICE_NAME.with_key("service.name"));
+        .push(service_name.with_key("service.name"));
     resources
         .attributes
         .0


### PR DESCRIPTION
Currently, we hard-code the trace service name to "linkerd-proxy". This allows this name to be configured through an env that can be set by the injector, annotations, etc.

linkerd/linkerd2#11157