### PR TITLE
chore(app/test): remove unused functions

### DIFF
--- a/linkerd/app/test/src/lib.rs
+++ b/linkerd/app/test/src/lib.rs
@@ -34,15 +34,6 @@ pub fn resolver<E>() -> resolver::Dst<E> {
     resolver::Resolver::default()
 }
 
-pub fn profiles() -> resolver::Profiles {
-    profile::resolver()
-}
-
-#[cfg(feature = "client-policy")]
-pub fn client_policies() -> resolver::ClientPolicies {
-    resolver::Resolver::default()
-}
-
 pub fn connect<E>() -> connect::Connect<E> {
     connect::Connect::default()
 }


### PR DESCRIPTION
`linkerd-app-test` exposes some functions that we never use elsewhere.

this commit removes these functions.