### PR TITLE
chore(hyper): upgrade hyper to include hyperium/hyper#3796

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -943,8 +943,7 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 [[package]]
 name = "hyper"
 version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+source = "git+https://github.com/hyperium/hyper.git?rev=a24f0c0a#a24f0c0af8e1f4c6b7cc3a47c83eb6e4af88aca6"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,3 +101,11 @@ hyper = { version = "0.14", default-features = false }
 linkerd2-proxy-api = "0.15.0"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging"] }
 # linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "main" }
+
+# NB: hyperium/hyper#3796 backports the server connection builder's
+# `max_pending_accept_reset_streams()` method. once released, we can depend on
+# 0.14.32 or later, but until then will point our hyper dependency to the
+# commit in the 0.14 branch.
+[patch.'crates-io'.hyper]
+git = "https://github.com/hyperium/hyper.git"
+rev = "a24f0c0a"


### PR DESCRIPTION
this commit bumps the version of the workspace's hyper dependency to include hyperium/hyper#3796, which backports the server connection builder's `max_pending_accept_reset_streams()` method.

see linkerd/linkerd2#8733 for more information on upgrading to hyper 1.0.

this commit is based upon #3456.

to show the hyper commit in the context of the git log:

```sh
; basename $(pwd)
hyper

; git remote get-url upstream
git@github.com:hyperium/hyper.git

; git log --oneline --decorate 0.14.x -5
a24f0c0a (HEAD -> 0.14.x, upstream/0.14.x) feat(server): backport `max_pending_accept_reset_streams()` to builder (#3796)
96550840 chore(ci): pin hashbrown for MSRV job (#3797)
7829148b (tag: v0.14.31) v0.14.31
97b595e5 perf(http1): improve parsing of sequentially partial messages
739d5e63 chore(ci): pin some deps for MSRV job
```