### PR TITLE
fix(inbound): correct error message when transport header is missing

### DIFF
--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -25,8 +25,8 @@ struct RefusedNoHeader;
 pub struct RefusedNoIdentity(());
 
 #[derive(Debug, Error)]
-#[error("a named target must be provided on gateway connections")]
-struct RefusedNoTarget;
+#[error("direct connections require transport header negotiation")]
+struct TransportHeaderRequired(());
 
 #[derive(Debug, Clone)]
 pub(crate) struct LocalTcp {
@@ -222,7 +222,7 @@ impl<N> Inbound<N> {
                     if client.header_negotiated() {
                         Ok(client)
                     } else {
-                        Err(RefusedNoTarget.into())
+                        Err(TransportHeaderRequired(()).into())
                     }
                 })
                 .push(svc::ArcNewService::layer())


### PR DESCRIPTION
The RefusedNoTarget error type is a remnant of an older version of the direct stack. This commit updates the error message to reflect the current state of the code: we require ALPN-negotiated transport headers on all direct connections.