### PR TITLE
chore(metrics): clean up feature flagging

### DIFF
--- a/linkerd/http/metrics/Cargo.toml
+++ b/linkerd/http/metrics/Cargo.toml
@@ -23,5 +23,5 @@ tracing = "0.1"
 
 linkerd-error = { path = "../../error" }
 linkerd-http-classify = { path = "../classify" }
-linkerd-metrics = { path = "../../metrics", features = ["linkerd-stack"] }
+linkerd-metrics = { path = "../../metrics", features = ["stack"] }
 linkerd-stack = { path = "../../stack" }

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 
 [features]
 default = []
-process = ["linkerd-system"]
-stack = ["linkerd-stack"]
+process = ["dep:linkerd-system"]
+stack = ["dep:linkerd-stack"]
 test_util = []
 
 [dependencies]
@@ -17,13 +17,14 @@ deflate = { version = "1", features = ["gzip"] }
 http = { workspace = true }
 http-body = { workspace = true }
 hyper = { workspace = true, features = ["deprecated", "http1", "http2"] }
-linkerd-http-box = { path = "../http/box" }
-linkerd-stack = { path = "../stack", optional = true }
-linkerd-system = { path = "../system", optional = true }
 parking_lot = "0.12"
 prometheus-client = "0.22"
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
+
+linkerd-http-box = { path = "../http/box" }
+linkerd-stack = { path = "../stack", optional = true }
+linkerd-system = { path = "../system", optional = true }
 
 [dev-dependencies]
 quickcheck = { version = "1", default-features = false }

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -8,14 +8,14 @@ mod fmt;
 mod gauge;
 mod histogram;
 pub mod latency;
-#[cfg(feature = "linkerd-stack")]
+#[cfg(feature = "stack")]
 mod new_metrics;
 #[cfg(feature = "process")]
 pub mod process;
 mod serve;
 mod store;
 
-#[cfg(feature = "linkerd-stack")]
+#[cfg(feature = "stack")]
 pub use self::new_metrics::NewMetrics;
 pub use self::{
     counter::Counter,


### PR DESCRIPTION
linkerd-metrics exposes a 'stack' feature but uses a 'linkerd-stack' feature internally. This change cleans this up.