### PR TITLE
fix(http/retry): `PeekTrailersBody<B>` retains first frame

### DIFF
--- a/linkerd/http/retry/src/peek_trailers.rs
+++ b/linkerd/http/retry/src/peek_trailers.rs
@@ -182,7 +182,7 @@ impl<B: Body> PeekTrailersBody<B> {
                         },
                         // The body yielded an unknown kind of frame.
                         Some(Ok(None)) => Inner::Buffered {
-                            first: None,
+                            first: Some(Ok(first)),
                             second: None,
                             inner: body,
                         },
@@ -192,7 +192,7 @@ impl<B: Body> PeekTrailersBody<B> {
                     // that a second DATA frame is on the way, and we are no longer willing to
                     // await additional frames. There are no trailers to peek.
                     Inner::Buffered {
-                        first: None,
+                        first: Some(Ok(first)),
                         second: None,
                         inner: body,
                     }


### PR DESCRIPTION
see linkerd/linkerd2#14050.

this change fixes a logical bug with
`linkerd_http_retry::peek_trailers::PeekTrailersBody::<B>::read_body(..)`.

`read_body(..)` constructs a `PeekTrailersBody<B>`, by polling the inner
body to see whether or not it can reach the end of the stream by only
yielding to the asynchronous runtime once.

in linkerd/linkerd2-proxy#3559, we restructured this middleware's
internal modeling to reflect the `Frame<T>`-oriented signatures of the
`http_body::Body` trait's 1.0 interface.

unfortunately, this included a bug which could cause the first frame in
a stream to be discarded if the second `Body::poll_frame()` call
(_invoked via `now_or_never()`_) returns `Pending`. this could cause
non-deterministic errors for users when sending traffic to HTTPRoutes
and GRPCRoutes with retry annotations applied.

this change rectifies this problem, ensuring that the first frame is not
discarded when attempting to peek a body's trailers.

to confirm that this works as expected, additional test coverage is
introduced that confirms that the data and trailers of the inner body
are passed through faithfully.