### PR TITLE
chore(cargo.toml): define more workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,8 @@ http = { version = "0.2" }
 http-body = { version = "0.4" }
 hyper = { version = "0.14", default-features = false }
 linkerd2-proxy-api = "0.15.0"
+prost = { version = "0.12" }
+prost-types = { version = "0.12" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging"] }
 # linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "main" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ lto = true
 
 [workspace.dependencies]
 bytes = { version = "1" }
+h2 = { version = "0.3" }
 http = { version = "0.2" }
 http-body = { version = "0.4" }
 hyper = { version = "0.14", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,8 @@ linkerd2-proxy-api = "0.15.0"
 prost = { version = "0.12" }
 prost-types = { version = "0.12" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging"] }
+tonic = { version = "0.10", default-features = false }
+tonic-build = { version = "0.10", default-features = false }
 # linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "main" }
 
 # NB: hyperium/hyper#3796 backports the server connection builder's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,13 +102,16 @@ h2 = { version = "0.3" }
 http = { version = "0.2" }
 http-body = { version = "0.4" }
 hyper = { version = "0.14", default-features = false }
-linkerd2-proxy-api = "0.15.0"
 prost = { version = "0.12" }
 prost-types = { version = "0.12" }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging"] }
 tonic = { version = "0.10", default-features = false }
 tonic-build = { version = "0.10", default-features = false }
-# linkerd2-proxy-api = { git = "https://github.com/linkerd/linkerd2-proxy-api.git", branch = "main" }
+
+[workspace.dependencies.linkerd2-proxy-api]
+version = "0.15.0"
+# git = "https://github.com/linkerd/linkerd2-proxy-api.git"
+# branch = "main"
 
 # NB: hyperium/hyper#3796 backports the server connection builder's
 # `max_pending_accept_reset_streams()` method. once released, we can depend on

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ debug = 1
 lto = true
 
 [workspace.dependencies]
+bytes = { version = "1" }
 http = { version = "0.2" }
 http-body = { version = "0.4" }
 hyper = { version = "0.14", default-features = false }

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -32,6 +32,6 @@ regex = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["rt"] }
 tokio-stream = { version = "0.1", features = ["time", "sync"] }
-tonic = { version = "0.10", default-features = false, features = ["prost"] }
+tonic = { workspace = true, default-features = false, features = ["prost"] }
 tower = "0.4"
 tracing = "0.1"

--- a/linkerd/app/admin/Cargo.toml
+++ b/linkerd/app/admin/Cargo.toml
@@ -15,7 +15,7 @@ pprof = ["deflate", "dep:pprof"]
 log-streaming = ["linkerd-tracing/stream"]
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 deflate = { version = "1", optional = true, features = ["gzip"] }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "sync", "parking_lot"] }
 tokio-stream = { version = "0.1", features = ["time"] }
