### PR TITLE
metrics: Make hostname label on TLS metrics configurable

### DIFF
--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -83,6 +83,9 @@ pub struct Config {
 
     // Whether the proxy may include informational headers on HTTP responses.
     pub emit_headers: bool,
+
+    // Whether to populate hostname prometheus labels for HTTP and TLS traffic metrics.
+    pub allow_hostname_labels: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/linkerd/app/outbound/src/tls.rs
+++ b/linkerd/app/outbound/src/tls.rs
@@ -1,4 +1,4 @@
-use crate::{tcp, Outbound};
+use crate::{sidecar::AllowHostnameLabels, tcp, Outbound};
 use linkerd_app_core::{
     io,
     metrics::prom,
@@ -79,6 +79,7 @@ impl<C> Outbound<C> {
         // Tls target
         T: Clone + Debug + PartialEq + Eq + Hash + Send + Sync + 'static,
         T: svc::Param<watch::Receiver<Routes>>,
+        T: svc::Param<AllowHostnameLabels>,
         // Server-side connection
         I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + io::Peek,
         I: Debug + Send + Sync + Unpin + 'static,
@@ -112,6 +113,15 @@ impl<C> Outbound<C> {
 impl<T> svc::Param<ServerName> for Tls<T> {
     fn param(&self) -> ServerName {
         self.sni.clone()
+    }
+}
+
+impl<T> svc::Param<AllowHostnameLabels> for Tls<T>
+where
+    T: svc::Param<AllowHostnameLabels>,
+{
+    fn param(&self) -> AllowHostnameLabels {
+        self.parent.param()
     }
 }
 

--- a/linkerd/app/outbound/src/tls/logical.rs
+++ b/linkerd/app/outbound/src/tls/logical.rs
@@ -1,5 +1,5 @@
 use super::concrete;
-use crate::{BackendRef, Outbound, ParentRef};
+use crate::{sidecar::AllowHostnameLabels, BackendRef, Outbound, ParentRef};
 use linkerd_app_core::{io, svc, tls::ServerName, Addr, Error};
 use linkerd_proxy_client_policy as client_policy;
 use std::{fmt::Debug, hash::Hash, sync::Arc};
@@ -56,6 +56,7 @@ impl<N> Outbound<N> {
         // Logical target.
         T: svc::Param<watch::Receiver<Routes>>,
         T: svc::Param<ServerName>,
+        T: svc::Param<AllowHostnameLabels>,
         T: Eq + Hash + Clone + Debug + Send + Sync + 'static,
         // Concrete stack.
         I: io::AsyncRead + io::AsyncWrite + Debug + Send + Unpin + 'static,

--- a/linkerd/app/outbound/src/tls/logical/router.rs
+++ b/linkerd/app/outbound/src/tls/logical/router.rs
@@ -2,7 +2,7 @@ use super::{
     super::{concrete, Concrete},
     route, LogicalAddr, NoRoute,
 };
-use crate::{BackendRef, EndpointRef, RouteRef};
+use crate::{sidecar::AllowHostnameLabels, BackendRef, EndpointRef, RouteRef};
 use linkerd_app_core::{
     io, proxy::http, svc, tls::ServerName, transport::addrs::*, Addr, Error, NameAddr, Result,
 };
@@ -28,6 +28,7 @@ where
     // Parent target type.
     T: Eq + Hash + Clone + Debug + Send + Sync + 'static,
     T: svc::Param<ServerName>,
+    T: svc::Param<AllowHostnameLabels>,
 {
     pub fn layer<N, I, NSvc>(
         metrics: route::TlsRouteMetrics,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -573,6 +573,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 capacity: http_queue_capacity,
                 failfast_timeout: http_failfast_timeout,
             },
+            allow_hostname_labels: false,
         }
     };
 


### PR DESCRIPTION
This is a draft PR that illustrates a proposed approach for piping configuration for blanking the hostname label for outbound route metrics. 

