### PR TITLE
chore(hyper): enable `deprecated` feature flag 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,9 +942,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1276,7 +1276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 futures = { version = "0.3", default-features = false }
 http = "0.2"
-hyper = "0.14"
+hyper = { version = "0.14", features = ["deprecated"] }
 pin-project = "1"
 tower = { version = "0.4", default-features = false, features = ["load"] }
 tokio = { version = "1", features = ["macros"] }

--- a/linkerd/app/admin/Cargo.toml
+++ b/linkerd/app/admin/Cargo.toml
@@ -17,7 +17,7 @@ log-streaming = ["linkerd-tracing/stream"]
 [dependencies]
 deflate = { version = "1", optional = true, features = ["gzip"] }
 http = "0.2"
-hyper = { version = "0.14", features = ["http1", "http2"] }
+hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 pprof = { version = "0.14", optional = true, features = ["prost-codec"] }
 serde = "1"

--- a/linkerd/app/admin/src/server/log/level.rs
+++ b/linkerd/app/admin/src/server/log/level.rs
@@ -21,6 +21,7 @@ where
         }
 
         http::Method::PUT => {
+            #[allow(deprecated)] // linkerd/linkerd2#8733
             let body = hyper::body::aggregate(req.into_body())
                 .await
                 .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;

--- a/linkerd/app/admin/src/server/log/stream.rs
+++ b/linkerd/app/admin/src/server/log/stream.rs
@@ -52,6 +52,7 @@ where
         // If the request is a QUERY, use the request body
         method if method.as_str() == "QUERY" => {
             // TODO(eliza): validate that the request has a content-length...
+            #[allow(deprecated)] // linkerd/linkerd2#8733
             let body = recover!(
                 hyper::body::aggregate(req.into_body())
                     .await

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "1"
 drain = { version = "0.1", features = ["retain"] }
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["http1", "http2"] }
+hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.10"
 prometheus-client = "0.22"

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -45,13 +45,13 @@ path = "../../proxy/server-policy"
 features = ["proto"]
 
 [target.'cfg(fuzzing)'.dependencies]
-hyper = { version = "0.14", features = ["http1", "http2"] }
+hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 linkerd-app-test = { path = "../test" }
 arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 
 [dev-dependencies]
-hyper = { version = "0.14", features = ["http1", "http2"] }
+hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 linkerd-app-test = { path = "../test" }
 linkerd-http-metrics = { path = "../../http/metrics", features = ["test-util"] }
 linkerd-idle-cache = { path = "../../idle-cache", features = ["test-util"] }

--- a/linkerd/app/inbound/fuzz/Cargo.toml
+++ b/linkerd/app/inbound/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 
 [target.'cfg(fuzzing)'.dependencies]
 arbitrary = { version = "1", features = ["derive"] }
-hyper = { version = "0.14", features = ["http1", "http2"] }
+hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 http = "0.2"
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 linkerd-app-core = { path = "../../core" }

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     Config, Inbound,
 };
-use hyper::{body::HttpBody, client::conn::Builder as ClientBuilder, Body, Request, Response};
+use hyper::{body::HttpBody, Body, Request, Response};
 use linkerd_app_core::{
     classify,
     errors::respond::L5D_PROXY_ERROR,
@@ -46,9 +46,11 @@ where
 
 #[tokio::test(flavor = "current_thread")]
 async fn unmeshed_http1_hello_world() {
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     let mut server = hyper::server::conn::Http::new();
     server.http1_only(true);
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     let _trace = trace_init();
 
     // Build a mock "connector" that returns the upstream "server" IO.
@@ -82,9 +84,11 @@ async fn unmeshed_http1_hello_world() {
 #[tokio::test(flavor = "current_thread")]
 async fn downgrade_origin_form() {
     // Reproduces https://github.com/linkerd/linkerd2/issues/5298
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     let mut server = hyper::server::conn::Http::new();
     server.http1_only(true);
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     client.http2_only(true);
     let _trace = trace_init();
 
@@ -120,9 +124,11 @@ async fn downgrade_origin_form() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn downgrade_absolute_form() {
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     let mut server = hyper::server::conn::Http::new();
     server.http1_only(true);
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     client.http2_only(true);
     let _trace = trace_init();
 
@@ -165,7 +171,8 @@ async fn http1_bad_gateway_meshed_response_error_header() {
 
     // Build a client using the connect that always errors so that responses
     // are BAD_GATEWAY.
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     let profiles = profile::resolver();
     let profile_tx =
         profiles.profile_tx(NameAddr::from_str_and_port("foo.svc.cluster.local", 5550).unwrap());
@@ -203,7 +210,8 @@ async fn http1_bad_gateway_unmeshed_response() {
 
     // Build a client using the connect that always errors so that responses
     // are BAD_GATEWAY.
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     let profiles = profile::resolver();
     let profile_tx =
         profiles.profile_tx(NameAddr::from_str_and_port("foo.svc.cluster.local", 5550).unwrap());
@@ -238,12 +246,14 @@ async fn http1_connect_timeout_meshed_response_error_header() {
 
     // Build a mock connect that sleeps longer than the default inbound
     // connect timeout.
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     let server = hyper::server::conn::Http::new();
     let connect = support::connect().endpoint(Target::addr(), connect_timeout(server));
 
     // Build a client using the connect that always sleeps so that responses
     // are GATEWAY_TIMEOUT.
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     let profiles = profile::resolver();
     let profile_tx =
         profiles.profile_tx(NameAddr::from_str_and_port("foo.svc.cluster.local", 5550).unwrap());
@@ -280,12 +290,14 @@ async fn http1_connect_timeout_unmeshed_response_error_header() {
 
     // Build a mock connect that sleeps longer than the default inbound
     // connect timeout.
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     let server = hyper::server::conn::Http::new();
     let connect = support::connect().endpoint(Target::addr(), connect_timeout(server));
 
     // Build a client using the connect that always sleeps so that responses
     // are GATEWAY_TIMEOUT.
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     let profiles = profile::resolver();
     let profile_tx =
         profiles.profile_tx(NameAddr::from_str_and_port("foo.svc.cluster.local", 5550).unwrap());
@@ -321,7 +333,8 @@ async fn h2_response_meshed_error_header() {
     let connect = support::connect().endpoint_fn_boxed(Target::addr(), connect_error());
 
     // Build a client using the connect that always errors.
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     client.http2_only(true);
     let profiles = profile::resolver();
     let profile_tx =
@@ -359,7 +372,8 @@ async fn h2_response_unmeshed_error_header() {
     let connect = support::connect().endpoint_fn_boxed(Target::addr(), connect_error());
 
     // Build a client using the connect that always errors.
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     client.http2_only(true);
     let profiles = profile::resolver();
     let profile_tx =
@@ -399,7 +413,8 @@ async fn grpc_meshed_response_error_header() {
     let connect = support::connect().endpoint_fn_boxed(Target::addr(), connect_error());
 
     // Build a client using the connect that always errors.
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     client.http2_only(true);
     let profiles = profile::resolver();
     let profile_tx =
@@ -438,7 +453,8 @@ async fn grpc_unmeshed_response_error_header() {
     let connect = support::connect().endpoint_fn_boxed(Target::addr(), connect_error());
 
     // Build a client using the connect that always errors.
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     client.http2_only(true);
     let profiles = profile::resolver();
     let profile_tx =
@@ -477,6 +493,7 @@ async fn grpc_response_class() {
 
     // Build a mock connector serves a gRPC server that returns errors.
     let connect = {
+        #[allow(deprecated)] // linkerd/linkerd2#8733
         let mut server = hyper::server::conn::Http::new();
         server.http2_only(true);
         support::connect().endpoint_fn_boxed(
@@ -486,7 +503,8 @@ async fn grpc_response_class() {
     };
 
     // Build a client using the connect that always errors.
-    let mut client = ClientBuilder::new();
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let mut client = hyper::client::conn::Builder::new();
     client.http2_only(true);
     let profiles = profile::resolver();
     let profile_tx =
@@ -550,6 +568,7 @@ async fn grpc_response_class() {
 }
 
 #[tracing::instrument]
+#[allow(deprecated)] // linkerd/linkerd2#8733
 fn hello_server(
     http: hyper::server::conn::Http,
 ) -> impl Fn(Remote<ServerAddr>) -> io::Result<io::BoxedIo> {
@@ -571,6 +590,7 @@ fn hello_server(
 }
 
 #[tracing::instrument]
+#[allow(deprecated)] // linkerd/linkerd2#8733
 fn grpc_status_server(
     http: hyper::server::conn::Http,
     status: tonic::Code,
@@ -617,6 +637,7 @@ fn connect_error() -> impl Fn(Remote<ServerAddr>) -> io::Result<io::BoxedIo> {
 }
 
 #[tracing::instrument]
+#[allow(deprecated)] // linkerd/linkerd2#8733
 fn connect_timeout(
     http: hyper::server::conn::Http,
 ) -> Box<dyn FnMut(Remote<ServerAddr>) -> ConnectFuture + Send> {

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -23,6 +23,7 @@ h2 = "0.3"
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14", features = [
+    "deprecated",
     "http1",
     "http2",
     "stream",

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -372,6 +372,7 @@ where
                 let _ = listening_tx.send(());
             }
 
+            #[allow(deprecated)] // linkerd/linkerd2#8733
             let mut http = hyper::server::conn::Http::new().with_executor(TracingExecutor);
             http.http2_only(true);
             loop {

--- a/linkerd/app/integration/src/server.rs
+++ b/linkerd/app/integration/src/server.rs
@@ -194,6 +194,7 @@ impl Server {
             async move {
                 tracing::info!("support server running");
                 let mut new_svc = NewSvc(Arc::new(self.routes));
+                #[allow(deprecated)] // linkerd/linkerd2#8733
                 let mut http = hyper::server::conn::Http::new().with_executor(TracingExecutor);
                 match self.version {
                     Run::Http1 => http.http1_only(true),

--- a/linkerd/app/integration/src/tap.rs
+++ b/linkerd/app/integration/src/tap.rs
@@ -209,6 +209,7 @@ where
         // just can't prove it.
         let req = futures::executor::block_on(async move {
             let (parts, body) = req.into_parts();
+            #[allow(deprecated)] // linkerd/linkerd2#8733
             let body = match hyper::body::to_bytes(body).await {
                 Ok(body) => body,
                 Err(_) => unreachable!("body should not fail"),

--- a/linkerd/app/integration/src/tests/discovery.rs
+++ b/linkerd/app/integration/src/tests/discovery.rs
@@ -481,16 +481,16 @@ mod http2 {
 
         let res = fut.await.expect("beta response");
         assert_eq!(res.status(), http::StatusCode::OK);
-        assert_eq!(
-            String::from_utf8(
-                hyper::body::to_bytes(res.into_body())
-                    .await
-                    .unwrap()
-                    .to_vec(),
-            )
-            .unwrap(),
-            "beta"
-        );
+
+        #[allow(deprecated)] // linkerd/linkerd2#8733
+        let body = String::from_utf8(
+            hyper::body::to_bytes(res.into_body())
+                .await
+                .unwrap()
+                .to_vec(),
+        )
+        .unwrap();
+        assert_eq!(body, "beta");
     }
 }
 

--- a/linkerd/app/integration/src/tests/profiles.rs
+++ b/linkerd/app/integration/src/tests/profiles.rs
@@ -129,6 +129,7 @@ impl TestBuilder {
             async move {
                 // Read the entire body before responding, so that the
                 // client doesn't fail when writing it out.
+                #[allow(deprecated)] // linkerd/linkerd2#8733
                 let _body = hyper::body::to_bytes(req.into_body()).await;
                 tracing::debug!(body = ?_body.as_ref().map(|body| body.len()), "recieved body");
                 Ok::<_, Error>(if fail {

--- a/linkerd/app/integration/src/tests/shutdown.rs
+++ b/linkerd/app/integration/src/tests/shutdown.rs
@@ -48,11 +48,14 @@ async fn h2_exercise_goaways_connections() {
 
     let bodies = resps
         .into_iter()
-        .map(|resp| {
-            hyper::body::aggregate(resp.into_body())
-                // Make sure the bodies weren't cut off
-                .map_ok(|buf| assert_eq!(buf.remaining(), RESPONSE_SIZE))
-        })
+        .map(
+            #[allow(deprecated)] // linkerd/linkerd2#8733
+            |resp| {
+                hyper::body::aggregate(resp.into_body())
+                    // Make sure the bodies weren't cut off
+                    .map_ok(|buf| assert_eq!(buf.remaining(), RESPONSE_SIZE))
+            },
+        )
         .collect::<Vec<_>>();
 
     // See that the proxy gives us all the bodies.

--- a/linkerd/app/integration/src/tests/tap.rs
+++ b/linkerd/app/integration/src/tests/tap.rs
@@ -253,10 +253,9 @@ async fn grpc_headers_end() {
         .unwrap();
     assert_eq!(res.status(), 200);
     assert_eq!(res.headers()["grpc-status"], "1");
-    assert_eq!(
-        hyper::body::to_bytes(res.into_body()).await.unwrap().len(),
-        0
-    );
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    let bytes = hyper::body::to_bytes(res.into_body()).await.unwrap().len();
+    assert_eq!(bytes, 0);
 
     let event = events.skip(2).next().await.expect("2nd").expect("stream");
     assert_eq!(event.response_end_eos_grpc(), 1);

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -1304,6 +1304,7 @@ async fn metrics_compression() {
                 );
             }
 
+            #[allow(deprecated)] // linkerd/linkerd2#8733
             let mut body = hyper::body::aggregate(resp.into_body())
                 .await
                 .expect("response body concat");

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1601,6 +1601,7 @@ async fn http2_request_without_authority() {
     let io = tokio::net::TcpStream::connect(&addr)
         .await
         .expect("connect error");
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     let (mut client, conn) = hyper::client::conn::Builder::new()
         .http2_only(true)
         .handshake(io)

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -52,7 +52,7 @@ linkerd-tonic-watch = { path = "../../tonic-watch" }
 [dev-dependencies]
 futures-util = "0.3"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["http1", "http2"] }
+hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-rustls = "0.24"
 tokio-test = "0.4"

--- a/linkerd/app/outbound/src/http/endpoint/tests.rs
+++ b/linkerd/app/outbound/src/http/endpoint/tests.rs
@@ -239,6 +239,7 @@ fn serve(version: ::http::Version) -> io::Result<io::BoxedIo> {
         future::ok::<_, Infallible>(rsp.body(hyper::Body::default()).unwrap())
     });
 
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     let mut http = hyper::server::conn::Http::new();
     match version {
         ::http::Version::HTTP_10 | ::http::Version::HTTP_11 => http.http1_only(true),

--- a/linkerd/app/outbound/src/http/logical/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/tests.rs
@@ -144,6 +144,7 @@ async fn assert_rsp<T: std::fmt::Debug>(
 {
     let rsp = rsp.await.expect("response must not fail");
     assert_eq!(rsp.status(), status, "expected status code to be {status}");
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     let body = hyper::body::to_bytes(rsp.into_body())
         .await
         .expect("body must not fail");

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -17,7 +17,7 @@ futures = { version = "0.3", default-features = false }
 h2 = "0.3"
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["http1", "http2"] }
+hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 linkerd-app-core = { path = "../core" }
 linkerd-http-route = { path = "../../http/route", optional = true }
 linkerd-identity = { path = "../../identity" }

--- a/linkerd/app/test/src/http_util.rs
+++ b/linkerd/app/test/src/http_util.rs
@@ -3,18 +3,18 @@ use crate::{
     io, ContextError,
 };
 use futures::FutureExt;
-use hyper::{
-    body::HttpBody,
-    client::conn::{Builder as ClientBuilder, SendRequest},
-    Body, Request, Response,
-};
+use hyper::{body::HttpBody, Body, Request, Response};
 use parking_lot::Mutex;
 use std::{future::Future, sync::Arc};
 use tokio::task::JoinHandle;
 use tower::{util::ServiceExt, Service};
 use tracing::Instrument;
 
+#[allow(deprecated)] // linkerd/linkerd2#8733
+use hyper::client::conn::{Builder as ClientBuilder, SendRequest};
+
 pub struct Server {
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     settings: hyper::server::conn::Http,
     f: HandleFuture,
 }
@@ -26,6 +26,7 @@ type BoxServer = svc::BoxTcp<io::DuplexStream>;
 impl Default for Server {
     fn default() -> Self {
         Self {
+            #[allow(deprecated)] // linkerd/linkerd2#8733
             settings: hyper::server::conn::Http::new(),
             f: Box::new(|_| {
                 Ok(Response::builder()
@@ -56,6 +57,7 @@ pub async fn run_proxy(mut server: BoxServer) -> (io::DuplexStream, JoinHandle<R
     (client_io, tokio::spawn(proxy))
 }
 
+#[allow(deprecated)] // linkerd/linkerd2#8733
 pub async fn connect_client(
     client_settings: &mut ClientBuilder,
     io: io::DuplexStream,
@@ -73,6 +75,7 @@ pub async fn connect_client(
     (client, tokio::spawn(client_bg))
 }
 
+#[allow(deprecated)] // linkerd/linkerd2#8733
 pub async fn connect_and_accept(
     client_settings: &mut ClientBuilder,
     server: BoxServer,
@@ -95,6 +98,7 @@ pub async fn connect_and_accept(
 }
 
 #[tracing::instrument(skip(client))]
+#[allow(deprecated)] // linkerd/linkerd2#8733
 pub async fn http_request(
     client: &mut SendRequest<Body>,
     request: Request<Body>,
@@ -117,6 +121,7 @@ where
     T: HttpBody,
     T::Error: Into<Error>,
 {
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     let body = hyper::body::to_bytes(body)
         .await
         .map_err(ContextError::ctx("HTTP response body stream failed"))?;

--- a/linkerd/http/executor/Cargo.toml
+++ b/linkerd/http/executor/Cargo.toml
@@ -10,6 +10,6 @@ HTTP runtime components for Linkerd.
 """
 
 [dependencies]
-hyper = "0.14"
+hyper = { version = "0.14", features = ["deprecated"] }
 tokio = { version = "1", features = ["rt"] }
 tracing = "0.1"

--- a/linkerd/http/metrics/Cargo.toml
+++ b/linkerd/http/metrics/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["http1", "http2"] }
+hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 parking_lot = "0.12"
 pin-project = "1"
 tokio = { version = "1", features = ["time"] }

--- a/linkerd/http/retry/Cargo.toml
+++ b/linkerd/http/retry/Cargo.toml
@@ -24,6 +24,6 @@ linkerd-metrics = { path = "../../metrics" }
 linkerd-stack = { path = "../../stack" }
 
 [dev-dependencies]
-hyper = "0.14"
+hyper = { version = "0.14", features = ["deprecated"] }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/linkerd/http/upgrade/Cargo.toml
+++ b/linkerd/http/upgrade/Cargo.toml
@@ -15,7 +15,7 @@ drain = "0.1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", default-features = false, features = ["client"] }
+hyper = { version = "0.14", default-features = false, features = ["deprecated", "client"] }
 pin-project = "1"
 tokio = { version = "1", default-features = false }
 tower = { version = "0.4", default-features = false }

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -15,7 +15,7 @@ test_util = []
 [dependencies]
 deflate = { version = "1", features = ["gzip"] }
 http = "0.2"
-hyper = { version = "0.14", features = ["http1", "http2"] }
+hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 linkerd-stack = { path = "../stack", optional = true }
 linkerd-system = { path = "../system", optional = true }
 parking_lot = "0.12"

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -22,6 +22,7 @@ http-body = "0.4"
 httparse = "1"
 hyper = { version = "0.14", features = [
     "client",
+    "deprecated",
     "http1",
     "http2",
     "server",

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -1,9 +1,6 @@
 use crate::TracingExecutor;
 use futures::prelude::*;
-use hyper::{
-    body::HttpBody,
-    client::conn::{self, SendRequest},
-};
+use hyper::{body::HttpBody, client::conn};
 use linkerd_error::{Error, Result};
 use linkerd_stack::{MakeConnection, Service};
 use std::{
@@ -26,7 +23,8 @@ pub struct Connect<C, B> {
 
 #[derive(Debug)]
 pub struct Connection<B> {
-    tx: SendRequest<B>,
+    #[allow(deprecated)] // linkerd/linkerd2#8733
+    tx: hyper::client::conn::SendRequest<B>,
 }
 
 // === impl Connect ===
@@ -89,6 +87,7 @@ where
         Box::pin(
             async move {
                 let (io, _meta) = connect.err_into::<Error>().await?;
+                #[allow(deprecated)] // linkerd/linkerd2#8733
                 let mut builder = conn::Builder::new();
                 builder.executor(TracingExecutor).http2_only(true);
                 match flow_control {

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -34,6 +34,7 @@ pub struct NewServeHttp<X, N> {
 #[derive(Clone, Debug)]
 pub struct ServeHttp<N> {
     version: Version,
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     server: hyper::server::conn::Http<TracingExecutor>,
     inner: N,
     drain: drain::Watch,
@@ -75,6 +76,7 @@ where
             max_pending_accept_reset_streams,
         } = h2;
 
+        #[allow(deprecated)] // linkerd/linkerd2#8733
         let mut srv = hyper::server::conn::Http::new().with_executor(TracingExecutor);
         match flow_control {
             None => {}

--- a/linkerd/proxy/http/src/server/tests.rs
+++ b/linkerd/proxy/http/src/server/tests.rs
@@ -26,6 +26,7 @@ async fn h2_connection_window_exhaustion() {
         h2::ServerParams::default(),
         // An HTTP/2 client with constrained connection and stream windows to
         // force window exhaustion.
+        #[allow(deprecated)] // linkerd/linkerd2#8733
         hyper::client::conn::Builder::new()
             .http2_initial_connection_window_size(CLIENT_CONN_WINDOW)
             .http2_initial_stream_window_size(CLIENT_STREAM_WINDOW),
@@ -99,6 +100,7 @@ async fn h2_stream_window_exhaustion() {
         // A basic HTTP/2 server configuration with no overrides.
         h2::ServerParams::default(),
         // An HTTP/2 client with stream windows to force window exhaustion.
+        #[allow(deprecated)] // linkerd/linkerd2#8733
         hyper::client::conn::Builder::new().http2_initial_stream_window_size(CLIENT_STREAM_WINDOW),
     )
     .await;
@@ -142,6 +144,7 @@ async fn h2_stream_window_exhaustion() {
 const LOG_LEVEL: &str = "h2::proto=trace,hyper=trace,linkerd=trace,info";
 
 struct TestServer {
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     client: hyper::client::conn::SendRequest<BoxBody>,
     server: Handle,
 }
@@ -181,6 +184,7 @@ async fn timeout<F: Future>(inner: F) -> Result<F::Output, time::error::Elapsed>
 
 impl TestServer {
     #[tracing::instrument(skip_all)]
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     async fn connect(params: Params, client: &mut hyper::client::conn::Builder) -> Self {
         // Build the HTTP server with a mocked inner service so that we can handle
         // requests.
@@ -201,6 +205,7 @@ impl TestServer {
         Self { client, server }
     }
 
+    #[allow(deprecated)] // linkerd/linkerd2#8733
     async fn connect_h2(h2: h2::ServerParams, client: &mut hyper::client::conn::Builder) -> Self {
         Self::connect(
             // A basic HTTP/2 server configuration with no overrides.

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 http = "0.2"
-hyper = { version = "0.14", features = ["http1", "http2"] }
+hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.10"
 linkerd2-proxy-api = { workspace = true, features = ["tap"] }

--- a/linkerd/proxy/tap/src/accept.rs
+++ b/linkerd/proxy/tap/src/accept.rs
@@ -45,6 +45,7 @@ impl AcceptPermittedClients {
     {
         let svc = TapServer::new(tap);
         Box::pin(async move {
+            #[allow(deprecated)] // linkerd/linkerd2#8733
             hyper::server::conn::Http::new()
                 .with_executor(TracingExecutor)
                 .http2_only(true)


### PR DESCRIPTION
this is a prepatory chore, laying more ground to facilitate upgrading our hyper dependency to the 1.0 major release. this commit adds the `deprecated` cargo feature to each of the hyper dependencies in the cargo workspace.

to prevent this from introducing a large number of compiler warnings to the build, the `#[allow(deprecated)]` attribute is added to relevant expressions.

these uses of deprecated interfaces will be updated in subsequent commits. broadly, these fall into a few common cases:

* `hyper::client::conn::SendRequest` now has protocol specific `h1` and
  `h2` variants.

* `hyper::server::conn::Builder` now has protocol specific `h1` and
  `h2` variants.

* `hyper::server::conn::Http` is deprecated.

* functions like `hyper::body::aggregate(..)` and
  `hyper::body::to_bytes(..)` are deprecated.

see https://github.com/linkerd/linkerd2/issues/8733 for more information on the hyper 1.0 upgrade process.
