### PR TITLE
chore(deps): upgrade to tower 0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,7 @@ dependencies = [
  "pin-project",
  "tokio",
  "tokio-test",
- "tower 0.4.13",
+ "tower 0.5.2",
 ]
 
 [[package]]
@@ -1438,7 +1438,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -1461,7 +1461,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -1530,7 +1530,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -1551,7 +1551,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-test",
  "tracing",
 ]
@@ -1590,7 +1590,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -1626,7 +1626,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1674,7 +1674,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-test",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-test",
  "tracing",
 ]
@@ -1703,7 +1703,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1880,7 +1880,7 @@ dependencies = [
  "http",
  "linkerd-stack",
  "pin-project",
- "tower 0.4.13",
+ "tower 0.5.2",
 ]
 
 [[package]]
@@ -1899,7 +1899,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -1909,7 +1909,7 @@ version = "0.1.0"
 dependencies = [
  "http",
  "linkerd-stack",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -1940,7 +1940,7 @@ dependencies = [
  "http-body",
  "linkerd-stack",
  "pin-project",
- "tower 0.4.13",
+ "tower 0.5.2",
 ]
 
 [[package]]
@@ -1964,7 +1964,7 @@ dependencies = [
  "pin-project",
  "thiserror 2.0.12",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2018,7 +2018,7 @@ dependencies = [
  "pin-project",
  "thiserror 2.0.12",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
  "try-lock",
 ]
@@ -2054,7 +2054,7 @@ dependencies = [
  "linkerd-tracing",
  "parking_lot",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2257,7 +2257,7 @@ dependencies = [
  "rand 0.9.0",
  "tokio",
  "tokio-test",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-test",
  "tracing",
 ]
@@ -2281,7 +2281,7 @@ dependencies = [
  "pin-project",
  "prost 0.13.5",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2299,7 +2299,7 @@ dependencies = [
  "linkerd-stack",
  "rand 0.9.0",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2364,7 +2364,7 @@ version = "0.1.0"
 dependencies = [
  "futures",
  "linkerd-error",
- "tower 0.4.13",
+ "tower 0.5.2",
 ]
 
 [[package]]
@@ -2379,7 +2379,7 @@ dependencies = [
  "linkerd-stack",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2422,7 +2422,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-test",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-test",
  "tracing",
  "try-lock",
@@ -2457,7 +2457,7 @@ dependencies = [
  "linkerd-proxy-core",
  "pin-project",
  "thiserror 2.0.12",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2496,7 +2496,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
  "x509-parser",
 ]
@@ -2528,7 +2528,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2544,7 +2544,7 @@ dependencies = [
  "pin-project",
  "rand 0.9.0",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
 ]
 
 [[package]]
@@ -2575,7 +2575,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-test",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-test",
  "tracing",
 ]
@@ -2587,7 +2587,7 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-stack",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2629,7 +2629,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2654,7 +2654,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-test",
  "tracing",
 ]
@@ -2667,7 +2667,7 @@ dependencies = [
  "parking_lot",
  "tokio",
  "tokio-test",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tower-test",
 ]
 
@@ -2678,7 +2678,7 @@ dependencies = [
  "futures",
  "linkerd-error",
  "linkerd-stack",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -2699,7 +2699,7 @@ dependencies = [
  "pin-project",
  "thiserror 2.0.12",
  "tokio",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
  "untrusted",
 ]
@@ -2765,7 +2765,7 @@ dependencies = [
  "linkerd-stack",
  "rand 0.8.5",
  "thiserror 1.0.69",
- "tower 0.4.13",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -4282,10 +4282,14 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.8.0",
  "pin-project-lite",
  "sync_wrapper",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ tokio-rustls = { version = "0.26", default-features = false, features = [
 ] }
 tonic = { version = "0.12", default-features = false }
 tonic-build = { version = "0.12", default-features = false }
-tower = { version = "0.4", default-features = false }
+tower = { version = "0.5", default-features = false }
 tower-service = { version = "0.3" }
 tower-test = { version = "0.4" }
 

--- a/linkerd/app/gateway/src/server.rs
+++ b/linkerd/app/gateway/src/server.rs
@@ -64,10 +64,10 @@ impl Gateway {
                             SessionProtocol::Http1 => http::Variant::Http1,
                             SessionProtocol::Http2 => http::Variant::H2,
                         };
-                        return Ok(svc::Either::A(Http { parent, version }));
+                        return Ok(svc::Either::Left(Http { parent, version }));
                     }
 
-                    Ok(svc::Either::B(Opaq(parent)))
+                    Ok(svc::Either::Right(Opaq(parent)))
                 },
                 opaq,
             )

--- a/linkerd/app/inbound/src/accept.rs
+++ b/linkerd/app/inbound/src/accept.rs
@@ -53,12 +53,12 @@ impl<N> Inbound<N> {
                     move |t: T| -> Result<_, Error> {
                         let addr: OrigDstAddr = t.param();
                         if addr.port() == proxy_port {
-                            return Ok(svc::Either::B(t));
+                            return Ok(svc::Either::Right(t));
                         }
 
                         let policy = policies.get_policy(addr);
                         tracing::debug!(policy = ?&*policy.borrow(), "Accepted");
-                        Ok(svc::Either::A(Accept {
+                        Ok(svc::Either::Left(Accept {
                             client_addr: t.param(),
                             orig_dst_addr: addr,
                             policy,

--- a/linkerd/app/inbound/src/direct.rs
+++ b/linkerd/app/inbound/src/direct.rs
@@ -157,14 +157,14 @@ impl<N> Inbound<N> {
                                     port,
                                     name: None,
                                     protocol,
-                                } => Ok(svc::Either::A({
+                                } => Ok(svc::Either::Left({
                                     // When the transport header targets an alternate port (but does
                                     // not identify an alternate target name), we check the new
                                     // target's policy (rather than the inbound proxy's address).
                                     let addr = (client.local_addr.ip(), port).into();
                                     let policy = policies.get_policy(OrigDstAddr(addr));
                                     match protocol {
-                                        None => svc::Either::A(LocalTcp {
+                                        None => svc::Either::Left(LocalTcp {
                                             server_addr: Remote(ServerAddr(addr)),
                                             client_addr: client.client_addr,
                                             client_id: client.client_id,
@@ -174,7 +174,7 @@ impl<N> Inbound<N> {
                                             // When TransportHeader includes the protocol, but does not
                                             // include an alternate name we go through the Inbound HTTP
                                             // stack.
-                                            svc::Either::B(LocalHttp {
+                                            svc::Either::Right(LocalHttp {
                                                 addr: Remote(ServerAddr(addr)),
                                                 policy,
                                                 protocol,
@@ -188,7 +188,7 @@ impl<N> Inbound<N> {
                                     port,
                                     name: Some(name),
                                     protocol,
-                                } => Ok(svc::Either::B({
+                                } => Ok(svc::Either::Right({
                                     // When the transport header provides an alternate target, the
                                     // connection is a gateway connection. We check the _gateway
                                     // address's_ policy (rather than the target address).

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -163,14 +163,14 @@ impl<C> Inbound<C> {
                     |(rx, logical): (Option<profiles::Receiver>, Logical)| -> Result<_, Infallible> {
                         if let Some(rx) = rx {
                             if let Some(addr) = rx.logical_addr() {
-                                return Ok(svc::Either::A(Profile {
+                                return Ok(svc::Either::Left(Profile {
                                     addr,
                                     logical,
                                     profiles: rx,
                                 }));
                             }
                         }
-                        Ok(svc::Either::B(logical))
+                        Ok(svc::Either::Right(logical))
                     },
                     http.clone().into_inner(),
                 )
@@ -189,7 +189,7 @@ impl<C> Inbound<C> {
                         // discovery (so that we skip the profile stack above).
                         let addr = match logical.logical.clone() {
                             Some(addr) => addr,
-                            None => return Ok(svc::Either::B((None, logical))),
+                            None => return Ok(svc::Either::Right((None, logical))),
                         };
                         if !allow_profile.matches(addr.name()) {
                             tracing::debug!(
@@ -197,9 +197,9 @@ impl<C> Inbound<C> {
                                 suffixes = %allow_profile,
                                 "Skipping discovery, address not in configured DNS suffixes",
                             );
-                            return Ok(svc::Either::B((None, logical)));
+                            return Ok(svc::Either::Right((None, logical)));
                         }
-                        Ok(svc::Either::A(logical))
+                        Ok(svc::Either::Left(logical))
                     },
                     router
                         .check_new_service::<(Option<profiles::Receiver>, Logical), http::Request<_>>()

--- a/linkerd/app/outbound/src/http/logical.rs
+++ b/linkerd/app/outbound/src/http/logical.rs
@@ -148,7 +148,7 @@ where
                                 );
                                 let parent_ref = ParentRef::from(ep.clone());
                                 let backend_ref = BackendRef::from(ep);
-                                svc::Either::A(Concrete {
+                                svc::Either::Left(Concrete {
                                     parent_ref,
                                     backend_ref,
                                     target: concrete::Dispatch::Forward(remote, meta),
@@ -157,8 +157,10 @@ where
                                     failure_accrual: Default::default(),
                                 })
                             }
-                            Self::Profile(profile) => svc::Either::B(svc::Either::A(profile)),
-                            Self::Policy(policy) => svc::Either::B(svc::Either::B(policy)),
+                            Self::Profile(profile) => {
+                                svc::Either::Right(svc::Either::Left(profile))
+                            }
+                            Self::Policy(policy) => svc::Either::Right(svc::Either::Right(policy)),
                         })
                     },
                     // Switch profile and policy routing.

--- a/linkerd/app/outbound/src/http/logical/policy.rs
+++ b/linkerd/app/outbound/src/http/logical/policy.rs
@@ -72,8 +72,8 @@ where
             http.push_switch(
                 |pp: Policy<T>| {
                     Ok::<_, Infallible>(match pp {
-                        Self::Http(http) => svc::Either::A(http),
-                        Self::Grpc(grpc) => svc::Either::B(grpc),
+                        Self::Http(http) => svc::Either::Left(http),
+                        Self::Grpc(grpc) => svc::Either::Right(grpc),
                     })
                 },
                 grpc.into_inner(),

--- a/linkerd/app/outbound/src/http/retry.rs
+++ b/linkerd/app/outbound/src/http/retry.rs
@@ -1,14 +1,11 @@
-use futures::{
-    future::{self, Either},
-    FutureExt,
-};
+use futures::{future, FutureExt};
 use linkerd_app_core::{
     classify,
     http_metrics::retries::Handle,
     metrics::{self, ProfileRouteLabels},
     profiles::{self, http::Route},
     proxy::http::{Body, ClientHandle, EraseResponse},
-    svc::{layer, Param},
+    svc::{layer, Either, Param},
     Error, Result,
 };
 use linkerd_http_classify::{Classify, ClassifyEos, ClassifyResponse};

--- a/linkerd/app/outbound/src/ingress.rs
+++ b/linkerd/app/outbound/src/ingress.rs
@@ -326,14 +326,14 @@ impl<N> Outbound<N> {
                     |(detected, parent): (http::Detection, T)| -> Result<_, Infallible> {
                         match detected {
                             http::Detection::Http(version) => {
-                                return Ok(svc::Either::A(Http { version, parent }));
+                                return Ok(svc::Either::Left(Http { version, parent }));
                             }
                             http::Detection::ReadTimeout(timeout) => {
                                 tracing::info!("Continuing after timeout: {timeout:?}");
                             }
                             _ => {}
                         }
-                        Ok(svc::Either::B(parent))
+                        Ok(svc::Either::Right(parent))
                     },
                     fallback,
                 )

--- a/linkerd/app/outbound/src/opaq/concrete.rs
+++ b/linkerd/app/outbound/src/opaq/concrete.rs
@@ -222,7 +222,7 @@ impl<C> Outbound<C> {
                     move |parent: T| -> Result<_, Infallible> {
                         Ok(match parent.param() {
                             Dispatch::Balance(addr, ewma) => {
-                                svc::Either::A(svc::Either::A(Balance {
+                                svc::Either::Left(svc::Either::Left(Balance {
                                     addr,
                                     ewma,
                                     queue,
@@ -231,14 +231,14 @@ impl<C> Outbound<C> {
                             }
 
                             Dispatch::Forward(addr, meta) => {
-                                svc::Either::A(svc::Either::B(Endpoint {
+                                svc::Either::Left(svc::Either::Right(Endpoint {
                                     addr,
                                     is_local: false,
                                     metadata: meta,
                                     parent,
                                 }))
                             }
-                            Dispatch::Fail { message } => svc::Either::B(message),
+                            Dispatch::Fail { message } => svc::Either::Right(message),
                         })
                     },
                     svc::stack(fail).check_new_clone().into_inner(),

--- a/linkerd/app/outbound/src/tls/concrete.rs
+++ b/linkerd/app/outbound/src/tls/concrete.rs
@@ -195,7 +195,7 @@ impl<C> Outbound<C> {
                     move |parent: T| -> Result<_, Infallible> {
                         Ok(match parent.param() {
                             Dispatch::Balance(concrete, ewma) => {
-                                svc::Either::A(svc::Either::A(Balance {
+                                svc::Either::Left(svc::Either::Left(Balance {
                                     concrete,
                                     ewma,
                                     queue,
@@ -204,14 +204,14 @@ impl<C> Outbound<C> {
                             }
 
                             Dispatch::Forward(addr, meta) => {
-                                svc::Either::A(svc::Either::B(Endpoint {
+                                svc::Either::Left(svc::Either::Right(Endpoint {
                                     addr,
                                     is_local: false,
                                     metadata: meta,
                                     parent,
                                 }))
                             }
-                            Dispatch::Fail { message } => svc::Either::B(message),
+                            Dispatch::Fail { message } => svc::Either::Right(message),
                         })
                     },
                     svc::stack(fail).check_new_clone().into_inner(),

--- a/linkerd/retry/src/lib.rs
+++ b/linkerd/retry/src/lib.rs
@@ -1,13 +1,13 @@
 #![deny(rust_2018_idioms, clippy::disallowed_methods, clippy::disallowed_types)]
 #![forbid(unsafe_code)]
 
-use futures::future::{self, Either};
+use futures::future;
 use linkerd_error::{Error, Result};
 use linkerd_stack::{
     layer::{self, Layer},
     proxy::Proxy,
     util::AndThen,
-    NewService, Service,
+    Either, NewService, Service,
 };
 use std::{
     future::Future,

--- a/linkerd/service-profiles/src/http.rs
+++ b/linkerd/service-profiles/src/http.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tower::retry::budget::Budget;
+use tower::retry::budget::TpsBudget;
 
 pub use self::proxy::NewProxyRouter;
 
@@ -56,7 +56,7 @@ pub enum ResponseMatch {
 
 #[derive(Clone, Debug)]
 pub struct Retries {
-    budget: Arc<Budget>,
+    budget: Arc<TpsBudget>,
 }
 
 #[derive(Clone, Default)]
@@ -107,7 +107,7 @@ impl Route {
         self.timeout
     }
 
-    pub fn set_retries(&mut self, budget: Arc<Budget>) {
+    pub fn set_retries(&mut self, budget: Arc<TpsBudget>) {
         self.retries = Some(Retries { budget });
     }
 
@@ -201,7 +201,7 @@ impl ResponseMatch {
 // === impl Retries ===
 
 impl Retries {
-    pub fn budget(&self) -> &Arc<Budget> {
+    pub fn budget(&self) -> &Arc<TpsBudget> {
         &self.budget
     }
 }

--- a/linkerd/stack/src/either.rs
+++ b/linkerd/stack/src/either.rs
@@ -1,5 +1,8 @@
 use crate::{layer, NewService};
-pub use tower::util::Either;
+
+// pub use tower::util::Either;
+pub use self::vendor::Either;
+mod vendor;
 
 #[derive(Clone, Debug)]
 pub struct NewEither<L, R> {
@@ -30,8 +33,8 @@ where
 
     fn new_service(&self, target: Either<T, U>) -> Self::Service {
         match target {
-            Either::A(t) => Either::A(self.left.new_service(t)),
-            Either::B(t) => Either::B(self.right.new_service(t)),
+            Either::Left(t) => Either::Left(self.left.new_service(t)),
+            Either::Right(t) => Either::Right(self.right.new_service(t)),
         }
     }
 }
@@ -47,8 +50,8 @@ where
 
     fn new_service(&self, target: T) -> Self::Service {
         match self {
-            Either::A(n) => Either::A(n.new_service(target)),
-            Either::B(n) => Either::B(n.new_service(target)),
+            Either::Left(n) => Either::Left(n.new_service(target)),
+            Either::Right(n) => Either::Right(n.new_service(target)),
         }
     }
 }

--- a/linkerd/stack/src/either/vendor.rs
+++ b/linkerd/stack/src/either/vendor.rs
@@ -1,0 +1,101 @@
+//! Contains [`Either`] and related types and functions.
+//!
+//! See [`Either`] documentation for more details.
+//!
+//! TODO(kate): this is a lightly modified variant of `tower`'s `Either` service.
+//!
+//! This is pulled in-tree to punt on addressing breaking changes to the trait bounds of
+//! `Either<A, B>`'s `Service` implementation, related to how it no longer boxes the errors
+//! returned by its inner services. see #3744.
+//!
+//! This is vendored from <https://github.com/tower-rs/tower/commit/8b84b98d93a2493422a0ecddb6251f292a904cff>.
+//!
+//! The variants `A` and `B` have been renamed to `Left` and `Right` to match the names of the v0.5
+//! interface.
+
+use futures::ready;
+use linkerd_error::Error;
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tower::Layer;
+use tower::Service;
+
+/// Combine two different service types into a single type.
+///
+/// Both services must be of the same request, response, and error types.
+/// [`Either`] is useful for handling conditional branching in service middleware
+/// to different inner service types.
+#[pin_project(project = EitherProj)]
+#[derive(Clone, Debug)]
+pub enum Either<A, B> {
+    /// One type of backing [`Service`].
+    Left(#[pin] A),
+    /// The other type of backing [`Service`].
+    Right(#[pin] B),
+}
+
+impl<A, B, Request> Service<Request> for Either<A, B>
+where
+    A: Service<Request>,
+    A::Error: Into<Error>,
+    B: Service<Request, Response = A::Response>,
+    B::Error: Into<Error>,
+{
+    type Response = A::Response;
+    type Error = Error;
+    type Future = Either<A::Future, B::Future>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        use self::Either::*;
+
+        match self {
+            Left(service) => Poll::Ready(Ok(ready!(service.poll_ready(cx)).map_err(Into::into)?)),
+            Right(service) => Poll::Ready(Ok(ready!(service.poll_ready(cx)).map_err(Into::into)?)),
+        }
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        use self::Either::*;
+
+        match self {
+            Left(service) => Left(service.call(request)),
+            Right(service) => Right(service.call(request)),
+        }
+    }
+}
+
+impl<A, B, T, AE, BE> Future for Either<A, B>
+where
+    A: Future<Output = Result<T, AE>>,
+    AE: Into<Error>,
+    B: Future<Output = Result<T, BE>>,
+    BE: Into<Error>,
+{
+    type Output = Result<T, Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.project() {
+            EitherProj::Left(fut) => Poll::Ready(Ok(ready!(fut.poll(cx)).map_err(Into::into)?)),
+            EitherProj::Right(fut) => Poll::Ready(Ok(ready!(fut.poll(cx)).map_err(Into::into)?)),
+        }
+    }
+}
+
+impl<S, A, B> Layer<S> for Either<A, B>
+where
+    A: Layer<S>,
+    B: Layer<S>,
+{
+    type Service = Either<A::Service, B::Service>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        match self {
+            Either::Left(layer) => Either::Left(layer.layer(inner)),
+            Either::Right(layer) => Either::Right(layer.layer(inner)),
+        }
+    }
+}

--- a/linkerd/stack/src/loadshed.rs
+++ b/linkerd/stack/src/loadshed.rs
@@ -177,13 +177,15 @@ mod tests {
         // shedding load.
         let mut oneshot5 = spawn_svc("oneshot5");
         assert_pending!(oneshot5.poll());
+        let mut oneshot6 = spawn_svc("oneshot6");
+        assert_pending!(oneshot6.poll());
 
         // The buffer is now full, so the loadshed service should fail any
         // additional requests.
-        let mut oneshot6 = spawn_svc("oneshot6");
         let mut oneshot7 = spawn_svc("oneshot7");
-        assert_ready_err!(oneshot6.poll());
+        let mut oneshot8 = spawn_svc("oneshot8");
         assert_ready_err!(oneshot7.poll());
+        assert_ready_err!(oneshot8.poll());
 
         // Complete all remaining requests
         handle.allow(3);

--- a/linkerd/stack/src/queue.rs
+++ b/linkerd/stack/src/queue.rs
@@ -34,9 +34,11 @@ pub struct NewQueueWithoutTimeout<X, Req, N> {
     _req: PhantomData<fn(Req)>,
 }
 
-pub type Queue<Req, Rsp, E = Error> = gate::Gate<Buffer<BoxService<Req, Rsp, E>, Req>>;
+pub type Queue<Req, Rsp, E = Error> =
+    gate::Gate<Buffer<Req, <BoxService<Req, Rsp, E> as tower::Service<Req>>::Future>>;
 
-pub type QueueWithoutTimeout<Req, Rsp, E = Error> = Buffer<BoxService<Req, Rsp, E>, Req>;
+pub type QueueWithoutTimeout<Req, Rsp, E = Error> =
+    Buffer<Req, <BoxService<Req, Rsp, E> as tower::Service<Req>>::Future>;
 
 // === impl NewQueue ===
 

--- a/linkerd/stack/src/unwrap_or.rs
+++ b/linkerd/stack/src/unwrap_or.rs
@@ -26,8 +26,8 @@ impl<T, U> Predicate<(Option<T>, U)> for UnwrapOr<U> {
 
     fn check(&mut self, (t, u): (Option<T>, U)) -> Result<Either<(T, U), U>, Error> {
         match t {
-            Some(t) => Ok(Either::A((t, u))),
-            None => Ok(Either::B(u)),
+            Some(t) => Ok(Either::Left((t, u))),
+            None => Ok(Either::Right(u)),
         }
     }
 }
@@ -36,7 +36,8 @@ impl<T, U: Default> Predicate<Option<T>> for UnwrapOr<U> {
     type Request = Either<T, U>;
 
     fn check(&mut self, t: Option<T>) -> Result<Either<T, U>, Error> {
-        Ok(t.map(Either::A).unwrap_or_else(|| Either::B(U::default())))
+        Ok(t.map(Either::Left)
+            .unwrap_or_else(|| Either::Right(U::default())))
     }
 }
 


### PR DESCRIPTION
## chore(deps)!: upgrade to tower 0.5

this commit updates our tower dependency from 0.4 to 0.5.

note that this commit does not affect the `tower-service` and
`tower-layer` crates, reëxported by `tower` itself. the `Service<T>`
trait and the closely related `Layer<S>` trait have not been changed.

the `tower` crate's utilities have changed in various ways, some of
particular note for the linkerd2 proxy. see these items, excerpted from
the tower changelog:

- **retry**: **Breaking Change** `retry::Policy::retry` now accepts `&mut Req` and `&mut Res` instead of the previous mutable versions. This
increases the flexibility of the retry policy. To update, update your method signature to include `mut` for both parameters. ([tower-rs/tower#584])
- **retry**: **Breaking Change** Change Policy to accept &mut self ([tower-rs/tower#681])
- **retry**: **Breaking Change** `Budget` is now a trait. This allows end-users to implement their own budget and bucket implementations. ([tower-rs/tower#703])
- **util**: **Breaking Change** `Either::A` and `Either::B` have been renamed `Either::Left` and `Either::Right`, respectively. ([tower-rs/tower#637])
- **util**: **Breaking Change** `Either` now requires its two services to have the same error type. ([tower-rs/tower#637])
- **util**: **Breaking Change** `Either` no longer implemenmts `Future`. ([tower-rs/tower#637])
- **buffer**: **Breaking Change** `Buffer<S, Request>` is now generic over `Buffer<Request, S::Future>.` ([tower-rs/tower#654])

see:

* <https://github.com/tower-rs/tower/pull/584>
* <https://github.com/tower-rs/tower/pull/681>
* <https://github.com/tower-rs/tower/pull/703>
* <https://github.com/tower-rs/tower/pull/637>
* <https://github.com/tower-rs/tower/pull/654>

the `Either` trait bounds are particularly impactful for us. because
this runs counter to how we treat errors (skewing towards boxed errors,
in general), we temporarily vendor a version of `Either` from the 0.4
release, whose variants have been renamed to match the 0.5 interface.

updating to box the inner `A` and `B` services' errors, so we satiate
the new `A::Error = B::Error` bounds, can be addressed as a follow-on.
that's intentionally left as a separate change, due to the net size of
our patchset between this branch and #3504.

* <https://github.com/tower-rs/tower/compare/v0.4.x...master>
* <https://github.com/tower-rs/tower/blob/master/tower/CHANGELOG.md>

this work is based upon #3504. for more information, see:

* https://github.com/linkerd/linkerd2/issues/8733
* https://github.com/linkerd/linkerd2-proxy/pull/3504
* https://github.com/tower-rs/tower/pull/815
* https://github.com/tower-rs/tower/pull/817
* https://github.com/tower-rs/tower/pull/818
* https://github.com/tower-rs/tower/pull/819

### fix(stack/loadshed): update test affected by tower-rs/tower#635

this commit updates a test that was affected by breaking changes in
tower's `Buffer` middleware. see this excerpt from the description of
that change:

> I had to change some of the integration tests slightly as part of this
> change. This is because the buffer implementation using semaphore
> permits is _very subtly_ different from one using a bounded channel. In
> the `Semaphore`-based implementation, a semaphore permit is stored in
> the `Message` struct sent over the channel. This is so that the capacity
> is used as long as the message is in flight. However, when the worker
> task is processing a message that's been recieved from the channel,
> the permit is still not dropped. Essentially, the one message actively
> held by the worker task _also_ occupies one "slot" of capacity, so the
> actual channel capacity is one less than the value passed to the
> constructor, _once the first request has been sent to the worker_. The
> bounded MPSC changed this behavior so that capacity is only occupied
> while a request is actually in the channel, which broke some tests
> that relied on the old (and technically wrong) behavior.

bear particular attention to this:

> The bounded MPSC changed this behavior so that capacity is only
> occupied while a request is actually in the channel, which broke some
> tests that relied on the old (and technically wrong) behavior.

that pr adds an additional message to the channel in tests exercising
the laod-shedding behavior, on account of the previous (incorrect)
behavior.

https://github.com/tower-rs/tower/pull/635/files#r797108274

this commit performs the same change for our corresponding test, adding
an additional `ready()` call before we hit the buffer's limit.
