### PR TITLE
refactor(app/outbound): `Connect` fields are not pub

### DIFF
--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -8,8 +8,8 @@ use std::task::{Context, Poll};
 
 #[derive(Clone, Debug)]
 pub struct Connect {
-    pub addr: Remote<ServerAddr>,
-    pub tls: tls::ConditionalClientTls,
+    addr: Remote<ServerAddr>,
+    tls: tls::ConditionalClientTls,
 }
 
 /// Prevents outbound connections on the loopback interface, unless the
@@ -77,6 +77,12 @@ where
 
 // === impl Connect ===
 
+impl Connect {
+    pub fn new(addr: Remote<ServerAddr>, tls: tls::ConditionalClientTls) -> Self {
+        Self { addr, tls }
+    }
+}
+
 impl svc::Param<Remote<ServerAddr>> for Connect {
     fn param(&self) -> Remote<ServerAddr> {
         self.addr
@@ -86,5 +92,16 @@ impl svc::Param<Remote<ServerAddr>> for Connect {
 impl svc::Param<tls::ConditionalClientTls> for Connect {
     fn param(&self) -> tls::ConditionalClientTls {
         self.tls.clone()
+    }
+}
+
+#[cfg(test)]
+impl Connect {
+    pub fn addr(&self) -> &Remote<ServerAddr> {
+        &self.addr
+    }
+
+    pub fn tls(&self) -> &tls::ConditionalClientTls {
+        &self.tls
     }
 }


### PR DESCRIPTION
this structure exposes its fields, but those fields are never accessed
elsewhere, aside from test code.

this commit removes the `pub` directives from the address and tls
fields. in their stead, test interfaces are added to allow the
`tagged_transport` test suite to function.