### PR TITLE
transport: fix wrong type in non-linux orig_dst_* method

### DIFF
--- a/linkerd/proxy/transport/src/orig_dst.rs
+++ b/linkerd/proxy/transport/src/orig_dst.rs
@@ -118,7 +118,7 @@ fn orig_dst_addr_v6(sock: &TcpStream) -> io::Result<SocketAddr> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn orig_dst_addr_v4(_: &TcpStream) -> io::Result<OrigDstAddr> {
+fn orig_dst_addr_v4(_: &TcpStream) -> io::Result<SocketAddr> {
     Err(io::Error::new(
         io::ErrorKind::Other,
         "SO_ORIGINAL_DST not supported on this operating system",
@@ -126,7 +126,7 @@ fn orig_dst_addr_v4(_: &TcpStream) -> io::Result<OrigDstAddr> {
 }
 
 #[cfg(not(target_os = "linux"))]
-fn orig_dst_addr_v6(_: &TcpStream) -> io::Result<OrigDstAddr> {
+fn orig_dst_addr_v6(_: &TcpStream) -> io::Result<SocketAddr> {
     Err(io::Error::new(
         io::ErrorKind::Other,
         "SO_ORIGINAL_DST not supported on this operating system",


### PR DESCRIPTION
Fixes a discrepancy between the types used for non Linux vs the types used for Linux based builds in our orig_dst code.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>