### PR TITLE
chore(app/trace-collector): remove `Default` bounds

### DIFF
--- a/linkerd/app/src/trace_collector/otel_collector.rs
+++ b/linkerd/app/src/trace_collector/otel_collector.rs
@@ -34,7 +34,7 @@ where
     S: GrpcService<BoxBody> + Clone + Send + 'static,
     S::Error: Into<Error>,
     S::Future: Send,
-    S::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    S::ResponseBody: Body<Data = tonic::codegen::Bytes> + Send + 'static,
     <S::ResponseBody as Body>::Error: Into<Error> + Send,
 {
     let (span_sink, spans_rx) = mpsc::channel(crate::trace_collector::SPAN_BUFFER_CAPACITY);

--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -24,7 +24,7 @@ pub async fn export_spans<T, S>(client: T, node: Node, spans: S, metrics: Regist
 where
     T: GrpcService<BoxBody> + Clone,
     T::Error: Into<Error>,
-    T::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    T::ResponseBody: Body<Data = tonic::codegen::Bytes> + Send + 'static,
     <T::ResponseBody as Body>::Error: Into<Error> + Send,
     S: Stream<Item = ExportSpan> + Unpin,
 {
@@ -49,7 +49,7 @@ impl<T, S> SpanExporter<T, S>
 where
     T: GrpcService<BoxBody>,
     T::Error: Into<Error>,
-    T::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    T::ResponseBody: Body<Data = tonic::codegen::Bytes> + Send + 'static,
     <T::ResponseBody as Body>::Error: Into<Error> + Send,
     S: Stream<Item = ExportSpan> + Unpin,
 {

--- a/linkerd/opentelemetry/src/lib.rs
+++ b/linkerd/opentelemetry/src/lib.rs
@@ -39,7 +39,7 @@ pub async fn export_spans<T, S>(
 ) where
     T: GrpcService<BoxBody> + Clone,
     T::Error: Into<Error>,
-    T::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    T::ResponseBody: Body<Data = tonic::codegen::Bytes> + Send + 'static,
     <T::ResponseBody as Body>::Error: Into<Error> + Send,
     S: Stream<Item = ExportSpan> + Unpin,
 {
@@ -66,7 +66,7 @@ impl<T, S> SpanExporter<T, S>
 where
     T: GrpcService<BoxBody> + Clone,
     T::Error: Into<Error>,
-    T::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    T::ResponseBody: Body<Data = tonic::codegen::Bytes> + Send + 'static,
     <T::ResponseBody as Body>::Error: Into<Error> + Send,
     S: Stream<Item = ExportSpan> + Unpin,
 {


### PR DESCRIPTION
see https://github.com/linkerd/linkerd2/issues/8733 for more information.

in hyper 1.x, `Incoming` bodies do not provide a `Default` implementation. compare the trait implementations here:

* https://docs.rs/hyper/0.14.31/hyper/body/struct.Body.html#impl-Default-for-Body
* https://docs.rs/hyper/latest/hyper/body/struct.Incoming.html#trait-implementations

this commit removes these bounds from the
`linkerd_app::trace_collector::otel_collector::SpanExporter<T, S>` and other connected functions.