### PR TITLE
V2.292.0 light metrics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -A deprecated --cfg tokio_unstable"
-  RUSTUP_MAX_RETRIES: 11
+  RUSTUP_MAX_RETRIES: 12
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.ref || github.head_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTFLAGS: "-D warnings -A deprecated --cfg tokio_unstable"
-  RUSTUP_MAX_RETRIES: 10
+  RUSTUP_MAX_RETRIES: 11
 
 concurrency:
   group: ${{ github.workflow }}-${{ inputs.ref || github.head_ref }}
@@ -135,7 +135,7 @@ jobs:
           - os: windows
             arch: arm64
           - os: windows
-            arch: arm  
+            arch: arm
 
     # If we're not actually building on a release tag, don't short-circuit on
     # errors. This helps us know whether a failure is platform-specific.

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -273,8 +273,6 @@ impl Param<metrics::EndpointLabels> for Permitted {
     fn param(&self) -> metrics::EndpointLabels {
         metrics::InboundEndpointLabels {
             tls: self.http.tcp.tls.clone(),
-            authority: None,
-            target_addr: self.http.tcp.addr.into(),
             policy: self.permit.labels.clone(),
         }
         .into()

--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -396,10 +396,6 @@ fn endpoint_labels(
     move |t: &Logical| -> metrics::EndpointLabels {
         metrics::InboundEndpointLabels {
             tls: t.tls.clone(),
-            authority: unsafe_authority_labels
-                .then(|| t.logical.as_ref().map(|d| d.as_http_authority()))
-                .flatten(),
-            target_addr: t.addr.into(),
             policy: t.permit.labels.clone(),
         }
         .into()

--- a/linkerd/app/integration/src/tests/discovery.rs
+++ b/linkerd/app/integration/src/tests/discovery.rs
@@ -454,14 +454,12 @@ mod http2 {
         // Simulate the first server falling over without discovery
         // knowing about it...
         tracing::info!(%alpha.addr, "Stopping");
-        let alpha_addr = alpha.addr;
         alpha.join().await;
 
         // Wait until the proxy has seen the `alpha` disconnect...
         metrics::metric("tcp_close_total")
             .label("peer", "dst")
             .label("direction", "outbound")
-            .label("target_addr", alpha_addr.to_string())
             .value(1u64)
             .assert_in(&metrics)
             .await;

--- a/linkerd/app/integration/src/tests/telemetry.rs
+++ b/linkerd/app/integration/src/tests/telemetry.rs
@@ -56,8 +56,8 @@ impl Fixture {
 
         let client = client::new(proxy.inbound, "tele.test.svc.cluster.local");
         let tcp_dst_labels = metrics::labels().label("direction", "inbound");
-        let tcp_src_labels = tcp_dst_labels.clone().label("target_addr", orig_dst);
-        let labels = tcp_dst_labels.clone().label("target_port", orig_dst.port());
+        let tcp_src_labels = tcp_dst_labels.clone();
+        let labels = tcp_dst_labels.clone();
         let tcp_src_labels = tcp_src_labels.label("peer", "src");
         let tcp_dst_labels = tcp_dst_labels.label("peer", "dst");
         Fixture {
@@ -94,9 +94,7 @@ impl Fixture {
         let metrics = client::http1(proxy.admin, "localhost");
 
         let client = client::new(proxy.outbound, "tele.test.svc.cluster.local");
-        let tcp_labels = metrics::labels()
-            .label("direction", "outbound")
-            .label("target_addr", orig_dst);
+        let tcp_labels = metrics::labels().label("direction", "outbound")
         let labels = tcp_labels.clone();
         let tcp_src_labels = tcp_labels.clone().label("peer", "src");
         let tcp_dst_labels = tcp_labels.label("peer", "dst");
@@ -151,7 +149,6 @@ impl TcpFixture {
         let src_labels = metrics::labels()
             .label("direction", "inbound")
             .label("peer", "src")
-            .label("target_addr", orig_dst)
             .label("srv_kind", "default")
             .label("srv_name", "all-unauthenticated");
 
@@ -191,8 +188,7 @@ impl TcpFixture {
             .label("direction", "outbound")
             .label("peer", "src")
             .label("tls", "no_identity")
-            .label("no_tls_reason", "loopback")
-            .label("target_addr", orig_dst);
+            .label("no_tls_reason", "loopback");
         let dst_labels = metrics::labels()
             .label("direction", "outbound")
             .label("peer", "dst");
@@ -216,7 +212,6 @@ async fn admin_request_count() {
     let metrics = fixture.metrics;
     let metric = metrics::metric("request_total")
         .label("direction", "inbound")
-        .label("target_addr", metrics.target_addr())
         .value(1usize);
 
     // We can't assert that the metric is not present, since `GET /metrics`
@@ -231,7 +226,6 @@ async fn admin_transport_metrics() {
     let metrics = fixture.metrics;
     let labels = metrics::labels()
         .label("direction", "inbound")
-        .label("target_addr", metrics.target_addr())
         .label("peer", "src");
 
     let mut open_total = labels.metric("tcp_open_total").value(1usize);
@@ -306,18 +300,13 @@ async fn test_http_count(metric_name: &str, fixture: impl Future<Output = Fixtur
     } = fixture.await;
 
     let metric = labels.metric(metric_name);
-
     let scrape = metrics.get("/metrics").await;
-    assert!(
-        metric.is_not_in(scrape),
-        "{metric:?} should not be in /metrics"
-    );
 
     info!("client.get(/)");
     assert_eq!(client.get("/").await, "hello");
 
-    // after seeing a request, the request count should be 1.
-    metric.value(1u64).assert_in(&metrics).await;
+    // after seeing a request, the request carry the correct labels
+    metric.assert_in(&metrics).await;
 }
 
 mod response_classification {
@@ -406,7 +395,6 @@ mod response_classification {
                             "success"
                         },
                     )
-                    .value(1u64)
                     .assert_in(&metrics)
                     .await;
             }
@@ -554,9 +542,7 @@ mod outbound_dst_labels {
         let metrics = client::http1(proxy.admin, "localhost");
 
         let client = client::new(proxy.outbound, host);
-        let tcp_labels = metrics::labels()
-            .label("direction", "outbound")
-            .label("target_addr", addr);
+        let tcp_labels = metrics::labels().label("direction", "outbound");
         let labels = tcp_labels.clone();
         let f = Fixture {
             client,
@@ -698,140 +684,6 @@ mod outbound_dst_labels {
             "response_latency_ms_count",
         ] {
             labels.metric(metric).assert_in(&metrics).await;
-        }
-    }
-
-    // XXX(ver) This test is broken and/or irrelevant. linkerd/linkerd2#751.
-    #[tokio::test]
-    #[ignore]
-    async fn controller_updates_addr_labels() {
-        let _trace = trace_init();
-        info!("running test server");
-
-        let (
-            Fixture {
-                client,
-                metrics,
-                proxy: _proxy,
-                _profile,
-                dst_tx,
-                labels,
-                ..
-            },
-            addr,
-        ) = fixture("labeled.test.svc.cluster.local").await;
-        let dst_tx = dst_tx.unwrap();
-        dst_tx.send(
-            controller::destination_add(addr)
-                .addr_label("addr_label", "foo")
-                .set_label("set_label", "unchanged"),
-        );
-
-        let labels1 = labels
-            .clone()
-            .label("dst_addr_label", "foo")
-            .label("dst_set_label", "unchanged");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-
-        // the first request should be labeled with `dst_addr_label="foo"`
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels1.metric(metric).value(1u64).assert_in(&metrics).await;
-        }
-
-        dst_tx.send(
-            controller::destination_add(addr)
-                .addr_label("addr_label", "bar")
-                .set_label("set_label", "unchanged"),
-        );
-
-        let labels2 = labels
-            .label("dst_addr_label", "bar")
-            .label("dst_set_label", "unchanged");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-
-        // the second request should increment stats labeled with `dst_addr_label="bar"`
-        // the first request should be labeled with `dst_addr_label="foo"`
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels1.metric(metric).value(1u64).assert_in(&metrics).await;
-        }
-
-        // stats recorded from the first request should still be present.
-        // the first request should be labeled with `dst_addr_label="foo"`
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels2.metric(metric).value(1u64).assert_in(&metrics).await;
-        }
-    }
-
-    // XXX(ver) This test is broken and/or irrelevant. linkerd/linkerd2#751.
-    #[ignore]
-    #[tokio::test]
-    async fn controller_updates_set_labels() {
-        let _trace = trace_init();
-        info!("running test server");
-        let (
-            Fixture {
-                client,
-                metrics,
-                proxy: _proxy,
-                _profile,
-                dst_tx,
-                labels,
-                ..
-            },
-            addr,
-        ) = fixture("labeled.test.svc.cluster.local").await;
-        let dst_tx = dst_tx.unwrap();
-        dst_tx.send(controller::destination_add(addr).set_label("set_label", "foo"));
-
-        let labels1 = labels.clone().label("dst_set_label", "foo");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // the first request should be labeled with `dst_addr_label="foo"
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels1.metric(metric).value(1u64).assert_in(&client).await;
-        }
-
-        dst_tx.send(controller::destination_add(addr).set_label("set_label", "bar"));
-        let labels2 = labels.label("dst_set_label", "bar");
-
-        info!("client.get(/)");
-        assert_eq!(client.get("/").await, "hello");
-        // the second request should increment stats labeled with `dst_addr_label="bar"`
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels2.metric(metric).value(1u64).assert_in(&metrics).await;
-        }
-        // stats recorded from the first request should still be present.
-        for &metric in &[
-            "request_total",
-            "response_total",
-            "response_latency_ms_count",
-        ] {
-            labels1.metric(metric).value(1u64).assert_in(&metrics).await;
         }
     }
 }
@@ -1337,8 +1189,7 @@ async fn metrics_compression() {
 
     let mut metric = labels
         .metric("response_latency_ms_count")
-        .label("status_code", 200)
-        .value(1u64);
+        .label("status_code", 200);
 
     for &encoding in encodings {
         assert_eventually_contains!(do_scrape(encoding).await, &metric);
@@ -1348,6 +1199,6 @@ async fn metrics_compression() {
     assert_eq!(client.get("/").await, "hello");
 
     for &encoding in encodings {
-        assert_eventually_contains!(do_scrape(encoding).await, metric.set_value(2u64));
+        assert_eventually_contains!(do_scrape(encoding).await, metric);
     }
 }

--- a/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
+++ b/linkerd/app/integration/src/tests/telemetry/tcp_errors.rs
@@ -103,8 +103,8 @@ impl Test {
     }
 }
 
-fn metric(proxy: &proxy::Listening) -> metrics::MetricMatch {
-    metrics::metric(METRIC).label("target_addr", proxy.inbound_server.as_ref().unwrap().addr)
+fn metric(_proxy: &proxy::Listening) -> metrics::MetricMatch {
+    metrics::metric(METRIC)
 }
 
 /// Tests that the detect metric is labeled and incremented on timeout.
@@ -246,7 +246,7 @@ async fn inbound_direct_multi() {
     let (proxy, metrics) = Test::new(proxy).run().await;
     let client = crate::tcp::client(proxy.inbound);
 
-    let metric = metrics::metric(METRIC).label("target_addr", proxy.inbound);
+    let metric = metrics::metric(METRIC);
     let timeout_metric = metric.clone().label("error", "tls detection timeout");
     let no_tls_metric = metric.clone().label("error", "unexpected");
 
@@ -293,8 +293,7 @@ async fn inbound_invalid_ip() {
 
     let client = crate::tcp::client(proxy.inbound);
     let metric = metric(&proxy)
-        .label("error", "unexpected")
-        .label("target_addr", fake_ip);
+        .label("error", "unexpected");
 
     let tcp_client = client.connect().await;
     tcp_client.write(TcpFixture::HELLO_MSG).await;
@@ -357,7 +356,6 @@ async fn inbound_direct_success() {
     let no_tls_client = crate::tcp::client(proxy1.inbound);
 
     let metric = metrics::metric(METRIC)
-        .label("target_addr", proxy1.inbound)
         .label("error", "tls detection timeout")
         .value(1u64);
 

--- a/linkerd/app/outbound/src/http/concrete.rs
+++ b/linkerd/app/outbound/src/http/concrete.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use linkerd_app_core::{
     config::{ConnectConfig, QueueConfig},
-    metrics::{prefix_labels, EndpointLabels, OutboundEndpointLabels, OutboundZoneLocality},
+    metrics::{prefix_outbound_endpoint_labels, EndpointLabels, OutboundEndpointLabels, OutboundZoneLocality},
     profiles,
     proxy::{
         api_resolve::{ConcreteAddr, Metadata, ProtocolHint},
@@ -219,11 +219,9 @@ where
 {
     fn param(&self) -> OutboundEndpointLabels {
         OutboundEndpointLabels {
-            authority: self.parent.param(),
-            labels: prefix_labels("dst", self.metadata.labels().iter()),
+            labels: prefix_outbound_endpoint_labels(self.metadata.labels().iter()),
             zone_locality: self.param(),
             server_id: self.param(),
-            target_addr: self.addr.into(),
         }
     }
 }

--- a/linkerd/app/outbound/src/http/endpoint/tests.rs
+++ b/linkerd/app/outbound/src/http/endpoint/tests.rs
@@ -310,11 +310,9 @@ impl svc::Param<transport::labels::Key> for Endpoint {
 impl svc::Param<metrics::OutboundEndpointLabels> for Endpoint {
     fn param(&self) -> metrics::OutboundEndpointLabels {
         metrics::OutboundEndpointLabels {
-            authority: None,
             labels: None,
             zone_locality: OutboundZoneLocality::Unknown,
             server_id: self.param(),
-            target_addr: self.addr.into(),
         }
     }
 }

--- a/linkerd/app/outbound/src/opaq/concrete.rs
+++ b/linkerd/app/outbound/src/opaq/concrete.rs
@@ -352,19 +352,10 @@ where
     T: svc::Param<Logical>,
 {
     fn param(&self) -> metrics::OutboundEndpointLabels {
-        let authority = self
-            .parent
-            .param()
-            .addr
-            .name_addr()
-            .map(|a| a.as_http_authority());
-
         metrics::OutboundEndpointLabels {
-            authority,
             labels: metrics::prefix_labels("dst", self.metadata.labels().iter()),
             zone_locality: self.param(),
             server_id: self.param(),
-            target_addr: self.addr.into(),
         }
     }
 }

--- a/linkerd/metrics/src/latency.rs
+++ b/linkerd/metrics/src/latency.rs
@@ -6,14 +6,7 @@ use super::histogram::{Bounds, Bucket, Histogram};
 /// milliseconds.
 pub const BOUNDS: &Bounds = &Bounds(&[
     Bucket::Le(1.0),
-    Bucket::Le(2.0),
-    Bucket::Le(3.0),
-    Bucket::Le(4.0),
-    Bucket::Le(5.0),
     Bucket::Le(10.0),
-    Bucket::Le(20.0),
-    Bucket::Le(30.0),
-    Bucket::Le(40.0),
     Bucket::Le(50.0),
     Bucket::Le(100.0),
     Bucket::Le(200.0),
@@ -21,15 +14,8 @@ pub const BOUNDS: &Bounds = &Bounds(&[
     Bucket::Le(400.0),
     Bucket::Le(500.0),
     Bucket::Le(1_000.0),
-    Bucket::Le(2_000.0),
-    Bucket::Le(3_000.0),
-    Bucket::Le(4_000.0),
     Bucket::Le(5_000.0),
     Bucket::Le(10_000.0),
-    Bucket::Le(20_000.0),
-    Bucket::Le(30_000.0),
-    Bucket::Le(40_000.0),
-    Bucket::Le(50_000.0),
     // A final upper bound.
     Bucket::Inf,
 ]);


### PR DESCRIPTION
# Overview

This PR attempts to update Personio's Linkerd proxy version from [v2.207.0](https://github.com/linkerd/linkerd2-proxy/releases/tag/release%2Fv2.207.0) to [v2.292.0](https://github.com/linkerd/linkerd2-proxy/releases/tag/release%2Fv2.292.0)

It mimics previous upgrade changes to reduce metric cardinality from  https://github.com/personio/linkerd2-proxy/pull/125 and https://github.com/personio/linkerd2-proxy/pull/166.