### PR TITLE
feat(app): Backend frame count metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,7 +1506,9 @@ dependencies = [
  "ahash",
  "bytes",
  "futures",
+ "futures-util",
  "http",
+ "http-body",
  "hyper",
  "linkerd-app-core",
  "linkerd-app-test",
@@ -1744,6 +1746,7 @@ dependencies = [
 name = "linkerd-http-prom"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "futures",
  "http",
  "http-body",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -50,6 +50,8 @@ linkerd-tonic-stream = { path = "../../tonic-stream" }
 linkerd-tonic-watch = { path = "../../tonic-watch" }
 
 [dev-dependencies]
+futures-util = "0.3"
+http-body = "0.4"
 hyper = { version = "0.14", features = ["http1", "http2"] }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-rustls = "0.24"

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -110,7 +110,7 @@ impl<L: StreamLabel> RouteBackendMetrics<L> {
         &self,
         l: &labels::RouteBackend,
     ) -> linkerd_http_prom::body_data::response::BodyDataMetrics {
-        self.body_metrics.get(l)
+        self.body_metrics.metrics(l)
     }
 }
 
@@ -156,6 +156,6 @@ where
         let Self(families) = self;
         let labels = labels::RouteBackend(t.param(), t.param(), t.param());
 
-        families.get(&labels)
+        families.metrics(&labels)
     }
 }

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -1,6 +1,7 @@
 use crate::{BackendRef, ParentRef, RouteRef};
 use linkerd_app_core::{metrics::prom, svc};
 use linkerd_http_prom::{
+    body_data::response::{BodyDataMetrics, NewRecordBodyData, ResponseBodyFamilies},
     record_response::{self, NewResponseDuration, StreamLabel},
     NewCountRequests, RequestCount, RequestCountFamilies,
 };
@@ -15,6 +16,7 @@ mod tests;
 pub struct RouteBackendMetrics<L: StreamLabel> {
     requests: RequestCountFamilies<labels::RouteBackend>,
     responses: ResponseMetrics<L>,
+    body_metrics: ResponseBodyFamilies<labels::RouteBackend>,
 }
 
 type ResponseMetrics<L> = record_response::ResponseMetrics<
@@ -26,14 +28,24 @@ pub fn layer<T, N>(
     metrics: &RouteBackendMetrics<T::StreamLabel>,
 ) -> impl svc::Layer<
     N,
-    Service = NewCountRequests<
-        ExtractRequestCount,
-        NewResponseDuration<T, ExtractRecordDurationParams<ResponseMetrics<T::StreamLabel>>, N>,
+    Service = NewRecordBodyData<
+        ExtractRecordBodyDataParams,
+        NewCountRequests<
+            ExtractRequestCount,
+            NewResponseDuration<T, ExtractRecordDurationParams<ResponseMetrics<T::StreamLabel>>, N>,
+        >,
     >,
 > + Clone
 where
     T: MkStreamLabel,
     N: svc::NewService<T>,
+    NewRecordBodyData<
+        ExtractRecordBodyDataParams,
+        NewCountRequests<
+            ExtractRequestCount,
+            NewResponseDuration<T, ExtractRecordDurationParams<ResponseMetrics<T::StreamLabel>>, N>,
+        >,
+    >: svc::NewService<T>,
     NewCountRequests<
         ExtractRequestCount,
         NewResponseDuration<T, ExtractRecordDurationParams<ResponseMetrics<T::StreamLabel>>, N>,
@@ -44,12 +56,16 @@ where
     let RouteBackendMetrics {
         requests,
         responses,
+        body_metrics,
     } = metrics.clone();
+
     svc::layer::mk(move |inner| {
         use svc::Layer;
-        NewCountRequests::layer_via(ExtractRequestCount(requests.clone())).layer(
-            NewRecordDuration::layer_via(ExtractRecordDurationParams(responses.clone()))
-                .layer(inner),
+        NewRecordBodyData::layer_via(ExtractRecordBodyDataParams(body_metrics.clone())).layer(
+            NewCountRequests::layer_via(ExtractRequestCount(requests.clone())).layer(
+                NewRecordDuration::layer_via(ExtractRecordDurationParams(responses.clone()))
+                    .layer(inner),
+            ),
         )
     })
 }