-tonic = { version = "0.10", default-features = false, features = ["prost"] }
+tonic = { workspace = true, default-features = false, features = ["prost"] }
 tracing = "0.1"
 parking_lot = "0.12"
 pin-project = "1"

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -13,7 +13,7 @@ independently of the inbound and outbound proxy logic.
 """
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 drain = { version = "0.1", features = ["retain"] }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -16,7 +16,7 @@ linkerd-proxy-client-policy = { path = "../../proxy/client-policy" }
 once_cell = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
-tonic = { version = "0.10", default-features = false }
+tonic = { workspace = true, default-features = false }
 tower = { version = "0.4", default-features = false }
 tracing = "0.1"
 

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -18,7 +18,7 @@ test-util = [
 ]
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 http = { workspace = true }
 futures = { version = "0.3", default-features = false }
 linkerd-app-core = { path = "../core" }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -36,7 +36,7 @@ parking_lot = "0.12"
 rangemap = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
-tonic = { version = "0.10", default-features = false }
+tonic = { workspace = true, default-features = false }
 tower = { version = "0.4", features = ["util"] }
 tracing = "0.1"
 

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -17,7 +17,7 @@ default = []
 flakey = []
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 futures = { version = "0.3", default-features = false, features = ["executor"] }
 h2 = "0.3"
 http = { workspace = true }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -19,7 +19,7 @@ flakey = []
 [dependencies]
 bytes = { workspace = true }
 futures = { version = "0.3", default-features = false, features = ["executor"] }
-h2 = "0.3"
+h2 = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 hyper = { workspace = true, features = [

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -50,7 +50,7 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-rustls = { workspace = true }
 rustls-pemfile = "2.2"
 tower = { version = "0.4", default-features = false }
-tonic = { version = "0.10", features = ["transport"], default-features = false }
+tonic = { workspace = true, features = ["transport"], default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "fmt",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -29,7 +29,7 @@ pin-project = "1"
 prometheus-client = "0.22"
 thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
-tonic = { version = "0.10", default-features = false }
+tonic = { workspace = true, default-features = false }
 tower = { version = "0.4", features = ["util"] }
 tracing = "0.1"
 

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -19,7 +19,7 @@ prometheus-client-rust-242 = [] # TODO
 
 [dependencies]
 ahash = "0.8"
-bytes = "1"
+bytes = { workspace = true }
 http = { workspace = true }
 futures = { version = "0.3", default-features = false }
 linkerd2-proxy-api = { workspace = true, features = ["outbound"] }

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -14,7 +14,7 @@ client-policy = ["linkerd-proxy-client-policy", "tonic", "linkerd-http-route"]
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-h2 = "0.3"
+h2 = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -29,7 +29,7 @@ regex = "1"
 tokio = { version = "1", features = ["io-util", "net", "rt", "sync"] }
 tokio-test = "0.4"
 tokio-stream = { version = "0.1", features = ["sync"] }
-tonic = { version = "0.10", default-features = false, optional = true }
+tonic = { workspace = true, default-features = false, optional = true }
 tower = { version = "0.4", default-features = false }
 tracing = "0.1"
 thiserror = "2"

--- a/linkerd/detect/Cargo.toml
+++ b/linkerd/detect/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-bytes = "1"
+bytes = { workspace = true }
 linkerd-error = { path = "../error" }
 linkerd-io = { path = "../io" }
 linkerd-stack = { path = "../stack" }

--- a/linkerd/duplex/Cargo.toml
+++ b/linkerd/duplex/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["io-util"] }
 pin-project = "1"

--- a/linkerd/http/box/Cargo.toml
+++ b/linkerd/http/box/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/linkerd/http/metrics/Cargo.toml
+++ b/linkerd/http/metrics/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 test-util = []
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/linkerd/http/prom/Cargo.toml
+++ b/linkerd/http/prom/Cargo.toml
@@ -13,7 +13,7 @@ Tower middleware for Prometheus metrics.
 test-util = []
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/linkerd/http/retry/Cargo.toml
+++ b/linkerd/http/retry/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 http-body = { workspace = true }
 http = { workspace = true }

--- a/linkerd/http/upgrade/Cargo.toml
+++ b/linkerd/http/upgrade/Cargo.toml
@@ -10,7 +10,7 @@ Facilities for HTTP/1 upgrades.
 """
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 drain = "0.1"
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }

--- a/linkerd/io/Cargo.toml
+++ b/linkerd/io/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 [dependencies]
 async-trait = "0.1"
 futures = { version = "0.3", default-features = false }
-bytes = "1"
+bytes = { workspace = true }
 linkerd-errno = { path = "../errno" }
 tokio = { version = "1", features = ["io-util", "net"] }
 tokio-test = { version = "0.4", optional = true }

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -14,7 +14,7 @@ linkerd-error = { path = "../error" }
 linkerd-metrics = { path = "../metrics" }
 linkerd-trace-context = { path = "../trace-context" }
 opencensus-proto = { path = "../../opencensus-proto" }
