### PR TITLE
feat(app,dns): add prometheus metrics to `Dns`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,6 +1734,7 @@ dependencies = [
  "hickory-resolver",
  "linkerd-dns-name",
  "linkerd-error",
+ "prometheus-client",
  "thiserror 2.0.12",
  "tokio",
  "tracing",

--- a/linkerd/app/core/src/dns.rs
+++ b/linkerd/app/core/src/dns.rs
@@ -18,7 +18,7 @@ pub struct Config {
 
 pub struct Dns {
     resolver: Resolver,
-    dns_records_resolved: Family<Labels, Counter>,
+    dns_resolutions_total: Family<Labels, Counter>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -41,11 +41,11 @@ impl Dns {
     pub fn resolver(&self, client: &'static str) -> Resolver {
         let Self {
             resolver,
-            dns_records_resolved,
+            dns_resolutions_total,
         } = self;
 
         let get_counter = |outcome| {
-            dns_records_resolved
+            dns_resolutions_total
                 .get_or_create(&Labels { client, outcome })
                 .clone()
         };
@@ -63,18 +63,18 @@ impl Dns {
 
 impl Config {
     pub fn build(self, registry: &mut Registry) -> Dns {
-        let dns_records_resolved = Family::default();
+        let dns_resolutions_total = Family::default();
         registry.register(
-            "dns_records_resolved",
+            "dns_resolutions_total",
             "Counts the number of DNS records that have been resolved.",
-            dns_records_resolved.clone(),
+            dns_resolutions_total.clone(),
         );
 
         let resolver =
             Resolver::from_system_config_with(&self).expect("system DNS config must be valid");
         Dns {
             resolver,
-            dns_records_resolved,
+            dns_resolutions_total,
         }
     }
 }

--- a/linkerd/app/core/src/dns.rs
+++ b/linkerd/app/core/src/dns.rs
@@ -1,13 +1,10 @@
-use linkerd_metrics::prom::{
-    encoding::{EncodeLabel, EncodeLabelSet, EncodeLabelValue, LabelSetEncoder, LabelValueEncoder},
-    Counter, Family, Registry,
-};
-use std::{
-    fmt::{Display, Write},
-    time::Duration,
-};
+use self::metrics::Labels;
+use linkerd_metrics::prom::{Counter, Family, Registry};
+use std::time::Duration;
 
 pub use linkerd_dns::*;
+
+mod metrics;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -20,25 +17,6 @@ pub struct Dns {
     resolutions: Family<Labels, Counter>,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-struct Labels {
-    client: &'static str,
-    record_type: RecordType,
-    result: Outcome,
-}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-enum RecordType {
-    A,
-    Srv,
-}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-enum Outcome {
-    Ok,
-    NotFound,
-}
-
 // === impl Dns ===
 
 impl Dns {
@@ -47,42 +25,6 @@ impl Dns {
         let metrics = self.metrics(client);
 
         self.resolver.clone().with_metrics(metrics)
-    }
-
-    fn metrics(&self, client: &'static str) -> Metrics {
-        let family = &self.resolutions;
-
-        let a_records_resolved = (*family.get_or_create(&Labels {
-            client,
-            record_type: RecordType::A,
-            result: Outcome::Ok,
-        }))
-        .clone();
-        let a_records_not_found = (*family.get_or_create(&Labels {
-            client,
-            record_type: RecordType::A,
-            result: Outcome::NotFound,
-        }))
-        .clone();
-        let srv_records_resolved = (*family.get_or_create(&Labels {
-            client,
-            record_type: RecordType::Srv,
-            result: Outcome::Ok,
-        }))
-        .clone();
-        let srv_records_not_found = (*family.get_or_create(&Labels {
-            client,
-            record_type: RecordType::Srv,
-            result: Outcome::NotFound,
-        }))
-        .clone();
-
-        Metrics {
-            a_records_resolved,
-            a_records_not_found,
-            srv_records_resolved,
-            srv_records_not_found,
-        }
     }
 }
 
@@ -114,57 +56,5 @@ impl ConfigureResolver for Config {
         opts.positive_max_ttl = self.max_ttl;
         opts.negative_min_ttl = self.min_ttl;
         opts.negative_max_ttl = self.max_ttl;
-    }
-}
-
-// === impl Labels ===
-
-impl EncodeLabelSet for Labels {
-    fn encode(&self, mut encoder: LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
-        let Self {
-            client,
-            record_type,
-            result,
-        } = self;
-
-        ("client", *client).encode(encoder.encode_label())?;
-        ("record_type", record_type).encode(encoder.encode_label())?;
-        ("result", result).encode(encoder.encode_label())?;
-
-        Ok(())
-    }
-}
-
-// === impl Outcome ===
-
-impl EncodeLabelValue for &Outcome {
-    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
-        encoder.write_str(self.to_string().as_str())
-    }
-}
-
-impl Display for Outcome {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            Self::Ok => "ok",
-            Self::NotFound => "not_found",
-        })
-    }
-}
-
-// === impl RecordType ===
-
-impl EncodeLabelValue for &RecordType {
-    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
-        encoder.write_str(self.to_string().as_str())
-    }
-}
-
-impl Display for RecordType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(match self {
-            Self::A => "A/AAAA",
-            Self::Srv => "SRV",
-        })
     }
 }