@@ -57,15 +73,20 @@ where
 #[derive(Clone, Debug)]
 pub struct ExtractRequestCount(RequestCountFamilies<labels::RouteBackend>);
 
+#[derive(Clone, Debug)]
+pub struct ExtractRecordBodyDataParams(ResponseBodyFamilies<labels::RouteBackend>);
+
 // === impl RouteBackendMetrics ===
 
 impl<L: StreamLabel> RouteBackendMetrics<L> {
     pub fn register(reg: &mut prom::Registry, histo: impl IntoIterator<Item = f64>) -> Self {
         let requests = RequestCountFamilies::register(reg);
         let responses = record_response::ResponseMetrics::register(reg, histo);
+        let body_metrics = ResponseBodyFamilies::register(reg);
         Self {
             requests,
             responses,
+            body_metrics,
         }
     }
 
@@ -83,6 +104,14 @@ impl<L: StreamLabel> RouteBackendMetrics<L> {
     pub(crate) fn get_statuses(&self, l: &L::StatusLabels) -> prom::Counter {
         self.responses.get_statuses(l)
     }
+
+    #[cfg(test)]
+    pub(crate) fn get_response_body_metrics(
+        &self,
+        l: &labels::RouteBackend,
+    ) -> linkerd_http_prom::body_data::response::BodyDataMetrics {
+        self.body_metrics.get(l)
+    }
 }
 
 impl<L: StreamLabel> Default for RouteBackendMetrics<L> {
@@ -90,6 +119,7 @@ impl<L: StreamLabel> Default for RouteBackendMetrics<L> {
         Self {
             requests: Default::default(),
             responses: Default::default(),
+            body_metrics: Default::default(),
         }
     }
 }
@@ -99,6 +129,7 @@ impl<L: StreamLabel> Clone for RouteBackendMetrics<L> {
         Self {
             requests: self.requests.clone(),
             responses: self.responses.clone(),
+            body_metrics: self.body_metrics.clone(),
         }
     }
 }
@@ -112,5 +143,19 @@ where
     fn extract_param(&self, t: &T) -> RequestCount {
         self.0
             .metrics(&labels::RouteBackend(t.param(), t.param(), t.param()))
+    }
+}
+
+// === impl ExtractRecordBodyDataParams ===
+
+impl<T> svc::ExtractParam<BodyDataMetrics, T> for ExtractRecordBodyDataParams
+where
+    T: svc::Param<ParentRef> + svc::Param<RouteRef> + svc::Param<BackendRef>,
+{
+    fn extract_param(&self, t: &T) -> BodyDataMetrics {
+        let Self(families) = self;
+        let labels = labels::RouteBackend(t.param(), t.param(), t.param());
+
+        families.get(&labels)
     }
 }

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
@@ -5,9 +5,11 @@ use super::{
     LabelGrpcRouteBackendRsp, LabelHttpRouteBackendRsp, RouteBackendMetrics,
 };
 use crate::http::{concrete, logical::Concrete};
+use bytes::Buf;
 use linkerd_app_core::{
     svc::{self, http::BoxBody, Layer, NewService},
     transport::{Remote, ServerAddr},
+    Error,
 };
 use linkerd_proxy_client_policy as policy;
 
