### PR TITLE
Middleware for rate-limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,6 +1293,7 @@ dependencies = [
  "linkerd-app-test",
  "linkerd-http-access-log",
  "linkerd-http-metrics",
+ "linkerd-identity",
  "linkerd-idle-cache",
  "linkerd-io",
  "linkerd-meshtls",

--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -166,6 +166,16 @@ impl SyntheticHttpResponse {
         }
     }
 
+    pub fn rate_limited(msg: impl ToString) -> Self {
+        Self {
+            http_status: http::StatusCode::TOO_MANY_REQUESTS,
+            grpc_status: tonic::Code::ResourceExhausted,
+            close_connection: false,
+            message: Cow::Owned(msg.to_string()),
+            location: None,
+        }
+    }
+
     pub fn loop_detected(msg: impl ToString) -> Self {
         Self {
             http_status: http::StatusCode::LOOP_DETECTED,

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -24,6 +24,7 @@ futures = { version = "0.3", default-features = false }
 linkerd-app-core = { path = "../core" }
 linkerd-app-test = { path = "../test", optional = true }
 linkerd-http-access-log = { path = "../../http/access-log" }
+linkerd-identity = { path = "../../identity" }
 linkerd-idle-cache = { path = "../../idle-cache" }
 linkerd-meshtls = { path = "../../meshtls", optional = true }
 linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true }

--- a/linkerd/app/inbound/src/http.rs
+++ b/linkerd/app/inbound/src/http.rs
@@ -1,4 +1,4 @@
-mod router;
+pub mod router;
 mod server;
 mod set_identity_header;
 #[cfg(test)]

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -241,6 +241,8 @@ impl<C> Inbound<C> {
                 .check_new_service::<(policy::HttpRoutePermit, T), http::Request<http::BoxBody>>()
                 .push(svc::ArcNewService::layer())
                 .push(policy::NewHttpPolicy::layer(rt.metrics.http_authz.clone()))
+                .push(svc::ArcNewService::layer())
+                .push(policy::http_local_rate_limit::NewHttpLocalRateLimit::layer())
                 // Used by tap.
                 .push_http_insert_target::<tls::ConditionalServerTls>()
                 .push_http_insert_target::<Remote<ClientAddr>>()

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -203,6 +203,10 @@ impl errors::HttpRescue<Error> for ServerRescue {
             ));
         }
 
+        if errors::is_caused_by::<policy::http::RateLimitError>(&*error) {
+            return Ok(errors::SyntheticHttpResponse::rate_limited(error));
+        }
+
         if errors::is_caused_by::<crate::GatewayDomainInvalid>(&*error) {
             return Ok(errors::SyntheticHttpResponse::not_found(error));
         }

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -203,7 +203,7 @@ impl errors::HttpRescue<Error> for ServerRescue {
             ));
         }
 
