### PR TITLE
refactor(app/integration): remove `pb` reëxport

### DIFF
--- a/linkerd/app/integration/src/controller.rs
+++ b/linkerd/app/integration/src/controller.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub use linkerd2_proxy_api::destination as pb;
+use linkerd2_proxy_api::destination as pb;
 use linkerd2_proxy_api::net;
 use linkerd_app_core::proxy::http::TracingExecutor;
 use parking_lot::Mutex;

--- a/linkerd/app/integration/src/tests/profiles.rs
+++ b/linkerd/app/integration/src/tests/profiles.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 struct TestBuilder {
     server: server::Server,
     routes: Vec<controller::RouteBuilder>,
-    budget: Option<controller::pb::RetryBudget>,
+    budget: Option<linkerd2_proxy_api::destination::RetryBudget>,
     default_routes: bool,
 }
 
@@ -39,7 +39,10 @@ impl TestBuilder {
         }
     }
 
-    fn with_budget(self, budget: impl Into<Option<controller::pb::RetryBudget>>) -> Self {
+    fn with_budget(
+        self,
+        budget: impl Into<Option<linkerd2_proxy_api::destination::RetryBudget>>,
+    ) -> Self {
         Self {
             budget: budget.into(),
             ..self

--- a/linkerd/app/integration/src/tests/transparency.rs
+++ b/linkerd/app/integration/src/tests/transparency.rs
@@ -310,7 +310,7 @@ async fn outbound_opaque_tcp_server_first() {
     let name = format!("opaque.test.svc.cluster.local:{}", srv.addr.port());
     let dstctl = controller::new();
     let profile = dstctl.profile_tx(srv.addr);
-    profile.send(controller::pb::DestinationProfile {
+    profile.send(linkerd2_proxy_api::destination::DestinationProfile {
         fully_qualified_name: name.clone(),
         ..Default::default()
     });


### PR DESCRIPTION
`linkerd_app_integration::controller` provides a reëxport of the protobuffer types provided by `linkerd2_proxy_api::destination`.

this reëxport is only used in three places externally. for simplicity, this commit demotes this alias to an internally visible `use`, and updates this handful of references to use
`linkerd2_proxy_api::destination` directly.