### PR TITLE
Include pod UID and container name as optional trace labels

### DIFF
--- a/linkerd/app/src/env/trace.rs
+++ b/linkerd/app/src/env/trace.rs
@@ -14,6 +14,10 @@ pub(super) fn read_trace_attributes(path: &std::path::Path) -> HashMap<String, S
     }
 }
 
+pub(super) fn parse_env_trace_attributes(attrs: &str) -> HashMap<String, String> {
+    parse_attrs(attrs)
+}
+
 fn parse_attrs(attrs: &str) -> HashMap<String, String> {
     attrs
         .lines()


### PR DESCRIPTION
It's useful to include these fields in the trace span attributes to help correlate traffic within a cluster.

This propagates these labels through the trace initialization, similar to how we handle the service name (and other labels that last for the entire pod lifetime).

See https://github.com/linkerd/linkerd2/pull/13501 for the corresponding control plane change.