### PR TITLE
fix(ci): work around broken `linkerd install --crds`

### DIFF
--- a/justfile
+++ b/justfile
@@ -280,7 +280,8 @@ k3d-load-linkerd: _tag-set _k3d-ready
 
 # Install crds on the test cluster.
 _linkerd-crds-install: _k3d-ready
-    {{ _linkerd }} install --crds --set installGatewayAPI=true \
+    {{ _kubectl }} apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+    {{ _linkerd }} install --crds \
         | {{ _kubectl }} apply -f -
     {{ _kubectl }} wait crd --for condition=established \
         --selector='linkerd.io/control-plane-ns' \


### PR DESCRIPTION
The latest edge doesn't properly install gateway API crds. This changes our justfile to install the resources from the upstream release instead of the Linkerd CLI.