### PR TITLE
chore(deny.toml): remove stale `idna` directive

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -59,8 +59,6 @@ skip = [
     # https://github.com/hawkw/matchers/pull/4
     { name = "regex-automata", version = "0.1" },
     { name = "regex-syntax", version = "0.6" },
-    # `trust-dns-proto`, depends on `idna` v0.4.0 while `url` depends on v0.5.0
-    { name = "idna" },
     # Some dependencies still use indexmap v1.
     { name = "indexmap", version = "1" },
     { name = "hashbrown", version = "0.12" },


### PR DESCRIPTION
if one runs `cargo deny check` on the current state of main, or checks deny logs in ci, one observes this waning:

```sh
$ cargo deny check
warning[unnecessary-skip]: skip 'idna' applied to a crate with only one version
   ┌─ /path/to/linkerd/linkerd2-proxy/deny.toml:63:15
   │
63 │     { name = "idna" },
   │               ━━━━ unnecessary skip configuration

advisories ok, bans ok, licenses ok, sources ok
```

today, our dependency graph only contains one version of `idna`, which has since release a 1.0 version:

```sh
$ cargo tree -i -p idna
idna v1.0.3
├── hickory-proto v0.24.2
└── url v2.5.4
```

this commit updates the `deny.toml` file, removing this directive to permit duplicate versions, now that this is no longer the case.