### PR TITLE
refactor(app): Outline route label extractor

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -132,7 +132,7 @@ where
                             route_ref,
                             ..
                         } = &rt.params;
-                        retry::RetryLabelExtract(parent_ref.clone(), route_ref.clone())
+                        metrics::labels::RouteLabelExtract(parent_ref.clone(), route_ref.clone())
                     };
                     let metrics = metrics.retry.clone();
                     retry::NewHttpRetry::layer_via_mk(mk_extract, metrics)

--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -124,18 +124,9 @@ where
                 .push_on_service(svc::LoadShed::layer())
                 .push(filters::NewApplyFilters::<Self, _, _>::layer())
                 .push({
-                    // TODO(kate): extracting route labels like this should ideally live somewhere
-                    // else, like e.g. the `SetExtensions` middleware.
-                    let mk_extract = |rt: &Self| {
-                        let Route {
-                            parent_ref,
-                            route_ref,
-                            ..
-                        } = &rt.params;
-                        metrics::labels::RouteLabelExtract(parent_ref.clone(), route_ref.clone())
-                    };
+                    let mk = Self::label_extractor;
                     let metrics = metrics.retry.clone();
-                    retry::NewHttpRetry::layer_via_mk(mk_extract, metrics)
+                    retry::NewHttpRetry::layer_via_mk(mk, metrics)
                 })
                 .check_new::<Self>()
                 .check_new_service::<Self, http::Request<http::BoxBody>>()

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
@@ -215,6 +215,26 @@ impl EncodeLabelSet for GrpcRsp {
     }
 }
 
+// === impl MatchedRoute ===
+
+impl<T, M, F, P> super::super::MatchedRoute<T, M, F, P> {
+    /// Returns a [`RouteLabelExtract`].
+    ///
+    /// The extractor returned by this function provides a [`ExtractParam<P, T>`] implementation
+    /// that can be used to acquire the route-level labels corresponding to a given outbound
+    /// request.
+    pub(crate) fn label_extractor(&self) -> RouteLabelExtract {
+        use super::super::Route;
+        let Route {
+            parent_ref,
+            route_ref,
+            ..
+        } = &self.params;
+
+        RouteLabelExtract(parent_ref.clone(), route_ref.clone())
+    }
+}
+
 // === impl RouteLabelExtract ===
 
 impl<B> ExtractParam<Route, http::Request<B>> for RouteLabelExtract {


### PR DESCRIPTION
this PR, based upon #3308, generalizes the `ExtractParam<P, T>` type used to retrieve Prometheus labels for the route-level retry middleware. this is a helpful component we'll want in order to build route-level frame counting middleware.

#### refactor(app): Hoist label extractor out of retry middleware

this commit promotes the `RetryLabelExtract` type out of the route retry middleware, and into the metrics
submodule.

in preparation for generalizing this component, we rename it to `RouteLabelExtract`.

#### refactor(app): Outline route label extraction

this addresses the `TODO` comment, moving the `RouteLabelExtract` type out of the policy route layer
function.

this defines a method on `MatchedRoute` which may be called to retrieve a `RouteLabelExtract`. that type
holds references to the contruction-time information about the route, and can be used to later inspect an
outbound request at call-time, returning a `labels::Route` set of labels.

this is a helpful piece of reusable glue that is broadly useful in instrumenting our route-level
middleware.


### :link: related

* #3308
* #3334
* #3318 
