### PR TITLE
feat(inbound): support LINKERD2_PROXY_INBOUND_AUTHORITY_LABELS=unsafe

### DIFF
--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -273,6 +273,7 @@ impl Param<metrics::EndpointLabels> for Permitted {
     fn param(&self) -> metrics::EndpointLabels {
         metrics::InboundEndpointLabels {
             tls: self.http.tcp.tls.clone(),
+            authority: None,
             target_addr: self.http.tcp.addr.into(),
             policy: self.permit.labels.clone(),
         }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -66,6 +66,7 @@ pub enum EndpointLabels {
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct InboundEndpointLabels {
     pub tls: tls::ConditionalServerTls,
+    pub authority: Option<http::uri::Authority>,
     pub target_addr: SocketAddr,
     pub policy: RouteAuthzLabels,
 }
@@ -316,6 +317,11 @@ impl FmtLabels for EndpointLabels {
 
 impl FmtLabels for InboundEndpointLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(a) = self.authority.as_ref() {
+            Authority(a).fmt_labels(f)?;
+            write!(f, ",")?;
+        }
+
         (
             (TargetAddr(self.target_addr), TlsAccept::from(&self.tls)),
             &self.policy,

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -391,6 +391,7 @@ impl Param<metrics::EndpointLabels> for Logical {
     fn param(&self) -> metrics::EndpointLabels {
         metrics::InboundEndpointLabels {
             tls: self.tls.clone(),
+            authority: self.logical.as_ref().map(|d| d.as_http_authority()),
             target_addr: self.addr.into(),
             policy: self.permit.labels.clone(),
         }

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -83,9 +83,9 @@ impl<C> Inbound<C> {
     {
         self.map_stack(|config, rt, connect| {
             let allow_profile = config.allow_discovery.clone();
+            let unsafe_authority_labels = config.unsafe_authority_labels;
             let h1_params = config.proxy.connect.http1;
             let h2_params = config.proxy.connect.http2.clone();
-            let unsafe_authority_labels = false;
 
             // Creates HTTP clients for each inbound port & HTTP settings.
             let http = connect

--- a/linkerd/app/inbound/src/http/tests.rs
+++ b/linkerd/app/inbound/src/http/tests.rs
@@ -665,6 +665,7 @@ async fn grpc_response_class() {
         .get_response_total(
             &metrics::EndpointLabels::Inbound(metrics::InboundEndpointLabels {
                 tls: Target::meshed_h2().1,
+                authority: Some("foo.svc.cluster.local:5550".parse().unwrap()),
                 target_addr: "127.0.0.1:80".parse().unwrap(),
                 policy: metrics::RouteAuthzLabels {
                     route: metrics::RouteLabels {

--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -55,6 +55,9 @@ pub struct Config {
 
     /// Configures how HTTP requests are buffered *for each inbound port*.
     pub http_request_queue: QueueConfig,
+
+    /// Enables unsafe authority labels.
+    pub unsafe_authority_labels: bool,
 }
 
 #[derive(Clone)]

--- a/linkerd/app/inbound/src/test_util.rs
+++ b/linkerd/app/inbound/src/test_util.rs
@@ -89,6 +89,7 @@ pub fn default_config() -> Config {
         },
         discovery_idle_timeout: Duration::from_secs(20),
         profile_skip_timeout: Duration::from_secs(1),
+        unsafe_authority_labels: false,
     }
 }
 

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -57,7 +57,9 @@ impl Fixture {
         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
         let tcp_dst_labels = metrics::labels().label("direction", "inbound");
         let tcp_src_labels = tcp_dst_labels.clone().label("target_addr", orig_dst);
-        let labels = tcp_dst_labels.clone().label("target_port", orig_dst.port());
+        let labels = tcp_dst_labels
+            .clone()
+            .label("authority", "tele.test.svc.cluster.local");
         let tcp_src_labels = tcp_src_labels.label("peer", "src");
         let tcp_dst_labels = tcp_dst_labels.label("peer", "dst");
         Fixture {

--- a/linkerd/http/metrics/src/requests.rs
+++ b/linkerd/http/metrics/src/requests.rs
@@ -59,13 +59,25 @@ impl<T: Hash + Eq, C: Hash + Eq> Requests<T, C> {
 
     pub fn to_layer<L, N, Tgt>(
         &self,
-    ) -> impl layer::Layer<N, Service = NewHttpMetrics<N, T, L, C, N::Service>> + Clone
+    ) -> impl layer::Layer<N, Service = NewHttpMetrics<N, T, (), L, C, N::Service>> + Clone
     where
         L: ClassifyResponse<Class = C> + Send + Sync + 'static,
         N: svc::NewService<Tgt>,
     {
+        self.to_layer_via(())
+    }
+
+    pub fn to_layer_via<L, N, Tgt, X>(
+        &self,
+        params: X,
+    ) -> impl layer::Layer<N, Service = NewHttpMetrics<N, T, X, L, C, N::Service>> + Clone
+    where
+        L: ClassifyResponse<Class = C> + Send + Sync + 'static,
+        N: svc::NewService<Tgt>,
+        X: Clone,
+    {
         let reg = self.0.clone();
-        NewMetrics::layer(reg)
+        NewMetrics::layer_via(reg, params)
     }
 }
 

--- a/linkerd/http/metrics/src/requests/service.rs
+++ b/linkerd/http/metrics/src/requests/service.rs
@@ -18,8 +18,8 @@ use std::{
 use tokio::time::Instant;
 
 /// Wraps services to record metrics.
-pub type NewHttpMetrics<N, K, C, Class, S> =
-    NewMetrics<N, K, Mutex<Metrics<Class>>, HttpMetrics<S, C>>;
+pub type NewHttpMetrics<N, K, X, C, Class, S> =
+    NewMetrics<N, K, X, Mutex<Metrics<Class>>, HttpMetrics<S, C>>;
 
 /// A middleware that records HTTP metrics.
 #[pin_project]

--- a/linkerd/metrics/src/new_metrics.rs
+++ b/linkerd/metrics/src/new_metrics.rs
@@ -7,67 +7,86 @@ use std::{fmt, hash::Hash, marker::PhantomData, sync::Arc};
 /// Wraps an `N`-typed inner `NewService`, extracting `K`-typed label from each target. The label
 /// scope is used to procure an `M`-typed sensor that is used to actually record metrics. The new
 /// service uses the inner service and the `M`-typed sensor to construct a new `S`-typed service.
-pub struct NewMetrics<N, K: Hash + Eq, M, S> {
+pub struct NewMetrics<N, K: Hash + Eq, X, M, S> {
     store: SharedStore<K, M>,
     inner: N,
+    params: X,
     _svc: PhantomData<fn() -> S>,
 }
 
-impl<N, K, M, S> NewMetrics<N, K, M, S>
+impl<N, K, X, M, S> NewMetrics<N, K, X, M, S>
 where
     K: Hash + Eq,
+    X: Clone,
 {
-    pub fn layer(store: SharedStore<K, M>) -> impl svc::layer::Layer<N, Service = Self> + Clone {
+    pub fn layer_via(
+        store: SharedStore<K, M>,
+        params: X,
+    ) -> impl svc::layer::Layer<N, Service = Self> + Clone {
         svc::layer::mk(move |inner| Self {
             store: store.clone(),
             inner,
+            params: params.clone(),
             _svc: PhantomData,
         })
     }
 }
 
-impl<N, K, M, S, T> svc::NewService<T> for NewMetrics<N, K, M, S>
+impl<N, K, M, S> NewMetrics<N, K, (), M, S>
 where
-    T: svc::Param<K>,
+    K: Hash + Eq,
+{
+    pub fn layer(store: SharedStore<K, M>) -> impl svc::layer::Layer<N, Service = Self> + Clone {
+        Self::layer_via(store, ())
+    }
+}
+
+impl<N, K, X, M, S, T> svc::NewService<T> for NewMetrics<N, K, X, M, S>
+where
     N: svc::NewService<T>,
     S: From<(N::Service, Arc<M>)>,
     M: Default,
     K: Hash + Eq,
+    X: svc::ExtractParam<K, T>,
 {
     type Service = S;
 
     fn new_service(&self, target: T) -> Self::Service {
-        let key = target.param();
+        let key = self.params.extract_param(&target);
         let inner = self.inner.new_service(target);
         let metric = self.store.lock().get_or_default(key).clone();
         S::from((inner, metric))
     }
 }
 
-impl<N, K, M, S> Clone for NewMetrics<N, K, M, S>
+impl<N, K, X, M, S> Clone for NewMetrics<N, K, X, M, S>
 where
     N: Clone,
     K: Hash + Eq,
+    X: Clone,
 {
     fn clone(&self) -> Self {
         Self {
             store: self.store.clone(),
             inner: self.inner.clone(),
+            params: self.params.clone(),
             _svc: PhantomData,
         }
     }
 }
 
-impl<N, K, M, S> fmt::Debug for NewMetrics<N, K, M, S>
+impl<N, K, X, M, S> fmt::Debug for NewMetrics<N, K, X, M, S>
 where
     N: fmt::Debug,
     K: Hash + Eq + fmt::Debug,
+    X: fmt::Debug,
     M: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use std::any::type_name;
         f.debug_struct(type_name::<Self>())
             .field("store", &self.store)
+            .field("params", &self.params)
             .field("inner", &self.inner)
             .field("svc", &format_args!("PhantomData<{}>", type_name::<S>()))
             .finish()


### PR DESCRIPTION
commit ce43a13e395c46a12b9b4cc7e41db16115293e58
Author: Oliver Gould <ver@buoyant.io>
Date:   Mon Mar 31 23:10:45 2025 +0000

    chore(http-metrics): use ExtractParam for labels

commit f3c3676f67a625c1392a93ded38fe07fe264be52
Author: Oliver Gould <ver@buoyant.io>
Date:   Mon Mar 31 23:12:36 2025 +0000

    Revert "feat(metrics)!: remove authority label on inbound metrics (#3547)"
    
    This reverts commit 3ab83ed3ff7a970f786111474e5fcff9b394b208.

commit c251f5a12c1f5e77d2f6684a7b91fe22ce9e8321
Author: Oliver Gould <ver@buoyant.io>
Date:   Mon Mar 31 23:26:56 2025 +0000

    refactor(inbound): configure endpoint authority labels conditionally

commit 7e999a7b8340e8884a628d7c7d9631515706b810
Author: Oliver Gould <ver@buoyant.io>
Date:   Mon Mar 31 23:36:07 2025 +0000

    feat(inbound): support LINKERD2_PROXY_INBOUND_AUTHORITY_LABELS=unsafe