### PR TITLE
chore: use workspace-level package metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,13 @@ members = [
 debug = 1
 lto = true
 
+[workspace.package]
+version = "0.1.0"
+authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
+license = "Apache-2.0"
+edition = "2021"
+publish = false
+
 [workspace.dependencies]
 bytes = { version = "1" }
 drain = { version = "0.1", default-features = false }

--- a/hyper-balance/Cargo.toml
+++ b/hyper-balance/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "hyper-balance"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/addr/Cargo.toml
+++ b/linkerd/addr/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-addr"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 http = { workspace = true }

--- a/linkerd/addr/fuzz/Cargo.toml
+++ b/linkerd/addr/fuzz/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-addr-fuzz"
-version = "0.0.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-app"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Configures and executes the proxy
 

--- a/linkerd/app/admin/Cargo.toml
+++ b/linkerd/app/admin/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-app-admin"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 The linkerd proxy's admin server.
 """

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-app-core"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Core infrastructure for the proxy application
 

--- a/linkerd/app/gateway/Cargo.toml
+++ b/linkerd/app/gateway/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-app-gateway"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 http = { workspace = true }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-app-inbound"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Configures and runs the inbound proxy
 """

--- a/linkerd/app/inbound/fuzz/Cargo.toml
+++ b/linkerd/app/inbound/fuzz/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-app-inbound-fuzz"
-version = "0.0.0"
+version = { workspace = true }
 authors = ["Automatically generated"]
-publish = false
-edition = "2021"
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-app-integration"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Proxy integration tests
 

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-app-outbound"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Configures and runs the outbound proxy
 """

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-app-test"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Proxy test helpers
 """

--- a/linkerd/conditional/Cargo.toml
+++ b/linkerd/conditional/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "linkerd-conditional"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]

--- a/linkerd/distribute/Cargo.toml
+++ b/linkerd/distribute/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-distribute"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 ahash = "0.8"

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-dns"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/dns/fuzz/Cargo.toml
+++ b/linkerd/dns/fuzz/Cargo.toml
@@ -1,10 +1,10 @@
-
 [package]
 name = "linkerd-dns-fuzz"
-version = "0.0.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/dns/name/Cargo.toml
+++ b/linkerd/dns/name/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-dns-name"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 thiserror = "2"

--- a/linkerd/duplex/Cargo.toml
+++ b/linkerd/duplex/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-duplex"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }

--- a/linkerd/errno/Cargo.toml
+++ b/linkerd/errno/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "linkerd-errno"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }

--- a/linkerd/error-respond/Cargo.toml
+++ b/linkerd/error-respond/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "linkerd-error-respond"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
-
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/error/Cargo.toml
+++ b/linkerd/error/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-error"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/exp-backoff/Cargo.toml
+++ b/linkerd/exp-backoff/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-exp-backoff"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/http/access-log/Cargo.toml
+++ b/linkerd/http/access-log/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-access-log"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 edition = "2018"
-publish = false
+publish = { workspace = true }
 
 [dependencies]
 futures-core = "0.3"

--- a/linkerd/http/body-compat/Cargo.toml
+++ b/linkerd/http/body-compat/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-body-compat"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 http = { workspace = true }

--- a/linkerd/http/box/Cargo.toml
+++ b/linkerd/http/box/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-box"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }

--- a/linkerd/http/classify/Cargo.toml
+++ b/linkerd/http/classify/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-classify"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/http/detect/Cargo.toml
+++ b/linkerd/http/detect/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "linkerd-http-detect"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }

--- a/linkerd/http/executor/Cargo.toml
+++ b/linkerd/http/executor/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-executor"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 HTTP runtime components for Linkerd.
 """

--- a/linkerd/http/h2/Cargo.toml
+++ b/linkerd/http/h2/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "linkerd-http-h2"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = "HTTP/2-specific configuration types"

--- a/linkerd/http/insert/Cargo.toml
+++ b/linkerd/http/insert/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-insert"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Tower middleware to insert parameters into HTTP extensions.
 """

--- a/linkerd/http/metrics/Cargo.toml
+++ b/linkerd/http/metrics/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-metrics"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [features]
 test-util = []

--- a/linkerd/http/override-authority/Cargo.toml
+++ b/linkerd/http/override-authority/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-override-authority"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Tower middleware to override request authorities.
 """

--- a/linkerd/http/prom/Cargo.toml
+++ b/linkerd/http/prom/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-prom"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-edition = "2021"
-publish = false
-license = "Apache-2.0"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Tower middleware for Prometheus metrics.
 """

--- a/linkerd/http/retain/Cargo.toml
+++ b/linkerd/http/retain/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-retain"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Tower middleware to manage service lifecycles.
 

--- a/linkerd/http/retry/Cargo.toml
+++ b/linkerd/http/retry/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-retry"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }

--- a/linkerd/http/route/Cargo.toml
+++ b/linkerd/http/route/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-http-route"
-version = "0.1.0"
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [features]
 proto = ["linkerd2-proxy-api"]

--- a/linkerd/http/stream-timeouts/Cargo.toml
+++ b/linkerd/http/stream-timeouts/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-stream-timeouts"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Tower middleware to express deadlines on streams.
 """

--- a/linkerd/http/upgrade/Cargo.toml
+++ b/linkerd/http/upgrade/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-http-upgrade"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Facilities for HTTP/1 upgrades.
 """

--- a/linkerd/http/variant/Cargo.toml
+++ b/linkerd/http/variant/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-http-variant"
-version = "0.1.0"
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 HTTP version types.
 """

--- a/linkerd/identity/Cargo.toml
+++ b/linkerd/identity/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-identity"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 prometheus-client = { workspace = true }

--- a/linkerd/idle-cache/Cargo.toml
+++ b/linkerd/idle-cache/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-idle-cache"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [features]
 test-util = []

--- a/linkerd/io/Cargo.toml
+++ b/linkerd/io/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-io"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 General I/O primitives.
 """

--- a/linkerd/meshtls/Cargo.toml
+++ b/linkerd/meshtls/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-meshtls"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 edition = "2018"
-publish = false
+publish = { workspace = true }
 
 [features]
 rustls = ["linkerd-meshtls-rustls", "__has_any_tls_impls"]

--- a/linkerd/meshtls/boring/Cargo.toml
+++ b/linkerd/meshtls/boring/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-meshtls-boring"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 edition = "2018"
-publish = false
+publish = { workspace = true }
 
 [dependencies]
 boring = "4"

--- a/linkerd/meshtls/rustls/Cargo.toml
+++ b/linkerd/meshtls/rustls/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-meshtls-rustls"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 edition = "2018"
-publish = false
+publish = { workspace = true }
 
 [features]
 test-util = ["linkerd-tls-test-util"]

--- a/linkerd/meshtls/verifier/Cargo.toml
+++ b/linkerd/meshtls/verifier/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-meshtls-verifier"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 tracing = "0.1"

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-metrics"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [features]
 default = []

--- a/linkerd/mock/http-body/Cargo.toml
+++ b/linkerd/mock/http-body/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-mock-http-body"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Mock `http_body::Body` facilities for use in tests.
 """

--- a/linkerd/opaq-route/Cargo.toml
+++ b/linkerd/opaq-route/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "linkerd-opaq-route"
-version = "0.1.0"
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }

--- a/linkerd/opencensus/Cargo.toml
+++ b/linkerd/opencensus/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-opencensus"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/opentelemetry/Cargo.toml
+++ b/linkerd/opentelemetry/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-opentelemetry"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/pool/Cargo.toml
+++ b/linkerd/pool/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-pool"
-version = "0.1.0"
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 tower-service = { workspace = true }

--- a/linkerd/pool/mock/Cargo.toml
+++ b/linkerd/pool/mock/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-pool-mock"
-version = "0.1.0"
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 parking_lot = "0.12"

--- a/linkerd/pool/p2c/Cargo.toml
+++ b/linkerd/pool/p2c/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-pool-p2c"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 ahash = "0.8"

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-api-resolve"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Implements the Resolve trait using the proxy's gRPC API
 """

--- a/linkerd/proxy/balance/Cargo.toml
+++ b/linkerd/proxy/balance/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-proxy-balance"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/proxy/balance/gauge-endpoints/Cargo.toml
+++ b/linkerd/proxy/balance/gauge-endpoints/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-proxy-balance-gauge-endpoints"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 prometheus-client = { workspace = true }