@@ -112,6 +114,128 @@ async fn http_request_statuses() {
     assert_eq!(ok.get(), 1);
     assert_eq!(no_content.get(), 1);
     assert_eq!(mixed.get(), 1);
+}
+
+/// Tests that metrics count frames in the backend response body.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn body_data_layer_records_frames() -> Result<(), Error> {
+    use http_body::Body;
+    use linkerd_app_core::proxy::http;
+    use linkerd_http_prom::body_data::response::BodyDataMetrics;
+    use tower::{Service, ServiceExt};
+
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let metrics = super::RouteBackendMetrics::default();
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let backend_ref = crate::BackendRef(policy::Meta::new_default("backend"));
+
+    let (mut svc, mut handle) =
+        mock_http_route_backend_metrics(&metrics, &parent_ref, &route_ref, &backend_ref);
+    handle.allow(1);
+
+    // Create a request.
+    let req = {
+        let empty = hyper::Body::empty();
+        let body = BoxBody::new(empty);
+        http::Request::builder().method("DOOT").body(body).unwrap()
+    };
+
+    // Call the service once it is ready to accept a request.
+    tracing::info!("calling service");
+    svc.ready().await.expect("ready");
+    let call = svc.call(req);
+    let (req, send_resp) = handle.next_request().await.unwrap();
+    debug_assert_eq!(req.method().as_str(), "DOOT");
+
+    // Acquire the counters for this backend.
+    tracing::info!("acquiring response body metrics");
+    let labels = labels::RouteBackend(parent_ref.clone(), route_ref.clone(), backend_ref.clone());
+    let BodyDataMetrics {
+        frames_total,
+        frames_bytes,
+    } = metrics.get_response_body_metrics(&labels);
+
+    // Before we've sent a response, the counter should be zero.
+    assert_eq!(frames_total.get(), 0);
+    assert_eq!(frames_bytes.get(), 0);
+
+    // Create a response whose body is backed by a channel that we can send chunks to, send it.
+    tracing::info!("sending response");
+    let mut resp_tx = {
+        let (tx, body) = hyper::Body::channel();
+        let body = BoxBody::new(body);
+        let resp = http::Response::builder()
+            .status(http::StatusCode::IM_A_TEAPOT)
+            .body(body)
+            .unwrap();
+        send_resp.send_response(resp);
+        tx
+    };
+
+    // Before we've sent any bytes, the counter should be zero.
+    assert_eq!(frames_total.get(), 0);
+    assert_eq!(frames_bytes.get(), 0);
+
+    // On the client end, poll our call future and await the response.
+    tracing::info!("polling service future");
+    let (parts, body) = call.await?.into_parts();
+    debug_assert_eq!(parts.status, 418);
+
+    let mut body = Box::pin(body);
+
+    /// Returns the next chunk from a boxed body.
+    async fn read_chunk(body: &mut std::pin::Pin<Box<BoxBody>>) -> Result<Vec<u8>, Error> {
+        use std::task::{Context, Poll};
+        let mut ctx = Context::from_waker(futures_util::task::noop_waker_ref());
+        let data = match body.as_mut().poll_data(&mut ctx) {
+            Poll::Ready(Some(Ok(d))) => d,
+            _ => panic!("next chunk should be ready"),
+        };
+        let chunk = data.chunk().to_vec();
+        Ok(chunk)
+    }
+
+    {
+        // Send a chunk, confirm that our counters are incremented.
+        tracing::info!("sending first chunk");
+        resp_tx.send_data("hello".into()).await?;
+        let chunk = read_chunk(&mut body).await?;
+        debug_assert_eq!("hello".as_bytes(), chunk, "should get same value back out");
+        assert_eq!(frames_total.get(), 1);
+        assert_eq!(frames_bytes.get(), 5);
+    }
+
+    {
+        // Send another chunk, confirm that our counters are incremented once more.
+        tracing::info!("sending second chunk");
+        resp_tx.send_data(", world!".into()).await?;
+        let chunk = read_chunk(&mut body).await?;
+        debug_assert_eq!(
+            ", world!".as_bytes(),
+            chunk,
+            "should get same value back out"
+        );
+        assert_eq!(frames_total.get(), 2);
+        assert_eq!(frames_bytes.get(), 5 + 8);
+    }
+
+    {
+        // Close the body, show that the counters remain at the same values.
+        use std::task::{Context, Poll};
+        tracing::info!("closing response body");
+        drop(resp_tx);
+        let mut ctx = Context::from_waker(futures_util::task::noop_waker_ref());
+        match body.as_mut().poll_data(&mut ctx) {
+            Poll::Ready(None) => {}
+            _ => panic!("got unexpected poll result"),
+        };
+        assert_eq!(frames_total.get(), 2);
+        assert_eq!(frames_bytes.get(), 5 + 8);
+    }
+
+    Ok(())
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]

--- a/linkerd/http/prom/Cargo.toml
+++ b/linkerd/http/prom/Cargo.toml
@@ -13,6 +13,7 @@ Tower middleware for Prometheus metrics.
 test-util = []
 
 [dependencies]
+bytes = "1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"

--- a/linkerd/http/prom/src/body_data.rs
+++ b/linkerd/http/prom/src/body_data.rs
@@ -1,0 +1,5 @@
+pub mod request;
+pub mod response;
+
+mod body;
+mod metrics;

