### PR TITLE
chore(ci): disable unnecessary k3s components

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -138,7 +138,7 @@ jobs:
           echo "LINKERD_TAG=$tag" >> "$GITHUB_ENV"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - run: just docker
-      - run: just-k3d create
+      - run: just k3d-create
       - run: just k3d-load-linkerd
       - run: just linkerd-install
       - run: just linkerd-check-control-plane-proxy

--- a/justfile
+++ b/justfile
@@ -258,6 +258,12 @@ _tag-set:
 _k3d-ready:
     @just-k3d ready
 
+export K3D_CLUSTER_NAME := "l5d-proxy"
+export K3D_CREATE_FLAGS := "--no-lb"
+export K3S_DISABLE := "local-storage,traefik,servicelb,metrics-server@server:*"
+k3d-create: && _k3d-ready
+    @just-k3d create
+
 k3d-load-linkerd: _tag-set _k3d-ready
     for i in \
         '{{ _controller-image }}:{{ linkerd-tag }}' \


### PR DESCRIPTION
We can run our testing k3d cluster with minimal components enabled. This will speed up the cluster creation and deletion process (i.e. especially in CI).