### PR TITLE
Allow duplicate weighted backend keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,6 @@ name = "linkerd-distribute"
 version = "0.1.0"
 dependencies = [
  "ahash",
- "indexmap 2.6.0",
  "linkerd-stack",
  "parking_lot",
  "rand",

--- a/linkerd/distribute/Cargo.toml
+++ b/linkerd/distribute/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 ahash = "0.8"
-indexmap = "2"
 linkerd-stack = { path = "../stack" }
 parking_lot = "0.12"
 rand = { version = "0.8", features = ["small_rng"] }

--- a/linkerd/distribute/src/keys.rs
+++ b/linkerd/distribute/src/keys.rs
@@ -1,21 +1,16 @@
+use ahash::{HashMap, HashMapExt};
 use rand::{
     distributions::{WeightedError, WeightedIndex},
     prelude::Distribution as _,
     Rng,
 };
-use std::{collections::HashMap, hash::Hash};
+use std::hash::Hash;
 
 /// Uniquely identifies a key/backend pair for a distribution. This allows
 /// backends to have the same key and still participate in request distribution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct KeyId {
+pub(crate) struct KeyId {
     idx: usize,
-}
-
-impl KeyId {
-    pub(crate) fn new(idx: usize) -> Self {
-        Self { idx }
-    }
 }
 
 #[derive(Debug)]
@@ -35,6 +30,14 @@ pub struct WeightedKey<K> {
 pub(crate) struct WeightedKeySelector<'a, K> {
     keys: &'a WeightedServiceKeys<K>,
     index: WeightedIndex<u32>,
+}
+
+// === impl KeyId ===
+
+impl KeyId {
+    pub(crate) fn new(idx: usize) -> Self {
+        Self { idx }
+    }
 }
 
 // === impl UnweightedKeys ===

--- a/linkerd/distribute/src/keys.rs
+++ b/linkerd/distribute/src/keys.rs
@@ -1,0 +1,160 @@
+use rand::{
+    distributions::{WeightedError, WeightedIndex},
+    prelude::Distribution as _,
+    Rng,
+};
+use std::{collections::HashMap, hash::Hash};
+
+/// Uniquely identifies a key/backend pair for a distribution. This allows
+/// backends to have the same key and still participate in request distribution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct KeyId {
+    idx: usize,
+}
+
+impl KeyId {
+    pub(crate) fn new(idx: usize) -> Self {
+        Self { idx }
+    }
+}
+
+#[derive(Debug)]
+pub struct ServiceKeys<K> {
+    ids: Vec<KeyId>,
+    keys: HashMap<KeyId, K>,
+}
+
+pub type WeightedServiceKeys<K> = ServiceKeys<WeightedKey<K>>;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct WeightedKey<K> {
+    pub key: K,
+    pub weight: u32,
+}
+
+pub(crate) struct WeightedKeySelector<'a, K> {
+    keys: &'a WeightedServiceKeys<K>,
+    index: WeightedIndex<u32>,
+}
+
+// === impl UnweightedKeys ===
+
+// PartialEq, Eq, and Hash are all valid to implement for UnweightedKeys since
+// there is a defined iteration order for the keys, but it cannot be automatically
+// derived for HashMap fields.
+impl<K: PartialEq> PartialEq for ServiceKeys<K> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.ids != other.ids {
+            return false;
+        }
+
+        for id in &self.ids {
+            if self.keys.get(id) != other.keys.get(id) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl<K: Eq> Eq for ServiceKeys<K> {}
+
+impl<K: Hash> Hash for ServiceKeys<K> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.ids.hash(state);
+        // Normally we would also hash the length, but self.ids and
+        // self.keys have the same length
+        for id in &self.ids {
+            self.keys.get(id).hash(state);
+        }
+    }
+}
+
+impl<K> ServiceKeys<K> {
+    pub(crate) fn new(iter: impl Iterator<Item = K>) -> Self {
+        let mut ids = Vec::new();
+        let mut keys = HashMap::new();
+        for (idx, key) in iter.enumerate() {
+            let id = KeyId::new(idx);
+            ids.push(id);
+            keys.insert(id, key);
+        }
+
+        Self { ids, keys }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.ids.is_empty()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.ids.len()
+    }
+
+    /// Returns the key `K` associated with the given [`KeyId`].
+    ///
+    /// The output of using a [`KeyId`] not produced by the same instance of
+    /// [`ServiceKeys`] is unspecified, and it is likely to panic.
+    ///
+    /// # Panics
+    ///
+    /// This will panic if no entry is associated with the given lookup key.
+    pub(crate) fn get(&self, id: KeyId) -> &K {
+        self.keys
+            .get(&id)
+            .expect("distribution lookup keys must be valid")
+    }
+
+    fn try_get_id(&self, idx: usize) -> Option<KeyId> {
+        self.ids.get(idx).copied()
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &KeyId> {
+        self.ids.iter()
+    }
+}
+
+// === impl WeightedKeys ===
+
+impl<K> WeightedServiceKeys<K> {
+    pub(crate) fn into_unweighted(self) -> ServiceKeys<K> {
+        ServiceKeys {
+            ids: self.ids,
+            keys: self
+                .keys
+                .into_iter()
+                .map(|(id, key)| (id, key.key))
+                .collect(),
+        }
+    }
+
+    pub(crate) fn weighted_index(&self) -> Result<WeightedIndex<u32>, WeightedError> {
+        WeightedIndex::new(self.ids.iter().map(|&id| self.get(id).weight))
+    }
+
+    pub(crate) fn validate_weights(&self) -> Result<(), WeightedError> {
+        self.weighted_index()?;
+        Ok(())
+    }
+
+    pub(crate) fn selector(&self) -> WeightedKeySelector<'_, K> {
+        let index = self.weighted_index().expect("distribution must be valid");
+        WeightedKeySelector { keys: self, index }
+    }
+}
+
+// === impl WeightedKeySelector ===
+
+impl<K> WeightedKeySelector<'_, K> {
+    pub(crate) fn select_weighted<R: Rng + ?Sized>(&self, rng: &mut R) -> KeyId {
+        let idx = self.index.sample(rng);
+        self.keys
+            .try_get_id(idx)
+            .expect("distrubtion must select a valid backend")
+    }
+
+    pub(crate) fn disable_backend(&mut self, id: KeyId) -> Result<(), WeightedError> {
+        self.index.update_weights(&[(id.idx, &0)])
+    }
+}