--- a/linkerd/http/prom/src/body_data/body.rs
+++ b/linkerd/http/prom/src/body_data/body.rs
@@ -1,0 +1,80 @@
+use super::metrics::BodyDataMetrics;
+use http::HeaderMap;
+use http_body::SizeHint;
+use pin_project::pin_project;
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// An instrumented body.
+#[pin_project]
+pub struct Body<B> {
+    /// The inner body.
+    #[pin]
+    inner: B,
+    /// Metrics with which the inner body will be instrumented.
+    metrics: BodyDataMetrics,
+}
+
+impl<B> Body<B> {
+    /// Returns a new, instrumented body.
+    pub(crate) fn new(body: B, metrics: BodyDataMetrics) -> Self {
+        Self {
+            inner: body,
+            metrics,
+        }
+    }
+}
+
+impl<B> http_body::Body for Body<B>
+where
+    B: http_body::Body,
+{
+    type Data = B::Data;
+    type Error = B::Error;
+
+    /// Attempt to pull out the next data buffer of this stream.
+    fn poll_data(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+        let this = self.project();
+        let inner = this.inner;
+        let BodyDataMetrics {
+            frames_total,
+            frames_bytes,
+        } = this.metrics;
+
+        let data = std::task::ready!(inner.poll_data(cx));
+
+        if let Some(Ok(data)) = data.as_ref() {
+            // We've polled and yielded a new chunk! Increment our telemetry.
+            //
+            // NB: We're careful to call `remaining()` rather than `chunk()`, which
+            // "can return a shorter slice (this allows non-continuous internal representation)."
+            let bytes = <B::Data as bytes::Buf>::remaining(data)
+                .try_into()
+                .unwrap_or(u64::MAX);
+            frames_bytes.inc_by(bytes);
+            frames_total.inc();
+        }
+
+        Poll::Ready(data)
+    }
+
+    fn poll_trailers(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<HeaderMap>, Self::Error>> {
+        self.project().inner.poll_trailers(cx)
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> SizeHint {
+        self.inner.size_hint()
+    }
+}

--- a/linkerd/http/prom/src/body_data/body.rs
+++ b/linkerd/http/prom/src/body_data/body.rs
@@ -63,6 +63,7 @@ where
         Poll::Ready(data)
     }
 
+    #[inline]
     fn poll_trailers(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -70,10 +71,12 @@ where
         self.project().inner.poll_trailers(cx)
     }
 
+    #[inline]
     fn is_end_stream(&self) -> bool {
         self.inner.is_end_stream()
     }
 
+    #[inline]
     fn size_hint(&self) -> SizeHint {
         self.inner.size_hint()
     }

--- a/linkerd/http/prom/src/body_data/metrics.rs
+++ b/linkerd/http/prom/src/body_data/metrics.rs
@@ -77,7 +77,7 @@ where
     }
 
     /// Returns the [`BodyDataMetrics`] for the given label set.
