### PR TITLE
chore(deps): address RUSTSEC-2025-0014

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,12 +946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1205,47 @@ checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
 dependencies = [
  "jemalloc-sys",
  "libc",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d699bc6dfc879fb1bf9bdff0d4c56f0884fc6f0d0eb0fba397a6d00cd9a6b85e"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d16e75759ee0aa64c57a56acbf43916987b20c77373cb7e808979e02b93c9f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962e1dfe9b2d75a84536cf5bf5eaaa4319aa7906c7160134a22883ac316d5f31"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a63c62e404e7b92979d2792352d885a7f8f83fd1d0d31eea582d77b2ceca697e"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -1665,7 +1700,7 @@ version = "0.1.0"
 dependencies = [
  "futures-core",
  "http",
- "humantime",
+ "jiff",
  "linkerd-identity",
  "linkerd-proxy-transport",
  "linkerd-stack",
@@ -3121,6 +3156,15 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"

--- a/linkerd/http/access-log/Cargo.toml
+++ b/linkerd/http/access-log/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 futures-core = "0.3"
 http = { workspace = true }
-humantime = "2"
+jiff = { version = "0.2", features = ["std"] }
 pin-project = "1"
 tokio = { version = "1", features = ["time"] }
 tracing = "0.1"

--- a/linkerd/http/access-log/src/lib.rs
+++ b/linkerd/http/access-log/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     net::SocketAddr,
     pin::Pin,
     task::{Context, Poll},
-    time::{Duration, SystemTime},
+    time::Duration,
 };
 use svc::{NewService, Param};
 use tokio::time::Instant;
@@ -210,6 +210,6 @@ where
 }
 
 #[inline]
-fn now() -> humantime::Rfc3339Timestamp {
-    humantime::format_rfc3339(SystemTime::now())
+fn now() -> String {
+    jiff::Timestamp::now().to_string()
 }


### PR DESCRIPTION
this commit replaces `humantime`, which is no longer maintained, with `jiff`.

see this error when `main` today is built:

```
error[unmaintained]: humantime is unmaintained
   ┌─ /linkerd/linkerd2-proxy/Cargo.lock:78:1
   │
78 │ humantime 2.1.0 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected
   │
   ├ ID: RUSTSEC-2025-0014
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0014
   ├ Latest `humantime` crates.io release is four years old and GitHub repository has
     not seen commits in four years. Question about maintenance status has not gotten
     any reaction from maintainer: https://github.com/tailhook/humantime/issues/31

     ## Possible alternatives

      * [jiff](https://crates.io/crates/jiff) provides same kind of functionality
   ├ Announcement: https://github.com/tailhook/humantime/issues/31
   ├ Solution: No safe upgrade is available!
   ├ humantime v2.1.0
     └── linkerd-http-access-log v0.1.0
         └── linkerd-app-inbound v0.1.0
             ├── linkerd-app v0.1.0
             │   ├── linkerd-app-integration v0.1.0
             │   └── linkerd2-proxy v0.1.0
             ├── linkerd-app-admin v0.1.0
             │   ├── linkerd-app v0.1.0 (*)
             │   └── (dev) linkerd-app-integration v0.1.0 (*)
             └── linkerd-app-gateway v0.1.0
                 └── linkerd-app v0.1.0 (*)

advisories FAILED, bans ok, licenses ok, sources ok
```

see:
  * https://github.com/rustsec/advisory-db/pull/2249.
  * https://github.com/tailhook/humantime/issues/31.