### PR TITLE
refactor(app/integration): inline `Running` future

### DIFF
--- a/linkerd/app/integration/src/lib.rs
+++ b/linkerd/app/integration/src/lib.rs
@@ -217,15 +217,6 @@ impl Shutdown {
 
 pub type ShutdownRx = Pin<Box<dyn Future<Output = ()> + Send>>;
 
-/// A channel used to signal when a Client's related connection is running or closed.
-pub fn running() -> (oneshot::Sender<()>, Running) {
-    let (tx, rx) = oneshot::channel();
-    let rx = Box::pin(rx.map(|_| ()));
-    (tx, rx)
-}
-
-pub type Running = Pin<Box<dyn Future<Output = ()> + Send + Sync + 'static>>;
-
 pub fn s(bytes: &[u8]) -> &str {
     ::std::str::from_utf8(bytes).unwrap()
 }


### PR DESCRIPTION
`linkerd_app_integration::running()` is a public function that is not used by any external callers. this function is used in one place, when setting up test client used for integration tests.

this commit inlines this logic, and moves the associated `Running` type alias down alongside the `Run` enum.