### PR TITLE
refactor(app/outbound): forward-compatible test code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,6 +1513,7 @@ dependencies = [
  "linkerd-app-core",
  "linkerd-app-test",
  "linkerd-distribute",
+ "linkerd-http-body-compat",
  "linkerd-http-classify",
  "linkerd-http-prom",
  "linkerd-http-retry",

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -61,6 +61,7 @@ tokio-test = "0.4"
 tower-test = "0.4"
 
 linkerd-app-test = { path = "../test", features = ["client-policy"] }
+linkerd-http-body-compat = { path = "../../http/body-compat" }
 linkerd-http-prom = { path = "../../http/prom", features = ["test-util"] }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 linkerd-meshtls = { path = "../../meshtls", features = ["rustls"] }

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/test_util.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/test_util.rs
@@ -1,3 +1,4 @@
+use http::Response;
 use linkerd_app_core::{
     metrics::prom::Counter,
     proxy::http::Body,
@@ -23,11 +24,11 @@ pub async fn send_assert_incremented(
     };
     assert_eq!(counter.get(), init);
     send(tx);
-    if let Ok(mut rsp) = call.await {
-        if !rsp.body().is_end_stream() {
+    if let Ok(mut body) = call.await.map(Response::into_body) {
+        if !body.is_end_stream() {
             assert_eq!(counter.get(), 0);
-            while let Some(Ok(_)) = rsp.body_mut().data().await {}
-            let _ = rsp.body_mut().trailers().await;
+            while let Some(Ok(_)) = body.data().await {}
+            let _ = body.trailers().await;
         }
     }
     assert_eq!(counter.get(), init + 1);


### PR DESCRIPTION
see https://github.com/linkerd/linkerd2/issues/8733 for more information.

see https://github.com/linkerd/linkerd2-proxy/pull/3559 and https://github.com/linkerd/linkerd2-proxy/pull/3614 for more information on the `ForwardCompatibleBody<B>` wrapper.

this branch updates test code in `linkerd-app-outbound` so that it interacts with request and response bodies via an adapter that polls for frames in a manner consistent with the 1.0 api of `http_body`.

this allows us to limit the diff in https://github.com/linkerd/linkerd2-proxy/pull/3504, which will only need to remove this adapter once using hyper 1.0.

see #3671 and #3673, which perform the same change for `linkerd-app-inbound` and `linkerd-app-integration`, respectively.