### PR TITLE
nit(http/retry): remove extra body poll in tests

### DIFF
--- a/linkerd/http/retry/src/replay/tests.rs
+++ b/linkerd/http/retry/src/replay/tests.rs
@@ -340,8 +340,6 @@ async fn eos_only_when_fully_replayed() {
         .expect("yields a frame")
         .into_data()
         .expect("yields a data frame");
-    // TODO(kate): the initial body doesn't report ending until it has (not) yielded trailers.
-    assert!(initial.frame().await.is_none());
     assert!(initial.is_end_stream());
     assert!(!replay.is_end_stream());
     drop(initial);
@@ -611,8 +609,6 @@ async fn size_hint_is_correct_across_replays() {
 
     // Read the body, check the size hint again.
     assert_eq!(chunk(&mut initial).await.as_deref(), Some(BODY));
-    // TODO(kate): the initial body doesn't report ending until it has (not) yielded trailers.
-    assert!(initial.frame().await.is_none());
     debug_assert!(initial.is_end_stream());
     // TODO(kate): this currently misreports the *remaining* size of the body.
     // let size = initial.size_hint();


### PR DESCRIPTION
the initial replay body, circa the usage of our "compatibility" layer (4b53081, #3598), used to need an extra poll to confirm the absence of trailers before it would report itself as reaching the end of the stream. these tests were added in (afda8a7b3, #3583).

this was an artifact of how the compatibility middleware masked the previous `poll_data()` and `poll_trailer()` methods behind a forward-compatible `poll_frame()`- and `frame()`-oriented interface.

this commit removes these extra calls to `initial.frame().await`, now that the initial body will report the end of stream without an extra call to await a `None`.

* #3598
* #3583