### PR TITLE
nit(app/integration): sort cargo dependencies

### DIFF
--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -23,38 +23,48 @@ h2 = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
-hyper = { workspace = true, features = [
-    "http1",
-    "http2",
-    "client",
-    "server",
-] }
 hyper-util = { workspace = true, features = ["service"] }
 ipnet = "2"
 linkerd-app = { path = "..", features = ["allow-loopback"] }
 linkerd-app-core = { path = "../core" }
-linkerd-metrics = { path = "../../metrics", features = ["test_util"] }
-linkerd2-proxy-api = { workspace = true, features = [
-    "destination",
-    "arbitrary",
-] }
 linkerd-app-test = { path = "../test" }
+linkerd-metrics = { path = "../../metrics", features = ["test_util"] }
 linkerd-tracing = { path = "../../tracing" }
 maplit = "1"
 parking_lot = "0.12"
 regex = "1"
+rustls-pemfile = "2.2"
 socket2 = "0.5"
 tokio = { version = "1", features = ["io-util", "net", "rt", "macros"] }
-tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-rustls = { workspace = true }
-rustls-pemfile = "2.2"
-tower = { workspace = true, default-features = false }
+tokio-stream = { version = "0.1", features = ["sync"] }
 tonic = { workspace = true, features = ["transport"], default-features = false }
+tower = { workspace = true, default-features = false }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", default-features = false, features = [
+
+[dependencies.hyper]
+workspace = true
+features = [
+    "client",
+    "http1",
+    "http2",
+    "server",
+]
+
+[dependencies.linkerd2-proxy-api]
+workspace = true
+features = [
+    "arbitrary",
+    "destination",
+]
+
+[dependencies.tracing-subscriber]
+version = "0.3"
+default-features = false
+features = [
     "fmt",
     "std",
-] }
+]
 
 [dev-dependencies]
 flate2 = { version = "1", default-features = false, features = [


### PR DESCRIPTION
this alphabetizes dependencies in `linkerd-app-integration`'s manifest.