### PR TITLE
chore(proxy/identity-client): remove `Default` bounds

### DIFF
--- a/linkerd/proxy/identity-client/src/certify.rs
+++ b/linkerd/proxy/identity-client/src/certify.rs
@@ -93,7 +93,7 @@ impl Certify {
         C: Credentials,
         N: NewService<(), Service = S>,
         S: GrpcService<BoxBody>,
-        S::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+        S::ResponseBody: Body<Data = tonic::codegen::Bytes> + Send + 'static,
         <S::ResponseBody as Body>::Error: Into<Error> + Send,
     {
         debug!("Identity daemon running");
@@ -155,7 +155,7 @@ async fn certify<C, S>(
 where
     C: Credentials,
     S: GrpcService<BoxBody>,
-    S::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    S::ResponseBody: Body<Data = tonic::codegen::Bytes> + Send + 'static,
     <S::ResponseBody as Body>::Error: Into<Error> + Send,
 {
     let req = tonic::Request::new(api::CertifyRequest {


### PR DESCRIPTION
https://github.com/linkerd/linkerd2/issues/8733 for more information.

see also, https://github.com/linkerd/linkerd2-proxy/pull/3651 for another related pull request.

in hyper 1.x, `Incoming` bodies do not provide a `Default` implementation. compare the trait implementations here:

* https://docs.rs/hyper/0.14.31/hyper/body/struct.Body.html#impl-Default-for-Body
* https://docs.rs/hyper/latest/hyper/body/struct.Incoming.html#trait-implementations

this commit removes these bounds from
`linkerd_proxy_identity_client::Certify<C, S>`.