### PR TITLE
refactor: move away from legacy `hyper::body::HttpBody`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "http",
+ "http-body",
  "hyper",
  "pin-project",
  "tokio",
@@ -1312,6 +1313,7 @@ dependencies = [
 name = "linkerd-app-admin"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "deflate",
  "futures",
  "http",
@@ -1999,7 +2001,9 @@ version = "0.1.0"
 dependencies = [
  "deflate",
  "http",
+ "http-body",
  "hyper",
+ "linkerd-http-box",
  "linkerd-stack",
  "linkerd-system",
  "parking_lot",
@@ -2335,8 +2339,10 @@ dependencies = [
 name = "linkerd-proxy-tap"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "futures",
  "http",
+ "http-body",
  "hyper",
  "ipnet",
  "linkerd-conditional",

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
+http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated"] }
 pin-project = "1"
 tower = { version = "0.4", default-features = false, features = ["load"] }

--- a/hyper-balance/src/lib.rs
+++ b/hyper-balance/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
-use hyper::body::HttpBody;
+use http_body::Body;
 use pin_project::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -38,7 +38,7 @@ pub struct PendingUntilEosBody<T, B> {
 
 impl<T, B> TrackCompletion<T, http::Response<B>> for PendingUntilFirstData
 where
-    B: HttpBody,
+    B: Body,
 {
     type Output = http::Response<PendingUntilFirstDataBody<T, B>>;
 
@@ -59,7 +59,7 @@ where
 
 impl<T, B> TrackCompletion<T, http::Response<B>> for PendingUntilEos
 where
-    B: HttpBody,
+    B: Body,
 {
     type Output = http::Response<PendingUntilEosBody<T, B>>;
 
@@ -80,7 +80,7 @@ where
 
 impl<T, B> Default for PendingUntilFirstDataBody<T, B>
 where
-    B: HttpBody + Default,
+    B: Body + Default,
 {
     fn default() -> Self {
         Self {
@@ -90,9 +90,9 @@ where
     }
 }
 
-impl<T, B> HttpBody for PendingUntilFirstDataBody<T, B>
+impl<T, B> Body for PendingUntilFirstDataBody<T, B>
 where
-    B: HttpBody,
+    B: Body,
     T: Send + 'static,
 {
     type Data = B::Data;
@@ -138,7 +138,7 @@ where
 
 impl<T, B> Default for PendingUntilEosBody<T, B>
 where
-    B: HttpBody + Default,
+    B: Body + Default,
 {
     fn default() -> Self {
         Self {
@@ -148,7 +148,7 @@ where
     }
 }
 
-impl<T: Send + 'static, B: HttpBody> HttpBody for PendingUntilEosBody<T, B> {
+impl<T: Send + 'static, B: Body> Body for PendingUntilEosBody<T, B> {
     type Data = B::Data;
     type Error = B::Error;
 
@@ -198,7 +198,7 @@ impl<T: Send + 'static, B: HttpBody> HttpBody for PendingUntilEosBody<T, B> {
 mod tests {
     use super::{PendingUntilEos, PendingUntilFirstData};
     use futures::future::poll_fn;
-    use hyper::body::HttpBody;
+    use http_body::Body;
     use std::collections::VecDeque;
     use std::io::Cursor;
     use std::pin::Pin;
@@ -429,7 +429,7 @@ mod tests {
 
     #[derive(Default)]
     struct TestBody(VecDeque<&'static str>, Option<http::HeaderMap>);
-    impl HttpBody for TestBody {
+    impl Body for TestBody {
         type Data = Cursor<&'static str>;
         type Error = &'static str;
 
@@ -456,7 +456,7 @@ mod tests {
 
     #[derive(Default)]
     struct ErrBody(Option<&'static str>);
-    impl HttpBody for ErrBody {
+    impl Body for ErrBody {
         type Data = Cursor<&'static str>;
         type Error = &'static str;
 

--- a/linkerd/app/admin/Cargo.toml
+++ b/linkerd/app/admin/Cargo.toml
@@ -15,6 +15,7 @@ pprof = ["deflate", "dep:pprof"]
 log-streaming = ["linkerd-tracing/stream"]
 
 [dependencies]
+bytes = "1"
 deflate = { version = "1", optional = true, features = ["gzip"] }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/linkerd/app/admin/src/server.rs
+++ b/linkerd/app/admin/src/server.rs
@@ -74,12 +74,12 @@ impl<M> Admin<M> {
             Response::builder()
                 .status(StatusCode::OK)
                 .header(http::header::CONTENT_TYPE, "text/plain")
-                .body(BoxBody::new::<String>("ready\n".into()))
+                .body(BoxBody::from_static("ready\n"))
                 .expect("builder with known status code must not fail")
         } else {
             Response::builder()
                 .status(StatusCode::SERVICE_UNAVAILABLE)
-                .body(BoxBody::new::<String>("not ready\n".into()))
+                .body(BoxBody::from_static("not ready\n"))
                 .expect("builder with known status code must not fail")
         }
     }
@@ -88,7 +88,7 @@ impl<M> Admin<M> {
         Response::builder()
             .status(StatusCode::OK)
             .header(http::header::CONTENT_TYPE, "text/plain")
-            .body(BoxBody::new::<String>("live\n".into()))
+            .body(BoxBody::from_static("live\n"))
             .expect("builder with known status code must not fail")
     }
 
@@ -143,22 +143,20 @@ impl<M> Admin<M> {
             return Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header(http::header::CONTENT_TYPE, "text/plain")
-                .body(BoxBody::new::<String>(
-                    "shutdown endpoint is not enabled\n".into(),
-                ))
+                .body(BoxBody::from_static("shutdown endpoint is not enabled\n"))
                 .expect("builder with known status code must not fail");
         }
         if self.shutdown_tx.send(()).is_ok() {
             Response::builder()
                 .status(StatusCode::OK)
                 .header(http::header::CONTENT_TYPE, "text/plain")
-                .body(BoxBody::new::<String>("shutdown\n".into()))
+                .body(BoxBody::from_static("shutdown\n"))
                 .expect("builder with known status code must not fail")
         } else {
             Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
                 .header(http::header::CONTENT_TYPE, "text/plain")
-                .body(BoxBody::new::<String>("shutdown listener dropped\n".into()))
+                .body(BoxBody::from_static("shutdown listener dropped\n"))
                 .expect("builder with known status code must not fail")
         }
     }

--- a/linkerd/app/admin/src/server/json.rs
+++ b/linkerd/app/admin/src/server/json.rs
@@ -44,7 +44,7 @@ pub(crate) fn accepts_json<B>(req: &http::Request<B>) -> Result<(), http::Respon
             tracing::warn!(?accept, "Accept header will not accept 'application/json'");
             return Err(http::Response::builder()
                 .status(StatusCode::NOT_ACCEPTABLE)
-                .body(BoxBody::new::<String>(JSON_MIME.into()))
+                .body(BoxBody::from_static(JSON_MIME))
                 .expect("builder with known status code must not fail"));
         }
     }
@@ -63,7 +63,7 @@ fn mk_rsp(status: StatusCode, val: &impl serde::Serialize) -> http::Response<Box
             tracing::warn!(?error, "failed to serialize JSON value");
             http::Response::builder()
                 .status(StatusCode::INTERNAL_SERVER_ERROR)
-                .body(BoxBody::new::<String>(format!(
+                .body(BoxBody::new(format!(
                     "failed to serialize JSON value: {error}"
                 )))
                 .expect("builder with known status code must not fail")

--- a/linkerd/app/core/src/errors/respond.rs
+++ b/linkerd/app/core/src/errors/respond.rs
@@ -388,7 +388,7 @@ impl<R> Respond<R> {
 
 impl<B, R> respond::Respond<http::Response<B>, Error> for Respond<R>
 where
-    B: Default + hyper::body::HttpBody,
+    B: Default + linkerd_proxy_http::Body,
     R: HttpRescue<Error> + Clone,
 {
     type Response = http::Response<ResponseBody<R, B>>;
@@ -444,15 +444,15 @@ where
 
 // === impl ResponseBody ===
 
-impl<R, B: Default + hyper::body::HttpBody> Default for ResponseBody<R, B> {
+impl<R, B: Default + linkerd_proxy_http::Body> Default for ResponseBody<R, B> {
     fn default() -> Self {
         ResponseBody::Passthru(B::default())
     }
 }
 
-impl<R, B> hyper::body::HttpBody for ResponseBody<R, B>
+impl<R, B> linkerd_proxy_http::Body for ResponseBody<R, B>
 where
-    B: hyper::body::HttpBody<Error = Error>,
+    B: linkerd_proxy_http::Body<Error = Error>,
     R: HttpRescue<B::Error>,
 {
     type Data = B::Data;

--- a/linkerd/app/gateway/src/http/gateway.rs
+++ b/linkerd/app/gateway/src/http/gateway.rs
@@ -66,7 +66,7 @@ where
 
 impl<B, S> tower::Service<http::Request<B>> for HttpGateway<S>
 where
-    B: http::HttpBody + 'static,
+    B: http::Body + 'static,
     S: tower::Service<http::Request<B>, Response = http::Response<http::BoxBody>>,
     S::Error: Into<Error> + 'static,
     S::Future: Send + 'static,

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -684,7 +684,7 @@ fn hello_server(
         let (client_io, server_io) = support::io::duplex(4096);
         let hello_svc = hyper::service::service_fn(|request: Request<hyper::Body>| async move {
             tracing::info!(?request);
-            Ok::<_, io::Error>(Response::new(BoxBody::new("Hello world!".to_string())))
+            Ok::<_, io::Error>(Response::new(BoxBody::from_static("Hello world!")))
         });
         tokio::spawn(
             server

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -6,12 +6,12 @@ use crate::{
     },
     Config, Inbound,
 };
-use hyper::{body::HttpBody, Body, Request, Response};
+use hyper::{Request, Response};
 use linkerd_app_core::{
     classify,
     errors::respond::L5D_PROXY_ERROR,
     identity, io, metrics,
-    proxy::http,
+    proxy::http::{self, Body as _, BoxBody},
     svc::{self, http::TracingExecutor, NewService, Param},
     tls,
     transport::{ClientAddr, OrigDstAddr, Remote, ServerAddr},
@@ -68,7 +68,7 @@ async fn unmeshed_http1_hello_world() {
     let req = Request::builder()
         .method(http::Method::GET)
         .uri("http://foo.svc.cluster.local:5550")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -142,7 +142,7 @@ async fn downgrade_origin_form() {
         .uri("/")
         .header(http::header::HOST, "foo.svc.cluster.local")
         .header("l5d-orig-proto", "HTTP/1.1")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -216,7 +216,7 @@ async fn downgrade_absolute_form() {
         .uri("http://foo.svc.cluster.local:5550/")
         .header(http::header::HOST, "foo.svc.cluster.local")
         .header("l5d-orig-proto", "HTTP/1.1; absolute-form")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -260,7 +260,7 @@ async fn http1_bad_gateway_meshed_response_error_header() {
     let req = Request::builder()
         .method(http::Method::GET)
         .uri("http://foo.svc.cluster.local:5550")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -307,7 +307,7 @@ async fn http1_bad_gateway_unmeshed_response() {
     let req = Request::builder()
         .method(http::Method::GET)
         .uri("http://foo.svc.cluster.local:5550")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -355,7 +355,7 @@ async fn http1_connect_timeout_meshed_response_error_header() {
     let req = Request::builder()
         .method(http::Method::GET)
         .uri("http://foo.svc.cluster.local:5550")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -405,7 +405,7 @@ async fn http1_connect_timeout_unmeshed_response_error_header() {
     let req = Request::builder()
         .method(http::Method::GET)
         .uri("http://foo.svc.cluster.local:5550")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -450,7 +450,7 @@ async fn h2_response_meshed_error_header() {
     let req = Request::builder()
         .method(http::Method::GET)
         .uri("http://foo.svc.cluster.local:5550")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -490,7 +490,7 @@ async fn h2_response_unmeshed_error_header() {
     let req = Request::builder()
         .method(http::Method::GET)
         .uri("http://foo.svc.cluster.local:5550")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -533,7 +533,7 @@ async fn grpc_meshed_response_error_header() {
         .method(http::Method::GET)
         .uri("http://foo.svc.cluster.local:5550")
         .header(http::header::CONTENT_TYPE, "application/grpc")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -574,7 +574,7 @@ async fn grpc_unmeshed_response_error_header() {
         .method(http::Method::GET)
         .uri("http://foo.svc.cluster.local:5550")
         .header(http::header::CONTENT_TYPE, "application/grpc")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
     let rsp = client
         .send_request(req)
@@ -628,7 +628,7 @@ async fn grpc_response_class() {
         .method(http::Method::POST)
         .uri("http://foo.svc.cluster.local:5550")
         .header(http::header::CONTENT_TYPE, "application/grpc")
-        .body(Body::default())
+        .body(hyper::Body::default())
         .unwrap();
 
     let mut rsp = client
@@ -682,9 +682,9 @@ fn hello_server(
         let _e = span.enter();
         tracing::info!("mock connecting");
         let (client_io, server_io) = support::io::duplex(4096);
-        let hello_svc = hyper::service::service_fn(|request: Request<Body>| async move {
+        let hello_svc = hyper::service::service_fn(|request: Request<hyper::Body>| async move {
             tracing::info!(?request);
-            Ok::<_, io::Error>(Response::new(Body::from("Hello world!")))
+            Ok::<_, io::Error>(Response::new(BoxBody::new("Hello world!".to_string())))
         });
         tokio::spawn(
             server
@@ -709,9 +709,9 @@ fn grpc_status_server(
             server
                 .serve_connection(
                     server_io,
-                    hyper::service::service_fn(move |request: Request<Body>| async move {
+                    hyper::service::service_fn(move |request: Request<hyper::Body>| async move {
                         tracing::info!(?request);
-                        let (mut tx, rx) = Body::channel();
+                        let (mut tx, rx) = hyper::Body::channel();
                         tokio::spawn(async move {
                             let mut trls = ::http::HeaderMap::new();
                             trls.insert(

--- a/linkerd/app/inbound/src/policy/api.rs
+++ b/linkerd/app/inbound/src/policy/api.rs
@@ -35,7 +35,7 @@ impl<S> Api<S>
 where
     S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error> + Clone,
     S::ResponseBody:
-        http::HttpBody<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+        http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
 {
     pub(super) fn new(
         workload: Arc<str>,
@@ -61,7 +61,7 @@ where
     S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
     S: Clone + Send + Sync + 'static,
     S::ResponseBody:
-        http::HttpBody<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+        http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
     S::Future: Send + 'static,
 {
     type Response =

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -42,7 +42,7 @@ impl Config {
     where
         C: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
         C: Clone + Unpin + Send + Sync + 'static,
-        C::ResponseBody: http::HttpBody<Data = tonic::codegen::Bytes, Error = Error>,
+        C::ResponseBody: http::Body<Data = tonic::codegen::Bytes, Error = Error>,
         C::ResponseBody: Default + Send + 'static,
         C::Future: Send,
     {

--- a/linkerd/app/inbound/src/policy/store.rs
+++ b/linkerd/app/inbound/src/policy/store.rs
@@ -78,7 +78,7 @@ impl<S> Store<S> {
         S: Clone + Send + Sync + 'static,
         S::Future: Send,
         S::ResponseBody:
-            http::HttpBody<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+            http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
     {
         let opaque_default = Self::make_opaque(default.clone());
         // The initial set of policies never expire from the cache.
@@ -143,7 +143,7 @@ where
     S: Clone + Send + Sync + 'static,
     S::Future: Send,
     S::ResponseBody:
-        http::HttpBody<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+        http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
 {
     fn get_policy(&self, dst: OrigDstAddr) -> AllowPolicy {
         // Lookup the policy for the target port in the cache. If it doesn't

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -29,7 +29,7 @@ impl Inbound<()> {
     where
         C: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
         C: Clone + Unpin + Send + Sync + 'static,
-        C::ResponseBody: http::HttpBody<Data = tonic::codegen::Bytes, Error = Error>,
+        C::ResponseBody: http::Body<Data = tonic::codegen::Bytes, Error = Error>,
         C::ResponseBody: Default + Send + 'static,
         C::Future: Send,
     {

--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -26,7 +26,7 @@ pub use bytes::{Buf, BufMut, Bytes};
 pub use futures::stream::{Stream, StreamExt};
 pub use futures::{future, FutureExt, TryFuture, TryFutureExt};
 pub use http::{HeaderMap, Request, Response, StatusCode};
-pub use http_body::Body as HttpBody;
+pub use http_body::Body;
 pub use linkerd_app as app;
 pub use linkerd_app_core::{drain, Addr};
 pub use linkerd_app_test::*;

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -44,7 +44,7 @@ impl<C> Outbound<C> {
         T: svc::Param<http::client::Params>,
         T: Clone + Send + Sync + 'static,
         // Http endpoint body.
-        B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
+        B: http::Body<Error = Error> + std::fmt::Debug + Default + Send + 'static,
         B::Data: Send + 'static,
         // TCP endpoint stack.
         C: svc::MakeConnection<Connect<T>> + Clone + Send + Sync + Unpin + 'static,
@@ -81,7 +81,7 @@ impl<T> Outbound<svc::ArcNewHttp<T, http::BoxBody>> {
         T: tap::Inspect,
         T: Clone + Send + Sync + 'static,
         // Http endpoint body.
-        B: http::HttpBody<Error = Error> + std::fmt::Debug + Default + Send + 'static,
+        B: http::Body<Error = Error> + std::fmt::Debug + Default + Send + 'static,
         B::Data: Send + 'static,
     {
         self.map_stack(|config, rt, inner| {

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/test_util.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/test_util.rs
@@ -1,6 +1,6 @@
-use hyper::body::HttpBody;
 use linkerd_app_core::{
     metrics::prom::Counter,
+    proxy::http::Body,
     svc::{self, http::BoxBody, Service, ServiceExt},
 };
 

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
@@ -317,7 +317,7 @@ async fn http_route_request_body_frames() {
     tracing::info!("sending request to service");
     let resp = {
         use http::{Response, StatusCode};
-        let body = BoxBody::new("earl grey".to_owned());
+        let body = BoxBody::from_static("earl grey");
         let resp = Response::builder()
             .status(StatusCode::IM_A_TEAPOT)
             .body(body)

--- a/linkerd/app/outbound/src/http/logical/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/tests.rs
@@ -1,7 +1,7 @@
 use super::{policy, Outbound, ParentRef, Routes};
 use crate::test_util::*;
 use linkerd_app_core::{
-    proxy::http::{self, BoxBody, HttpBody, StatusCode},
+    proxy::http::{self, Body, BoxBody, StatusCode},
     svc::{self, NewService, ServiceExt},
     transport::addrs::*,
     Error, NameAddr, Result,

--- a/linkerd/app/outbound/src/http/logical/tests/retries.rs
+++ b/linkerd/app/outbound/src/http/logical/tests/retries.rs
@@ -1,8 +1,7 @@
 use super::*;
-use hyper::body::HttpBody;
 use linkerd_app_core::{
     errors,
-    proxy::http::{self, StatusCode},
+    proxy::http::{self, Body, StatusCode},
     svc::http::stream_timeouts::StreamDeadlineError,
     trace,
 };

--- a/linkerd/app/outbound/src/http/logical/tests/timeouts.rs
+++ b/linkerd/app/outbound/src/http/logical/tests/timeouts.rs
@@ -4,7 +4,7 @@ use linkerd_app_core::{
     proxy::http::{
         self,
         stream_timeouts::{BodyTimeoutError, ResponseTimeoutError},
-        BoxBody, HttpBody,
+        Body, BoxBody,
     },
     trace,
 };

--- a/linkerd/app/outbound/src/http/retry.rs
+++ b/linkerd/app/outbound/src/http/retry.rs
@@ -4,7 +4,7 @@ use linkerd_app_core::{
     http_metrics::retries::Handle,
     metrics::{self, ProfileRouteLabels},
     profiles::{self, http::Route},
-    proxy::http::{ClientHandle, EraseResponse, HttpBody},
+    proxy::http::{Body, ClientHandle, EraseResponse},
     svc::{layer, Either, Param},
     Error, Result,
 };
@@ -71,9 +71,9 @@ impl<ReqB, RspB>
     retry::Policy<http::Request<ReplayBody<ReqB>>, http::Response<PeekTrailersBody<RspB>>, Error>
     for RetryPolicy
 where
-    ReqB: HttpBody + Unpin,
+    ReqB: Body + Unpin,
     ReqB::Error: Into<Error>,
-    RspB: HttpBody + Unpin,
+    RspB: Body + Unpin,
 {
     type Future = future::Ready<Self>;
 
@@ -150,9 +150,9 @@ where
 
 impl<ReqB, RspB> retry::PrepareRetry<http::Request<ReqB>, http::Response<RspB>> for RetryPolicy
 where
-    ReqB: HttpBody + Unpin,
+    ReqB: Body + Unpin,
     ReqB::Error: Into<Error>,
-    RspB: HttpBody + Unpin + Send + 'static,
+    RspB: Body + Unpin + Send + 'static,
     RspB::Data: Unpin + Send,
     RspB::Error: Unpin + Send,
 {

--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -147,7 +147,7 @@ impl Outbound<()> {
     where
         C: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
         C: Clone + Unpin + Send + Sync + 'static,
-        C::ResponseBody: proxy::http::HttpBody<Data = tonic::codegen::Bytes, Error = Error>,
+        C::ResponseBody: proxy::http::Body<Data = tonic::codegen::Bytes, Error = Error>,
         C::ResponseBody: Default + Send + 'static,
         C::Future: Send,
     {

--- a/linkerd/app/outbound/src/policy/api.rs
+++ b/linkerd/app/outbound/src/policy/api.rs
@@ -34,7 +34,7 @@ impl<S> Api<S>
 where
     S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error> + Clone,
     S::ResponseBody:
-        http::HttpBody<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+        http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
 {
     pub(crate) fn new(
         workload: Arc<str>,
@@ -60,7 +60,7 @@ where
     S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
     S: Clone + Send + Sync + 'static,
     S::ResponseBody:
-        http::HttpBody<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+        http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
     S::Future: Send + 'static,
 {
     type Response =

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -73,7 +73,7 @@ pub use self::mock_body::MockBody;
 
 mod mock_body {
     use bytes::Bytes;
-    use linkerd_app_core::proxy::http::HttpBody;
+    use linkerd_app_core::proxy::http::Body;
     use linkerd_app_core::{Error, Result};
     use std::{
         future::Future,
@@ -128,7 +128,7 @@ mod mock_body {
         }
     }
 
-    impl HttpBody for MockBody {
+    impl Body for MockBody {
         type Data = Bytes;
         type Error = Error;
 

--- a/linkerd/app/src/trace_collector/oc_collector.rs
+++ b/linkerd/app/src/trace_collector/oc_collector.rs
@@ -1,6 +1,6 @@
 use crate::trace_collector::EnabledCollector;
 use linkerd_app_core::{
-    control::ControlAddr, http_tracing::CollectorProtocol, proxy::http::HttpBody, Error,
+    control::ControlAddr, http_tracing::CollectorProtocol, proxy::http::Body, Error,
 };
 use linkerd_opencensus::{self as opencensus, metrics, proto};
 use std::{collections::HashMap, time::SystemTime};
@@ -21,8 +21,8 @@ where
     S: GrpcService<BoxBody> + Clone + Send + 'static,
     S::Error: Into<Error>,
     S::Future: Send,
-    S::ResponseBody: Default + HttpBody<Data = tonic::codegen::Bytes> + Send + 'static,
-    <S::ResponseBody as HttpBody>::Error: Into<Error> + Send,
+    S::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <S::ResponseBody as Body>::Error: Into<Error> + Send,
 {
     let (span_sink, spans_rx) = mpsc::channel(crate::trace_collector::SPAN_BUFFER_CAPACITY);
     let spans_rx = ReceiverStream::new(spans_rx);

--- a/linkerd/app/src/trace_collector/otel_collector.rs
+++ b/linkerd/app/src/trace_collector/otel_collector.rs
@@ -1,6 +1,6 @@
 use super::EnabledCollector;
 use linkerd_app_core::{
-    control::ControlAddr, http_tracing::CollectorProtocol, proxy::http::HttpBody, Error,
+    control::ControlAddr, http_tracing::CollectorProtocol, proxy::http::Body, Error,
 };
 use linkerd_opentelemetry::{
     self as opentelemetry, metrics,
@@ -25,8 +25,8 @@ where
     S: GrpcService<BoxBody> + Clone + Send + 'static,
     S::Error: Into<Error>,
     S::Future: Send,
-    S::ResponseBody: Default + HttpBody<Data = tonic::codegen::Bytes> + Send + 'static,
-    <S::ResponseBody as HttpBody>::Error: Into<Error> + Send,
+    S::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <S::ResponseBody as Body>::Error: Into<Error> + Send,
 {
     let (span_sink, spans_rx) = mpsc::channel(crate::trace_collector::SPAN_BUFFER_CAPACITY);
     let spans_rx = ReceiverStream::new(spans_rx);

--- a/linkerd/http/box/src/body.rs
+++ b/linkerd/http/box/src/body.rs
@@ -46,6 +46,11 @@ impl BoxBody {
     pub fn empty() -> Self {
         Self::default()
     }
+
+    /// Returns a [`BoxBody`] with the contents of a static string.
+    pub fn from_static(body: &'static str) -> Self {
+        Self::new(body.to_string())
+    }
 }
 
 impl Body for BoxBody {

--- a/linkerd/http/upgrade/src/glue.rs
+++ b/linkerd/http/upgrade/src/glue.rs
@@ -1,7 +1,7 @@
 use crate::upgrade::Http11Upgrade;
 use bytes::Bytes;
 use futures::TryFuture;
-use hyper::body::HttpBody;
+use http_body::Body;
 use hyper::client::connect as hyper_connect;
 use linkerd_error::{Error, Result};
 use linkerd_io::{self as io, AsyncRead, AsyncWrite};
@@ -50,7 +50,7 @@ pub struct HyperConnectFuture<F> {
 
 // === impl UpgradeBody ===
 
-impl HttpBody for UpgradeBody {
+impl Body for UpgradeBody {
     type Data = Bytes;
     type Error = hyper::Error;
 

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -15,7 +15,9 @@ test_util = []
 [dependencies]
 deflate = { version = "1", features = ["gzip"] }
 http = { workspace = true }
+http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
+linkerd-http-box = { path = "../http/box" }
 linkerd-stack = { path = "../stack", optional = true }
 linkerd-system = { path = "../system", optional = true }
 parking_lot = "0.12"

--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -4,7 +4,7 @@
 pub mod metrics;
 
 use futures::stream::{Stream, StreamExt};
-use http_body::Body as HttpBody;
+use http_body::Body;
 use linkerd_error::Error;
 use linkerd_trace_context::export::{ExportSpan, SpanKind};
 use metrics::Registry;
@@ -24,8 +24,8 @@ pub async fn export_spans<T, S>(client: T, node: Node, spans: S, metrics: Regist
 where
     T: GrpcService<BoxBody> + Clone,
     T::Error: Into<Error>,
-    T::ResponseBody: Default + HttpBody<Data = tonic::codegen::Bytes> + Send + 'static,
-    <T::ResponseBody as HttpBody>::Error: Into<Error> + Send,
+    T::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <T::ResponseBody as Body>::Error: Into<Error> + Send,
     S: Stream<Item = ExportSpan> + Unpin,
 {
     debug!("Span exporter running");
@@ -49,8 +49,8 @@ impl<T, S> SpanExporter<T, S>
 where
     T: GrpcService<BoxBody>,
     T::Error: Into<Error>,
-    T::ResponseBody: Default + HttpBody<Data = tonic::codegen::Bytes> + Send + 'static,
-    <T::ResponseBody as HttpBody>::Error: Into<Error> + Send,
+    T::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <T::ResponseBody as Body>::Error: Into<Error> + Send,
     S: Stream<Item = ExportSpan> + Unpin,
 {
     const MAX_BATCH_SIZE: usize = 1000;

--- a/linkerd/opentelemetry/src/lib.rs
+++ b/linkerd/opentelemetry/src/lib.rs
@@ -4,7 +4,7 @@
 pub mod metrics;
 
 use futures::stream::{Stream, StreamExt};
-use http_body::Body as HttpBody;
+use http_body::Body;
 use linkerd_error::Error;
 use linkerd_trace_context as trace_context;
 use metrics::Registry;
@@ -35,8 +35,8 @@ pub async fn export_spans<T, S>(
 ) where
     T: GrpcService<BoxBody> + Clone,
     T::Error: Into<Error>,
-    T::ResponseBody: Default + HttpBody<Data = tonic::codegen::Bytes> + Send + 'static,
-    <T::ResponseBody as HttpBody>::Error: Into<Error> + Send,
+    T::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <T::ResponseBody as Body>::Error: Into<Error> + Send,
     S: Stream<Item = ExportSpan> + Unpin,
 {
     debug!("Span exporter running");
@@ -62,8 +62,8 @@ impl<T, S> SpanExporter<T, S>
 where
     T: GrpcService<BoxBody> + Clone,
     T::Error: Into<Error>,
-    T::ResponseBody: Default + HttpBody<Data = tonic::codegen::Bytes> + Send + 'static,
-    <T::ResponseBody as HttpBody>::Error: Into<Error> + Send,
+    T::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <T::ResponseBody as Body>::Error: Into<Error> + Send,
     S: Stream<Item = ExportSpan> + Unpin,
 {
     const MAX_BATCH_SIZE: usize = 1000;

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -63,7 +63,7 @@ where
     C::Connection: Unpin + Send,
     C::Metadata: Send,
     C::Future: Unpin + Send + 'static,
-    B: hyper::body::HttpBody + Send + 'static,
+    B: crate::Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<Error> + Send + Sync,
 {
@@ -123,7 +123,7 @@ where
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
     C::Error: Into<Error>,
-    B: hyper::body::HttpBody + Send + 'static,
+    B: crate::Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<Error> + Send + Sync,
 {

--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -70,7 +70,7 @@ where
     C: MakeConnection<(crate::Version, T)> + Clone + Send + Sync + 'static,
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
-    B: hyper::body::HttpBody + Send + 'static,
+    B: crate::Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<Error> + Send + Sync,
 {

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -1,6 +1,5 @@
-use crate::TracingExecutor;
+use crate::{Body, TracingExecutor};
 use futures::prelude::*;
-use hyper::body::HttpBody;
 use linkerd_error::{Error, Result};
 use linkerd_stack::{MakeConnection, Service};
 use std::{
@@ -56,7 +55,7 @@ where
     C::Connection: Send + Unpin + 'static,
     C::Metadata: Send,
     C::Future: Send + 'static,
-    B: HttpBody + Send + 'static,
+    B: Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<Error> + Send + Sync,
 {
@@ -144,7 +143,7 @@ where
 
 impl<B> tower::Service<http::Request<B>> for Connection<B>
 where
-    B: HttpBody + Send + 'static,
+    B: Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<Error> + Send + Sync,
 {

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -35,7 +35,7 @@ pub use http::{
     header::{self, HeaderMap, HeaderName, HeaderValue},
     uri, Method, Request, Response, StatusCode,
 };
-pub use hyper::body::HttpBody;
+pub use http_body::Body;
 pub use linkerd_http_box::{BoxBody, BoxRequest, BoxResponse, EraseResponse};
 pub use linkerd_http_classify as classify;
 pub use linkerd_http_executor::TracingExecutor;

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -1,7 +1,6 @@
-use super::{h1, h2};
+use super::{h1, h2, Body};
 use futures::prelude::*;
 use http::header::{HeaderValue, TRANSFER_ENCODING};
-use hyper::body::HttpBody;
 use linkerd_error::{Error, Result};
 use linkerd_http_box::BoxBody;
 use linkerd_stack::{layer, MakeConnection, Service};
@@ -56,7 +55,7 @@ where
     C: MakeConnection<(crate::Version, T)> + Clone + Send + Sync + 'static,
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
-    B: hyper::body::HttpBody + Send + 'static,
+    B: crate::Body + Send + 'static,
     B::Data: Send,
     B::Error: Into<Error> + Send + Sync,
 {
@@ -198,7 +197,7 @@ fn test_downgrade_h2_error() {
 
 // === impl UpgradeResponseBody ===
 
-impl HttpBody for UpgradeResponseBody {
+impl Body for UpgradeResponseBody {
     type Data = bytes::Bytes;
     type Error = Error;
 
@@ -227,7 +226,7 @@ impl HttpBody for UpgradeResponseBody {
 
     #[inline]
     fn size_hint(&self) -> http_body::SizeHint {
-        HttpBody::size_hint(&self.inner)
+        Body::size_hint(&self.inner)
     }
 }
 

--- a/linkerd/proxy/http/src/server/tests.rs
+++ b/linkerd/proxy/http/src/server/tests.rs
@@ -1,9 +1,9 @@
 use std::vec;
 
 use super::*;
+use crate::Body;
 use bytes::Bytes;
 use futures::FutureExt;
-use http_body::Body;
 use linkerd_stack::CloneParam;
 use tokio::time;
 use tower::ServiceExt;

--- a/linkerd/proxy/spire-client/src/api.rs
+++ b/linkerd/proxy/spire-client/src/api.rs
@@ -116,8 +116,8 @@ impl<S> Api<S>
 where
     S: tonic::client::GrpcService<tonic::body::BoxBody> + Clone,
     S::Error: Into<Error>,
-    S::ResponseBody: Default + http::HttpBody<Data = tonic::codegen::Bytes> + Send + 'static,
-    <S::ResponseBody as http::HttpBody>::Error: Into<Error> + Send,
+    S::ResponseBody: Default + http::Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <S::ResponseBody as http::Body>::Error: Into<Error> + Send,
 {
     pub fn watch(client: S, backoff: ExponentialBackoff) -> Watch<S> {
         let client = Client::new(client);
@@ -129,8 +129,8 @@ impl<S> Service<()> for Api<S>
 where
     S: tonic::client::GrpcService<tonic::body::BoxBody> + Clone,
     S: Clone + Send + Sync + 'static,
-    S::ResponseBody: Default + http::HttpBody<Data = tonic::codegen::Bytes> + Send + 'static,
-    <S::ResponseBody as http::HttpBody>::Error: Into<Error> + Send,
+    S::ResponseBody: Default + http::Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    <S::ResponseBody as http::Body>::Error: Into<Error> + Send,
     S::Future: Send + 'static,
 {
     type Response =

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
+bytes = "1"
 http = { workspace = true }
+http-body = { workspace = true }
 hyper = { workspace = true, features = ["backports", "deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.10"

--- a/linkerd/proxy/tap/src/grpc/server.rs
+++ b/linkerd/proxy/tap/src/grpc/server.rs
@@ -1,8 +1,9 @@
 use super::match_::Match;
 use crate::{iface, Inspect, Registry};
+use bytes::Buf;
 use futures::ready;
 use futures::stream::Stream;
-use hyper::body::{Buf, HttpBody};
+use http_body::Body;
 use linkerd2_proxy_api::{http_types, tap as api};
 use linkerd_conditional::Conditional;
 use linkerd_proxy_http::HasH2Reason;
@@ -236,7 +237,7 @@ impl iface::Tap for Tap {
         inspect: &I,
     ) -> Option<(TapRequestPayload, TapResponse)>
     where
-        B: HttpBody,
+        B: Body,
         I: Inspect,
     {
         let shared = self.shared.upgrade()?;
@@ -346,7 +347,7 @@ impl iface::Tap for Tap {
 impl iface::TapResponse for TapResponse {
     type TapPayload = TapResponsePayload;
 
-    fn tap<B: HttpBody>(self, rsp: &http::Response<B>) -> TapResponsePayload {
+    fn tap<B: Body>(self, rsp: &http::Response<B>) -> TapResponsePayload {
         let response_init_at = Instant::now();
 
         let headers = if self.extract_headers {

--- a/linkerd/proxy/tap/src/lib.rs
+++ b/linkerd/proxy/tap/src/lib.rs
@@ -72,7 +72,7 @@ pub trait Inspect {
 /// for Registry/Layer/grpc, but need not be implemented outside of the `tap`
 /// module.
 mod iface {
-    use hyper::body::{Buf, HttpBody};
+    use bytes::Buf;
     use linkerd_proxy_http::HasH2Reason;
 
     pub trait Tap: Clone {
@@ -87,7 +87,7 @@ mod iface {
         ///
         /// If the tap cannot be initialized, for instance because the tap has
         /// completed or been canceled, then `None` is returned.
-        fn tap<B: HttpBody, I: super::Inspect>(
+        fn tap<B: http_body::Body, I: super::Inspect>(
             &mut self,
             req: &http::Request<B>,
             inspect: &I,
@@ -106,7 +106,7 @@ mod iface {
         type TapPayload: TapPayload;
 
         /// Record a response and obtain a handle to tap its body.
-        fn tap<B: HttpBody>(self, rsp: &http::Response<B>) -> Self::TapPayload;
+        fn tap<B: http_body::Body>(self, rsp: &http::Response<B>) -> Self::TapPayload;
 
         /// Record a service failure.
         fn fail<E: HasH2Reason>(self, error: &E);


### PR DESCRIPTION
this is an incremental step away from hyper 0.14's request and response
body interfaces, and towards the 1.0 body types. see
<https://github.com/linkerd/linkerd2/issues/8733> for more information
about upgrading to hyper 1.0.

hyper 0.14 provides a `hyper::body::Body` that is removed in the 1.0
interface. `hyper-util` now provides a workable default body type. hyper
0.14 reëxports `http_body::Body` as `HttpBody`. hyper 1.0 reëxports this
trait as `hyper::body::Body` without any renaming.

this commit moves application code away from hyper's legacy `Body` type
and the `HttpBody` trait alias. this commit moves assorted interfaces
towards the boxed `BoxBody` type instead. when possible, code is tweaked
such that it refers to the reëxport in `linkerd-proxy-http`, rather than
directly through `hyper`.

NB: this commit is based upon https://github.com/linkerd/linkerd2-proxy/pull/3466.