### PR TITLE
refactor(proxy/http): a concrete `orig_proto` error

### DIFF
--- a/linkerd/proxy/http/src/client.rs
+++ b/linkerd/proxy/http/src/client.rs
@@ -135,7 +135,7 @@ where
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<()>> {
         match self {
             Self::H2(ref mut svc) => svc.poll_ready(cx).map_err(Into::into),
-            Self::OrigProtoUpgrade(ref mut svc) => svc.poll_ready(cx),
+            Self::OrigProtoUpgrade(ref mut svc) => svc.poll_ready(cx).map_err(Into::into),
             Self::Http1(ref mut svc) => svc.poll_ready(cx),
         }
     }
@@ -156,7 +156,7 @@ where
 
             match self {
                 Self::Http1(ref mut svc) => svc.call(req),
-                Self::OrigProtoUpgrade(ref mut svc) => svc.call(req),
+                Self::OrigProtoUpgrade(ref mut svc) => svc.call(req).map_err(Into::into).boxed(),
                 Self::H2(ref mut svc) => Box::pin(
                     svc.call(req)
                         .err_into::<Error>()


### PR DESCRIPTION
this commit introduces a concrete error type for the `orig_proto` upgrade layer.

this layer is used by the proxy's http client to transparently upgrade outbound http/1 traffic to http/2. rather than boxing errors, we define a concrete error type to facilitate inspecting errors in the future.

for now, the top-level http client continues to box errors thrown by the "orig_proto" upgrade client.

**nb:** this is based upon #3894.