### PR TITLE
chore(app/trace-collector): remove `Default` bound

### DIFF
--- a/linkerd/app/src/trace_collector/oc_collector.rs
+++ b/linkerd/app/src/trace_collector/oc_collector.rs
@@ -21,7 +21,7 @@ where
     S: GrpcService<BoxBody> + Clone + Send + 'static,
     S::Error: Into<Error>,
     S::Future: Send,
-    S::ResponseBody: Default + Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    S::ResponseBody: Body<Data = tonic::codegen::Bytes> + Send + 'static,
     <S::ResponseBody as Body>::Error: Into<Error> + Send,
 {
     let (span_sink, spans_rx) = mpsc::channel(crate::trace_collector::SPAN_BUFFER_CAPACITY);


### PR DESCRIPTION
see #3651 and linkerd/linkerd2#8733.

#3651 missed this unused trait bound, which we want to loosen to account for changes in hyper's api.