--- a/linkerd/proxy/balance/queue/Cargo.toml
+++ b/linkerd/proxy/balance/queue/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-balance-queue"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-client-policy"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [features]
 proto = [

--- a/linkerd/proxy/core/Cargo.toml
+++ b/linkerd/proxy/core/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-core"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Core interfaces needed to implement proxy components
 """

--- a/linkerd/proxy/dns-resolve/Cargo.toml
+++ b/linkerd/proxy/dns-resolve/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-dns-resolve"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Service Dns Resolutions for the proxy
 """

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-http"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 HTTP-specific implementations that rely on other proxy infrastructure
 

--- a/linkerd/proxy/http/fuzz/Cargo.toml
+++ b/linkerd/proxy/http/fuzz/Cargo.toml
@@ -1,10 +1,10 @@
-
 [package]
 name = "linkerd-proxy-http-fuzz"
-version = "0.0.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/proxy/identity-client/Cargo.toml
+++ b/linkerd/proxy/identity-client/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-identity-client"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/proxy/resolve/Cargo.toml
+++ b/linkerd/proxy/resolve/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-resolve"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Utilities for working with `Resolve` implementations
 """

--- a/linkerd/proxy/server-policy/Cargo.toml
+++ b/linkerd/proxy/server-policy/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-server-policy"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [features]
 proto = ["linkerd-http-route/proto", "linkerd2-proxy-api", "prost-types"]

--- a/linkerd/proxy/spire-client/Cargo.toml
+++ b/linkerd/proxy/spire-client/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-spire-client"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-tap"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }

--- a/linkerd/proxy/tcp/Cargo.toml
+++ b/linkerd/proxy/tcp/Cargo.toml
@@ -1,11 +1,10 @@
 [package]
 name = "linkerd-proxy-tcp"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
-
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-proxy-transport"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Transport-level implementations that rely on core proxy infrastructure
 """

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-reconnect"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 linkerd-error = { path = "../error" }

--- a/linkerd/retry/Cargo.toml
+++ b/linkerd/retry/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-retry"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/router/Cargo.toml
+++ b/linkerd/router/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-router"
-version = "0.1.0"
-edition = "2021"
-license = "Apache-2.0"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 ahash = "0.8"

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-service-profiles"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Implements client layers for Linkerd ServiceProfiles.
 """

--- a/linkerd/signal/Cargo.toml
+++ b/linkerd/signal/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-signal"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 tokio = { version = "1", features = ["macros", "signal"] }

--- a/linkerd/stack/Cargo.toml
+++ b/linkerd/stack/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-stack"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Utilities for composing Tower services.
 """

--- a/linkerd/stack/metrics/Cargo.toml
+++ b/linkerd/stack/metrics/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-stack-metrics"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 linkerd-metrics = { path = "../../metrics" }

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-stack-tracing"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-tls"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 async-trait = "0.1"

--- a/linkerd/tls/fuzz/Cargo.toml
+++ b/linkerd/tls/fuzz/Cargo.toml
@@ -1,10 +1,10 @@
-
 [package]
 name = "linkerd-tls-fuzz"
-version = "0.0.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/tls/route/Cargo.toml
+++ b/linkerd/tls/route/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-tls-route"
-version = "0.1.0"
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [features]
 proto = ["linkerd2-proxy-api"]

--- a/linkerd/tls/test-util/Cargo.toml
+++ b/linkerd/tls/test-util/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "linkerd-tls-test-util"
-version = "0.1.0"
-license = "Apache-2.0"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 edition = "2018"
-publish = false
+publish = { workspace = true }

--- a/linkerd/tonic-stream/Cargo.toml
+++ b/linkerd/tonic-stream/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-tonic-stream"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }

--- a/linkerd/tonic-watch/Cargo.toml
+++ b/linkerd/tonic-watch/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-tonic-watch"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 Provides a utility for creating robust watches from a service that returns a stream.
 """

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-trace-context"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 base64 = "0.13"

--- a/linkerd/tracing/Cargo.toml
+++ b/linkerd/tracing/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-tracing"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [features]
 default = []

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-transport-header"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 async-trait = "0.1"

--- a/linkerd/transport-header/fuzz/Cargo.toml
+++ b/linkerd/transport-header/fuzz/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "linkerd-transport-header-fuzz"
-version = "0.0.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-publish = false
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [package.metadata]
 cargo-fuzz = true

--- a/linkerd/transport-metrics/Cargo.toml
+++ b/linkerd/transport-metrics/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd-transport-metrics"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """Transport-level metrics"""
 
 [dependencies]

--- a/linkerd/workers/Cargo.toml
+++ b/linkerd/workers/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "linkerd-workers"
-version = "0.1.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = "CPU core allocation logic for Linkerd"
 
 [dependencies]

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "linkerd2-proxy"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = "The main proxy executable"
 
 [features]

--- a/opencensus-proto/Cargo.toml
+++ b/opencensus-proto/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "opencensus-proto"
-version = "0.1.0"
+version = { workspace = true }
 authors = ["The OpenCensus Authors"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 gRPC bindings for OpenCensus.
 

--- a/opentelemetry-proto/Cargo.toml
+++ b/opentelemetry-proto/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "opentelemetry-proto"
-version = "0.1.0"
+version = { workspace = true }
 authors = ["The OpenTelemetry Authors"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 description = """
 gRPC bindings for OpenTelemetry.
 

--- a/spiffe-proto/Cargo.toml
+++ b/spiffe-proto/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "spiffe-proto"
-version = "0.1.0"
-authors = ["Linkerd Developers <cncf-linkerd-dev@lists.cncf.io>"]
-license = "Apache-2.0"
-edition = "2021"
-publish = false
+version = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
 
 [dependencies]
 bytes = { workspace = true }


### PR DESCRIPTION
this commit adds a `[workspace.package]` table at the root of the cargo workspace. constituent manifests are updated to use the workspace-level metadata.

this is generally a superficial chore, but has a pleasant future upside: when new rust editions are released (e.g. 2024), we will only need to update the edition specified at the root of the workspace.