### PR TITLE
refactor(outbound): simplify http route metric labeling

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/tests.rs
@@ -1,5 +1,3 @@
-use crate::http::policy::route::MatchedRoute;
-
 use super::{
     super::{Grpc, Http, Route},
     labels,
@@ -593,10 +591,8 @@ pub fn mock_http_route_metrics(
         &req,
     )
     .expect("find default route");
-
-    let extract = MatchedRoute::label_extractor;
     let (tx, handle) = tower_test::mock::pair::<http::Request<BoxBody>, http::Response<BoxBody>>();
-    let svc = super::layer(metrics, extract, body_data)
+    let svc = super::layer(metrics, body_data)
         .layer(move |_t: Http<()>| tx.clone())
         .new_service(Http {
             r#match,
@@ -642,9 +638,8 @@ pub fn mock_grpc_route_metrics(
     )
     .expect("find default route");
 
-    let extract = MatchedRoute::label_extractor;
     let (tx, handle) = tower_test::mock::pair::<http::Request<BoxBody>, http::Response<BoxBody>>();
-    let svc = super::layer(metrics, extract, body_data)
+    let svc = super::layer(metrics, body_data)
         .layer(move |_t: Grpc<()>| tx.clone())
         .new_service(Grpc {
             r#match,

--- a/linkerd/app/outbound/src/http/logical/policy/route/retry.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/retry.rs
@@ -1,7 +1,4 @@
-use super::{
-    extensions,
-    metrics::labels::{Route as RouteLabels, RouteLabelExtract},
-};
+use super::{extensions, metrics::labels::Route as RouteLabels};
 use futures::future::{Either, Ready};
 use linkerd_app_core::{
     cause_ref, classify,
@@ -15,8 +12,7 @@ use linkerd_http_retry::{self as retry, peek_trailers::PeekTrailersBody};
 use linkerd_proxy_client_policy as policy;
 use tokio::time;
 
-pub type NewHttpRetry<F, N> =
-    retry::NewHttpRetry<RetryPolicy, RouteLabels, F, RouteLabelExtract, N>;
+pub type NewHttpRetry<X, N> = retry::NewHttpRetry<RetryPolicy, RouteLabels, (), X, N>;
 
 #[derive(Clone, Debug)]
 pub struct RetryPolicy {

--- a/linkerd/app/outbound/src/http/logical/policy/router.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/router.rs
@@ -65,7 +65,8 @@ where
     route::MatchedRoute<T, M::Summary, F, P>: route::filters::Apply
         + svc::Param<classify::Request>
         + svc::Param<route::extensions::Params>
-        + route::metrics::MkStreamLabel,
+        + route::metrics::MkStreamLabel
+        + svc::ExtractParam<route::metrics::labels::Route, http::Request<http::BoxBody>>,
     route::MatchedBackend<T, M::Summary, F>: route::filters::Apply + route::metrics::MkStreamLabel,
 {
     /// Builds a stack that applies routes to distribute requests over a cached

--- a/linkerd/http/retry/src/lib.rs
+++ b/linkerd/http/retry/src/lib.rs
@@ -85,6 +85,14 @@ struct Metrics {
 
 // === impl NewHttpRetry ===
 
+impl<P, L: Clone, ReqX, N> NewHttpRetry<P, L, (), ReqX, N> {
+    pub fn layer(
+        metrics: MetricFamilies<L>,
+    ) -> impl tower::layer::Layer<N, Service = Self> + Clone {
+        Self::layer_via_mk((), metrics)
+    }
+}
+
 impl<P, L: Clone, X: Clone, ReqX, N> NewHttpRetry<P, L, X, ReqX, N> {
     pub fn layer_via_mk(
         extract: X,


### PR DESCRIPTION
The outbound HTTP route labels use multiple ExtractParam implementations to convert a matched route target to set of labels (using an HTTP request).

This change removes the RouteLabelExtract type, in favor of implementing label extraction on the route target type directly.