### PR TITLE
build(deps): bump linkerd2-proxy-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api.git?branch=main#2be6843a95360eaa370363c42e3aa85142b7a36c"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api.git?branch=main#6c316cc41a3a0e194a70f22b5698ec21ce245e99"
 dependencies = [
  "h2",
  "http",


### PR DESCRIPTION
This fixes a compilation error caused by a missing feature flag.