### PR TITLE
metrics: correctly reflect closed connections in route metrics

### DIFF
--- a/linkerd/app/outbound/src/metrics/transport.rs
+++ b/linkerd/app/outbound/src/metrics/transport.rs
@@ -211,11 +211,7 @@ where
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(|error| {
-            let error = error.into();
-            self.metrics.inc_closed(Some(&*error));
-            error
-        })
+        self.inner.poll_ready(cx).map_err(Into::into)
     }
 
     fn call(&mut self, io: I) -> Self::Future {

--- a/linkerd/app/outbound/src/metrics/transport.rs
+++ b/linkerd/app/outbound/src/metrics/transport.rs
@@ -211,7 +211,11 @@ where
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(Into::into)
+        self.inner.poll_ready(cx).map_err(|error| {
+            let error = error.into();
+            self.metrics.inc_closed(Some(&*error));
+            error
+        })
     }
 
     fn call(&mut self, io: I) -> Self::Future {

--- a/linkerd/app/outbound/src/opaq/logical/route.rs
+++ b/linkerd/app/outbound/src/opaq/logical/route.rs
@@ -91,7 +91,7 @@ where
                 .push_map_target(|t| t)
                 .push_map_target(|b: Backend<T>| b.concrete)
                 // apply backend filters
-                .push_filter(filters::apply)
+                .push(filters::NewApplyFilters::layer())
                 .lift_new()
                 .push(NewDistribute::layer())
                 // The router does not take the backend's availability into
@@ -99,7 +99,7 @@ where
                 // leaking tasks onto the runtime.
                 .push_on_service(svc::LoadShed::layer())
                 // apply route level filters
-                .push_filter(filters::apply)
+                .push(filters::NewApplyFilters::layer())
                 .push(svc::NewMapErr::layer_with(|rt: &Self| {
                     let route = rt.params.route_ref.clone();
                     move |source| RouteError {

--- a/linkerd/app/outbound/src/opaq/logical/route/filters.rs
+++ b/linkerd/app/outbound/src/opaq/logical/route/filters.rs
@@ -1,30 +1,98 @@
-use linkerd_app_core::{svc, Error};
+use linkerd_app_core::{io, svc, Error};
 use linkerd_proxy_client_policy::opaq;
-use std::{fmt::Debug, sync::Arc};
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
-pub(crate) fn apply<T>(t: T) -> Result<T, Error>
+#[derive(Clone, Debug)]
+pub struct NewApplyFilters<N> {
+    inner: N,
+}
+
+#[derive(Clone, Debug)]
+pub struct ApplyFilters<S> {
+    inner: S,
+    filters: Arc<[opaq::Filter]>,
+}
+
+// === impl NewApplyFilters ===
+
+impl<N> NewApplyFilters<N> {
+    pub fn layer() -> impl svc::layer::Layer<N, Service = Self> + Clone {
+        svc::layer::mk(move |inner| Self { inner })
+    }
+}
+
+impl<T, N, S> svc::NewService<T> for NewApplyFilters<N>
 where
-    T: Clone,
+    N: svc::NewService<T, Service = S>,
     T: svc::Param<Arc<[opaq::Filter]>>,
 {
-    let filters: &[opaq::Filter] = &t.param();
-    if let Some(filter) = filters.iter().next() {
-        match filter {
-            opaq::Filter::Forbidden => {
-                return Err(errors::TCPForbiddenRoute.into());
-            }
+    type Service = ApplyFilters<S>;
 
-            opaq::Filter::Invalid(message) => {
-                return Err(errors::TCPInvalidBackend(message.clone()).into());
-            }
-
-            opaq::Filter::InternalError(message) => {
-                return Err(errors::TCPInvalidPolicy(message).into());
-            }
+    fn new_service(&self, target: T) -> Self::Service {
+        let filters: Arc<[opaq::Filter]> = target.param();
+        let svc = self.inner.new_service(target);
+        ApplyFilters {
+            inner: svc,
+            filters,
         }
     }
+}
 
-    Ok(t)
+// === impl ApplyFilters ===
+
+impl<S> ApplyFilters<S> {
+    fn apply_filters(&self) -> Result<(), Error> {
+        if let Some(filter) = self.filters.iter().next() {
+            match filter {
+                opaq::Filter::Forbidden => {
+                    return Err(errors::TCPForbiddenRoute.into());
+                }
+
+                opaq::Filter::Invalid(message) => {
+                    return Err(errors::TCPInvalidBackend(message.clone()).into());
+                }
+
+                opaq::Filter::InternalError(message) => {
+                    return Err(errors::TCPInvalidPolicy(message).into());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<I, S> svc::Service<I> for ApplyFilters<S>
+where
+    I: io::AsyncRead + io::AsyncWrite + Send + 'static,
+    S: svc::Service<I> + Send + Clone + 'static,
+    S::Error: Into<Error>,
+    S::Future: Send,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<S::Response, Error>> + Send + 'static>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, io: I) -> Self::Future {
+        let call = self.inner.call(io);
+        let apply = self.apply_filters();
+
+        Box::pin(async move {
+            apply?;
+            call.await.map_err(Into::into)
+        })
+    }
 }
 
 pub mod errors {

--- a/linkerd/app/outbound/src/tls/logical/route.rs
+++ b/linkerd/app/outbound/src/tls/logical/route.rs
@@ -95,7 +95,7 @@ where
                 .push_map_target(|t| t)
                 .push_map_target(|b: Backend<T>| b.concrete)
                 // apply backend filters
-                .push_filter(filters::apply)
+                .push(filters::NewApplyFilters::layer())
                 .lift_new()
                 .push(NewDistribute::layer())
                 // The router does not take the backend's availability into
@@ -103,7 +103,7 @@ where
                 // leaking tasks onto the runtime.
                 .push_on_service(svc::LoadShed::layer())
                 // apply route level filters
-                .push_filter(filters::apply)
+                .push(filters::NewApplyFilters::layer())
                 .push(svc::NewMapErr::layer_with(|rt: &Self| {
                     let route = rt.params.route_ref.clone();
                     move |source| RouteError {

--- a/linkerd/app/outbound/src/tls/logical/route/filters.rs
+++ b/linkerd/app/outbound/src/tls/logical/route/filters.rs
@@ -1,9 +1,8 @@
+use futures::{future, TryFutureExt};
 use linkerd_app_core::{io, svc, Error};
 use linkerd_proxy_client_policy::tls;
 use std::{
     fmt::Debug,
-    future::Future,
-    pin::Pin,
     sync::Arc,
     task::{Context, Poll},
 };
@@ -77,7 +76,10 @@ where
 {
     type Response = S::Response;
     type Error = Error;
-    type Future = Pin<Box<dyn Future<Output = Result<S::Response, Error>> + Send + 'static>>;
+    type Future = future::Either<
+        future::ErrInto<S::Future, Error>,
+        future::Ready<Result<S::Response, Error>>,
+    >;
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -85,13 +87,10 @@ where
     }
 
     fn call(&mut self, io: I) -> Self::Future {
-        let call = self.inner.call(io);
-        let apply = self.apply_filters();
-
-        Box::pin(async move {
-            apply?;
-            call.await.map_err(Into::into)
-        })
+        if let Err(e) = self.apply_filters() {
+            return future::Either::Right(future::err(e));
+        }
+        future::Either::Left(self.inner.call(io).err_into())
     }
 }
 

--- a/linkerd/app/outbound/src/tls/logical/route/filters.rs
+++ b/linkerd/app/outbound/src/tls/logical/route/filters.rs
@@ -1,30 +1,98 @@
-use linkerd_app_core::{svc, Error};
+use linkerd_app_core::{io, svc, Error};
 use linkerd_proxy_client_policy::tls;
-use std::{fmt::Debug, sync::Arc};
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
 
-pub(crate) fn apply<T>(t: T) -> Result<T, Error>
+#[derive(Clone, Debug)]
+pub struct NewApplyFilters<N> {
+    inner: N,
+}
+
+#[derive(Clone, Debug)]
+pub struct ApplyFilters<S> {
+    inner: S,
+    filters: Arc<[tls::Filter]>,
+}
+
+// === impl NewApplyFilters ===
+
+impl<N> NewApplyFilters<N> {
+    pub fn layer() -> impl svc::layer::Layer<N, Service = Self> + Clone {
+        svc::layer::mk(move |inner| Self { inner })
+    }
+}
+
+impl<T, N, S> svc::NewService<T> for NewApplyFilters<N>
 where
-    T: Clone,
+    N: svc::NewService<T, Service = S>,
     T: svc::Param<Arc<[tls::Filter]>>,
 {
-    let filters: &[tls::Filter] = &t.param();
-    if let Some(filter) = filters.iter().next() {
-        match filter {
-            tls::Filter::Forbidden => {
-                return Err(errors::TLSForbiddenRoute.into());
-            }
+    type Service = ApplyFilters<S>;
 
-            tls::Filter::Invalid(message) => {
-                return Err(errors::TLSInvalidBackend(message.clone()).into());
-            }
-
-            tls::Filter::InternalError(message) => {
-                return Err(errors::TLSInvalidPolicy(message).into());
-            }
+    fn new_service(&self, target: T) -> Self::Service {
+        let filters: Arc<[tls::Filter]> = target.param();
+        let svc = self.inner.new_service(target);
+        ApplyFilters {
+            inner: svc,
+            filters,
         }
     }
+}
 
-    Ok(t)
+// === impl ApplyFilters ===
+
+impl<S> ApplyFilters<S> {
+    fn apply_filters(&self) -> Result<(), Error> {
+        if let Some(filter) = self.filters.iter().next() {
+            match filter {
+                tls::Filter::Forbidden => {
+                    return Err(errors::TLSForbiddenRoute.into());
+                }
+
+                tls::Filter::Invalid(message) => {
+                    return Err(errors::TLSInvalidBackend(message.clone()).into());
+                }
+
+                tls::Filter::InternalError(message) => {
+                    return Err(errors::TLSInvalidPolicy(message).into());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl<I, S> svc::Service<I> for ApplyFilters<S>
+where
+    I: io::AsyncRead + io::AsyncWrite + Send + 'static,
+    S: svc::Service<I> + Send + Clone + 'static,
+    S::Error: Into<Error>,
+    S::Future: Send,
+{
+    type Response = S::Response;
+    type Error = Error;
+    type Future = Pin<Box<dyn Future<Output = Result<S::Response, Error>> + Send + 'static>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, io: I) -> Self::Future {
+        let call = self.inner.call(io);
+        let apply = self.apply_filters();
+
+        Box::pin(async move {
+            apply?;
+            call.await.map_err(Into::into)
+        })
+    }
 }
 
 pub mod errors {


### PR DESCRIPTION
This PR fixes a problem that was introduced in the following commit: https://github.com/linkerd/linkerd2-proxy/pull/3355/commits/5ac135212f1a7f51d083d99bf7e7d7231d5d972d

The problem is that if a particular route is configured to fail a connection, the `poll_ready` call on the inner service will return the error and the service will never get called. Therefore in order to capture that in metrics, we need to increment the metrics counter if we encounter errors while calling` poll_ready` on the inner service.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>