### PR TITLE
chore(deps): dependabot group for unicode components

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,16 +30,7 @@ updates:
           - "hickory*"
       icu4x:
         patterns:
-          - "icu_collections"
-          - "icu_locid"
-          - "icu_locid_transform"
-          - "icu_locid_transform_data"
-          - "icu_normalizer"
-          - "icu_normalizer_data"
-          - "icu_properties"
-          - "icu_properties_data"
-          - "icu_provider"
-          - "icu_provider_macros"
+          - "icu_*"
       opentelemetry:
         patterns:
           - "opentelemetry*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,12 +22,12 @@ updates:
       boring:
         patterns:
           - "boring*"
-      hickory:
-        patterns:
-          - "hickory*"
       futures:
         patterns:
           - "futures*"
+      hickory:
+        patterns:
+          - "hickory*"
       icu4x:
         patterns:
           - "icu_collections"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,18 @@ updates:
       futures:
         patterns:
           - "futures*"
+      icu4x:
+        patterns:
+          - "icu_collections"
+          - "icu_locid"
+          - "icu_locid_transform"
+          - "icu_locid_transform_data"
+          - "icu_normalizer"
+          - "icu_normalizer_data"
+          - "icu_properties"
+          - "icu_properties_data"
+          - "icu_provider"
+          - "icu_provider_macros"
       opentelemetry:
         patterns:
           - "opentelemetry*"


### PR DESCRIPTION
this commit introduces a new dependabot group.

this will update all of the crates maintained by the icu4x organization
in lockstep. we depend upon these transitively to handle urls.

```
; cargo tree | rg icu_ | rg 'icu_\w*' --only-matching | sort | uniq
icu_collections
icu_locid
icu_locid_transform
icu_locid_transform_data
icu_normalizer
icu_normalizer_data
icu_properties
icu_properties_data
icu_provider
icu_provider_macros
```

see:

- https://docs.rs/icu/latest/icu/
- https://icu.unicode.org/
- https://github.com/orgs/unicode-org/repositories?type=all
- https://crates.io/crates/idna
- https://github.com/linkerd/linkerd2-proxy/pull/3811
- https://github.com/linkerd/linkerd2-proxy/pull/3812
- https://github.com/linkerd/linkerd2-proxy/pull/3813