### PR TITLE
chore(app/spire): make spire compilation possible for non-linux targets

### DIFF
--- a/linkerd/app/src/spire.rs
+++ b/linkerd/app/src/spire.rs
@@ -17,7 +17,7 @@ pub struct Config {
 
 // Connects to SPIRE workload API via Unix Domain Socket
 pub struct Client {
-    #[allow(dead_code)]
+    #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     config: Config,
 }
 


### PR DESCRIPTION
At the moment the fact that SPIRE uses Unix domain sockets prevents us from building
the proxy for non-unix targets. This PR adds special casing that allows us to build for
these targets but makes the spire client fail at runtime. Non-unix support for Spire shall
be introduced at a later stage.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>