### PR TITLE
chore(deps): update to ring 0.17.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -3441,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.11"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da5349ae27d3887ca812fb375b45a4fbb36d8d12d2df394968cd86e35683fe73"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2025-0009.html

0.17.11 is vulnerable to RUSTSEC-2025-0009. this commit updates the `ring` dependency to a patched version.

```
; git switch main                                                                                           
Switched to branch 'main'                                                                                   
Your branch is up to date with 'origin/main'.                                                               
; cargo deny check                                                                                          
error[vulnerability]: Some AES functions may panic when overflow checking is enabled.
    ┌─ /linkerd/linkerd2-proxy/Cargo.lock:262:1
    │                                                                                                       
262 │ ring 0.17.11 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
```