### PR TITLE
Ver/zd/tls stack

### DIFF
--- a/linkerd/app/outbound/src/tls.rs
+++ b/linkerd/app/outbound/src/tls.rs
@@ -135,15 +135,6 @@ impl<T> svc::ExtractParam<tls::server::Timeout, T> for DetectParams {
     }
 }
 
-impl<T> svc::InsertParam<ServerName, T> for DetectParams {
-    type Target = (ServerName, T);
-
-    #[inline]
-    fn insert_param(&self, sni: ServerName, target: T) -> Self::Target {
-        (sni, target)
-    }
-}
-
 // === impl TlsMetrics ===
 
 impl TlsMetrics {

--- a/linkerd/app/outbound/src/tls.rs
+++ b/linkerd/app/outbound/src/tls.rs
@@ -7,7 +7,7 @@ use linkerd_app_core::{
         core::Resolve,
     },
     svc,
-    tls::{NewDetectSni, ServerName},
+    tls::{NewDetectRequiredSni, ServerName},
     transport::addrs::*,
     Error,
 };
@@ -98,7 +98,9 @@ impl<C> Outbound<C> {
                     // Use a dedicated target type to configure parameters for
                     // the TLS stack. It also helps narrow the cache key.
                     .push_map_target(|(sni, parent): (ServerName, T)| Tls { sni, parent })
-                    .push(NewDetectSni::layer(config.proxy.detect_protocol_timeout))
+                    .push(NewDetectRequiredSni::layer(
+                        config.proxy.detect_protocol_timeout,
+                    ))
                     .arc_new_clone_tcp()
             })
     }

--- a/linkerd/app/outbound/src/tls.rs
+++ b/linkerd/app/outbound/src/tls.rs
@@ -7,7 +7,7 @@ use linkerd_app_core::{
         core::Resolve,
     },
     svc,
-    tls::{self, detect_sni::NewDetectSni, server::Timeout, ServerName},
+    tls::{NewDetectSni, ServerName},
     transport::addrs::*,
     Error,
 };
@@ -24,9 +24,6 @@ struct Tls<T> {
     sni: ServerName,
     parent: T,
 }
-
-#[derive(Clone)]
-struct DetectParams(Timeout);
 
 pub fn spawn_routes<T>(
     mut route_rx: watch::Receiver<T>,
@@ -97,13 +94,11 @@ impl<C> Outbound<C> {
             .push_tls_concrete(resolve)
             .push_tls_logical()
             .map_stack(|config, _rt, stk| {
-                let detect_timeout = Timeout(config.proxy.detect_protocol_timeout);
-
                 stk.push_new_idle_cached(config.discovery_idle_timeout)
                     // Use a dedicated target type to configure parameters for
                     // the TLS stack. It also helps narrow the cache key.
                     .push_map_target(|(sni, parent): (ServerName, T)| Tls { sni, parent })
-                    .push(NewDetectSni::layer(DetectParams(detect_timeout)))
+                    .push(NewDetectSni::layer(config.proxy.detect_protocol_timeout))
                     .arc_new_clone_tcp()
             })
     }
@@ -123,15 +118,6 @@ where
 {
     fn param(&self) -> watch::Receiver<logical::Routes> {
         self.parent.param()
-    }
-}
-
-// === impl DetectParams ===
-
-impl<T> svc::ExtractParam<tls::server::Timeout, T> for DetectParams {
-    #[inline]
-    fn extract_param(&self, _: &T) -> tls::server::Timeout {
-        self.0
     }
 }
 

--- a/linkerd/app/outbound/src/tls/logical/tests.rs
+++ b/linkerd/app/outbound/src/tls/logical/tests.rs
@@ -3,7 +3,6 @@ use crate::test_util::*;
 use linkerd_app_core::{
     io,
     svc::{self, NewService},
-    tls,
     transport::addrs::*,
     Result,
 };
@@ -41,9 +40,6 @@ struct MockServer {
 struct ConnectTcp {
     srvs: Arc<Mutex<HashMap<SocketAddr, MockServer>>>,
 }
-
-#[derive(Clone)]
-struct DetectParams;
 
 // === impl MockServer ===
 
@@ -116,15 +112,6 @@ impl<T: svc::Param<Remote<ServerAddr>>> svc::Service<T> for ConnectTcp {
         assert_eq!(addr, mock.addr);
         let local = Local(ClientAddr(addr));
         future::ok::<_, support::io::Error>((mock.io.build(), local))
-    }
-}
-
-// === impl DetectParams ===
-
-impl<T> svc::ExtractParam<tls::server::Timeout, T> for DetectParams {
-    #[inline]
-    fn extract_param(&self, _: &T) -> tls::server::Timeout {
-        tls::server::Timeout(Duration::from_secs(1))
     }
 }
 

--- a/linkerd/app/outbound/src/tls/logical/tests.rs
+++ b/linkerd/app/outbound/src/tls/logical/tests.rs
@@ -128,15 +128,6 @@ impl<T> svc::ExtractParam<tls::server::Timeout, T> for DetectParams {
     }
 }
 
