### PR TITLE
feat(outbound): add outbound_tcp_protocol_connections counter

### DIFF
--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -36,6 +36,7 @@ pub struct OutboundMetrics {
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PromMetrics {
+    pub(crate) protocol: crate::protocol::MetricsFamilies,
     pub(crate) http_detect: crate::http::DetectMetricsFamilies<ParentRef>,
     pub(crate) http: crate::http::HttpMetrics,
     pub(crate) opaq: crate::opaq::OpaqMetrics,
@@ -89,6 +90,9 @@ where
 
 impl PromMetrics {
     pub fn register(registry: &mut prom::Registry) -> Self {
+        let protocol = crate::protocol::MetricsFamilies::register(
+            registry.sub_registry_with_prefix("tcp_protocol"),
+        );
         let http_detect = crate::http::DetectMetricsFamilies::register(
             // Scoped consistently with the inbound metrics.
             registry.sub_registry_with_prefix("tcp_detect_http"),
@@ -103,6 +107,7 @@ impl PromMetrics {
         let tls = crate::tls::TlsMetrics::register(registry.sub_registry_with_prefix("tls"));
 
         Self {
+            protocol,
             http_detect,
             http,
             opaq,

--- a/linkerd/app/outbound/src/protocol/metrics.rs
+++ b/linkerd/app/outbound/src/protocol/metrics.rs
@@ -1,0 +1,125 @@
+use super::Protocol;
+use crate::ParentRef;
+use linkerd_app_core::{
+    metrics::prom::{self, EncodeLabelSetMut},
+    svc,
+};
+
+#[derive(Clone, Debug)]
+pub struct NewRecord<N> {
+    inner: N,
+    metrics: MetricsFamilies,
+}
+
+#[derive(Clone, Debug)]
+pub struct Record<S> {
+    inner: S,
+    counter: prom::Counter,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct MetricsFamilies {
+    connections: prom::Family<Labels, prom::Counter>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct Labels {
+    protocol: Protocol,
+    parent_ref: ParentRef,
+}
+
+// === impl MetricsFamilies ===
+
+impl MetricsFamilies {
+    pub fn register(reg: &mut prom::Registry) -> Self {
+        let connections = prom::Family::default();
+        reg.register(
+            "connections",
+            "Outbound TCP connections by protocol configuration",
+            connections.clone(),
+        );
+
+        Self { connections }
+    }
+}
+
+// === impl NewRecord ===
+
+impl<N> NewRecord<N> {
+    pub fn layer(metrics: MetricsFamilies) -> impl svc::layer::Layer<N, Service = Self> + Clone {
+        svc::layer::mk(move |inner| Self {
+            inner,
+            metrics: metrics.clone(),
+        })
+    }
+}
+
+impl<T, N> svc::NewService<T> for NewRecord<N>
+where
+    T: svc::Param<Protocol>,
+    T: svc::Param<ParentRef>,
+    N: svc::NewService<T>,
+{
+    type Service = Record<N::Service>;
+
+    fn new_service(&self, target: T) -> Self::Service {
+        let counter = (*self.metrics.connections.get_or_create(&Labels {
+            protocol: target.param(),
+            parent_ref: target.param(),
+        }))
+        .clone();
+
+        let inner = self.inner.new_service(target);
+        Record { inner, counter }
+    }
+}
+
+// === impl Record ===
+
+impl<S, I> svc::Service<I> for Record<S>
+where
+    S: svc::Service<I>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, io: I) -> Self::Future {
+        self.counter.inc();
+        self.inner.call(io)
+    }
+}
+
+// === impl Labels ===
+
+impl prom::EncodeLabelSetMut for Labels {
+    fn encode_label_set(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+        use prom::encoding::EncodeLabel;
+
+        let protocol = match self.protocol {
+            Protocol::Http1 => "http/1",
+            Protocol::Http2 => "http/2",
+            Protocol::Detect => "detect",
+            Protocol::Opaque => "opaq",
+            Protocol::Tls => "tls",
+        };
+
+        ("protocol", protocol).encode(enc.encode_label())?;
+        self.parent_ref.encode_label_set(enc)?;
+
+        Ok(())
+    }
+}
+
+impl prom::encoding::EncodeLabelSet for Labels {
+    fn encode(&self, mut enc: prom::encoding::LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
+        self.encode_label_set(&mut enc)
+    }
+}

--- a/linkerd/app/outbound/src/protocol/tests.rs
+++ b/linkerd/app/outbound/src/protocol/tests.rs
@@ -1,0 +1,223 @@
+use super::*;
+use futures::future;
+use linkerd_app_core::{
+    io,
+    metrics::prom,
+    svc::{Layer, NewService, Service, ServiceExt},
+    trace, Error,
+};
+use linkerd_proxy_client_policy::Meta;
+use std::sync::Arc;
+
+// Mock target type that implements the required params
+#[derive(Clone, Debug)]
+struct MockTarget {
+    protocol: Protocol,
+    parent_ref: ParentRef,
+}
+
+impl MockTarget {
+    fn new(port: u16, protocol: Protocol) -> Self {
+        Self {
+            protocol,
+            parent_ref: ParentRef(Arc::new(Meta::Resource {
+                group: "".into(),
+                kind: "Service".into(),
+                namespace: "myns".into(),
+                name: "mysvc".into(),
+                port: port.try_into().ok(),
+                section: None,
+            })),
+        }
+    }
+}
+
+impl svc::Param<Protocol> for MockTarget {
+    fn param(&self) -> Protocol {
+        self.protocol
+    }
+}
+
+impl svc::Param<ParentRef> for MockTarget {
+    fn param(&self) -> ParentRef {
+        self.parent_ref.clone()
+    }
+}
+
+// Test helpers
+fn new_ok<T>() -> svc::ArcNewTcp<T, io::BoxedIo> {
+    svc::ArcNewService::new(|_| svc::BoxService::new(svc::mk(|_| future::ok::<(), Error>(()))))
+}
+
+// Metric assertion helpers
+macro_rules! assert_counted {
+    ($registry:expr, $proto:expr, $port:expr, $value:expr) => {{
+        let mut buf = String::new();
+        prom::encoding::text::encode_registry(&mut buf, $registry).expect("encode registry failed");
+        let lines = buf.split_terminator('\n').collect::<Vec<_>>();
+        let metric = format!(
+            "connections_total{{protocol=\"{}\",parent_group=\"\",parent_kind=\"Service\",parent_namespace=\"myns\",parent_name=\"mysvc\",parent_port=\"{}\",parent_section_name=\"\"}}",
+            $proto, $port
+        );
+        assert_eq!(
+            lines.iter().find(|l| l.starts_with(&metric)),
+            Some(&&*format!("{metric} {}", $value)),
+            "metric '{metric}' not found in:\n{buf}",
+        );
+    }};
+}
+
+// Test each protocol type
+#[tokio::test(flavor = "current_thread")]
+async fn http1() {
+    let _trace = trace::test::trace_init();
+
+    let target = MockTarget::new(8080, Protocol::Http1);
+    let (io, _) = io::duplex(100);
+
+    let mut registry = prom::Registry::default();
+    let metrics = MetricsFamilies::register(&mut registry);
+
+    metrics::NewRecord::layer(metrics.clone())
+        .layer(new_ok())
+        .new_service(target)
+        .oneshot(io::BoxedIo::new(io))
+        .await
+        .expect("service must not fail");
+
+    assert_counted!(&registry, "http/1", 8080, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http2() {
+    let _trace = trace::test::trace_init();
+
+    let target = MockTarget::new(8081, Protocol::Http2);
+    let (io, _) = io::duplex(100);
+
+    let mut registry = prom::Registry::default();
+    let metrics = MetricsFamilies::register(&mut registry);
+
+    metrics::NewRecord::layer(metrics.clone())
+        .layer(new_ok())
+        .new_service(target)
+        .oneshot(io::BoxedIo::new(io))
+        .await
+        .expect("service must not fail");
+
+    assert_counted!(&registry, "http/2", 8081, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn opaque() {
+    let _trace = trace::test::trace_init();
+
+    let (io, _) = io::duplex(100);
+
+    let mut registry = prom::Registry::default();
+    let metrics = MetricsFamilies::register(&mut registry);
+
+    metrics::NewRecord::layer(metrics.clone())
+        .layer(new_ok())
+        .new_service(MockTarget::new(8082, Protocol::Opaque))
+        .oneshot(io::BoxedIo::new(io))
+        .await
+        .expect("service must not fail");
+
+    assert_counted!(&registry, "opaq", 8082, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn detect() {
+    let _trace = trace::test::trace_init();
+
+    let (io, _) = io::duplex(100);
+
+    let mut registry = prom::Registry::default();
+    let metrics = MetricsFamilies::register(&mut registry);
+
+    metrics::NewRecord::layer(metrics.clone())
+        .layer(new_ok())
+        .new_service(MockTarget::new(8083, Protocol::Detect))
+        .oneshot(io::BoxedIo::new(io))
+        .await
+        .expect("service must not fail");
+
+    assert_counted!(&registry, "detect", 8083, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn tls() {
+    let _trace = trace::test::trace_init();
+
+    let (io, _) = io::duplex(100);
+
+    let mut registry = prom::Registry::default();
+    let metrics = MetricsFamilies::register(&mut registry);
+
+    metrics::NewRecord::layer(metrics.clone())
+        .layer(new_ok())
+        .new_service(MockTarget::new(8084, Protocol::Tls))
+        .oneshot(io::BoxedIo::new(io))
+        .await
+        .expect("service must not fail");
+
+    assert_counted!(&registry, "tls", 8084, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn http1_x3() {
+    let _trace = trace::test::trace_init();
+
+    let target = MockTarget::new(8085, Protocol::Http1);
+
+    let mut registry = prom::Registry::default();
+    let metrics = MetricsFamilies::register(&mut registry);
+    let mut svc = metrics::NewRecord::layer(metrics.clone())
+        .layer(new_ok())
+        .new_service(target);
+
+    // Make three connections
+    for _ in 0..3 {
+        let (io, _) = io::duplex(100);
+        svc.ready().await.expect("ready");
+        svc.call(io::BoxedIo::new(io))
+            .await
+            .expect("service must not fail");
+    }
+
+    assert_counted!(&registry, "http/1", 8085, 3);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multiple() {
+    let _trace = trace::test::trace_init();
+
+    let mut registry = prom::Registry::default();
+    let metrics = MetricsFamilies::register(&mut registry);
+
+    // Make one connection of each type
+    let protocols = vec![
+        (8090, Protocol::Http1),
+        (8091, Protocol::Http2),
+        (8092, Protocol::Opaque),
+        (8093, Protocol::Detect),
+        (8094, Protocol::Tls),
+    ];
+
+    for (port, protocol) in protocols {
+        let (io, _) = io::duplex(100);
+        metrics::NewRecord::layer(metrics.clone())
+            .layer(new_ok())
+            .new_service(MockTarget::new(port, protocol))
+            .oneshot(io::BoxedIo::new(io))
+            .await
+            .expect("service must not fail");
+    }
+
+    assert_counted!(&registry, "http/1", 8090, 1);
+    assert_counted!(&registry, "http/2", 8091, 1);
+    assert_counted!(&registry, "opaq", 8092, 1);
+    assert_counted!(&registry, "detect", 8093, 1);
+    assert_counted!(&registry, "tls", 8094, 1);
+}


### PR DESCRIPTION
The outbound proxy makes protocol decisions based on the discovery response, keyed on a "parent" reference.

This change adds a connection counter, `outbound_tcp_protocol_connections`, that counts dispatched connections by protocol configuration ("http/1", "http/2", "opaq", "tls", "detect")