### PR TITLE
chore(deps): `tower` crates are workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4078,7 +4078,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
 tonic = { version = "0.10", default-features = false }
 tonic-build = { version = "0.10", default-features = false }
 tower = { version = "0.4.13", default-features = false }
+tower-service = { version = "0.3" }
 
 [workspace.dependencies.linkerd2-proxy-api]
 version = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ tonic = { version = "0.10", default-features = false }
 tonic-build = { version = "0.10", default-features = false }
 tower = { version = "0.4.13", default-features = false }
 tower-service = { version = "0.3" }
+tower-test = { version = "0.4" }
 
 [workspace.dependencies.linkerd2-proxy-api]
 version = "0.15.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
 ] }
 tonic = { version = "0.10", default-features = false }
 tonic-build = { version = "0.10", default-features = false }
+tower = { version = "0.4.13", default-features = false }
 
 [workspace.dependencies.linkerd2-proxy-api]
 version = "0.15.0"

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -12,7 +12,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated"] }
 pin-project = "1"
-tower = { version = "0.4", default-features = false, features = ["load"] }
+tower = { workspace = true, default-features = false, features = ["load"] }
 tokio = { version = "1", features = ["macros"] }
 
 [dev-dependencies]

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -33,5 +33,5 @@ thiserror = "2"
 tokio = { version = "1", features = ["rt"] }
 tokio-stream = { version = "0.1", features = ["time", "sync"] }
 tonic = { workspace = true, default-features = false, features = ["prost"] }
-tower = "0.4"
+tower = { workspace = true }
 tracing = "0.1"

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -17,7 +17,7 @@ once_cell = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
 tonic = { workspace = true, default-features = false }
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 tracing = "0.1"
 
 [dev-dependencies]
@@ -26,6 +26,6 @@ linkerd-app-outbound = { path = "../outbound", features = ["test-util"] }
 linkerd-proxy-server-policy = { path = "../../proxy/server-policy" }
 tokio = { version = "1", features = ["rt", "macros"] }
 tokio-test = "0.4"
-tower = { version = "0.4", default-features = false, features = ["util"] }
+tower = { workspace = true, default-features = false, features = ["util"] }
 tower-test = "0.4"
 linkerd-app-test = { path = "../test" }

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -27,5 +27,5 @@ linkerd-proxy-server-policy = { path = "../../proxy/server-policy" }
 tokio = { version = "1", features = ["rt", "macros"] }
 tokio-test = "0.4"
 tower = { workspace = true, default-features = false, features = ["util"] }
-tower-test = "0.4"
+tower-test = { workspace = true }
 linkerd-app-test = { path = "../test" }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -37,7 +37,7 @@ rangemap = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
 tonic = { workspace = true, default-features = false }
