### PR TITLE
fix(grpc): Handle timeouts with a DeadlineExceeded error

### DIFF
--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -120,7 +120,7 @@ impl SyntheticHttpResponse {
         Self {
             close_connection: true,
             http_status: http::StatusCode::GATEWAY_TIMEOUT,
-            grpc_status: tonic::Code::Unavailable,
+            grpc_status: tonic::Code::DeadlineExceeded,
             message: Cow::Owned(msg.to_string()),
             location: None,
         }
@@ -130,7 +130,7 @@ impl SyntheticHttpResponse {
         Self {
             close_connection: false,
             http_status: http::StatusCode::GATEWAY_TIMEOUT,
-            grpc_status: tonic::Code::Unavailable,
+            grpc_status: tonic::Code::DeadlineExceeded,
             message: Cow::Owned(msg.to_string()),
             location: None,
         }


### PR DESCRIPTION
When the proxy encounters gateway timeouts, it reports a gRPC Unavailable status code. This is at odds with the [grpc
docs](https://grpc.io/docs/guides/deadlines/) which suggest that DeadlineExceeded should be used.

This change updates the proxy's error handler to return DeadlineExceeded when a gRPC request encounters a timeout.