### PR TITLE
policy: use client-policy responses in opaq stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1338,6 +1338,7 @@ dependencies = [
  "linkerd-io",
  "linkerd-meshtls",
  "linkerd-meshtls-rustls",
+ "linkerd-opaq-route",
  "linkerd-proxy-client-policy",
  "linkerd-retry",
  "linkerd-stack",
@@ -1739,6 +1740,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "linkerd-opaq-route"
+version = "0.1.0"
+dependencies = [
+ "rand",
+ "regex",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "linkerd-opencensus"
 version = "0.1.0"
 dependencies = [
@@ -1902,6 +1913,7 @@ dependencies = [
  "linkerd-error",
  "linkerd-exp-backoff",
  "linkerd-http-route",
+ "linkerd-opaq-route",
  "linkerd-proxy-api-resolve",
  "linkerd-proxy-core",
  "linkerd-tls-route",
@@ -2385,8 +2397,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c72fb98d969e1e94e95d52a6fcdf4693764702c369e577934256e72fb5bc61"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?rev=c5648ae2a1e405cc6b8aca20522356ebdf20f1ea#c5648ae2a1e405cc6b8aca20522356ebdf20f1ea"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
     "linkerd/meshtls/rustls",
     "linkerd/meshtls/verifier",
     "linkerd/metrics",
+    "linkerd/opaq-route",
     "linkerd/opencensus",
     "linkerd/opentelemetry",
     "linkerd/pool",
@@ -89,4 +90,4 @@ debug = 1
 lto = true
 
 [workspace.dependencies]
-linkerd2-proxy-api = "0.14.0"
+linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', rev = 'c5648ae2a1e405cc6b8aca20522356ebdf20f1ea' }

--- a/linkerd/app/integration/src/policy.rs
+++ b/linkerd/app/integration/src/policy.rs
@@ -167,11 +167,13 @@ pub fn outbound_default_opaque_route(dst: impl ToString) -> outbound::OpaqueRout
                     distribution::FirstAvailable {
                         backends: vec![opaque_route::RouteBackend {
                             backend: Some(backend(dst)),
+                            invalid: None,
                         }],
                     },
                 )),
             }),
         }],
+        error: None,
     }
 }
 

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -45,6 +45,7 @@ linkerd-proxy-client-policy = { path = "../../proxy/client-policy", features = [
 ] }
 linkerd-retry = { path = "../../retry" }
 linkerd-tls-route = { path = "../../tls/route" }
+linkerd-opaq-route = { path = "../../opaq-route" }
 linkerd-tonic-stream = { path = "../../tonic-stream" }
 linkerd-tonic-watch = { path = "../../tonic-watch" }
 

--- a/linkerd/app/outbound/src/http/logical/profile.rs
+++ b/linkerd/app/outbound/src/http/logical/profile.rs
@@ -2,11 +2,11 @@ use super::{
     super::{concrete, retry},
     CanonicalDstHeader, Concrete, NoRoute,
 };
-use crate::{policy, BackendRef, ParentRef, UNKNOWN_META};
+use crate::{service_meta, BackendRef, ParentRef, UNKNOWN_META};
 use linkerd_app_core::{
     classify, metrics,
     proxy::http::{self, balance},
-    svc, Error, NameAddr,
+    svc, Error,
 };
 use linkerd_distribute as distribute;
 use std::{fmt::Debug, hash::Hash, sync::Arc, time};
@@ -106,26 +106,6 @@ where
             routes,
             targets,
         } = routes;
-
-        fn service_meta(addr: &NameAddr) -> Option<Arc<policy::Meta>> {
-            let mut parts = addr.name().split('.');
-
-            let name = parts.next()?;
-            let namespace = parts.next()?;
-
-            if !parts.next()?.eq_ignore_ascii_case("svc") {
-                return None;
-            }
-
-            Some(Arc::new(policy::Meta::Resource {
-                group: "core".to_string(),
-                kind: "Service".to_string(),
-                namespace: namespace.to_string(),
-                name: name.to_string(),
-                section: None,
-                port: Some(addr.port().try_into().ok()?),
-            }))
-        }
 
         let parent_meta = service_meta(&addr).unwrap_or_else(|| UNKNOWN_META.clone());
 

