### PR TITLE
chore(linkerd2-proxy): always enable multicore features

### DIFF
--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -8,8 +8,7 @@ publish = false
 description = "The main proxy executable"
 
 [features]
-default = ["multicore", "meshtls-rustls"]
-multicore = ["tokio/rt-multi-thread", "num_cpus"]
+default = ["meshtls-rustls"]
 meshtls-boring = ["linkerd-meshtls/boring"]
 meshtls-boring-fips = ["linkerd-meshtls/boring-fips"]
 meshtls-rustls = ["linkerd-meshtls/rustls"]
@@ -25,8 +24,8 @@ linkerd-metrics = { path = "../linkerd/metrics" }
 # control its feature flags.
 linkerd-meshtls = { path = "../linkerd/meshtls" }
 linkerd-signal = { path = "../linkerd/signal" }
-num_cpus = { version = "1", optional = true }
-tokio = { version = "1", features = ["rt", "time", "net"] }
+num_cpus = "1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "net"] }
 tracing = "0.1"
 
 [target.x86_64-unknown-linux-gnu.dependencies]

--- a/linkerd2-proxy/src/rt.rs
+++ b/linkerd2-proxy/src/rt.rs
@@ -1,7 +1,6 @@
 use tokio::runtime::{Builder, Runtime};
 use tracing::{info, warn};
 
-#[cfg(feature = "multicore")]
 pub(crate) fn build() -> Runtime {
     // The proxy creates an additional admin thread, but it would be wasteful to
     // allocate a whole core to it; so we let the main runtime consume all
@@ -53,16 +52,6 @@ pub(crate) fn build() -> Runtime {
                 .expect("failed to build threaded runtime!")
         }
     }
-}
-
-#[cfg(not(feature = "multicore"))]
-pub(crate) fn build() -> Runtime {
-    Builder::new()
-        .enable_all()
-        .thread_name("proxy")
-        .basic_scheduler()
-        .build()
-        .expect("failed to build basic runtime!")
 }
 
 /// Spawns a task to scrape metrics for the given runtime at a regular interval.


### PR DESCRIPTION
The proxy predates the multi-threaded tokio runtime. When switching to it, we added a 'multicore' feature to adopt it incrementally. This has been the only supported configuration for many years now.

This change removes the needless feature flag to simplify the runtime configuration.