### PR TITLE
refactor(app/inbound): forward-compatible test code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,6 +1442,7 @@ dependencies = [
  "linkerd-app-core",
  "linkerd-app-test",
  "linkerd-http-access-log",
+ "linkerd-http-body-compat",
  "linkerd-http-metrics",
  "linkerd-idle-cache",
  "linkerd-io",

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -56,6 +56,7 @@ linkerd-meshtls-rustls = { path = "../../meshtls/rustls", features = [
 [dev-dependencies]
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 linkerd-app-test = { path = "../test" }
+linkerd-http-body-compat = { path = "../../http/body-compat" }
 linkerd-http-metrics = { path = "../../http/metrics", features = ["test-util"] }
 linkerd-idle-cache = { path = "../../idle-cache", features = ["test-util"] }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }


### PR DESCRIPTION
see https://github.com/linkerd/linkerd2/issues/8733 for more information.

see https://github.com/linkerd/linkerd2-proxy/pull/3559 and https://github.com/linkerd/linkerd2-proxy/pull/3614 for more information on the `ForwardCompatibleBody<B>` wrapper.

this branch updates test code in `linkerd-app-inbound` so that it interacts with request and response bodies via an adapter that polls for frames in a manner consistent with the 1.0 api of `http_body`.

this allows us to limit the diff in https://github.com/linkerd/linkerd2-proxy/pull/3504, which will only need to remove this adapter once using hyper 1.0.

see #3672 and #3673, which perform the same change for `linkerd-app-outbound` and `linkerd-app-integration`, respectively.