### PR TITLE
fix(errno): comment typo in errno list

### DIFF
--- a/linkerd/errno/src/lib.rs
+++ b/linkerd/errno/src/lib.rs
@@ -78,7 +78,7 @@ mod code {
             15 => ENOTBLK,          // Block device required
             16 => EBUSY,            // Device or resource busy
             17 => EEXIST,           // File exists
-            18 => EXDEV,            // Cross-device linkgit pus
+            18 => EXDEV,            // Cross-device link
             19 => ENODEV,           // No such device
             20 => ENOTDIR,          // Not a directory
             21 => EISDIR,           // Is a directory


### PR DESCRIPTION
## Summary
- fix typo in errno doc comment

## Testing
- `cargo check -p linkerd-errno`
- `cargo test -p linkerd-errno`


------
https://chatgpt.com/codex/tasks/task_e_68408fffcd5c8320b2f27a9a33a6ae3c