### PR TITLE
chore(deps): `prost-build` is a workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,6 +105,7 @@ http = { version = "0.2" }
 http-body = { version = "0.4" }
 hyper = { version = "0.14.32", default-features = false }
 prost = { version = "0.12" }
+prost-build = { version = "0.12", default-features = false }
 prost-types = { version = "0.12" }
 tokio-rustls = { version = "0.26", default-features = false, features = [
     "ring",

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -23,7 +23,7 @@ arbitrary = { version = "1", features = ["derive"] }
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 
 [dev-dependencies]
-prost-build = { version = "0.12", default-features = false }
+prost-build = { workspace = true }
 tokio = { version = "1", features = ["macros"] }
 tokio-test = "0.4"
 


### PR DESCRIPTION
see https://github.com/linkerd/linkerd2/issues/8733 for more information.

this commit moves `prost-build` so that it is now managed as a workspace dependency. while only used in tests, these tests can fail if this is not versioned in lockstep with our other protobuffer dependencies.

see #3456 (c740b6d8), #3466 (ca50d6bb), and especially #3473 (b87455a9) for some other previous pr's that moved dependencies to be managed at the workspace level.