### PR TITLE
chore(deps): group symbolic dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,9 @@ updates:
           - "tokio-rustls"
           - "rustls*"
           - "ring"
+      symbolic:
+        patterns:
+          - "symbolic-*"
       tracing:
         patterns:
           - "tracing*"


### PR DESCRIPTION
we use the `symbolic-common` and `symbolic-demangle` crates in our dependency tree. these live in the same repo, here: <https://github.com/getsentry/symbolic>

this commit introduces a "group" so that dependabot will upgrade them in lockstep, rather than individually, such as in pull requests like
 #3853, #3852, #3857, #3858, or #3860.