### PR TITLE
chore(app/outbound): remove `Default` bounds

### DIFF
--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -148,7 +148,7 @@ impl Outbound<()> {
         C: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
         C: Clone + Unpin + Send + Sync + 'static,
         C::ResponseBody: proxy::http::Body<Data = tonic::codegen::Bytes, Error = Error>,
-        C::ResponseBody: Default + Send + 'static,
+        C::ResponseBody: Send + 'static,
         C::Future: Send,
     {
         policy::Api::new(workload, limits, Duration::from_secs(10), client)

--- a/linkerd/app/outbound/src/policy/api.rs
+++ b/linkerd/app/outbound/src/policy/api.rs
@@ -33,8 +33,7 @@ static INVALID_POLICY: once_cell::sync::OnceCell<ClientPolicy> = once_cell::sync
 impl<S> Api<S>
 where
     S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error> + Clone,
-    S::ResponseBody:
-        http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+    S::ResponseBody: http::Body<Data = tonic::codegen::Bytes, Error = Error> + Send + 'static,
 {
     pub(crate) fn new(
         workload: Arc<str>,
@@ -59,8 +58,7 @@ impl<S> Service<Addr> for Api<S>
 where
     S: tonic::client::GrpcService<tonic::body::BoxBody, Error = Error>,
     S: Clone + Send + Sync + 'static,
-    S::ResponseBody:
-        http::Body<Data = tonic::codegen::Bytes, Error = Error> + Default + Send + 'static,
+    S::ResponseBody: http::Body<Data = tonic::codegen::Bytes, Error = Error> + Send + 'static,
     S::Future: Send + 'static,
 {
     type Response =


### PR DESCRIPTION
see https://github.com/linkerd/linkerd2/issues/8733 for more information.

see also, #3651 #3653, and #3654 for some related pull requests.

in hyper 1.x, `Incoming` bodies do not provide a `Default` implementation. compare the trait implementations here:

* https://docs.rs/hyper/0.14.31/hyper/body/struct.Body.html#impl-Default-for-Body
* https://docs.rs/hyper/latest/hyper/body/struct.Incoming.html#trait-implementations

this commit removes `Default` bounds from policy lookup in the outbound proxy. this means that in `linkerd-app`, we can invoke `Outbound::build_policies()` when using hyper 1.x (_see #3504_)