### PR TITLE
feat(app): Route frame count metrics

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -133,7 +133,11 @@ where
                 // Set request extensions based on the route configuration
                 // AND/OR headers
                 .push(extensions::NewSetExtensions::layer())
-                .push(metrics::layer(&metrics.requests))
+                .push(metrics::layer(
+                    &metrics.requests,
+                    Self::label_extractor,
+                    &metrics.body_data,
+                ))
                 .check_new::<Self>()
                 .check_new_service::<Self, http::Request<http::BoxBody>>()
                 // Configure a classifier to use in the endpoint stack.

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
@@ -1,3 +1,5 @@
+use crate::http::policy::route::MatchedRoute;
+
 use super::{
     super::{Grpc, Http, Route},
     labels,
@@ -12,19 +14,25 @@ use linkerd_app_core::{
         Layer, NewService,
     },
 };
+use linkerd_http_prom::body_data::request::RequestBodyFamilies;
 use linkerd_proxy_client_policy as policy;
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn http_request_statuses() {
     let _trace = linkerd_tracing::test::trace_init();
 
-    let metrics = super::HttpRouteMetrics::default().requests;
+    let super::HttpRouteMetrics {
+        requests,
+        body_data,
+        ..
+    } = super::HttpRouteMetrics::default();
     let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
     let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
-    let (mut svc, mut handle) = mock_http_route_metrics(&metrics, &parent_ref, &route_ref);
+    let (mut svc, mut handle) =
+        mock_http_route_metrics(&requests, &body_data, &parent_ref, &route_ref);
 
     // Send one request and ensure it's counted.
-    let ok = metrics.get_statuses(&labels::Rsp(
+    let ok = requests.get_statuses(&labels::Rsp(
         labels::Route::new(parent_ref.clone(), route_ref.clone(), &Uri::default()),
         labels::HttpRsp {
             status: Some(http::StatusCode::OK),
@@ -43,7 +51,7 @@ async fn http_request_statuses() {
 
     // Send another request and ensure it's counted with a different response
     // status.
-    let no_content = metrics.get_statuses(&labels::Rsp(
+    let no_content = requests.get_statuses(&labels::Rsp(
         labels::Route::new(parent_ref.clone(), route_ref.clone(), &Uri::default()),
         labels::HttpRsp {
             status: Some(http::StatusCode::NO_CONTENT),
@@ -67,7 +75,7 @@ async fn http_request_statuses() {
     .await;
 
     // Emit a response with an error and ensure it's counted.
-    let unknown = metrics.get_statuses(&labels::Rsp(
+    let unknown = requests.get_statuses(&labels::Rsp(
         labels::Route::new(parent_ref.clone(), route_ref.clone(), &Uri::default()),
         labels::HttpRsp {
             status: None,
@@ -81,7 +89,7 @@ async fn http_request_statuses() {
 
     // Emit a successful response with a body that fails and ensure that both
     // the status and error are recorded.
-    let mixed = metrics.get_statuses(&labels::Rsp(
+    let mixed = requests.get_statuses(&labels::Rsp(
         labels::Route::new(parent_ref, route_ref, &Uri::default()),
         labels::HttpRsp {
             status: Some(http::StatusCode::OK),
@@ -115,13 +123,18 @@ async fn http_request_hostnames() {
 
     let _trace = linkerd_tracing::test::trace_init();
 
-    let metrics = super::HttpRouteMetrics::default().requests;
+    let super::HttpRouteMetrics {
+        requests,
+        body_data,
+        ..
+    } = super::HttpRouteMetrics::default();
     let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
     let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
-    let (mut svc, mut handle) = mock_http_route_metrics(&metrics, &parent_ref, &route_ref);
+    let (mut svc, mut handle) =
+        mock_http_route_metrics(&requests, &body_data, &parent_ref, &route_ref);
 
     let get_counter = |host: Option<&'static str>, status: Option<http::StatusCode>| {
-        metrics.get_statuses(&labels::Rsp(
+        requests.get_statuses(&labels::Rsp(
             labels::Route::new_with_name(
                 parent_ref.clone(),
                 route_ref.clone(),
@@ -230,16 +243,168 @@ async fn http_request_hostnames() {
 }
 
 #[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn http_route_request_body_frames() {
+    use linkerd_http_prom::body_data::request::BodyDataMetrics;
+
+    let _trace = linkerd_tracing::test::trace_init();
+
+    let super::HttpRouteMetrics {
+        requests,
+        body_data,
+        ..
+    } = super::HttpRouteMetrics::default();
+    let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
+    let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
+    let (mut svc, mut handle) =
+        mock_http_route_metrics(&requests, &body_data, &parent_ref, &route_ref);
+    handle.allow(1);
+
+    let labels = labels::Route::new(
+        parent_ref,
+        route_ref,
+        &http::uri::Uri::from_static("http://frame.count.test/"),
+    );
+    let BodyDataMetrics {
+        // TODO(kate): currently, histograms do not expose their observation count or sum. so,
+        // we're left unable to exercise these metrics until prometheus/client_rust#242 lands.
+        //   - https://github.com/prometheus/client_rust/pull/241
+        //   - https://github.com/prometheus/client_rust/pull/242
+        #[cfg(feature = "prometheus-client-rust-242")]
+        frame_size,
+        ..
+    } = body_data.metrics(&labels);
+
+    // Create a request whose body is backed by a channel that we can send chunks to.
+    tracing::info!("creating request");
+    let (req, tx) = {
+        let (tx, body) = hyper::Body::channel();
+        let body = BoxBody::new(body);
+        let req = http::Request::builder()
+            .uri("http://frame.count.test")
+            .method("BARK")
+            .body(body)
+            .unwrap();
+        (req, tx)
+    };
+
+    // Before the service has been called, the counters should be zero.
+    #[cfg(feature = "prometheus-client-rust-242")]
+    {
+        assert_eq!(frame_size.count(), 0);
+        assert_eq!(frame_size.sum(), 0);
+    }
+
+    // Call the service.
+    tracing::info!("sending request to service");
+    let (fut, resp_tx, rx) = {
+        use tower::{Service, ServiceExt};
+        tracing::info!("calling service");
+        let fut = svc.ready().await.expect("ready").call(req);
+        let (req, send_resp) = handle.next_request().await.unwrap();
+        let (parts, rx) = req.into_parts();
+        debug_assert_eq!(parts.method.as_str(), "BARK");
+        (fut, send_resp, rx)
+    };
+
+    // Before the client has sent any body chunks, the counters should be zero.
+    #[cfg(feature = "prometheus-client-rust-242")]
+    {
+        assert_eq!(frame_size.count(), 0);
+        assert_eq!(frame_size.sum(), 0);
+    }
+
+    // Send a response back to the client.
+    tracing::info!("sending request to service");
+    let resp = {
+        use http::{Response, StatusCode};
+        let body = BoxBody::new("earl grey".to_owned());
+        let resp = Response::builder()
+            .status(StatusCode::IM_A_TEAPOT)
+            .body(body)
+            .unwrap();
+        resp_tx.send_response(resp);
+        fut.await.expect("resp")
+    };
+
+    // The counters should still be zero.
+    #[cfg(feature = "prometheus-client-rust-242")]
+    {
+        assert_eq!(frame_size.count(), 0);
+        assert_eq!(frame_size.sum(), 0);
+    }
+
+    // Read the response body.
+    tracing::info!("reading response body");
+    {
+        use http_body::Body;
+        let (parts, body) = resp.into_parts();
+        debug_assert_eq!(parts.status, 418);
+        let bytes = body.collect().await.expect("resp body").to_bytes();
+        debug_assert_eq!(bytes, "earl grey");
+    }
+
+    // Reading the response body should not affect the counters should still be zero.
+    #[cfg(feature = "prometheus-client-rust-242")]
+    {
+        assert_eq!(frame_size.count(), 0);
+        assert_eq!(frame_size.sum(), 0);
+    }
+
+    /// Returns the next chunk from a boxed body.
+    async fn read_chunk(body: &mut std::pin::Pin<Box<BoxBody>>) -> Vec<u8> {
+        use bytes::Buf;
+        use http_body::Body;
+        use std::task::{Context, Poll};
+        let mut ctx = Context::from_waker(futures_util::task::noop_waker_ref());
+        let data = match body.as_mut().poll_data(&mut ctx) {
+            Poll::Ready(Some(Ok(d))) => d,
+            _ => panic!("next chunk should be ready"),
+        };
+        data.chunk().to_vec()
+    }
+
+    // And now, send request body bytes.
+    tracing::info!("sending request body bytes");
+    {
+        // Get the client's sending half, and the server's receiving half of the request body.
+        let (mut tx, mut rx) = (tx, Box::pin(rx));
+
+        tx.send_data(b"milk".as_slice().into()).await.unwrap();
+        let chunk = read_chunk(&mut rx).await;
+        debug_assert_eq!(chunk, b"milk");
+        #[cfg(feature = "prometheus-client-rust-242")]
+        assert_eq!(frames_total.get(), 1); // bytes are counted once polled.
+        #[cfg(feature = "prometheus-client-rust-242")]
+        assert_eq!(frames_bytes.get(), 4);
+
+        tx.send_data(b"syrup".as_slice().into()).await.unwrap();
+        let chunk = read_chunk(&mut rx).await;
+        debug_assert_eq!(chunk, b"syrup");
+        #[cfg(feature = "prometheus-client-rust-242")]
+        assert_eq!(frames_total.get(), 2);
+        #[cfg(feature = "prometheus-client-rust-242")]
+        assert_eq!(frames_bytes.get(), 4 + 5);
+    }
+
+    tracing::info!("passed");
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn grpc_request_statuses_ok() {
     let _trace = linkerd_tracing::test::trace_init();
 
-    let metrics = super::GrpcRouteMetrics::default().requests;
+    let super::GrpcRouteMetrics {
+        requests,
+        body_data,
+        ..
+    } = super::GrpcRouteMetrics::default();
     let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
     let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
-    let (mut svc, mut handle) = mock_grpc_route_metrics(&metrics, &parent_ref, &route_ref);
+    let (mut svc, mut handle) =
+        mock_grpc_route_metrics(&requests, &body_data, &parent_ref, &route_ref);
 
     // Send one request and ensure it's counted.
-    let ok = metrics.get_statuses(&labels::Rsp(
+    let ok = requests.get_statuses(&labels::Rsp(
         labels::Route::new(
             parent_ref.clone(),
             route_ref.clone(),
@@ -274,14 +439,19 @@ async fn grpc_request_statuses_ok() {
 async fn grpc_request_statuses_not_found() {
     let _trace = linkerd_tracing::test::trace_init();
 
-    let metrics = super::GrpcRouteMetrics::default().requests;
+    let super::GrpcRouteMetrics {
+        requests,
+        body_data,
+        ..
+    } = super::GrpcRouteMetrics::default();
     let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
     let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
-    let (mut svc, mut handle) = mock_grpc_route_metrics(&metrics, &parent_ref, &route_ref);
+    let (mut svc, mut handle) =
+        mock_grpc_route_metrics(&requests, &body_data, &parent_ref, &route_ref);
 
     // Send another request and ensure it's counted with a different response
     // status.
-    let not_found = metrics.get_statuses(&labels::Rsp(
+    let not_found = requests.get_statuses(&labels::Rsp(
         labels::Route::new(
             parent_ref.clone(),
             route_ref.clone(),
@@ -316,12 +486,17 @@ async fn grpc_request_statuses_not_found() {
 async fn grpc_request_statuses_error_response() {
     let _trace = linkerd_tracing::test::trace_init();
 
-    let metrics = super::GrpcRouteMetrics::default().requests;
+    let super::GrpcRouteMetrics {
+        requests,
+        body_data,
+        ..
+    } = super::GrpcRouteMetrics::default();
     let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
     let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
-    let (mut svc, mut handle) = mock_grpc_route_metrics(&metrics, &parent_ref, &route_ref);
+    let (mut svc, mut handle) =
+        mock_grpc_route_metrics(&requests, &body_data, &parent_ref, &route_ref);
 
-    let unknown = metrics.get_statuses(&labels::Rsp(
+    let unknown = requests.get_statuses(&labels::Rsp(
         labels::Route::new(
             parent_ref.clone(),
             route_ref.clone(),
@@ -350,12 +525,17 @@ async fn grpc_request_statuses_error_response() {
 async fn grpc_request_statuses_error_body() {
     let _trace = linkerd_tracing::test::trace_init();
 
-    let metrics = super::GrpcRouteMetrics::default().requests;
+    let super::GrpcRouteMetrics {
+        requests,
+        body_data,
+        ..
+    } = super::GrpcRouteMetrics::default();
     let parent_ref = crate::ParentRef(policy::Meta::new_default("parent"));
     let route_ref = crate::RouteRef(policy::Meta::new_default("route"));
-    let (mut svc, mut handle) = mock_grpc_route_metrics(&metrics, &parent_ref, &route_ref);
+    let (mut svc, mut handle) =
+        mock_grpc_route_metrics(&requests, &body_data, &parent_ref, &route_ref);
 
-    let unknown = metrics.get_statuses(&labels::Rsp(
+    let unknown = requests.get_statuses(&labels::Rsp(
         labels::Route::new(
             parent_ref.clone(),
             route_ref.clone(),
@@ -392,6 +572,7 @@ const MOCK_GRPC_REQ_URI: &str = "http://host/svc/method";
 
 pub fn mock_http_route_metrics(
     metrics: &RequestMetrics<LabelHttpRouteRsp>,
+    body_data: &RequestBodyFamilies<labels::Route>,
     parent_ref: &crate::ParentRef,
     route_ref: &crate::RouteRef,
 ) -> (svc::BoxHttp, Handle) {
@@ -413,8 +594,9 @@ pub fn mock_http_route_metrics(
     )
     .expect("find default route");
 
+    let extract = MatchedRoute::label_extractor;
     let (tx, handle) = tower_test::mock::pair::<http::Request<BoxBody>, http::Response<BoxBody>>();
-    let svc = super::layer(metrics)
+    let svc = super::layer(metrics, extract, body_data)
         .layer(move |_t: Http<()>| tx.clone())
         .new_service(Http {
             r#match,
@@ -434,6 +616,7 @@ pub fn mock_http_route_metrics(
 
 pub fn mock_grpc_route_metrics(
     metrics: &RequestMetrics<LabelGrpcRouteRsp>,
+    body_data: &RequestBodyFamilies<labels::Route>,
     parent_ref: &crate::ParentRef,
     route_ref: &crate::RouteRef,
 ) -> (svc::BoxHttp, Handle) {
@@ -459,8 +642,9 @@ pub fn mock_grpc_route_metrics(
     )
     .expect("find default route");
 
+    let extract = MatchedRoute::label_extractor;
     let (tx, handle) = tower_test::mock::pair::<http::Request<BoxBody>, http::Response<BoxBody>>();
-    let svc = super::layer(metrics)
+    let svc = super::layer(metrics, extract, body_data)
         .layer(move |_t: Grpc<()>| tx.clone())
         .new_service(Grpc {
             r#match,

--- a/linkerd/http/prom/src/body_data/metrics.rs
+++ b/linkerd/http/prom/src/body_data/metrics.rs
@@ -4,6 +4,13 @@ use linkerd_metrics::prom::{
     self, metrics::family::MetricConstructor, Family, Histogram, Registry, Unit,
 };
 
+/// Counters for request body frames.
+#[derive(Clone, Debug)]
+pub struct RequestBodyFamilies<L> {
+    /// Counts the number of request body frames by size.
+    frame_sizes: Family<L, Histogram, NewHisto>,
+}
+
 /// Counters for response body frames.
 #[derive(Clone, Debug)]
 pub struct ResponseBodyFamilies<L> {
@@ -18,12 +25,62 @@ pub struct BodyDataMetrics {
     pub frame_size: Histogram,
 }
 
+/// A constructor for creating new [`Histogram`]s in a [`Family`].
 #[derive(Clone, Copy)]
 struct NewHisto;
+
+// === impl NewHisto ===
 
 impl MetricConstructor<Histogram> for NewHisto {
     fn new_metric(&self) -> Histogram {
         Histogram::new([128.0, 1024.0, 10240.0].into_iter())
+    }
+}
+
+// === impl RequestBodyFamilies ===
+
+impl<L> Default for RequestBodyFamilies<L>
+where
+    L: Clone + std::hash::Hash + Eq,
+{
+    fn default() -> Self {
+        Self {
+            frame_sizes: Family::new_with_constructor(NewHisto),
+        }
+    }
+}
+
+impl<L> RequestBodyFamilies<L>
+where
+    L: prom::encoding::EncodeLabelSet
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Eq
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    /// Registers and returns a new family of body data metrics.
+    pub fn register(registry: &mut Registry) -> Self {
+        let frame_sizes = Family::new_with_constructor(NewHisto);
+        registry.register_with_unit(
+            "request_frame_size",
+            "Request data frame sizes",
+            Unit::Bytes,
+            frame_sizes.clone(),
+        );
+
+        Self { frame_sizes }
+    }
+
+    /// Returns the [`BodyDataMetrics`] for the given label set.
+    pub fn metrics(&self, labels: &L) -> BodyDataMetrics {
+        let Self { frame_sizes } = self;
+
+        let frame_size = frame_sizes.get_or_create(labels).clone();
+
+        BodyDataMetrics { frame_size }
     }
 }
 

--- a/linkerd/http/prom/src/body_data/request.rs
+++ b/linkerd/http/prom/src/body_data/request.rs
@@ -1,1 +1,126 @@
-// TODO(kate): write a middleware for request body.
+//! Tower middleware to instrument request bodies.
+
+pub use super::metrics::{BodyDataMetrics, RequestBodyFamilies};
+
+use http::{Request, Response};
+use linkerd_error::Error;
+use linkerd_http_box::BoxBody;
+use linkerd_stack::{self as svc, layer::Layer, ExtractParam, NewService, Service};
+use std::marker::PhantomData;
+
+/// A [`NewService<T>`] that creates [`RecordBodyData`] services.
+#[derive(Clone, Debug)]
+pub struct NewRecordBodyData<N, X, ReqX, L> {
+    /// The inner [`NewService<T>`].
+    inner: N,
+    extract: X,
+    metrics: RequestBodyFamilies<L>,
+    marker: PhantomData<ReqX>,
+}
+
+/// Tracks body frames for an inner `S`-typed [`Service`].
+#[derive(Clone, Debug)]
+pub struct RecordBodyData<S, ReqX, L> {
+    /// The inner [`Service<T>`].
+    inner: S,
+    extract: ReqX,
+    metrics: RequestBodyFamilies<L>,
+}
+
+// === impl NewRecordBodyData ===
+
+impl<N, X, ReqX, L> NewRecordBodyData<N, X, ReqX, L>
+where
+    X: Clone,
+    L: Clone,
+{
+    /// Returns a [`Layer<S>`] that tracks body chunks.
+    ///
+    /// This uses an `X`-typed [`ExtractParam<P, T>`] implementation to extract service parameters
+    /// from a `T`-typed target.
+    pub fn new(extract: X, metrics: RequestBodyFamilies<L>) -> impl Layer<N, Service = Self> {
+        svc::layer::mk(move |inner| Self {
+            inner,
+            extract: extract.clone(),
+            metrics: metrics.clone(),
+            marker: PhantomData,
+        })
+    }
+}
+
+impl<T, N, X, ReqX, L> NewService<T> for NewRecordBodyData<N, X, ReqX, L>
+where
+    N: NewService<T>,
+    X: ExtractParam<ReqX, T>,
+    L: Clone,
+{
+    type Service = RecordBodyData<N::Service, ReqX, L>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let Self {
+            inner,
+            extract,
+            metrics,
+            marker: _,
+        } = self;
+
+        let extract = extract.extract_param(&target);
+        let inner = inner.new_service(target);
+        let metrics = metrics.clone();
+
+        RecordBodyData {
+            inner,
+            extract,
+            metrics,
+        }
+    }
+}
+
+// === impl RecordBodyData ===
+
+impl<ReqB, RespB, S, ReqX, L> Service<Request<ReqB>> for RecordBodyData<S, ReqX, L>
+where
+    S: Service<Request<BoxBody>, Response = Response<RespB>>,
+    S::Future: Send + 'static,
+    ReqB: http_body::Body + Send + 'static,
+    ReqB::Data: Send + 'static,
+    ReqB::Error: Into<Error>,
+    ReqX: ExtractParam<L, Request<ReqB>>,
+    L: linkerd_metrics::prom::encoding::EncodeLabelSet
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Eq
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    #[inline]
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqB>) -> Self::Future {
+        let Self {
+            inner,
+            extract,
+            metrics,
+        } = self;
+
+        let req = {
+            let labels = extract.extract_param(&req);
+            let metrics = metrics.metrics(&labels);
+            let instrument = |b| super::body::Body::new(b, metrics);
+            req.map(instrument).map(BoxBody::new)
+        };
+
+        inner.call(req)
+    }
+}


### PR DESCRIPTION
feat(app): Route frame count metrics

### ⛅ overview

this introduces a new tower middleware for Prometheus metrics, used for
instrumenting HTTP and gRPC request bodies, and observing (a) the
number of frames yielded by a body, (b) the number of bytes included
in body frames, and (c) a distribution of the size of frames yielded.

this builds upon the backend-level metrics added in #3308. this
additionally uses the route label extractor, hoisted out of the retry
middleware's Prometheus telemetry in #3337.

### 📝 changes

* a `linkerd_http_prom::body_data::request::NewRecordBodyData::NewRecordBodyData`
middleware is added, which complements the equivalent
`linkerd_http_prom::body_data::response` middleware.

* this is added to policy routes' metrics layer.

see prometheus/client_rust#241 and prometheus/client_rust#242, which
track upstream proposals to add accessors to `Histogram` that will allow
us to make test assertions that metrics are working properly. for now,
these are feature gated as also done in #3308.

---

### :link: related

* #3308
* #3337
* #3318 