### PR TITLE
refactor: `FmtLabels` impls use exhaustive bindings

### DIFF
--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -525,7 +525,13 @@ impl StackLabels {
 
 impl FmtLabels for StackLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.direction.fmt_labels(f)?;
-        write!(f, ",protocol=\"{}\",name=\"{}\"", self.protocol, self.name)
+        let Self {
+            direction,
+            protocol,
+            name,
+        } = self;
+
+        direction.fmt_labels(f)?;
+        write!(f, ",protocol=\"{}\",name=\"{}\"", protocol, name)
     }
 }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -391,13 +391,15 @@ impl FmtLabels for ServerAuthzLabels {
 
 impl FmtLabels for RouteLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.server.fmt_labels(f)?;
+        let Self { server, route } = self;
+
+        server.fmt_labels(f)?;
         write!(
             f,
             ",route_group=\"{}\",route_kind=\"{}\",route_name=\"{}\"",
-            self.route.group(),
-            self.route.kind(),
-            self.route.name(),
+            route.group(),
+            route.kind(),
+            route.name(),
         )
     }
 }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -431,7 +431,8 @@ impl FmtLabels for OutboundEndpointLabels {
             server_id,
             authority,
             labels,
-            zone_locality,
+            // TODO(kate): this label is not currently emitted.
+            zone_locality: _,
             target_addr,
         } = self;
 

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -283,10 +283,16 @@ impl ProfileRouteLabels {
 
 impl FmtLabels for ProfileRouteLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.direction.fmt_labels(f)?;
-        write!(f, ",dst=\"{}\"", self.addr)?;
+        let Self {
+            direction,
+            addr,
+            labels,
+        } = self;
 
-        if let Some(labels) = self.labels.as_ref() {
+        direction.fmt_labels(f)?;
+        write!(f, ",dst=\"{}\"", addr)?;
+
+        if let Some(labels) = labels.as_ref() {
             write!(f, ",{}", labels)?;
         }
 

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -325,16 +325,19 @@ impl FmtLabels for EndpointLabels {
 
 impl FmtLabels for InboundEndpointLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(a) = self.authority.as_ref() {
+        let Self {
+            tls,
+            authority,
+            target_addr,
+            policy,
+        } = self;
+
+        if let Some(a) = authority.as_ref() {
             Authority(a).fmt_labels(f)?;
             write!(f, ",")?;
         }
 
-        (
-            (TargetAddr(self.target_addr), TlsAccept::from(&self.tls)),
-            &self.policy,
-        )
-            .fmt_labels(f)?;
+        ((TargetAddr(*target_addr), TlsAccept::from(tls)), policy).fmt_labels(f)?;
 
         Ok(())
     }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -469,7 +469,8 @@ impl FmtLabels for Direction {
 
 impl FmtLabels for Authority<'_> {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "authority=\"{}\"", self.0)
+        let Self(authority) = self;
+        write!(f, "authority=\"{}\"", authority)
     }
 }
 

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -250,8 +250,10 @@ impl svc::Param<ControlLabels> for control::ControlAddr {
 
 impl FmtLabels for ControlLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "addr=\"{}\",", self.addr)?;
-        TlsConnect::from(&self.server_id).fmt_labels(f)?;
+        let Self { addr, server_id } = self;
+
+        write!(f, "addr=\"{}\",", addr)?;
+        TlsConnect::from(server_id).fmt_labels(f)?;
 
         Ok(())
     }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -376,13 +376,15 @@ impl prom::EncodeLabelSetMut for ServerLabel {
 
 impl FmtLabels for ServerAuthzLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.server.fmt_labels(f)?;
+        let Self { server, authz } = self;
+
+        server.fmt_labels(f)?;
         write!(
             f,
             ",authz_group=\"{}\",authz_kind=\"{}\",authz_name=\"{}\"",
-            self.authz.group(),
-            self.authz.kind(),
-            self.authz.name()
+            authz.group(),
+            authz.kind(),
+            authz.name()
         )
     }
 }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -427,16 +427,24 @@ impl svc::Param<OutboundZoneLocality> for OutboundEndpointLabels {
 
 impl FmtLabels for OutboundEndpointLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if let Some(a) = self.authority.as_ref() {
+        let Self {
+            server_id,
+            authority,
+            labels,
+            zone_locality,
+            target_addr,
+        } = self;
+
+        if let Some(a) = authority.as_ref() {
             Authority(a).fmt_labels(f)?;
             write!(f, ",")?;
         }
 
-        let ta = TargetAddr(self.target_addr);
-        let tls = TlsConnect::from(&self.server_id);
+        let ta = TargetAddr(*target_addr);
+        let tls = TlsConnect::from(server_id);
         (ta, tls).fmt_labels(f)?;
 
-        if let Some(labels) = self.labels.as_ref() {
+        if let Some(labels) = labels.as_ref() {
             write!(f, ",{}", labels)?;
         }
 

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -345,13 +345,14 @@ impl FmtLabels for InboundEndpointLabels {
 
 impl FmtLabels for ServerLabel {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self(meta, port) = self;
         write!(
             f,
             "srv_group=\"{}\",srv_kind=\"{}\",srv_name=\"{}\",srv_port=\"{}\"",
-            self.0.group(),
-            self.0.kind(),
-            self.0.name(),
-            self.1
+            meta.group(),
+            meta.kind(),
+            meta.name(),
+            port
         )
     }
 }

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -406,13 +406,15 @@ impl FmtLabels for RouteLabels {
 
 impl FmtLabels for RouteAuthzLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.route.fmt_labels(f)?;
+        let Self { route, authz } = self;
+
+        route.fmt_labels(f)?;
         write!(
             f,
             ",authz_group=\"{}\",authz_kind=\"{}\",authz_name=\"{}\"",
-            self.authz.group(),
-            self.authz.kind(),
-            self.authz.name(),
+            authz.group(),
+            authz.kind(),
+            authz.name(),
         )
     }
 }

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -125,7 +125,8 @@ impl<'t> From<&'t tls::ConditionalServerTlsLabels> for TlsAccept<'t> {
 
 impl FmtLabels for TlsAccept<'_> {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
+        let Self(tls) = self;
+        match tls {
             Conditional::None(tls::NoServerTls::Disabled) => {
                 write!(f, "tls=\"disabled\"")
             }

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -174,12 +174,13 @@ impl FmtLabels for TlsConnect<'_> {
 
 impl FmtLabels for TargetAddr {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self(target_addr) = self;
         write!(
             f,
             "target_addr=\"{}\",target_ip=\"{}\",target_port=\"{}\"",
-            self.0,
-            self.0.ip(),
-            self.0.port()
+            target_addr,
+            target_addr.ip(),
+            target_addr.port()
         )
     }
 }

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -99,14 +99,17 @@ impl ServerLabels {
 
 impl FmtLabels for ServerLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.direction.fmt_labels(f)?;
+        let Self {
+            direction,
+            tls,
+            target_addr,
+            policy,
+        } = self;
+
+        direction.fmt_labels(f)?;
         f.write_str(",peer=\"src\",")?;
 
-        (
-            (TargetAddr(self.target_addr), TlsAccept(&self.tls)),
-            self.policy.as_ref(),
-        )
-            .fmt_labels(f)?;
+        ((TargetAddr(*target_addr), TlsAccept(tls)), policy.as_ref()).fmt_labels(f)?;
 
         Ok(())
     }

--- a/linkerd/app/inbound/src/metrics/authz.rs
+++ b/linkerd/app/inbound/src/metrics/authz.rs
@@ -251,18 +251,24 @@ impl FmtMetrics for TcpAuthzMetrics {
 
 impl FmtLabels for HTTPLocalRateLimitLabels {
     fn fmt_labels(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.server.fmt_labels(f)?;
-        if let Some(rl) = &self.rate_limit {
+        let Self {
+            server,
+            rate_limit,
+            scope,
+        } = self;
+
+        server.fmt_labels(f)?;
+        if let Some(rl) = rate_limit {
             write!(
                 f,
                 ",ratelimit_group=\"{}\",ratelimit_kind=\"{}\",ratelimit_name=\"{}\",ratelimit_scope=\"{}\"",
                 rl.group(),
                 rl.kind(),
                 rl.name(),
-                self.scope,
+                scope,
             )
         } else {
-            write!(f, ",ratelimit_scope=\"{}\"", self.scope)
+            write!(f, ",ratelimit_scope=\"{}\"", scope)
         }
     }
 }

--- a/linkerd/app/inbound/src/metrics/authz.rs
+++ b/linkerd/app/inbound/src/metrics/authz.rs
@@ -287,7 +287,13 @@ impl<L> Key<L> {
 
 impl<L: FmtLabels> FmtLabels for Key<L> {
     fn fmt_labels(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        (self.target, (&self.labels, TlsAccept(&self.tls))).fmt_labels(f)
+        let Self {
+            target,
+            tls,
+            labels,
+        } = self;
+
+        (target, (labels, TlsAccept(tls))).fmt_labels(f)
     }
 }
 

--- a/linkerd/http/metrics/src/requests/report.rs
+++ b/linkerd/http/metrics/src/requests/report.rs
@@ -146,6 +146,7 @@ where
 
 impl FmtLabels for Status {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "status_code=\"{}\"", self.0.as_u16())
+        let Self(status) = self;
+        write!(f, "status_code=\"{}\"", status.as_u16())
     }
 }

--- a/linkerd/metrics/src/fmt.rs
+++ b/linkerd/metrics/src/fmt.rs
@@ -208,8 +208,10 @@ impl<M: FmtMetrics> FmtMetrics for Option<M> {
 impl<A: FmtMetrics, B: FmtMetrics> FmtMetrics for AndThen<A, B> {
     #[inline]
     fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt_metrics(f)?;
-        self.1.fmt_metrics(f)?;
+        let Self(a, b) = self;
+
+        a.fmt_metrics(f)?;
+        b.fmt_metrics(f)?;
 
         Ok(())
     }

--- a/linkerd/metrics/src/fmt.rs
+++ b/linkerd/metrics/src/fmt.rs
@@ -188,8 +188,6 @@ impl<A: FmtLabels, B: FmtLabels> FmtLabels for (Option<A>, B) {
     }
 }
 
-// === impl FmtMetrics ===
-
 impl<'a, A: FmtMetrics + 'a> FmtMetrics for &'a A {
     #[inline]
     fn fmt_metrics(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/linkerd/metrics/src/histogram.rs
+++ b/linkerd/metrics/src/histogram.rs
@@ -224,7 +224,8 @@ impl<V: Into<u64>, F: Factor> FmtMetric for Histogram<V, F> {
 
 impl<K: fmt::Display, V: fmt::Display> FmtLabels for Label<K, V> {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}=\"{}\"", self.0, self.1)
+        let Self(k, v) = self;
+        write!(f, "{}=\"{}\"", k, v)
     }
 }
 

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -82,7 +82,8 @@ impl<K: Eq + Hash + FmtLabels> Registry<K> {
 
 impl FmtLabels for Eos {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.0 {
+        let Self(errno) = self;
+        match errno {
             None => f.pad("errno=\"\""),
             Some(errno) => write!(f, "errno=\"{}\"", errno),
         }


### PR DESCRIPTION
this is based on #3987.