### PR TITLE
nit: golf `NameRef::try_from_ascii_str()`

### DIFF
--- a/linkerd/dns/name/src/name.rs
+++ b/linkerd/dns/name/src/name.rs
@@ -118,8 +118,9 @@ impl<'a> NameRef<'a> {
             return Err(InvalidName);
         }
 
-        let s = std::str::from_utf8(dns_name).map_err(|_| InvalidName)?;
-        Ok(Self(s))
+        std::str::from_utf8(dns_name)
+            .map(Self)
+            .map_err(|_| InvalidName)
     }
 
     pub fn try_from_ascii_str(n: &'a str) -> Result<Self, InvalidName> {


### PR DESCRIPTION
this golfs down the return expression in
`NameRef::try_from_ascii_str()`.

rather than binding our `s` to a temporary variable in order to return a `Self(s)` result, we can take the same result and use `Result::map` to convert a `Result<&'a str, InvalidName>` to a
`Result<NameRef<'a>, InvalidName>`.