### PR TITLE
fix(just): make dev versions semver

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ toolchain := ""
 
 features := ""
 
-export LINKERD2_PROXY_VERSION := env_var_or_default("LINKERD2_PROXY_VERSION", "0.0.0-dev." + `git rev-parse --short HEAD`)
+export LINKERD2_PROXY_VERSION := env_var_or_default("LINKERD2_PROXY_VERSION", "0.0.0-dev" + `git rev-parse --short HEAD`)
 export LINKERD2_PROXY_VENDOR := env_var_or_default("LINKERD2_PROXY_VENDOR", `whoami` + "@" + `hostname`)
 
 # The version name to use for packages.


### PR DESCRIPTION
Our build can occaisionally fail when the sha is not a valid semver label:

    --- stdout
    cargo:rustc-env=GIT_SHA=025979070
    cargo:rustc-env=LINKERD2_PROXY_BUILD_DATE=2025-03-08T16:32:34Z
    --- stderr
    thread 'main' panicked at linkerd/app/core/build.rs:18:17:
    LINKERD2_PROXY_VERSION must be semver: version='0.0.0-dev.025979070'
       error='invalid leading zero in pre-release identifier'

To fix this, the dot is removed so the version string is 0.0.0-dev025979070, which is valid.