--- a/linkerd/app/outbound/src/opaq.rs
+++ b/linkerd/app/outbound/src/opaq.rs
@@ -1,4 +1,4 @@
-use crate::{tcp, Outbound};
+use crate::{policy, service_meta, tcp, Outbound, ParentRef, UNKNOWN_META};
 use linkerd_app_core::{
     io,
     metrics::prom,
@@ -11,15 +11,17 @@ use linkerd_app_core::{
     transport::addrs::*,
     Error,
 };
-use std::{fmt::Debug, hash::Hash};
+use std::{fmt::Debug, hash::Hash, net::SocketAddr};
+use tokio::sync::watch;
 
 mod concrete;
 mod logical;
 
-pub use self::logical::Logical;
+pub(crate) use self::logical::route::ForbiddenRoute;
+pub use self::logical::{Concrete, LogicalAddr, Routes};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct Opaq(Logical);
+struct Opaq<T>(T);
 
 #[derive(Clone, Debug, Default)]
 pub struct OpaqMetrics {
@@ -36,8 +38,9 @@ impl<C> Outbound<C> {
     pub fn push_opaq_cached<T, I, R>(self, resolve: R) -> Outbound<svc::ArcNewCloneTcp<T, I>>
     where
         // Opaque target
-        T: svc::Param<Logical>,
-        T: Clone + Send + Sync + 'static,
+        T: svc::Param<LogicalAddr>,
+        T: Clone + Debug + PartialEq + Eq + Hash + Send + Sync + 'static,
+        T: svc::Param<watch::Receiver<Routes>>,
         // Server-side connection
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr,
         I: Debug + Send + Sync + Unpin + 'static,
@@ -57,7 +60,7 @@ impl<C> Outbound<C> {
                 stk.push_new_idle_cached(config.discovery_idle_timeout)
                     // Use a dedicated target type to configure parameters for
                     // the opaque stack. It also helps narrow the cache key.
-                    .push_map_target(|t: T| Opaq(t.param()))
+                    .push_map_target(|parent: T| Opaq(parent))
                     .arc_new_clone_tcp()
             })
     }
@@ -65,18 +68,21 @@ impl<C> Outbound<C> {
 
 // === impl Opaq ===
 
-impl svc::Param<Logical> for Opaq {
-    fn param(&self) -> Logical {
-        self.0.clone()
+impl<T> svc::Param<LogicalAddr> for Opaq<T>
+where
+    T: svc::Param<LogicalAddr>,
+{
+    fn param(&self) -> LogicalAddr {
+        self.0.param()
     }
 }
 
-impl svc::Param<Option<profiles::Receiver>> for Opaq {
-    fn param(&self) -> Option<profiles::Receiver> {
-        match self.0.param() {
-            Logical::Route(_, rx) => Some(rx),
-            _ => None,
-        }
+impl<T> svc::Param<watch::Receiver<logical::Routes>> for Opaq<T>
+where
+    T: svc::Param<watch::Receiver<logical::Routes>>,
+{
+    fn param(&self) -> watch::Receiver<logical::Routes> {
+        self.0.param()
     }
 }
 
@@ -88,4 +94,157 @@ impl OpaqMetrics {
             concrete::BalancerMetrics::register(registry.sub_registry_with_prefix("balancer"));
         Self { balance }
     }
+}
+
+fn should_override_opaq_policy(
+    rx: &watch::Receiver<profiles::Profile>,
+) -> Option<profiles::LogicalAddr> {
+    let p = rx.borrow();
+    if p.has_targets() {
+        p.addr.clone()
+    } else {
+        None
+    }
+}
+/// Given both profiles and policy information, this function constructs `opaq::Routes``.
+/// The decision on whether profiles or policy should be used is made by inspecting the
+/// returned profiles and checking whether there are any targets defined. This is done
+/// in order to support traffic splits. Everything else should be delivered through client
+/// policy.
+pub fn routes_from_discovery(
+    orig_dst: SocketAddr,
+    profile: Option<profiles::Receiver>,
+    mut policy: policy::Receiver,
+) -> watch::Receiver<Routes> {
+    if let Some(mut profile) = profile.map(watch::Receiver::from) {
+        if let Some(addr) = should_override_opaq_policy(&profile) {
+            tracing::debug!("Using ServiceProfile");
+            let init = routes_from_profile(addr.clone(), &profile.borrow_and_update());
+            return spawn_routes(profile, init, move |profile: &profiles::Profile| {
+                Some(routes_from_profile(addr.clone(), profile))
+            });
+        }
+    }
+
+    tracing::debug!("Using ClientPolicy routes");
+    let init = routes_from_policy(orig_dst, &policy.borrow_and_update())
+        .expect("initial policy must be opaque");
+    spawn_routes(policy, init, move |policy: &policy::ClientPolicy| {
+        routes_from_policy(orig_dst, policy)
+    })
+}
+
+fn routes_from_policy(orig_dst: SocketAddr, policy: &policy::ClientPolicy) -> Option<Routes> {
+    let parent_ref = ParentRef(policy.parent.clone());
+    let routes = match policy.protocol {
+        policy::Protocol::Opaque(policy::opaq::Opaque { ref routes }) => routes.clone(),
+        // we support a detect stack to cover the case when we do detection and fallback to opaq
+        policy::Protocol::Detect { ref opaque, .. } => opaque.routes.clone(),
+        _ => {
+            tracing::info!("Ignoring a discovery update that changed a route from opaq");
+            return None;
+        }
+    };
+
+    Some(Routes {
+        addr: orig_dst.into(),
+        meta: parent_ref,
+        routes,
+        backends: policy.backends.clone(),
+    })
+}
+
+fn routes_from_profile(addr: profiles::LogicalAddr, profile: &profiles::Profile) -> Routes {
+    // TODO: make configurable
+    let queue = {
+        policy::Queue {
+            capacity: 100,
+            failfast_timeout: std::time::Duration::from_secs(3),
+        }
+    };
+
+    const EWMA: policy::Load = policy::Load::PeakEwma(policy::PeakEwma {
+        default_rtt: std::time::Duration::from_millis(30),
+        decay: std::time::Duration::from_secs(10),
+    });
+
+    let parent_meta = service_meta(&addr).unwrap_or_else(|| UNKNOWN_META.clone());
+
+    let backends: Vec<(policy::RouteBackend<policy::opaq::Filter>, u32)> = profile
+        .targets
+        .iter()
+        .map(|target| {
+            let backend_meta = service_meta(&target.addr).unwrap_or_else(|| UNKNOWN_META.clone());
+            let backend = policy::RouteBackend {
+                backend: policy::Backend {
+                    meta: backend_meta,
+                    queue,
+                    dispatcher: policy::BackendDispatcher::BalanceP2c(
+                        EWMA,
+                        policy::EndpointDiscovery::DestinationGet {
+                            path: target.addr.to_string(),
+                        },
+                    ),
+                },
+                filters: std::sync::Arc::new([]),
+            };
+
+            (backend, target.weight)
+        })
+        .collect();
+
+    let distribution = policy::RouteDistribution::RandomAvailable(backends.clone().into());
+
+    let route = policy::opaq::Route {
+        policy: policy::opaq::Policy {
+            meta: parent_meta.clone(),
+            params: (),
+            filters: std::sync::Arc::new([]),
+            distribution,
+        },
+        forbidden: false,
+    };
+
+    Routes {
+        addr: addr.0.into(),
+        backends: backends.into_iter().map(|(b, _)| b.backend).collect(),
+        meta: ParentRef(parent_meta),
+        routes: std::sync::Arc::new([route]),
+    }
+}
+
+fn spawn_routes<T>(
+    mut route_rx: watch::Receiver<T>,
+    init: Routes,
+    mut mk: impl FnMut(&T) -> Option<Routes> + Send + Sync + 'static,
+) -> watch::Receiver<Routes>
+where
+    T: Send + Sync + 'static,
+{
+    let (tx, rx) = watch::channel(init);
+
+    tokio::spawn(async move {
+        loop {
+            let res = tokio::select! {
+                biased;
+                _ = tx.closed() => return,
+                res = route_rx.changed() => res,
+            };
+
+            if res.is_err() {
+                // Drop the `tx` sender when the profile sender is
+                // dropped.
+                return;
+            }
+
+            if let Some(routes) = (mk)(&*route_rx.borrow_and_update()) {
+                if tx.send(routes).is_err() {
+                    // Drop the `tx` sender when all of its receivers are dropped.
+                    return;
+                }
+            }
+        }
+    });
+
+    rx
 }

--- a/linkerd/app/outbound/src/opaq/logical.rs
+++ b/linkerd/app/outbound/src/opaq/logical.rs
@@ -1,30 +1,34 @@
 use super::concrete;
-use crate::Outbound;
-use linkerd_app_core::{
-    io,
-    profiles::{self, Profile},
-    proxy::{api_resolve::Metadata, tcp::balance},
-    svc,
-    transport::addrs::*,
-    Error, Infallible, NameAddr,
-};
-use linkerd_distribute as distribute;
-use std::{fmt::Debug, hash::Hash, time};
+use crate::{BackendRef, Outbound, ParentRef};
+use linkerd_app_core::{io, svc, Addr, Error};
+use linkerd_proxy_client_policy as client_policy;
+use std::{fmt::Debug, hash::Hash, sync::Arc};
 use tokio::sync::watch;
+
+pub mod route;
+pub mod router;
 
 #[cfg(test)]
 mod tests;
 
-#[derive(Clone, Debug)]
-pub enum Logical {
-    Route(NameAddr, profiles::Receiver),
-    Forward(Remote<ServerAddr>, Metadata),
+/// Indicates the address used for logical routing.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct LogicalAddr(pub Addr);
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Routes {
+    pub addr: Addr,
+    pub meta: ParentRef,
+    pub routes: Arc<[client_policy::opaq::Route]>,
+    pub backends: Arc<[client_policy::Backend]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Concrete<T> {
     target: concrete::Dispatch,
     parent: T,
+    parent_ref: ParentRef,
+    backend_ref: BackendRef,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -34,36 +38,10 @@ pub struct NoRoute;
 #[derive(Debug, thiserror::Error)]
 #[error("logical service {addr}: {source}")]
 pub struct LogicalError {
-    addr: NameAddr,
+    addr: Addr,
     #[source]
     source: Error,
 }
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-struct Params<T: Eq + Hash + Clone + Debug> {
-    parent: T,
-    route: RouteParams<T>,
-    backends: distribute::Backends<Concrete<T>>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct RouteParams<T> {
-    parent: T,
-    distribution: Distribution<T>,
-}
-
-type NewBackendCache<T, N, S> = distribute::NewBackendCache<Concrete<T>, (), N, S>;
-type NewDistribute<T, N> = distribute::NewDistribute<Concrete<T>, (), N>;
-type Distribution<T> = distribute::Distribution<Concrete<T>>;
-
-#[derive(Clone, Debug)]
-struct Routable<T> {
-    parent: T,
-    addr: NameAddr,
-    profile: profiles::Receiver,
-}
-
-// === impl Outbound ===
 
 impl<N> Outbound<N> {
     /// Builds a `NewService` that produces a router service for each logical
@@ -77,7 +55,8 @@ impl<N> Outbound<N> {
     pub fn push_opaq_logical<T, I, NSvc>(self) -> Outbound<svc::ArcNewCloneTcp<T, I>>
     where
         // Opaque logical target.
-        T: svc::Param<Logical>,
+        T: svc::Param<watch::Receiver<Routes>>,
+        T: svc::Param<LogicalAddr>,
         T: Eq + Hash + Clone + Debug + Send + Sync + 'static,
         // Server-side socket.
         I: io::AsyncRead + io::AsyncWrite + Debug + Send + Unpin + 'static,
@@ -87,194 +66,34 @@ impl<N> Outbound<N> {
         NSvc::Future: Send,
         NSvc::Error: Into<Error>,
     {
-        self.map_stack(|_, _, concrete| {
-            let route = svc::layers()
-                .lift_new()
-                .push(NewDistribute::layer())
-                // The router does not take the backend's availability into
-                // consideration, so we must eagerly fail requests to prevent
-                // leaking tasks onto the runtime.
-                .push_on_service(svc::LoadShed::layer());
-
-            // A `NewService`--instantiated once per logical target--that caches
-            // a set of concrete services so that, as the watch provides new
-            // `Params`, we can reuse inner services.
-            let router = svc::layers()
-                // Each `RouteParams` provides a `Distribution` that is used to
-                // choose a concrete service for a given route.
-                .lift_new()
-                .push(NewBackendCache::layer())
-                // Lazily cache a service for each `RouteParams`
-                // returned from the `SelectRoute` impl.
-                .push_on_service(route)
-                .push(svc::NewOneshotRoute::<Params<T>, _, _>::layer_cached());
-
-            // For each `Routable` target, watch its `Profile`, maintaining a
-            // cache of all concrete services used by the router.
+        self.map_stack(|_config, _, concrete| {
             concrete
-                .clone()
-                // Share the concrete stack with each router stack.
                 .lift_new()
-                // Rebuild this router stack every time the profile changes.
-                .push_on_service(router)
-                .push(svc::NewSpawnWatch::<Profile, _>::layer_into::<Params<T>>())
-                .push(svc::NewMapErr::layer_from_target::<LogicalError, _>())
-                .push_switch(
-                    |parent: T| -> Result<_, Infallible> {
-                        Ok(match parent.param() {
-                            Logical::Route(addr, profile) => svc::Either::A(Routable {
-                                addr,
-                                parent,
-                                profile,
-                            }),
-                            Logical::Forward(addr, meta) => svc::Either::B(Concrete {
-                                target: concrete::Dispatch::Forward(addr, meta),
-                                parent,
-                            }),
-                        })
-                    },
-                    concrete.into_inner(),
-                )
+                .push_on_service(svc::layer::mk(move |concrete: N| {
+                    svc::stack(concrete.clone())
+                        .push(router::Router::layer())
+                        .push(svc::NewMapErr::layer_from_target::<LogicalError, _>())
+                        .arc_new_clone_tcp()
+                        .into_inner()
+                }))
+                // Rebuild the inner router stack every time the watch changes.
+                .push(svc::NewSpawnWatch::<Routes, _>::layer_into::<
+                    router::Router<T>,
+                >())
                 .arc_new_clone_tcp()
         })
     }
 }
 
-// === impl Routable ===
+// === impl LogicalError ===
 
-impl<T> svc::Param<watch::Receiver<profiles::Profile>> for Routable<T> {
-    fn param(&self) -> watch::Receiver<profiles::Profile> {
-        self.profile.clone().into()
-    }
-}
-
-// === impl Params ===
-
-impl<T> From<(Profile, Routable<T>)> for Params<T>
+impl<T> From<(&router::Router<T>, Error)> for LogicalError
 where
     T: Eq + Hash + Clone + Debug,
 {
-    fn from((profile, routable): (Profile, Routable<T>)) -> Self {
-        const EWMA: balance::EwmaConfig = balance::EwmaConfig {
-            default_rtt: time::Duration::from_millis(30),
-            decay: time::Duration::from_secs(10),
-        };
-
-        // Create concrete targets for all of the profile's routes.
-        let (backends, distribution) = if profile.targets.is_empty() {
-            let concrete = Concrete {
-                target: concrete::Dispatch::Balance(routable.addr.clone(), routable.addr, EWMA),
-                parent: routable.parent.clone(),
-            };
-            let backends = std::iter::once(concrete.clone()).collect();
-            let distribution = Distribution::first_available(std::iter::once(concrete));
-            (backends, distribution)
-        } else {
-            let backends = profile
-                .targets
-                .iter()
-                .map(|t| Concrete {
-                    target: concrete::Dispatch::Balance(
-                        routable.addr.clone(),
-                        t.addr.clone(),
-                        EWMA,
-                    ),
-                    parent: routable.parent.clone(),
-                })
-                .collect();
-            let distribution = Distribution::random_available(profile.targets.iter().cloned().map(
-                |profiles::Target { addr, weight }| {
-                    let concrete = Concrete {
-                        target: concrete::Dispatch::Balance(routable.addr.clone(), addr, EWMA),
-                        parent: routable.parent.clone(),
-                    };
-                    (concrete, weight)
-                },
-            ))
-            .expect("distribution must be valid");
-
-            (backends, distribution)
-        };
-
-        let route = RouteParams {
-            parent: routable.parent.clone(),
-            distribution,
-        };
-
-        Self {
-            parent: routable.parent,
-            backends,
-            route,
-        }
-    }
-}
-
-impl<T> svc::Param<distribute::Backends<Concrete<T>>> for Params<T>
-where
-    T: Clone + Eq + Hash + Debug,
-{
-    fn param(&self) -> distribute::Backends<Concrete<T>> {
-        self.backends.clone()
-    }
-}
-
-impl<T> svc::Param<profiles::LogicalAddr> for Params<T>
-where
-    T: svc::Param<profiles::LogicalAddr>,
-    T: Clone + Eq + Hash + Debug,
-{
-    fn param(&self) -> profiles::LogicalAddr {
-        self.parent.param()
-    }
-}
-
-impl<T, I> svc::router::SelectRoute<I> for Params<T>
-where
-    T: Clone + Eq + Hash + Debug,
-{
-    type Key = RouteParams<T>;
-    type Error = std::convert::Infallible;
-
-    fn select(&self, _: &I) -> Result<Self::Key, Self::Error> {
-        Ok(self.route.clone())
-    }
-}
-
-// === impl RouteParams ===
-
-impl<T: Clone> svc::Param<Distribution<T>> for RouteParams<T> {
-    fn param(&self) -> Distribution<T> {
-        self.distribution.clone()
-    }
-}
-
-// === impl LogicalError ===
-
-impl<T> From<(&Routable<T>, Error)> for LogicalError {
-    fn from((target, source): (&Routable<T>, Error)) -> Self {
-        Self {
-            addr: target.addr.clone(),
-            source,
-        }
-    }
-}
-
-// === impl Concrete ===
-
-impl<T> std::ops::Deref for Concrete<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.parent
-    }
-}
-
-impl<T> svc::Param<Option<profiles::LogicalAddr>> for Concrete<T>
-where
-    T: svc::Param<Option<profiles::Receiver>>,
-{
-    fn param(&self) -> Option<profiles::LogicalAddr> {
-        (**self).param()?.logical_addr()
+    fn from((target, source): (&router::Router<T>, Error)) -> Self {
+        let LogicalAddr(addr) = svc::Param::param(target);
+        Self { addr, source }
     }
 }
 
@@ -284,32 +103,11 @@ impl<T> svc::Param<concrete::Dispatch> for Concrete<T> {
     }
 }
 
-// === impl Logical ===
-
-impl std::cmp::PartialEq for Logical {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Route(laddr, _), Self::Route(raddr, _)) => laddr == raddr,
-            (Self::Forward(laddr, lmeta), Self::Forward(raddr, rmeta)) => {
-                laddr == raddr && lmeta == rmeta
-            }
-            _ => false,
-        }
-    }
-}
-
-impl std::cmp::Eq for Logical {}
-
-impl std::hash::Hash for Logical {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        match self {
-            Self::Route(addr, _) => {
-                addr.hash(state);
-            }
-            Self::Forward(addr, meta) => {
-                addr.hash(state);
-                meta.hash(state);
-            }
-        }
+impl<T> svc::Param<LogicalAddr> for Concrete<T>
+where
+    T: svc::Param<LogicalAddr>,
+{
+    fn param(&self) -> LogicalAddr {
+        self.parent.param()
     }
 }

--- a/linkerd/app/outbound/src/opaq/logical/route.rs
+++ b/linkerd/app/outbound/src/opaq/logical/route.rs
@@ -2,7 +2,7 @@ use super::super::Concrete;
 use crate::{ParentRef, RouteRef};
 use linkerd_app_core::{io, svc, Addr, Error};
 use linkerd_distribute as distribute;
-use linkerd_tls_route as tls_route;
+use linkerd_opaq_route as opaq_route;
 use std::{fmt::Debug, hash::Hash};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -13,7 +13,7 @@ pub(crate) struct Backend<T> {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct MatchedRoute<T> {
-    pub(super) r#match: tls_route::RouteMatch,
+    pub(super) r#match: opaq_route::RouteMatch,
     pub(super) params: Route<T>,
 }
 
@@ -29,7 +29,7 @@ pub(crate) struct Route<T> {
 
 /// Indicates that traffic is not allowed to pass through a route
 #[derive(Debug, thiserror::Error)]
-#[error("forbidden tls route")]
+#[error("forbidden tcp route")]
 pub(crate) struct ForbiddenRoute;
 
 pub(crate) type BackendDistribution<T> = distribute::Distribution<Backend<T>>;

--- a/linkerd/app/outbound/src/opaq/logical/router.rs
+++ b/linkerd/app/outbound/src/opaq/logical/router.rs
@@ -3,31 +3,27 @@ use super::{
     route, LogicalAddr, NoRoute,
 };
 use crate::{BackendRef, EndpointRef, RouteRef};
-use linkerd_app_core::{
-    io, proxy::http, svc, tls::ServerName, transport::addrs::*, Addr, Error, NameAddr, Result,
-};
+use linkerd_app_core::{io, proxy::http, svc, transport::addrs::*, Addr, Error, NameAddr, Result};
 use linkerd_distribute as distribute;
+use linkerd_opaq_route as opaq_route;
 use linkerd_proxy_client_policy as policy;
-use linkerd_tls_route as tls_route;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct Router<T: Clone + Debug + Eq + Hash> {
     pub(super) parent: T,
     pub(super) addr: Addr,
-    pub(super) routes: Arc<[tls_route::Route<route::Route<T>>]>,
+    pub(super) routes: Arc<[opaq_route::Route<route::Route<T>>]>,
     pub(super) backends: distribute::Backends<Concrete<T>>,
 }
 
 type NewBackendCache<T, N, S> = distribute::NewBackendCache<Concrete<T>, (), N, S>;
 
 // === impl Router ===
-
 impl<T> Router<T>
 where
     // Parent target type.
     T: Eq + Hash + Clone + Debug + Send + Sync + 'static,
-    T: svc::Param<ServerName>,
 {
     pub fn layer<N, I, NSvc>() -> impl svc::Layer<N, Service = svc::ArcNewCloneTcp<Self, I>> + Clone
     where
@@ -52,12 +48,12 @@ where
     }
 }
 
-impl<T> From<(crate::tls::Routes, T)> for Router<T>
+impl<T> From<(crate::opaq::Routes, T)> for Router<T>
 where
     T: Eq + Hash + Clone + Debug,
 {
-    fn from((rts, parent): (crate::tls::Routes, T)) -> Self {
-        let crate::tls::Routes {
+    fn from((rts, parent): (crate::opaq::Routes, T)) -> Self {
+        let crate::opaq::Routes {
             addr,
             meta: parent_ref,
             routes,
@@ -76,13 +72,14 @@ where
             }
         };
 
-        let mk_dispatch = move |bke: &policy::Backend| match bke.dispatcher {
+        let mk_dispatch = move |bke: &policy::Backend, addr: Addr| match bke.dispatcher {
             policy::BackendDispatcher::BalanceP2c(
                 policy::Load::PeakEwma(policy::PeakEwma { decay, default_rtt }),
                 policy::EndpointDiscovery::DestinationGet { ref path },
             ) => mk_concrete(
                 BackendRef(bke.meta.clone()),
                 concrete::Dispatch::Balance(
+                    addr,
                     path.parse::<NameAddr>()
                         .expect("destination must be a nameaddr"),
                     http::balance::EwmaConfig { decay, default_rtt },
@@ -101,43 +98,47 @@ where
         };
 
         let mk_route_backend =
-            |route_ref: &RouteRef, rb: &policy::RouteBackend<policy::tls::Filter>| {
-                let concrete = mk_dispatch(&rb.backend);
+            |route_ref: &RouteRef, rb: &policy::RouteBackend<policy::opaq::Filter>, addr: Addr| {
+                let concrete = mk_dispatch(&rb.backend, addr);
                 route::Backend {
                     route_ref: route_ref.clone(),
                     concrete,
                 }
             };
 
-        let mk_distribution =
-            |rr: &RouteRef, d: &policy::RouteDistribution<policy::tls::Filter>| match d {
-                policy::RouteDistribution::Empty => route::BackendDistribution::Empty,
-                policy::RouteDistribution::FirstAvailable(backends) => {
-                    route::BackendDistribution::first_available(
-                        backends.iter().map(|b| mk_route_backend(rr, b)),
-                    )
-                }
-                policy::RouteDistribution::RandomAvailable(backends) => {
-                    route::BackendDistribution::random_available(
-                        backends
-                            .iter()
-                            .map(|(rb, weight)| (mk_route_backend(rr, rb), *weight)),
-                    )
-                    .expect("distribution must be valid")
-                }
-            };
+        let mk_distribution = |rr: &RouteRef,
+                               d: &policy::RouteDistribution<policy::opaq::Filter>,
+                               addr: Addr| match d {
+            policy::RouteDistribution::Empty => route::BackendDistribution::Empty,
+            policy::RouteDistribution::FirstAvailable(backends) => {
+                route::BackendDistribution::first_available(
+                    backends
+                        .iter()
+                        .map(|b| mk_route_backend(rr, b, addr.clone())),
+                )
+            }
+            policy::RouteDistribution::RandomAvailable(backends) => {
+                route::BackendDistribution::random_available(
+                    backends
+                        .iter()
+                        .map(|(rb, weight)| (mk_route_backend(rr, rb, addr.clone()), *weight)),
+                )
+                .expect("distribution must be valid")
+            }
+        };
 
         let mk_policy =
-            |policy::RoutePolicy::<policy::tls::Filter, ()> {
+            |policy::RoutePolicy::<policy::opaq::Filter, ()> {
                  meta, distribution, ..
              },
+             addr: Addr,
              forbidden: bool| {
                 let route_ref = RouteRef(meta);
                 let parent_ref = parent_ref.clone();
 
-                let distribution = mk_distribution(&route_ref, &distribution);
+                let distribution = mk_distribution(&route_ref, &distribution, addr.clone());
                 route::Route {
-                    addr: addr.clone(),
+                    addr,
                     parent: parent.clone(),
                     parent_ref: parent_ref.clone(),
                     route_ref,
@@ -148,22 +149,16 @@ where
 
         let routes = routes
             .iter()
-            .map(|route| tls_route::Route {
-                snis: route.snis.clone(),
-                rules: route
-                    .rules
-                    .iter()
-                    .cloned()
-                    .map(|tls_route::Rule { matches, policy }| tls_route::Rule {
-                        matches,
-                        policy: mk_policy(policy, route.forbidden),
-                    })
-                    .collect(),
+            .map(|route| opaq_route::Route {
+                policy: mk_policy(route.policy.clone(), addr.clone(), route.forbidden),
                 forbidden: route.forbidden,
             })
             .collect();
 
-        let backends = backends.iter().map(mk_dispatch).collect();
+        let backends = backends
+            .iter()
+            .map(|b| mk_dispatch(b, addr.clone()))
+            .collect();
 
         Self {
             routes,
@@ -177,18 +172,13 @@ where
 impl<T, I> svc::router::SelectRoute<I> for Router<T>
 where
     T: Clone + Eq + Hash + Debug,
-    T: svc::Param<ServerName>,
 {
     type Key = route::MatchedRoute<T>;
     type Error = NoRoute;
 
     fn select(&self, _: &I) -> Result<Self::Key, Self::Error> {
-        use linkerd_tls_route::SessionInfo;
-
-        let server_name: ServerName = self.parent.param();
-        tracing::trace!("Selecting TLS route for {:?}", server_name);
-        let si = SessionInfo { sni: server_name };
-        let (r#match, params) = policy::tls::find(&self.routes, si).ok_or(NoRoute)?;
+        tracing::trace!("Selecting Opaq route");
+        let (r#match, params) = policy::opaq::find(&self.routes).ok_or(NoRoute)?;
         tracing::debug!(meta = ?params.route_ref, "Selected route");
         tracing::trace!(?r#match);
 

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -38,6 +38,12 @@ struct TlsSidecar {
     routes: watch::Receiver<tls::Routes>,
 }
 
+#[derive(Clone, Debug)]
+struct OpaqSidecar {
+    orig_dst: OrigDstAddr,
+    routes: watch::Receiver<opaq::Routes>,
+}
+
 // === impl Outbound ===
 
 impl Outbound<()> {
@@ -58,7 +64,14 @@ impl Outbound<()> {
         R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
         R::Resolution: Unpin,
     {
-        let opaq = self.to_tcp_connect().push_opaq_cached(resolve.clone());
+        let opaq = self.clone().with_stack(
+            self.to_tcp_connect()
+                .push_opaq_cached(resolve.clone())
+                .into_stack()
+                .push_map_target(OpaqSidecar::from)
+                .arc_new_clone_tcp(),
+        );
+
         let tls = self
             .to_tcp_connect()
             .push_tls_cached(resolve.clone())
@@ -151,23 +164,6 @@ impl svc::Param<Protocol> for Sidecar {
     }
 }
 
-impl svc::Param<opaq::Logical> for Sidecar {
-    fn param(&self) -> opaq::Logical {
-        if let Some(profile) = self.profile.clone() {
-            if let Some(profiles::LogicalAddr(addr)) = profile.logical_addr() {
-                return opaq::Logical::Route(addr, profile);
-            }
-
-            if let Some((addr, metadata)) = profile.endpoint() {
-                return opaq::Logical::Forward(Remote(ServerAddr(addr)), metadata);
-            }
-        }
-
-        let OrigDstAddr(addr) = self.orig_dst;
-        opaq::Logical::Forward(Remote(ServerAddr(addr)), Default::default())
-    }
-}
-
 impl PartialEq for Sidecar {
     fn eq(&self, other: &Self) -> bool {
         self.orig_dst == other.orig_dst
@@ -214,6 +210,7 @@ impl From<protocol::Http<Sidecar>> for HttpSidecar {
         let routes = http::spawn_routes(policy, init, move |policy: &policy::ClientPolicy| {
             Self::mk_policy_routes(orig_dst, version, policy)
         });
+
         HttpSidecar {
             orig_dst,
             version,
@@ -397,5 +394,42 @@ impl std::cmp::Eq for TlsSidecar {}
 impl std::hash::Hash for TlsSidecar {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.orig_dst.hash(state);
+    }
+}
+
+// === impl OpaqSidecar ===
+
+impl From<Sidecar> for OpaqSidecar {
+    fn from(parent: Sidecar) -> Self {
+        let orig_dst = parent.orig_dst;
+        let routes = opaq::routes_from_discovery(*orig_dst, parent.profile, parent.policy);
+        OpaqSidecar { orig_dst, routes }
+    }
+}
+
+impl svc::Param<watch::Receiver<opaq::Routes>> for OpaqSidecar {
+    fn param(&self) -> watch::Receiver<opaq::Routes> {
+        self.routes.clone()
+    }
+}
+
+impl std::cmp::PartialEq for OpaqSidecar {
+    fn eq(&self, other: &Self) -> bool {
+        self.orig_dst == other.orig_dst
+    }
+}
+
+impl std::cmp::Eq for OpaqSidecar {}
+
+impl std::hash::Hash for OpaqSidecar {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.orig_dst.hash(state);
+    }
+}
+
+impl svc::Param<opaq::LogicalAddr> for OpaqSidecar {
+    fn param(&self) -> opaq::LogicalAddr {
+        let routes = self.routes.borrow();
+        opaq::LogicalAddr(routes.addr.clone())
     }
 }

--- a/linkerd/app/outbound/src/tls.rs
+++ b/linkerd/app/outbound/src/tls.rs
@@ -17,6 +17,7 @@ use tokio::sync::watch;
 mod concrete;
 mod logical;
 
+pub(crate) use self::logical::route::ForbiddenRoute;
 pub use self::logical::{Concrete, Routes};
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/linkerd/app/outbound/src/tls/logical/tests.rs
+++ b/linkerd/app/outbound/src/tls/logical/tests.rs
@@ -167,6 +167,7 @@ fn sni_route(backend: client_policy::Backend, sni: sni::MatchSni) -> client_poli
                 }])),
             },
         }],
+        forbidden: false,
     }
 }
 

--- a/linkerd/app/test/src/resolver/client_policy.rs
+++ b/linkerd/app/test/src/resolver/client_policy.rs
@@ -81,6 +81,19 @@ impl ClientPolicies {
             }],
         }]);
 
+        let opaq_routes = Arc::new([opaq::Route {
+            policy: opaq::Policy {
+                meta: Meta::new_default("default"),
+                filters: Arc::new([]),
+                params: Default::default(),
+                distribution: RouteDistribution::FirstAvailable(Arc::new([RouteBackend {
+                    filters: Arc::new([]),
+                    backend: backend.clone(),
+                }])),
+            },
+            forbidden: false,
+        }]);
+
         let protocol = Protocol::Detect {
             timeout: Duration::from_secs(10),
             http1: http::Http1 {
@@ -92,15 +105,7 @@ impl ClientPolicies {
                 failure_accrual: Default::default(),
             },
             opaque: opaq::Opaque {
-                policy: Some(opaq::Policy {
-                    meta: Meta::new_default("default"),
-                    filters: Arc::new([]),
-                    params: Default::default(),
-                    distribution: RouteDistribution::FirstAvailable(Arc::new([RouteBackend {
-                        filters: Arc::new([]),
-                        backend: backend.clone(),
-                    }])),
-                }),
+                routes: opaq_routes,
             },
         };
         let policy = ClientPolicy {

--- a/linkerd/opaq-route/Cargo.toml
+++ b/linkerd/opaq-route/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "linkerd-opaq-route"
+version = "0.1.0"
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+regex = "1"
+rand = "0.8"
+thiserror = "1"
+tracing = "0.1"

--- a/linkerd/opaq-route/src/lib.rs
+++ b/linkerd/opaq-route/src/lib.rs
@@ -1,0 +1,52 @@
+//! An TLS route matching library for Linkerd to support the TLSRoute
+//! Kubernetes Gateway API types.
+
+#![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
+#![forbid(unsafe_code)]
+
+use r#match::SessionMatch;
+use tracing::trace;
+
+pub mod r#match;
+
+/// Groups routing rules under a common set of SNIs.
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub struct Route<P> {
+    /// Must not be empty.
+    pub policy: P,
+
+    /// Indicates that traffic should not pass through this route
+    pub forbidden: bool,
+}
+
+/// Policies for a given set of route matches.
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct Rule<P> {
+    pub policy: P,
+}
+
+/// Summarizes a matched route so that route matches may be compared/ordered. A
+/// greater match is preferred over a lesser match.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub struct RouteMatch {
+    route: r#match::SessionMatch,
+}
+
+pub fn find<P>(routes: &[Route<P>]) -> Option<(RouteMatch, &P)> {
+    trace!(routes = ?routes.len(), "Finding matching route");
+    best(routes.iter().filter_map(|rt| {
+        Some((
+            RouteMatch {
+                route: SessionMatch::default(),
+            },
+            &rt.policy,
+        ))
+    }))
+}
+
+#[inline]
+fn best<M: Ord, P>(matches: impl Iterator<Item = (M, P)>) -> Option<(M, P)> {
+    // This is roughly equivalent to `max_by(...)` but we want to ensure
+    // that the first match wins.
+    matches.reduce(|(m0, p0), (m1, p1)| if m0 >= m1 { (m0, p0) } else { (m1, p1) })
+}

--- a/linkerd/opaq-route/src/lib.rs
+++ b/linkerd/opaq-route/src/lib.rs
@@ -34,13 +34,13 @@ pub struct RouteMatch {
 
 pub fn find<P>(routes: &[Route<P>]) -> Option<(RouteMatch, &P)> {
     trace!(routes = ?routes.len(), "Finding matching route");
-    best(routes.iter().filter_map(|rt| {
-        Some((
+    best(routes.iter().map(|rt| {
+        (
             RouteMatch {
                 route: SessionMatch::default(),
             },
             &rt.policy,
-        ))
+        )
     }))
 }
 

--- a/linkerd/opaq-route/src/match.rs
+++ b/linkerd/opaq-route/src/match.rs
@@ -1,0 +1,21 @@
+use std::cmp::Ordering;
+
+/// Matches TCP sessions. For now, this is a placeholder
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct MatchSession(());
+
+/// Summarizes a matched TCP session. For now this is a placeholder
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Default)]
+pub struct SessionMatch(());
+
+impl std::cmp::PartialOrd for SessionMatch {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::cmp::Ord for SessionMatch {
+    fn cmp(&self, _: &Self) -> std::cmp::Ordering {
+        Ordering::Equal
+    }
+}

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -27,6 +27,7 @@ linkerd-error = { path = "../../error" }
 linkerd-exp-backoff = { path = "../../exp-backoff" }
 linkerd-http-route = { path = "../../http/route" }
 linkerd-tls-route = { path = "../../tls/route" }
+linkerd-opaq-route = { path = "../../opaq-route" }
 linkerd-proxy-api-resolve = { path = "../api-resolve" }
 linkerd-proxy-core = { path = "../core" }
 

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -373,7 +373,7 @@ pub mod proto {
             }: grpc_route::RouteBackend,
         ) -> Result<RouteBackend<Filter>, InvalidBackend> {
             let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
-            RouteBackend::try_from_proto(backend, filters)
+            RouteBackend::try_from_proto(backend, filters, None)
         }
     }
 

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -444,7 +444,7 @@ pub mod proto {
             }: http_route::RouteBackend,
         ) -> Result<Self, Self::Error> {
             let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
-            RouteBackend::try_from_proto(backend, filters)
+            RouteBackend::try_from_proto(backend, filters, None)
         }
     }
 

--- a/linkerd/proxy/client-policy/src/opaq.rs
+++ b/linkerd/proxy/client-policy/src/opaq.rs
@@ -1,11 +1,16 @@
-use crate::RoutePolicy;
+use linkerd_opaq_route as opaq;
+use std::sync::Arc;
 
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub use linkerd_opaq_route::{find, RouteMatch};
+
+pub type Policy = crate::RoutePolicy<Filter, ()>;
+pub type Route = opaq::Route<Policy>;
+pub type Rule = opaq::Rule<Policy>;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Opaque {
-    pub policy: Option<Policy>,
+    pub routes: Arc<[Route]>,
 }
-
-pub type Policy = RoutePolicy<Filter, ()>;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct NonIoErrors;
@@ -47,11 +52,6 @@ pub(crate) mod proto {
         #[error("an opaque route must have exactly one rule, but {0} were provided")]
         OnlyOneRule(usize),
 
-        /// Note: this restriction may be removed in the future, if a way of
-        /// actually matching rules for opaque routes is added.
-        #[error("a `ProxyProtocol::Opaque` must have exactly one route, but {0} were provided")]
-        OnlyOneRoute(usize),
-
         #[error("no filters can be configured on opaque routes yet")]
         NoFilters,
 
@@ -59,59 +59,51 @@ pub(crate) mod proto {
         Missing(&'static str),
     }
 
+    pub(crate) fn fill_route_backends(rts: &[Route], set: &mut BackendSet) {
+        for Route { ref policy, .. } in rts {
+            policy.distribution.fill_backends(set);
+        }
+    }
+
     impl TryFrom<outbound::proxy_protocol::Opaque> for Opaque {
         type Error = InvalidOpaqueRoute;
         fn try_from(proto: outbound::proxy_protocol::Opaque) -> Result<Self, Self::Error> {
-            if proto.routes.len() != 1 {
-                return Err(InvalidOpaqueRoute::OnlyOneRoute(proto.routes.len()));
-            }
-
-            proto
+            let routes = proto
                 .routes
                 .into_iter()
-                .next()
-                .ok_or(InvalidOpaqueRoute::OnlyOneRoute(0))?
-                .try_into()
+                .map(try_route)
+                .collect::<Result<Arc<[_]>, _>>()?;
+
+            Ok(Self { routes })
         }
     }
 
-    impl TryFrom<outbound::OpaqueRoute> for Opaque {
-        type Error = InvalidOpaqueRoute;
+    fn try_route(
+        outbound::OpaqueRoute {
+            metadata,
+            rules,
+            error,
+        }: outbound::OpaqueRoute,
+    ) -> Result<Route, InvalidOpaqueRoute> {
+        let meta = Arc::new(
+            metadata
+                .ok_or(InvalidMeta("missing metadata"))?
+                .try_into()?,
+        );
 
-        fn try_from(
-            outbound::OpaqueRoute { metadata, rules }: outbound::OpaqueRoute,
-        ) -> Result<Self, Self::Error> {
-            let meta = Arc::new(
-                metadata
-                    .ok_or(InvalidMeta("missing metadata"))?
-                    .try_into()?,
-            );
-
-            // Currently, opaque rules have no match expressions, so if there's
-            // more than one rule, we have no way of determining which one to
-            // use. Therefore, require that there's exactly one rule.
-            if rules.len() != 1 {
-                return Err(InvalidOpaqueRoute::OnlyOneRule(rules.len()));
-            }
-
-            let policy = rules
-                .into_iter()
-                .map(|rule| try_rule(&meta, rule))
-                .next()
-                .ok_or(InvalidOpaqueRoute::OnlyOneRule(0))??;
-
-            Ok(Self {
-                policy: Some(policy),
-            })
+        // Currently, opaque rules have no match expressions, so if there's
+        // more than one rule, we have no way of determining which one to
+        // use. Therefore, require that there's exactly one rule.
+        if rules.len() != 1 {
+            return Err(InvalidOpaqueRoute::OnlyOneRule(rules.len()));
         }
-    }
 
-    impl Opaque {
-        pub(crate) fn fill_backends(&self, set: &mut BackendSet) {
-            for p in &self.policy {
-                p.distribution.fill_backends(set);
-            }
-        }
+        let rule = rules.first().cloned().expect("already checked");
+        let policy = try_rule(&meta, rule)?;
+        Ok(Route {
+            policy,
+            forbidden: error.is_some(),
+        })
     }
 
     fn try_rule(
@@ -175,10 +167,14 @@ pub(crate) mod proto {
     impl TryFrom<opaque_route::RouteBackend> for RouteBackend<Filter> {
         type Error = InvalidBackend;
         fn try_from(
-            opaque_route::RouteBackend { backend }: opaque_route::RouteBackend,
+            opaque_route::RouteBackend { backend, invalid }: opaque_route::RouteBackend,
         ) -> Result<Self, Self::Error> {
             let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
-            RouteBackend::try_from_proto(backend, std::iter::empty::<()>())
+            RouteBackend::try_from_proto(
+                backend,
+                std::iter::empty::<()>(),
+                invalid.map(|inv| inv.message),
+            )
         }
     }
 

--- a/linkerd/proxy/client-policy/src/tls.rs
+++ b/linkerd/proxy/client-policy/src/tls.rs
@@ -27,6 +27,7 @@ pub fn default(distribution: crate::RouteDistribution<Filter>) -> Route {
                 distribution,
             },
         }],
+        forbidden: false,
     }
 }
 

--- a/linkerd/service-profiles/src/lib.rs
+++ b/linkerd/service-profiles/src/lib.rs
@@ -193,6 +193,12 @@ impl Profile {
     pub fn has_routes_or_targets(&self) -> bool {
         !self.http_routes.is_empty() || !self.targets.is_empty()
     }
+
+    /// Returns `true` if this profile provides configuration that should
+    /// override a client policy configuration.
+    pub fn has_targets(&self) -> bool {
+        !self.targets.is_empty()
+    }
 }
 
 // === impl LookupAddr ===

--- a/linkerd/tls/route/src/lib.rs
+++ b/linkerd/tls/route/src/lib.rs
@@ -26,6 +26,9 @@ pub struct Route<P> {
 
     /// Must not be empty.
     pub rules: Vec<Rule<P>>,
+
+    /// Indicates that traffic should not pass through this route
+    pub forbidden: bool,
 }
 
 /// Policies for a given set of route matches.

--- a/linkerd/tls/route/src/tests.rs
+++ b/linkerd/tls/route/src/tests.rs
@@ -23,6 +23,7 @@ fn sni_precedence() {
                 policy: Policy::Unexpected,
                 matches: vec![],
             }],
+            forbidden: false,
         },
         Route {
             snis: vec!["foo.example.com".parse().unwrap()],
@@ -30,6 +31,7 @@ fn sni_precedence() {
                 policy: Policy::Expected,
                 matches: vec![],
             }],
+            forbidden: false,
         },
     ];
 
@@ -54,11 +56,13 @@ fn first_identical_wins() {
                 Rule::default(),
             ],
             snis: vec![],
+            forbidden: false,
         },
         // Redundant route.
         Route {
             rules: vec![Rule::default()],
             snis: vec![],
+            forbidden: false,
         },
     ];
 
@@ -78,6 +82,7 @@ fn no_match_suffix() {
             policy: Policy::Unexpected,
             matches: vec![],
         }],
+        forbidden: false,
     }];
 
     let si = SessionInfo {
@@ -95,6 +100,7 @@ fn no_match_exact() {
             policy: Policy::Unexpected,
             matches: vec![],
         }],
+        forbidden: false,
     }];
 
     let si = SessionInfo {


### PR DESCRIPTION
This work (based on the early [sketch seen here](https://github.com/linkerd/linkerd2-proxy/compare/ver/opaq-policy)) changes the `opaq` routing stack to use not only profiles routing but to consider client policy responses as well. The way this is done is that we use the `opaq:Routes` type to express the routing information our stack contains. This type is geared towards the client-policy API. Whenever we need to use the profiles response, we simply translate its contents to a client-policy one.

Notable changes in this PR are: 

- we introduce an `OpaqSidecar` type that holds `opaq::Routes` objects which are routes that have been constructed from either `profiles` or `policy` response
- during the construction of the `OpaqSidecar` we consider profiles responses only if there are extra targets in the response (in order to support `TrafficSplit` functionality). In any other case we prefer the policy response.
- we depend on the new, not yet released proxy API in order to support the notion of invalid routes and backends and enable explicit failure for TCP and TLS routes.
- we eagerly fail routes that have been marked as forbidden and record that in tcp/tls metrics.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>