### PR TITLE
chore(hyper): define hyper as a workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ debug = 1
 lto = true
 
 [workspace.dependencies]
+hyper = { version = "0.14", default-features = false }
 linkerd2-proxy-api = "0.15.0"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging"] }
 # linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "main" }

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 futures = { version = "0.3", default-features = false }
 http = "0.2"
-hyper = { version = "0.14", features = ["deprecated"] }
+hyper = { workspace = true, features = ["deprecated"] }
 pin-project = "1"
 tower = { version = "0.4", default-features = false, features = ["load"] }
 tokio = { version = "1", features = ["macros"] }

--- a/linkerd/app/admin/Cargo.toml
+++ b/linkerd/app/admin/Cargo.toml
@@ -18,7 +18,7 @@ log-streaming = ["linkerd-tracing/stream"]
 deflate = { version = "1", optional = true, features = ["gzip"] }
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
+hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 pprof = { version = "0.14", optional = true, features = ["prost-codec"] }
 serde = "1"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -17,7 +17,7 @@ bytes = "1"
 drain = { version = "0.1", features = ["retain"] }
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
+hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.10"
 prometheus-client = "0.22"

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -45,13 +45,13 @@ path = "../../proxy/server-policy"
 features = ["proto"]
 
 [target.'cfg(fuzzing)'.dependencies]
-hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
+hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 linkerd-app-test = { path = "../test" }
 arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 
 [dev-dependencies]
-hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
+hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 linkerd-app-test = { path = "../test" }
 linkerd-http-metrics = { path = "../../http/metrics", features = ["test-util"] }
 linkerd-idle-cache = { path = "../../idle-cache", features = ["test-util"] }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -22,7 +22,7 @@ futures = { version = "0.3", default-features = false, features = ["executor"] }
 h2 = "0.3"
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", features = [
+hyper = { workspace = true, features = [
     "backports",
     "deprecated",
     "http1",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -54,7 +54,7 @@ linkerd-tonic-watch = { path = "../../tonic-watch" }
 [dev-dependencies]
 futures-util = "0.3"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["backports", "deprecated", "http1", "http2"] }
+hyper = { workspace = true, features = ["backports", "deprecated", "http1", "http2"] }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-rustls = { workspace = true }
 tokio-test = "0.4"

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -17,7 +17,7 @@ futures = { version = "0.3", default-features = false }
 h2 = "0.3"
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
+hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 linkerd-app-core = { path = "../core" }
 linkerd-http-route = { path = "../../http/route", optional = true }
 linkerd-identity = { path = "../../identity" }

--- a/linkerd/http/executor/Cargo.toml
+++ b/linkerd/http/executor/Cargo.toml
@@ -10,6 +10,6 @@ HTTP runtime components for Linkerd.
 """
 
 [dependencies]
-hyper = { version = "0.14", features = ["deprecated"] }
+hyper = { workspace = true, features = ["deprecated"] }
 tokio = { version = "1", features = ["rt"] }
 tracing = "0.1"

--- a/linkerd/http/metrics/Cargo.toml
+++ b/linkerd/http/metrics/Cargo.toml
@@ -14,7 +14,7 @@ bytes = "1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
+hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 parking_lot = "0.12"
 pin-project = "1"
 tokio = { version = "1", features = ["time"] }

--- a/linkerd/http/retry/Cargo.toml
+++ b/linkerd/http/retry/Cargo.toml
@@ -24,6 +24,6 @@ linkerd-metrics = { path = "../../metrics" }
 linkerd-stack = { path = "../../stack" }
 
 [dev-dependencies]
-hyper = { version = "0.14", features = ["deprecated"] }
+hyper = { workspace = true, features = ["deprecated"] }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/linkerd/http/upgrade/Cargo.toml
+++ b/linkerd/http/upgrade/Cargo.toml
@@ -15,7 +15,7 @@ drain = "0.1"
 futures = { version = "0.3", default-features = false }
 http = "0.2"
 http-body = "0.4"
-hyper = { version = "0.14", default-features = false, features = ["deprecated", "client"] }
+hyper = { workspace = true, default-features = false, features = ["deprecated", "client"] }
 pin-project = "1"
 tokio = { version = "1", default-features = false }
 tower = { version = "0.4", default-features = false }

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -15,7 +15,7 @@ test_util = []
 [dependencies]
 deflate = { version = "1", features = ["gzip"] }
 http = "0.2"
-hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
+hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 linkerd-stack = { path = "../stack", optional = true }
 linkerd-system = { path = "../system", optional = true }
 parking_lot = "0.12"

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -20,7 +20,7 @@ h2 = "0.3"
 http = "0.2"
 http-body = "0.4"
 httparse = "1"
-hyper = { version = "0.14", features = [
+hyper = { workspace = true, features = [
     "backports",
     "client",
     "deprecated",

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 http = "0.2"
-hyper = { version = "0.14", features = ["backports", "deprecated", "http1", "http2"] }
+hyper = { workspace = true, features = ["backports", "deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.10"
 linkerd2-proxy-api = { workspace = true, features = ["tap"] }


### PR DESCRIPTION
this commit alters various crates' manifests, pointing to a common workspace-level hyper dependency.

note that the lockfile is not altered; this commit does *not* affect the version of hyper
used, or have any other affect on the dependency graph. this will make future maintenance
of our hyper dependency marginally easier.

see linkerd/linkerd2#8733 for more information on upgrading to hyper 1.0.