### PR TITLE
refactor(app/integration): clarify `<SyncSvc as Service<T>>::call()`

### DIFF
--- a/linkerd/app/integration/src/tap.rs
+++ b/linkerd/app/integration/src/tap.rs
@@ -192,9 +192,8 @@ type ResponseFuture =
 
 impl<B> tower::Service<http::Request<B>> for SyncSvc
 where
-    B: Body + Send + 'static,
-    B::Data: Send + 'static,
-    B::Error: std::fmt::Debug + Send + 'static,
+    B: Body,
+    B::Error: std::fmt::Debug,
 {
     type Response = http::Response<hyper::Body>;
     type Error = String;


### PR DESCRIPTION
 ## refactor(app/integration): clarify `<SyncSvc as Service<T>>::call()`

this commit makes some cosmetic changes to
`linkerd_app_integration::tap::SyncSvc`'s implementation of
`tower::Service<T>`.

documentation comments are added to clarify something that makes this
service slightly interesting, and notably different from code suitable
for use in production / real-world contexts.

this service wraps an underlying `Client`, and provides a service
implementation that deals with arbitrary `B`-typed request bodies.
this provides a flexible adapter that simplifies test code.

this service, however, *blocks* the calling thread (off-task) to collect
the body into a cheaply-cloneable `Bytes`.

this commit outlines that logic into an associated function and adds
additional documentation noting this property, and the basis for this
assumption.

 ## refactor(app/integration): loosen `SyncSvc` bounds

the bounds placed upon the inbound request's `B`-typed body are overly
restrictive for `<SyncSvc as Service<T>>`. this commit removes some
superfluous bounds, so that only those that are currently needed by this
code are now required.

 ## refactor(app/integration): use `Result::expect()`

a small cosmetic change.
