### PR TITLE
chore(cargo.toml): define http workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,8 @@ debug = 1
 lto = true
 
 [workspace.dependencies]
+http = { version = "0.2" }
+http-body = { version = "0.4" }
 hyper = { version = "0.14", default-features = false }
 linkerd2-proxy-api = "0.15.0"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging"] }

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-http = "0.2"
+http = { workspace = true }
 hyper = { workspace = true, features = ["deprecated"] }
 pin-project = "1"
 tower = { version = "0.4", default-features = false, features = ["load"] }

--- a/linkerd/addr/Cargo.toml
+++ b/linkerd/addr/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-http = "0.2"
+http = { workspace = true }
 ipnet = "2.10"
 linkerd-dns-name = { path = "../dns/name" }
 thiserror = "2"

--- a/linkerd/app/admin/Cargo.toml
+++ b/linkerd/app/admin/Cargo.toml
@@ -16,8 +16,8 @@ log-streaming = ["linkerd-tracing/stream"]
 
 [dependencies]
 deflate = { version = "1", optional = true, features = ["gzip"] }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 pprof = { version = "0.14", optional = true, features = ["prost-codec"] }

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -15,8 +15,8 @@ independently of the inbound and outbound proxy logic.
 [dependencies]
 bytes = "1"
 drain = { version = "0.1", features = ["retain"] }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.10"

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-http = "0.2"
+http = { workspace = true }
 futures = { version = "0.3", default-features = false }
 linkerd-app-core = { path = "../core" }
 linkerd-app-inbound = { path = "../inbound" }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -19,7 +19,7 @@ test-util = [
 
 [dependencies]
 bytes = "1"
-http = "0.2"
+http = { workspace = true }
 futures = { version = "0.3", default-features = false }
 linkerd-app-core = { path = "../core" }
 linkerd-app-test = { path = "../test", optional = true }

--- a/linkerd/app/inbound/fuzz/Cargo.toml
+++ b/linkerd/app/inbound/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [target.'cfg(fuzzing)'.dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 hyper = { version = "0.14", features = ["deprecated", "http1", "http2"] }
-http = "0.2"
+http = { workspace = true }
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 linkerd-app-core = { path = "../../core" }
 linkerd-app-inbound = { path = ".." }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -20,8 +20,8 @@ flakey = []
 bytes = "1"
 futures = { version = "0.3", default-features = false, features = ["executor"] }
 h2 = "0.3"
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 hyper = { workspace = true, features = [
     "backports",
     "deprecated",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -20,7 +20,7 @@ prometheus-client-rust-242 = [] # TODO
 [dependencies]
 ahash = "0.8"
 bytes = "1"
-http = "0.2"
+http = { workspace = true }
 futures = { version = "0.3", default-features = false }
 linkerd2-proxy-api = { workspace = true, features = ["outbound"] }
 once_cell = "1"
@@ -53,7 +53,7 @@ linkerd-tonic-watch = { path = "../../tonic-watch" }
 
 [dev-dependencies]
 futures-util = "0.3"
-http-body = "0.4"
+http-body = { workspace = true }
 hyper = { workspace = true, features = ["backports", "deprecated", "http1", "http2"] }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-rustls = { workspace = true }

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -15,8 +15,8 @@ client-policy = ["linkerd-proxy-client-policy", "tonic", "linkerd-http-route"]
 [dependencies]
 futures = { version = "0.3", default-features = false }
 h2 = "0.3"
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 linkerd-app-core = { path = "../core" }
 linkerd-http-route = { path = "../../http/route", optional = true }

--- a/linkerd/http/access-log/Cargo.toml
+++ b/linkerd/http/access-log/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 futures-core = "0.3"
-http = "0.2"
+http = { workspace = true }
 humantime = "2"
 pin-project = "1"
 tokio = { version = "1", features = ["time"] }

--- a/linkerd/http/box/Cargo.toml
+++ b/linkerd/http/box/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 [dependencies]
 bytes = "1"
 futures = { version = "0.3", default-features = false }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 pin-project = "1"
 
 linkerd-error = { path = "../../error" }

--- a/linkerd/http/classify/Cargo.toml
+++ b/linkerd/http/classify/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 pin-project = "1"
 tokio = { version = "1", default-features = false }
 tracing = "0.1"

--- a/linkerd/http/insert/Cargo.toml
+++ b/linkerd/http/insert/Cargo.toml
@@ -11,7 +11,7 @@ Tower middleware to insert parameters into HTTP extensions.
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-http = "0.2"
+http = { workspace = true }
 pin-project = "1"
 tower = { version = "0.4", default-features = false }
 

--- a/linkerd/http/metrics/Cargo.toml
+++ b/linkerd/http/metrics/Cargo.toml
@@ -12,8 +12,8 @@ test-util = []
 [dependencies]
 bytes = "1"
 futures = { version = "0.3", default-features = false }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 parking_lot = "0.12"
 pin-project = "1"

--- a/linkerd/http/override-authority/Cargo.toml
+++ b/linkerd/http/override-authority/Cargo.toml
@@ -10,7 +10,7 @@ Tower middleware to override request authorities.
 """
 
 [dependencies]
-http = "0.2"
+http = { workspace = true }
 tower = { version = "0.4", default-features = false }
 tracing = "0.1"
 

--- a/linkerd/http/prom/Cargo.toml
+++ b/linkerd/http/prom/Cargo.toml
@@ -15,8 +15,8 @@ test-util = []
 [dependencies]
 bytes = "1"
 futures = { version = "0.3", default-features = false }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 parking_lot = "0.12"
 pin-project = "1"
 prometheus-client = "0.22"

--- a/linkerd/http/retain/Cargo.toml
+++ b/linkerd/http/retain/Cargo.toml
@@ -12,8 +12,8 @@ This is mostly intended to support cache eviction.
 """
 
 [dependencies]
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 pin-project = "1"
 tower = { version = "0.4", default-features = false }
 

--- a/linkerd/http/retry/Cargo.toml
+++ b/linkerd/http/retry/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 [dependencies]
 bytes = "1"
 futures = { version = "0.3", default-features = false }
-http-body = "0.4"
-http = "0.2"
+http-body = { workspace = true }
+http = { workspace = true }
 parking_lot = "0.12"
 tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.4", features = ["retry"] }

--- a/linkerd/http/route/Cargo.toml
+++ b/linkerd/http/route/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 proto = ["linkerd2-proxy-api"]
 
 [dependencies]
-http = "0.2"
+http = { workspace = true }
 regex = "1"
 rand = "0.8"
 thiserror = "2"

--- a/linkerd/http/stream-timeouts/Cargo.toml
+++ b/linkerd/http/stream-timeouts/Cargo.toml
@@ -11,8 +11,8 @@ Tower middleware to express deadlines on streams.
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 parking_lot = "0.12"
 pin-project = "1"
 thiserror = "2"

--- a/linkerd/http/upgrade/Cargo.toml
+++ b/linkerd/http/upgrade/Cargo.toml
@@ -13,8 +13,8 @@ Facilities for HTTP/1 upgrades.
 bytes = "1"
 drain = "0.1"
 futures = { version = "0.3", default-features = false }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 hyper = { workspace = true, default-features = false, features = ["deprecated", "client"] }
 pin-project = "1"
 tokio = { version = "1", default-features = false }

--- a/linkerd/http/version/Cargo.toml
+++ b/linkerd/http/version/Cargo.toml
@@ -10,5 +10,5 @@ HTTP version types.
 """
 
 [dependencies]
-http = "0.2"
+http = { workspace = true }
 thiserror = "2"

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -14,7 +14,7 @@ test_util = []
 
 [dependencies]
 deflate = { version = "1", features = ["gzip"] }
-http = "0.2"
+http = { workspace = true }
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 linkerd-stack = { path = "../stack", optional = true }
 linkerd-system = { path = "../system", optional = true }

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 linkerd-error = { path = "../error" }
 linkerd-metrics = { path = "../metrics" }
 linkerd-trace-context = { path = "../trace-context" }

--- a/linkerd/opentelemetry/Cargo.toml
+++ b/linkerd/opentelemetry/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 futures = { version = "0.3", default-features = false }
 http = "0.2"
-http-body = "0.4"
+http-body = { workspace = true }
 linkerd-error = { path = "../error" }
 linkerd-metrics = { path = "../metrics" }
 linkerd-trace-context = { path = "../trace-context" }

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -20,8 +20,8 @@ linkerd-stack = { path = "../../stack" }
 linkerd-tonic-stream = { path = "../../tonic-stream" }
 linkerd-tls = { path = "../../tls" }
 linkerd-identity = { path = "../../identity" }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 pin-project = "1"
 prost = "0.12"
 tonic = { version = "0.10", default-features = false }

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -18,7 +18,7 @@ proto = [
 [dependencies]
 ahash = "0.8"
 ipnet = "2"
-http = "0.2"
+http = { workspace = true }
 once_cell = { version = "1" }
 prost-types = { version = "0.12", optional = true }
 tonic = { version = "0.10", default-features = false }

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -17,8 +17,8 @@ bytes = "1"
 drain = "0.1"
 futures = { version = "0.3", default-features = false }
 h2 = "0.3"
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 httparse = "1"
 hyper = { workspace = true, features = [
     "backports",

--- a/linkerd/proxy/identity-client/Cargo.toml
+++ b/linkerd/proxy/identity-client/Cargo.toml
@@ -20,4 +20,4 @@ thiserror = "2"
 tokio = { version = "1", features = ["time", "sync"] }
 tonic = { version = "0.10", default-features = false }
 tracing = "0.1"
-http-body = "0.4"
+http-body = { workspace = true }

--- a/linkerd/proxy/server-policy/Cargo.toml
+++ b/linkerd/proxy/server-policy/Cargo.toml
@@ -13,7 +13,7 @@ test-util = []
 [dependencies]
 governor = { version = "0.8", default-features = false, features = ["std"] }
 ipnet = "2"
-http = "0.2"
+http = { workspace = true }
 prost-types = { version = "0.12", optional = true }
 thiserror = "2"
 

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-http = "0.2"
+http = { workspace = true }
 hyper = { workspace = true, features = ["backports", "deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.10"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -12,8 +12,8 @@ Implements client layers for Linkerd ServiceProfiles.
 [dependencies]
 bytes = "1"
 futures = { version = "0.3", default-features = false }
-http = "0.2"
-http-body = "0.4"
+http = { workspace = true }
+http-body = { workspace = true }
 linkerd2-proxy-api = { workspace = true, features = ["destination"] }
 once_cell = "1.20"
 prost-types = "0.12"

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "0.13"
 bytes = "1"
 futures = { version = "0.3", default-features = false }
 hex = "0.4"
-http = "0.2"
+http = { workspace = true }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 rand = "0.8"


### PR DESCRIPTION
this is a follow-up to https://github.com/linkerd/linkerd2-proxy/pull/3456, addressing a suggestion that was made
during review:

- <https://github.com/linkerd/linkerd2-proxy/pull/3456#pullrequestreview-2502446232>
- <https://github.com/linkerd/linkerd2/issues/8733>

this branch modifies the workspace manifest, defining `http` and `http-body`
as common workspace dependencies.

no changes to the lockfile are made because these commits do not affect
the dependency graph of the project.