### PR TITLE
feat(app): Add hostname label to http metrics

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
@@ -4,7 +4,14 @@ use super::{
     test_util::*,
     LabelGrpcRouteRsp, LabelHttpRouteRsp, RequestMetrics,
 };
-use linkerd_app_core::svc::{self, http::BoxBody, Layer, NewService};
+use linkerd_app_core::{
+    dns,
+    svc::{
+        self,
+        http::{uri::Uri, BoxBody},
+        Layer, NewService,
+    },
+};
 use linkerd_proxy_client_policy as policy;
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
@@ -18,7 +25,7 @@ async fn http_request_statuses() {
 
     // Send one request and ensure it's counted.
     let ok = metrics.get_statuses(&labels::Rsp(
-        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::Route::new(parent_ref.clone(), route_ref.clone(), &Uri::default()),
         labels::HttpRsp {
             status: Some(http::StatusCode::OK),
             error: None,
@@ -37,7 +44,7 @@ async fn http_request_statuses() {
     // Send another request and ensure it's counted with a different response
     // status.
     let no_content = metrics.get_statuses(&labels::Rsp(
-        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::Route::new(parent_ref.clone(), route_ref.clone(), &Uri::default()),
         labels::HttpRsp {
             status: Some(http::StatusCode::NO_CONTENT),
             error: None,
@@ -61,7 +68,7 @@ async fn http_request_statuses() {
 
     // Emit a response with an error and ensure it's counted.
     let unknown = metrics.get_statuses(&labels::Rsp(
-        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::Route::new(parent_ref.clone(), route_ref.clone(), &Uri::default()),
         labels::HttpRsp {
             status: None,
             error: Some(labels::Error::Unknown),
@@ -75,7 +82,7 @@ async fn http_request_statuses() {
     // Emit a successful response with a body that fails and ensure that both
     // the status and error are recorded.
     let mixed = metrics.get_statuses(&labels::Rsp(
-        labels::Route(parent_ref, route_ref),
+        labels::Route::new(parent_ref, route_ref, &Uri::default()),
         labels::HttpRsp {
             status: Some(http::StatusCode::OK),
             error: Some(labels::Error::Unknown),
@@ -100,6 +107,131 @@ async fn http_request_statuses() {
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn http_request_hostnames() {
+    const HOST_1: &str = "great.website";
+    const URI_1_1: &str = "https://great.website/path/to/index.html#fragment";
+    const URI_1_2: &str = "https://great.website/another/index.html";
+    const HOST_2: &str = "different.website";
+    const URI_2: &str = "https://different.website/index.html";
+    const URI_3: &str = "https://[3fff::]/index.html";
+
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::HttpRouteMetrics::default().requests;
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let (mut svc, mut handle) = mock_http_route_metrics(&metrics, &parent_ref, &route_ref);
+
+    let get_counter = |host: Option<&'static str>, status: Option<http::StatusCode>| {
+        metrics.get_statuses(&labels::Rsp(
+            labels::Route::new_with_name(
+                parent_ref.clone(),
+                route_ref.clone(),
+                host.map(str::parse::<dns::Name>).map(Result::unwrap),
+            ),
+            labels::HttpRsp {
+                status,
+                error: None,
+            },
+        ))
+    };
+
+    let host1_ok = get_counter(Some(HOST_1), Some(http::StatusCode::OK));
+    let host1_teapot = get_counter(Some(HOST_1), Some(http::StatusCode::IM_A_TEAPOT));
+    let host2_ok = get_counter(Some(HOST_2), Some(http::StatusCode::OK));
+    let unlabeled_ok = get_counter(None, Some(http::StatusCode::OK));
+
+    // Send one request and ensure it's counted.
+    send_assert_incremented(
+        &host1_ok,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .uri(URI_1_1)
+            .body(BoxBody::default())
+            .unwrap(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .status(200)
+                    .body(BoxBody::default())
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+    assert_eq!(host1_ok.get(), 1);
+    assert_eq!(host1_teapot.get(), 0);
+    assert_eq!(host2_ok.get(), 0);
+
+    // Send another request to a different path on the same host.
+    send_assert_incremented(
+        &host1_teapot,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .uri(URI_1_2)
+            .body(BoxBody::default())
+            .unwrap(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .status(418)
+                    .body(BoxBody::default())
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+    assert_eq!(host1_ok.get(), 1);
+    assert_eq!(host1_teapot.get(), 1);
+    assert_eq!(host2_ok.get(), 0);
+
+    // Send a request to a different host.
+    send_assert_incremented(
+        &host2_ok,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .uri(URI_2)
+            .body(BoxBody::default())
+            .unwrap(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .status(200)
+                    .body(BoxBody::default())
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+    assert_eq!(host1_ok.get(), 1);
+    assert_eq!(host1_teapot.get(), 1);
+    assert_eq!(host2_ok.get(), 1);
+
+    // Send a request to a url with an ip address host component, show that it is not labeled.
+    send_assert_incremented(
+        &unlabeled_ok,
+        &mut handle,
+        &mut svc,
+        http::Request::builder()
+            .uri(URI_3)
+            .body(BoxBody::default())
+            .unwrap(),
+        |tx| {
+            tx.send_response(
+                http::Response::builder()
+                    .status(200)
+                    .body(BoxBody::default())
+                    .unwrap(),
+            )
+        },
+    )
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn grpc_request_statuses_ok() {
     let _trace = linkerd_tracing::test::trace_init();
 
@@ -110,7 +242,11 @@ async fn grpc_request_statuses_ok() {
 
     // Send one request and ensure it's counted.
     let ok = metrics.get_statuses(&labels::Rsp(
-        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::Route::new(
+            parent_ref.clone(),
+            route_ref.clone(),
+            &Uri::from_static(MOCK_GRPC_REQ_URI),
+        ),
         labels::GrpcRsp {
             status: Some(tonic::Code::Ok),
             error: None,
@@ -152,7 +288,11 @@ async fn grpc_request_statuses_not_found() {
     // Send another request and ensure it's counted with a different response
     // status.
     let not_found = metrics.get_statuses(&labels::Rsp(
-        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::Route::new(
+            parent_ref.clone(),
+            route_ref.clone(),
+            &Uri::from_static(MOCK_GRPC_REQ_URI),
+        ),
         labels::GrpcRsp {
             status: Some(tonic::Code::NotFound),
             error: None,
@@ -192,7 +332,11 @@ async fn grpc_request_statuses_error_response() {
     let (mut svc, mut handle) = mock_grpc_route_metrics(&metrics, &parent_ref, &route_ref);
 
     let unknown = metrics.get_statuses(&labels::Rsp(
-        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::Route::new(
+            parent_ref.clone(),
+            route_ref.clone(),
+            &Uri::from_static(MOCK_GRPC_REQ_URI),
+        ),
         labels::GrpcRsp {
             status: None,
             error: Some(labels::Error::Unknown),
@@ -222,7 +366,11 @@ async fn grpc_request_statuses_error_body() {
     let (mut svc, mut handle) = mock_grpc_route_metrics(&metrics, &parent_ref, &route_ref);
 
     let unknown = metrics.get_statuses(&labels::Rsp(
-        labels::Route(parent_ref.clone(), route_ref.clone()),
+        labels::Route::new(
+            parent_ref.clone(),
+            route_ref.clone(),
+            &Uri::from_static(MOCK_GRPC_REQ_URI),
+        ),
         labels::GrpcRsp {
             status: None,
             error: Some(labels::Error::Unknown),
@@ -251,6 +399,8 @@ async fn grpc_request_statuses_error_body() {
 }
 
 // === Utils ===
+
+const MOCK_GRPC_REQ_URI: &str = "http://host/svc/method";
 
 pub fn mock_http_route_metrics(
     metrics: &RequestMetrics<LabelHttpRouteRsp>,
@@ -301,7 +451,7 @@ pub fn mock_grpc_route_metrics(
 ) -> (svc::BoxHttp, Handle) {
     let req = http::Request::builder()
         .method("POST")
-        .uri("http://host/svc/method")
+        .uri(MOCK_GRPC_REQ_URI)
         .body(())
         .unwrap();
     let (r#match, _) = policy::route::find(

--- a/linkerd/app/outbound/src/http/logical/policy/route/retry.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/retry.rs
@@ -1,11 +1,12 @@
 use super::{extensions, metrics::labels::Route as RouteLabels};
+use crate::{ParentRef, RouteRef};
 use futures::future::{Either, Ready};
 use linkerd_app_core::{
     cause_ref, classify,
     exp_backoff::ExponentialBackoff,
     is_caused_by,
     proxy::http::{self, stream_timeouts::ResponseTimeoutError},
-    svc::{self, http::h2},
+    svc::{self, http::h2, ExtractParam},
     Error, Result,
 };
 use linkerd_http_retry::{self as retry, peek_trailers::PeekTrailersBody};
@@ -16,7 +17,8 @@ use tokio::time;
 #[derive(Copy, Clone, Debug)]
 pub struct IsRetry(());
 
-pub type NewHttpRetry<N> = retry::NewHttpRetry<RetryPolicy, RouteLabels, N>;
+pub type NewHttpRetry<F, N> =
+    retry::NewHttpRetry<RetryPolicy, RouteLabels, F, RetryLabelExtract, N>;
 
 #[derive(Clone, Debug)]
 pub struct RetryPolicy {
@@ -28,6 +30,9 @@ pub struct RetryPolicy {
     pub max_request_bytes: usize,
     pub backoff: Option<ExponentialBackoff>,
 }
+
+#[derive(Clone, Debug)]
+pub struct RetryLabelExtract(pub ParentRef, pub RouteRef);
 
 pub type RouteRetryMetrics = retry::MetricFamilies<RouteLabels>;
 
@@ -156,5 +161,16 @@ impl RetryPolicy {
         // that they can be inspected. here.
 
         false
+    }
+}
+
+// === impl RetryLabelExtract ===
+
+impl<B> ExtractParam<RouteLabels, http::Request<B>> for RetryLabelExtract {
+    fn extract_param(&self, t: &http::Request<B>) -> RouteLabels {
+        let Self(parent, route) = self;
+        let uri = t.uri();
+
+        RouteLabels::new(parent.clone(), route.clone(), uri)
     }
 }

--- a/linkerd/http/prom/src/record_response/request.rs
+++ b/linkerd/http/prom/src/record_response/request.rs
@@ -72,6 +72,9 @@ where
     pub fn get_statuses(&self, labels: &StatL) -> Counter {
         (*self.statuses.get_or_create(labels)).clone()
     }
+
+    // TODO(kate): it'd be nice if we could avoid creating a time series if it does not exist,
+    // so that tests can confirm that certain label sets do not exist within the family.
 }
 
 impl<DurL, StatL> Default for RequestMetrics<DurL, StatL>


### PR DESCRIPTION
this commit introduces an additional label to HTTP and gRPC route
metrics, containing the DNS host of requests. requests destined for an
ip address of some kind are not recorded with a hostname metric, as a
way to help minimize the impact of time series cardinality.

the core of this change is in this field addition:

```diff
// /linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
-pub struct Route(pub ParentRef, pub RouteRef);
+pub struct Route {
+    parent: ParentRef,
+    route: RouteRef,
+    hostname: Option<dns::Name>,
+}
```

see this part of the change to our `MkStreamLabel` implementation, used
in our metrics tracking request durtion, and counting response status
codes:

```diff
-    fn mk_stream_labeler<B>(&self, _: &::http::Request<B>) -> Option<Self::StreamLabel> {
+    fn mk_stream_labeler<B>(&self, req: &::http::Request<B>) -> Option<Self::StreamLabel> {
         let parent = self.params.parent_ref.clone();
         let route = self.params.route_ref.clone();
-        Some(metrics::LabelHttpRsp::from(metrics::labels::Route::from((
-            parent, route,
-        ))))
+        Some(metrics::LabelHttpRsp::from(metrics::labels::Route::new(
+            parent,
+            route,
+            req.uri(),
+        )))
     }
```

we now inspect the request, and use the URI to label metrics related to
this traffic by hostname.

a `http_request_hostnames()` test case is added to exercise this.

some todo comments are left, noting where we would ideally like to
simplify or generalize the machinery related to `RetryLabelExtract`, the
type that bridges the labels needed based on our `NewService<T>` target,
and the request type later accepted by the instantiated `Service<T>`.