### PR TITLE
feat(http/retry): add a unit test suite to `PeekTrailersBody<B>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,6 +1806,7 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tracing",
  "parking_lot",
+ "pin-project",
  "thiserror 2.0.11",
  "tokio",
  "tower",

--- a/linkerd/http/retry/Cargo.toml
+++ b/linkerd/http/retry/Cargo.toml
@@ -12,6 +12,7 @@ futures = { version = "0.3", default-features = false }
 http-body = { workspace = true }
 http = { workspace = true }
 parking_lot = "0.12"
+pin-project = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.4", features = ["retry"] }
 tracing = "0.1"

--- a/linkerd/http/retry/src/peek_trailers.rs
+++ b/linkerd/http/retry/src/peek_trailers.rs
@@ -16,6 +16,9 @@ use std::{
 /// If the first frame of the body stream was *not* a `TRAILERS` frame, this
 /// behaves identically to a normal body.
 pub struct PeekTrailersBody<B: Body = BoxBody> {
+    /// The inner [`Body`].
+    ///
+    /// This is the request or response body whose trailers are being peeked.
     inner: B,
 
     /// The first DATA frame received from the inner body, or an error that
@@ -46,6 +49,10 @@ pub type WithPeekTrailersBody<B> = Either<
 // === impl WithTrailers ===
 
 impl<B: Body> PeekTrailersBody<B> {
+    /// Returns a reference to the body's trailers, if available.
+    ///
+    /// This function will return `None` if the body's trailers could not be peeked, or if there
+    /// were no trailers included.
     pub fn peek_trailers(&self) -> Option<&http::HeaderMap> {
         self.trailers
             .as_ref()
@@ -116,6 +123,9 @@ impl<B: Body> PeekTrailersBody<B> {
         http::Response::from_parts(parts, body)
     }
 
+    /// Returns a response with an inert [`PeekTrailersBody<B>`].
+    ///
+    /// This will not peek the inner body's trailers.
     fn no_trailers(rsp: http::Response<B>) -> http::Response<Self> {
         rsp.map(|inner| Self {
             inner,

--- a/linkerd/http/retry/src/peek_trailers.rs
+++ b/linkerd/http/retry/src/peek_trailers.rs
@@ -212,3 +212,185 @@ where
         hint
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::PeekTrailersBody;
+    use bytes::Bytes;
+    use http::{HeaderMap, HeaderValue};
+    use http_body::Body;
+    use linkerd_error::Error;
+    use std::{
+        collections::VecDeque,
+        ops::Not,
+        pin::Pin,
+        task::{Context, Poll},
+    };
+
+    /// A "mock" body.
+    ///
+    /// This type contains polling results for [`Body`].
+    #[derive(Default)]
+    struct MockBody {
+        data_polls: VecDeque<Poll<Option<Result<Bytes, Error>>>>,
+        trailer_polls: VecDeque<Poll<Result<Option<http::HeaderMap>, Error>>>,
+    }
+
+    fn data() -> Option<Result<Bytes, Error>> {
+        let bytes = Bytes::from_static(b"hello");
+        Some(Ok(bytes))
+    }
+
+    fn trailers() -> Result<Option<http::HeaderMap>, Error> {
+        let mut trls = HeaderMap::with_capacity(1);
+        let value = HeaderValue::from_static("shiny");
+        trls.insert("trailer", value);
+        Ok(Some(trls))
+    }
+
+    #[tokio::test]
+    async fn cannot_peek_empty() {
+        let (_guard, _handle) = linkerd_tracing::test::trace_init();
+        let empty = MockBody::default();
+        let peek = PeekTrailersBody::read_body(empty).await;
+        assert!(peek.peek_trailers().is_none());
+        // TODO(kate): this will not return `true`.
+        // assert!(peek.is_end_stream());
+    }
+
+    #[tokio::test]
+    async fn peeks_only_trailers() {
+        let (_guard, _handle) = linkerd_tracing::test::trace_init();
+        let only_trailers = MockBody::default().then_yield_trailer(Poll::Ready(trailers()));
+        let peek = PeekTrailersBody::read_body(only_trailers).await;
+        assert!(peek.peek_trailers().is_some());
+        assert!(peek.is_end_stream().not());
+    }
+
+    #[tokio::test]
+    async fn peeks_one_frame_with_immediate_trailers() {
+        let (_guard, _handle) = linkerd_tracing::test::trace_init();
+        let body = MockBody::default()
+            .then_yield_data(Poll::Ready(data()))
+            .then_yield_trailer(Poll::Ready(trailers()));
+        let peek = PeekTrailersBody::read_body(body).await;
+        assert!(peek.peek_trailers().is_some());
+        assert!(peek.is_end_stream().not());
+    }
+
+    #[tokio::test]
+    async fn cannot_peek_one_frame_with_eventual_trailers() {
+        let (_guard, _handle) = linkerd_tracing::test::trace_init();
+        let body = MockBody::default()
+            .then_yield_data(Poll::Ready(data()))
+            .then_yield_trailer(Poll::Pending)
+            .then_yield_trailer(Poll::Ready(trailers()));
+        let peek = PeekTrailersBody::read_body(body).await;
+        assert!(peek.peek_trailers().is_none());
+        assert!(peek.is_end_stream().not());
+    }
+
+    #[tokio::test]
+    async fn peeks_one_eventual_frame_with_immediate_trailers() {
+        let (_guard, _handle) = linkerd_tracing::test::trace_init();
+        let body = MockBody::default()
+            .then_yield_data(Poll::Pending)
+            .then_yield_data(Poll::Ready(data()))
+            .then_yield_trailer(Poll::Ready(trailers()));
+        let peek = PeekTrailersBody::read_body(body).await;
+        assert!(peek.peek_trailers().is_some());
+        assert!(peek.is_end_stream().not());
+    }
+
+    #[tokio::test]
+    async fn cannot_peek_two_frames_with_immediate_trailers() {
+        let (_guard, _handle) = linkerd_tracing::test::trace_init();
+        let body = MockBody::default()
+            .then_yield_data(Poll::Ready(data()))
+            .then_yield_data(Poll::Ready(data()))
+            .then_yield_trailer(Poll::Ready(trailers()));
+        let peek = PeekTrailersBody::read_body(body).await;
+        assert!(peek.peek_trailers().is_none());
+        assert!(peek.is_end_stream().not());
+    }
+
+    // === impl MockBody ===
+
+    impl MockBody {
+        /// Appends a poll outcome for [`Body::poll_data()`].
+        fn then_yield_data(mut self, poll: Poll<Option<Result<Bytes, Error>>>) -> Self {
+            self.data_polls.push_back(poll);
+            self
+        }
+
+        /// Appends a poll outcome for [`Body::poll_trailers()`].
+        fn then_yield_trailer(
+            mut self,
+            poll: Poll<Result<Option<http::HeaderMap>, Error>>,
+        ) -> Self {
+            self.trailer_polls.push_back(poll);
+            self
+        }
+
+        /// Schedules a task to be awoken.
+        fn schedule(cx: &Context<'_>) {
+            let waker = cx.waker().clone();
+            tokio::spawn(async move {
+                waker.wake();
+            });
+        }
+    }
+
+    impl Body for MockBody {
+        type Data = Bytes;
+        type Error = Error;
+
+        fn poll_data(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Option<Result<Self::Data, Self::Error>>> {
+            let poll = self
+                .get_mut()
+                .data_polls
+                .pop_front()
+                .unwrap_or(Poll::Ready(None));
+            // If we return `Poll::Pending`, we must schedule the task to be awoken.
+            if poll.is_pending() {
+                Self::schedule(cx);
+            }
+            poll
+        }
+
+        fn poll_trailers(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<Option<http::HeaderMap>, Self::Error>> {
+            let Self {
+                data_polls,
+                trailer_polls,
+            } = self.get_mut();
+
+            let poll = if data_polls.is_empty() {
+                trailer_polls.pop_front().unwrap_or(Poll::Ready(Ok(None)))
+            } else {
+                // If the data frames have not all been yielded, yield `Pending`.
+                //
+                // TODO(kate): this arm should panic. it indicates `PeekTrailersBody<B>` isn't
+                // respecting the contract outlined in
+                // <https://docs.rs/http-body/0.4.6/http_body/trait.Body.html#tymethod.poll_trailers>.
+                Poll::Pending
+            };
+
+            // If we return `Poll::Pending`, we must schedule the task to be awoken.
+            if poll.is_pending() {
+                Self::schedule(cx);
+            }
+
+            poll
+        }
+
+        fn is_end_stream(&self) -> bool {
+            self.data_polls.is_empty() && self.trailer_polls.is_empty()
+        }
+    }
+}


### PR DESCRIPTION
https://github.com/linkerd/linkerd2/issues/8733 tracks the upgrade to hyper 1.0.

the `PeekTrailersBody<B>` body middleware, provided by the `linkerd-http-retry` crate, is uniquely positioned to be adversely affected by the changes to the `Body` trait. this type, in order to attempt to peek an inner `B`-typed body's HTTP/2 trailers, has some subtle and nuanced edge cases.

the intent of this type is to only yield the asynchronous task responsible for reading the body _once_. depending on what the inner body yields, and when, this can result in combinations of: no data frames and no trailers, no data frames with trailers, one data frame and no trailers, one data frame with trailers, or two data frames. moreover, depending on which of these are yielded, the body will call `.await` some scenarios, and only poll functions _once_ in others.

migrating this to the `Frame<T>` and `poll_frame()` style of the 1.0 `Body` interface, away from the 0.4 interface that provides distinct `poll_data()` and `poll_trailers()` methods, is fundamentally tricky.

this branch is most importantly focused on introducing a unit test suite to `PeekTrailersBody<B>`, to help provide assurance that our body middleware behaves as expected across this migration boundary.

along the way, some documentation is added, and some minor changes are made to the control flow of the polling logic to carve a path for later changes related to polling.