--- a/linkerd/app/core/src/dns.rs
+++ b/linkerd/app/core/src/dns.rs
@@ -1,8 +1,7 @@
 use linkerd_metrics::prom::{
-    encoding::{EncodeLabelSet, EncodeLabelValue, LabelSetEncoder, LabelValueEncoder},
+    encoding::{EncodeLabel, EncodeLabelSet, EncodeLabelValue, LabelSetEncoder, LabelValueEncoder},
     Counter, Family, Registry,
 };
-use prometheus_client::encoding::EncodeLabel;
 use std::{
     fmt::{Display, Write},
     time::Duration,

--- a/linkerd/app/core/src/dns.rs
+++ b/linkerd/app/core/src/dns.rs
@@ -49,15 +49,13 @@ impl Dns {
                 .get_or_create(&Labels { client, outcome })
                 .clone()
         };
-        let a_records_resolved = get_counter(Outcome::A);
-        let srv_records_resolved = get_counter(Outcome::Srv);
-        let lookups_failed = get_counter(Outcome::Failure);
+        let metrics = Metrics {
+            a_records_resolved: get_counter(Outcome::A),
+            srv_records_resolved: get_counter(Outcome::Srv),
+            lookups_failed: get_counter(Outcome::Failure),
+        };
 
-        resolver
-            .clone()
-            .with_a_records_resolved_counter(a_records_resolved)
-            .with_srv_records_resolved_counter(srv_records_resolved)
-            .with_lookups_failed_counter(lookups_failed)
+        resolver.clone().with_metrics(metrics)
     }
 }
 

