### PR TITLE
refactor(app/integration): call `tcp::client()` directly

### DIFF
--- a/linkerd/app/integration/src/client.rs
+++ b/linkerd/app/integration/src/client.rs
@@ -76,10 +76,6 @@ pub fn http2_tls<T: Into<String>>(addr: SocketAddr, auth: T, tls: TlsConfig) -> 
     Client::new(addr, auth.into(), Run::Http2, Some(tls))
 }
 
-pub fn tcp(addr: SocketAddr) -> tcp::TcpClient {
-    tcp::client(addr)
-}
-
 pub struct Client {
     addr: SocketAddr,
     run: Run,

--- a/linkerd/app/integration/src/tests/identity.rs
+++ b/linkerd/app/integration/src/tests/identity.rs
@@ -33,7 +33,7 @@ async fn nonblocking_identity_detection() {
         .await;
 
     let proxy = proxy.inbound(srv).run_with_test_env(env).await;
-    let client = client::tcp(proxy.inbound);
+    let client = crate::tcp::client(proxy.inbound);
 
     // Create an idle connection and then an active connection. Ensure that
     // protocol detection on the idle connection does not block communication on

--- a/linkerd/app/integration/src/tests/shutdown.rs
+++ b/linkerd/app/integration/src/tests/shutdown.rs
@@ -117,7 +117,7 @@ async fn tcp_waits_for_proxies_to_close() {
         .await;
     let proxy = proxy::new().inbound(srv).shutdown_signal(rx).run().await;
 
-    let client = client::tcp(proxy.inbound);
+    let client = crate::tcp::client(proxy.inbound);
 
     let tcp_client = client.connect().await;
 

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -145,7 +145,7 @@ impl TcpFixture {
             .run()
             .await;
 
-        let client = client::tcp(proxy.inbound);
+        let client = crate::tcp::client(proxy.inbound);
         let metrics = client::http1(proxy.admin, "localhost");
 
         let src_labels = metrics::labels()
@@ -184,7 +184,7 @@ impl TcpFixture {
             .run()
             .await;
 
-        let client = client::tcp(proxy.outbound);
+        let client = crate::tcp::client(proxy.outbound);
         let metrics = client::http1(proxy.admin, "localhost");
 
         let src_labels = metrics::labels()

--- a/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
+++ b/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
@@ -113,7 +113,7 @@ async fn inbound_timeout() {
     let _trace = trace_init();
 
     let (proxy, metrics) = Test::default().run().await;
-    let client = client::tcp(proxy.inbound);
+    let client = crate::tcp::client(proxy.inbound);
 
     let _tcp_client = client.connect().await;
 
@@ -133,7 +133,7 @@ async fn inbound_io_err() {
     let _trace = trace_init();
 
     let (proxy, metrics) = Test::default().run().await;
-    let client = client::tcp(proxy.inbound);
+    let client = crate::tcp::client(proxy.inbound);
 
     let tcp_client = client.connect().await;
 
@@ -167,7 +167,7 @@ async fn inbound_success() {
         "foo.ns1.svc.cluster.local",
         client_config.clone(),
     );
-    let no_tls_client = client::tcp(proxy.inbound);
+    let no_tls_client = crate::tcp::client(proxy.inbound);
 
     let metric = metric(&proxy)
         .label("error", "tls detection timeout")
@@ -198,7 +198,7 @@ async fn inbound_multi() {
     let _trace = trace_init();
 
     let (proxy, metrics) = Test::default().run().await;
-    let client = client::tcp(proxy.inbound);
+    let client = crate::tcp::client(proxy.inbound);
 
     let metric = metric(&proxy);
     let timeout_metric = metric.clone().label("error", "tls detection timeout");
@@ -244,7 +244,7 @@ async fn inbound_direct_multi() {
     let proxy = proxy::new().inbound(srv).inbound_direct();
 
     let (proxy, metrics) = Test::new(proxy).run().await;
-    let client = client::tcp(proxy.inbound);
+    let client = crate::tcp::client(proxy.inbound);
 
     let metric = metrics::metric(METRIC).label("target_addr", proxy.inbound);
     let timeout_metric = metric.clone().label("error", "tls detection timeout");
@@ -291,7 +291,7 @@ async fn inbound_invalid_ip() {
         .run()
         .await;
 
-    let client = client::tcp(proxy.inbound);
+    let client = crate::tcp::client(proxy.inbound);
     let metric = metric(&proxy)
         .label("error", "unexpected")
         .label("target_addr", fake_ip);
@@ -354,7 +354,7 @@ async fn inbound_direct_success() {
         .await;
 
     let tls_client = client::http1(proxy2.outbound, auth);
-    let no_tls_client = client::tcp(proxy1.inbound);
+    let no_tls_client = crate::tcp::client(proxy1.inbound);
 
     let metric = metrics::metric(METRIC)
         .label("target_addr", proxy1.inbound)

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -70,7 +70,7 @@ async fn outbound_tcp() {
         .run()
         .await;
 
-    let client = client::tcp(proxy.outbound);
+    let client = crate::tcp::client(proxy.outbound);
 
     let tcp_client = client.connect().await;
 
@@ -109,7 +109,7 @@ async fn outbound_tcp_external() {
         .run()
         .await;
 
-    let client = client::tcp(proxy.outbound);
+    let client = crate::tcp::client(proxy.outbound);
 
     let tcp_client = client.connect().await;
 
@@ -139,7 +139,7 @@ async fn inbound_tcp() {
         .await;
     let proxy = proxy::new().inbound(srv).run().await;
 
-    let client = client::tcp(proxy.inbound);
+    let client = crate::tcp::client(proxy.inbound);
 
     let tcp_client = client.connect().await;
 
@@ -360,7 +360,7 @@ async fn serve_server_first(mut sock: tokio::net::TcpStream, tx: mpsc::Sender<()
 
 async fn server_first_client(addr: SocketAddr, mut rx: mpsc::Receiver<()>) {
     const TIMEOUT: Duration = Duration::from_secs(5);
-    let client = client::tcp(addr);
+    let client = crate::tcp::client(addr);
 
     let tcp_client = client.connect().await;
 
@@ -402,7 +402,7 @@ async fn tcp_connections_close_if_client_closes() {
         .await;
     let proxy = proxy::new().inbound(srv).run().await;
 
-    let client = client::tcp(proxy.inbound);
+    let client = crate::tcp::client(proxy.inbound);
 
     let tcp_client = client.connect().await;
     tcp_client.write(msg1).await;
@@ -608,7 +608,7 @@ macro_rules! http1_tests {
             let mk = $proxy;
             let proxy = mk(srv).await;
 
-            let client = client::tcp(proxy.inbound);
+            let client = crate::tcp::client(proxy.inbound);
 
             let tcp_client = client.connect().await;
 
@@ -764,7 +764,7 @@ macro_rules! http1_tests {
             let mk = $proxy;
             let proxy = mk(srv).await;
 
-            let client = client::tcp(proxy.inbound);
+            let client = crate::tcp::client(proxy.inbound);
 
             let tcp_client = client.connect().await;
 
@@ -856,7 +856,7 @@ macro_rules! http1_tests {
             let mk = $proxy;
             let proxy = mk(srv).await;
 
-            let client = client::tcp(proxy.inbound);
+            let client = crate::tcp::client(proxy.inbound);
 
             let tcp_client = client.connect().await;
 
@@ -898,7 +898,7 @@ macro_rules! http1_tests {
 
             // A TCP client is used since the HTTP client would stop these requests
             // from ever touching the network.
-            let client = client::tcp(proxy.inbound);
+            let client = crate::tcp::client(proxy.inbound);
 
             let bad_uris = vec!["/origin-form", "/", "http://test/bar", "http://test", "*"];
 
@@ -1397,7 +1397,7 @@ async fn http10_without_host() {
         .await;
     let proxy = proxy::new().inbound(srv).run().await;
 
-    let client = client::tcp(proxy.inbound);
+    let client = crate::tcp::client(proxy.inbound);
 
     let tcp_client = client.connect().await;
 


### PR DESCRIPTION
`linkerd_app_integration::tcp` provides a `TcpClient` type that is distinct from the primary `linkerd_app_integration::client::Client` type broadly used in integration tests.

this commit makes a small change to reduce indirection, and clarify that this is constructing a different client implementation from a different submodule.

this removes `linkerd_app_integration::client::tcp()`, and updates test code to call the `tcp::client()` function that this is masking.

this is the client-side equivalent to #3688 (a10d1d7e).