-        if errors::is_caused_by::<policy::http::RateLimitError>(&*error) {
+        if errors::is_caused_by::<policy::http_local_rate_limit::RateLimitError>(&*error) {
             return Ok(errors::SyntheticHttpResponse::rate_limited(error));
         }
 

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -2,6 +2,7 @@ mod api;
 mod config;
 pub mod defaults;
 pub mod http;
+pub mod http_local_rate_limit;
 mod store;
 mod tcp;
 

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -1,7 +1,7 @@
 mod api;
 mod config;
 pub mod defaults;
-mod http;
+pub mod http;
 mod store;
 mod tcp;
 

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -7,10 +7,11 @@ use futures::{future, TryFutureExt};
 use linkerd_app_core::{
     metrics::{RouteAuthzLabels, RouteLabels},
     svc::{self, ServiceExt},
-    tls,
+    tls::{self, ClientId, ServerTls},
     transport::{ClientAddr, OrigDstAddr, Remote},
-    Error, Result,
+    Conditional, Error, Result,
 };
+use linkerd_identity::Id;
 use linkerd_proxy_server_policy::{grpc, http, route::RouteMatch};
 use std::{sync::Arc, task};
 
@@ -82,6 +83,10 @@ pub struct GrpcRouteInjectedFailure {
 #[derive(Debug, thiserror::Error)]
 #[error("invalid server policy: {0}")]
 pub struct HttpInvalidPolicy(&'static str);
+
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+#[error("too many requests")]
+pub struct RateLimitError(());
 
 // === impl NewHttpPolicy ===
 
@@ -155,6 +160,10 @@ where
     }
 
     fn call(&mut self, mut req: ::http::Request<B>) -> Self::Future {
+        if self.rate_limit().is_err() {
+            return future::Either::Right(future::err(RateLimitError(()).into()));
+        }
+
         // Find an appropriate route for the request and ensure that it's
         // authorized.
         let permit = match self.policy.routes() {
@@ -286,6 +295,54 @@ impl<T, N> HttpPolicyService<T, N> {
         self.metrics
             .route_not_found(labels, self.connection.dst, self.connection.tls.clone());
         HttpRouteNotFound(()).into()
+    }
+
+    fn rate_limit(&self) -> std::result::Result<(), ()> {
+        let arc_rl = self.policy.borrow().local_rate_limit.clone();
+        let rl = Arc::clone(&arc_rl);
+
+        if let Some(lim) = &rl.total {
+            if lim.check().is_err() {
+                tracing::info!("Global rate limit exceeded");
+                return Err(());
+            }
+        }
+
+        let client_id = self.get_client_id().unwrap_or("UNKNOWN");
+        let mut has_err = false;
+        let _ = &rl
+            .overrides
+            .iter()
+            .filter(|lim| lim.ids.contains(&client_id.to_string()))
+            .for_each(|lim| {
+                if lim.rate_limit.check_key(&lim.ids).is_err() {
+                    tracing::info!("Override rate limit exceeded");
+                    has_err = true;
+                }
+            });
+
+        if has_err {
+            return Err(());
+        }
+
+        if let Some(lim) = &rl.identity {
+            if lim.check_key(&client_id.to_string()).is_err() {
+                tracing::info!("Identity rate limit exceeded");
+                return Err(());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_client_id(&self) -> Option<&str> {
+        match &self.connection.tls {
+            Conditional::Some(ServerTls::Established {
+                client_id: Some(ClientId(Id::Dns(dns_name))),
+                ..
+            }) => Some(dns_name.as_str()),
+            _ => None,
+        }
     }
 }
 

--- a/linkerd/app/inbound/src/policy/http_local_rate_limit.rs
+++ b/linkerd/app/inbound/src/policy/http_local_rate_limit.rs
@@ -1,0 +1,143 @@
+use crate::policy::AllowPolicy;
+use futures::{future, TryFutureExt};
+use linkerd_app_core::{
+    svc::{self, ServiceExt},
+    tls::{self, ClientId, ServerTls},
+    Conditional, Error,
+};
+use linkerd_identity::Id;
+use std::{sync::Arc, task};
+
+#[derive(Clone, Debug)]
+pub struct NewHttpLocalRateLimit<N> {
+    inner: N,
+}
+
+#[derive(Clone, Debug)]
+pub struct HttpLocalRateLimitService<T, N> {
+    target: T,
+    policy: AllowPolicy,
+    tls: tls::ConditionalServerTls,
+    inner: N,
+}
+
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+#[error("too many requests")]
+pub struct RateLimitError(());
+
+
+// === impl NewHttpPolicy ===
+
+impl<N> NewHttpLocalRateLimit<N> {
+    pub fn layer() -> impl svc::layer::Layer<N, Service = Self> + Clone {
+        svc::layer::mk(move |inner| Self {
+            inner,
+        })
+    }
+}
+
+// === impl HttpLocalRateLimitService ===
+
+impl<T, N> svc::NewService<T> for NewHttpLocalRateLimit<N>
+where
+    T: svc::Param<AllowPolicy>,
+    T: svc::Param<tls::ConditionalServerTls>,
+    N: Clone,
+{
+    type Service = HttpLocalRateLimitService<T, N>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let client = target.param();
+        let tls = target.param();
+        let policy: AllowPolicy = target.param();
+        HttpLocalRateLimitService {
+            target,
+            policy,
+            tls,
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<B, T, N, S> svc::Service<::http::Request<B>> for HttpLocalRateLimitService<T, N>
+where
+    T: Clone,
+    N: svc::NewService<(HttpRoutePermit, T), Service = S>,
+    S: svc::Service<::http::Request<B>>,
+    S::Error: Into<Error>,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = future::Either<
+        future::ErrInto<svc::stack::Oneshot<S, ::http::Request<B>>, Error>,
+        future::Ready<Result<Self::Response>>,
+    >;
+
+    #[inline]
+    fn poll_ready(&mut self, _: &mut task::Context<'_>) -> task::Poll<Result<()>> {
+        task::Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, mut req: ::http::Request<B>) -> Self::Future {
+        if self.rate_limit().is_err() {
+            return future::Either::Right(future::err(RateLimitError(()).into()));
+        }
+
+        future::Either::Left(
+            self.inner
+                .new_service((permit, self.target.clone()))
+                .oneshot(req)
+                .err_into::<Error>(),
+        )
+    }
+}
+
+impl<T, N> HttpLocalRateLimitService<T, N> {
+    fn rate_limit(&self) -> std::result::Result<(), ()> {
+        let arc_rl = self.policy.borrow().local_rate_limit.clone();
+        let rl = Arc::clone(&arc_rl);
+
+        if let Some(lim) = &rl.total {
+            if lim.check().is_err() {
+                tracing::info!("Global rate limit exceeded");
+                return Err(());
+            }
+        }
+
+        let client_id = self.get_client_id().unwrap_or("UNKNOWN");
+        let mut has_err = false;
+        let _ = &rl
+            .overrides
+            .iter()
+            .filter(|lim| lim.ids.contains(&client_id.to_string()))
+            .for_each(|lim| {
+                if lim.rate_limit.check_key(&lim.ids).is_err() {
+                    tracing::info!("Override rate limit exceeded");
+                    has_err = true;
+                }
+            });
+
+        if has_err {
+            return Err(());
+        }
+
+        if let Some(lim) = &rl.identity {
+            if lim.check_key(&client_id.to_string()).is_err() {
+                tracing::info!("Identity rate limit exceeded");
+                return Err(());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn get_client_id(&self) -> Option<&str> {
+        match &self.connection.tls {
+            Conditional::Some(ServerTls::Established {
+                client_id: Some(ClientId(Id::Dns(dns_name))),
+                ..
+            }) => Some(dns_name.as_str()),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
This is based off of #3305 

In the first commit (4ace6bc1) I added the rate-limiting logic into the HttpPolicyService, and managed to successfully test this end-to-end.
In the second commit (013bffa0) I moved that logic into a separate middleware HttpLocalRateLimitService, but couldn't manage to align the types for the tower service.