### PR TITLE
refactor(app/core): build.rs prints invalid proxy version

### DIFF
--- a/linkerd/app/core/build.rs
+++ b/linkerd/app/core/build.rs
@@ -14,8 +14,8 @@ fn set_env(name: &str, cmd: &mut Command) {
 fn version() -> String {
     if let Ok(v) = std::env::var("LINKERD2_PROXY_VERSION") {
         if !v.is_empty() {
-            if semver::Version::parse(&v).is_err() {
-                panic!("LINKERD2_PROXY_VERSION must be semver");
+            if let Err(err) = semver::Version::parse(&v) {
+                panic!("LINKERD2_PROXY_VERSION must be semver: version='{v}' error='{err}'");
             }
             return v;
         }


### PR DESCRIPTION
if this build script panics due to an invalid proxy version environment variable, the panic can be somewhat cryptic. a message saying `LINKERD2_PROXY_VERSION must be semver` is printed, but the proxy version that caused this is not shown.

this commit adds the version and the error to this panic message.

now, building with an invalid proxy version provides us with the following:

```
; LINKERD2_PROXY_VERSION='invalid' cargo build -p linkerd-app-core
   Compiling linkerd-app-core v0.1.0 (/linkerd2-proxy/linkerd/app/core)
error: failed to run custom build command for `linkerd-app-core v0.1.0 (/linkerd2-proxy/linkerd/app/core)`
note: To improve backtraces for build dependencies, set the CARGO_PROFILE_DEV_BUILD_OVERRIDE_DEBUG=true environment variable to enable debug information generation.

Caused by:
  process didn't exit successfully: `/linkerd2-proxy/target/debug/build/linkerd-app-core-756fc82028bfbcc0/build-script-build` (exit status: 101)
  --- stdout
  cargo:rustc-env=GIT_SHA=e53b6b9d

  cargo:rustc-env=LINKERD2_PROXY_BUILD_DATE=2024-12-20T01:18:08Z

  --- stderr
  thread 'main' panicked at linkerd/app/core/build.rs:18:17:
  LINKERD2_PROXY_VERSION must be semver: version='invalid' error='unexpected character 'i' while parsing major version number'
```