### PR TITLE
chore(deps): add `tokio-boring` to dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
     groups:
       boring:
         patterns:
+          - "tokio-boring"
           - "boring*"
       futures:
         patterns:


### PR DESCRIPTION
this adds `tokio-boring` to the `boring` group.

this will group these crates together and bump them in lockstep.

see, for example:
* #3838
* #3840