### PR TITLE
fix: report error causes properly

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -83,8 +83,8 @@ pub enum ParseError {
     ),
     #[error("not a valid port range")]
     NotAPortRange,
-    #[error(transparent)]
-    AddrError(addr::Error),
+    #[error("{0}")]
+    AddrError(#[source] addr::Error),
     #[error("only two addresses are supported")]
     TooManyAddrs,
     #[error("not a valid identity name")]

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -252,7 +252,7 @@ impl Metrics {
 
 #[cfg(test)]
 mod tests {
-    use super::{Name, Resolver, Suffix};
+    use super::{InvalidSrv, Name, Resolver, SrvRecordError, Suffix};
     use hickory_resolver::proto::rr::{domain, rdata};
     use std::{net, str::FromStr};
 
@@ -392,6 +392,20 @@ mod tests {
             let socket = Resolver::srv_to_socket_addr(srv).unwrap();
             assert_eq!(socket.ip(), net::IpAddr::from_str(case.output).unwrap());
         }
+    }
+
+    #[test]
+    fn srv_record_reports_cause_correctly() {
+        let srv = "foobar.linkerd-dst-headless.linkerd.svc.cluster.local."
+            .parse::<hickory_resolver::Name>()
+            .map(|name| rdata::SRV::new(1, 1, 8086, name))
+            .expect("a valid domain name");
+
+        let error = SrvRecordError::Invalid(InvalidSrv(srv));
+        let error: Box<dyn std::error::Error + 'static> = Box::new(error);
+
+        assert!(linkerd_error::is_caused_by::<InvalidSrv>(&*error));
+        assert!(linkerd_error::cause_ref::<InvalidSrv>(&*error).is_some());
     }
 }
 

--- a/linkerd/dns/src/lib.rs
+++ b/linkerd/dns/src/lib.rs
@@ -43,7 +43,7 @@ struct ARecordError(#[from] hickory_resolver::ResolveError);
 
 #[derive(Debug, Error)]
 enum SrvRecordError {
-    #[error(transparent)]
+    #[error("{0}")]
     Invalid(#[from] InvalidSrv),
     #[error("failed to resolve SRV record: {0}")]
     Resolve(#[from] hickory_resolver::ResolveError),

--- a/linkerd/meshtls/rustls/src/creds.rs
+++ b/linkerd/meshtls/rustls/src/creds.rs
@@ -16,8 +16,8 @@ use tokio_rustls::rustls::{self, crypto::CryptoProvider};
 use tracing::warn;
 
 #[derive(Debug, Error)]
-#[error(transparent)]
-pub struct InvalidKey(KeyRejected);
+#[error("{0}")]
+pub struct InvalidKey(#[source] KeyRejected);
 
 #[derive(Debug, Error)]
 #[error("invalid trust roots")]

--- a/linkerd/proxy/client-policy/src/http.rs
+++ b/linkerd/proxy/client-policy/src/http.rs
@@ -162,10 +162,10 @@ pub mod proto {
         #[error("missing {0}")]
         Missing(&'static str),
 
-        #[error(transparent)]
+        #[error("{0}")]
         Timeout(#[from] InvalidTimeouts),
 
-        #[error(transparent)]
+        #[error("{0}")]
         Retry(#[from] InvalidRetry),
     }
 

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -427,7 +427,7 @@ pub mod proto {
 
     #[derive(Debug, thiserror::Error)]
     pub enum InvalidBackoff {
-        #[error(transparent)]
+        #[error("{0}")]
         Backoff(#[from] linkerd_exp_backoff::InvalidBackoff),
         #[error("invalid duration: {0}")]
         Duration(#[from] prost_types::DurationError),


### PR DESCRIPTION
the `linkerd-error` crate includes two functions that can be used to
examine the cause of a dynamic, boxed error. for example, here is the
`is_caused_by()` function, used in some of our error recovery logic:

```rust
/// Determines whether the provided error was caused by an `E` typed error.
pub fn is_caused_by<E: std::error::Error + 'static>(
    mut error: &(dyn std::error::Error + 'static),
) -> bool {
    loop {
        if error.is::<E>() {
            return true;
        }
        error = match error.source() {
            Some(e) => e,
            None => return false,
        };
    }
}
```

we rely on [`thiserror`](https://github.com/dtolnay/thiserror/) to
generate boilerplate code for our error structures. this includes an
attribute called `transparent` that will delegate down to an inner
error.

however, this delegation means that the causal chains inspected by
the function above might not properly identify an inner error. this
test, for example, fails:

```rust
// linkerd/dns/src/lib.rs
#[derive(Debug, Clone, Error)]
#[error("invalid SRV record {:?}", self.0)]
struct InvalidSrv(rdata::SRV);

#[derive(Debug, Error)]
enum SrvRecordError {
    #[error(transparent)]
    Invalid(#[from] InvalidSrv),
    #[error("failed to resolve SRV record: {0}")]
    Resolve(#[from] hickory_resolver::ResolveError),
}

#[test]
fn srv_record_reports_cause_correctly() {
    let srv = "foobar.linkerd-dst-headless.linkerd.svc.cluster.local."
        .parse::<hickory_resolver::Name>()
        .map(|name| rdata::SRV::new(1, 1, 8086, name))
        .expect("a valid domain name");

    let error = SrvRecordError::Invalid(InvalidSrv(srv));
    let error: Box<dyn std::error::Error + 'static> = Box::new(error);

    assert!(linkerd_error::is_caused_by::<InvalidSrv>(&*error));
    assert!(linkerd_error::cause_ref::<InvalidSrv>(&*error).is_some());
}
```

the `transparent` attribute will delegate directly down to `InvalidSrv`
when `Error::source()` is invoked. this means that our downcasting logic
in `linkerd-error` used to ascertain causes of dynamic, boxed errors
will fail to identify a `SrvRecordError` as being caused by an
`InvalidSrv`.

by replacing the `transparent` attribute with a `"{0}"` display
attribute, we continue to transparently show the inner error when
printed as a string, but will include `InvalidSrv` in the causal chain.

this branch replaces `transparent` attributes in an assortment of
error variants.