### PR TITLE
chore(deps): remove unused `opencensus`, `opentelemetry` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,7 +2057,6 @@ name = "linkerd-opencensus"
 version = "0.1.0"
 dependencies = [
  "futures",
- "http",
  "http-body",
  "linkerd-error",
  "linkerd-metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2082,7 +2082,6 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "tokio",
- "tokio-stream",
  "tonic",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2074,7 +2074,6 @@ name = "linkerd-opentelemetry"
 version = "0.1.0"
 dependencies = [
  "futures",
- "http",
  "http-body",
  "linkerd-error",
  "linkerd-metrics",

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-http = { workspace = true }
 http-body = { workspace = true }
 linkerd-error = { path = "../error" }
 linkerd-metrics = { path = "../metrics" }

--- a/linkerd/opencensus/src/lib.rs
+++ b/linkerd/opencensus/src/lib.rs
@@ -3,11 +3,11 @@
 
 pub mod metrics;
 
+use self::metrics::Registry;
 use futures::stream::{Stream, StreamExt};
 use http_body::Body;
 use linkerd_error::Error;
 use linkerd_trace_context::export::{ExportSpan, SpanKind};
-use metrics::Registry;
 pub use opencensus_proto as proto;
 use opencensus_proto::{
     agent::{

--- a/linkerd/opentelemetry/Cargo.toml
+++ b/linkerd/opentelemetry/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-http = "0.2"
 http-body = { workspace = true }
 linkerd-error = { path = "../error" }
 linkerd-metrics = { path = "../metrics" }

--- a/linkerd/opentelemetry/Cargo.toml
+++ b/linkerd/opentelemetry/Cargo.toml
@@ -20,5 +20,4 @@ tonic = { workspace = true, default-features = false, features = [
     "codegen",
 ] }
 tokio = { version = "1", features = ["macros", "sync", "time"] }
-tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"

--- a/linkerd/opentelemetry/src/lib.rs
+++ b/linkerd/opentelemetry/src/lib.rs
@@ -3,11 +3,11 @@
 
 pub mod metrics;
 
+use self::metrics::Registry;
 use futures::stream::{Stream, StreamExt};
 use http_body::Body;
 use linkerd_error::Error;
-use linkerd_trace_context as trace_context;
-use metrics::Registry;
+use linkerd_trace_context::{self as trace_context, export::ExportSpan};
 pub use opentelemetry as otel;
 use opentelemetry::{
     trace::{SpanContext, SpanId, SpanKind, Status, TraceFlags, TraceId, TraceState},
@@ -23,12 +23,10 @@ use opentelemetry_proto::{
     },
     transform::{common::ResourceAttributesWithSchema, trace::group_spans_by_resource_and_scope},
 };
-pub use opentelemetry_sdk as sdk;
-pub use opentelemetry_sdk::trace::SpanData;
 use opentelemetry_sdk::trace::SpanLinks;
+pub use opentelemetry_sdk::{self as sdk, trace::SpanData};
 use tokio::{sync::mpsc, time};
 use tonic::{self as grpc, body::BoxBody, client::GrpcService};
-use trace_context::export::ExportSpan;
 use tracing::{debug, info, trace};
 
 pub async fn export_spans<T, S>(


### PR DESCRIPTION
noticed while addressing `cargo-deny` errors in #3504. these crates include a few unused dependencies, which we can remove. while we are in the neighborhood, we make some subjective tweaks to tidy up these imports.