--- a/linkerd/distribute/src/lib.rs
+++ b/linkerd/distribute/src/lib.rs
@@ -4,13 +4,15 @@
 #![forbid(unsafe_code)]
 
 mod cache;
+mod keys;
 mod params;
 mod service;
 mod stack;
 
 pub use self::{
     cache::{BackendCache, NewBackendCache},
-    params::{Backends, Distribution, WeightedKeys},
+    keys::WeightedServiceKeys,
+    params::{Backends, Distribution},
     service::Distribute,
     stack::NewDistribute,
 };

--- a/linkerd/distribute/src/params.rs
+++ b/linkerd/distribute/src/params.rs
@@ -1,11 +1,10 @@
-use ahash::AHashSet;
-use rand::distributions::WeightedError;
-use std::{fmt::Debug, hash::Hash, sync::Arc};
-
 use crate::{
     keys::{ServiceKeys, WeightedKey},
     WeightedServiceKeys,
 };
+use ahash::AHashSet;
+use rand::distributions::WeightedError;
+use std::{fmt::Debug, hash::Hash, sync::Arc};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Backends<K>(pub(crate) Arc<AHashSet<K>>)

--- a/linkerd/distribute/src/params.rs
+++ b/linkerd/distribute/src/params.rs
@@ -1,6 +1,11 @@
 use ahash::AHashSet;
