### PR TITLE
chore(hyper): upgrade to hyper 0.14.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,8 +942,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
-source = "git+https://github.com/hyperium/hyper.git?rev=a24f0c0a#a24f0c0af8e1f4c6b7cc3a47c83eb6e4af88aca6"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,15 +99,7 @@ lto = true
 [workspace.dependencies]
 http = { version = "0.2" }
 http-body = { version = "0.4" }
-hyper = { version = "0.14", default-features = false }
+hyper = { version = "0.14.32", default-features = false }
 linkerd2-proxy-api = "0.15.0"
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging"] }
 # linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "main" }
-
-# NB: hyperium/hyper#3796 backports the server connection builder's
-# `max_pending_accept_reset_streams()` method. once released, we can depend on
-# 0.14.32 or later, but until then will point our hyper dependency to the
-# commit in the 0.14 branch.
-[patch.'crates-io'.hyper]
-git = "https://github.com/hyperium/hyper.git"
-rev = "a24f0c0a"

--- a/deny.toml
+++ b/deny.toml
@@ -71,5 +71,4 @@ skip-tree = [
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-allow-git = ["https://github.com/hyperium/hyper.git"]
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
this commit upgrades to hyper 0.14.32, removing the manifest's `[patch]` section.

hyperium/hyper#3796 backported a method we use when building http/2 connections. #3457 patched the workspace to rely on a git dependency of hyper at commit `a24f0c0a`. this work has been released in version 0.14.32.

this commit also changes `deny.toml`, removing the exception we carved out for hyper in #3457.

for more information, see:

* hyperium/hyper#3796
* linkerd/linkerd2#8733
* https://github.com/hyperium/hyper/commits/0.14.x
* #3457
* 03f55779