### PR TITLE
nit(opencensus): format use statements

### DIFF
--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -9,11 +9,13 @@ use linkerd_error::Error;
 use linkerd_trace_context::export::{ExportSpan, SpanKind};
 use metrics::Registry;
 pub use opencensus_proto as proto;
-use opencensus_proto::agent::common::v1::Node;
-use opencensus_proto::agent::trace::v1::{
-    trace_service_client::TraceServiceClient, ExportTraceServiceRequest,
+use opencensus_proto::{
+    agent::{
+        common::v1::Node,
+        trace::v1::{trace_service_client::TraceServiceClient, ExportTraceServiceRequest},
+    },
+    trace::v1::{Span, TruncatableString},
 };
-use opencensus_proto::trace::v1::{Span, TruncatableString};
 use std::collections::HashMap;
 use tokio::{sync::mpsc, time};
 use tokio_stream::wrappers::ReceiverStream;


### PR DESCRIPTION
this commit makes some superficial adjustments to import statements in `linkerd-opencensus`. we have a convention of using crate-level symbol groupings in `use` statements. this commit follows that convention.