### PR TITLE
identity: add named pipe support for spire client

### DIFF
--- a/linkerd/app/src/identity.rs
+++ b/linkerd/app/src/identity.rs
@@ -109,7 +109,7 @@ impl Config {
                 }
             }
             Self::Spire { client, tls } => {
-                let addr = client.socket_addr.clone();
+                let addr = client.workload_api_addr.clone();
                 let spire = spire::client::Spire::new(tls.id.clone());
 
                 let (store, receiver, ready) = watch(tls, metrics.cert)?;

--- a/linkerd/app/src/spire.rs
+++ b/linkerd/app/src/spire.rs
@@ -1,21 +1,19 @@
 use linkerd_app_core::{exp_backoff::ExponentialBackoff, Error};
 use std::sync::Arc;
-use tokio::net::UnixStream;
 use tokio::sync::watch;
 use tonic::transport::{Endpoint, Uri};
 
 pub use linkerd_app_core::identity::client::spire as client;
 
-const UNIX_PREFIX: &str = "unix:";
 const TONIC_DEFAULT_URI: &str = "http://[::]:50051";
 
 #[derive(Clone, Debug)]
 pub struct Config {
-    pub socket_addr: Arc<String>,
+    pub workload_api_addr: Arc<String>,
     pub backoff: ExponentialBackoff,
 }
 
-// Connects to SPIRE workload API via Unix Domain Socket
+// Connects to SPIRE workload API
 pub struct Client {
     config: Config,
 }
@@ -41,23 +39,39 @@ impl tower::Service<()> for Client {
     }
 
     fn call(&mut self, _req: ()) -> Self::Future {
-        let socket = self.config.socket_addr.clone();
+        let addr = self.config.workload_api_addr.clone();
         let backoff = self.config.backoff;
         Box::pin(async move {
-            // Strip the 'unix:' prefix for tonic compatibility.
-            let stripped_path = socket
-                .strip_prefix(UNIX_PREFIX)
-                .unwrap_or(socket.as_str())
-                .to_string();
-
             // We will ignore this uri because uds do not use it
             // if your connector does use the uri it will be provided
             // as the request to the `MakeConnection`.
-            let chan = Endpoint::try_from(TONIC_DEFAULT_URI)?
-                .connect_with_connector(tower::util::service_fn(move |_: Uri| {
-                    UnixStream::connect(stripped_path.clone())
-                }))
-                .await?;
+            let chan =
+                Endpoint::try_from(TONIC_DEFAULT_URI)?
+                    .connect_with_connector(tower::util::service_fn(move |_: Uri| {
+                        #[cfg(unix)]
+                        {
+                            use tokio::net::UnixStream;
+                            const UNIX_PREFIX: &str = "unix:";
+
+                            // Strip the 'unix:' prefix for tonic compatibility.
+                            let socket_path = addr
+                                .strip_prefix(UNIX_PREFIX)
+                                .unwrap_or(addr.as_str())
+                                .to_string();
+
+                            UnixStream::connect(socket_path.clone())
+                        }
+
+                        #[cfg(windows)]
+                        {
+                            use tokio::net::windows::named_pipe;
+                            let named_pipe_path = addr.clone();
+                            async move {
+                                named_pipe::ClientOptions::new().open(named_pipe_path.as_str())
+                            }
+                        }
+                    }))
+                    .await?;
 
             let api = client::Api::watch(chan, backoff);
             let receiver = api.spawn_watch(()).await?;


### PR DESCRIPTION
This change does two things: 
- adds support for `NamedPipes` to our SPIRE client. This will allow the client to connect to spire agents running on Windows hosts
- renames the `LINKERD2_PROXY_IDENTITY_SPIRE_SOCKET` to `LINKERD2_PROXY_IDENTITY_SPIRE_WORKLOAD_API_ADDRESS` and deprecates the former.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>