### PR TITLE
feat(outbound)!: disable 'hostname' metrics label

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route.rs
@@ -174,7 +174,7 @@ impl<B, T> svc::ExtractParam<metrics::labels::Route, http::Request<B>> for Http<
         metrics::labels::Route::new(
             self.params.parent_ref.clone(),
             self.params.route_ref.clone(),
-            req.uri(),
+            self.params.params.export_hostname_labels.then(|| req.uri()),
         )
     }
 }
@@ -187,10 +187,9 @@ impl<T> metrics::MkStreamLabel for Http<T> {
     fn mk_stream_labeler<B>(&self, req: &::http::Request<B>) -> Option<Self::StreamLabel> {
         let parent = self.params.parent_ref.clone();
         let route = self.params.route_ref.clone();
+        let uri = self.params.params.export_hostname_labels.then(|| req.uri());
         Some(metrics::LabelHttpRsp::from(metrics::labels::Route::new(
-            parent,
-            route,
-            req.uri(),
+            parent, route, uri,
         )))
     }
 }
@@ -240,7 +239,7 @@ impl<B, T> svc::ExtractParam<metrics::labels::Route, http::Request<B>> for Grpc<
         metrics::labels::Route::new(
             self.params.parent_ref.clone(),
             self.params.route_ref.clone(),
-            req.uri(),
+            self.params.params.export_hostname_labels.then(|| req.uri()),
         )
     }
 }
