### PR TITLE
docs(http/retry): document `ReplayBody::poll_*()` panics

### DIFF
--- a/linkerd/http/retry/src/replay.rs
+++ b/linkerd/http/retry/src/replay.rs
@@ -160,6 +160,12 @@ where
     type Data = Data;
     type Error = Error;
 
+    /// Polls for the next chunk of data in this stream.
+    ///
+    /// # Panics
+    ///
+    /// This panics if another clone has currently acquired the state. A [`ReplayBody<B>`] MUST
+    /// NOT be polled until the previous body has been dropped.
     fn poll_data(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -248,6 +254,14 @@ where
         Poll::Ready(Some(Ok(Data::Initial(chunk))))
     }
 
+    /// Polls for an optional **single** [`HeaderMap`] of trailers.
+    ///
+    /// This function should only be called once `poll_data` returns `None`.
+    ///
+    /// # Panics
+    ///
+    /// This panics if another clone has currently acquired the state. A [`ReplayBody<B>`] MUST
+    /// NOT be polled until the previous body has been dropped.
     fn poll_trailers(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,


### PR DESCRIPTION
a `ReplayBody<B>` demands a particular contract of its users: one must not poll two bodies in parallel. this is currently mentioned as an implicit assumption on an internal helper function, `acquire_state<'a>`, here:

https://github.com/linkerd/linkerd2-proxy/blob/main/linkerd/http/retry/src/replay.rs#L127-L131

```rust
    /// # Panics
    ///
    /// This panics if another clone has currently acquired the state, based on
    /// the assumption that a retry body will not be polled until the previous
    /// request has been dropped.
    fn acquire_state<'a>(
        state: &'a mut Option<BodyState<B>>,
        shared: &Mutex<Option<BodyState<B>>>,
    ) -> &'a mut BodyState<B> {
        state.get_or_insert_with(|| shared.lock().take().expect("missing body state"))
    }
```

this commit echoes this sentiment on the relevant public-facing parts of this middleware: its `Body` trait methods.