### PR TITLE
refactor(http/upgrade): remove `HttpConnect` extension

### DIFF
--- a/linkerd/http/upgrade/src/upgrade.rs
+++ b/linkerd/http/upgrade/src/upgrade.rs
@@ -37,11 +37,6 @@ struct Http11UpgradeHalves {
     client: Http11Upgrade,
 }
 
-/// A marker type inserted into Extensions to signal it was an HTTP CONNECT
-/// request.
-#[derive(Debug)]
-pub struct HttpConnect;
-
 struct Inner {
     server: TryLock<Option<OnUpgrade>>,
     client: TryLock<Option<OnUpgrade>>,

--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -166,14 +166,9 @@ where
 
 /// Checks responses to determine if they are successful HTTP upgrades.
 fn is_upgrade<B>(res: &http::Response<B>, is_http_connect: bool) -> bool {
-    #[inline]
-    fn is_connect_success<B>(res: &http::Response<B>, is_http_connect: bool) -> bool {
-        is_http_connect && res.status().is_success()
-    }
-
     // Upgrades were introduced in HTTP/1.1
     if res.version() != http::Version::HTTP_11 {
-        if is_connect_success(res, is_http_connect) {
+        if is_http_connect && res.status().is_success() {
             tracing::warn!(
                 "A successful response to a CONNECT request had an incorrect HTTP version \
                 (expected HTTP/1.1, got {:?})",
@@ -189,7 +184,7 @@ fn is_upgrade<B>(res: &http::Response<B>, is_http_connect: bool) -> bool {
     }
 
     // CONNECT requests are complete if status code is 2xx.
-    if is_connect_success(res, is_http_connect) {
+    if is_http_connect && res.status().is_success() {
         return true;
     }
 

--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -169,8 +169,8 @@ fn is_upgrade<B>(rsp: &http::Response<B>, is_http_connect: bool) -> bool {
     use http::Version;
 
     match rsp.version() {
-        // Upgrades were introduced in HTTP/1.1
         Version::HTTP_11 => match rsp.status() {
+            // `101 Switching Protocols` indicates an upgrade.
             http::StatusCode::SWITCHING_PROTOCOLS => true,
             // CONNECT requests are complete if status code is 2xx.
             status if is_http_connect && status.is_success() => true,
@@ -178,6 +178,9 @@ fn is_upgrade<B>(rsp: &http::Response<B>, is_http_connect: bool) -> bool {
             _ => false,
         },
         version => {
+            // Upgrades are specific to HTTP/1.1. They are not included in HTTP/1.0, nor are they
+            // supported in HTTP/2. If this response is associated with any protocol version
+            // besides HTTP/1.1, it is not applicable to an upgrade.
             if is_http_connect && rsp.status().is_success() {
                 tracing::warn!(
                     "A successful response to a CONNECT request had an incorrect HTTP version \

--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -165,20 +165,20 @@ where
 }
 
 /// Checks responses to determine if they are successful HTTP upgrades.
-fn is_upgrade<B>(res: &http::Response<B>, is_http_connect: bool) -> bool {
+fn is_upgrade<B>(rsp: &http::Response<B>, is_http_connect: bool) -> bool {
     // Upgrades were introduced in HTTP/1.1
-    if res.version() != http::Version::HTTP_11 {
-        if is_http_connect && res.status().is_success() {
+    if rsp.version() != http::Version::HTTP_11 {
+        if is_http_connect && rsp.status().is_success() {
             tracing::warn!(
                 "A successful response to a CONNECT request had an incorrect HTTP version \
                 (expected HTTP/1.1, got {:?})",
-                res.version()
+                rsp.version()
             );
         }
         return false;
     }
 
-    match res.status() {
+    match rsp.status() {
         http::StatusCode::SWITCHING_PROTOCOLS => true,
         // CONNECT requests are complete if status code is 2xx.
         status if is_http_connect && status.is_success() => true,

--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -166,8 +166,10 @@ where
 
 /// Checks responses to determine if they are successful HTTP upgrades.
 fn is_upgrade<B>(rsp: &http::Response<B>, is_http_connect: bool) -> bool {
+    use http::Version;
+
     // Upgrades were introduced in HTTP/1.1
-    if rsp.version() != http::Version::HTTP_11 {
+    if rsp.version() != Version::HTTP_11 {
         if is_http_connect && rsp.status().is_success() {
             tracing::warn!(
                 "A successful response to a CONNECT request had an incorrect HTTP version \

--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -178,18 +178,13 @@ fn is_upgrade<B>(res: &http::Response<B>, is_http_connect: bool) -> bool {
         return false;
     }
 
-    // 101 Switching Protocols
-    if res.status() == http::StatusCode::SWITCHING_PROTOCOLS {
-        return true;
+    match res.status() {
+        http::StatusCode::SWITCHING_PROTOCOLS => true,
+        // CONNECT requests are complete if status code is 2xx.
+        status if is_http_connect && status.is_success() => true,
+        // Just a regular HTTP response...
+        _ => false,
     }
-
-    // CONNECT requests are complete if status code is 2xx.
-    if is_http_connect && res.status().is_success() {
-        return true;
-    }
-
-    // Just a regular HTTP response...
-    false
 }
 
 /// Returns if the request target is in `absolute-form`.


### PR DESCRIPTION
this branch is motivated by [review feedback](https://github.com/linkerd/linkerd2-proxy/pull/3504#discussion_r1999706761) from #3504. see
linkerd/linkerd2#8733 for more information on upgrading `hyper`. there,
we asked:

> I wonder if we should be a little more defensive about cloning [`HttpConnect`]. What does cloning it mean? When handling a CONNECT request, we can't clone the request, really. (Technically, we can't clone the body, but practically, it means we can't clone the request). Can we easily track whether this was accidentally cloned (i.e. with a custom Clone impl or Arc or some such) and validate at runtime (i.e., in proxy::http::h1) that everything is copacetic?

`linkerd-http-upgrade` provides a `HttpConnect` type that is intended
for use as a response extension. this commit performs a refactor,
removing this type.

we use this extension in a single piece of tower middleware. typically,
these sorts of extensions are intended for e.g. passing state between
distinct layers of tower middleware, or otherwise facilitating
extensions to the HTTP family of protocols.

this extension is only constructed and subsequently referenced within a
single file, in the `linkerd_proxy_http::http::h1::Client`. we can
perform the same task by using the `is_http_connect` boolean we use to
conditionally insert this extension.

then, this branch removes a helper function for a computation whose
amortization is no longer as helpful. now that we are passing
`is_http_connect` down into this function, we are no longer inspecting
the response's extensions. because of that, the only work to do is to
check the status code, which is a very cheap comparison.

this also restates an `if version != HTTP_11 { .. }` conditional block as
a match statement. this is a code motion change, none of the inner blocks
are changed.

reviewers are encouraged to examine this branch commit-by-commit; because
of the sensitivity of this change, this refactor is performed in small,
methodical changes.