### PR TITLE
policy: use TLS/TCP filters from proxy API response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api.git?branch=main#6c316cc41a3a0e194a70f22b5698ec21ce245e99"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/errors-to-filters#22b68a1a3b4d0c0e470efbfedfc239bfbd5cd9ee"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2588,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "linkerd2-proxy-api"
 version = "0.14.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/errors-to-filters#22b68a1a3b4d0c0e470efbfedfc239bfbd5cd9ee"
+source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/errors-to-filters#5a3dae76f9245fb51f6250669bc51416e33e840b"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -2587,8 +2587,9 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.14.0"
-source = "git+https://github.com/linkerd/linkerd2-proxy-api?branch=zd/errors-to-filters#5a3dae76f9245fb51f6250669bc51416e33e840b"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4682c00263191a5bfa4fbe64f6d80b22ff2b49aaa294da5aac062f5abc6eb9e"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,4 +92,4 @@ lto = true
 
 [workspace.dependencies]
 #linkerd2-proxy-api = "0.14.0"
-linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "main" }
+linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', branch = 'zd/errors-to-filters' }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,5 +91,5 @@ debug = 1
 lto = true
 
 [workspace.dependencies]
-#linkerd2-proxy-api = "0.14.0"
-linkerd2-proxy-api = { git = 'https://github.com/linkerd/linkerd2-proxy-api', branch = 'zd/errors-to-filters' }
+linkerd2-proxy-api = "0.15.0"
+# linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "main" }

--- a/linkerd/app/integration/src/policy.rs
+++ b/linkerd/app/integration/src/policy.rs
@@ -162,18 +162,18 @@ pub fn outbound_default_opaque_route(dst: impl ToString) -> outbound::OpaqueRout
         metadata: Some(api::meta::Metadata {
             kind: Some(api::meta::metadata::Kind::Default("default".to_string())),
         }),
-        error: None,
         rules: vec![outbound::opaque_route::Rule {
             backends: Some(opaque_route::Distribution {
                 kind: Some(distribution::Kind::FirstAvailable(
                     distribution::FirstAvailable {
                         backends: vec![opaque_route::RouteBackend {
                             backend: Some(backend(dst)),
-                            invalid: None,
+                            filters: Vec::new(),
                         }],
                     },
                 )),
             }),
+            filters: Vec::new(),
         }],
     }
 }

--- a/linkerd/app/outbound/src/opaq/logical/route/filters.rs
+++ b/linkerd/app/outbound/src/opaq/logical/route/filters.rs
@@ -10,11 +10,11 @@ where
     let filters: &[opaq::Filter] = &t.param();
     if let Some(filter) = filters.iter().next() {
         match filter {
-            opaq::Filter::ForbiddenRoute => {
+            opaq::Filter::Forbidden => {
                 return Err(errors::TCPForbiddenRoute.into());
             }
 
-            opaq::Filter::InvalidBackend(message) => {
+            opaq::Filter::Invalid(message) => {
                 return Err(errors::TCPInvalidBackend(message.clone()).into());
             }
 

--- a/linkerd/app/outbound/src/tls/logical/route/filters.rs
+++ b/linkerd/app/outbound/src/tls/logical/route/filters.rs
@@ -10,11 +10,11 @@ where
     let filters: &[tls::Filter] = &t.param();
     if let Some(filter) = filters.iter().next() {
         match filter {
-            tls::Filter::ForbiddenRoute => {
+            tls::Filter::Forbidden => {
                 return Err(errors::TLSForbiddenRoute.into());
             }
 
-            tls::Filter::InvalidBackend(message) => {
+            tls::Filter::Invalid(message) => {
                 return Err(errors::TLSInvalidBackend(message.clone()).into());
             }
 


### PR DESCRIPTION
This PR updates the proxy API dependency to a new version that uses filters to express errors for TLS and TCP routes. 

This PR depends on https://github.com/linkerd/linkerd2-proxy-api/pull/405

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>