-tower = { version = "0.4", features = ["util"] }
+tower = { workspace = true, features = ["util"] }
 tracing = "0.1"
 
 [dependencies.linkerd-proxy-server-policy]

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1", features = ["io-util", "net", "rt", "macros"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-rustls = { workspace = true }
 rustls-pemfile = "2.2"
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 tonic = { workspace = true, features = ["transport"], default-features = false }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = [

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -58,7 +58,7 @@ hyper = { workspace = true, features = ["backports", "deprecated", "http1", "htt
 tokio = { version = "1", features = ["macros", "sync", "time"] }
 tokio-rustls = { workspace = true }
 tokio-test = "0.4"
-tower-test = "0.4"
+tower-test = { workspace = true }
 
 linkerd-app-test = { path = "../test", features = ["client-policy"] }
 linkerd-http-body-compat = { path = "../../http/body-compat" }

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -30,7 +30,7 @@ prometheus-client = "0.22"
 thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
 tonic = { workspace = true, default-features = false }
-tower = { version = "0.4", features = ["util"] }
+tower = { workspace = true, features = ["util"] }
 tracing = "0.1"
 
 linkerd-app-core = { path = "../core" }

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -30,7 +30,7 @@ tokio = { version = "1", features = ["io-util", "net", "rt", "sync"] }
 tokio-test = "0.4"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = { workspace = true, default-features = false, optional = true }
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 tracing = "0.1"
 thiserror = "2"
 

--- a/linkerd/detect/Cargo.toml
+++ b/linkerd/detect/Cargo.toml
@@ -14,5 +14,5 @@ linkerd-io = { path = "../io" }
 linkerd-stack = { path = "../stack" }
 tokio = { version = "1", features = ["time"] }
 thiserror = "2"
-tower = "0.4"
+tower = { workspace = true }
 tracing = "0.1"

--- a/linkerd/distribute/Cargo.toml
+++ b/linkerd/distribute/Cargo.toml
@@ -15,4 +15,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 tokio-test = "0.4"
-tower-test = "0.4"
+tower-test = { workspace = true }

--- a/linkerd/http/classify/Cargo.toml
+++ b/linkerd/http/classify/Cargo.toml
@@ -20,5 +20,5 @@ linkerd-stack = { path = "../../stack" }
 
 [dev-dependencies]
 tokio-test = "0.4"
-tower-test = "0.4"
+tower-test = { workspace = true }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }

--- a/linkerd/http/insert/Cargo.toml
+++ b/linkerd/http/insert/Cargo.toml
@@ -13,6 +13,6 @@ Tower middleware to insert parameters into HTTP extensions.
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
 pin-project = "1"
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/http/metrics/Cargo.toml
+++ b/linkerd/http/metrics/Cargo.toml
@@ -18,7 +18,7 @@ hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 parking_lot = "0.12"
 pin-project = "1"
 tokio = { version = "1", features = ["time"] }
-tower = "0.4"
+tower = { workspace = true }
 tracing = "0.1"
 
 linkerd-error = { path = "../../error" }

--- a/linkerd/http/override-authority/Cargo.toml
+++ b/linkerd/http/override-authority/Cargo.toml
@@ -11,7 +11,7 @@ Tower middleware to override request authorities.
 
 [dependencies]
 http = { workspace = true }
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 tracing = "0.1"
 
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/http/retain/Cargo.toml
+++ b/linkerd/http/retain/Cargo.toml
@@ -15,6 +15,6 @@ This is mostly intended to support cache eviction.
 http = { workspace = true }
 http-body = { workspace = true }
 pin-project = "1"
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/http/retry/Cargo.toml
+++ b/linkerd/http/retry/Cargo.toml
@@ -14,7 +14,7 @@ http = { workspace = true }
 parking_lot = "0.12"
 pin-project = "1"
 tokio = { version = "1", features = ["macros", "rt"] }
-tower = { version = "0.4", features = ["retry"] }
+tower = { workspace = true, features = ["retry"] }
 tracing = "0.1"
 thiserror = "2"
 

--- a/linkerd/http/upgrade/Cargo.toml
+++ b/linkerd/http/upgrade/Cargo.toml
@@ -22,7 +22,7 @@ hyper = { workspace = true, default-features = false, features = [
 pin-project = "1"
 thiserror = "2"
 tokio = { version = "1", default-features = false }
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 tracing = "0.1"
 try-lock = "0.2"
 

--- a/linkerd/idle-cache/Cargo.toml
+++ b/linkerd/idle-cache/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1", default-features = false, features = [
     "sync",
     "time",
 ] }
-tower = { version = "0.4", default-features = false, features = ["util"] }
+tower = { workspace = true, default-features = false, features = ["util"] }
 tracing = "0.1"
 
 [dev-dependencies]

--- a/linkerd/pool/Cargo.toml
+++ b/linkerd/pool/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-tower-service = "0.3"
+tower-service = { workspace = true }

--- a/linkerd/pool/mock/Cargo.toml
+++ b/linkerd/pool/mock/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 parking_lot = "0.12"
 thiserror = "2"
 tokio = { version = "1", features = ["sync", "time"] }
-tower-test = "0.4"
+tower-test = { workspace = true }
 tracing = "0.1"
 
 linkerd-error = { path = "../../error" }

--- a/linkerd/pool/p2c/Cargo.toml
+++ b/linkerd/pool/p2c/Cargo.toml
@@ -31,4 +31,4 @@ linkerd-tracing = { path = "../../tracing" }
 parking_lot = "0.12"
 quickcheck = { version = "1", default-features = false }
 tokio-test = "0.4"
-tower-test = "0.4"
+tower-test = { workspace = true }

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -25,5 +25,5 @@ http-body = { workspace = true }
 pin-project = "1"
 prost = { workspace = true }
 tonic = { workspace = true, default-features = false }
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 tracing = "0.1"

--- a/linkerd/proxy/balance/queue/Cargo.toml
+++ b/linkerd/proxy/balance/queue/Cargo.toml
@@ -25,7 +25,7 @@ linkerd-stack = { path = "../../../stack" }
 [dev-dependencies]
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-test = "0.4"
-tower-test = "0.4"
+tower-test = { workspace = true }
 
 linkerd-pool-mock = { path = "../../../pool/mock" }
 linkerd-tracing = { path = "../../../tracing" }

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -18,5 +18,5 @@ linkerd-proxy-core = { path = "../core" }
 linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
-tower = "0.4"
+tower = { workspace = true }
 tracing = "0.1"

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -59,7 +59,7 @@ linkerd-stack = { path = "../../stack" }
 
 [dev-dependencies]
 tokio-test = "0.4"
-tower-test = "0.4"
+tower-test = { workspace = true }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }
 
 [lints.rust]

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -36,7 +36,7 @@ pin-project = "1"
 rand = "0.9"
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 tracing = "0.1"
 try-lock = "0.2"
 

--- a/linkerd/proxy/resolve/Cargo.toml
+++ b/linkerd/proxy/resolve/Cargo.toml
@@ -14,6 +14,6 @@ futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 linkerd-proxy-core = { path = "../core" }
 thiserror = "2"
-tower = "0.4"
+tower = { workspace = true }
 tracing = "0.1"
 pin-project = "1"

--- a/linkerd/proxy/spire-client/Cargo.toml
+++ b/linkerd/proxy/spire-client/Cargo.toml
@@ -17,7 +17,7 @@ linkerd-exp-backoff = { path = "../../exp-backoff" }
 linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["time", "sync"] }
 tonic = { workspace = true }
