### PR TITLE
chore(proxy/http): address `hyper::client::conn::Builder` deprecations

### DIFF
--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -21,6 +21,7 @@ http = "0.2"
 http-body = "0.4"
 httparse = "1"
 hyper = { version = "0.14", features = [
+    "backports",
     "client",
     "deprecated",
     "http1",


### PR DESCRIPTION
this branch contains a sequence of commits that focus on addressing deprecation warnings related to `hyper::client::conn::Builder`. this branch enables the `backports` feature, and then replaces some of these builders with the backported, http/2 specific, `hyper::client::conn::http2::Builder` type.

relates to https://github.com/linkerd/linkerd2/issues/8733.