### PR TITLE
chore(just): set installGatewayAPI in CRD install

### DIFF
--- a/justfile
+++ b/justfile
@@ -274,7 +274,7 @@ k3d-load-linkerd: _tag-set _k3d-ready
 
 # Install crds on the test cluster.
 _linkerd-crds-install: _k3d-ready
-    {{ _linkerd }} install --crds \
+    {{ _linkerd }} install --crds --set installGatewayAPI=true \
         | {{ _kubectl }} apply -f -
     {{ _kubectl }} wait crd --for condition=established \
         --selector='linkerd.io/control-plane-ns' \


### PR DESCRIPTION
The new installGatewayAPI option is needed to bundle vendored gateway CRDs for testing.