### PR TITLE
Change default trace protocol to OpenTelemetry

### DIFF
--- a/linkerd/app/core/src/http_tracing.rs
+++ b/linkerd/app/core/src/http_tracing.rs
@@ -10,8 +10,8 @@ use tokio::sync::mpsc;
 
 #[derive(Debug, Copy, Clone, Default)]
 pub enum CollectorProtocol {
-    #[default]
     OpenCensus,
+    #[default]
     OpenTelemetry,
 }
 


### PR DESCRIPTION
Now that OpenTelemetry has been available for a few releases, we should enable it as the default to begin to phase out OpenCensus.

This sets the default protocol for the proxy, we'll need to make the corresponding changes to the control plane as well.