### PR TITLE
chore(proxy/http): address `hyper::client::conn::SendRequest` deprecation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,8 +943,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "hyper"
 version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+source = "git+https://github.com/cratelyn/hyper?branch=kate/send-request-legacy-glue#de82efbe8a6a61dbda3cb53b4cf91a60c44724da"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,6 @@ lto = true
 [workspace.dependencies]
 linkerd2-proxy-api = "0.15.0"
 # linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "main" }
+
+[patch.crates-io]
+hyper = { git = "https://github.com/cratelyn/hyper", branch = "kate/send-request-legacy-glue" }

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -21,6 +21,7 @@ http = "0.2"
 http-body = "0.4"
 httparse = "1"
 hyper = { version = "0.14", features = [
+    "backports",
     "client",
     "deprecated",
     "http1",


### PR DESCRIPTION
this commit updates code in `linkerd-proxy-http`'s HTTP/2 client code, and the `linkerd-app-test` crate's `TestServer`, to use the new `hyper::client::conn::http2::SendRequest` backported from the 1.x major release.

see <https://github.com/hyperium/hyper/issues/2960> for more information.

this commit refrains from updating the broader client connection system, and addresses the breaking changes to `SendRequest` made in the 1.0 major release, namely:

* send request is no longer a tower service:
  * <https://docs.rs/hyper/0.14.31/hyper/client/conn/struct.SendRequest.html#impl-Service%3CRequest%3CB%3E%3E-for-SendRequest%3CB%3E>
  * <https://docs.rs/hyper/1.5.1/hyper/client/conn/http2/struct.SendRequest.html#trait-implementations>

* `send_request()` now returns an anonymous `impl Future` and not a named `ResponseFuture`, as in `0.14`.
  * <https://docs.rs/hyper/0.14.31/hyper/client/conn/struct.ResponseFuture.html>
  * <https://docs.rs/hyper/1.5.1/hyper/client/conn/http2/struct.SendRequest.html#method.send_request>

NB: this change depends on <https://github.com/hyperium/hyper/pull/3798>.