### PR TITLE
refactor(app/test): address hyper deprecations in test helpers

### DIFF
--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -262,9 +262,7 @@ async fn http1_connect_timeout_meshed_response_error_header() {
 
     // Build a mock connect that sleeps longer than the default inbound
     // connect timeout.
-    #[allow(deprecated)] // linkerd/linkerd2#8733
-    let server = hyper::server::conn::Http::new();
-    let connect = support::connect().endpoint(Target::addr(), connect_timeout(server));
+    let connect = support::connect().endpoint(Target::addr(), connect_timeout());
 
     // Build a client using the connect that always sleeps so that responses
     // are GATEWAY_TIMEOUT.
@@ -309,9 +307,7 @@ async fn http1_connect_timeout_unmeshed_response_error_header() {
 
     // Build a mock connect that sleeps longer than the default inbound
     // connect timeout.
-    #[allow(deprecated)] // linkerd/linkerd2#8733
-    let server = hyper::server::conn::Http::new();
-    let connect = support::connect().endpoint(Target::addr(), connect_timeout(server));
+    let connect = support::connect().endpoint(Target::addr(), connect_timeout());
 
     // Build a client using the connect that always sleeps so that responses
     // are GATEWAY_TIMEOUT.
@@ -675,10 +671,7 @@ fn connect_error() -> impl Fn(Remote<ServerAddr>) -> io::Result<io::BoxedIo> {
 }
 
 #[tracing::instrument]
-#[allow(deprecated)] // linkerd/linkerd2#8733
-fn connect_timeout(
-    http: hyper::server::conn::Http,
-) -> Box<dyn FnMut(Remote<ServerAddr>) -> ConnectFuture + Send> {
+fn connect_timeout() -> Box<dyn FnMut(Remote<ServerAddr>) -> ConnectFuture + Send> {
     Box::new(move |endpoint| {
         let span = tracing::info_span!("connect_timeout", ?endpoint);
         Box::pin(

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -15,7 +15,7 @@ use linkerd_app_core::{
     svc::{self, http::TracingExecutor, NewService, Param},
     tls,
     transport::{ClientAddr, OrigDstAddr, Remote, ServerAddr},
-    NameAddr, ProxyRuntime,
+    Error, NameAddr, ProxyRuntime,
 };
 use linkerd_app_test::connect::ConnectFuture;
 use linkerd_tracing::test::trace_init;
@@ -80,7 +80,12 @@ async fn unmeshed_http1_hello_world() {
     let body = http_util::body_to_string(rsp.into_body()).await.unwrap();
     assert_eq!(body, "Hello world!");
 
-    bg.await.expect("background task failed");
+    // Wait for all of the background tasks to complete, panicking if any returned an error.
+    bg.join_all()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<()>, Error>>()
+        .expect("background task failed");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -122,7 +127,12 @@ async fn downgrade_origin_form() {
     let body = http_util::body_to_string(rsp.into_body()).await.unwrap();
     assert_eq!(body, "Hello world!");
 
-    bg.await.expect("background task failed");
+    // Wait for all of the background tasks to complete, panicking if any returned an error.
+    bg.join_all()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<()>, Error>>()
+        .expect("background task failed");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -163,7 +173,12 @@ async fn downgrade_absolute_form() {
     let body = http_util::body_to_string(rsp.into_body()).await.unwrap();
     assert_eq!(body, "Hello world!");
 
-    bg.await.expect("background task failed");
+    // Wait for all of the background tasks to complete, panicking if any returned an error.
+    bg.join_all()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<()>, Error>>()
+        .expect("background task failed");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -205,7 +220,12 @@ async fn http1_bad_gateway_meshed_response_error_header() {
     // logical error context is added.
     check_error_header(rsp.headers(), "server is not listening");
 
-    bg.await.expect("background task failed");
+    // Wait for all of the background tasks to complete, panicking if any returned an error.
+    bg.join_all()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<()>, Error>>()
+        .expect("background task failed");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -246,7 +266,12 @@ async fn http1_bad_gateway_unmeshed_response() {
         "response must not contain L5D_PROXY_ERROR header"
     );
 
-    bg.await.expect("background task failed");
+    // Wait for all of the background tasks to complete, panicking if any returned an error.
+    bg.join_all()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<()>, Error>>()
+        .expect("background task failed");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -291,7 +316,12 @@ async fn http1_connect_timeout_meshed_response_error_header() {
     // logical error context is added.
     check_error_header(rsp.headers(), "connect timed out after 1s");
 
-    bg.await.expect("background task failed");
+    // Wait for all of the background tasks to complete, panicking if any returned an error.
+    bg.join_all()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<()>, Error>>()
+        .expect("background task failed");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -334,7 +364,12 @@ async fn http1_connect_timeout_unmeshed_response_error_header() {
         "response must not contain L5D_PROXY_ERROR header"
     );
 
-    bg.await.expect("background task failed");
+    // Wait for all of the background tasks to complete, panicking if any returned an error.
+    bg.join_all()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<()>, Error>>()
+        .expect("background task failed");
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -376,7 +411,7 @@ async fn h2_response_meshed_error_header() {
     // Drop the client and discard the result of awaiting the proxy background
     // task. The result is discarded because it hits an error that is related
     // to the mock implementation and has no significance to the test.
-    let _ = bg.await;
+    let _ = bg.join_all().await;
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -420,7 +455,7 @@ async fn h2_response_unmeshed_error_header() {
     // Drop the client and discard the result of awaiting the proxy background
     // task. The result is discarded because it hits an error that is related
     // to the mock implementation and has no significance to the test.
-    let _ = bg.await;
+    let _ = bg.join_all().await;
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -463,7 +498,7 @@ async fn grpc_meshed_response_error_header() {
     // Drop the client and discard the result of awaiting the proxy background
     // task. The result is discarded because it hits an error that is related
     // to the mock implementation and has no significance to the test.
-    let _ = bg.await;
+    let _ = bg.join_all().await;
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -508,7 +543,7 @@ async fn grpc_unmeshed_response_error_header() {
     // Drop the client and discard the result of awaiting the proxy background
     // task. The result is discarded because it hits an error that is related
     // to the mock implementation and has no significance to the test.
-    let _ = bg.await;
+    let _ = bg.join_all().await;
 }
 
 #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
this commit changes the `connect_and_accept(..)` helper function used in
the proxy's unit tests, altering its logic such that it now runs
background tasks inside of a `JoinSet`.

then, subsequent commits hoist code out of `run_proxy()` and `connect_client()`, and consolidate our `async move {}` blocks. this both simplifies the control flow of this test infrastructure, but also addresses some more hyper deprecations.

for more information about our progressing upgrade to hyper 1.0, see https://github.com/linkerd/linkerd2/issues/8733.

NB: this branch is based upon #3432.