### PR TITLE
refactor(http/upgrade): internal interfaces are private

### DIFF
--- a/linkerd/http/upgrade/src/glue.rs
+++ b/linkerd/http/upgrade/src/glue.rs
@@ -22,7 +22,7 @@ pub struct UpgradeBody<B = BoxBody> {
     /// to be inserted into the Http11Upgrade half.
     #[pin]
     body: B,
-    pub(super) upgrade: Option<(Http11Upgrade, hyper::upgrade::OnUpgrade)>,
+    upgrade: Option<(Http11Upgrade, hyper::upgrade::OnUpgrade)>,
 }
 
 /// Glue for any `tokio_connect::Connect` to implement `hyper::client::Connect`.

--- a/linkerd/http/upgrade/src/glue.rs
+++ b/linkerd/http/upgrade/src/glue.rs
@@ -113,7 +113,10 @@ impl<B: Default> Default for UpgradeBody<B> {
 }
 
 impl<B> UpgradeBody<B> {
-    pub fn new(body: B, upgrade: Option<(Http11Upgrade, hyper::upgrade::OnUpgrade)>) -> Self {
+    pub(crate) fn new(
+        body: B,
+        upgrade: Option<(Http11Upgrade, hyper::upgrade::OnUpgrade)>,
+    ) -> Self {
         Self { body, upgrade }
     }
 }

--- a/linkerd/http/upgrade/src/upgrade.rs
+++ b/linkerd/http/upgrade/src/upgrade.rs
@@ -32,11 +32,11 @@ pub struct Http11Upgrade {
 /// A named "tuple" returned by `Http11Upgade::new()` of the two halves of
 /// an upgrade.
 #[derive(Debug)]
-pub struct Http11UpgradeHalves {
+struct Http11UpgradeHalves {
     /// The "server" half.
-    pub server: Http11Upgrade,
+    server: Http11Upgrade,
     /// The "client" half.
-    pub client: Http11Upgrade,
+    client: Http11Upgrade,
 }
 
 /// A marker type inserted into Extensions to signal it was an HTTP CONNECT

--- a/linkerd/http/upgrade/src/upgrade.rs
+++ b/linkerd/http/upgrade/src/upgrade.rs
@@ -70,7 +70,7 @@ impl Http11Upgrade {
     ///
     /// Each handle is used to insert 1 half of the upgrade. When both handles
     /// have inserted, the upgrade future will be spawned onto the executor.
-    pub fn halves(upgrade_drain_signal: drain::Watch) -> Http11UpgradeHalves {
+    fn halves(upgrade_drain_signal: drain::Watch) -> Http11UpgradeHalves {
         let inner = Arc::new(Inner {
             server: TryLock::new(None),
             client: TryLock::new(None),

--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -170,7 +170,7 @@ where
 }
 
 /// Checks responses to determine if they are successful HTTP upgrades.
-pub(crate) fn is_upgrade<B>(res: &http::Response<B>) -> bool {
+fn is_upgrade<B>(res: &http::Response<B>) -> bool {
     #[inline]
     fn is_connect_success<B>(res: &http::Response<B>) -> bool {
         res.extensions().get::<HttpConnect>().is_some() && res.status().is_success()


### PR DESCRIPTION
the `linkerd-http-upgrade` crate supports HTTP/1.1 upgrades. currently, it exposes a number of functions and types in its public interface that are strictly internal helpers. this branch redefines various interfaces and fields as private, to clarify the public interface of the crate.