### PR TITLE
refactor(app/outbound): forward-compatible test code

### DIFF
--- a/linkerd/app/outbound/src/http/logical/tests/timeouts.rs
+++ b/linkerd/app/outbound/src/http/logical/tests/timeouts.rs
@@ -4,7 +4,7 @@ use linkerd_app_core::{
     proxy::http::{
         self,
         stream_timeouts::{BodyTimeoutError, ResponseTimeoutError},
-        Body, BoxBody,
+        BoxBody,
     },
     trace,
 };
@@ -124,8 +124,12 @@ async fn request_timeout_response_body() {
     .await;
 
     info!("Verifying that the request body times out with the expected stream error");
-    let mut rsp = call.await.unwrap().into_body();
-    let error = time::timeout(TIMEOUT * 2, rsp.data())
+    let mut rsp = call
+        .await
+        .unwrap()
+        .map(linkerd_http_body_compat::ForwardCompatibleBody::new)
+        .into_body();
+    let error = time::timeout(TIMEOUT * 2, rsp.frame())
         .await
         .expect("should timeout internally")
         .expect("should timeout internally")
@@ -208,10 +212,14 @@ async fn response_timeout_response_body() {
     );
 
     info!("Sending a request that responds immediately but does not complete");
-    let mut rsp = send_req(svc.clone(), http_get()).await.unwrap().into_body();
+    let mut rsp = send_req(svc.clone(), http_get())
+        .await
+        .unwrap()
+        .map(linkerd_http_body_compat::ForwardCompatibleBody::new)
+        .into_body();
 
     info!("Verifying that the request body times out with the expected stream error");
-    let error = time::timeout(TIMEOUT * 2, rsp.data())
+    let error = time::timeout(TIMEOUT * 2, rsp.frame())
         .await
         .expect("should timeout internally")
         .expect("should timeout internally")
@@ -284,8 +292,12 @@ async fn idle_timeout_response_body() {
     .await;
 
     info!("Verifying that the request body times out with the expected stream error");
-    let mut rsp = call.await.unwrap().into_body();
-    let error = time::timeout(TIMEOUT * 2, rsp.data())
+    let mut rsp = call
+        .await
+        .unwrap()
+        .map(linkerd_http_body_compat::ForwardCompatibleBody::new)
+        .into_body();
+    let error = time::timeout(TIMEOUT * 2, rsp.frame())
         .await
         .expect("should timeout internally")
         .expect("should timeout internally")


### PR DESCRIPTION
see https://github.com/linkerd/linkerd2/issues/8733 for more information.

see https://github.com/linkerd/linkerd2-proxy/pull/3559 and https://github.com/linkerd/linkerd2-proxy/pull/3614 for more information on the `ForwardCompatibleBody<B>` wrapper.

this branch updates test code in `linkerd-app-outbound` related to timeouts so that it interacts with request and response bodies via an adapter that polls for frames in a manner consistent with the 1.0 api of `http_body`.

this allows us to limit the diff in
https://github.com/linkerd/linkerd2-proxy/pull/3504, which will only need to remove this adapter once using hyper 1.0.

see #3671, #3672, and #3673, which performed the same change for `linkerd-app-inbound`, other code in `linkerd-app-outbound`, and `linkerd-app-integration`, respectively.