### PR TITLE
feat(inbound): include srv_port label in server metrics

### DIFF
--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -199,18 +199,21 @@ mod tests {
                 negotiated_protocol: None,
             }),
             ([192, 0, 2, 4], 40000).into(),
-            PolicyServerLabel(Arc::new(Meta::Resource {
-                group: "policy.linkerd.io".into(),
-                kind: "server".into(),
-                name: "testserver".into(),
-            })),
+            PolicyServerLabel(
+                Arc::new(Meta::Resource {
+                    group: "policy.linkerd.io".into(),
+                    kind: "server".into(),
+                    name: "testserver".into(),
+                }),
+                40000,
+            ),
         );
         assert_eq!(
             labels.to_string(),
             "direction=\"inbound\",peer=\"src\",\
             target_addr=\"192.0.2.4:40000\",target_ip=\"192.0.2.4\",target_port=\"40000\",\
             tls=\"true\",client_id=\"foo.id.example.com\",\
-            srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testserver\""
+            srv_group=\"policy.linkerd.io\",srv_kind=\"server\",srv_name=\"testserver\",srv_port=\"40000\""
         );
     }
 }

--- a/linkerd/app/gateway/src/http/tests.rs
+++ b/linkerd/app/gateway/src/http/tests.rs
@@ -62,7 +62,7 @@ async fn upgraded_request_remains_relative_form() {
 
     impl svc::Param<ServerLabel> for Target {
         fn param(&self) -> ServerLabel {
-            ServerLabel(policy::Meta::new_default("test"))
+            ServerLabel(policy::Meta::new_default("test"), 4143)
         }
     }
 

--- a/linkerd/app/inbound/src/http.rs
+++ b/linkerd/app/inbound/src/http.rs
@@ -238,11 +238,14 @@ pub mod fuzz {
 
     impl svc::Param<policy::ServerLabel> for Target {
         fn param(&self) -> policy::ServerLabel {
-            policy::ServerLabel(Arc::new(policy::Meta::Resource {
-                group: "policy.linkerd.io".into(),
-                kind: "server".into(),
-                name: "testsrv".into(),
-            }))
+            policy::ServerLabel(
+                Arc::new(policy::Meta::Resource {
+                    group: "policy.linkerd.io".into(),
+                    kind: "server".into(),
+                    name: "testsrv".into(),
+                }),
+                1000,
+            )
         }
     }
 

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -655,11 +655,14 @@ async fn grpc_response_class() {
                 target_addr: "127.0.0.1:80".parse().unwrap(),
                 policy: metrics::RouteAuthzLabels {
                     route: metrics::RouteLabels {
-                        server: metrics::ServerLabel(Arc::new(policy::Meta::Resource {
-                            group: "policy.linkerd.io".into(),
-                            kind: "server".into(),
-                            name: "testsrv".into(),
-                        })),
+                        server: metrics::ServerLabel(
+                            Arc::new(policy::Meta::Resource {
+                                group: "policy.linkerd.io".into(),
+                                kind: "server".into(),
+                                name: "testsrv".into(),
+                            }),
+                            80,
+                        ),
                         route: policy::Meta::new_default("default"),
                     },
                     authz: Arc::new(policy::Meta::Resource {
@@ -889,11 +892,14 @@ impl svc::Param<policy::AllowPolicy> for Target {
 
 impl svc::Param<policy::ServerLabel> for Target {
     fn param(&self) -> policy::ServerLabel {
-        policy::ServerLabel(Arc::new(policy::Meta::Resource {
-            group: "policy.linkerd.io".into(),
-            kind: "server".into(),
-            name: "testsrv".into(),
-        }))
+        policy::ServerLabel(
+            Arc::new(policy::Meta::Resource {
+                group: "policy.linkerd.io".into(),
+                kind: "server".into(),
+                name: "testsrv".into(),
+            }),
+            80,
+        )
     }
 }
 

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -133,7 +133,7 @@ impl AllowPolicy {
 
     #[inline]
     pub fn server_label(&self) -> ServerLabel {
-        ServerLabel(self.server.borrow().meta.clone())
+        ServerLabel(self.server.borrow().meta.clone(), self.dst.port())
     }
 
     pub fn ratelimit_label(&self, error: &RateLimitError) -> HTTPLocalRateLimitLabels {
@@ -220,7 +220,7 @@ impl ServerPermit {
             protocol: server.protocol.clone(),
             labels: ServerAuthzLabels {
                 authz: authz.meta.clone(),
-                server: ServerLabel(server.meta.clone()),
+                server: ServerLabel(server.meta.clone(), dst.port()),
             },
         }
     }

--- a/linkerd/app/inbound/src/policy/tcp/tests.rs
+++ b/linkerd/app/inbound/src/policy/tcp/tests.rs
@@ -43,11 +43,14 @@ async fn unauthenticated_allowed() {
                     kind: "serverauthorization".into(),
                     name: "unauth".into()
                 }),
-                server: ServerLabel(Arc::new(Meta::Resource {
-                    group: "policy.linkerd.io".into(),
-                    kind: "server".into(),
-                    name: "test".into()
-                }))
+                server: ServerLabel(
+                    Arc::new(Meta::Resource {
+                        group: "policy.linkerd.io".into(),
+                        kind: "server".into(),
+                        name: "test".into()
+                    }),
+                    1000
+                )
             },
         }
     );
@@ -96,11 +99,14 @@ async fn authenticated_identity() {
                     kind: "serverauthorization".into(),
                     name: "tls-auth".into()
                 }),
-                server: ServerLabel(Arc::new(Meta::Resource {
-                    group: "policy.linkerd.io".into(),
-                    kind: "server".into(),
-                    name: "test".into()
-                }))
+                server: ServerLabel(
+                    Arc::new(Meta::Resource {
+                        group: "policy.linkerd.io".into(),
+                        kind: "server".into(),
+                        name: "test".into()
+                    }),
+                    1000
+                )
             }
         }
     );
@@ -159,11 +165,14 @@ async fn authenticated_suffix() {
                     kind: "serverauthorization".into(),
                     name: "tls-auth".into()
                 }),
-                server: ServerLabel(Arc::new(Meta::Resource {
-                    group: "policy.linkerd.io".into(),
-                    kind: "server".into(),
-                    name: "test".into()
-                })),
+                server: ServerLabel(
+                    Arc::new(Meta::Resource {
+                        group: "policy.linkerd.io".into(),
+                        kind: "server".into(),
+                        name: "test".into()
+                    }),
+                    1000
+                ),
             }
         }
     );
@@ -219,11 +228,14 @@ async fn tls_unauthenticated() {
                     kind: "serverauthorization".into(),
                     name: "tls-unauth".into()
                 }),
-                server: ServerLabel(Arc::new(Meta::Resource {
-                    group: "policy.linkerd.io".into(),
-                    kind: "server".into(),
-                    name: "test".into()
-                })),
+                server: ServerLabel(
+                    Arc::new(Meta::Resource {
+                        group: "policy.linkerd.io".into(),
+                        kind: "server".into(),
+                        name: "test".into()
+                    }),
+                    1000
+                ),
             }
         }
     );


### PR DESCRIPTION
We include a group/version/kind for inbound server resources, but we do not indicate which specific port the server is applied to. This is important context to understand the inbound proxy's behavior, especially when using the default servers.

This change adds a `srv_port` label to inbound server metrics to definitively and consistently indicate the server port used for inbound policy.

This change also adds prometheus_client compatible label formatting for
consistency.