-use rand::distributions::{WeightedError, WeightedIndex};
+use rand::distributions::WeightedError;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
+
+use crate::{
+    keys::{ServiceKeys, WeightedKey},
+    WeightedServiceKeys,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Backends<K>(pub(crate) Arc<AHashSet<K>>)
@@ -16,17 +21,11 @@ pub enum Distribution<K> {
     Empty,
 
     /// A distribution that uses the first available backend in an ordered list.
-    FirstAvailable(Arc<[K]>),
+    FirstAvailable(Arc<ServiceKeys<K>>),
 
     /// A distribution that uses the first available backend when randomly
     /// selecting over a weighted distribution of backends.
-    RandomAvailable(Arc<WeightedKeys<K>>),
-}
-
-#[derive(Debug, PartialEq, Eq, Hash)]
-pub struct WeightedKeys<K> {
-    keys: Vec<K>,
-    weights: Vec<u32>,
+    RandomAvailable(Arc<WeightedServiceKeys<K>>),
 }
 
 // === impl Backends ===
@@ -64,46 +63,29 @@ impl<K> Default for Distribution<K> {
 }
 
 impl<K> Distribution<K> {
-    pub fn first_available(keys: impl IntoIterator<Item = K>) -> Self {
-        let keys: Arc<[K]> = keys.into_iter().collect();
+    pub fn first_available(iter: impl IntoIterator<Item = K>) -> Self {
+        let keys = ServiceKeys::new(iter.into_iter());
         if keys.is_empty() {
             return Self::Empty;
         }
-        Self::FirstAvailable(keys)
+
+        Self::FirstAvailable(Arc::new(keys))
     }
 
     pub fn random_available<T: IntoIterator<Item = (K, u32)>>(
         iter: T,
     ) -> Result<Self, WeightedError> {
-        let (keys, weights): (Vec<_>, Vec<_>) = iter.into_iter().filter(|(_, w)| *w > 0).unzip();
-        if keys.len() < 2 {
-            return Ok(Self::first_available(keys));
+        let weighted_keys = WeightedServiceKeys::new(
+            iter.into_iter()
+                .map(|(key, weight)| WeightedKey { key, weight }),
+        );
+        if weighted_keys.len() < 2 {
+            return Ok(Self::FirstAvailable(Arc::new(
+                weighted_keys.into_unweighted(),
+            )));
         }
-        // Error if the distribution is invalid.
-        let _index = WeightedIndex::new(weights.iter().copied())?;
-        Ok(Self::RandomAvailable(Arc::new(WeightedKeys {
-            keys,
-            weights,
-        })))
-    }
 
-    pub(crate) fn keys(&self) -> &[K] {
-        match self {
-            Self::Empty => &[],
-            Self::FirstAvailable(keys) => keys,
-            Self::RandomAvailable(keys) => keys.keys(),
-        }
-    }
-}
-
-// === impl WeightedKeys ===
-
-impl<K> WeightedKeys<K> {
-    pub(crate) fn keys(&self) -> &[K] {
-        &self.keys
-    }
-
-    pub(crate) fn index(&self) -> WeightedIndex<u32> {
-        WeightedIndex::new(self.weights.iter().copied()).expect("distribution must be valid")
+        weighted_keys.validate_weights()?;
+        Ok(Self::RandomAvailable(Arc::new(weighted_keys)))
     }
 }

--- a/linkerd/distribute/src/service/first.rs
+++ b/linkerd/distribute/src/service/first.rs
@@ -1,0 +1,80 @@
+use crate::keys::ServiceKeys;
+use linkerd_stack::{NewService, Service};
+use std::task::{Context, Poll};
+
+#[derive(Debug)]
+pub(crate) struct FirstAvailableSelection<S> {
+    backends: Vec<S>,
+
+    /// Stores the index of the backend that has been polled to ready. The
+    /// service at this index will be used on the next invocation of
+    /// `Service::call`.
+    ready_idx: Option<usize>,
+}
+
+impl<S> FirstAvailableSelection<S> {
+    pub fn new<K, N>(keys: &ServiceKeys<K>, make_svc: N) -> Self
+    where
+        N: for<'a> NewService<&'a K, Service = S>,
+    {
+        Self {
+            backends: keys
+                .iter()
+                .map(|&id| make_svc.new_service(keys.get(id)))
+                .collect(),
+            ready_idx: None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn get_ready_idx(&self) -> Option<usize> {
+        self.ready_idx
+    }
+}
+
+impl<S: Clone> Clone for FirstAvailableSelection<S> {
+    fn clone(&self) -> Self {
+        Self {
+            backends: self.backends.clone(),
+            // Clear the ready index so that the new clone must become ready
+            // independently.
+            ready_idx: None,
+        }
+    }
+}
+
+impl<Req, S> Service<Req> for FirstAvailableSelection<S>
+where
+    S: Service<Req>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // If we've already chosen a ready index, then skip polling.
+        if self.ready_idx.is_some() {
+            return Poll::Ready(Ok(()));
+        }
+
+        for (idx, svc) in self.backends.iter_mut().enumerate() {
+            if svc.poll_ready(cx)?.is_ready() {
+                self.ready_idx = Some(idx);
+                return Poll::Ready(Ok(()));
+            }
+        }
+        debug_assert!(self.ready_idx.is_none());
+        Poll::Pending
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        let idx = self
+            .ready_idx
+            .take()
+            .expect("poll_ready must be called first");
+
+        let svc = self.backends.get_mut(idx).expect("index must exist");
+
+        svc.call(req)
+    }
+}

--- a/linkerd/distribute/src/service/random.rs
+++ b/linkerd/distribute/src/service/random.rs
@@ -1,0 +1,120 @@
+use crate::{keys::KeyId, WeightedServiceKeys};
+use ahash::HashMap;
+use linkerd_stack::{NewService, Service};
+use rand::{distributions::WeightedError, rngs::SmallRng, SeedableRng};
+use std::{
+    hash::Hash,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+#[derive(Debug)]
+pub(crate) struct RandomAvailableSelection<K, S> {
+    keys: Arc<WeightedServiceKeys<K>>,
+    backends: HashMap<KeyId, S>,
+    rng: SmallRng,
+
+    /// Stores the index of the backend that has been polled to ready. The
+    /// service at this index will be used on the next invocation of
+    /// `Service::call`.
+    ready_idx: Option<KeyId>,
+}
+
+fn new_rng() -> SmallRng {
+    SmallRng::from_rng(rand::thread_rng()).expect("RNG must initialize")
+}
+
+impl<K, S> RandomAvailableSelection<K, S> {
+    pub fn new<N>(keys: &Arc<WeightedServiceKeys<K>>, make_svc: N) -> Self
+    where
+        N: for<'a> NewService<&'a K, Service = S>,
+    {
+        Self {
+            keys: keys.clone(),
+            backends: keys
+                .iter()
+                .map(|&id| (id, make_svc.new_service(&keys.get(id).key)))
+                .collect(),
+            ready_idx: None,
+            rng: new_rng(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn get_ready_idx(&self) -> Option<KeyId> {
+        self.ready_idx
+    }
+}
+
+impl<K, S: Clone> Clone for RandomAvailableSelection<K, S> {
+    fn clone(&self) -> Self {
+        Self {
+            keys: self.keys.clone(),
+            backends: self.backends.clone(),
+            rng: new_rng(),
+            // Clear the ready index so that the new clone must become ready
+            // independently.
+            ready_idx: None,
+        }
+    }
+}
+
+impl<Req, K, S> Service<Req> for RandomAvailableSelection<K, S>
+where
+    K: Hash + Eq,
+    S: Service<Req>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // If we've already chosen a ready index, then skip polling.
+        if self.ready_idx.is_some() {
+            return Poll::Ready(Ok(()));
+        }
+
+        let mut selector = self.keys.selector();
+        loop {
+            let id = selector.select_weighted(&mut self.rng);
+            let svc = self
+                .backends
+                .get_mut(&id)
+                .expect("distributions must not reference unknown backends");
+
+            if svc.poll_ready(cx)?.is_ready() {
+                self.ready_idx = Some(id);
+                return Poll::Ready(Ok(()));
+            }
+
+            // Since the backend we just tried isn't ready, zero out the weight
+            // so that it's not tried again in this round, i.e. subsequent calls
+            // to `poll_ready` can try this backend again.
+            match selector.disable_backend(id) {
+                Ok(()) => {}
+                Err(WeightedError::AllWeightsZero) => {
+                    // There are no backends remaining.
+                    break;
+                }
+                Err(error) => {
+                    tracing::error!(%error, "unexpected error updating weights; giving up");
+                    break;
+                }
+            }
+        }
+
+        debug_assert!(self.ready_idx.is_none());
+        Poll::Pending
+    }
+
+    fn call(&mut self, req: Req) -> Self::Future {
+        let id = self
+            .ready_idx
+            .take()
+            .expect("poll_ready must be called first");
+
+        let svc = self.backends.get_mut(&id).expect("index must exist");
+
+        svc.call(req)
+    }
+}

--- a/linkerd/distribute/src/stack.rs
+++ b/linkerd/distribute/src/stack.rs
@@ -55,16 +55,9 @@ where
     /// Referencing other keys causes a panic.
     fn new_service(&self, target: T) -> Self::Service {
         let dist = self.extract.extract_param(&target);
-        tracing::debug!(backends = ?dist.keys(), "New distribution");
+        tracing::debug!(backends = ?dist, "New distribution");
 
-        // Build the backends needed for this distribution, in the required
-        // order (so that weighted indices align).
         let newk = self.inner.new_service(target);
-        let backends = dist
-            .keys()
-            .iter()
-            .map(|k| (k.clone(), newk.new_service(k.clone())))
-            .collect();
-        Distribute::new(backends, dist)
+        Distribute::new(dist, |k: &K| newk.new_service(k.clone()))
     }
 }


### PR DESCRIPTION
Currently, if the proxy receives two backends with the same metadata, one of the backends will get dropped because the backend metadata is used as the key in a hash map. Attempting to then randomly distribute requests to the backends can panic when selecting the now non-existent backend.

This is fixed by no longer using backend metadata as a hash map key, instead generating separate IDs that are stored in a vec to retain the declared order of backends while also being used to look up the backend and associated weight independetly.

Validated with new unit tests excercising duplicate backend keys, as well as a few around the invariants use to store the backends.