### PR TITLE
chore(fuzz): address hyper deprecations in fuzz tests

### DIFF
--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -49,6 +49,9 @@ hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
 linkerd-app-test = { path = "../test" }
 arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
+linkerd-meshtls-rustls = { path = "../../meshtls/rustls", features = [
+    "test-util",
+] }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }

--- a/linkerd/app/inbound/fuzz/Cargo.toml
+++ b/linkerd/app/inbound/fuzz/Cargo.toml
@@ -1,4 +1,3 @@
-
 [package]
 name = "linkerd-app-inbound-fuzz"
 version = "0.0.0"

--- a/linkerd/app/inbound/src/http.rs
+++ b/linkerd/app/inbound/src/http.rs
@@ -227,6 +227,9 @@ pub mod fuzz {
                         kind: "server".into(),
                         name: "testsrv".into(),
                     }),
+                    local_rate_limit: Arc::new(
+                        linkerd_proxy_server_policy::LocalRateLimit::default(),
+                    ),
                 },
             );
             policy

--- a/linkerd/app/inbound/src/http.rs
+++ b/linkerd/app/inbound/src/http.rs
@@ -18,7 +18,7 @@ pub mod fuzz {
         test_util::{support::connect::Connect, *},
         Config, Inbound,
     };
-    use hyper::{client::conn::Builder as ClientBuilder, Body, Request, Response};
+    use hyper::{Body, Request, Response};
     use libfuzzer_sys::arbitrary::Arbitrary;
     use linkerd_app_core::{
         identity, io,
@@ -41,9 +41,8 @@ pub mod fuzz {
     }
 
     pub async fn fuzz_entry_raw(requests: Vec<HttpRequestSpec>) {
-        let mut server = hyper::server::conn::Http::new();
-        server.http1_only(true);
-        let mut client = ClientBuilder::new();
+        let server = hyper::server::conn::http1::Builder::new();
+        let mut client = hyper::client::conn::http1::Builder::new();
         let connect =
             support::connect().endpoint_fn_boxed(Target::addr(), hello_fuzz_server(server));
         let profiles = profile::resolver();
@@ -55,7 +54,7 @@ pub mod fuzz {
         let cfg = default_config();
         let (rt, _shutdown) = runtime();
         let server = build_fuzz_server(cfg, rt, profiles, connect).new_service(Target::HTTP1);
-        let (mut client, bg) = http_util::connect_and_accept(&mut client, server).await;
+        let (mut client, bg) = http_util::connect_and_accept_http1(&mut client, server).await;
 
         // Now send all of the requests
         for inp in requests.iter() {
@@ -74,14 +73,7 @@ pub mod fuzz {
                             .header(header_name, header_value)
                             .body(Body::default())
                         {
-                            let rsp = client
-                                .ready()
-                                .await
-                                .expect("HTTP client poll_ready failed")
-                                .call(req)
-                                .await
-                                .expect("HTTP client request failed");
-                            tracing::info!(?rsp);
+                            let rsp = client.send_request(req).await;
                             tracing::info!(?rsp);
                             if let Ok(rsp) = rsp {
                                 let body = http_util::body_to_string(rsp.into_body()).await;
@@ -93,18 +85,18 @@ pub mod fuzz {
             }
         }
 
-        drop(client);
         // It's okay if the background task returns an error, as this would
         // indicate that the proxy closed the connection --- which it will do on
         // invalid inputs. We want to ensure that the proxy doesn't crash in the
         // face of these inputs, and the background task will panic in this
         // case.
-        let res = bg.await;
+        drop(client);
+        let res = bg.join_all().await;
         tracing::info!(?res, "background tasks completed")
     }
 
     fn hello_fuzz_server(
-        http: hyper::server::conn::Http,
+        http: hyper::server::conn::http1::Builder,
     ) -> impl Fn(Remote<ServerAddr>) -> io::Result<io::BoxedIo> {
         move |_endpoint| {
             let (client_io, server_io) = support::io::duplex(4096);

--- a/linkerd/app/test/src/http_util.rs
+++ b/linkerd/app/test/src/http_util.rs
@@ -13,52 +13,6 @@ type BoxServer = svc::BoxTcp<io::DuplexStream>;
 ///
 /// Returns a tuple containing (1) a [`SendRequest`] that can be used to transmit a request and
 /// await a response, and (2) a [`JoinSet<T>`] running background tasks.
-#[allow(deprecated)] // linkerd/linkerd2#8733
-pub async fn connect_and_accept(
-    client_settings: &mut hyper::client::conn::Builder,
-    server: BoxServer,
-) -> (
-    hyper::client::conn::SendRequest<hyper::Body>,
-    JoinSet<Result<(), Error>>,
-) {
-    tracing::info!(settings = ?client_settings, "connecting client with");
-    let (client_io, server_io) = io::duplex(4096);
-
-    let (client, conn) = client_settings
-        .handshake(client_io)
-        .await
-        .expect("Client must connect");
-
-    let mut bg = tokio::task::JoinSet::new();
-    bg.spawn(
-        async move {
-            server
-                .oneshot(server_io)
-                .await
-                .map_err(ContextError::ctx("proxy background task failed"))?;
-            tracing::info!("proxy serve task complete");
-            Ok(())
-        }
-        .instrument(tracing::info_span!("proxy")),
-    );
-    bg.spawn(
-        async move {
-            conn.await
-                .map_err(ContextError::ctx("client background task failed"))
-                .map_err(Error::from)?;
-            tracing::info!("client background complete");
-            Ok(())
-        }
-        .instrument(tracing::info_span!("client_bg")),
-    );
-
-    (client, bg)
-}
-
-/// Connects a client and server, running a proxy between them.
-///
-/// Returns a tuple containing (1) a [`SendRequest`] that can be used to transmit a request and
-/// await a response, and (2) a [`JoinSet<T>`] running background tasks.
 pub async fn connect_and_accept_http1(
     client_settings: &mut hyper::client::conn::http1::Builder,
     server: BoxServer,


### PR DESCRIPTION
**nb:** this branch is based upon #3454.

see https://github.com/linkerd/linkerd2/issues/8733 for more information on upgrading to hyper 1.0.

### refactor(app/test): remove unused `http_util::connect_and_accept(..)`

this removes `connect_and_accept(..)`. this will break fuzzing builds,
but it is not used elsewhere.

### chore(fuzz): address hyper deprecation in inbound fuzz tests

this commit addresses hyper deprecations in the inbound proxy's fuzz tests.

note that this commit does not compile. it was observed that some breakage had
accrued, because ci does not seem to be properly checking the fuzz tests.

### chore(fuzz): address preëxisting fuzz breakage

this commit addresses breakage found in the fuzz tests, tied to
other previous work.

after these changes, one can observe that the fuzz tests build and run
once more by running the following:

```sh
cargo +nightly fuzz run --fuzz-dir=linkerd/app/inbound/fuzz/ fuzz_target_1
```