### PR TITLE
chore(app/test): remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,6 @@ name = "linkerd-app-test"
 version = "0.1.0"
 dependencies = [
  "futures",
- "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -1739,12 +1738,10 @@ dependencies = [
  "hyper-util",
  "linkerd-app-core",
  "linkerd-http-route",
- "linkerd-identity",
  "linkerd-io",
  "linkerd-proxy-client-policy",
  "parking_lot",
  "pin-project",
- "regex",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",

--- a/linkerd/app/test/Cargo.toml
+++ b/linkerd/app/test/Cargo.toml
@@ -14,7 +14,6 @@ client-policy = ["linkerd-proxy-client-policy", "tonic", "linkerd-http-route"]
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-h2 = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
@@ -22,12 +21,10 @@ hyper = { workspace = true, features = ["http1", "http2"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 linkerd-app-core = { path = "../core" }
 linkerd-http-route = { path = "../../http/route", optional = true }
-linkerd-identity = { path = "../../identity" }
 linkerd-proxy-client-policy = { path = "../../proxy/client-policy", optional = true }
 linkerd-io = { path = "../../io", features = ["tokio-test"] }
 parking_lot = "0.12"
 pin-project = "1"
-regex = "1"
 tokio = { version = "1", features = ["io-util", "net", "rt", "sync"] }
 tokio-test = "0.4"
 tokio-stream = { version = "0.1", features = ["sync"] }


### PR DESCRIPTION
`linkerd-app-test` relies on some dependencies that are unused.

this commit removes these dependencies from the crate's manifest.

see #3928 and #3929.