### PR TITLE
chore(just): add .exe extension to windows binaries

### DIFF
--- a/justfile
+++ b/justfile
@@ -50,8 +50,8 @@ _target := if os + '-' + arch == "linux-amd64" {
 _cargo := 'just-cargo profile=' + profile + ' target=' + _target + ' toolchain=' + toolchain
 
 _target_dir := "target" / _target / profile
-_target_bin := _target_dir / "linkerd2-proxy"
-_package_name := "linkerd2-proxy-" + package_version + "-" + arch + (if libc == 'musl' { '-static' } else { '' }) + (if os == 'windows' { '.exe' } else { '' })
+_target_bin := _target_dir / "linkerd2-proxy" + if os == 'windows' { '.exe' } else { '' }
+_package_name := "linkerd2-proxy-" + package_version + "-" + os + "-" + arch + if libc == 'musl' { '-static' } else { '' }
 _package_dir := "target/package" / _package_name
 shasum := "shasum -a 256"
 


### PR DESCRIPTION
#3683 introduced the `os` param into our just file. This parameter was used to set the `_package_name` variable but not the `_target_bin` one. As a result of that the `_strip:` task was failing for windows builds as it was incorrectly looking for a binary that was missing (one without an .exe extension).

This PR adds the following changes: 
 - correctly adds the `.exe` extension to `_target_bin` when `os` is windows
 - adds the `os` to the name of the produces artifact

The latter means that release artifacts shall be names as: 

```
linkerd2-proxy-v2.286.0-windows-amd64.tar.gz 
linkerd2-proxy-v2.286.0-linux-amd64.tar.gz 
```

