### PR TITLE
chore(deps): `tower` is a workspace dependency

### DIFF
--- a/linkerd/app/admin/Cargo.toml
+++ b/linkerd/app/admin/Cargo.toml
@@ -33,7 +33,7 @@ linkerd-app-inbound = { path = "../inbound" }
 linkerd-tracing = { path = "../../tracing" }
 
 [dependencies.tower]
-version = "0.4"
+workspace = true
 default-features = false
 features = [
     "buffer",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -74,7 +74,7 @@ linkerd-tls = { path = "../../tls" }
 linkerd-trace-context = { path = "../../trace-context" }
 
 [dependencies.tower]
-version = "0.4"
+workspace = true
 default-features = false
 features = ["make", "spawn-ready", "timeout", "util", "limit"]
 

--- a/linkerd/pool/p2c/Cargo.toml
+++ b/linkerd/pool/p2c/Cargo.toml
@@ -21,7 +21,7 @@ linkerd-pool = { path = ".." }
 linkerd-stack = { path = "../../stack" }
 
 [dependencies.tower]
-version = "0.4.13"
+workspace = true
 default-features = false
 features = ["load", "ready-cache"]
 

--- a/linkerd/proxy/balance/Cargo.toml
+++ b/linkerd/proxy/balance/Cargo.toml
@@ -20,6 +20,6 @@ linkerd-proxy-balance-queue = { path = "queue" }
 linkerd-stack = { path = "../../stack" }
 
 [dependencies.tower]
-version = "0.4.13"
+workspace = true
 default-features = false
 features = ["load"]

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -14,6 +14,6 @@ futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 
 [dependencies.tower]
-version = "0.4"
+workspace = true
 default-features = false
 features = ["util"]


### PR DESCRIPTION
pr #3715 missed a small handful of cargo dependencies. this commit marks these so that they use the workspace-level tower version.