### PR TITLE
refactor(app/integration): remove unused `request_init_method()`

### DIFF
--- a/linkerd/app/integration/src/tap.rs
+++ b/linkerd/app/integration/src/tap.rs
@@ -106,7 +106,6 @@ pub trait TapEventExt {
     //fn id(&self) -> (u32, u64);
     fn event(&self) -> &pb::tap_event::http::Event;
 
-    fn request_init_method(&self) -> String;
     fn request_init_authority(&self) -> &str;
     fn request_init_path(&self) -> &str;
 
@@ -131,16 +130,6 @@ impl TapEventExt for pb::TapEvent {
                 event: Some(ref ev),
             })) => ev,
             _ => panic!("unknown event: {:?}", self.event),
-        }
-    }
-
-    fn request_init_method(&self) -> String {
-        match self.event() {
-            pb::tap_event::http::Event::RequestInit(_ev) => {
-                //TODO: ugh
-                unimplemented!("method");
-            }
-            e => panic!("not RequestInit event: {:?}", e),
         }
     }
 


### PR DESCRIPTION
`TapEventExt` provides an extension trait interface that we use to extends `linkerd_proxy_api::tap::TapEvent` with additional interfaces for use in integration tests.

this commit removes `request_init_path()`. this method was originally added in 3ac6b72c4 (#154), but was never actually implemented and will only ever panic when invoked. thus, it can be removed.