### PR TITLE
build(rustls): Upgrade tokio-rustls to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,23 +3423,26 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "log",
+ "once_cell",
  "ring",
+ "rustls-pki-types",
  "rustls-webpki",
- "sct",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.21.7",
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3450,11 +3453,12 @@ checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -3475,16 +3479,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
 
 [[package]]
 name = "semver"
@@ -3627,6 +3621,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"
@@ -3874,9 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.24.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
  "tokio",
@@ -4497,6 +4497,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerovec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,10 @@ http-body = { version = "0.4" }
 hyper = { version = "0.14.32", default-features = false }
 prost = { version = "0.12" }
 prost-types = { version = "0.12" }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+    "logging",
+] }
 tonic = { version = "0.10", default-features = false }
 tonic-build = { version = "0.10", default-features = false }
 

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -47,8 +47,8 @@ regex = "1"
 socket2 = "0.5"
 tokio = { version = "1", features = ["io-util", "net", "rt", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tokio-rustls = "0.24"
-rustls-pemfile = "1.0"
+tokio-rustls = { workspace = true }
+rustls-pemfile = "2.2"
 tower = { version = "0.4", default-features = false }
 tonic = { workspace = true, features = ["transport"], default-features = false }
 tracing = "0.1"

--- a/linkerd/app/integration/src/client.rs
+++ b/linkerd/app/integration/src/client.rs
@@ -2,8 +2,7 @@ use super::*;
 use linkerd_app_core::proxy::http::TracingExecutor;
 use parking_lot::Mutex;
 use std::io;
-use tokio::net::TcpStream;
-use tokio::task::JoinHandle;
+use tokio::{net::TcpStream, task::JoinHandle};
 use tokio_rustls::rustls::{self, ClientConfig};
 use tracing::info_span;
 
@@ -15,12 +14,13 @@ type Sender = mpsc::UnboundedSender<(Request, oneshot::Sender<Result<Response, C
 #[derive(Clone)]
 pub struct TlsConfig {
     client_config: Arc<ClientConfig>,
-    name: rustls::ServerName,
+    name: rustls::pki_types::ServerName<'static>,
 }
 
 impl TlsConfig {
-    pub fn new(client_config: Arc<ClientConfig>, name: &str) -> Self {
-        let name = rustls::ServerName::try_from(name).expect("name must be a valid DNS name");
+    pub fn new(client_config: Arc<ClientConfig>, name: &'static str) -> Self {
+        let name =
+            rustls::pki_types::ServerName::try_from(name).expect("name must be a valid DNS name");
         TlsConfig {
             client_config,
             name,

--- a/linkerd/app/integration/src/identity.rs
+++ b/linkerd/app/integration/src/identity.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use linkerd2_proxy_api::identity as pb;
-use tokio_rustls::rustls;
+use tokio_rustls::rustls::{self, pki_types::CertificateDer, server::WebPkiClientVerifier};
 use tonic as grpc;
 
 pub struct Identity {
@@ -36,7 +36,7 @@ type Certify = Box<
 
 static TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
 static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] =
-    &[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256];
+    &[rustls::crypto::ring::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256];
 
 struct Certificates {
     pub leaf: Vec<u8>,
@@ -50,11 +50,17 @@ impl Certificates {
     {
         let f = fs::File::open(p)?;
         let mut r = io::BufReader::new(f);
-        let mut certs = rustls_pemfile::certs(&mut r)
+        let mut certs = rustls_pemfile::certs(&mut r);
+        let leaf = certs
+            .next()
+            .expect("no leaf cert in pemfile")
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "rustls error reading certs"))?
+            .as_ref()
+            .to_vec();
+        let intermediates = certs
+            .map(|cert| cert.map(|cert| cert.as_ref().to_vec()))
+            .collect::<Result<Vec<_>, _>>()
             .map_err(|_| io::Error::new(io::ErrorKind::Other, "rustls error reading certs"))?;
-        let mut certs = certs.drain(..);
-        let leaf = certs.next().expect("no leaf cert in pemfile");
-        let intermediates = certs.collect();
 
         Ok(Certificates {
             leaf,
@@ -62,11 +68,14 @@ impl Certificates {
         })
     }
 
-    pub fn chain(&self) -> Vec<rustls::Certificate> {
+    pub fn chain(&self) -> Vec<rustls::pki_types::CertificateDer<'static>> {
         let mut chain = Vec::with_capacity(self.intermediates.len() + 1);
         chain.push(self.leaf.clone());
         chain.extend(self.intermediates.clone());
-        chain.into_iter().map(rustls::Certificate).collect()
+        chain
+            .into_iter()
+            .map(rustls::pki_types::CertificateDer::from)
+            .collect()
     }
 
     pub fn response(&self) -> pb::CertifyResponse {
@@ -79,43 +88,49 @@ impl Certificates {
 }
 
 impl Identity {
-    fn load_key<P>(p: P) -> rustls::PrivateKey
+    fn load_key<P>(p: P) -> rustls::pki_types::PrivateKeyDer<'static>
     where
         P: AsRef<Path>,
     {
         let p8 = fs::read(&p).expect("read key");
-        rustls::PrivateKey(p8)
+        rustls::pki_types::PrivateKeyDer::try_from(p8).expect("decode key")
     }
 
     fn configs(
         trust_anchors: &str,
         certs: &Certificates,
-        key: rustls::PrivateKey,
+        key: rustls::pki_types::PrivateKeyDer<'static>,
     ) -> (Arc<rustls::ClientConfig>, Arc<rustls::ServerConfig>) {
         use std::io::Cursor;
         let mut roots = rustls::RootCertStore::empty();
-        let trust_anchors =
-            rustls_pemfile::certs(&mut Cursor::new(trust_anchors)).expect("error parsing pemfile");
-        let (added, skipped) = roots.add_parsable_certificates(&trust_anchors[..]);
+        let trust_anchors = rustls_pemfile::certs(&mut Cursor::new(trust_anchors))
+            .map(|bytes| bytes.map(CertificateDer::from))
+            .collect::<Result<Vec<_>, _>>()
+            .expect("error parsing pemfile");
+        let (added, skipped) = roots.add_parsable_certificates(trust_anchors);
         assert_ne!(added, 0, "trust anchors must include at least one cert");
         assert_eq!(skipped, 0, "no certs in pemfile should be invalid");
 
-        let client_config = rustls::ClientConfig::builder()
-            .with_cipher_suites(TLS_SUPPORTED_CIPHERSUITES)
-            .with_safe_default_kx_groups()
+        let mut provider = rustls::crypto::ring::default_provider();
+        provider.cipher_suites = TLS_SUPPORTED_CIPHERSUITES.to_vec();
+        let provider = Arc::new(provider);
+
+        let client_config = rustls::ClientConfig::builder_with_provider(provider.clone())
             .with_protocol_versions(TLS_VERSIONS)
             .expect("client config must be valid")
             .with_root_certificates(roots.clone())
             .with_no_client_auth();
 
-        let server_config = rustls::ServerConfig::builder()
-            .with_cipher_suites(TLS_SUPPORTED_CIPHERSUITES)
-            .with_safe_default_kx_groups()
+        let client_cert_verifier =
+            WebPkiClientVerifier::builder_with_provider(Arc::new(roots), provider.clone())
+                .allow_unauthenticated()
+                .build()
+                .expect("server verifier must be valid");
+
+        let server_config = rustls::ServerConfig::builder_with_provider(provider)
             .with_protocol_versions(TLS_VERSIONS)
             .expect("server config must be valid")
-            .with_client_cert_verifier(Arc::new(
-                rustls::server::AllowAnyAnonymousOrAuthenticatedClient::new(roots),
-            ))
+            .with_client_cert_verifier(client_cert_verifier)
             .with_single_cert(certs.chain(), key)
             .unwrap();
 

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -56,7 +56,7 @@ futures-util = "0.3"
 http-body = { workspace = true }
 hyper = { workspace = true, features = ["backports", "deprecated", "http1", "http2"] }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
-tokio-rustls = "0.24"
+tokio-rustls = { workspace = true }
 tokio-test = "0.4"
 tower-test = "0.4"
 

--- a/linkerd/meshtls/rustls/Cargo.toml
+++ b/linkerd/meshtls/rustls/Cargo.toml
@@ -12,11 +12,11 @@ test-util = ["linkerd-tls-test-util"]
 [dependencies]
 futures = { version = "0.3", default-features = false }
 ring = { version = "0.17", features = ["std"] }
-rustls-pemfile = "1.0"
-rustls-webpki = { version = "0.101.5", features = ["std"] }
+rustls-pemfile = "2.2"
+rustls-webpki = { version = "0.102.8", features = ["std"] }
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
-tokio-rustls = { version = "0.24", features = ["dangerous_configuration"] }
+tokio-rustls = { workspace = true }
 tracing = "0.1"
 
 linkerd-dns-name = { path = "../../dns/name" }

--- a/linkerd/meshtls/rustls/src/creds.rs
+++ b/linkerd/meshtls/rustls/src/creds.rs
@@ -10,7 +10,7 @@ use ring::error::KeyRejected;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::watch;
-use tokio_rustls::rustls;
+use tokio_rustls::rustls::{self, crypto::CryptoProvider};
 use tracing::warn;
 
 #[derive(Debug, Error)]
@@ -27,7 +27,9 @@ pub fn watch(
     roots_pem: &str,
 ) -> Result<(Store, Receiver)> {
     let mut roots = rustls::RootCertStore::empty();
-    let certs = match rustls_pemfile::certs(&mut std::io::Cursor::new(roots_pem)) {
+    let certs = match rustls_pemfile::certs(&mut std::io::Cursor::new(roots_pem))
+        .collect::<Result<Vec<_>, _>>()
+    {
         Err(error) => {
             warn!(%error, "invalid trust anchors file");
             return Err(error.into());
@@ -39,7 +41,7 @@ pub fn watch(
         Ok(certs) => certs,
     };
 
-    let (added, skipped) = roots.add_parsable_certificates(&certs[..]);
+    let (added, skipped) = roots.add_parsable_certificates(certs);
     if skipped != 0 {
         warn!("Skipped {} invalid trust anchors", skipped);
     }
@@ -88,6 +90,12 @@ pub fn watch(
     Ok((store, rx))
 }
 
+fn default_provider() -> CryptoProvider {
+    let mut provider = rustls::crypto::ring::default_provider();
+    provider.cipher_suites = params::TLS_SUPPORTED_CIPHERSUITES.to_vec();
+    provider
+}
+
 #[cfg(feature = "test-util")]
 pub fn for_test(ent: &linkerd_tls_test_util::Entity) -> (Store, Receiver) {
     watch(
@@ -104,7 +112,7 @@ pub fn default_for_test() -> (Store, Receiver) {
 }
 
 mod params {
-    use tokio_rustls::rustls;
+    use tokio_rustls::rustls::{self, crypto::WebPkiSupportedAlgorithms};
 
     // These must be kept in sync:
     pub static SIGNATURE_ALG_RING_SIGNING: &ring::signature::EcdsaSigningAlgorithm =
@@ -113,7 +121,14 @@ mod params {
         rustls::SignatureScheme::ECDSA_NISTP256_SHA256;
     pub const SIGNATURE_ALG_RUSTLS_ALGORITHM: rustls::SignatureAlgorithm =
         rustls::SignatureAlgorithm::ECDSA;
+    pub static SUPPORTED_SIG_ALGS: &WebPkiSupportedAlgorithms = &WebPkiSupportedAlgorithms {
+        all: &[webpki::ring::ECDSA_P256_SHA256],
+        mapping: &[(
+            SIGNATURE_ALG_RUSTLS_SCHEME,
+            &[webpki::ring::ECDSA_P256_SHA256],
+        )],
+    };
     pub static TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
     pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] =
-        &[rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256];
+        &[rustls::crypto::ring::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256];
 }

--- a/linkerd/meshtls/rustls/src/creds.rs
+++ b/linkerd/meshtls/rustls/src/creds.rs
@@ -121,12 +121,49 @@ mod params {
         rustls::SignatureScheme::ECDSA_NISTP256_SHA256;
     pub const SIGNATURE_ALG_RUSTLS_ALGORITHM: rustls::SignatureAlgorithm =
         rustls::SignatureAlgorithm::ECDSA;
+    // A subset of the algorithms supported by rustls+ring, imported from
+    // https://github.com/rustls/rustls/blob/v/0.23.21/rustls/src/crypto/ring/mod.rs#L107
     pub static SUPPORTED_SIG_ALGS: &WebPkiSupportedAlgorithms = &WebPkiSupportedAlgorithms {
-        all: &[webpki::ring::ECDSA_P256_SHA256],
-        mapping: &[(
-            SIGNATURE_ALG_RUSTLS_SCHEME,
-            &[webpki::ring::ECDSA_P256_SHA256],
-        )],
+        all: &[
+            webpki::ring::ECDSA_P256_SHA256,
+            webpki::ring::ECDSA_P256_SHA384,
+            webpki::ring::ECDSA_P384_SHA256,
+            webpki::ring::ECDSA_P384_SHA384,
+            webpki::ring::ED25519,
+            webpki::ring::RSA_PKCS1_2048_8192_SHA256,
+            webpki::ring::RSA_PKCS1_2048_8192_SHA384,
+            webpki::ring::RSA_PKCS1_2048_8192_SHA512,
+            webpki::ring::RSA_PKCS1_3072_8192_SHA384,
+        ],
+        mapping: &[
+            (
+                rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+                &[
+                    webpki::ring::ECDSA_P384_SHA384,
+                    webpki::ring::ECDSA_P256_SHA384,
+                ],
+            ),
+            (
+                rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+                &[
+                    webpki::ring::ECDSA_P256_SHA256,
+                    webpki::ring::ECDSA_P384_SHA256,
+                ],
+            ),
+            (rustls::SignatureScheme::ED25519, &[webpki::ring::ED25519]),
+            (
+                rustls::SignatureScheme::RSA_PKCS1_SHA512,
+                &[webpki::ring::RSA_PKCS1_2048_8192_SHA512],
+            ),
+            (
+                rustls::SignatureScheme::RSA_PKCS1_SHA384,
+                &[webpki::ring::RSA_PKCS1_2048_8192_SHA384],
+            ),
+            (
+                rustls::SignatureScheme::RSA_PKCS1_SHA256,
+                &[webpki::ring::RSA_PKCS1_2048_8192_SHA256],
+            ),
+        ],
     };
     pub static TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
     pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] =

--- a/linkerd/meshtls/rustls/src/creds/receiver.rs
+++ b/linkerd/meshtls/rustls/src/creds/receiver.rs
@@ -70,10 +70,13 @@ mod tests {
     /// incoming handshakes, but that doesn't matter for these tests, where we
     /// don't actually do any TLS.
     fn empty_server_config() -> rustls::ServerConfig {
-        rustls::ServerConfig::builder()
-            .with_safe_defaults()
-            .with_client_cert_verifier(Arc::new(rustls::server::NoClientAuth))
-            .with_cert_resolver(Arc::new(rustls::server::ResolvesServerCertUsingSni::new()))
+        rustls::ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_protocol_versions(rustls::ALL_VERSIONS)
+        .expect("client config must be valid")
+        .with_client_cert_verifier(Arc::new(rustls::server::NoClientAuth))
+        .with_cert_resolver(Arc::new(rustls::server::ResolvesServerCertUsingSni::new()))
     }
 
     /// Returns the simplest default rustls client config.
@@ -82,10 +85,13 @@ mod tests {
     /// it doesn't trust any root certificates. However, that doesn't actually
     /// matter for these tests, which don't actually do TLS.
     fn empty_client_config() -> rustls::ClientConfig {
-        rustls::ClientConfig::builder()
-            .with_safe_defaults()
-            .with_root_certificates(rustls::RootCertStore::empty())
-            .with_no_client_auth()
+        rustls::ClientConfig::builder_with_provider(Arc::new(
+            rustls::crypto::ring::default_provider(),
+        ))
+        .with_protocol_versions(rustls::ALL_VERSIONS)
+        .expect("client config must be valid")
+        .with_root_certificates(rustls::RootCertStore::empty())
+        .with_no_client_auth()
     }
 
     #[tokio::test]

--- a/linkerd/meshtls/rustls/src/creds/store.rs
+++ b/linkerd/meshtls/rustls/src/creds/store.rs
@@ -1,5 +1,4 @@
-use super::params::*;
-use super::InvalidKey;
+use super::{default_provider, params::*, InvalidKey};
 use linkerd_dns_name as dns;
 use linkerd_error::Result;
 use linkerd_identity as id;
@@ -7,12 +6,12 @@ use linkerd_meshtls_verifier as verifier;
 use ring::{rand, signature::EcdsaKeyPair};
 use std::{convert::TryFrom, sync::Arc};
 use tokio::sync::watch;
-use tokio_rustls::rustls;
+use tokio_rustls::rustls::{self, pki_types::UnixTime, server::WebPkiClientVerifier};
 use tracing::debug;
 
 pub struct Store {
     roots: rustls::RootCertStore,
-    server_cert_verifier: Arc<dyn rustls::client::ServerCertVerifier>,
+    server_cert_verifier: Arc<dyn rustls::client::danger::ServerCertVerifier>,
     server_id: id::Id,
     server_name: dns::Name,
     client_tx: watch::Sender<Arc<rustls::ClientConfig>>,
@@ -20,18 +19,16 @@ pub struct Store {
     random: ring::rand::SystemRandom,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct Key(Arc<EcdsaKeyPair>);
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct CertResolver(Arc<rustls::sign::CertifiedKey>);
 
 pub(super) fn client_config_builder(
-    cert_verifier: Arc<dyn rustls::client::ServerCertVerifier>,
+    cert_verifier: Arc<dyn rustls::client::danger::ServerCertVerifier>,
 ) -> rustls::ConfigBuilder<rustls::ClientConfig, rustls::client::WantsClientCert> {
-    rustls::ClientConfig::builder()
-        .with_cipher_suites(TLS_SUPPORTED_CIPHERSUITES)
-        .with_safe_default_kx_groups()
+    rustls::ClientConfig::builder_with_provider(Arc::new(default_provider()))
         .with_protocol_versions(TLS_VERSIONS)
         .expect("client config must be valid")
         // XXX: Rustls's built-in verifiers don't let us tweak things as fully
@@ -44,6 +41,7 @@ pub(super) fn client_config_builder(
         // builder API does internally. However, we want to share the verifier
         // with the `Store` so that it can be used in `Store::validate` which
         // requires using this API.
+        .dangerous()
         .with_custom_certificate_verifier(cert_verifier)
 }
 
@@ -57,12 +55,15 @@ pub(super) fn server_config(
     // controlling the set of trusted signature algorithms), but they provide good enough
     // defaults for now.
     // TODO: lock down the verification further.
-    let client_cert_verifier = Arc::new(
-        rustls::server::AllowAnyAnonymousOrAuthenticatedClient::new(roots),
-    );
-    rustls::ServerConfig::builder()
-        .with_cipher_suites(TLS_SUPPORTED_CIPHERSUITES)
-        .with_safe_default_kx_groups()
+    let provider = Arc::new(default_provider());
+
+    let client_cert_verifier =
+        WebPkiClientVerifier::builder_with_provider(Arc::new(roots), provider.clone())
+            .allow_unauthenticated()
+            .build()
+            .expect("server verifier must be valid");
+
+    rustls::ServerConfig::builder_with_provider(provider)
         .with_protocol_versions(TLS_VERSIONS)
         .expect("server config must be valid")
         .with_client_cert_verifier(client_cert_verifier)
@@ -76,7 +77,7 @@ impl Store {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         roots: rustls::RootCertStore,
-        server_cert_verifier: Arc<dyn rustls::client::ServerCertVerifier>,
+        server_cert_verifier: Arc<dyn rustls::client::danger::ServerCertVerifier>,
         server_id: id::Id,
         server_name: dns::Name,
         client_tx: watch::Sender<Arc<rustls::ClientConfig>>,
@@ -107,25 +108,23 @@ impl Store {
 
     /// Ensures the certificate is valid for the services we terminate for TLS. This assumes that
     /// server cert validation does the same or more validation than client cert validation.
-    fn validate(&self, certs: &[rustls::Certificate]) -> Result<()> {
-        let name = rustls::ServerName::try_from(self.server_name.as_str())
+    fn validate(&self, certs: &[rustls::pki_types::CertificateDer<'_>]) -> Result<()> {
+        let name = rustls::pki_types::ServerName::try_from(self.server_name.as_str())
             .expect("server name must be a valid DNS name");
         static NO_OCSP: &[u8] = &[];
         let end_entity = &certs[0];
         let intermediates = &certs[1..];
-        let no_scts = &mut std::iter::empty();
-        let now = std::time::SystemTime::now();
+        let now = UnixTime::now();
         self.server_cert_verifier.verify_server_cert(
             end_entity,
             intermediates,
             &name,
-            no_scts,
             NO_OCSP,
             now,
         )?;
 
         // verify the id as the cert verifier does not do that (on purpose)
-        verifier::verify_id(&end_entity.0, &self.server_id).map_err(Into::into)
+        verifier::verify_id(end_entity, &self.server_id).map_err(Into::into)
     }
 }
 impl id::Credentials for Store {
@@ -138,11 +137,11 @@ impl id::Credentials for Store {
         _expiry: std::time::SystemTime,
     ) -> Result<()> {
         let mut chain = Vec::with_capacity(intermediates.len() + 1);
-        chain.push(rustls::Certificate(leaf));
+        chain.push(rustls::pki_types::CertificateDer::from(leaf));
         chain.extend(
             intermediates
                 .into_iter()
-                .map(|id::DerX509(der)| rustls::Certificate(der)),
+                .map(|id::DerX509(der)| rustls::pki_types::CertificateDer::from(der)),
         );
 
         // Use the client's verifier to validate the certificate for our local name.

--- a/linkerd/meshtls/rustls/src/server.rs
+++ b/linkerd/meshtls/rustls/src/server.rs
@@ -7,7 +7,7 @@ use linkerd_tls::{ClientId, NegotiatedProtocol, NegotiatedProtocolRef, ServerNam
 use std::{pin::Pin, sync::Arc, task::Context};
 use thiserror::Error;
 use tokio::sync::watch;
-use tokio_rustls::rustls::{Certificate, ServerConfig};
+use tokio_rustls::rustls::{pki_types::CertificateDer, ServerConfig};
 use tracing::debug;
 
 /// A Service that terminates TLS connections using a dynamically updated server configuration.
@@ -129,7 +129,7 @@ where
 fn client_identity<I>(tls: &tokio_rustls::server::TlsStream<I>) -> Option<ClientId> {
     let (_io, session) = tls.get_ref();
     let certs = session.peer_certificates()?;
-    let c = certs.first().map(Certificate::as_ref)?;
+    let c = certs.first().map(CertificateDer::as_ref)?;
 
     verifier::client_identity(c).map(ClientId)
 }


### PR DESCRIPTION
This is a retry of https://github.com/linkerd/linkerd2-proxy/pull/3419, which was reverted by https://github.com/linkerd/linkerd2-proxy/pull/3553.

This includes a fix that caused the control plane to never be ready due to a reduction in the set of supported signature algorithms. See https://github.com/linkerd/linkerd2-proxy/commit/01e0782e3aa1afe9f8d6f79a24a17382e7b6132a for details.