### PR TITLE
nit(app): consolidate `impl Config` blocks

### DIFF
--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -83,13 +83,13 @@ pub struct App {
     tap: tap::Tap,
 }
 
+// === impl Config ===
+
 impl Config {
     pub fn try_from_env() -> Result<Self, env::EnvError> {
         env::Env.try_config()
     }
-}
 
-impl Config {
     /// Build an application.
     ///
     /// It is currently required that this be run on a Tokio runtime, since some
@@ -357,6 +357,8 @@ impl Config {
         }
     }
 }
+
+// === impl App ===
 
 impl App {
     pub fn admin_addr(&self) -> Local<ServerAddr> {


### PR DESCRIPTION
this is a trivial, cosmetic change.

`Config` has two consecutive `impl` blocks in the `linkerd-app` library. these do not include distinct generics or trait bounds, so the methods contained therein do not need to live in two distinct `impl` blocks.

this commit consolidates these blocks.

while we are performing this change, we add two `=== impl T ===` banners, which are used throughout the project as greppable strings to find methods and trait implementations for a given type.