### PR TITLE
refactor(app): Simplify backend metrics tower layer

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -24,18 +24,18 @@ type ResponseMetrics<L> = record_response::ResponseMetrics<
     <L as StreamLabel>::StatusLabels,
 >;
 
+type MetricsLayer<T, N> = BodyDataLayer<RequestLayer<ResponseLayer<T, N>>>;
+type BodyDataLayer<N> = NewRecordBodyData<ExtractRecordBodyDataParams, N>;
+type RequestLayer<N> = NewCountRequests<ExtractRequestCount, N>;
+type ResponseLayer<T, N> = NewResponseDuration<
+    T,
+    ExtractRecordDurationParams<ResponseMetrics<<T as MkStreamLabel>::StreamLabel>>,
+    N,
+>;
+
 pub fn layer<T, N>(
     metrics: &RouteBackendMetrics<T::StreamLabel>,
-) -> impl svc::Layer<
-    N,
-    Service = NewRecordBodyData<
-        ExtractRecordBodyDataParams,
-        NewCountRequests<
-            ExtractRequestCount,
-            NewResponseDuration<T, ExtractRecordDurationParams<ResponseMetrics<T::StreamLabel>>, N>,
-        >,
-    >,
-> + Clone
+) -> impl svc::Layer<N, Service = MetricsLayer<T, N>> + Clone
 where
     T: MkStreamLabel,
 {

--- a/linkerd/http/prom/src/body_data/response.rs
+++ b/linkerd/http/prom/src/body_data/response.rs
@@ -34,7 +34,7 @@ impl<X: Clone, N> NewRecordBodyData<X, N> {
     ///
     /// This uses an `X`-typed [`ExtractParam<P, T>`] implementation to extract service parameters
     /// from a `T`-typed target.
-    pub fn layer_via(extract: X) -> impl Layer<N, Service = Self> {
+    pub fn layer_via(extract: X) -> impl Layer<N, Service = Self> + Clone {
         svc::layer::mk(move |inner| Self {
             extract: extract.clone(),
             inner,


### PR DESCRIPTION
**nb:** this is based on #3308. this is a refactor branch aimed at finding a way to simplify the somewhat burdensome types in the metrics middleware's `layer(..)` function.

#### refactor(app): Define layer type aliases
    
this isn't a "simplification" so much as an outlining of the chunky types in this function signature.

that said... it's subjectively nice to outline the definition of our layers into a `MetricsLayer<T, N>`
that we can use as shorthand in the function signature of `layer(..)`.
    
#### refactor(app): Simplify backend metrics layer bounds
    
this commit changes the backend-level metrics layer function, so that it invokes
`linkerd_app_core::svc::layers()` rather than `linkerd_app_core::svc::layer::mk()`.

this has a nice effect in that it simplifies the bounds of the `layer` function.
