### PR TITLE
chore(app/inbound): remove `Default` bounds

### DIFF
--- a/linkerd/app/inbound/src/policy/api.rs
+++ b/linkerd/app/inbound/src/policy/api.rs
@@ -34,8 +34,7 @@ static INVALID_POLICY: once_cell::sync::OnceCell<ServerPolicy> = once_cell::sync
 impl<S> Api<S>
 where
     S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error> + Clone,
-    S::ResponseBody:
-        http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+    S::ResponseBody: http::Body<Data = tonic::codegen::Bytes, Error = Error> + Send + 'static,
 {
     pub(super) fn new(
         workload: Arc<str>,
@@ -60,8 +59,7 @@ impl<S> Service<u16> for Api<S>
 where
     S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
     S: Clone + Send + Sync + 'static,
-    S::ResponseBody:
-        http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+    S::ResponseBody: http::Body<Data = tonic::codegen::Bytes, Error = Error> + Send + 'static,
     S::Future: Send + 'static,
 {
     type Response =

--- a/linkerd/app/inbound/src/policy/config.rs
+++ b/linkerd/app/inbound/src/policy/config.rs
@@ -43,7 +43,7 @@ impl Config {
         C: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
         C: Clone + Unpin + Send + Sync + 'static,
         C::ResponseBody: http::Body<Data = tonic::codegen::Bytes, Error = Error>,
-        C::ResponseBody: Default + Send + 'static,
+        C::ResponseBody: Send + 'static,
         C::Future: Send,
     {
         match self {

--- a/linkerd/app/inbound/src/policy/store.rs
+++ b/linkerd/app/inbound/src/policy/store.rs
@@ -77,8 +77,7 @@ impl<S> Store<S> {
         S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
         S: Clone + Send + Sync + 'static,
         S::Future: Send,
-        S::ResponseBody:
-            http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+        S::ResponseBody: http::Body<Data = tonic::codegen::Bytes, Error = Error> + Send + 'static,
     {
         let opaque_default = Self::make_opaque(default.clone());
         // The initial set of policies never expire from the cache.
@@ -142,8 +141,7 @@ where
     S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
     S: Clone + Send + Sync + 'static,
     S::Future: Send,
-    S::ResponseBody:
-        http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+    S::ResponseBody: http::Body<Data = tonic::codegen::Bytes, Error = Error> + Send + 'static,
 {
     fn get_policy(&self, dst: OrigDstAddr) -> AllowPolicy {
         // Lookup the policy for the target port in the cache. If it doesn't

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -30,7 +30,7 @@ impl Inbound<()> {
         C: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
         C: Clone + Unpin + Send + Sync + 'static,
         C::ResponseBody: http::Body<Data = tonic::codegen::Bytes, Error = Error>,
-        C::ResponseBody: Default + Send + 'static,
+        C::ResponseBody: Send + 'static,
         C::Future: Send,
     {
         self.config


### PR DESCRIPTION
see https://github.com/linkerd/linkerd2/issues/8733 for more information.

see also, #3651 and #3653 for some related pull requests.

in hyper 1.x, `Incoming` bodies do not provide a `Default` implementation. compare the trait implementations here:

* https://docs.rs/hyper/0.14.31/hyper/body/struct.Body.html#impl-Default-for-Body
* https://docs.rs/hyper/latest/hyper/body/struct.Incoming.html#trait-implementations

this commit removes `Default` bounds from policy lookup in the inbound proxy. this means that in `linkerd-app`, we can invoke `Inbound::build_policies()` when using hyper 1.x (_see #3504_)