### PR TITLE
chore(deps): `drain` is a workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ lto = true
 
 [workspace.dependencies]
 bytes = { version = "1" }
+drain = { version = "0.1", default-features = false }
 h2 = { version = "0.3" }
 http = { version = "0.2" }
 http-body = { version = "0.4" }

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -14,7 +14,7 @@ independently of the inbound and outbound proxy logic.
 
 [dependencies]
 bytes = { workspace = true }
-drain = { version = "0.1", features = ["retain"] }
+drain = { workspace = true, features = ["retain"] }
 http = { workspace = true }
 http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }

--- a/linkerd/http/upgrade/Cargo.toml
+++ b/linkerd/http/upgrade/Cargo.toml
@@ -11,7 +11,7 @@ Facilities for HTTP/1 upgrades.
 
 [dependencies]
 bytes = { workspace = true }
-drain = "0.1"
+drain = { workspace = true }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -14,7 +14,7 @@ This should probably be decomposed into smaller, decoupled crates.
 [dependencies]
 async-trait = "0.1"
 bytes = { workspace = true }
-drain = "0.1"
+drain = { workspace = true }
 futures = { version = "0.3", default-features = false }
 h2 = { workspace = true }
 http = { workspace = true }


### PR DESCRIPTION
see https://github.com/linkerd/linkerd2/issues/8733 and https://github.com/linkerd/linkerd2-proxy/pull/3504 for more information.

see also linkerd/drain-rs#36 for a related pull request that updated `drain`'s `tower` dependency. see #3715 (2f97549a) for a related pull request that made `tower` a workspace dependency.

see #3456 (c740b6d8), #3466 (ca50d6bb), #3473 (b87455a9), and #3701 (cf4ef39), for some other previous pr's that moved dependencies to be managed at the workspace level.