### PR TITLE
refactor(app): `MockBoxy` convenience functions for test code

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
@@ -148,11 +148,7 @@ async fn grpc_request_statuses_ok() {
         |tx| {
             tx.send_response(
                 http::Response::builder()
-                    .body(BoxBody::new(MockBody::trailers(async move {
-                        let mut trailers = http::HeaderMap::new();
-                        trailers.insert("grpc-status", http::HeaderValue::from_static("0"));
-                        Ok(Some(trailers))
-                    })))
+                    .body(BoxBody::new(MockBody::grpc_status(0)))
                     .unwrap(),
             )
         },
@@ -191,11 +187,7 @@ async fn grpc_request_statuses_not_found() {
         |tx| {
             tx.send_response(
                 http::Response::builder()
-                    .body(BoxBody::new(MockBody::trailers(async move {
-                        let mut trailers = http::HeaderMap::new();
-                        trailers.insert("grpc-status", http::HeaderValue::from_static("5"));
-                        Ok(Some(trailers))
-                    })))
+                    .body(BoxBody::new(MockBody::grpc_status(5)))
                     .unwrap(),
             )
         },

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics/tests.rs
@@ -101,9 +101,7 @@ async fn http_request_statuses() {
         tx.send_response(
             http::Response::builder()
                 .status(200)
-                .body(BoxBody::new(MockBody::new(async {
-                    Err("a spooky ghost".into())
-                })))
+                .body(BoxBody::new(MockBody::error("a spooky ghost")))
                 .unwrap(),
         )
     })
@@ -267,9 +265,7 @@ async fn grpc_request_statuses_error_body() {
         |tx| {
             tx.send_response(
                 http::Response::builder()
-                    .body(BoxBody::new(MockBody::new(async {
-                        Err("a spooky ghost".into())
-                    })))
+                    .body(BoxBody::new(MockBody::error("a spooky ghost")))
                     .unwrap(),
             )
         },

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
@@ -262,11 +262,7 @@ async fn grpc_request_statuses_ok() {
         |tx| {
             tx.send_response(
                 http::Response::builder()
-                    .body(BoxBody::new(MockBody::trailers(async move {
-                        let mut trailers = http::HeaderMap::new();
-                        trailers.insert("grpc-status", http::HeaderValue::from_static("0"));
-                        Ok(Some(trailers))
-                    })))
+                    .body(BoxBody::new(MockBody::grpc_status(0)))
                     .unwrap(),
             )
         },
@@ -308,11 +304,7 @@ async fn grpc_request_statuses_not_found() {
         |tx| {
             tx.send_response(
                 http::Response::builder()
-                    .body(BoxBody::new(MockBody::trailers(async move {
-                        let mut trailers = http::HeaderMap::new();
-                        trailers.insert("grpc-status", http::HeaderValue::from_static("5"));
-                        Ok(Some(trailers))
-                    })))
+                    .body(BoxBody::new(MockBody::grpc_status(5)))
                     .unwrap(),
             )
         },

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
@@ -92,9 +92,7 @@ async fn http_request_statuses() {
         tx.send_response(
             http::Response::builder()
                 .status(200)
-                .body(BoxBody::new(MockBody::new(async {
-                    Err("a spooky ghost".into())
-                })))
+                .body(BoxBody::new(MockBody::error("a spooky ghost")))
                 .unwrap(),
         )
     })
@@ -388,9 +386,7 @@ async fn grpc_request_statuses_error_body() {
         |tx| {
             tx.send_response(
                 http::Response::builder()
-                    .body(BoxBody::new(MockBody::new(async {
-                        Err("a spooky ghost".into())
-                    })))
+                    .body(BoxBody::new(MockBody::error("a spooky ghost")))
                     .unwrap(),
             )
         },

--- a/linkerd/app/outbound/src/http/logical/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/tests.rs
@@ -131,11 +131,7 @@ async fn mk_grpc_rsp(code: tonic::Code) -> Result<Response> {
     Ok(http::Response::builder()
         .version(::http::Version::HTTP_2)
         .header("content-type", "application/grpc")
-        .body(BoxBody::new(MockBody::trailers(async move {
-            let mut trls = http::HeaderMap::default();
-            trls.insert("grpc-status", (code as u8).to_string().parse().unwrap());
-            Ok(Some(trls))
-        })))
+        .body(BoxBody::new(MockBody::grpc_status(code as u8)))
         .unwrap())
 }
 

--- a/linkerd/app/outbound/src/http/logical/tests/timeouts.rs
+++ b/linkerd/app/outbound/src/http/logical/tests/timeouts.rs
@@ -74,9 +74,7 @@ async fn request_timeout_request_body() {
         svc.clone(),
         http::Request::builder()
             .method("POST")
-            .body(BoxBody::new(MockBody::new(async move {
-                futures::future::pending().await
-            })))
+            .body(BoxBody::new(MockBody::pending()))
             .unwrap(),
     );
 
@@ -119,9 +117,7 @@ async fn request_timeout_response_body() {
         future::ok(
             http::Response::builder()
                 .status(200)
-                .body(http::BoxBody::new(MockBody::new(async move {
-                    futures::future::pending().await
-                })))
+                .body(BoxBody::new(MockBody::pending()))
                 .unwrap(),
         ),
     )
@@ -203,9 +199,7 @@ async fn response_timeout_response_body() {
                 info!("Serving a response that never completes");
                 Ok(http::Response::builder()
                     .status(200)
-                    .body(http::BoxBody::new(MockBody::new(async move {
-                        futures::future::pending().await
-                    })))
+                    .body(http::BoxBody::new(MockBody::pending()))
                     .unwrap())
             })
             .await;
@@ -252,9 +246,7 @@ async fn response_timeout_ignores_request_body() {
         info!("Serving a response that never completes");
         Ok(http::Response::builder()
             .status(200)
-            .body(http::BoxBody::new(MockBody::new(async move {
-                futures::future::pending().await
-            })))
+            .body(http::BoxBody::new(MockBody::pending()))
             .unwrap())
     })
     .await;
@@ -286,9 +278,7 @@ async fn idle_timeout_response_body() {
         info!("Serving a response that never completes");
         Ok(http::Response::builder()
             .status(200)
-            .body(http::BoxBody::new(MockBody::new(async move {
-                futures::future::pending().await
-            })))
+            .body(http::BoxBody::new(MockBody::pending()))
             .unwrap())
     })
     .await;

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -111,12 +111,19 @@ mod mock_body {
             Self::new(fut)
         }
 
-        pub fn trailers(
-            trailers: impl Future<Output = Result<Option<http::HeaderMap>>> + Send + 'static,
-        ) -> Self {
+        /// Returns a [`MockBody`] that yields this gRPC code in its trailers section.
+        pub fn grpc_status(code: u8) -> Self {
+            let trailers = {
+                let mut trailers = http::HeaderMap::with_capacity(1);
+                let status = code.to_string().parse().unwrap();
+                trailers.insert("grpc-status", status);
+                trailers
+            };
+            let fut = futures::future::ready(Ok(Some(trailers)));
+
             Self {
                 data: None,
-                trailers: Some(Box::pin(trailers)),
+                trailers: Some(Box::pin(fut)),
             }
         }
     }

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -104,6 +104,13 @@ mod mock_body {
             Self::new(fut)
         }
 
+        /// Returns a [`MockBody`] that yields an error when polled.
+        pub fn error(msg: &'static str) -> Self {
+            let err = Err(msg.into());
+            let fut = futures::future::ready(err);
+            Self::new(fut)
+        }
+
         pub fn trailers(
             trailers: impl Future<Output = Result<Option<http::HeaderMap>>> + Send + 'static,
         ) -> Self {

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -98,6 +98,12 @@ mod mock_body {
             }
         }
 
+        /// Returns a [`MockBody`] that never yields any data.
+        pub fn pending() -> Self {
+            let fut = futures::future::pending();
+            Self::new(fut)
+        }
+
         pub fn trailers(
             trailers: impl Future<Output = Result<Option<http::HeaderMap>>> + Send + 'static,
         ) -> Self {


### PR DESCRIPTION
there are a few common cases in the test code that interacts with our `MockBody` type, used in proxy
test cases to examine corner cases like timeouts or mid-stream errors, and for use in gRPC tests.

this branch introduces three new `MockBody` methods; `pending()`, `error()`, and `grpc_status()`, to help
provide succinct helper calls for their corresponding test coverage.

### refactor(app): add `pending()` helper for mock body

in timeout tests, we construct mock bodies that are backed by a `Pending<T>` future that will never yield
any data.

this introduces a small `pending()` helper to the `MockBody` type used in test code in the outbound proxy.

### refactor(app): add `error()` helper for mock body

in metrics tests, we construct mock bodies that will yield an error when polled, to examine how telemetry
measures certain edge cases.

this introduces a small `error()` helper to the `MockBody` type used in test code in the outbound proxy.

### refactor(app): add `grpc_status()` helper for mock body

in metrics tests, we construct mock bodies that will yield an gRPC status code in its trailers section when
polled, to examine how telemetry measures gRPC responses.

this refactors the `trailers()` function to more narrowly focus on the test coverage needed, to help reduce
boilerplate in test code.
