### PR TITLE
Prevent panic on zero DNS negative TTL during backoff

### DIFF
--- a/linkerd/app/core/src/control.rs
+++ b/linkerd/app/core/src/control.rs
@@ -114,8 +114,10 @@ impl Config {
                 warn!(error, "Failed to resolve control-plane component");
                 if let Some(e) = crate::errors::cause_ref::<dns::ResolveError>(&*error) {
                     if let Some(ttl) = e.negative_ttl() {
+                        let min_duration = time::Duration::from_millis(100);
+                        let interval = std::cmp::max(ttl, min_duration);
                         return Ok::<_, Error>(Either::Left(
-                            IntervalStream::new(time::interval(ttl)).map(|_| ()),
+                            IntervalStream::new(time::interval(interval)).map(|_| ()),
                         ));
                     }
                 }


### PR DESCRIPTION
This change addresses a panic that can occur in the control plane client's DNS resolution backoff logic within `linkerd/app/core/src/control.rs`.

**Problem:**

When resolving the control plane address, if a `dns::ResolveError` occurs and provides a negative TTL via `negative_ttl()`, this TTL is used to schedule the next resolution attempt using `tokio::time::interval(ttl)`.

However, if the `negative_ttl()` returns `Some(Duration::ZERO)`, passing a zero duration to `time::interval` causes a panic:
```
thread 'main' panicked at linkerd/app/core/src/control.rs:87:49:
`period` must be non-zero.
   0:     0x563f974dd323 - <unknown>
   1:     0x563f9680ed2c - <unknown>
   2:     0x563f974b030d - <unknown>
   3:     0x563f974de99e - <unknown>
   4:     0x563f974de564 - <unknown>
   5:     0x563f974df5c5 - <unknown>
   6:     0x563f974eecc9 - <unknown>
   7:     0x563f974eec96 - <unknown>
   8:     0x563f96737dfa - <unknown>
   9:     0x563f974f116c - <unknown>
  10:     0x563f97233597 - <unknown>
  11:     0x563f9715cc1a - <unknown>
  12:     0x563f9727a651 - <unknown>
  13:     0x563f971a91af - <unknown>
  14:     0x563f96c5a01c - <unknown>
  15:     0x563f967902b3 - <unknown>
  16:     0x563f96c56ba5 - <unknown>
  17:     0x7fc1ccd2624a - <unknown>
  18:     0x7fc1ccd26305 - __libc_start_main
  19:     0x563f9674f711 - <unknown>
  20:                0x0 - <unknown>
  ```
  
This panic was observed in production environments, particularly during restarts or issues with the `linkerd-destination` service. When the proxy sidecar panicked due to this error, it resulted in service unavailability for meshed applications, requiring manual restarts of deployments to recover connectivity.

**Solution:**

This commit introduces a minimum backoff duration (`min_duration` = 100ms) for cases where a negative TTL is provided by the DNS resolver. It uses `std::cmp::max(ttl, min_duration)` to ensure that the duration passed to `time::interval` is never zero.

This prevents the panic and ensures the proxy gracefully handles zero TTLs by applying a minimal delay before the next resolution attempt, improving resilience during control plane discovery issues.