-    pub fn get(&self, labels: &L) -> BodyDataMetrics {
+    pub fn metrics(&self, labels: &L) -> BodyDataMetrics {
         let Self {
             resp_body_frames_total,
             resp_body_frames_bytes,

--- a/linkerd/http/prom/src/body_data/metrics.rs
+++ b/linkerd/http/prom/src/body_data/metrics.rs
@@ -1,0 +1,94 @@
+//! Prometheus counters for request and response bodies.
+
+use linkerd_metrics::prom::{self, Counter, Family, Registry};
+
+/// Counters for response body frames.
+#[derive(Clone, Debug)]
+pub struct ResponseBodyFamilies<L> {
+    /// Counts the number of response body frames.
+    resp_body_frames_total: Family<L, Counter>,
+    /// Counts the total number of bytes in response body frames.
+    resp_body_frames_bytes: Family<L, Counter>,
+}
+
+/// Counters to instrument a request or response body.
+#[derive(Clone, Debug, Default)]
+pub struct BodyDataMetrics {
+    /// Counts the number of request body frames.
+    pub frames_total: Counter,
+    /// Counts the total number of bytes in request body frames.
+    pub frames_bytes: Counter,
+}
+
+// === impl ResponseBodyFamilies ===
+
+impl<L> Default for ResponseBodyFamilies<L>
+where
+    L: Clone + std::hash::Hash + Eq,
+{
+    fn default() -> Self {
+        Self {
+            resp_body_frames_total: Default::default(),
+            resp_body_frames_bytes: Default::default(),
+        }
+    }
+}
+
+impl<L> ResponseBodyFamilies<L>
+where
+    L: prom::encoding::EncodeLabelSet
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Eq
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    const RESP_BODY_FRAMES_TOTAL_NAME: &'static str = "resp_body_frames_total";
+    const RESP_BODY_FRAMES_TOTAL_HELP: &'static str =
+        "Counts the number of frames in response bodies.";
+
+    const RESP_BODY_FRAMES_BYTES_NAME: &'static str = "resp_body_frames_bytes";
+    const RESP_BODY_FRAMES_BYTES_HELP: &'static str =
+        "Counts the total number of bytes in response bodies.";
+
+    /// Registers and returns a new family of body data metrics.
+    pub fn register(registry: &mut Registry) -> Self {
+        let resp_body_frames_total = Family::default();
+        registry.register(
+            Self::RESP_BODY_FRAMES_TOTAL_NAME,
+            Self::RESP_BODY_FRAMES_TOTAL_HELP,
+            resp_body_frames_total.clone(),
+        );
+
+        let resp_body_frames_bytes = Family::default();
+        registry.register_with_unit(
+            Self::RESP_BODY_FRAMES_BYTES_NAME,
+            Self::RESP_BODY_FRAMES_BYTES_HELP,
+            prom::Unit::Bytes,
+            resp_body_frames_bytes.clone(),
+        );
+
+        Self {
+            resp_body_frames_total,
+            resp_body_frames_bytes,
+        }
+    }
+
+    /// Returns the [`BodyDataMetrics`] for the given label set.
+    pub fn get(&self, labels: &L) -> BodyDataMetrics {
+        let Self {
+            resp_body_frames_total,
+            resp_body_frames_bytes,
+        } = self;
+
+        let frames_total = resp_body_frames_total.get_or_create(labels).clone();
+        let frames_bytes = resp_body_frames_bytes.get_or_create(labels).clone();
+
+        BodyDataMetrics {
+            frames_total,
+            frames_bytes,
+        }
+    }
+}

--- a/linkerd/http/prom/src/body_data/metrics.rs
+++ b/linkerd/http/prom/src/body_data/metrics.rs
@@ -1,23 +1,30 @@
 //! Prometheus counters for request and response bodies.
 
-use linkerd_metrics::prom::{self, Counter, Family, Registry};
+use linkerd_metrics::prom::{
+    self, metrics::family::MetricConstructor, Family, Histogram, Registry, Unit,
+};
 
 /// Counters for response body frames.
 #[derive(Clone, Debug)]
 pub struct ResponseBodyFamilies<L> {
-    /// Counts the number of response body frames.
-    resp_body_frames_total: Family<L, Counter>,
-    /// Counts the total number of bytes in response body frames.
-    resp_body_frames_bytes: Family<L, Counter>,
+    /// Counts the number of response body frames by size.
+    frame_sizes: Family<L, Histogram, NewHisto>,
 }
 
 /// Counters to instrument a request or response body.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct BodyDataMetrics {
     /// Counts the number of request body frames.
-    pub frames_total: Counter,
-    /// Counts the total number of bytes in request body frames.
-    pub frames_bytes: Counter,
+    pub frame_size: Histogram,
+}
+
+#[derive(Clone, Copy)]
+struct NewHisto;
+
+impl MetricConstructor<Histogram> for NewHisto {
+    fn new_metric(&self) -> Histogram {
+        Histogram::new([128.0, 1024.0, 10240.0].into_iter())
+    }
 }
 
 // === impl ResponseBodyFamilies ===
@@ -28,8 +35,7 @@ where
 {
     fn default() -> Self {
         Self {
-            resp_body_frames_total: Default::default(),
-            resp_body_frames_bytes: Default::default(),
+            frame_sizes: Family::new_with_constructor(NewHisto),
         }
     }
 }
@@ -45,50 +51,25 @@ where
         + Sync
         + 'static,
 {
-    const RESP_BODY_FRAMES_TOTAL_NAME: &'static str = "resp_body_frames_total";
-    const RESP_BODY_FRAMES_TOTAL_HELP: &'static str =
-        "Counts the number of frames in response bodies.";
-
-    const RESP_BODY_FRAMES_BYTES_NAME: &'static str = "resp_body_frames_bytes";
-    const RESP_BODY_FRAMES_BYTES_HELP: &'static str =
-        "Counts the total number of bytes in response bodies.";
-
     /// Registers and returns a new family of body data metrics.
     pub fn register(registry: &mut Registry) -> Self {
-        let resp_body_frames_total = Family::default();
-        registry.register(
-            Self::RESP_BODY_FRAMES_TOTAL_NAME,
-            Self::RESP_BODY_FRAMES_TOTAL_HELP,
-            resp_body_frames_total.clone(),
-        );
-
-        let resp_body_frames_bytes = Family::default();
+        let frame_sizes = Family::new_with_constructor(NewHisto);
         registry.register_with_unit(
-            Self::RESP_BODY_FRAMES_BYTES_NAME,
-            Self::RESP_BODY_FRAMES_BYTES_HELP,
-            prom::Unit::Bytes,
-            resp_body_frames_bytes.clone(),
+            "response_frame_size",
+            "Response data frame sizes",
+            Unit::Bytes,
+            frame_sizes.clone(),
         );
 
-        Self {
-            resp_body_frames_total,
-            resp_body_frames_bytes,
-        }
+        Self { frame_sizes }
     }
 
     /// Returns the [`BodyDataMetrics`] for the given label set.
     pub fn metrics(&self, labels: &L) -> BodyDataMetrics {
-        let Self {
-            resp_body_frames_total,
-            resp_body_frames_bytes,
-        } = self;
+        let Self { frame_sizes } = self;
 
-        let frames_total = resp_body_frames_total.get_or_create(labels).clone();
-        let frames_bytes = resp_body_frames_bytes.get_or_create(labels).clone();
+        let frame_size = frame_sizes.get_or_create(labels).clone();
 
-        BodyDataMetrics {
-            frames_total,
-            frames_bytes,
-        }
+        BodyDataMetrics { frame_size }
     }
 }

--- a/linkerd/http/prom/src/body_data/request.rs
+++ b/linkerd/http/prom/src/body_data/request.rs
@@ -1,0 +1,1 @@
+// TODO(kate): write a middleware for request body.

--- a/linkerd/http/prom/src/body_data/response.rs
+++ b/linkerd/http/prom/src/body_data/response.rs
@@ -86,20 +86,9 @@ where
 
         let Self { inner, metrics } = self;
         let metrics = metrics.clone();
-        let instrument = Box::new(|resp| Self::instrument_response(resp, metrics));
-
-        inner.call(req).map_ok(instrument).boxed()
-    }
-}
-
-impl<S> RecordBodyData<S> {
-    fn instrument_response<B>(resp: Response<B>, metrics: BodyDataMetrics) -> Response<BoxBody>
-    where
-        B: Body + Send + 'static,
-        B::Data: Send + 'static,
-        B::Error: Into<Error>,
-    {
-        resp.map(|b| super::body::Body::new(b, metrics))
-            .map(BoxBody::new)
+        inner
+            .call(req)
+            .map_ok(|rsp| rsp.map(|b| BoxBody::new(super::body::Body::new(b, metrics))))
+            .boxed()
     }
 }

