### PR TITLE
Extract zone locality into separate TCP metric

### DIFF
--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -4,7 +4,7 @@ use super::{
     handle_proxy_error_headers::{self, NewHandleProxyErrorHeaders},
     NewRequireIdentity,
 };
-use crate::{tcp::tagged_transport, Outbound};
+use crate::{tcp::tagged_transport, zone::TcpZoneLabels, Outbound};
 use linkerd_app_core::{
     classify, config, errors, http_tracing, metrics,
     proxy::{api_resolve::ProtocolHint, http, tap},
@@ -234,6 +234,13 @@ impl<T: svc::Param<Option<http::AuthorityOverride>>> svc::Param<Option<http::Aut
 impl<T: svc::Param<transport::labels::Key>> svc::Param<transport::labels::Key> for Connect<T> {
     #[inline]
     fn param(&self) -> transport::labels::Key {
+        self.inner.param()
+    }
+}
+
+impl<T: svc::Param<TcpZoneLabels>> svc::Param<TcpZoneLabels> for Connect<T> {
+    #[inline]
+    fn param(&self) -> TcpZoneLabels {
         self.inner.param()
     }
 }

--- a/linkerd/app/outbound/src/http/endpoint/tests.rs
+++ b/linkerd/app/outbound/src/http/endpoint/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{http, tcp, test_util::*};
 use ::http::header::{CONNECTION, UPGRADE};
+use linkerd_app_core::metrics::OutboundZoneLocality;
 use linkerd_app_core::{
     io,
     proxy::api_resolve::ProtocolHint,
@@ -300,6 +301,7 @@ impl svc::Param<metrics::OutboundEndpointLabels> for Endpoint {
         metrics::OutboundEndpointLabels {
             authority: None,
             labels: None,
+            zone_locality: OutboundZoneLocality::Unknown,
             server_id: self.param(),
             target_addr: self.addr.into(),
         }

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -46,6 +46,7 @@ mod sidecar;
 pub mod tcp;
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_util;
+mod zone;
 
 pub use self::discover::{spawn_synthesized_profile_policy, synthesize_forward_policy, Discovery};
 use self::metrics::OutboundMetrics;

--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -37,6 +37,7 @@ pub struct OutboundMetrics {
 pub(crate) struct PromMetrics {
     pub(crate) http: crate::http::HttpMetrics,
     pub(crate) opaq: crate::opaq::OpaqMetrics,
+    pub(crate) zone: crate::zone::TcpZoneMetrics,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -47,7 +48,7 @@ pub struct BalancerMetricsParams<K>(balance::MetricFamilies<K>);
 
 struct ScopedKey<'a, 'b>(&'a str, &'b str);
 
-// === impl BalancerMetricsPaarams ===
+// === impl BalancerMetricsParams ===
 
 impl<K> BalancerMetricsParams<K>
 where
@@ -80,6 +81,7 @@ where
         Self(balance::MetricFamilies::default())
     }
 }
+
 // === impl PromMetrics ===
 
 impl PromMetrics {
@@ -89,8 +91,9 @@ impl PromMetrics {
         let http = crate::http::HttpMetrics::register(registry);
 
         let opaq = crate::opaq::OpaqMetrics::register(registry.sub_registry_with_prefix("tcp"));
+        let zone = crate::zone::TcpZoneMetrics::register(registry.sub_registry_with_prefix("tcp"));
 
-        Self { http, opaq }
+        Self { http, opaq, zone }
     }
 }
 

--- a/linkerd/app/outbound/src/opaq/concrete.rs
+++ b/linkerd/app/outbound/src/opaq/concrete.rs
@@ -1,10 +1,16 @@
-use crate::{metrics::BalancerMetricsParams, stack_labels, BackendRef, Outbound, ParentRef};
+use crate::{
+    metrics::BalancerMetricsParams,
+    stack_labels,
+    zone::{tcp_zone_labels, TcpZoneLabels},
+    BackendRef, Outbound, ParentRef,
+};
 use linkerd_app_core::{
     config::QueueConfig,
     drain, io,
     metrics::{
         self,
         prom::{self, EncodeLabelSetMut},
+        OutboundZoneLocality,
     },
     profiles,
     proxy::{
@@ -323,9 +329,22 @@ where
         metrics::OutboundEndpointLabels {
             authority,
             labels: metrics::prefix_labels("dst", self.metadata.labels().iter()),
+            zone_locality: self.param(),
             server_id: self.param(),
             target_addr: self.addr.into(),
         }
+    }
+}
+
+impl<T> svc::Param<OutboundZoneLocality> for Endpoint<T> {
+    fn param(&self) -> OutboundZoneLocality {
+        OutboundZoneLocality::new(&self.metadata)
+    }
+}
+
+impl<T> svc::Param<TcpZoneLabels> for Endpoint<T> {
+    fn param(&self) -> TcpZoneLabels {
+        tcp_zone_labels(self.param())
     }
 }
 

--- a/linkerd/app/outbound/src/tcp.rs
+++ b/linkerd/app/outbound/src/tcp.rs
@@ -1,3 +1,4 @@
+pub use self::connect::Connect;
 use crate::Outbound;
 use linkerd_app_core::{
     io, svc,
@@ -8,9 +9,6 @@ use linkerd_app_core::{
 mod connect;
 mod endpoint;
 pub mod tagged_transport;
-
-pub use self::connect::Connect;
-pub use linkerd_app_core::proxy::tcp::Forward;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Accept {

--- a/linkerd/app/outbound/src/zone.rs
+++ b/linkerd/app/outbound/src/zone.rs
@@ -1,0 +1,41 @@
+use linkerd_app_core::{metrics::OutboundZoneLocality, transport::metrics::zone};
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
+use std::{fmt::Debug, hash::Hash};
+
+pub type TcpZoneMetrics = zone::TcpZoneMetricsParams<TcpZoneOpLabel>;
+pub type TcpZoneLabels = zone::TcpZoneLabels<TcpZoneOpLabel>;
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, EncodeLabelSet)]
+pub struct TcpZoneOpLabel {
+    op: TcpZoneOp,
+    zone_locality: OutboundZoneLocality,
+}
+
+impl TcpZoneOpLabel {
+    fn new_send_labels(zone_locality: OutboundZoneLocality) -> Self {
+        Self {
+            op: TcpZoneOp::Send,
+            zone_locality,
+        }
+    }
+
+    fn new_recv_labels(zone_locality: OutboundZoneLocality) -> Self {
+        Self {
+            op: TcpZoneOp::Recv,
+            zone_locality,
+        }
+    }
+}
+
+pub fn tcp_zone_labels(zone_locality: OutboundZoneLocality) -> TcpZoneLabels {
+    zone::TcpZoneLabels {
+        recv_labels: TcpZoneOpLabel::new_recv_labels(zone_locality),
+        send_labels: TcpZoneOpLabel::new_send_labels(zone_locality),
+    }
+}
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, EncodeLabelValue)]
+enum TcpZoneOp {
+    Send,
+    Recv,
+}

--- a/linkerd/proxy/api-resolve/src/metadata.rs
+++ b/linkerd/proxy/api-resolve/src/metadata.rs
@@ -27,6 +27,7 @@ pub struct Metadata {
     authority_override: Option<Authority>,
 
     http2: HTTP2ClientParams,
+    is_zone_local: Option<bool>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
@@ -53,11 +54,13 @@ impl Default for Metadata {
             tagged_transport_port: None,
             protocol_hint: ProtocolHint::Unknown,
             http2: HTTP2ClientParams::default(),
+            is_zone_local: None,
         }
     }
 }
 
 impl Metadata {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         labels: impl IntoIterator<Item = (String, String)>,
         protocol_hint: ProtocolHint,
@@ -66,6 +69,7 @@ impl Metadata {
         authority_override: Option<Authority>,
         weight: u32,
         http2: HTTP2ClientParams,
+        is_zone_local: Option<bool>,
     ) -> Self {
         Self {
             labels: labels.into_iter().collect::<BTreeMap<_, _>>().into(),
@@ -75,6 +79,7 @@ impl Metadata {
             authority_override,
             weight,
             http2,
+            is_zone_local,
         }
     }
 
@@ -85,6 +90,10 @@ impl Metadata {
     /// Returns the endpoint's labels from the destination service, if it has them.
     pub fn labels(&self) -> Labels {
         self.labels.clone()
+    }
+
+    pub fn is_zone_local(&self) -> Option<bool> {
+        self.is_zone_local
     }
 
     pub fn protocol_hint(&self) -> ProtocolHint {

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -5,6 +5,7 @@ mod client;
 mod report;
 mod sensor;
 mod server;
+pub mod zone;
 
 pub use self::{
     client::Client,

--- a/linkerd/transport-metrics/src/zone.rs
+++ b/linkerd/transport-metrics/src/zone.rs
@@ -1,0 +1,80 @@
+use linkerd_metrics::prom;
+use linkerd_stack::{ExtractParam, Param};
+use std::{fmt::Debug, hash::Hash};
+
+pub use self::sensor::ZoneSensorIo;
+
+pub mod client;
+mod sensor;
+
+#[derive(Clone, Debug)]
+pub struct TcpZoneMetrics {
+    pub recv_bytes: prom::Counter,
+    pub send_bytes: prom::Counter,
+}
+
+#[derive(Clone, Debug)]
+pub struct TcpZoneMetricsParams<L> {
+    transfer_cost: prom::Family<L, prom::Counter>,
+}
+
+impl<L: Clone + Eq + Hash> Default for TcpZoneMetricsParams<L> {
+    fn default() -> Self {
+        Self {
+            transfer_cost: prom::Family::default(),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub struct TcpZoneLabels<L> {
+    pub recv_labels: L,
+    pub send_labels: L,
+}
+
+impl<L> TcpZoneMetricsParams<L>
+where
+    L: Clone + Hash + Eq + prom::encoding::EncodeLabelSet + Debug + Send + Sync + 'static,
+{
+    pub fn register(registry: &mut prom::Registry) -> Self {
+        let transfer_cost = prom::Family::default();
+        registry.register_with_unit(
+            "transfer_cost",
+            "The total amount of data transferred in and out of this proxy, by cost zone",
+            prom::Unit::Bytes,
+            transfer_cost.clone(),
+        );
+
+        TcpZoneMetricsParams { transfer_cost }
+    }
+}
+
+impl<L> TcpZoneMetricsParams<L>
+where
+    L: Clone + Hash + Eq,
+{
+    pub fn metrics(&self, labels: TcpZoneLabels<L>) -> TcpZoneMetrics {
+        let recv_bytes = self
+            .transfer_cost
+            .get_or_create(&labels.recv_labels)
+            .clone();
+        let send_bytes = self
+            .transfer_cost
+            .get_or_create(&labels.send_labels)
+            .clone();
+        TcpZoneMetrics {
+            recv_bytes,
+            send_bytes,
+        }
+    }
+}
+
+impl<T, L> ExtractParam<TcpZoneMetrics, T> for TcpZoneMetricsParams<L>
+where
+    T: Param<TcpZoneLabels<L>>,
+    L: Clone + Hash + Eq,
+{
+    fn extract_param(&self, t: &T) -> TcpZoneMetrics {
+        self.metrics(t.param())
+    }
+}

--- a/linkerd/transport-metrics/src/zone/client.rs
+++ b/linkerd/transport-metrics/src/zone/client.rs
@@ -1,0 +1,77 @@
+use crate::zone::{
+    sensor::{ZoneMetricsSensor, ZoneSensorIo},
+    TcpZoneMetrics,
+};
+use futures::{ready, TryFuture};
+use linkerd_stack::{layer, ExtractParam, MakeConnection, Service};
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+#[derive(Clone, Debug)]
+pub struct ZoneMetricsClient<P, S> {
+    inner: S,
+    params: P,
+}
+
+#[pin_project]
+pub struct ConnectFuture<F> {
+    #[pin]
+    inner: F,
+    metrics: Option<TcpZoneMetrics>,
+}
+
+// === impl Client ===
+
+impl<P: Clone, S> ZoneMetricsClient<P, S> {
+    pub fn layer(params: P) -> impl layer::Layer<S, Service = Self> + Clone {
+        layer::mk(move |inner| Self {
+            inner,
+            params: params.clone(),
+        })
+    }
+}
+
+impl<T, P, S> Service<T> for ZoneMetricsClient<P, S>
+where
+    P: ExtractParam<TcpZoneMetrics, T>,
+    S: MakeConnection<T>,
+{
+    type Response = (ZoneSensorIo<S::Connection>, S::Metadata);
+    type Error = S::Error;
+    type Future = ConnectFuture<S::Future>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, target: T) -> Self::Future {
+        let metrics = self.params.extract_param(&target);
+        let inner = self.inner.connect(target);
+        ConnectFuture {
+            metrics: Some(metrics),
+            inner,
+        }
+    }
+}
+
+// === impl ConnectFuture ===
+
+impl<I, M, F: TryFuture<Ok = (I, M)>> Future for ConnectFuture<F> {
+    type Output = Result<(ZoneSensorIo<I>, M), F::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let (io, meta) = ready!(this.inner.try_poll(cx))?;
+        let metrics = this
+            .metrics
+            .take()
+            .expect("future must not be polled after ready");
+        let io = ZoneSensorIo::new(io, ZoneMetricsSensor { metrics });
+        Poll::Ready(Ok((io, meta)))
+    }
+}

--- a/linkerd/transport-metrics/src/zone/sensor.rs
+++ b/linkerd/transport-metrics/src/zone/sensor.rs
@@ -1,0 +1,24 @@
+use crate::zone::TcpZoneMetrics;
+
+#[derive(Clone, Debug)]
+pub struct ZoneMetricsSensor {
+    pub metrics: TcpZoneMetrics,
+}
+
+pub type ZoneSensorIo<T> = linkerd_io::SensorIo<T, ZoneMetricsSensor>;
+
+impl linkerd_io::Sensor for ZoneMetricsSensor {
+    fn record_read(&mut self, sz: usize) {
+        self.metrics.recv_bytes.inc_by(sz as u64);
+    }
+
+    fn record_write(&mut self, sz: usize) {
+        self.metrics.send_bytes.inc_by(sz as u64);
+    }
+
+    fn record_close(&mut self, _eos: Option<linkerd_errno::Errno>) {}
+
+    fn record_error<T>(&mut self, op: linkerd_io::Poll<T>) -> linkerd_io::Poll<T> {
+        op
+    }
+}


### PR DESCRIPTION
Currently, the destination controller populates a zone locality field in the metric labels for an endpoint. This works fine, but can be expensive to query against in prometheus due to the high cardinality of the metrics it is attached to.

This introduces a separate `outbound_tcp_bytes_total` metric with only the zone locality as a label, which is the most common use of this label.

This includes some extra infrastructure to wire the new metric through as we currently don't use prometheus-client for transport metrics. Eventually, the existing metrics could and/or should be migrated, but that is saved for a future change.