### PR TITLE
refactor(http/retry): outline bounded replay buffer

### DIFF
--- a/linkerd/http/retry/src/replay.rs
+++ b/linkerd/http/retry/src/replay.rs
@@ -1,11 +1,15 @@
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::Buf;
 use http::HeaderMap;
 use http_body::{Body, SizeHint};
 use linkerd_error::Error;
 use linkerd_http_box::BoxBody;
 use parking_lot::Mutex;
-use std::{collections::VecDeque, io::IoSlice, pin::Pin, sync::Arc, task::Context, task::Poll};
+use std::{pin::Pin, sync::Arc, task::Context, task::Poll};
 use thiserror::Error;
+
+pub use self::buffer::{BufList, Data};
+
+mod buffer;
 
 /// Unit tests for [`ReplayBody<B>`].
 #[cfg(test)]
@@ -45,21 +49,6 @@ pub struct ReplayBody<B = BoxBody> {
 #[derive(Debug, Error)]
 #[error("replay body discarded after reaching maximum buffered bytes limit")]
 pub struct Capped;
-
-/// Data returned by `ReplayBody`'s `http_body::Body` implementation is either
-/// `Bytes` returned by the initial body, or a list of all `Bytes` chunks
-/// returned by the initial body (when replaying it).
-#[derive(Debug)]
-pub enum Data {
-    Initial(Bytes),
-    Replay(BufList),
-}
-
-/// Body data composed of multiple `Bytes` chunks.
-#[derive(Clone, Debug, Default)]
-pub struct BufList {
-    bufs: VecDeque<Bytes>,
-}
 
 #[derive(Debug)]
 struct SharedState<B> {
@@ -357,140 +346,6 @@ impl<B> Drop for ReplayBody<B> {
         // If this clone owned the shared state, put it back.
         if let Some(state) = self.state.take() {
             *self.shared.body.lock() = Some(state);
-        }
-    }
-}
-
-// === impl Data ===
-
-impl Buf for Data {
-    #[inline]
-    fn remaining(&self) -> usize {
-        match self {
-            Data::Initial(buf) => buf.remaining(),
-            Data::Replay(bufs) => bufs.remaining(),
-        }
-    }
-
-    #[inline]
-    fn chunk(&self) -> &[u8] {
-        match self {
-            Data::Initial(buf) => buf.chunk(),
-            Data::Replay(bufs) => bufs.chunk(),
-        }
-    }
-
-    #[inline]
-    fn chunks_vectored<'iovs>(&'iovs self, iovs: &mut [IoSlice<'iovs>]) -> usize {
-        match self {
-            Data::Initial(buf) => buf.chunks_vectored(iovs),
-            Data::Replay(bufs) => bufs.chunks_vectored(iovs),
-        }
-    }
-
-    #[inline]
-    fn advance(&mut self, amt: usize) {
-        match self {
-            Data::Initial(buf) => buf.advance(amt),
-            Data::Replay(bufs) => bufs.advance(amt),
-        }
-    }
-
-    #[inline]
-    fn copy_to_bytes(&mut self, len: usize) -> Bytes {
-        match self {
-            Data::Initial(buf) => buf.copy_to_bytes(len),
-            Data::Replay(bufs) => bufs.copy_to_bytes(len),
-        }
-    }
-}
-
-// === impl BufList ===
-
-impl BufList {
-    fn push_chunk(&mut self, mut data: impl Buf) -> Bytes {
-        let len = data.remaining();
-        // `data` is (almost) certainly a `Bytes`, so `copy_to_bytes` should
-        // internally be a cheap refcount bump almost all of the time.
-        // But, if it isn't, this will copy it to a `Bytes` that we can
-        // now clone.
-        let bytes = data.copy_to_bytes(len);
-        // Buffer a clone of the bytes read on this poll.
-        self.bufs.push_back(bytes.clone());
-        // Return the bytes
-        bytes
-    }
-}
-
-impl Buf for BufList {
-    fn remaining(&self) -> usize {
-        self.bufs.iter().map(Buf::remaining).sum()
-    }
-
-    fn chunk(&self) -> &[u8] {
-        self.bufs.front().map(Buf::chunk).unwrap_or(&[])
-    }
-
-    fn chunks_vectored<'iovs>(&'iovs self, iovs: &mut [IoSlice<'iovs>]) -> usize {
-        // Are there more than zero iovecs to write to?
-        if iovs.is_empty() {
-            return 0;
-        }
-
-        // Loop over the buffers in the replay buffer list, and try to fill as
-        // many iovecs as we can from each buffer.
-        let mut filled = 0;
-        for buf in &self.bufs {
-            filled += buf.chunks_vectored(&mut iovs[filled..]);
-            if filled == iovs.len() {
-                return filled;
-            }
-        }
-
-        filled
-    }
-
-    fn advance(&mut self, mut amt: usize) {
-        while amt > 0 {
-            let rem = self.bufs[0].remaining();
-            // If the amount to advance by is less than the first buffer in
-            // the buffer list, advance that buffer's cursor by `amt`,
-            // and we're done.
-            if rem > amt {
-                self.bufs[0].advance(amt);
-                return;
-            }
-
-            // Otherwise, advance the first buffer to its end, and
-            // continue.
-            self.bufs[0].advance(rem);
-            amt -= rem;
-
-            self.bufs.pop_front();
-        }
-    }
-
-    fn copy_to_bytes(&mut self, len: usize) -> Bytes {
-        // If the length of the requested `Bytes` is <= the length of the front
-        // buffer, we can just use its `copy_to_bytes` implementation (which is
-        // just a reference count bump).
-        match self.bufs.front_mut() {
-            Some(first) if len <= first.remaining() => {
-                let buf = first.copy_to_bytes(len);
-                // If we consumed the first buffer, also advance our "cursor" by
-                // popping it.
-                if first.remaining() == 0 {
-                    self.bufs.pop_front();
-                }
-
-                buf
-            }
-            _ => {
-                assert!(len <= self.remaining(), "`len` greater than remaining");
-                let mut buf = BytesMut::with_capacity(len);
-                buf.put(self.take(len));
-                buf.freeze()
-            }
         }
     }
 }

--- a/linkerd/http/retry/src/replay/buffer.rs
+++ b/linkerd/http/retry/src/replay/buffer.rs
@@ -1,0 +1,151 @@
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use std::{collections::VecDeque, io::IoSlice};
+
+/// Data returned by `ReplayBody`'s `http_body::Body` implementation is either
+/// `Bytes` returned by the initial body, or a list of all `Bytes` chunks
+/// returned by the initial body (when replaying it).
+#[derive(Debug)]
+pub enum Data {
+    Initial(Bytes),
+    Replay(BufList),
+}
+
+/// Body data composed of multiple `Bytes` chunks.
+#[derive(Clone, Debug, Default)]
+pub struct BufList {
+    bufs: VecDeque<Bytes>,
+}
+
+// === impl Data ===
+
+impl Buf for Data {
+    #[inline]
+    fn remaining(&self) -> usize {
+        match self {
+            Data::Initial(buf) => buf.remaining(),
+            Data::Replay(bufs) => bufs.remaining(),
+        }
+    }
+
+    #[inline]
+    fn chunk(&self) -> &[u8] {
+        match self {
+            Data::Initial(buf) => buf.chunk(),
+            Data::Replay(bufs) => bufs.chunk(),
+        }
+    }
+
+    #[inline]
+    fn chunks_vectored<'iovs>(&'iovs self, iovs: &mut [IoSlice<'iovs>]) -> usize {
+        match self {
+            Data::Initial(buf) => buf.chunks_vectored(iovs),
+            Data::Replay(bufs) => bufs.chunks_vectored(iovs),
+        }
+    }
+
+    #[inline]
+    fn advance(&mut self, amt: usize) {
+        match self {
+            Data::Initial(buf) => buf.advance(amt),
+            Data::Replay(bufs) => bufs.advance(amt),
+        }
+    }
+
+    #[inline]
+    fn copy_to_bytes(&mut self, len: usize) -> Bytes {
+        match self {
+            Data::Initial(buf) => buf.copy_to_bytes(len),
+            Data::Replay(bufs) => bufs.copy_to_bytes(len),
+        }
+    }
+}
+
+// === impl BufList ===
+
+impl BufList {
+    pub(super) fn push_chunk(&mut self, mut data: impl Buf) -> Bytes {
+        let len = data.remaining();
+        // `data` is (almost) certainly a `Bytes`, so `copy_to_bytes` should
+        // internally be a cheap refcount bump almost all of the time.
+        // But, if it isn't, this will copy it to a `Bytes` that we can
+        // now clone.
+        let bytes = data.copy_to_bytes(len);
+        // Buffer a clone of the bytes read on this poll.
+        self.bufs.push_back(bytes.clone());
+        // Return the bytes
+        bytes
+    }
+}
+
+impl Buf for BufList {
+    fn remaining(&self) -> usize {
+        self.bufs.iter().map(Buf::remaining).sum()
+    }
+
+    fn chunk(&self) -> &[u8] {
+        self.bufs.front().map(Buf::chunk).unwrap_or(&[])
+    }
+
+    fn chunks_vectored<'iovs>(&'iovs self, iovs: &mut [IoSlice<'iovs>]) -> usize {
+        // Are there more than zero iovecs to write to?
+        if iovs.is_empty() {
+            return 0;
+        }
+
+        // Loop over the buffers in the replay buffer list, and try to fill as
+        // many iovecs as we can from each buffer.
+        let mut filled = 0;
+        for buf in &self.bufs {
+            filled += buf.chunks_vectored(&mut iovs[filled..]);
+            if filled == iovs.len() {
+                return filled;
+            }
+        }
+
+        filled
+    }
+
+    fn advance(&mut self, mut amt: usize) {
+        while amt > 0 {
+            let rem = self.bufs[0].remaining();
+            // If the amount to advance by is less than the first buffer in
+            // the buffer list, advance that buffer's cursor by `amt`,
+            // and we're done.
+            if rem > amt {
+                self.bufs[0].advance(amt);
+                return;
+            }
+
+            // Otherwise, advance the first buffer to its end, and
+            // continue.
+            self.bufs[0].advance(rem);
+            amt -= rem;
+
+            self.bufs.pop_front();
+        }
+    }
+
+    fn copy_to_bytes(&mut self, len: usize) -> Bytes {
+        // If the length of the requested `Bytes` is <= the length of the front
+        // buffer, we can just use its `copy_to_bytes` implementation (which is
+        // just a reference count bump).
+        match self.bufs.front_mut() {
+            Some(first) if len <= first.remaining() => {
+                let buf = first.copy_to_bytes(len);
+                // If we consumed the first buffer, also advance our "cursor" by
+                // popping it.
+                if first.remaining() == 0 {
+                    self.bufs.pop_front();
+                }
+
+                buf
+            }
+            _ => {
+                assert!(len <= self.remaining(), "`len` greater than remaining");
+                let mut buf = BytesMut::with_capacity(len);
+                buf.put(self.take(len));
+                buf.freeze()
+            }
+        }
+    }
+}

--- a/linkerd/http/retry/src/replay/buffer.rs
+++ b/linkerd/http/retry/src/replay/buffer.rs
@@ -12,7 +12,9 @@ pub enum Data {
     Replay(Replay),
 }
 
-/// Body data composed of multiple `Bytes` chunks.
+/// A replayable [`Buf`] of body data.
+///
+/// This storage is backed by cheaply cloneable [`Bytes`].
 #[derive(Clone, Debug, Default)]
 pub struct Replay {
     bufs: VecDeque<Bytes>,


### PR DESCRIPTION
the `ReplayBody<B>` middleware makes use of a `BufList` type to hold a
reference to bytes yielded by the inner body `B`. a `Data` enum is
composed on top to this, to allow bodies to either return (a) a replay
of a previous body, or (b) the iniial bytes yielded by the original
body.

this branch also takes the step of moving some code out of the
`ReplayBody::poll_data(..)` trait method along with inlining
`BufList::push_chunk(..)` , a small helper function that is only used
once.

this is intended to consolidate code related to buffering data yielded
by the underlying `B`-typed body, and extricate logic concerning the
bounding of this buffer from the now defunct `Body::poll_data()` trait
method.

see https://github.com/linkerd/linkerd2/issues/8733 for more information
about upgrading the proxy to hyper 1.0.

this will help make subsequent changes to the model of `ReplayBody<B>`
its corresponding `Body` implementation more reviewable, by proactively
reorganizing things in advance.