### PR TITLE
chore(deps): add `tonic` dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,9 @@ updates:
           - "tokio-rustls"
           - "rustls*"
           - "ring"
+      tonic:
+        patterns:
+          - "tonic*"
       tracing:
         patterns:
           - "tracing*"


### PR DESCRIPTION
this commit adds a group to the dependabot configuration.

this will mean that dependabot updates `tonic` and `tonic-build` in lockstep.