### PR TITLE
metrics: remove authority label on inbound http metrics

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -269,7 +269,6 @@ impl Param<metrics::EndpointLabels> for Permitted {
     fn param(&self) -> metrics::EndpointLabels {
         metrics::InboundEndpointLabels {
             tls: self.http.tcp.tls.clone(),
-            authority: None,
             target_addr: self.http.tcp.addr.into(),
             policy: self.permit.labels.clone(),
         }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -66,7 +66,6 @@ pub enum EndpointLabels {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct InboundEndpointLabels {
     pub tls: tls::ConditionalServerTls,
-    pub authority: Option<http::uri::Authority>,
     pub target_addr: SocketAddr,
     pub policy: RouteAuthzLabels,
 }
@@ -317,11 +316,6 @@ impl FmtLabels for EndpointLabels {
 
 impl FmtLabels for InboundEndpointLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(a) = self.authority.as_ref() {
-            Authority(a).fmt_labels(f)?;
-            write!(f, ",")?;
-        }
-
         (
             (TargetAddr(self.target_addr), TlsAccept::from(&self.tls)),
             &self.policy,

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -391,7 +391,6 @@ impl Param<metrics::EndpointLabels> for Logical {
     fn param(&self) -> metrics::EndpointLabels {
         metrics::InboundEndpointLabels {
             tls: self.tls.clone(),
-            authority: self.logical.as_ref().map(|d| d.as_http_authority()),
             target_addr: self.addr.into(),
             policy: self.permit.labels.clone(),
         }

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -646,7 +646,6 @@ async fn grpc_response_class() {
         .get_response_total(
             &metrics::EndpointLabels::Inbound(metrics::InboundEndpointLabels {
                 tls: Target::meshed_h2().1,
-                authority: Some("foo.svc.cluster.local:5550".parse().unwrap()),
                 target_addr: "127.0.0.1:80".parse().unwrap(),
                 policy: metrics::RouteAuthzLabels {
                     route: metrics::RouteLabels {

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -57,9 +57,7 @@ impl Fixture {
         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
         let tcp_dst_labels = metrics::labels().label("direction", "inbound");
         let tcp_src_labels = tcp_dst_labels.clone().label("target_addr", orig_dst);
-        let labels = tcp_dst_labels
-            .clone()
-            .label("authority", "tele.test.svc.cluster.local");
+        let labels = tcp_dst_labels.clone().label("target_port", orig_dst.port());
         let tcp_src_labels = tcp_src_labels.label("peer", "src");
         let tcp_dst_labels = tcp_dst_labels.label("peer", "dst");
         Fixture {


### PR DESCRIPTION
This change removes the `authority` label on inbound HTTP requests. 

The label is derived from the Host headers on inbound HTTP requests. This means
that the presence of this label can be exploited by a malicious client in order to produce
unbounded increase in the cardinality of the metrics reported in the proxy by sending
a large amount of HTTP requests with random `Host` headers.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>