### PR TITLE
chore(server-policy)!: feature-gate LocalRateLimit constructor

### DIFF
--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -60,6 +60,9 @@ linkerd-meshtls = { path = "../../meshtls", features = ["rustls"] }
 linkerd-meshtls-rustls = { path = "../../meshtls/rustls", features = [
     "test-util",
 ] }
+linkerd-proxy-server-policy = { path = "../../proxy/server-policy", features = [
+    "test-util",
+] }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }
 tokio = { version = "1", features = ["full", "macros"] }
 tokio-test = "0.4"

--- a/linkerd/app/inbound/src/policy/http/tests.rs
+++ b/linkerd/app/inbound/src/policy/http/tests.rs
@@ -382,7 +382,7 @@ async fn rate_limit_allow() {
     let rmeta = Meta::new_default("default");
 
     // Rate-limit with plenty of room for two consecutive requests
-    let rl = LocalRateLimit::new_no_overrides(Some(10), Some(5));
+    let rl = LocalRateLimit::new_no_overrides_for_test(Some(10), Some(5));
 
     let authorizations = Arc::new([Authorization {
         meta: rmeta.clone(),
@@ -433,7 +433,7 @@ async fn rate_limit_deny() {
     let rmeta = Meta::new_default("default");
 
     // Rate-limit with room for only one request per second
-    let rl = LocalRateLimit::new_no_overrides(Some(10), Some(1));
+    let rl = LocalRateLimit::new_no_overrides_for_test(Some(10), Some(1));
 
     let authorizations = Arc::new([Authorization {
         meta: rmeta.clone(),

--- a/linkerd/proxy/server-policy/Cargo.toml
+++ b/linkerd/proxy/server-policy/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [features]
 proto = ["linkerd-http-route/proto", "linkerd2-proxy-api", "prost-types"]
+test-util = []
 
 [dependencies]
 governor = { version = "0.7", default-features = false, features = ["std"] }

--- a/linkerd/proxy/server-policy/src/local_rate_limit.rs
+++ b/linkerd/proxy/server-policy/src/local_rate_limit.rs
@@ -44,6 +44,7 @@ pub enum RateLimitError {
 
 // === impl LocalRateLimit ===
 
+#[cfg(feature = "test-util")]
 impl LocalRateLimit {
     pub fn new_no_overrides(
         total: Option<u32>,

--- a/linkerd/proxy/server-policy/src/local_rate_limit.rs
+++ b/linkerd/proxy/server-policy/src/local_rate_limit.rs
@@ -88,6 +88,7 @@ impl<C: Clock> LocalRateLimit<C> {
 
 // === impl RateLimit ===
 
+#[cfg(feature = "test-util")]
 impl RateLimit<Direct, DefaultClock> {
     fn new(rps: u32) -> Option<Self> {
         let rps = NonZeroU32::new(rps)?;
@@ -97,6 +98,7 @@ impl RateLimit<Direct, DefaultClock> {
     }
 }
 
+#[cfg(feature = "test-util")]
 impl RateLimit<Keyed, DefaultClock> {
     fn new(rps: u32) -> Option<Self> {
         let rps = NonZeroU32::new(rps)?;

--- a/linkerd/proxy/server-policy/src/local_rate_limit.rs
+++ b/linkerd/proxy/server-policy/src/local_rate_limit.rs
@@ -4,7 +4,6 @@ use governor::{
     clock::{Clock, DefaultClock},
     middleware::NoOpMiddleware,
     state::{keyed::HashMapStateStore, InMemoryState, RateLimiter, StateStore},
-    Quota,
 };
 use linkerd_identity::Id;
 use std::{collections::HashMap, num::NonZeroU32, sync::Arc};
@@ -92,7 +91,7 @@ impl<C: Clock> LocalRateLimit<C> {
 impl RateLimit<Direct, DefaultClock> {
     fn new(rps: u32) -> Option<Self> {
         let rps = NonZeroU32::new(rps)?;
-        let limiter = RateLimiter::direct(Quota::per_second(rps));
+        let limiter = RateLimiter::direct(governor::Quota::per_second(rps));
 
         Some(Self { rps, limiter })
     }
@@ -102,7 +101,7 @@ impl RateLimit<Direct, DefaultClock> {
 impl RateLimit<Keyed, DefaultClock> {
     fn new(rps: u32) -> Option<Self> {
         let rps = NonZeroU32::new(rps)?;
-        let limiter = RateLimiter::hashmap(Quota::per_second(rps));
+        let limiter = RateLimiter::hashmap(governor::Quota::per_second(rps));
 
         Some(Self { rps, limiter })
     }
@@ -112,7 +111,7 @@ impl RateLimit<Keyed, DefaultClock> {
 impl RateLimit<Direct, FakeRelativeClock> {
     fn new(rps: u32) -> Option<Self> {
         let rps = NonZeroU32::new(rps)?;
-        let quota = Quota::per_second(rps);
+        let quota = governor::Quota::per_second(rps);
         let limiter = RateLimiter::direct_with_clock(quota, FakeRelativeClock::default());
 
         Some(Self { rps, limiter })
@@ -123,8 +122,8 @@ impl RateLimit<Direct, FakeRelativeClock> {
 impl RateLimit<Keyed, FakeRelativeClock> {
     fn new(rps: u32) -> Option<Self> {
         let rps = NonZeroU32::new(rps)?;
-        let limiter =
-            RateLimiter::hashmap_with_clock(Quota::per_second(rps), FakeRelativeClock::default());
+        let quota = governor::Quota::per_second(rps);
+        let limiter = RateLimiter::hashmap_with_clock(quota, FakeRelativeClock::default());
 
         Some(Self { rps, limiter })
     }

--- a/linkerd/proxy/server-policy/src/local_rate_limit/tests.rs
+++ b/linkerd/proxy/server-policy/src/local_rate_limit/tests.rs
@@ -70,11 +70,11 @@ async fn from_proto() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn check_rate_limits() {
-    let total = RateLimit::<Direct, FakeRelativeClock>::for_test(35);
-    let per_identity = RateLimit::<Keyed, FakeRelativeClock>::for_test(5);
+    let total = RateLimit::direct_for_test(35);
+    let per_identity = RateLimit::keyed_for_test(5);
     let overrides = hashmap! {
-        "client-3".parse().unwrap() => Arc::new(RateLimit::<Direct, FakeRelativeClock>::for_test(10)),
-        "client-4".parse().unwrap() => Arc::new(RateLimit::<Direct, FakeRelativeClock>::for_test(15)),
+        "client-3".parse().unwrap() => Arc::new(RateLimit::direct_for_test(10)),
+        "client-4".parse().unwrap() => Arc::new(RateLimit::direct_for_test(15)),
     };
     let rl = LocalRateLimit {
         total: Some(total),

--- a/linkerd/proxy/server-policy/src/local_rate_limit/tests.rs
+++ b/linkerd/proxy/server-policy/src/local_rate_limit/tests.rs
@@ -70,11 +70,11 @@ async fn from_proto() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn check_rate_limits() {
-    let total = RateLimit::<Direct, FakeRelativeClock>::new(35).unwrap();
-    let per_identity = RateLimit::<Keyed, FakeRelativeClock>::new(5).unwrap();
+    let total = RateLimit::<Direct, FakeRelativeClock>::for_test(35);
+    let per_identity = RateLimit::<Keyed, FakeRelativeClock>::for_test(5);
     let overrides = hashmap! {
-        "client-3".parse().unwrap() => Arc::new(RateLimit::<Direct, FakeRelativeClock>::new(10).unwrap()),
-        "client-4".parse().unwrap() => Arc::new(RateLimit::<Direct, FakeRelativeClock>::new(15).unwrap()),
+        "client-3".parse().unwrap() => Arc::new(RateLimit::<Direct, FakeRelativeClock>::for_test(10)),
+        "client-4".parse().unwrap() => Arc::new(RateLimit::<Direct, FakeRelativeClock>::for_test(15)),
     };
     let rl = LocalRateLimit {
         total: Some(total),


### PR DESCRIPTION
We only expect to use `LocalRateLimit::new_no_overrides` for tests.

This change adds a test-util featuer to the server-policy crate so that we can assert that this constructor doesn't sneak into release code.