### PR TITLE
chore(transport): Ignore TCP_USER_TIMEOUT on non-Linux systems and warn

### DIFF
--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -71,6 +71,7 @@ fn set_keepalive_or_warn(
     tokio::net::TcpStream::from_std(stream)
 }
 
+#[cfg(target_os = "linux")]
 fn set_user_timeout_or_warn(
     tcp: TcpStream,
     user_timeout: Option<Duration>,
@@ -84,4 +85,15 @@ fn set_user_timeout_or_warn(
     }
     let stream: std::net::TcpStream = socket2::Socket::into(sock);
     tokio::net::TcpStream::from_std(stream)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn set_user_timeout_or_warn(
+    tcp: TcpStream,
+    user_timeout: Option<Duration>,
+) -> io::Result<TcpStream> {
+    if user_timeout.is_some() {
+        tracing::warn!("TCP_USER_TIMEOUT is supported on Linux only.");
+    }
+    Ok(tcp)
 }

--- a/linkerd/proxy/transport/src/lib.rs
+++ b/linkerd/proxy/transport/src/lib.rs
@@ -93,7 +93,7 @@ fn set_user_timeout_or_warn(
     user_timeout: Option<Duration>,
 ) -> io::Result<TcpStream> {
     if user_timeout.is_some() {
-        tracing::warn!("TCP_USER_TIMEOUT is supported on Linux only.");
+        tracing::debug!("TCP_USER_TIMEOUT is supported on Linux only.");
     }
     Ok(tcp)
 }


### PR DESCRIPTION
Right now the proxy can be configured so that `TCP_USER_TIMEOUT` is set on connections.
This functionality is not present for non-linux targets. This introduces a warning in case a user
tries to set `TCP_USER_TIMEOUT` on a proxy that has been compiled for a target other than Linux.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>