### PR TITLE
chore(http): rename http/version to http/variant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1855,7 +1855,7 @@ dependencies = [
  "linkerd-duplex",
  "linkerd-error",
  "linkerd-http-box",
- "linkerd-http-version",
+ "linkerd-http-variant",
  "linkerd-io",
  "linkerd-stack",
  "pin-project",
@@ -1866,7 +1866,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "linkerd-http-version"
+name = "linkerd-http-variant"
 version = "0.1.0"
 dependencies = [
  "http",
@@ -2241,7 +2241,7 @@ dependencies = [
  "linkerd-http-retain",
  "linkerd-http-stream-timeouts",
  "linkerd-http-upgrade",
- "linkerd-http-version",
+ "linkerd-http-variant",
  "linkerd-io",
  "linkerd-proxy-balance",
  "linkerd-stack",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ members = [
     "linkerd/http/route",
     "linkerd/http/stream-timeouts",
     "linkerd/http/upgrade",
-    "linkerd/http/version",
+    "linkerd/http/variant",
     "linkerd/identity",
     "linkerd/idle-cache",
     "linkerd/io",

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -52,7 +52,7 @@ struct Tcp {
 #[derive(Clone, Debug)]
 struct Http {
     tcp: Tcp,
-    version: http::Version,
+    version: http::Variant,
 }
 
 #[derive(Clone, Debug)]
@@ -136,7 +136,7 @@ impl Config {
             }))
             .push_filter(
                 |(http, tcp): (
-                    Result<Option<http::Version>, detect::DetectTimeoutError<_>>,
+                    Result<Option<http::Variant>, detect::DetectTimeoutError<_>>,
                     Tcp,
                 )| {
                     match http {
@@ -150,10 +150,10 @@ impl Config {
                         //   confused/stale.
                         Err(_timeout) => {
                             let version = match tcp.tls {
-                                tls::ConditionalServerTls::None(_) => http::Version::Http1,
+                                tls::ConditionalServerTls::None(_) => http::Variant::Http1,
                                 tls::ConditionalServerTls::Some(tls::ServerTls::Established {
                                     ..
-                                }) => http::Version::H2,
+                                }) => http::Variant::H2,
                                 tls::ConditionalServerTls::Some(tls::ServerTls::Passthru {
                                     sni,
                                 }) => {
@@ -219,8 +219,8 @@ impl Param<transport::labels::Key> for Tcp {
 
 // === impl Http ===
 
-impl Param<http::Version> for Http {
-    fn param(&self) -> http::Version {
+impl Param<http::Variant> for Http {
+    fn param(&self) -> http::Variant {
         self.version
     }
 }

--- a/linkerd/app/gateway/src/http.rs
+++ b/linkerd/app/gateway/src/http.rs
@@ -28,7 +28,7 @@ pub(crate) use self::gateway::NewHttpGateway;
 pub struct Target<T = ()> {
     addr: GatewayAddr,
     routes: watch::Receiver<outbound::http::Routes>,
-    version: http::Version,
+    version: http::Variant,
     parent: T,
 }
 
@@ -74,7 +74,7 @@ impl Gateway {
         T: svc::Param<tls::ClientId>,
         T: svc::Param<inbound::policy::AllowPolicy>,
         T: svc::Param<Option<watch::Receiver<profiles::Profile>>>,
-        T: svc::Param<http::Version>,
+        T: svc::Param<http::Variant>,
         T: svc::Param<http::normalize_uri::DefaultAuthority>,
         T: Clone + Send + Sync + Unpin + 'static,
         // Endpoint resolution.
@@ -164,7 +164,7 @@ fn mk_routes(profile: &profiles::Profile) -> Option<outbound::http::Routes> {
 
 impl<B, T: Clone> svc::router::SelectRoute<http::Request<B>> for ByRequestVersion<T> {
     type Key = Target<T>;
-    type Error = http::version::Unsupported;
+    type Error = http::UnsupportedVariant;
 
     fn select(&self, req: &http::Request<B>) -> Result<Self::Key, Self::Error> {
         let mut t = self.0.clone();
@@ -192,8 +192,8 @@ impl<T> svc::Param<GatewayAddr> for Target<T> {
     }
 }
 
-impl<T> svc::Param<http::Version> for Target<T> {
-    fn param(&self) -> http::Version {
+impl<T> svc::Param<http::Variant> for Target<T> {
+    fn param(&self) -> http::Variant {
         self.version
     }
 }

--- a/linkerd/app/gateway/src/http/tests.rs
+++ b/linkerd/app/gateway/src/http/tests.rs
@@ -98,9 +98,9 @@ async fn upgraded_request_remains_relative_form() {
         }
     }
 
-    impl svc::Param<http::Version> for Target {
-        fn param(&self) -> http::Version {
-            http::Version::H2
+    impl svc::Param<http::Variant> for Target {
+        fn param(&self) -> http::Variant {
+            http::Variant::H2
         }
     }
 

--- a/linkerd/app/gateway/src/server.rs
+++ b/linkerd/app/gateway/src/server.rs
@@ -11,7 +11,7 @@ use tokio::sync::watch;
 /// Target for HTTP stacks.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Http<T> {
-    version: http::Version,
+    version: http::Variant,
     parent: outbound::Discovery<T>,
 }
 
@@ -61,8 +61,8 @@ impl Gateway {
                 |parent: outbound::Discovery<T>| -> Result<_, GatewayDomainInvalid> {
                     if let Some(proto) = (*parent).param() {
                         let version = match proto {
-                            SessionProtocol::Http1 => http::Version::Http1,
-                            SessionProtocol::Http2 => http::Version::H2,
+                            SessionProtocol::Http1 => http::Variant::Http1,
+                            SessionProtocol::Http2 => http::Variant::H2,
                         };
                         return Ok(svc::Either::A(Http { parent, version }));
                     }
@@ -154,8 +154,8 @@ impl<T> std::ops::Deref for Http<T> {
     }
 }
 
-impl<T> svc::Param<http::Version> for Http<T> {
-    fn param(&self) -> http::Version {
+impl<T> svc::Param<http::Variant> for Http<T> {
+    fn param(&self) -> http::Variant {
         self.version
     }
 }

--- a/linkerd/app/inbound/src/detect.rs
+++ b/linkerd/app/inbound/src/detect.rs
@@ -31,7 +31,7 @@ pub(crate) struct Forward {
 #[derive(Clone, Debug)]
 pub(crate) struct Http {
     tls: Tls,
-    http: http::Version,
+    http: http::Variant,
 }
 
 #[derive(Clone, Debug)]
@@ -128,7 +128,7 @@ impl Inbound<svc::ArcNewTcp<Http, io::BoxedIo>> {
                                     // proxy handle the protocol error if we're in an edge case.
                                     info!(%timeout, "Handling connection as HTTP/1 due to policy");
                                     Ok(svc::Either::A(Http {
-                                        http: http::Version::Http1,
+                                        http: http::Variant::Http1,
                                         tls,
                                     }))
                                 }
@@ -174,8 +174,8 @@ impl Inbound<svc::ArcNewTcp<Http, io::BoxedIo>> {
                             }
                             // Unmeshed services don't use protocol upgrading, so we can use the
                             // hint without further detection.
-                            Protocol::Http1 { .. } => http::Version::Http1,
-                            Protocol::Http2 { .. } | Protocol::Grpc { .. } => http::Version::H2,
+                            Protocol::Http1 { .. } => http::Variant::Http1,
+                            Protocol::Http2 { .. } | Protocol::Grpc { .. } => http::Variant::H2,
                             _ => unreachable!("opaque protocols must not hit the HTTP stack"),
                         };
                         Ok(svc::Either::A(Http { http, tls }))
@@ -342,8 +342,8 @@ impl svc::ExtractParam<detect::Config<http::DetectHttp>, Detect> for ConfigureHt
 
 // === impl Http ===
 
-impl svc::Param<http::Version> for Http {
-    fn param(&self) -> http::Version {
+impl svc::Param<http::Variant> for Http {
+    fn param(&self) -> http::Variant {
         self.http
     }
 }

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -347,11 +347,11 @@ impl svc::Param<policy::AllowPolicy> for LocalHttp {
     }
 }
 
-impl svc::Param<http::Version> for LocalHttp {
-    fn param(&self) -> http::Version {
+impl svc::Param<http::Variant> for LocalHttp {
+    fn param(&self) -> http::Variant {
         match self.protocol {
-            SessionProtocol::Http1 => http::Version::Http1,
-            SessionProtocol::Http2 => http::Version::H2,
+            SessionProtocol::Http1 => http::Variant::Http1,
+            SessionProtocol::Http2 => http::Variant::H2,
         }
     }
 }

--- a/linkerd/app/inbound/src/http.rs
+++ b/linkerd/app/inbound/src/http.rs
@@ -162,12 +162,12 @@ pub mod fuzz {
     }
 
     #[derive(Clone, Debug)]
-    struct Target(http::Version);
+    struct Target(http::Variant);
 
     // === impl Target ===
 
     impl Target {
-        const HTTP1: Self = Self(http::Version::Http1);
+        const HTTP1: Self = Self(http::Variant::Http1);
 
         fn addr() -> SocketAddr {
             ([127, 0, 0, 1], 80).into()
@@ -192,8 +192,8 @@ pub mod fuzz {
         }
     }
 
-    impl svc::Param<http::Version> for Target {
-        fn param(&self) -> http::Version {
+    impl svc::Param<http::Variant> for Target {
+        fn param(&self) -> http::Variant {
             self.0
         }
     }

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -33,7 +33,7 @@ struct Logical {
     /// The request's logical destination. Used for profile discovery.
     logical: Option<NameAddr>,
     addr: Remote<ServerAddr>,
-    http: http::Version,
+    http: http::Variant,
     tls: tls::ConditionalServerTls,
     permit: policy::HttpRoutePermit,
     labels: tap::Labels,
@@ -69,7 +69,7 @@ struct LogicalError {
 impl<C> Inbound<C> {
     pub(crate) fn push_http_router<T, P>(self, profiles: P) -> Inbound<svc::ArcNewCloneHttp<T>>
     where
-        T: Param<http::Version>
+        T: Param<http::Variant>
             + Param<Remote<ServerAddr>>
             + Param<Remote<ClientAddr>>
             + Param<tls::ConditionalServerTls>
@@ -105,8 +105,8 @@ impl<C> Inbound<C> {
                         addr: t.addr,
                         permit: t.permit,
                         params: match t.http {
-                            http::Version::Http1 => http::client::Params::Http1(h1_params),
-                            http::Version::H2 => http::client::Params::H2(h2_params.clone())
+                            http::Variant::Http1 => http::client::Params::Http1(h1_params),
+                            http::Variant::H2 => http::client::Params::H2(h2_params.clone())
                         },
                     }
                 })

--- a/linkerd/app/inbound/src/http/server.rs
+++ b/linkerd/app/inbound/src/http/server.rs
@@ -1,6 +1,6 @@
 use super::set_identity_header::NewSetIdentityHeader;
 use crate::{policy, Inbound};
-pub use linkerd_app_core::proxy::http::{normalize_uri, Version};
+pub use linkerd_app_core::proxy::http::{normalize_uri, Variant};
 use linkerd_app_core::{
     config::ProxyConfig,
     errors, http_tracing, io,
@@ -31,7 +31,7 @@ impl<H> Inbound<H> {
     pub fn push_http_server<T, HSvc>(self) -> Inbound<svc::ArcNewCloneHttp<T>>
     where
         // Connection target.
-        T: Param<Version>
+        T: Param<Variant>
             + Param<normalize_uri::DefaultAuthority>
             + Param<tls::ConditionalServerTls>
             + Param<ServerLabel>
@@ -95,7 +95,7 @@ impl<H> Inbound<H> {
     pub fn push_http_tcp_server<T, I, HSvc>(self) -> Inbound<svc::ArcNewTcp<T, I>>
     where
         // Connection target.
-        T: Param<Version>,
+        T: Param<Variant>,
         T: Clone + Send + Unpin + 'static,
         // Server-side socket.
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -763,7 +763,7 @@ fn connect_timeout() -> Box<dyn FnMut(Remote<ServerAddr>) -> ConnectFuture + Sen
 }
 
 #[derive(Clone, Debug)]
-struct Target(http::Version, tls::ConditionalServerTls);
+struct Target(http::Variant, tls::ConditionalServerTls);
 
 #[track_caller]
 fn check_error_header(hdrs: &::http::HeaderMap, expected: &str) {
@@ -782,17 +782,17 @@ fn check_error_header(hdrs: &::http::HeaderMap, expected: &str) {
 
 impl Target {
     const UNMESHED_HTTP1: Self = Self(
-        http::Version::Http1,
+        http::Variant::Http1,
         tls::ConditionalServerTls::None(tls::NoServerTls::NoClientHello),
     );
     const UNMESHED_H2: Self = Self(
-        http::Version::H2,
+        http::Variant::H2,
         tls::ConditionalServerTls::None(tls::NoServerTls::NoClientHello),
     );
 
     fn meshed_http1() -> Self {
         Self(
-            http::Version::Http1,
+            http::Variant::Http1,
             tls::ConditionalServerTls::Some(tls::ServerTls::Established {
                 client_id: Some(tls::ClientId(
                     "foosa.barns.serviceaccount.identity.linkerd.cluster.local"
@@ -806,7 +806,7 @@ impl Target {
 
     fn meshed_h2() -> Self {
         Self(
-            http::Version::H2,
+            http::Variant::H2,
             tls::ConditionalServerTls::Some(tls::ServerTls::Established {
                 client_id: Some(tls::ClientId(
                     "foosa.barns.serviceaccount.identity.linkerd.cluster.local"
@@ -841,8 +841,8 @@ impl svc::Param<Remote<ClientAddr>> for Target {
     }
 }
 
-impl svc::Param<http::Version> for Target {
-    fn param(&self) -> http::Version {
+impl svc::Param<http::Variant> for Target {
+    fn param(&self) -> http::Variant {
         self.0
     }
 }

--- a/linkerd/app/outbound/src/http.rs
+++ b/linkerd/app/outbound/src/http.rs
@@ -89,7 +89,7 @@ impl<T> Outbound<svc::ArcNewHttp<concrete::Endpoint<logical::Concrete<Http<T>>>>
     pub fn push_http_cached<R>(self, resolve: R) -> Outbound<svc::ArcNewCloneHttp<T>>
     where
         // Logical HTTP target.
-        T: svc::Param<http::Version>,
+        T: svc::Param<http::Variant>,
         T: svc::Param<watch::Receiver<Routes>>,
         T: Clone + Debug + PartialEq + Eq + Hash + Send + Sync + 'static,
         // Endpoint resolution.
@@ -109,11 +109,11 @@ impl<T> Outbound<svc::ArcNewHttp<concrete::Endpoint<logical::Concrete<Http<T>>>>
 
 // === impl Http ===
 
-impl<T> svc::Param<http::Version> for Http<T>
+impl<T> svc::Param<http::Variant> for Http<T>
 where
-    T: svc::Param<http::Version>,
+    T: svc::Param<http::Variant>,
 {
-    fn param(&self) -> http::Version {
+    fn param(&self) -> http::Variant {
         self.0.param()
     }
 }

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -277,23 +277,23 @@ impl<T> svc::Param<tls::ConditionalClientTls> for Endpoint<T> {
     }
 }
 
-impl<T> svc::Param<http::Version> for Endpoint<T>
+impl<T> svc::Param<http::Variant> for Endpoint<T>
 where
-    T: svc::Param<http::Version>,
+    T: svc::Param<http::Variant>,
 {
-    fn param(&self) -> http::Version {
+    fn param(&self) -> http::Variant {
         self.parent.param()
     }
 }
 
 impl<T> svc::Param<client::Params> for Endpoint<T>
 where
-    T: svc::Param<http::Version>,
+    T: svc::Param<http::Variant>,
 {
     fn param(&self) -> client::Params {
         match self.param() {
-            http::Version::H2 => client::Params::H2(self.http2.clone()),
-            http::Version::Http1 => {
+            http::Variant::H2 => client::Params::H2(self.http2.clone()),
+            http::Variant::Http1 => {
                 // When the target is local (i.e. same as source of traffic)
                 // then do not perform a protocol upgrade to HTTP/2
                 if self.is_local {

--- a/linkerd/app/outbound/src/http/endpoint.rs
+++ b/linkerd/app/outbound/src/http/endpoint.rs
@@ -20,7 +20,7 @@ mod tests;
 
 #[derive(Clone, Debug)]
 pub struct Connect<T> {
-    version: http::Version,
+    version: http::Variant,
     inner: T,
 }
 
@@ -191,8 +191,8 @@ where
         }
 
         match self.version {
-            http::Version::Http1 => Some(SessionProtocol::Http1),
-            http::Version::H2 => Some(SessionProtocol::Http2),
+            http::Variant::Http1 => Some(SessionProtocol::Http1),
+            http::Variant::H2 => Some(SessionProtocol::Http2),
         }
     }
 }

--- a/linkerd/app/outbound/src/http/endpoint/tests.rs
+++ b/linkerd/app/outbound/src/http/endpoint/tests.rs
@@ -34,7 +34,7 @@ async fn http11_forward() {
 
     let svc = stack.new_service(Endpoint {
         addr: Remote(ServerAddr(addr)),
-        version: http::Version::Http1,
+        version: http::Variant::Http1,
         hint: ProtocolHint::Unknown,
     });
 
@@ -70,7 +70,7 @@ async fn http2_forward() {
 
     let svc = stack.new_service(Endpoint {
         addr: Remote(ServerAddr(addr)),
-        version: http::Version::H2,
+        version: http::Variant::H2,
         hint: ProtocolHint::Unknown,
     });
 
@@ -108,7 +108,7 @@ async fn orig_proto_upgrade() {
 
     let svc = stack.new_service(Endpoint {
         addr: Remote(ServerAddr(addr)),
-        version: http::Version::Http1,
+        version: http::Variant::Http1,
         hint: ProtocolHint::Http2,
     });
 
@@ -164,7 +164,7 @@ async fn orig_proto_skipped_on_http_upgrade() {
 
     let svc = stack.new_service(Endpoint {
         addr: Remote(ServerAddr(addr)),
-        version: http::Version::Http1,
+        version: http::Variant::Http1,
         hint: ProtocolHint::Http2,
     });
 
@@ -206,7 +206,7 @@ async fn orig_proto_http2_noop() {
 
     let svc = stack.new_service(Endpoint {
         addr: Remote(ServerAddr(addr)),
-        version: http::Version::H2,
+        version: http::Variant::H2,
         hint: ProtocolHint::Http2,
     });
 
@@ -261,7 +261,7 @@ fn serve(version: ::http::Version) -> io::Result<io::BoxedIo> {
 struct Endpoint {
     addr: Remote<ServerAddr>,
     hint: ProtocolHint,
-    version: http::Version,
+    version: http::Variant,
 }
 
 // === impl Endpoint ===
@@ -320,8 +320,8 @@ impl svc::Param<metrics::EndpointLabels> for Endpoint {
     }
 }
 
-impl svc::Param<http::Version> for Endpoint {
-    fn param(&self) -> http::Version {
+impl svc::Param<http::Variant> for Endpoint {
+    fn param(&self) -> http::Variant {
         self.version
     }
 }
@@ -329,8 +329,8 @@ impl svc::Param<http::Version> for Endpoint {
 impl svc::Param<http::client::Params> for Endpoint {
     fn param(&self) -> http::client::Params {
         match self.version {
-            http::Version::H2 => http::client::Params::H2(Default::default()),
-            http::Version::Http1 => match self.hint {
+            http::Variant::H2 => http::client::Params::H2(Default::default()),
+            http::Variant::Http1 => match self.hint {
                 ProtocolHint::Unknown | ProtocolHint::Opaque => {
                     http::client::Params::Http1(http::h1::PoolSettings {
                         max_idle: 1,

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -216,11 +216,11 @@ where
 
 // === impl Concrete ===
 
-impl<T> svc::Param<http::Version> for Concrete<T>
+impl<T> svc::Param<http::Variant> for Concrete<T>
 where
-    T: svc::Param<http::Version>,
+    T: svc::Param<http::Variant>,
 {
-    fn param(&self) -> http::Version {
+    fn param(&self) -> http::Variant {
         self.parent.param()
     }
 }

--- a/linkerd/app/outbound/src/http/logical/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/tests.rs
@@ -26,7 +26,7 @@ type Response = http::Response<http::BoxBody>;
 #[derive(Clone, Debug)]
 struct Target {
     num: usize,
-    version: http::Version,
+    version: http::Variant,
     routes: watch::Receiver<Routes>,
 }
 
@@ -53,8 +53,8 @@ impl std::hash::Hash for Target {
     }
 }
 
-impl svc::Param<http::Version> for Target {
-    fn param(&self) -> http::Version {
+impl svc::Param<http::Variant> for Target {
+    fn param(&self) -> http::Variant {
         self.version
     }
 }
@@ -292,7 +292,7 @@ fn mock(params: policy::Params) -> (svc::BoxCloneHttp, Handle) {
 
     let svc = stack.new_service(Target {
         num: 1,
-        version: http::Version::H2,
+        version: http::Variant::H2,
         routes,
     });
 

--- a/linkerd/app/outbound/src/http/logical/tests/basic.rs
+++ b/linkerd/app/outbound/src/http/logical/tests/basic.rs
@@ -37,7 +37,7 @@ async fn routes() {
         })));
     let target = Target {
         num: 1,
-        version: http::Version::H2,
+        version: http::Variant::H2,
         routes,
     };
     let svc = stack.new_service(target);

--- a/linkerd/app/outbound/src/http/logical/tests/failure_accrual.rs
+++ b/linkerd/app/outbound/src/http/logical/tests/failure_accrual.rs
@@ -57,7 +57,7 @@ async fn consecutive_failures_accrue() {
         })));
     let target = Target {
         num: 1,
-        version: http::Version::H2,
+        version: http::Variant::H2,
         routes,
     };
     let svc = stack.new_service(target);
@@ -219,7 +219,7 @@ async fn balancer_doesnt_select_tripped_breakers() {
         })));
     let target = Target {
         num: 1,
-        version: http::Version::H2,
+        version: http::Variant::H2,
         routes,
     };
     let svc = stack.new_service(target);

--- a/linkerd/app/outbound/src/http/server.rs
+++ b/linkerd/app/outbound/src/http/server.rs
@@ -68,7 +68,7 @@ impl<N> Outbound<N> {
     >
     where
         // Target
-        T: svc::Param<http::Version>,
+        T: svc::Param<http::Variant>,
         T: Clone + Send + Unpin + 'static,
         // Server-side socket
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
@@ -196,7 +196,7 @@ impl errors::HttpRescue<Error> for ServerRescue {
 
 impl<T> svc::ExtractParam<http::ServerParams, T> for ExtractServerParams
 where
-    T: svc::Param<http::Version>,
+    T: svc::Param<http::Variant>,
 {
     #[inline]
     fn extract_param(&self, t: &T) -> http::ServerParams {

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -28,7 +28,7 @@ struct Sidecar {
 #[derive(Clone, Debug)]
 struct HttpSidecar {
     orig_dst: OrigDstAddr,
-    version: http::Version,
+    version: http::Variant,
     routes: watch::Receiver<http::Routes>,
 }
 
@@ -177,7 +177,7 @@ impl std::hash::Hash for Sidecar {
 impl From<protocol::Http<Sidecar>> for HttpSidecar {
     fn from(parent: protocol::Http<Sidecar>) -> Self {
         let orig_dst = parent.orig_dst;
-        let version = svc::Param::<http::Version>::param(&parent);
+        let version = svc::Param::<http::Variant>::param(&parent);
         let mut policy = parent.policy.clone();
 
         if let Some(mut profile) = parent.profile.clone().map(watch::Receiver::from) {
@@ -215,7 +215,7 @@ impl From<protocol::Http<Sidecar>> for HttpSidecar {
 impl HttpSidecar {
     fn mk_policy_routes(
         OrigDstAddr(orig_dst): OrigDstAddr,
-        version: http::Version,
+        version: http::Variant,
         policy: &policy::ClientPolicy,
     ) -> Option<http::Routes> {
         let parent_ref = ParentRef(policy.parent.clone());
@@ -231,8 +231,8 @@ impl HttpSidecar {
                 ref http2,
                 ..
             } => match version {
-                http::Version::Http1 => (http1.routes.clone(), http1.failure_accrual),
-                http::Version::H2 => (http2.routes.clone(), http2.failure_accrual),
+                http::Variant::Http1 => (http1.routes.clone(), http1.failure_accrual),
+                http::Variant::H2 => (http2.routes.clone(), http2.failure_accrual),
             },
             policy::Protocol::Http1(policy::http::Http1 {
                 ref routes,
@@ -284,8 +284,8 @@ impl HttpSidecar {
     }
 }
 
-impl svc::Param<http::Version> for HttpSidecar {
-    fn param(&self) -> http::Version {
+impl svc::Param<http::Variant> for HttpSidecar {
+    fn param(&self) -> http::Variant {
         self.version
     }
 }

--- a/linkerd/http/upgrade/Cargo.toml
+++ b/linkerd/http/upgrade/Cargo.toml
@@ -15,7 +15,10 @@ drain = "0.1"
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
 http-body = { workspace = true }
-hyper = { workspace = true, default-features = false, features = ["deprecated", "client"] }
+hyper = { workspace = true, default-features = false, features = [
+    "deprecated",
+    "client",
+] }
 pin-project = "1"
 tokio = { version = "1", default-features = false }
 tower = { version = "0.4", default-features = false }
@@ -25,6 +28,6 @@ try-lock = "0.2"
 linkerd-duplex = { path = "../../duplex" }
 linkerd-error = { path = "../../error" }
 linkerd-http-box = { path = "../box" }
-linkerd-http-version = { path = "../version" }
+linkerd-http-variant = { path = "../variant" }
 linkerd-io = { path = "../../io" }
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/http/upgrade/src/glue.rs
+++ b/linkerd/http/upgrade/src/glue.rs
@@ -145,7 +145,7 @@ impl<C, T> HyperConnect<C, T> {
 
 impl<C, T> Service<hyper::Uri> for HyperConnect<C, T>
 where
-    C: MakeConnection<(linkerd_http_version::Version, T)> + Clone + Send + Sync,
+    C: MakeConnection<(linkerd_http_variant::Variant, T)> + Clone + Send + Sync,
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
     T: Clone + Send + Sync,
@@ -162,7 +162,7 @@ where
         HyperConnectFuture {
             inner: self
                 .connect
-                .connect((linkerd_http_version::Version::Http1, self.target.clone())),
+                .connect((linkerd_http_variant::Variant::Http1, self.target.clone())),
             absolute_form: self.absolute_form,
         }
     }

--- a/linkerd/http/variant/Cargo.toml
+++ b/linkerd/http/variant/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
-name = "linkerd-http-version"
+name = "linkerd-http-variant"
 version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
 license = "Apache-2.0"
 edition = "2021"
 publish = false

--- a/linkerd/http/variant/src/lib.rs
+++ b/linkerd/http/variant/src/lib.rs
@@ -1,12 +1,12 @@
-//! HTTP version types.
+//! HTTP version variants.
 //!
-//! See [`Version`].
+//! See [`Variant`].
 
 use thiserror::Error;
 
 /// HTTP protocol version.
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Version {
+pub enum Variant {
     /// HTTP/1
     Http1,
     /// HTTP/2
@@ -18,7 +18,7 @@ pub enum Version {
 #[error("unsupported HTTP version {:?}", self.0)]
 pub struct Unsupported(http::Version);
 
-impl std::convert::TryFrom<http::Version> for Version {
+impl std::convert::TryFrom<http::Version> for Variant {
     type Error = Unsupported;
     fn try_from(v: http::Version) -> Result<Self, Unsupported> {
         match v {
@@ -29,7 +29,7 @@ impl std::convert::TryFrom<http::Version> for Version {
     }
 }
 
-impl std::fmt::Debug for Version {
+impl std::fmt::Debug for Variant {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Http1 => write!(f, "HTTP/1"),

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -52,7 +52,7 @@ linkerd-http-override-authority = { path = "../../http/override-authority" }
 linkerd-http-retain = { path = "../../http/retain" }
 linkerd-http-stream-timeouts = { path = "../../http/stream-timeouts" }
 linkerd-http-upgrade = { path = "../../http/upgrade" }
-linkerd-http-version = { path = "../../http/version" }
+linkerd-http-variant = { path = "../../http/variant" }
 linkerd-io = { path = "../../io" }
 linkerd-proxy-balance = { path = "../balance" }
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -59,7 +59,7 @@ impl<X, C, T, B> tower::Service<T> for MakeClient<X, C, B>
 where
     T: Clone + Send + Sync + 'static,
     X: ExtractParam<Params, T>,
-    C: MakeConnection<(crate::Version, T)> + Clone + Unpin + Send + Sync + 'static,
+    C: MakeConnection<(crate::Variant, T)> + Clone + Unpin + Send + Sync + 'static,
     C::Connection: Unpin + Send,
     C::Metadata: Send,
     C::Future: Unpin + Send + 'static,
@@ -119,7 +119,7 @@ type RspFuture = Pin<Box<dyn Future<Output = Result<http::Response<BoxBody>>> + 
 impl<C, T, B> Service<http::Request<B>> for Client<C, T, B>
 where
     T: Clone + Send + Sync + 'static,
-    C: MakeConnection<(crate::Version, T)> + Clone + Send + Sync + 'static,
+    C: MakeConnection<(crate::Variant, T)> + Clone + Send + Sync + 'static,
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
     C::Error: Into<Error>,

--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -67,7 +67,7 @@ type RspFuture = Pin<Box<dyn Future<Output = Result<http::Response<BoxBody>>> + 
 impl<C, T, B> Client<C, T, B>
 where
     T: Clone + Send + Sync + 'static,
-    C: MakeConnection<(crate::Version, T)> + Clone + Send + Sync + 'static,
+    C: MakeConnection<(crate::Variant, T)> + Clone + Send + Sync + 'static,
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
     B: crate::Body + Send + 'static,

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -51,7 +51,7 @@ type ConnectFuture<B> = Pin<Box<dyn Future<Output = Result<Connection<B>>> + Sen
 
 impl<C, B, T> Service<T> for Connect<C, B>
 where
-    C: MakeConnection<(crate::Version, T)>,
+    C: MakeConnection<(crate::Variant, T)>,
     C::Connection: Send + Unpin + 'static,
     C::Metadata: Send,
     C::Future: Send + 'static,
@@ -79,7 +79,7 @@ where
 
         let connect = self
             .connect
-            .connect((crate::Version::H2, target))
+            .connect((crate::Variant::H2, target))
             .instrument(trace_span!("connect").or_current());
 
         Box::pin(

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -44,7 +44,7 @@ pub use linkerd_http_override_authority::{AuthorityOverride, NewOverrideAuthorit
 pub use linkerd_http_retain::{self as retain, Retain};
 pub use linkerd_http_stream_timeouts::{self as stream_timeouts, EnforceTimeouts, StreamTimeouts};
 pub use linkerd_http_upgrade as upgrade;
-pub use linkerd_http_version::{self as version, Version};
+pub use linkerd_http_variant::{Unsupported as UnsupportedVariant, Variant};
 
 #[derive(Clone, Debug)]
 pub struct HeaderPair(pub HeaderName, pub HeaderValue);

--- a/linkerd/proxy/http/src/orig_proto.rs
+++ b/linkerd/proxy/http/src/orig_proto.rs
@@ -53,7 +53,7 @@ impl<C, T, B> Upgrade<C, T, B> {
 impl<C, T, B> Service<http::Request<B>> for Upgrade<C, T, B>
 where
     T: Clone + Send + Sync + 'static,
-    C: MakeConnection<(crate::Version, T)> + Clone + Send + Sync + 'static,
+    C: MakeConnection<(crate::Variant, T)> + Clone + Send + Sync + 'static,
     C::Connection: Unpin + Send,
     C::Future: Unpin + Send + 'static,
     B: crate::Body + Send + 'static,

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -1,5 +1,5 @@
 use crate::{
-    client_handle::SetClientHandle, h2, BoxBody, BoxRequest, ClientHandle, TracingExecutor, Version,
+    client_handle::SetClientHandle, h2, BoxBody, BoxRequest, ClientHandle, TracingExecutor, Variant,
 };
 use linkerd_error::Error;
 use linkerd_io::{self as io, PeerAddr};
@@ -18,7 +18,7 @@ mod tests;
 /// Configures HTTP server behavior.
 #[derive(Clone, Debug)]
 pub struct Params {
-    pub version: Version,
+    pub version: Variant,
     pub http2: h2::ServerParams,
     pub drain: drain::Watch,
 }
@@ -33,7 +33,7 @@ pub struct NewServeHttp<X, N> {
 /// Serves HTTP connections with an inner service.
 #[derive(Clone, Debug)]
 pub struct ServeHttp<N> {
-    version: Version,
+    version: Variant,
     http1: hyper::server::conn::http1::Builder,
     http2: hyper::server::conn::http2::Builder<TracingExecutor>,
     inner: N,
@@ -160,7 +160,7 @@ where
                 let (svc, closed) = res?;
                 debug!(?version, "Handling as HTTP");
                 match version {
-                    Version::Http1 => {
+                    Variant::Http1 => {
                         // Enable support for HTTP upgrades (CONNECT and websockets).
                         let svc = linkerd_http_upgrade::upgrade::Service::new(
                             BoxRequest::new(svc),
@@ -186,7 +186,7 @@ where
                         }
                     }
 
-                    Version::H2 => {
+                    Variant::H2 => {
                         let mut conn = http2.serve_connection(io, BoxRequest::new(svc));
 
                         tokio::select! {

--- a/linkerd/proxy/http/src/server/tests.rs
+++ b/linkerd/proxy/http/src/server/tests.rs
@@ -189,7 +189,7 @@ impl TestServer {
     ) -> Self {
         let params = Params {
             drain: drain(),
-            version: Version::H2,
+            version: Variant::H2,
             http2: h2,
         };
 


### PR DESCRIPTION
The proxy::http::Version type is very similar to the HTTP crate's Version type, though it is more constrained so that the proxy may exhaustively match on it. This change renames the module to http::variant to avoid confusion with the HTTP crate's Version type.

To disambiguate the HTTP version type, the proxy::http::Version type is renamed to proxy::http::Variant.