--- a/linkerd/http/prom/src/body_data/response.rs
+++ b/linkerd/http/prom/src/body_data/response.rs
@@ -1,0 +1,105 @@
+//! Tower middleware to instrument response bodies.
+
+pub use super::metrics::{BodyDataMetrics, ResponseBodyFamilies};
+
+use http::{Request, Response};
+use http_body::Body;
+use linkerd_error::Error;
+use linkerd_http_box::BoxBody;
+use linkerd_stack::{self as svc, layer::Layer, ExtractParam, NewService, Service};
+
+/// A [`NewService<T>`] that creates [`RecordBodyData`] services.
+#[derive(Clone, Debug)]
+pub struct NewRecordBodyData<X, N> {
+    /// The [`ExtractParam<P, T>`] strategy for obtaining our parameters.
+    extract: X,
+    /// The inner [`NewService<T>`].
+    inner: N,
+}
+
+/// Tracks body frames for an inner `S`-typed [`Service`].
+#[derive(Clone, Debug)]
+pub struct RecordBodyData<S> {
+    /// The inner [`Service<T>`].
+    inner: S,
+    /// The metrics to be affixed to the response body.
+    metrics: BodyDataMetrics,
+}
+
+// === impl NewRecordBodyData ===
+
+impl<X: Clone, N> NewRecordBodyData<X, N> {
+    /// Returns a [`Layer<S>`] that tracks body chunks.
+    ///
+    /// This uses an `X`-typed [`ExtractParam<P, T>`] implementation to extract service parameters
+    /// from a `T`-typed target.
+    pub fn layer_via(extract: X) -> impl Layer<N, Service = Self> {
+        svc::layer::mk(move |inner| Self {
+            extract: extract.clone(),
+            inner,
+        })
+    }
+}
+
+impl<T, X, N> NewService<T> for NewRecordBodyData<X, N>
+where
+    X: ExtractParam<BodyDataMetrics, T>,
+    N: NewService<T>,
+{
+    type Service = RecordBodyData<N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let Self { extract, inner } = self;
+
+        let metrics = extract.extract_param(&target);
+        let inner = inner.new_service(target);
+
+        RecordBodyData { inner, metrics }
+    }
+}
+
+// === impl RecordBodyData ===
+
+impl<ReqB, RespB, S> Service<Request<ReqB>> for RecordBodyData<S>
+where
+    S: Service<Request<ReqB>, Response = Response<RespB>>,
+    RespB: Body + Send + 'static,
+    RespB::Data: Send + 'static,
+    RespB::Error: Into<Error>,
+{
+    type Response = Response<BoxBody>;
+    type Error = S::Error;
+    type Future = futures::future::MapOk<
+        S::Future,
+        Box<dyn FnOnce(Response<RespB>) -> Self::Response + Send + 'static>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqB>) -> Self::Future {
+        use futures::TryFutureExt;
+
+        let Self { inner, metrics } = self;
+        let metrics = metrics.clone();
+        let instrument = Box::new(|resp| Self::instrument_response(resp, metrics));
+
+        inner.call(req).map_ok(instrument)
+    }
+}
+
+impl<S> RecordBodyData<S> {
+    fn instrument_response<B>(resp: Response<B>, metrics: BodyDataMetrics) -> Response<BoxBody>
+    where
+        B: Body + Send + 'static,
+        B::Data: Send + 'static,
+        B::Error: Into<Error>,
+    {
+        resp.map(|b| super::body::Body::new(b, metrics))
+            .map(BoxBody::new)
+    }
+}

