### PR TITLE
chore(cargo): add `config.toml` file

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = "--cfg tokio_unstable"


### PR DESCRIPTION
we use the `kubert` crate to export a collection of metrics measuring the behavior of our asynchronous tokio runtime.

in order for this crate to compile, one must set a compile-time flag. this can be done either by setting the `RUSTFLAGS` environment variable, or via a toml file in `.cargo/config.toml`.

helpful links:

- <https://github.com/olix0r/kubert?tab=readme-ov-file#kubert-prometheus-tokio>
- <https://docs.rs/tokio-metrics/latest/tokio_metrics/>
- <https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags>

this commit introduces a file providing this `rustflags` flag.

note that, per the cargo reference (linked above), the environment variable takes precedence over the value provided in the `config.toml` file.

so, providing this flag here will allow a conventional `cargo build` to build the project successfully without setting any environment variables, without interfering with users' ability to provide additional compiler flags when needed.