-tonic = { version = "0.10", default-features = false, features = [
+tonic = { workspace = true, default-features = false, features = [
     "prost",
     "codegen",
 ] }

--- a/linkerd/opentelemetry/Cargo.toml
+++ b/linkerd/opentelemetry/Cargo.toml
@@ -16,7 +16,7 @@ linkerd-trace-context = { path = "../trace-context" }
 opentelemetry = { version = "0.27", default-features = false, features = ["trace"] }
 opentelemetry_sdk = { version = "0.27", default-features = false, features = ["trace"] }
 opentelemetry-proto = { path = "../../opentelemetry-proto" }
-tonic = { version = "0.10", default-features = false, features = [
+tonic = { workspace = true, default-features = false, features = [
     "prost",
     "codegen",
 ] }

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -23,7 +23,7 @@ linkerd-identity = { path = "../../identity" }
 http = { workspace = true }
 http-body = { workspace = true }
 pin-project = "1"
-prost = "0.12"
+prost = { workspace = true }
 tonic = { version = "0.10", default-features = false }
 tower = { version = "0.4", default-features = false }
 tracing = "0.1"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -24,6 +24,6 @@ http = { workspace = true }
 http-body = { workspace = true }
 pin-project = "1"
 prost = { workspace = true }
-tonic = { version = "0.10", default-features = false }
+tonic = { workspace = true, default-features = false }
 tower = { version = "0.4", default-features = false }
 tracing = "0.1"

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -21,7 +21,7 @@ ipnet = "2"
 http = { workspace = true }
 once_cell = { version = "1" }
 prost-types = { workspace = true, optional = true }
-tonic = { version = "0.10", default-features = false }
+tonic = { workspace = true, default-features = false }
 thiserror = { version = "2", optional = true }
 
 linkerd-error = { path = "../../error" }

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -20,7 +20,7 @@ ahash = "0.8"
 ipnet = "2"
 http = { workspace = true }
 once_cell = { version = "1" }
-prost-types = { version = "0.12", optional = true }
+prost-types = { workspace = true, optional = true }
 tonic = { version = "0.10", default-features = false }
 thiserror = { version = "2", optional = true }
 

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -13,7 +13,7 @@ This should probably be decomposed into smaller, decoupled crates.
 
 [dependencies]
 async-trait = "0.1"
-bytes = "1"
+bytes = { workspace = true }
 drain = "0.1"
 futures = { version = "0.3", default-features = false }
 h2 = "0.3"

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1"
 bytes = { workspace = true }
 drain = "0.1"
 futures = { version = "0.3", default-features = false }
-h2 = "0.3"
+h2 = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 httparse = "1"

--- a/linkerd/proxy/identity-client/Cargo.toml
+++ b/linkerd/proxy/identity-client/Cargo.toml
@@ -18,6 +18,6 @@ parking_lot = "0.12"
 pin-project = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["time", "sync"] }
-tonic = { version = "0.10", default-features = false }
+tonic = { workspace = true, default-features = false }
 tracing = "0.1"
 http-body = { workspace = true }

--- a/linkerd/proxy/server-policy/Cargo.toml
+++ b/linkerd/proxy/server-policy/Cargo.toml
@@ -14,7 +14,7 @@ test-util = []
 governor = { version = "0.8", default-features = false, features = ["std"] }
 ipnet = "2"
 http = { workspace = true }
-prost-types = { version = "0.12", optional = true }
+prost-types = { workspace = true, optional = true }
 thiserror = "2"
 
 linkerd-http-route = { path = "../../http/route" }

--- a/linkerd/proxy/spire-client/Cargo.toml
+++ b/linkerd/proxy/spire-client/Cargo.toml
@@ -16,7 +16,7 @@ linkerd-tonic-watch = { path = "../../tonic-watch" }
 linkerd-exp-backoff = { path = "../../exp-backoff" }
 linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["time", "sync"] }
-tonic = "0.10"
+tonic = { workspace = true }
 tower = "0.4"
 tracing = "0.1"
 x509-parser = "0.16.0"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -27,7 +27,7 @@ rand = { version = "0.8" }
 thiserror = "2"
 tokio = { version = "1", features = ["time"] }
 tower = { version = "0.4", default-features = false }
-tonic = { version = "0.10", default-features = false }
+tonic = { workspace = true, default-features = false }
 tracing = "0.1"
 pin-project = "1"
 

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 hyper = { workspace = true, features = ["backports", "deprecated", "http1", "http2"] }

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -22,7 +22,7 @@ linkerd-proxy-http = { path = "../http" }
 linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }
 parking_lot = "0.12"
-prost-types = "0.12"
+prost-types = { workspace = true }
 rand = { version = "0.8" }
 thiserror = "2"
 tokio = { version = "1", features = ["time"] }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -16,7 +16,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 linkerd2-proxy-api = { workspace = true, features = ["destination"] }
 once_cell = "1.20"
-prost-types = "0.12"
+prost-types = { workspace = true }
 regex = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -20,7 +20,7 @@ prost-types = { workspace = true }
 regex = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tonic = { version = "0.10", default-features = false }
+tonic = { workspace = true, default-features = false }
 tower = { version = "0.4.13", features = ["retry", "util"] }
 thiserror = "2"
 tracing = "0.1"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -10,7 +10,7 @@ Implements client layers for Linkerd ServiceProfiles.
 """
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-bytes = "1"
+bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 linkerd-conditional = { path = "../conditional" }
 linkerd-dns-name = { path = "../dns/name" }

--- a/linkerd/tonic-stream/Cargo.toml
+++ b/linkerd/tonic-stream/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 futures = { version = "0.3", default-features = false }
 linkerd-stack = { path = "../stack" }
 pin-project = "1"
-tonic = { version = "0.10", default-features = false }
+tonic = { workspace = true, default-features = false }
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
 

--- a/linkerd/tonic-watch/Cargo.toml
+++ b/linkerd/tonic-watch/Cargo.toml
@@ -13,7 +13,7 @@ Provides a utility for creating robust watches from a service that returns a str
 futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
-tonic = { version = "0.10", default-features = false }
+tonic = { workspace = true, default-features = false }
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tracing = "0.1"
 

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 base64 = "0.13"
-bytes = "1"
+bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 hex = "0.4"
 http = { workspace = true }

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -14,7 +14,7 @@ linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }
 linkerd-io = { path = "../io" }
 linkerd-stack = { path = "../stack" }
-prost = "0.12"
+prost = { workspace = true }
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
 

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 async-trait = "0.1"
-bytes = "1"
+bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }

--- a/opencensus-proto/Cargo.toml
+++ b/opencensus-proto/Cargo.toml
@@ -12,7 +12,7 @@ Vendored from https://github.com/census-instrumentation/opencensus-proto/.
 """
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 

--- a/opencensus-proto/Cargo.toml
+++ b/opencensus-proto/Cargo.toml
@@ -13,8 +13,8 @@ Vendored from https://github.com/census-instrumentation/opencensus-proto/.
 
 [dependencies]
 bytes = "1"
-prost = "0.12"
-prost-types = "0.12"
+prost = { workspace = true }
+prost-types = { workspace = true }
 
 [dependencies.tonic]
 version = "0.10"

--- a/opencensus-proto/Cargo.toml
+++ b/opencensus-proto/Cargo.toml
@@ -17,12 +17,12 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 
 [dependencies.tonic]
-version = "0.10"
+workspace = true
 default-features = false
 features = ["prost", "codegen"]
 
 [dev-dependencies.tonic-build]
-version = "0.10"
+workspace = true
 default-features = false
 features = ["prost"]
 

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -12,14 +12,14 @@ Vendored from https://github.com/open-telemetry/opentelemetry-rust/.
 """
 
 [dependencies]
-tonic = { version = "0.10", features = ["codegen", "prost", "transport"] }
+tonic = { workspace = true, features = ["codegen", "prost", "transport"] }
 prost = { workspace = true }
 opentelemetry = { version = "0.27", default-features = false, features = ["trace"] }
 opentelemetry_sdk = { version = "0.27", default-features = false, features = ["trace"] }
 
 [dev-dependencies]
 opentelemetry = { version = "0.27", default-features = false, features = ["trace", "testing"] }
-tonic-build = { version = "0.10", default-features = false, features = ["prost"] }
+tonic-build = { workspace = true, default-features = false, features = ["prost"] }
 
 [lib]
 doctest = false

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -13,7 +13,7 @@ Vendored from https://github.com/open-telemetry/opentelemetry-rust/.
 
 [dependencies]
 tonic = { version = "0.10", features = ["codegen", "prost", "transport"] }
-prost = "0.12"
+prost = { workspace = true }
 opentelemetry = { version = "0.27", default-features = false, features = ["trace"] }
 opentelemetry_sdk = { version = "0.27", default-features = false, features = ["trace"] }
 

--- a/spiffe-proto/Cargo.toml
+++ b/spiffe-proto/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bytes = "1"
+bytes = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 

--- a/spiffe-proto/Cargo.toml
+++ b/spiffe-proto/Cargo.toml
@@ -12,12 +12,12 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 
 [dependencies.tonic]
-version = "0.10"
+workspace = true
 default-features = false
 features = ["prost", "codegen"]
 
 [dev-dependencies.tonic-build]
-version = "0.10"
+workspace = true
 default-features = false
 features = ["prost"]
 

--- a/spiffe-proto/Cargo.toml
+++ b/spiffe-proto/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [dependencies]
 bytes = "1"
-prost = "0.12"
-prost-types = "0.12"
+prost = { workspace = true }
+prost-types = { workspace = true }
 
 [dependencies.tonic]
 version = "0.10"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -6,6 +6,6 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies.tonic-build]
-version = "0.10"
+workspace = true
 default-features = false
 features = ["prost"]


### PR DESCRIPTION
in linkerd/linkerd2#8733, we're tracking work to upgrade to hyper 1.0.

when upgrading from 0.14 to 1.0, some related crates that depend on `hyper`, `http`, and `http-body` must also be upgraded as well. in linkerd/linkerd2-proxy-api#421, as part of the upgrade to hyper 1.0 we additionally bump the following:

* `h2`: 0.3 -> 0.4
* `http`: 0.2 -> 1.2
* `prost`: 0.12 -> 0.13
* `prost-types`: 0.12 -> 0.13
* `tonic`: 0.10 -> 0.12
* `tonic-build`: 0.10 -> 0.12

unlike linkerd2-proxy-api, the linkerd2-proxy repository is a particularly large cargo workspace. as a consequence of this, bumping these crates across our cargo workspace is a particularly noisy and involved change today. there are ~35 distinct package manifests that need to be changed!

to help ease development, future maintenance, and review of impending hyper upgrade changes, this branch consolidates all of the above into workspace dependencies. no changes to the lockfile are made because this branch does not affect the dependency graph of the project.

this follows from #3456 and #3466, which did this for `hyper`, `http`, and `http-body`. for more information, see:

* #3456
* #3466
* linkerd/linkerd2#8733