### PR TITLE
chore(meshtls/boring): sort dependencies

### DIFF
--- a/linkerd/meshtls/boring/Cargo.toml
+++ b/linkerd/meshtls/boring/Cargo.toml
@@ -10,17 +10,17 @@ publish = { workspace = true }
 boring = "4"
 futures = { version = "0.3", default-features = false }
 hex = "0.4"                                             # used for debug logging
-linkerd-error = { path = "../../error" }
-linkerd-dns-name = { path = "../../dns/name" }
-linkerd-identity = { path = "../../identity" }
-linkerd-io = { path = "../../io" }
-linkerd-stack = { path = "../../stack" }
-linkerd-tls = { path = "../../tls" }
-linkerd-meshtls-verifier = { path = "../verifier" }
-
 tokio = { version = "1", features = ["macros", "sync"] }
 tokio-boring = "4"
 tracing = { workspace = true }
+
+linkerd-dns-name = { path = "../../dns/name" }
+linkerd-error = { path = "../../error" }
+linkerd-identity = { path = "../../identity" }
+linkerd-io = { path = "../../io" }
+linkerd-meshtls-verifier = { path = "../verifier" }
+linkerd-stack = { path = "../../stack" }
+linkerd-tls = { path = "../../tls" }
 
 [features]
 fips = ["boring/fips"]


### PR DESCRIPTION
i noticed while examining how our meshtls feature flags interact that these dependencies are not sorted. this runs `:sort` across the dependencies listed in `linkerd-meshtls-boring`'s package manifest.