### PR TITLE
chore(ci): remove duplicate `connect_and_accept_http1(..)` function

### DIFF
--- a/linkerd/app/test/src/http_util.rs
+++ b/linkerd/app/test/src/http_util.rs
@@ -58,51 +58,6 @@ pub async fn connect_and_accept_http1(
 ///
 /// Returns a tuple containing (1) a [`SendRequest`] that can be used to transmit a request and
 /// await a response, and (2) a [`JoinSet<T>`] running background tasks.
-pub async fn connect_and_accept_http1(
-    client_settings: &mut hyper::client::conn::http1::Builder,
-    server: BoxServer,
-) -> (
-    hyper::client::conn::http1::SendRequest<hyper::Body>,
-    JoinSet<Result<(), Error>>,
-) {
-    tracing::info!(settings = ?client_settings, "connecting client with");
-    let (client_io, server_io) = io::duplex(4096);
-
-    let (client, conn) = client_settings
-        .handshake(client_io)
-        .await
-        .expect("Client must connect");
-
-    let mut bg = tokio::task::JoinSet::new();
-    bg.spawn(
-        async move {
-            server
-                .oneshot(server_io)
-                .await
-                .map_err(ContextError::ctx("proxy background task failed"))?;
-            tracing::info!("proxy serve task complete");
-            Ok(())
-        }
-        .instrument(tracing::info_span!("proxy")),
-    );
-    bg.spawn(
-        async move {
-            conn.await
-                .map_err(ContextError::ctx("client background task failed"))
-                .map_err(Error::from)?;
-            tracing::info!("client background complete");
-            Ok(())
-        }
-        .instrument(tracing::info_span!("client_bg")),
-    );
-
-    (client, bg)
-}
-
-/// Connects a client and server, running a proxy between them.
-///
-/// Returns a tuple containing (1) a [`SendRequest`] that can be used to transmit a request and
-/// await a response, and (2) a [`JoinSet<T>`] running background tasks.
 pub async fn connect_and_accept_http2<B>(
     client_settings: &mut hyper::client::conn::http2::Builder,
     server: BoxServer,


### PR DESCRIPTION
this commit removes a duplicate function that was errantly defined, due to some issues when merging previous (interdependent) pr's.

see
- #3455
- #3454
- linkerd/linkerd2#8733