### PR TITLE
feat(http/box): `BoxBody::empty()` creates an empty body

### DIFF
--- a/linkerd/http/box/src/body.rs
+++ b/linkerd/http/box/src/body.rs
@@ -39,6 +39,13 @@ impl BoxBody {
             inner: Box::pin(Inner(inner)),
         }
     }
+
+    /// Returns an empty [`BoxBody`].
+    ///
+    /// This is an alias for [`BoxBody::default()`].
+    pub fn empty() -> Self {
+        Self::default()
+    }
 }
 
 impl Body for BoxBody {


### PR DESCRIPTION
hyper 0.14's body type provides an `empty()` method that can be used to construct an empty request or response body.

this commit proposes an equivalent method for `BoxBody`. while it is semantically equivalent to `BoxBody::default()`, it can be helpful to clarify that this constructs an empty body.

<https://docs.rs/hyper/0.14.31/hyper/body/struct.Body.html#method.empty>

see https://github.com/linkerd/linkerd2/issues/8733.