--- a/linkerd/app/core/src/dns.rs
+++ b/linkerd/app/core/src/dns.rs
@@ -17,7 +17,7 @@ pub struct Config {
 
 pub struct Dns {
     resolver: Resolver,
-    dns_resolutions_total: Family<Labels, Counter>,
+    resolutions: Family<Labels, Counter>,
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -50,7 +50,7 @@ impl Dns {
     }
 
     fn metrics(&self, client: &'static str) -> Metrics {
-        let family = &self.dns_resolutions_total;
+        let family = &self.resolutions;
 
         let a_records_resolved = (*family.get_or_create(&Labels {
             client,
@@ -90,18 +90,18 @@ impl Dns {
 
 impl Config {
     pub fn build(self, registry: &mut Registry) -> Dns {
-        let dns_resolutions_total = Family::default();
+        let resolutions = Family::default();
         registry.register(
-            "dns_resolutions_total",
+            "resolutions",
             "Counts the number of DNS records that have been resolved.",
-            dns_resolutions_total.clone(),
+            resolutions.clone(),
         );
 
         let resolver =
             Resolver::from_system_config_with(&self).expect("system DNS config must be valid");
         Dns {
             resolver,
-            dns_resolutions_total,
+            resolutions,
         }
     }
 }

--- a/linkerd/app/core/src/dns.rs
+++ b/linkerd/app/core/src/dns.rs
@@ -1,5 +1,14 @@
+use linkerd_metrics::prom::{
+    encoding::{EncodeLabelSet, EncodeLabelValue, LabelSetEncoder, LabelValueEncoder},
+    Counter, Family, Registry,
+};
+use prometheus_client::encoding::EncodeLabel;
+use std::{
+    fmt::{Display, Write},
+    time::Duration,
+};
+
 pub use linkerd_dns::*;
-use std::time::Duration;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -8,16 +17,67 @@ pub struct Config {
 }
 
 pub struct Dns {
-    pub resolver: Resolver,
+    resolver: Resolver,
+    dns_records_resolved: Family<Labels, Counter>,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct Labels {
+    client: &'static str,
+    outcome: Outcome,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum Outcome {
+    A,
+    Srv,
+    Failure,
+}
+
+// === impl Dns ===
+
+impl Dns {
+    /// Returns a new [`Resolver`].
+    pub fn resolver(&self, client: &'static str) -> Resolver {
+        let Self {
+            resolver,
+            dns_records_resolved,
+        } = self;
+
+        let get_counter = |outcome| {
+            dns_records_resolved
+                .get_or_create(&Labels { client, outcome })
+                .clone()
+        };
+        let a_records_resolved = get_counter(Outcome::A);
+        let srv_records_resolved = get_counter(Outcome::Srv);
+        let lookups_failed = get_counter(Outcome::Failure);
+
+        resolver
+            .clone()
+            .with_a_records_resolved_counter(a_records_resolved)
+            .with_srv_records_resolved_counter(srv_records_resolved)
+            .with_lookups_failed_counter(lookups_failed)
+    }
 }
 
 // === impl Config ===
 
 impl Config {
-    pub fn build(self) -> Dns {
+    pub fn build(self, registry: &mut Registry) -> Dns {
+        let dns_records_resolved = Family::default();
+        registry.register(
+            "dns_records_resolved",
+            "Counts the number of DNS records that have been resolved.",
+            dns_records_resolved.clone(),
+        );
+
         let resolver =
             Resolver::from_system_config_with(&self).expect("system DNS config must be valid");
-        Dns { resolver }
+        Dns {
+            resolver,
+            dns_records_resolved,
+        }
     }
 }
 
@@ -29,5 +89,36 @@ impl ConfigureResolver for Config {
         opts.positive_max_ttl = self.max_ttl;
         opts.negative_min_ttl = self.min_ttl;
         opts.negative_max_ttl = self.max_ttl;
+    }
+}
+
+// === impl Labels ===
+
+impl EncodeLabelSet for Labels {
+    fn encode(&self, mut encoder: LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
+        let Self { client, outcome } = self;
+
+        ("client", *client).encode(encoder.encode_label())?;
+        ("outcome", outcome).encode(encoder.encode_label())?;
+
+        Ok(())
+    }
+}
+
+// === impl Outcome ===
+
+impl EncodeLabelValue for &Outcome {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
+        encoder.write_str(self.to_string().as_str())
+    }
+}
+
+impl Display for Outcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::A => "A/AAAA",
+            Self::Srv => "SRV",
+            Self::Failure => "failure",
+        })
     }
 }

--- a/linkerd/app/core/src/dns/metrics.rs
+++ b/linkerd/app/core/src/dns/metrics.rs
@@ -1,0 +1,115 @@
+use super::{Dns, Metrics};
+use linkerd_metrics::prom::encoding::{
+    EncodeLabel, EncodeLabelSet, EncodeLabelValue, LabelSetEncoder, LabelValueEncoder,
+};
+use std::fmt::{Display, Write};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(super) struct Labels {
+    client: &'static str,
+    record_type: RecordType,
+    result: Outcome,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum RecordType {
+    A,
+    Srv,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+enum Outcome {
+    Ok,
+    NotFound,
+}
+
+// === impl Dns ===
+
+impl Dns {
+    pub(super) fn metrics(&self, client: &'static str) -> Metrics {
+        let family = &self.resolutions;
+
+        let a_records_resolved = (*family.get_or_create(&Labels {
+            client,
+            record_type: RecordType::A,
+            result: Outcome::Ok,
+        }))
+        .clone();
+        let a_records_not_found = (*family.get_or_create(&Labels {
+            client,
+            record_type: RecordType::A,
+            result: Outcome::NotFound,
+        }))
+        .clone();
+        let srv_records_resolved = (*family.get_or_create(&Labels {
+            client,
+            record_type: RecordType::Srv,
+            result: Outcome::Ok,
+        }))
+        .clone();
+        let srv_records_not_found = (*family.get_or_create(&Labels {
+            client,
+            record_type: RecordType::Srv,
+            result: Outcome::NotFound,
+        }))
+        .clone();
+
+        Metrics {
+            a_records_resolved,
+            a_records_not_found,
+            srv_records_resolved,
+            srv_records_not_found,
+        }
+    }
+}
+// === impl Labels ===
+
+impl EncodeLabelSet for Labels {
+    fn encode(&self, mut encoder: LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
+        let Self {
+            client,
+            record_type,
+            result,
+        } = self;
+
+        ("client", *client).encode(encoder.encode_label())?;
+        ("record_type", record_type).encode(encoder.encode_label())?;
+        ("result", result).encode(encoder.encode_label())?;
+
+        Ok(())
+    }
+}
+
+// === impl Outcome ===
+
+impl EncodeLabelValue for &Outcome {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
+        encoder.write_str(self.to_string().as_str())
+    }
+}
+
+impl Display for Outcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Ok => "ok",
+            Self::NotFound => "not_found",
+        })
+    }
+}
+
+// === impl RecordType ===
+
+impl EncodeLabelValue for &RecordType {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), std::fmt::Error> {
+        encoder.write_str(self.to_string().as_str())
+    }
+}
+
+impl Display for RecordType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::A => "A/AAAA",
+            Self::Srv => "SRV",
+        })
+    }
+}

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -145,7 +145,7 @@ impl Config {
 
             info_span!("identity").in_scope(|| {
                 identity.build(
-                    dns.resolver("control_identity"),
+                    dns.resolver("identity"),
                     metrics.control.clone(),
                     id_metrics,
                 )
@@ -166,7 +166,7 @@ impl Config {
             let control_metrics =
                 ControlMetrics::register(registry.sub_registry_with_prefix("control_destination"));
             let metrics = metrics.control.clone();
-            let dns = dns.resolver("control_destination");
+            let dns = dns.resolver("destination");
             info_span!("dst").in_scope(|| {
                 dst.build(
                     dns,
@@ -182,7 +182,7 @@ impl Config {
         let policies = {
             let control_metrics =
                 ControlMetrics::register(registry.sub_registry_with_prefix("control_policy"));
-            let dns = dns.resolver("control_policy");
+            let dns = dns.resolver("policy");
             let metrics = metrics.control.clone();
             info_span!("policy").in_scope(|| {
                 policy.build(

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -134,7 +134,7 @@ impl Config {
         let (metrics, report) = Metrics::new(admin.metrics_retain_idle);
 
         debug!("Building DNS client");
-        let dns = dns.build(&mut registry);
+        let dns = dns.build(registry.sub_registry_with_prefix("control_dns"));
 
         // Ensure that we've obtained a valid identity before binding any servers.
         debug!("Building Identity client");

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -134,7 +134,7 @@ impl Config {
         let (metrics, report) = Metrics::new(admin.metrics_retain_idle);
 
         debug!("Building DNS client");
-        let dns = dns.build();
+        let dns = dns.build(&mut registry);
 
         // Ensure that we've obtained a valid identity before binding any servers.
         debug!("Building Identity client");
@@ -144,7 +144,11 @@ impl Config {
             );
 
             info_span!("identity").in_scope(|| {
-                identity.build(dns.resolver.clone(), metrics.control.clone(), id_metrics)
+                identity.build(
+                    dns.resolver("control_identity"),
+                    metrics.control.clone(),
+                    id_metrics,
+                )
             })?
         };
 
@@ -162,7 +166,7 @@ impl Config {
             let control_metrics =
                 ControlMetrics::register(registry.sub_registry_with_prefix("control_destination"));
             let metrics = metrics.control.clone();
-            let dns = dns.resolver.clone();
+            let dns = dns.resolver("control_destination");
             info_span!("dst").in_scope(|| {
                 dst.build(
                     dns,
@@ -178,7 +182,7 @@ impl Config {
         let policies = {
             let control_metrics =
                 ControlMetrics::register(registry.sub_registry_with_prefix("control_policy"));
-            let dns = dns.resolver.clone();
+            let dns = dns.resolver("control_policy");
             let metrics = metrics.control.clone();
             info_span!("policy").in_scope(|| {
                 policy.build(
@@ -198,7 +202,7 @@ impl Config {
                 ControlMetrics::register(&mut prom::Registry::default())
             };
             let identity = identity.receiver().new_client();
-            let dns = dns.resolver;
+            let dns = dns.resolver("trace_collector");
             let client_metrics = metrics.control.clone();
             let otel_metrics = metrics.opentelemetry;
             let oc_metrics = metrics.opencensus;

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -8,12 +8,13 @@ publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
+hickory-resolver = "0.25.1"
 linkerd-dns-name = { path = "./name" }
 linkerd-error = { path = "../error" }
+prometheus-client = { workspace = true }
 thiserror = "2"
-tracing = "0.1"
-hickory-resolver = "0.25.1"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
+tracing = "0.1"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }


### PR DESCRIPTION
this commit introduces a new metric family tracking the rate and outcome
of dns lookups made by the linkerd2 proxy. this metric family has two
labels, tracking (a) the control plane client responsible for a
particular lookup, (b) the outcome of the lookup.

this metric is named `control_dns_resolutions_total`.

this metric includes labels to count DNS resolutions for each distinct
control plane client, by record type (A/AAAA or SRV), and by outcome
(success or failure).

this commit generally does this via the addition of some new interfaces
to `linkerd-dns`'s `Resolver` structure. the `resolve_addrs()` method is
extended to increment particular counters if they have been installed.

the `linkerd-app` crate's `Dns` type now encapsulates its resolver, and
callers acquire a new resolver by providing a client name to its
`resolver()` method. this uses the client name to construct label sets
and create the corresponding time series for each client.

once proxies with this patch are running, and the viz extension has been
installed, one can query this metric like so:

**nb:** this screenshot shows an early prototype, this metric has since
been renamed.

![linkerd-dns-prometheus-metrics](https://github.com/user-attachments/assets/3138dcfc-6800-4c0f-8215-61d84085032b)

this promQL query...

```
sum(rate(control_dns_resolutions_total[1m])) by (app,client,result) > 0
```

...will show the per-minute rate of dns lookups/failures across each
application workload, for each control-plane client, for each possible
outcome.