### PR TITLE
chore(hyper): address miscellaneous deprecations

### DIFF
--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -651,7 +651,6 @@ fn hello_server(
 }
 
 #[tracing::instrument]
-#[allow(deprecated)] // linkerd/linkerd2#8733
 fn grpc_status_server(
     server: hyper::server::conn::http2::Builder<TracingExecutor>,
     status: tonic::Code,

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -23,6 +23,7 @@ h2 = "0.3"
 http = "0.2"
 http-body = "0.4"
 hyper = { version = "0.14", features = [
+    "backports",
     "deprecated",
     "http1",
     "http2",

--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -372,9 +372,7 @@ where
                 let _ = listening_tx.send(());
             }
 
-            #[allow(deprecated)] // linkerd/linkerd2#8733
-            let mut http = hyper::server::conn::Http::new().with_executor(TracingExecutor);
-            http.http2_only(true);
+            let http = hyper::server::conn::http2::Builder::new(TracingExecutor);
             loop {
                 let (sock, addr) = listener.accept().await?;
                 let span = tracing::debug_span!("conn", %addr).or_current();

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use linkerd_app_core::svc::http::TracingExecutor;
 use std::error::Error as _;
 use tokio::time::timeout;
 
@@ -1601,9 +1602,7 @@ async fn http2_request_without_authority() {
     let io = tokio::net::TcpStream::connect(&addr)
         .await
         .expect("connect error");
-    #[allow(deprecated)] // linkerd/linkerd2#8733
-    let (mut client, conn) = hyper::client::conn::Builder::new()
-        .http2_only(true)
+    let (mut client, conn) = hyper::client::conn::http2::Builder::new(TracingExecutor)
         .handshake(io)
         .await
         .expect("handshake error");

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -54,7 +54,7 @@ linkerd-tonic-watch = { path = "../../tonic-watch" }
 [dev-dependencies]
 futures-util = "0.3"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
+hyper = { version = "0.14", features = ["backports", "deprecated", "http1", "http2"] }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-rustls = "0.24"
 tokio-test = "0.4"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 http = "0.2"
-hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
+hyper = { version = "0.14", features = ["backports", "deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.10"
 linkerd2-proxy-api = { workspace = true, features = ["tap"] }

--- a/linkerd/proxy/tap/src/accept.rs
+++ b/linkerd/proxy/tap/src/accept.rs
@@ -45,10 +45,7 @@ impl AcceptPermittedClients {
     {
         let svc = TapServer::new(tap);
         Box::pin(async move {
-            #[allow(deprecated)] // linkerd/linkerd2#8733
-            hyper::server::conn::Http::new()
-                .with_executor(TracingExecutor)
-                .http2_only(true)
+            hyper::server::conn::http2::Builder::new(TracingExecutor)
                 .serve_connection(io, svc)
                 .await
                 .map_err(Into::into)


### PR DESCRIPTION
this branch addresses a small assortment of calls to deprecated hyper interfaces.

see <https://github.com/linkerd/linkerd2/issues/8733>.