@@ -253,10 +252,9 @@ impl<T> metrics::MkStreamLabel for Grpc<T> {
     fn mk_stream_labeler<B>(&self, req: &::http::Request<B>) -> Option<Self::StreamLabel> {
         let parent = self.params.parent_ref.clone();
         let route = self.params.route_ref.clone();
+        let uri = self.params.params.export_hostname_labels.then(|| req.uri());
         Some(metrics::LabelGrpcRsp::from(metrics::labels::Route::new(
-            parent,
-            route,
-            req.uri(),
+            parent, route, uri,
         )))
     }
 }

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
@@ -59,12 +59,10 @@ pub enum Error {
 // === impl Route ===
 
 impl Route {
-    pub fn new(parent: ParentRef, route: RouteRef, uri: &http::uri::Uri) -> Self {
+    pub fn new(parent: ParentRef, route: RouteRef, uri: Option<&http::uri::Uri>) -> Self {
         let hostname = uri
-            .host()
-            .map(str::as_bytes)
-            .map(dns::Name::try_from_ascii)
-            .and_then(Result::ok);
+            .and_then(http::uri::Uri::host)
+            .and_then(|h| dns::Name::try_from_ascii(h.as_bytes()).ok());
 
         Self {
             parent,

--- a/linkerd/app/outbound/src/tls/logical/router.rs
+++ b/linkerd/app/outbound/src/tls/logical/router.rs
@@ -130,11 +130,11 @@ where
                 }
             };
 
-        let mk_policy = |policy::RoutePolicy::<policy::tls::Filter, ()> {
+        let mk_policy = |policy::tls::Policy {
                              meta,
                              distribution,
                              filters,
-                             ..
+                             params,
                          }| {
             let route_ref = RouteRef(meta);
             let parent_ref = parent_ref.clone();
@@ -147,6 +147,7 @@ where
                 route_ref,
                 filters,
                 distribution,
+                params,
             }
         };
 

--- a/linkerd/app/outbound/src/tls/logical/tests.rs
+++ b/linkerd/app/outbound/src/tls/logical/tests.rs
@@ -158,7 +158,7 @@ fn sni_route(backend: client_policy::Backend, sni: sni::MatchSni) -> client_poli
         policy: Policy {
             meta: Meta::new_default("test_route"),
             filters: NO_FILTERS.clone(),
-            params: (),
+            params: Default::default(),
             distribution: RouteDistribution::FirstAvailable(Arc::new([RouteBackend {
                 filters: NO_FILTERS.clone(),
                 backend,

--- a/linkerd/proxy/client-policy/src/grpc.rs
+++ b/linkerd/proxy/client-policy/src/grpc.rs
@@ -14,6 +14,7 @@ pub struct RouteParams {
     pub timeouts: crate::http::Timeouts,
     pub retry: Option<Retry>,
     pub allow_l5d_request_headers: bool,
+    pub export_hostname_labels: bool,
 }
 
 // TODO HTTP2 settings
@@ -261,7 +262,13 @@ pub mod proto {
             .ok_or(InvalidGrpcRoute::Missing("distribution"))?
             .try_into()?;
 
-        let mut params = RouteParams::try_from_proto(timeouts, retry, allow_l5d_request_headers)?;
+        let export_hostname_labels = false;
+        let mut params = RouteParams::try_from_proto(
+            timeouts,
+            retry,
+            allow_l5d_request_headers,
+            export_hostname_labels,
+        )?;
         let legacy = request_timeout.map(TryInto::try_into).transpose()?;
         params.timeouts.request = params.timeouts.request.or(legacy);
 
@@ -281,6 +288,7 @@ pub mod proto {
             timeouts: Option<linkerd2_proxy_api::http_route::Timeouts>,
             retry: Option<grpc_route::Retry>,
             allow_l5d_request_headers: bool,
+            export_hostname_labels: bool,
         ) -> Result<Self, InvalidGrpcRoute> {
             Ok(Self {
                 retry: retry.map(Retry::try_from).transpose()?,
@@ -289,6 +297,7 @@ pub mod proto {
                     .transpose()?
                     .unwrap_or_default(),
                 allow_l5d_request_headers,
+                export_hostname_labels,
             })
         }
     }

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -14,6 +14,7 @@ pub struct RouteParams {
     pub timeouts: Timeouts,
     pub retry: Option<Retry>,
     pub allow_l5d_request_headers: bool,
+    pub export_hostname_labels: bool,
 }
 
 // TODO: keepalive settings, etc.
@@ -299,7 +300,13 @@ pub mod proto {
             .ok_or(InvalidHttpRoute::Missing("distribution"))?
             .try_into()?;
 
-        let mut params = RouteParams::try_from_proto(timeouts, retry, allow_l5d_request_headers)?;
+        let export_hostname_labels = false;
+        let mut params = RouteParams::try_from_proto(
+            timeouts,
+            retry,
+            allow_l5d_request_headers,
+            export_hostname_labels,
+        )?;
         let legacy = request_timeout.map(TryInto::try_into).transpose()?;
         params.timeouts.request = params.timeouts.request.or(legacy);
 
@@ -319,6 +326,7 @@ pub mod proto {
             timeouts: Option<linkerd2_proxy_api::http_route::Timeouts>,
             retry: Option<http_route::Retry>,
             allow_l5d_request_headers: bool,
+            export_hostname_labels: bool,
         ) -> Result<Self, InvalidHttpRoute> {
             Ok(Self {
                 retry: retry.map(Retry::try_from).transpose()?,
@@ -327,6 +335,7 @@ pub mod proto {
                     .transpose()?
                     .unwrap_or_default(),
                 allow_l5d_request_headers,
+                export_hostname_labels,
             })
         }
     }

--- a/linkerd/proxy/client-policy/src/tls.rs
+++ b/linkerd/proxy/client-policy/src/tls.rs
@@ -2,8 +2,13 @@ use linkerd_tls_route as tls;
 pub use linkerd_tls_route::{find, sni, RouteMatch};
 use std::sync::Arc;
 
-pub type Policy = crate::RoutePolicy<Filter, ()>;
+pub type Policy = crate::RoutePolicy<Filter, RouteParams>;
 pub type Route = tls::Route<Policy>;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+pub struct RouteParams {
+    pub export_hostname_labels: bool,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Tls {
@@ -23,7 +28,7 @@ pub fn default(distribution: crate::RouteDistribution<Filter>) -> Route {
         policy: Policy {
             meta: crate::Meta::new_default("default"),
             filters: Arc::new([]),
-            params: (),
+            params: Default::default(),
             distribution,
         },
     }
@@ -153,7 +158,7 @@ pub(crate) mod proto {
         Ok(Policy {
             meta: meta.clone(),
             filters,
-            params: (),
+            params: Default::default(),
             distribution,
         })
     }


### PR DESCRIPTION
The 'hostname' label value is derived from the request URI and can be influenced
by applications. If a client uses a high cardinality of hostname values, this
leads to the proxy exporting many metrics and ultimately exhausting resources.

This change disables the 'hostname' label by default. A new field is outed to
the HTTP and TLS route parameters, `export_hostname_labels`, which can be used
to enable the 'hostname' label; however, this type is not yet configurable.
Changes are required to the proxy API and, ultimately, the policy controller, to
make this field configurable.

When the hostname is not exported, an empty label value is used.

BREAKING: The 'hostname' label is now disabled by default.