### PR TITLE
nit(docs): fix broken intradoc links

### DIFF
--- a/linkerd/mock/http-body/src/lib.rs
+++ b/linkerd/mock/http-body/src/lib.rs
@@ -23,13 +23,15 @@ pub struct MockBody {
 // === impl MockBody ===
 
 impl MockBody {
-    /// Appends a poll outcome for [`Body::poll_data()`].
+    /// Appends a poll outcome for [`Body::poll_frame()`].
     pub fn then_yield_data(mut self, poll: Poll<Option<Result<Bytes, Error>>>) -> Self {
         self.data_polls.push_back(poll);
         self
     }
 
-    /// Appends a poll outcome for [`Body::poll_trailers()`].
+    /// Appends a [`Poll`] outcome for [`Body::poll_frame()`].
+    ///
+    /// These this will be yielded after data has been polled.
     pub fn then_yield_trailer(
         mut self,
         poll: Poll<Option<Result<http::HeaderMap, Error>>>,


### PR DESCRIPTION
this commit fixes some broken links now that we have updated to the latest 1.0 version of `http-body`.

this should address some warnings that can be seen in pull requests' "files" tab in github. see, for example:
`https://github.com/linkerd/linkerd2-proxy/pull/3818/files`.