### PR TITLE
metrics: Add ParentRef and BackendRef to opaq balancer metrics

### DIFF
--- a/linkerd/app/outbound/src/opaq/logical.rs
+++ b/linkerd/app/outbound/src/opaq/logical.rs
@@ -88,6 +88,8 @@ where
     }
 }
 
+// === impl Concrete ===
+
 impl<T> svc::Param<concrete::Dispatch> for Concrete<T> {
     fn param(&self) -> concrete::Dispatch {
         self.target.clone()
@@ -100,5 +102,17 @@ where
 {
     fn param(&self) -> Option<profiles::LogicalAddr> {
         self.parent.param()
+    }
+}
+
+impl<T> svc::Param<ParentRef> for Concrete<T> {
+    fn param(&self) -> ParentRef {
+        self.parent_ref.clone()
+    }
+}
+
+impl<T> svc::Param<BackendRef> for Concrete<T> {
+    fn param(&self) -> BackendRef {
+        self.backend_ref.clone()
     }
 }


### PR DESCRIPTION
This change adds resource coordinate labels for `Parent` and `Backend` to the `outbound_tcp_balancer_*` metrics.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>