### PR TITLE
build(deps): pin proxy-api to git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,8 +2514,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c72fb98d969e1e94e95d52a6fcdf4693764702c369e577934256e72fb5bc61"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api.git?branch=main#2be6843a95360eaa370363c42e3aa85142b7a36c"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,4 +89,5 @@ debug = 1
 lto = true
 
 [workspace.dependencies]
-linkerd2-proxy-api = "0.14.0"
+#linkerd2-proxy-api = "0.14.0"
+linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "main" }

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -530,6 +530,7 @@ impl From<DestinationBuilder> for pb::Update {
                     tls_identity,
                     authority_override: None,
                     http2: None,
+                    resource_ref: None,
                 }],
                 metric_labels: set_labels,
             })),
@@ -610,7 +611,11 @@ pub fn retry_budget(
 }
 
 pub fn dst_override(authority: String, weight: u32) -> pb::WeightedDst {
-    pb::WeightedDst { authority, weight }
+    pb::WeightedDst {
+        authority,
+        weight,
+        backend_ref: None,
+    }
 }
 
 pub fn route() -> RouteBuilder {

--- a/linkerd/app/integration/src/policy.rs
+++ b/linkerd/app/integration/src/policy.rs
@@ -45,6 +45,7 @@ pub fn all_unauthenticated() -> inbound::Server {
                 inbound::proxy_protocol::Detect {
                     timeout: Some(Duration::from_secs(10).try_into().unwrap()),
                     http_routes: vec![],
+                    http_local_rate_limit: None,
                 },
             )),
         }),
@@ -161,12 +162,14 @@ pub fn outbound_default_opaque_route(dst: impl ToString) -> outbound::OpaqueRout
         metadata: Some(api::meta::Metadata {
             kind: Some(api::meta::metadata::Kind::Default("default".to_string())),
         }),
+        error: None,
         rules: vec![outbound::opaque_route::Rule {
             backends: Some(opaque_route::Distribution {
                 kind: Some(distribution::Kind::FirstAvailable(
                     distribution::FirstAvailable {
                         backends: vec![opaque_route::RouteBackend {
                             backend: Some(backend(dst)),
+                            invalid: None,
                         }],
                     },
                 )),

--- a/linkerd/proxy/api-resolve/src/pb.rs
+++ b/linkerd/proxy/api-resolve/src/pb.rs
@@ -410,6 +410,7 @@ mod tests {
     #[test]
     fn zone_locality() {
         let addr = WeightedAddr {
+            resource_ref: None,
             addr: Some(TcpAddress {
                 ip: Some(IpAddress {
                     ip: Some(Ip::Ipv4(0)),

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -479,6 +479,10 @@ pub mod proto {
                 proxy_protocol::Kind::Http2(http) => Protocol::Http2(http.try_into()?),
                 proxy_protocol::Kind::Opaque(opaque) => Protocol::Opaque(opaque.try_into()?),
                 proxy_protocol::Kind::Grpc(grpc) => Protocol::Grpc(grpc.try_into()?),
+                proxy_protocol::Kind::Tls(_tls) => {
+                    // TODO(ver): impl TryFrom<proxy_protocol::Tls> for `tls::Tls`
+                    return Err(InvalidPolicy::Protocol("TLS not supported yet"));
+                }
             };
 
             let mut backends = BackendSet::default();

--- a/linkerd/proxy/client-policy/src/opaq.rs
+++ b/linkerd/proxy/client-policy/src/opaq.rs
@@ -79,7 +79,11 @@ pub(crate) mod proto {
         type Error = InvalidOpaqueRoute;
 
         fn try_from(
-            outbound::OpaqueRoute { metadata, rules }: outbound::OpaqueRoute,
+            outbound::OpaqueRoute {
+                metadata,
+                rules,
+                error: _, // TODO
+            }: outbound::OpaqueRoute,
         ) -> Result<Self, Self::Error> {
             let meta = Arc::new(
                 metadata
@@ -175,7 +179,10 @@ pub(crate) mod proto {
     impl TryFrom<opaque_route::RouteBackend> for RouteBackend<Filter> {
         type Error = InvalidBackend;
         fn try_from(
-            opaque_route::RouteBackend { backend }: opaque_route::RouteBackend,
+            opaque_route::RouteBackend {
+                backend,
+                invalid: _, // TODO
+            }: opaque_route::RouteBackend,
         ) -> Result<Self, Self::Error> {
             let backend = backend.ok_or(InvalidBackend::Missing("backend"))?;
             RouteBackend::try_from_proto(backend, std::iter::empty::<()>())

--- a/linkerd/proxy/server-policy/src/lib.rs
+++ b/linkerd/proxy/server-policy/src/lib.rs
@@ -154,6 +154,7 @@ pub mod proto {
                 api::proxy_protocol::Kind::Detect(api::proxy_protocol::Detect {
                     http_routes,
                     timeout,
+                    http_local_rate_limit: _,
                 }) => Protocol::Detect {
                     http: mk_routes!(http, http_routes, authorizations.clone())?,
                     timeout: timeout
@@ -162,13 +163,15 @@ pub mod proto {
                     tcp_authorizations: authorizations,
                 },
 
-                api::proxy_protocol::Kind::Http1(api::proxy_protocol::Http1 { routes }) => {
-                    Protocol::Http1(mk_routes!(http, routes, authorizations)?)
-                }
+                api::proxy_protocol::Kind::Http1(api::proxy_protocol::Http1 {
+                    routes,
+                    local_rate_limit: _,
+                }) => Protocol::Http1(mk_routes!(http, routes, authorizations)?),
 
-                api::proxy_protocol::Kind::Http2(api::proxy_protocol::Http2 { routes }) => {
-                    Protocol::Http2(mk_routes!(http, routes, authorizations)?)
-                }
+                api::proxy_protocol::Kind::Http2(api::proxy_protocol::Http2 {
+                    routes,
+                    local_rate_limit: _,
+                }) => Protocol::Http2(mk_routes!(http, routes, authorizations)?),
 
                 api::proxy_protocol::Kind::Grpc(api::proxy_protocol::Grpc { routes }) => {
                     Protocol::Grpc(mk_routes!(grpc, routes, authorizations)?)


### PR DESCRIPTION
While finalizing API changes for an upcoming release, we need to pin the `linkerd2-proxy-api` dependency to a specific commit in the `main` branch. This will allow us to completely validate end-to-end functionality before releasing the new version of the API crate.