-tower = "0.4"
+tower = { workspace = true }
 tracing = "0.1"
 x509-parser = "0.17.0"
 asn1 = { version = "0.6", package = "simple_asn1" }

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -26,7 +26,7 @@ prost-types = { workspace = true }
 rand = { version = "0.9" }
 thiserror = "2"
 tokio = { version = "1", features = ["time"] }
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 tonic = { workspace = true, default-features = false }
 tracing = "0.1"
 pin-project = "1"

--- a/linkerd/proxy/tcp/Cargo.toml
+++ b/linkerd/proxy/tcp/Cargo.toml
@@ -15,5 +15,5 @@ linkerd-proxy-balance = { path = "../../proxy/balance" }
 linkerd-stack = { path = "../../stack" }
 rand = "0.9"
 tokio = { version = "1" }
-tower = { version = "0.4.13", default-features = false }
+tower = { workspace = true, default-features = false }
 pin-project = "1"

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 futures = { version = "0.3", default-features = false }
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 tracing = "0.1"
 pin-project = "1"
 

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -19,4 +19,4 @@ linkerd-tracing = { path = "../tracing" }
 tokio = { version = "1", features = ["macros", "rt", "time"] }
 tokio-stream = { version = "0.1", features = ["time"] }
 tokio-test = "0.4"
-tower-test = "0.4"
+tower-test = { workspace = true }

