### PR TITLE
chore(gitignore): ignore `.cargo` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.cargo
+**/.cargo
 target
 **/target
 **/corpus


### PR DESCRIPTION
this commit supercedes #3443.

we use the kubert crate to export a collection of metrics measuring the behavior of our asynchronous tokio runtime.

in order for this crate to compile, one must set a compile-time flag. this can be done either by setting the RUSTFLAGS environment variable, or via a toml file in .cargo/config.toml.

helpful links:

- <https://github.com/olix0r/kubert?tab=readme-ov-file#kubert-prometheus-tokio>
- <https://docs.rs/tokio-metrics/latest/tokio_metrics/>
- <https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags>

this commit adds `.cargo` to the repository's gitignore, so that people may freely modify cargo configuration as needed when building the project from source.