### PR TITLE
refactor(app/integration): remove unused `TcpConn::target_addr()`

### DIFF
--- a/linkerd/app/integration/src/tcp.rs
+++ b/linkerd/app/integration/src/tcp.rs
@@ -148,10 +148,6 @@ impl TcpServer {
 }
 
 impl TcpConn {
-    pub fn target_addr(&self) -> SocketAddr {
-        self.addr
-    }
-
     pub async fn read(&self) -> Vec<u8> {
         self.try_read()
             .await


### PR DESCRIPTION
this method is not used by any test code, nor any other internal code.

this commit removes
`linkerd_app_integration::tcp::TcpConn::target_addr()`.