### PR TITLE
ci: increase linkerd-install readiness timeout

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -127,6 +127,8 @@ jobs:
     if: needs.meta.outputs.cargo_changed == 'true' || needs.meta.outputs.rust_changed == 'true'
     timeout-minutes: 20
     runs-on: ubuntu-latest
+    env:
+      WAIT_TIMOUT: 2m
     steps:
       - uses: linkerd/dev/actions/setup-tools@v43
       - name: scurl https://run.linkerd.io/install-edge | sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -128,7 +128,7 @@ jobs:
     timeout-minutes: 20
     runs-on: ubuntu-latest
     env:
-      WAIT_TIMOUT: 2m
+      WAIT_TIMEOUT: 2m
     steps:
       - uses: linkerd/dev/actions/setup-tools@v43
       - name: scurl https://run.linkerd.io/install-edge | sh

--- a/justfile
+++ b/justfile
@@ -57,6 +57,8 @@ _features := if features == "all" {
         "--no-default-features --features=" + features
     } else { "" }
 
+wait-timeout := env_var_or_default("WAIT_TIMEOUT", "1m")
+
 export CXX := 'clang++-14'
 
 #
@@ -272,7 +274,7 @@ _linkerd-crds-install: _k3d-ready
         | {{ _kubectl }} apply -f -
     {{ _kubectl }} wait crd --for condition=established \
         --selector='linkerd.io/control-plane-ns' \
-        --timeout=1m
+        --timeout={{ wait-timeout }}
 
 # Install linkerd on the test cluster using test images.
 linkerd-install *args='': _tag-set k3d-load-linkerd _linkerd-crds-install && _linkerd-ready
@@ -313,7 +315,7 @@ linkerd-check-control-plane-proxy:
 _linkerd-ready:
     {{ _kubectl }} wait pod --for=condition=ready \
         --namespace=linkerd --selector='linkerd.io/control-plane-component' \
-        --timeout=1m
+        --timeout={{ wait-timeout }}
 
 #
 # Dev Container


### PR DESCRIPTION
CI runs frequently timeout waiting for pod readiness. There is a hardcoded 1m timeout.

This change makes this timeout configurable, specifying a 2m timeout in the CI configuration.