--- a/linkerd/retry/Cargo.toml
+++ b/linkerd/retry/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
-tower = { version = "0.4", default-features = false, features = ["retry"] }
+tower = { workspace = true, default-features = false, features = ["retry"] }
 tracing = "0.1"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -21,7 +21,7 @@ regex = "1"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = { workspace = true, default-features = false }
-tower = { version = "0.4.13", features = ["retry", "util"] }
+tower = { workspace = true, features = ["retry", "util"] }
 thiserror = "2"
 tracing = "0.1"
 

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -20,7 +20,7 @@ pin-project = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt", "sync", "time"] }
 tokio-util = { version = "0.7" }
-tower = { version = "0.4", features = ["buffer", "filter", "spawn-ready", "util"] }
+tower = { workspace = true, features = ["buffer", "filter", "spawn-ready", "util"] }
 tracing = "0.1"
 
 [dev-dependencies]
@@ -28,4 +28,4 @@ linkerd-tracing = { path = "../tracing", features = ["ansi"] }
 tower-test = "0.4"
 tokio-test = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }
-tower = { version = "0.4", features = ["buffer", "filter", "util"] }
+tower = { workspace = true, features = ["buffer", "filter", "util"] }

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -25,7 +25,7 @@ tracing = "0.1"
 
 [dev-dependencies]
 linkerd-tracing = { path = "../tracing", features = ["ansi"] }
-tower-test = "0.4"
+tower-test = { workspace = true }
 tokio-test = "0.4"
 tokio = { version = "1", features = ["rt-multi-thread", "time", "macros"] }
 tower = { workspace = true, features = ["buffer", "filter", "util"] }

--- a/linkerd/stack/metrics/Cargo.toml
+++ b/linkerd/stack/metrics/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 linkerd-metrics = { path = "../../metrics" }
 parking_lot = "0.12"
-tower = { version = "0.4", default-features = false }
+tower = { workspace = true, default-features = false }
 tokio = { version = "1", features = ["time"] }
 
 [dev-dependencies]

--- a/linkerd/stack/metrics/Cargo.toml
+++ b/linkerd/stack/metrics/Cargo.toml
@@ -15,4 +15,4 @@ tokio = { version = "1", features = ["time"] }
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }
 tokio-test = "0.4"
-tower-test = "0.4"
+tower-test = { workspace = true }

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -10,5 +10,5 @@ publish = false
 futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 linkerd-stack = { path = ".." }
-tower = "0.4"
+tower = { workspace = true }
 tracing = "0.1"

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -19,7 +19,7 @@ linkerd-stack = { path = "../stack" }
 pin-project = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "time"] }
-tower = "0.4"
+tower = { workspace = true }
 tracing = "0.1"
 untrusted = "0.9"
 

--- a/linkerd/tonic-watch/Cargo.toml
+++ b/linkerd/tonic-watch/Cargo.toml
@@ -22,4 +22,4 @@ linkerd-tracing = { path = "../tracing" }
 tokio = { version = "1", features = ["macros"] }
 tokio-stream = { version = "0.1", features = ["sync", "time"] }
 tokio-test = "0.4"
-tower-test = "0.4"
+tower-test = { workspace = true }

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -16,5 +16,5 @@ linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 rand = "0.8"
 thiserror = "1"
-tower = { version = "0.4", default-features = false, features = ["util"] }
+tower = { workspace = true, default-features = false, features = ["util"] }
 tracing = "0.1"


### PR DESCRIPTION
see https://github.com/linkerd/linkerd2/issues/8733 for more information. see https://github.com/linkerd/linkerd2-proxy/pull/3504 as well.

see #3456 (c740b6d8), #3466 (ca50d6bb), #3473 (b87455a9), and #3701 (cf4ef39) for some other previous pr's that moved dependencies to be managed at the workspace level.

see also https://github.com/linkerd/drain-rs/pull/36 for another related pull request that relates to our tower dependency.

this branch alters the top-level manifest so that `tower`, `tower-service`, and `tower-test` are now defined as workspace dependencies whose versions are managed in a single place.