### PR TITLE
refactor(http/retry): port remaining `ReplayBody` tests to `Frame<T>`

### DIFF
--- a/linkerd/http/retry/src/compat.rs
+++ b/linkerd/http/retry/src/compat.rs
@@ -40,6 +40,12 @@ impl<B: Body> ForwardCompatibleBody<B> {
     pub(crate) fn frame(&mut self) -> combinators::Frame<'_, B> {
         combinators::Frame(self)
     }
+
+    /// Returns `true` when the end of stream has been reached.
+    #[cfg(test)]
+    pub(crate) fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
 }
 
 /// Future that resolves to the next frame from a `Body`.

--- a/linkerd/http/retry/src/replay.rs
+++ b/linkerd/http/retry/src/replay.rs
@@ -1016,10 +1016,14 @@ mod tests {
         T: http_body::Body + Unpin,
     {
         tracing::trace!("waiting for a body chunk...");
-        let chunk = body
-            .data()
+        let chunk = crate::compat::ForwardCompatibleBody::new(body)
+            .frame()
             .await
-            .map(|res| res.map_err(|_| ()).unwrap())
+            .expect("yields a result")
+            .ok()
+            .expect("yields a frame")
+            .into_data()
+            .ok()
             .map(string);
         tracing::info!(?chunk);
         chunk


### PR DESCRIPTION
based on #3564. see linkerd/linkerd2#8733.

this branch upgrades the remaining parts of the `ReplayBody<B>` test suite to poll bodies in terms of `Frame<T>`s.