### PR TITLE
chore(deps): use `prometheus-client` v0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "kubert-prometheus-tokio"
-version = "0.1.0"
+version = "0.2.0-alpha1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a101fa3df488c89130664aaf4652986da49e204fb1725d089122f75b22ff6cbb"
+checksum = "3dbcc33c25a942237489d4a50beffb704a01a0faff50ec0d5c97eb98b12c6c23"
 dependencies = [
  "prometheus-client",
  "tokio",
@@ -3199,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.22.3"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
 dependencies = [
  "dtoa",
  "itoa",
@@ -3922,9 +3922,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-metrics"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eace09241d62c98b7eeb1107d4c5c64ca3bd7da92e8c218c153ab3a78f9be112"
+checksum = "cb2bb07a8451c4c6fa8b3497ad198510d8b8dffa5df5cfb97a64102a58b113c8"
 dependencies = [
  "futures-util",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "kubert-prometheus-tokio"
-version = "0.2.0-alpha1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbcc33c25a942237489d4a50beffb704a01a0faff50ec0d5c97eb98b12c6c23"
+checksum = "639670482534c37eb44caf6f4b72cc5da2f2c06aed39d1fb0cba940569428212"
 dependencies = [
  "prometheus-client",
  "tokio",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -20,7 +20,7 @@ http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.11"
-prometheus-client = "0.22"
+prometheus-client = "0.23"
 regex = "1"
 serde_json = "1"
 thiserror = "2"

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -26,7 +26,7 @@ linkerd2-proxy-api = { workspace = true, features = ["outbound"] }
 once_cell = "1"
 parking_lot = "0.12"
 pin-project = "1"
-prometheus-client = "0.22"
+prometheus-client = "0.23"
 thiserror = "2"
 tokio = { version = "1", features = ["sync"] }
 tonic = { workspace = true, default-features = false }

--- a/linkerd/http/detect/src/metrics.rs
+++ b/linkerd/http/detect/src/metrics.rs
@@ -190,6 +190,6 @@ where
 
 impl MetricConstructor<Histogram> for MkDurations {
     fn new_metric(&self) -> Histogram {
-        Histogram::new([0.001, 0.1].into_iter())
+        Histogram::new([0.001, 0.1])
     }
 }

--- a/linkerd/http/prom/Cargo.toml
+++ b/linkerd/http/prom/Cargo.toml
@@ -19,7 +19,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 parking_lot = "0.12"
 pin-project = "1"
-prometheus-client = "0.22"
+prometheus-client = "0.23"
 thiserror = "2"
 tokio = { version = "1", features = ["time"] }
 

--- a/linkerd/http/prom/src/body_data/metrics.rs
+++ b/linkerd/http/prom/src/body_data/metrics.rs
@@ -33,7 +33,7 @@ struct NewHisto;
 
 impl MetricConstructor<Histogram> for NewHisto {
     fn new_metric(&self) -> Histogram {
-        Histogram::new([128.0, 1024.0, 10240.0].into_iter())
+        Histogram::new([128.0, 1024.0, 10240.0])
     }
 }
 

--- a/linkerd/identity/Cargo.toml
+++ b/linkerd/identity/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-prometheus-client = "0.22"
+prometheus-client = "0.23"
 thiserror = "2"
 tracing = "0.1"
 url = "2.5.4"

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -21,7 +21,7 @@ linkerd-http-box = { path = "../http/box" }
 linkerd-stack = { path = "../stack", optional = true }
 linkerd-system = { path = "../system", optional = true }
 parking_lot = "0.12"
-prometheus-client = "0.22"
+prometheus-client = "0.23"
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
 

--- a/linkerd/pool/p2c/Cargo.toml
+++ b/linkerd/pool/p2c/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 ahash = "0.8"
 futures = { version = "0.3", default-features = false }
 indexmap = "2"
-prometheus-client = "0.22"
+prometheus-client = "0.23"
 rand = { version = "0.9", features = ["small_rng"] }
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 tracing = "0.1"

--- a/linkerd/proxy/balance/gauge-endpoints/Cargo.toml
+++ b/linkerd/proxy/balance/gauge-endpoints/Cargo.toml
@@ -6,6 +6,6 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
-prometheus-client = "0.22"
+prometheus-client = "0.23"
 
 linkerd-stack = { path = "../../../stack" }

--- a/linkerd/proxy/balance/queue/Cargo.toml
+++ b/linkerd/proxy/balance/queue/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 futures = { version = "0.3", default-features = false }
 parking_lot = "0.12"
 pin-project = "1"
-prometheus-client = "0.22"
+prometheus-client = "0.23"
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 tokio-util = "0.7"

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -18,7 +18,7 @@ pprof = ["linkerd-app/pprof"]
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-kubert-prometheus-tokio = { version = "0.2.0-alpha1", features = ["rt"] }
+kubert-prometheus-tokio = { version = "0.2.0", features = ["rt"] }
 linkerd-app = { path = "../linkerd/app" }
 linkerd-metrics = { path = "../linkerd/metrics" }
 # We don't actually use code from this crate in `main`; it's here only so we can

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -18,7 +18,7 @@ pprof = ["linkerd-app/pprof"]
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-kubert-prometheus-tokio = { version = "0.1", features = ["rt"] }
+kubert-prometheus-tokio = { version = "0.2.0-alpha1", features = ["rt"] }
 linkerd-app = { path = "../linkerd/app" }
 linkerd-metrics = { path = "../linkerd/metrics" }
 # We don't actually use code from this crate in `main`; it's here only so we can


### PR DESCRIPTION
this updates the prometheus client dependency.

additionally, this commit updates the `kubert-prometheus-tokio` dependency, so that we agree on the client library in use.