### PR TITLE
fix(proxy/http): remove http/1 header read timeout

### DIFF
--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -112,7 +112,9 @@ where
         }
 
         let mut http1 = hyper::server::conn::http1::Builder::new();
-        http1.timer(hyper_util::rt::TokioTimer::new());
+        http1
+            .header_read_timeout(None)
+            .timer(hyper_util::rt::TokioTimer::new());
 
         debug!(?version, "Creating HTTP service");
         let inner = self.inner.new_service(target);


### PR DESCRIPTION
this fixes #14131. this relates to #14147, though it does not introduce a configurable option for this timeout.

 ### ✨ background

in hyper 0.14, http/1.1 connections had no default header read timeout. per the documentation for [`hyper::server::Builder::http1_header_read_timeout()`][read-timeout-previous]:

> Set a timeout for reading client request headers. If a client does not transmit the entire header within this time, the connection is closed.
>
> Default is None.

compare this with the latest hyper release, which enforces a 30 second timeout for http/1.1 connections. per the documentation for [`hyper::server::conn::http1::Builder::header_read_timeout`][read-timeout-current]:

> Set a timeout for reading client request headers. If a client does not transmit the entire header within this time, the connection is closed.
>
> Requires a [Timer](https://docs.rs/hyper/latest/hyper/rt/trait.Timer.html) set by [Builder::timer](https://docs.rs/hyper/latest/hyper/server/conn/http1/struct.Builder.html#method.timer) to take effect. Panics if header_read_timeout is configured without a [Timer](https://docs.rs/hyper/latest/hyper/rt/trait.Timer.html).
>
> Pass None to disable.
>
> Default is 30 seconds.

this was changed in hyperium/hyper#3395, which was included in [the v1.0 release][v1-changelog].

[read-timeout-previous]: https://docs.rs/hyper/0.14.31/hyper/server/struct.Builder.html#method.http1_header_read_timeout
[read-timeout-current]: https://docs.rs/hyper/latest/hyper/server/conn/http1/struct.Builder.html#method.header_read_timeout
[v1-changelog]: https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v100-2023-11-15

 ### 🔨 changes

this commit passes `None` to the `linkerd-proxy-http::server::ServeHttp` type's http/1 server-side connection builder, to remove the header read timeout. this restores the behavior that existed prior to linkerd/linkerd2#8733, which upgraded our hyper dependency from 0.14 to 1.0.

* https://github.com/linkerd/linkerd2/issues/14147
* https://github.com/linkerd/linkerd2/issues/14131
* https://github.com/linkerd/linkerd2/issues/8733
* https://github.com/hyperium/hyper/issues/3395