### PR TITLE
chore: bump dev from v44 to v45

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"DEV_VERSION": "v44",
+			"DEV_VERSION": "v45",
 			"http_proxy": "${localEnv:http_proxy}",
 			"https_proxy": "${localEnv:https_proxy}"
 		}
@@ -42,7 +42,7 @@
 	"overrideCommand": false,
 	"remoteUser": "code",
 	"containerEnv": {
-		"CXX": "clang++-14",
+		"CXX": "clang++-19",
 		"RUSTFLAGS": "--cfg tokio_unstable"
 	},
 	"mounts": [

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -22,8 +22,8 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v44-rust
+    runs-on: ubuntu-24.04
+    container: ghcr.io/linkerd/dev:v45-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   meta:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - id: changed
@@ -40,13 +40,13 @@ jobs:
   codecov:
     needs: meta
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.meta.outputs.any_changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     container:
-      image: docker://ghcr.io/linkerd/dev:v44-rust
+      image: docker://ghcr.io/linkerd/dev:v45-rust
       options: --security-opt seccomp=unconfined # 🤷
     env:
-      CXX: "/usr/bin/clang++-14"
+      CXX: "/usr/bin/clang++-19"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: Swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   list-changed:
     timeout-minutes: 3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: docker://rust:1.83.0
     steps:
       - run: apt update && apt install -y jo
@@ -47,7 +47,7 @@ jobs:
   build:
     needs: [list-changed]
     timeout-minutes: 40
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: docker://rust:1.83.0
     strategy:
       matrix:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   markdownlint:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: DavidAnson/markdownlint-cli2-action@a23dae216ce3fee4db69da41fed90d2a4af801cf

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,8 +22,8 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v44-rust
+    runs-on: ubuntu-24.04
+    container: ghcr.io/linkerd/dev:v45-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   meta:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - id: build
@@ -57,7 +57,7 @@ jobs:
   info:
     timeout-minutes: 3
     needs: meta
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Info
         run: |
@@ -74,9 +74,9 @@ jobs:
   actions:
     needs: meta
     if: needs.meta.outputs.actions_changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v44
+      - uses: linkerd/dev/actions/setup-tools@v45
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: just action-lint
       - run: just action-dev-check
@@ -84,8 +84,8 @@ jobs:
   rust:
     needs: meta
     if: needs.meta.outputs.cargo_changed == 'true' || needs.meta.outputs.rust_changed == 'true'
-    runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v44-rust
+    runs-on: ubuntu-24.04
+    container: ghcr.io/linkerd/dev:v45-rust
     permissions:
       contents: read
     timeout-minutes: 20
@@ -110,8 +110,8 @@ jobs:
     needs: meta
     if: needs.meta.outputs.cargo_changed == 'true'
     timeout-minutes: 20
-    runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v44-rust
+    runs-on: ubuntu-24.04
+    container: ghcr.io/linkerd/dev:v45-rust
     strategy:
       matrix:
         crate: ${{ fromJson(needs.meta.outputs.cargo_crates) }}
@@ -126,11 +126,11 @@ jobs:
     needs: meta
     if: needs.meta.outputs.cargo_changed == 'true' || needs.meta.outputs.rust_changed == 'true'
     timeout-minutes: 20
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       WAIT_TIMEOUT: 2m
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v44
+      - uses: linkerd/dev/actions/setup-tools@v45
       - name: scurl https://run.linkerd.io/install-edge | sh
         run: |
           scurl https://run.linkerd.io/install-edge | sh
@@ -152,7 +152,7 @@ jobs:
     timeout-minutes: 3
     needs: [meta, actions, rust, rust-crates, linkerd-install]
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     permissions:
       contents: write

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   last-release:
     if: github.repository == 'linkerd/linkerd2-proxy' # Don't run this in forks.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     env:
       GH_REPO: ${{ github.repository }}
@@ -41,7 +41,7 @@ jobs:
 
   last-commit:
     needs: last-release
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -62,7 +62,7 @@ jobs:
   trigger-release:
     needs: [last-release, last-commit]
     if: needs.last-release.outputs.recent == 'false' && needs.last-commit.outputs.after-release == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       actions: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ concurrency:
 jobs:
   meta:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: meta
         env:
@@ -105,7 +105,7 @@ jobs:
 
   info:
     needs: meta
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 3
     steps:
       - name: Inputs
@@ -131,9 +131,9 @@ jobs:
     # If we're not actually building on a release tag, don't short-circuit on
     # errors. This helps us know whether a failure is platform-specific.
     continue-on-error: ${{ needs.meta.outputs.publish != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 40
-    container: docker://ghcr.io/linkerd/dev:v44-rust-musl
+    container: docker://ghcr.io/linkerd/dev:v45-rust-musl
     env:
       LINKERD2_PROXY_VENDOR: ${{ github.repository_owner }}
       LINKERD2_PROXY_VERSION: ${{ needs.meta.outputs.version }}
@@ -157,7 +157,7 @@ jobs:
 
   publish:
     needs: [meta, package]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions:
       actions: write
@@ -212,7 +212,7 @@ jobs:
     needs: publish
     if: always()
     timeout-minutes: 3
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Results
         run: |

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,8 +13,8 @@ on:
 jobs:
   sh-lint:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v44
+      - uses: linkerd/dev/actions/setup-tools@v45
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: just sh-lint

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -13,8 +13,8 @@ permissions:
 
 jobs:
   devcontainer:
-    runs-on: ubuntu-latest
-    container: ghcr.io/linkerd/dev:v44-rust
+    runs-on: ubuntu-24.04
+    container: ghcr.io/linkerd/dev:v45-rust
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033
@@ -35,9 +35,9 @@ jobs:
 
 
   workflows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: linkerd/dev/actions/setup-tools@v44
+      - uses: linkerd/dev/actions/setup-tools@v45
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - shell: bash
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # This is intended **DEVELOPMENT ONLY**, i.e. so that proxy developers can
 # easily test the proxy in the context of the larger `linkerd2` project.
 
-ARG RUST_IMAGE=ghcr.io/linkerd/dev:v44-rust
+ARG RUST_IMAGE=ghcr.io/linkerd/dev:v45-rust
 
 # Use an arbitrary ~recent edge release image to get the proxy
 # identity-initializing and linkerd-await wrappers.

--- a/justfile
+++ b/justfile
@@ -59,7 +59,7 @@ _features := if features == "all" {
 
 wait-timeout := env_var_or_default("WAIT_TIMEOUT", "1m")
 
-export CXX := 'clang++-14'
+export CXX := 'clang++-19'
 
 #
 # Recipes


### PR DESCRIPTION
Updates LLVM from 14 to 19.

We pin ubuntu to 24.04 to ensure compatibility.