### PR TITLE
nit(app/integration): tidy `tcp` imports

### DIFF
--- a/linkerd/app/integration/src/tcp.rs
+++ b/linkerd/app/integration/src/tcp.rs
@@ -1,10 +1,11 @@
 use super::*;
-use std::collections::VecDeque;
-use std::io;
-use std::net::TcpListener as StdTcpListener;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use tokio::net::TcpStream;
-use tokio::task::JoinHandle;
+use std::{
+    collections::VecDeque,
+    io,
+    net::TcpListener as StdTcpListener,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+use tokio::{net::TcpStream, task::JoinHandle};
 
 type TcpConnSender = mpsc::UnboundedSender<(
     Option<Vec<u8>>,


### PR DESCRIPTION
we follow a convention of grouping imported symbols at the crate-level.

this commit tidies up imports in `linkerd_app_integration::tcp` to follow this convention.