### PR TITLE
feat: instrument HTTP protocol detection metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,6 +1725,7 @@ dependencies = [
  "linkerd-io",
  "linkerd-stack",
  "linkerd-tracing",
+ "prometheus-client",
  "thiserror 2.0.12",
  "tokio",
  "tokio-test",

--- a/linkerd/app/inbound/src/accept.rs
+++ b/linkerd/app/inbound/src/accept.rs
@@ -182,7 +182,11 @@ mod tests {
     }
 
     fn inbound() -> Inbound<()> {
-        Inbound::new(test_util::default_config(), test_util::runtime().0)
+        Inbound::new(
+            test_util::default_config(),
+            test_util::runtime().0,
+            &mut Default::default(),
+        )
     }
 
     fn new_panic<T>(msg: &'static str) -> svc::ArcNewTcp<T, io::DuplexStream> {

--- a/linkerd/app/inbound/src/detect/tests.rs
+++ b/linkerd/app/inbound/src/detect/tests.rs
@@ -13,6 +13,12 @@ const HTTP1: &[u8] = b"GET / HTTP/1.1\r\nhost: example.com\r\n\r\n";
 const HTTP2: &[u8] = b"PRI * HTTP/2.0\r\n";
 const NOT_HTTP: &[u8] = b"foo\r\nbar\r\nblah\r\n";
 
+const RESULTS_NOT_HTTP: &str = "results_total{result=\"not_http\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}";
+const RESULTS_HTTP1: &str = "results_total{result=\"http/1\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}";
+const RESULTS_HTTP2: &str = "results_total{result=\"http/2\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}";
+const RESULTS_READ_TIMEOUT: &str = "results_total{result=\"read_timeout\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}";
+const RESULTS_ERROR: &str = "results_total{result=\"error\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}";
+
 fn authzs() -> Arc<[Authorization]> {
     Arc::new([Authorization {
         authentication: Authentication::Unauthenticated,
@@ -127,11 +133,11 @@ async fn detect_http_non_http() {
         .await
         .expect("should succeed");
 
-    assert_contains_metric!(&registry, "results_total{result=\"not_http\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 1);
-    assert_contains_metric!(&registry, "results_total{result=\"http/1\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"http/2\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"read_timeout\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"error\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
+    assert_contains_metric!(&registry, RESULTS_NOT_HTTP, 1);
+    assert_contains_metric!(&registry, RESULTS_HTTP1, 0);
+    assert_contains_metric!(&registry, RESULTS_HTTP2, 0);
+    assert_contains_metric!(&registry, RESULTS_READ_TIMEOUT, 0);
+    assert_contains_metric!(&registry, RESULTS_ERROR, 0);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -168,11 +174,11 @@ async fn detect_http() {
         .await
         .expect("should succeed");
 
-    assert_contains_metric!(&registry, "results_total{result=\"not_http\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"http/1\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 1);
-    assert_contains_metric!(&registry, "results_total{result=\"http/2\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"read_timeout\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"error\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
+    assert_contains_metric!(&registry, RESULTS_NOT_HTTP, 0);
+    assert_contains_metric!(&registry, RESULTS_HTTP1, 1);
+    assert_contains_metric!(&registry, RESULTS_HTTP2, 0);
+    assert_contains_metric!(&registry, RESULTS_READ_TIMEOUT, 0);
+    assert_contains_metric!(&registry, RESULTS_ERROR, 0);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -204,11 +210,11 @@ async fn hinted_http1() {
         .await
         .expect("should succeed");
 
-    assert_contains_metric!(&registry, "results_total{result=\"not_http\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"http/1\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 1);
-    assert_contains_metric!(&registry, "results_total{result=\"http/2\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"read_timeout\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"error\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
+    assert_contains_metric!(&registry, RESULTS_NOT_HTTP, 0);
+    assert_contains_metric!(&registry, RESULTS_HTTP1, 1);
+    assert_contains_metric!(&registry, RESULTS_HTTP2, 0);
+    assert_contains_metric!(&registry, RESULTS_READ_TIMEOUT, 0);
+    assert_contains_metric!(&registry, RESULTS_ERROR, 0);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -240,11 +246,11 @@ async fn hinted_http1_supports_http2() {
         .await
         .expect("should succeed");
 
-    assert_contains_metric!(&registry, "results_total{result=\"not_http\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"http/1\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"http/2\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 1);
-    assert_contains_metric!(&registry, "results_total{result=\"read_timeout\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
-    assert_contains_metric!(&registry, "results_total{result=\"error\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}", 0);
+    assert_contains_metric!(&registry, RESULTS_NOT_HTTP, 0);
+    assert_contains_metric!(&registry, RESULTS_HTTP1, 0);
+    assert_contains_metric!(&registry, RESULTS_HTTP2, 1);
+    assert_contains_metric!(&registry, RESULTS_READ_TIMEOUT, 0);
+    assert_contains_metric!(&registry, RESULTS_ERROR, 0);
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -276,11 +282,11 @@ async fn hinted_http2() {
         .expect("should succeed");
 
     // No detection is performed when HTTP/2 is hinted, so no metrics are recorded.
-    assert_not_contains_metric!(&registry, "results_total{result=\"not_http\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}");
-    assert_not_contains_metric!(&registry, "results_total{result=\"http/1\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}");
-    assert_not_contains_metric!(&registry, "results_total{result=\"http/2\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}");
-    assert_not_contains_metric!(&registry, "results_total{result=\"read_timeout\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}");
-    assert_not_contains_metric!(&registry, "results_total{result=\"error\",srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testsrv\",srv_port=\"1000\"}");
+    assert_not_contains_metric!(&registry, RESULTS_NOT_HTTP);
+    assert_not_contains_metric!(&registry, RESULTS_HTTP1);
+    assert_not_contains_metric!(&registry, RESULTS_HTTP2);
+    assert_not_contains_metric!(&registry, RESULTS_READ_TIMEOUT);
+    assert_not_contains_metric!(&registry, RESULTS_ERROR);
 }
 
 fn client_id() -> tls::ClientId {

--- a/linkerd/app/inbound/src/detect/tests.rs
+++ b/linkerd/app/inbound/src/detect/tests.rs
@@ -48,17 +48,6 @@ fn allow(protocol: Protocol) -> AllowPolicy {
 }
 
 macro_rules! assert_contains_metric {
-    ($registry:expr, $metric:expr) => {{
-        let mut buf = String::new();
-        prom::encoding::text::encode_registry(&mut buf, $registry).expect("encode registry failed");
-        let lines = buf.split_terminator('\n').collect::<Vec<_>>();
-        assert!(
-            lines.iter().any(|l| *l.starts_with($metric)),
-            "metric '{}' not found in:\n{:?}",
-            $metric,
-            buf
-        );
-    }};
     ($registry:expr, $metric:expr, $value:expr) => {{
         let mut buf = String::new();
         prom::encoding::text::encode_registry(&mut buf, $registry).expect("encode registry failed");

--- a/linkerd/app/inbound/src/detect/tests.rs
+++ b/linkerd/app/inbound/src/detect/tests.rs
@@ -79,7 +79,7 @@ async fn detect_http_non_http() {
 
     inbound()
         .with_stack(new_panic("http stack must not be used"))
-        .push_detect_http(new_ok())
+        .push_detect_http(Default::default(), new_ok())
         .into_inner()
         .new_service(target)
         .oneshot(ior)
@@ -110,7 +110,7 @@ async fn detect_http() {
 
     inbound()
         .with_stack(new_ok())
-        .push_detect_http(new_panic("tcp stack must not be used"))
+        .push_detect_http(Default::default(), new_panic("tcp stack must not be used"))
         .into_inner()
         .new_service(target)
         .oneshot(ior)
@@ -136,7 +136,7 @@ async fn hinted_http1() {
 
     inbound()
         .with_stack(new_ok())
-        .push_detect_http(new_panic("tcp stack must not be used"))
+        .push_detect_http(Default::default(), new_panic("tcp stack must not be used"))
         .into_inner()
         .new_service(target)
         .oneshot(ior)
@@ -162,7 +162,7 @@ async fn hinted_http1_supports_http2() {
 
     inbound()
         .with_stack(new_ok())
-        .push_detect_http(new_panic("tcp stack must not be used"))
+        .push_detect_http(Default::default(), new_panic("tcp stack must not be used"))
         .into_inner()
         .new_service(target)
         .oneshot(ior)
@@ -187,7 +187,7 @@ async fn hinted_http2() {
 
     inbound()
         .with_stack(new_ok())
-        .push_detect_http(new_panic("tcp stack must not be used"))
+        .push_detect_http(Default::default(), new_panic("tcp stack must not be used"))
         .into_inner()
         .new_service(target)
         .oneshot(ior)
@@ -210,7 +210,11 @@ fn orig_dst_addr() -> OrigDstAddr {
 }
 
 fn inbound() -> Inbound<()> {
-    Inbound::new(test_util::default_config(), test_util::runtime().0)
+    Inbound::new(
+        test_util::default_config(),
+        test_util::runtime().0,
+        &mut Default::default(),
+    )
 }
 
 fn new_panic<T, I: 'static>(msg: &'static str) -> svc::ArcNewTcp<T, I> {

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -33,7 +33,7 @@ fn build_server<I>(
 where
     I: io::AsyncRead + io::AsyncWrite + io::PeerAddr + Send + Unpin + 'static,
 {
-    Inbound::new(cfg, rt)
+    Inbound::new(cfg, rt, &mut Default::default())
         .with_stack(connect)
         .map_stack(|cfg, _, s| {
             s.push_map_target(|t| Param::<Remote<ServerAddr>>::param(&t))

--- a/linkerd/app/inbound/src/metrics.rs
+++ b/linkerd/app/inbound/src/metrics.rs
@@ -25,16 +25,22 @@ pub struct InboundMetrics {
     /// Holds metrics that are common to both inbound and outbound proxies. These metrics are
     /// reported separately
     pub proxy: Proxy,
+
+    pub detect: crate::detect::MetricsFamilies,
 }
 
 impl InboundMetrics {
-    pub(crate) fn new(proxy: Proxy) -> Self {
+    pub(crate) fn new(proxy: Proxy, reg: &mut prom::Registry) -> Self {
+        let detect =
+            crate::detect::MetricsFamilies::register(reg.sub_registry_with_prefix("tcp_detect"));
+
         Self {
             http_authz: authz::HttpAuthzMetrics::default(),
             http_errors: error::HttpErrorMetrics::default(),
             tcp_authz: authz::TcpAuthzMetrics::default(),
             tcp_errors: error::TcpErrorMetrics::default(),
             proxy,
+            detect,
         }
     }
 }

--- a/linkerd/app/inbound/src/server.rs
+++ b/linkerd/app/inbound/src/server.rs
@@ -55,6 +55,8 @@ impl Inbound<()> {
         I: Debug + Unpin + Send + Sync + 'static,
         P: profiles::GetProfile<Error = Error>,
     {
+        let detect_metrics = self.runtime.metrics.detect.clone();
+
         // Handles connections to ports that can't be determined to be HTTP.
         let forward = self
             .clone()
@@ -97,7 +99,7 @@ impl Inbound<()> {
         // Determines how to handle an inbound connection, dispatching it to the appropriate
         // stack.
         http.push_http_tcp_server()
-            .push_detect(forward)
+            .push_detect(detect_metrics, forward)
             .push_accept(addr.port(), policies, direct)
             .into_inner()
     }

--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -36,6 +36,7 @@ pub struct OutboundMetrics {
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PromMetrics {
+    pub(crate) http_detect: crate::http::DetectMetricsFamilies<ParentRef>,
     pub(crate) http: crate::http::HttpMetrics,
     pub(crate) opaq: crate::opaq::OpaqMetrics,
     pub(crate) tls: crate::tls::TlsMetrics,
@@ -88,6 +89,11 @@ where
 
 impl PromMetrics {
     pub fn register(registry: &mut prom::Registry) -> Self {
+        let http_detect = crate::http::DetectMetricsFamilies::register(
+            // Scoped consistently with the inbound metrics.
+            registry.sub_registry_with_prefix("tcp_detect_http"),
+        );
+
         // NOTE: HTTP metrics are scoped internally, since this configures both
         // HTTP and gRPC scopes.
         let http = crate::http::HttpMetrics::register(registry);
@@ -97,6 +103,7 @@ impl PromMetrics {
         let tls = crate::tls::TlsMetrics::register(registry.sub_registry_with_prefix("tls"));
 
         Self {
+            http_detect,
             http,
             opaq,
             tls,

--- a/linkerd/app/outbound/src/sidecar.rs
+++ b/linkerd/app/outbound/src/sidecar.rs
@@ -158,6 +158,12 @@ impl svc::Param<Protocol> for Sidecar {
     }
 }
 
+impl svc::Param<ParentRef> for Sidecar {
+    fn param(&self) -> ParentRef {
+        ParentRef(self.policy.borrow().parent.clone())
+    }
+}
+
 impl PartialEq for Sidecar {
     fn eq(&self, other: &Self) -> bool {
         self.orig_dst == other.orig_dst

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -219,7 +219,11 @@ impl Config {
             span_sink: trace_collector.span_sink(),
             drain: drain_rx.clone(),
         };
-        let inbound = Inbound::new(inbound, runtime.clone());
+        let inbound = Inbound::new(
+            inbound,
+            runtime.clone(),
+            registry.sub_registry_with_prefix("inbound"),
+        );
         let outbound = Outbound::new(
             outbound,
             runtime,

--- a/linkerd/http/detect/Cargo.toml
+++ b/linkerd/http/detect/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies]
 bytes = { workspace = true }
 httparse = "1"
+prometheus-client = "0.22"
 thiserror = "2"
 tokio = { version = "1", features = ["time"] }
 tracing = { version = "0.1" }

--- a/linkerd/http/detect/src/metrics.rs
+++ b/linkerd/http/detect/src/metrics.rs
@@ -173,7 +173,7 @@ where
             match self.result {
                 DetectResult::NotHttp => "not_http",
                 DetectResult::Http1 => "http/1",
-                DetectResult::H2 => "h2",
+                DetectResult::H2 => "http/2",
                 DetectResult::ReadTimeout => "read_timeout",
                 DetectResult::Error => "error",
             },

--- a/linkerd/http/detect/src/metrics.rs
+++ b/linkerd/http/detect/src/metrics.rs
@@ -129,7 +129,7 @@ where
 impl Default for DetectMetrics {
     fn default() -> Self {
         Self {
-            duration: Histogram::new([0.001, 0.1].into_iter()),
+            duration: MkDurations.new_metric(),
             not_http: Counter::default(),
             http1: Counter::default(),
             h2: Counter::default(),

--- a/linkerd/http/detect/src/metrics.rs
+++ b/linkerd/http/detect/src/metrics.rs
@@ -1,0 +1,195 @@
+use linkerd_http_variant::Variant;
+use prometheus_client::{
+    encoding::EncodeLabelSet,
+    metrics::{
+        counter::Counter,
+        family::{Family, MetricConstructor},
+        histogram::Histogram,
+    },
+    registry::{Registry, Unit},
+};
+use std::{fmt::Debug, hash::Hash};
+use tokio::time;
+
+#[derive(Clone, Debug)]
+pub struct DetectMetricsFamilies<L>
+where
+    L: Clone + Hash + Eq + EncodeLabelSet + Debug + Send + Sync + 'static,
+{
+    duration: Family<L, Histogram, MkDurations>,
+    results: Family<DetectLabels<L>, Counter>,
+}
+
+#[derive(Clone, Debug)]
+pub struct DetectMetrics {
+    duration: Histogram,
+    not_http: Counter,
+    http1: Counter,
+    h2: Counter,
+    read_timeout: Counter,
+    error: Counter,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct DetectLabels<L>
+where
+    L: Clone + Hash + Eq + EncodeLabelSet + Debug + Send + Sync + 'static,
+{
+    result: DetectResult,
+    labels: L,
+}
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+enum DetectResult {
+    NotHttp,
+    Http1,
+    H2,
+    ReadTimeout,
+    Error,
+}
+
+#[derive(Clone, Debug, Default)]
+struct MkDurations;
+
+// === impl DetectMetricsFamilies ===
+
+impl<L> Default for DetectMetricsFamilies<L>
+where
+    L: Clone + Hash + Eq + EncodeLabelSet + Debug + Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self {
+            duration: Family::new_with_constructor(MkDurations),
+            results: Family::default(),
+        }
+    }
+}
+
+impl<L> DetectMetricsFamilies<L>
+where
+    L: Clone + Hash + Eq + EncodeLabelSet + Debug + Send + Sync + 'static,
+{
+    pub fn register(reg: &mut Registry) -> Self {
+        let duration = Family::new_with_constructor(MkDurations);
+        reg.register_with_unit(
+            "duration",
+            "Time taken for protocol detection",
+            Unit::Seconds,
+            duration.clone(),
+        );
+
+        let results = Family::default();
+        reg.register("results", "Protocol detection results", results.clone());
+
+        Self { duration, results }
+    }
+
+    pub fn metrics(&self, labels: L) -> DetectMetrics {
+        let duration = (*self.duration.get_or_create(&labels)).clone();
+
+        let not_http = (*self.results.get_or_create(&DetectLabels {
+            result: DetectResult::NotHttp,
+            labels: labels.clone(),
+        }))
+        .clone();
+        let http1 = (*self.results.get_or_create(&DetectLabels {
+            result: DetectResult::Http1,
+            labels: labels.clone(),
+        }))
+        .clone();
+        let h2 = (*self.results.get_or_create(&DetectLabels {
+            result: DetectResult::H2,
+            labels: labels.clone(),
+        }))
+        .clone();
+        let read_timeout = (*self.results.get_or_create(&DetectLabels {
+            result: DetectResult::ReadTimeout,
+            labels: labels.clone(),
+        }))
+        .clone();
+        let error = (*self.results.get_or_create(&DetectLabels {
+            result: DetectResult::Error,
+            labels,
+        }))
+        .clone();
+
+        DetectMetrics {
+            duration,
+            not_http,
+            http1,
+            h2,
+            read_timeout,
+            error,
+        }
+    }
+}
+
+// === impl DetectMetrics ===
+
+impl Default for DetectMetrics {
+    fn default() -> Self {
+        Self {
+            duration: Histogram::new([0.001, 0.1].into_iter()),
+            not_http: Counter::default(),
+            http1: Counter::default(),
+            h2: Counter::default(),
+            read_timeout: Counter::default(),
+            error: Counter::default(),
+        }
+    }
+}
+
+impl DetectMetrics {
+    pub(crate) fn observe(
+        &self,
+        result: &std::io::Result<super::Detection>,
+        elapsed: time::Duration,
+    ) {
+        match result {
+            Ok(super::Detection::NotHttp) => self.not_http.inc(),
+            Ok(super::Detection::Http(Variant::Http1)) => self.http1.inc(),
+            Ok(super::Detection::Http(Variant::H2)) => self.h2.inc(),
+            Ok(super::Detection::ReadTimeout(_)) => self.read_timeout.inc(),
+            Err(_) => self.error.inc(),
+        };
+        self.duration.observe(elapsed.as_secs_f64());
+    }
+}
+
+// === impl DetectLabels ===
+
+impl<L> EncodeLabelSet for DetectLabels<L>
+where
+    L: Clone + Hash + Eq + EncodeLabelSet + Debug + Send + Sync + 'static,
+{
+    fn encode(
+        &self,
+        mut enc: prometheus_client::encoding::LabelSetEncoder,
+    ) -> Result<(), std::fmt::Error> {
+        use prometheus_client::encoding::EncodeLabel;
+
+        (
+            "result",
+            match self.result {
+                DetectResult::NotHttp => "not_http",
+                DetectResult::Http1 => "http/1",
+                DetectResult::H2 => "h2",
+                DetectResult::ReadTimeout => "read_timeout",
+                DetectResult::Error => "error",
+            },
+        )
+            .encode(enc.encode_label())?;
+
+        self.labels.encode(enc)?;
+
+        Ok(())
+    }
+}
+
+// === impl MkDurations ===
+
+impl MetricConstructor<Histogram> for MkDurations {
+    fn new_metric(&self) -> Histogram {
+        Histogram::new([0.001, 0.1].into_iter())
+    }
+}

--- a/linkerd/proxy/http/src/lib.rs
+++ b/linkerd/proxy/http/src/lib.rs
@@ -36,7 +36,9 @@ pub use http::{
 pub use http_body::Body;
 pub use linkerd_http_box::{BoxBody, BoxRequest, BoxResponse, EraseResponse};
 pub use linkerd_http_classify as classify;
-pub use linkerd_http_detect::{DetectParams, Detection, NewDetect};
+pub use linkerd_http_detect::{
+    DetectMetrics, DetectMetricsFamilies, DetectParams, Detection, NewDetect,
+};
 pub use linkerd_http_executor::TracingExecutor;
 pub use linkerd_http_insert as insert;
 pub use linkerd_http_override_authority::{AuthorityOverride, NewOverrideAuthority};


### PR DESCRIPTION
This change updates the DetectHttp middleware to record metrics about HTTP
protocol detection. Specfically, it records the the counts of results and a very
coarse histogram of the time taken to detect the protocol.

The inbound, outbound, and admin (via inbound) stacks are updated to record
metrics against the main registry.

<details>
<summary><h3>Example metrics</h3></summary>

```
# HELP inbound_tcp_detect_http_duration_seconds Time taken for protocol detection.
# TYPE inbound_tcp_detect_http_duration_seconds histogram
# UNIT inbound_tcp_detect_http_duration_seconds seconds
inbound_tcp_detect_http_duration_seconds_sum{srv_group="",srv_kind="default",srv_name="all-unauthenticated",srv_port="4191"} 0.0019456109999999997
inbound_tcp_detect_http_duration_seconds_count{srv_group="",srv_kind="default",srv_name="all-unauthenticated",srv_port="4191"} 52
inbound_tcp_detect_http_duration_seconds_bucket{le="0.001",srv_group="",srv_kind="default",srv_name="all-unauthenticated",srv_port="4191"} 52
inbound_tcp_detect_http_duration_seconds_bucket{le="0.1",srv_group="",srv_kind="default",srv_name="all-unauthenticated",srv_port="4191"} 52
inbound_tcp_detect_http_duration_seconds_bucket{le="+Inf",srv_group="",srv_kind="default",srv_name="all-unauthenticated",srv_port="4191"} 52
```
```
# HELP inbound_tcp_detect_http_results Protocol detection results.
# TYPE inbound_tcp_detect_http_results counter
inbound_tcp_detect_http_results_total{result="read_timeout",srv_group="",srv_kind="default",srv_name="all-unauthenticated",srv_port="4191"} 0
inbound_tcp_detect_http_results_total{result="not_http",srv_group="",srv_kind="default",srv_name="all-unauthenticated",srv_port="4191"} 0
inbound_tcp_detect_http_results_total{result="http/1",srv_group="",srv_kind="default",srv_name="all-unauthenticated",srv_port="4191"} 52
inbound_tcp_detect_http_results_total{result="h2",srv_group="",srv_kind="default",srv_name="all-unauthenticated",srv_port="4191"} 0
inbound_tcp_detect_http_results_total{result="error",srv_group="",srv_kind="default",srv_name="all-unauthenticated",srv_port="4191"} 0
```
```
# HELP outbound_tcp_detect_http_duration_seconds Time taken for protocol detection.
# TYPE outbound_tcp_detect_http_duration_seconds histogram
# UNIT outbound_tcp_detect_http_duration_seconds seconds
outbound_tcp_detect_http_duration_seconds_sum{parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="voting-svc",parent_port="8080",parent_section_name=""} 0.000010969
outbound_tcp_detect_http_duration_seconds_count{parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="voting-svc",parent_port="8080",parent_section_name=""} 1
outbound_tcp_detect_http_duration_seconds_bucket{le="0.001",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="voting-svc",parent_port="8080",parent_section_name=""} 1
outbound_tcp_detect_http_duration_seconds_bucket{le="0.1",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="voting-svc",parent_port="8080",parent_section_name=""} 1
outbound_tcp_detect_http_duration_seconds_bucket{le="+Inf",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="voting-svc",parent_port="8080",parent_section_name=""} 1
outbound_tcp_detect_http_duration_seconds_sum{parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name=""} 0.000008034
outbound_tcp_detect_http_duration_seconds_count{parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name=""} 1
outbound_tcp_detect_http_duration_seconds_bucket{le="0.001",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name=""} 1
outbound_tcp_detect_http_duration_seconds_bucket{le="0.1",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name=""} 1
outbound_tcp_detect_http_duration_seconds_bucket{le="+Inf",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name=""} 1
```
```
# HELP outbound_tcp_detect_http_results Protocol detection results.
# TYPE outbound_tcp_detect_http_results counter
outbound_tcp_detect_http_results_total{result="http/1",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="voting-svc",parent_port="8080",parent_section_name=""} 0
outbound_tcp_detect_http_results_total{result="not_http",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="voting-svc",parent_port="8080",parent_section_name=""} 0
outbound_tcp_detect_http_results_total{result="not_http",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name=""} 0
outbound_tcp_detect_http_results_total{result="read_timeout",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="voting-svc",parent_port="8080",parent_section_name=""} 0
outbound_tcp_detect_http_results_total{result="h2",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="voting-svc",parent_port="8080",parent_section_name=""} 1
outbound_tcp_detect_http_results_total{result="error",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="voting-svc",parent_port="8080",parent_section_name=""} 0
outbound_tcp_detect_http_results_total{result="http/1",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name=""} 0
outbound_tcp_detect_http_results_total{result="h2",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name=""} 1
outbound_tcp_detect_http_results_total{result="error",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name=""} 0
outbound_tcp_detect_http_results_total{result="read_timeout",parent_group="core",parent_kind="Service",parent_namespace="emojivoto",parent_name="emoji-svc",parent_port="8080",parent_section_name=""} 0
```