-impl<T> svc::InsertParam<tls::ServerName, T> for DetectParams {
-    type Target = (tls::ServerName, T);
-
-    #[inline]
-    fn insert_param(&self, sni: tls::ServerName, target: T) -> Self::Target {
-        (sni, target)
-    }
-}
-
 fn spawn_io(
     client_hello: Vec<u8>,
 ) -> (

--- a/linkerd/app/outbound/src/tls/logical/tests/basic.rs
+++ b/linkerd/app/outbound/src/tls/logical/tests/basic.rs
@@ -35,7 +35,7 @@ async fn routes() {
         .map_stack(|config, _rt, stk| {
             stk.push_new_idle_cached(config.discovery_idle_timeout)
                 .push_map_target(|(sni, parent): (ServerName, _)| Tls { sni, parent })
-                .push(NewDetectSni::layer(DetectParams))
+                .push(NewDetectSni::layer(Duration::from_secs(1)))
                 .arc_new_clone_tcp()
         })
         .into_inner();

--- a/linkerd/app/outbound/src/tls/logical/tests/basic.rs
+++ b/linkerd/app/outbound/src/tls/logical/tests/basic.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::tls::Tls;
 use linkerd_app_core::{
     svc::ServiceExt,
-    tls::{NewDetectSni, ServerName},
+    tls::{NewDetectRequiredSni, ServerName},
     trace, NameAddr,
 };
 use linkerd_proxy_client_policy as client_policy;
@@ -35,7 +35,7 @@ async fn routes() {
         .map_stack(|config, _rt, stk| {
             stk.push_new_idle_cached(config.discovery_idle_timeout)
                 .push_map_target(|(sni, parent): (ServerName, _)| Tls { sni, parent })
-                .push(NewDetectSni::layer(Duration::from_secs(1)))
+                .push(NewDetectRequiredSni::layer(Duration::from_secs(1)))
                 .arc_new_clone_tcp()
         })
         .into_inner();

--- a/linkerd/tls/src/lib.rs
+++ b/linkerd/tls/src/lib.rs
@@ -2,13 +2,14 @@
 #![forbid(unsafe_code)]
 
 pub mod client;
-mod detect_sni;
 pub mod server;
 
 pub use self::{
     client::{Client, ClientTls, ConditionalClientTls, ConnectMeta, NoClientTls, ServerId},
-    detect_sni::{DetectSni, NewDetectSni},
-    server::{ClientId, ConditionalServerTls, NewDetectTls, NoServerTls, ServerTls},
+    server::{
+        ClientId, ConditionalServerTls, NewDetectRequiredSni, NewDetectTls, NoServerTls,
+        NoSniFoundError, ServerTls, SniDetectionTimeoutError,
+    },
 };
 
 use linkerd_dns_name as dns;

--- a/linkerd/tls/src/lib.rs
+++ b/linkerd/tls/src/lib.rs
@@ -2,7 +2,7 @@
 #![forbid(unsafe_code)]
 
 pub mod client;
-pub mod detect_sni;
+mod detect_sni;
 pub mod server;
 
 pub use self::{

--- a/linkerd/tls/src/lib.rs
+++ b/linkerd/tls/src/lib.rs
@@ -7,7 +7,7 @@ pub mod server;
 
 pub use self::{
     client::{Client, ClientTls, ConditionalClientTls, ConnectMeta, NoClientTls, ServerId},
-    detect_sni::NewDetectSni,
+    detect_sni::{DetectSni, NewDetectSni},
     server::{ClientId, ConditionalServerTls, NewDetectTls, NoServerTls, ServerTls},
 };
 

--- a/linkerd/tls/src/server.rs
+++ b/linkerd/tls/src/server.rs
@@ -1,4 +1,5 @@
 mod client_hello;
+mod required_sni;
 
 use crate::{NegotiatedProtocol, ServerName};
 use bytes::BytesMut;
@@ -17,6 +18,8 @@ use std::{
 use thiserror::Error;
 use tokio::time::{self, Duration};
 use tracing::{debug, trace, warn};
+
+pub use self::required_sni::{NewDetectRequiredSni, NoSniFoundError, SniDetectionTimeoutError};
 
 /// Describes the authenticated identity of a remote client.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
@@ -65,6 +68,7 @@ pub struct NewDetectTls<L, P, N> {
     _local_identity: std::marker::PhantomData<fn() -> L>,
 }
 
+/// A param type used to indicate the timeout after which detection should fail.
 #[derive(Copy, Clone, Debug)]
 pub struct Timeout(pub Duration);
 
@@ -192,7 +196,7 @@ where
 }
 
 /// Peek or buffer the provided stream to determine an SNI value.
-pub(crate) async fn detect_sni<I>(mut io: I) -> io::Result<(Option<ServerName>, DetectIo<I>)>
+async fn detect_sni<I>(mut io: I) -> io::Result<(Option<ServerName>, DetectIo<I>)>
 where
     I: io::Peek + io::AsyncRead + io::AsyncWrite + Send + Sync + Unpin,
 {


### PR DESCRIPTION
commit f78aa64be9afa2ab96c03f384b9fe78d71fd4942
Author: Oliver Gould <ver@buoyant.io>
Date:   Thu Oct 10 14:18:31 2024 +0000

    tls: Avoid InsertParam parameter.
    
    We don't actually use InsertParam all that much--only in the TLS server (which
    is obviously why it was included here). This change removes the InsertParam in
    favor of using a tuple, generally reducing boilerplate.
    
    It turns out that the TLS stack already has a map_target to handle turning the
    tuple-target into a Tls type, so it shouldn't be needed.

commit 67c0e849f8368473f722c6cdb0bffaecca5c8635
Author: Oliver Gould <ver@buoyant.io>
Date:   Thu Oct 10 14:49:32 2024 +0000

    tls: Remove ExtractParam from detect_sni
    
    Similarly, we don't actually care about extracting a timeout from the target.
    Using an ExtractParam causes needless boilerplate.
    
    This change updates the stack module to simply take a timeout parameter at
    construction time.

commit f6202d661163d7fdf5692b3a30f2a93e1e3496b8
Author: Oliver Gould <ver@buoyant.io>
Date:   Thu Oct 10 15:03:42 2024 +0000

    tls: Make the detect_tls module private
    
    We now only need to export the NewDetectSni type. The module reexport is not
    necessary.

commit ae88d2eecb7570b12161e4983c7890f56a7cdb88 (HEAD -> ver/zd/tls-stack, origin/ver/zd/tls-stack)
Author: Oliver Gould <ver@buoyant.io>
Date:   Thu Oct 10 15:20:17 2024 +0000

    tls: Reorganize NewDetectRequiredSni under the server module
    
    Because the DetectTls and DetectSni types are so similar -- and implemented in
    the context of a server inspecting a provided connection (and not a client
    establishing a TLS connection), this change reorganizes the module:
    
    * The DetectSni types are renamed to DetectRequiredSni to better reflect their
      purpose and difference from the DetectTls type.
    * The detect_sni module is renamed and moved to server::required_sni. This
      module is private and the relevant types are reexported from the server