--- a/linkerd/http/prom/src/body_data/response.rs
+++ b/linkerd/http/prom/src/body_data/response.rs
@@ -74,6 +74,7 @@ where
         Box<dyn FnOnce(Response<RespB>) -> Self::Response + Send + 'static>,
     >;
 
+    #[inline]
     fn poll_ready(
         &mut self,
         cx: &mut std::task::Context<'_>,

--- a/linkerd/http/prom/src/lib.rs
+++ b/linkerd/http/prom/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
+pub mod body_data;
 mod count_reqs;
 pub mod record_response;
 

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -85,7 +85,12 @@ pub trait Factor {
 const MAX_PRECISE_UINT64: u64 = 0x20_0000_0000_0000;
 
 impl Factor for () {
+    #[inline]
     fn factor(n: u64) -> f64 {
-        n.wrapping_rem(MAX_PRECISE_UINT64 + 1) as f64
+        to_f64(n)
     }
+}
+
+pub fn to_f64(n: u64) -> f64 {
+    n.wrapping_rem(MAX_PRECISE_UINT64 + 1) as f64
 }


### PR DESCRIPTION
### :cloud: overview

this introduces a new tower middleware for Prometheus metrics, used for instrumenting HTTP and gRPC
response bodies, and observing (a) the number of frames yielded by a body, and (b) the number of bytes
included in body frames.

this middleware allows operators to reason about how large or small the packets being served in a backend's
response bodies are.

a route-level middleware that instruments request bodies will be added in a follow-on PR.

 ### 📝 changes

an overview of changes made here:

* the `linkerd-http-prom` has a new `body_data` submodule. it exposes `request` and `response` halves, to
  be explicit about which body is being instrumented on a `tower::Service`.

* the `linkerd-http-prom` crate now has a collection of new dependencies: `bytes` is added as a dependency
  in order to inspect the data chunk when the inner body yields a new frame. `futures-util` and `http-body`
  are added as dev-dependencies for the accompanying test coverage.

* body metrics are affixed to the `RouteBackendMetrics<L>` structure, and registered at startup.


### :link: related

* #3334
* #3337
* #3318 