### PR TITLE
nit(detect): sort dependencies

### DIFF
--- a/linkerd/detect/Cargo.toml
+++ b/linkerd/detect/Cargo.toml
@@ -12,7 +12,7 @@ bytes = { workspace = true }
 linkerd-error = { path = "../error" }
 linkerd-io = { path = "../io" }
 linkerd-stack = { path = "../stack" }
-tokio = { version = "1", features = ["time"] }
 thiserror = "2"
+tokio = { version = "1", features = ["time"] }
 tower = { workspace = true }
 tracing = "0.1"


### PR DESCRIPTION
this is a follow-on to #3715.

this commit sorts the dependencies in this manifest.