### PR TITLE
feat(meshtls): Include AES_256_GCM as a supported ciphersuite

### DIFF
--- a/linkerd/meshtls/rustls/src/backend/aws_lc.rs
+++ b/linkerd/meshtls/rustls/src/backend/aws_lc.rs
@@ -4,8 +4,19 @@ use tokio_rustls::rustls::{
     crypto::{aws_lc_rs, WebPkiSupportedAlgorithms},
 };
 
-pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] =
-    &[rustls::crypto::aws_lc_rs::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256];
+#[cfg(not(feature = "aws-lc-fips"))]
+pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] = &[
+    aws_lc_rs::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+    aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
+    aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
+];
+// Prefer aes-256-gcm if fips is enabled, with chaha20-poly1305 as a fallback
+#[cfg(feature = "aws-lc-fips")]
+pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] = &[
+    aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
+    aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
+    aws_lc_rs::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+];
 pub static SUPPORTED_SIG_ALGS: &WebPkiSupportedAlgorithms = &WebPkiSupportedAlgorithms {
     all: &[
         webpki::aws_lc_rs::ECDSA_P256_SHA256,

--- a/linkerd/meshtls/rustls/src/backend/ring.rs
+++ b/linkerd/meshtls/rustls/src/backend/ring.rs
@@ -4,8 +4,11 @@ use tokio_rustls::rustls::{
     crypto::{ring, WebPkiSupportedAlgorithms},
 };
 
-pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] =
-    &[rustls::crypto::ring::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256];
+pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] = &[
+    ring::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+    ring::cipher_suite::TLS13_AES_128_GCM_SHA256,
+    ring::cipher_suite::TLS13_AES_256_GCM_SHA384,
+];
 // A subset of the algorithms supported by rustls+ring, imported from
 // https://github.com/rustls/rustls/blob/v/0.23.21/rustls/src/crypto/ring/mod.rs#L107
 pub static SUPPORTED_SIG_ALGS: &WebPkiSupportedAlgorithms = &WebPkiSupportedAlgorithms {


### PR DESCRIPTION
This is a strong ciphersuite that's reasonable to include as a supported option. We still prefer CHACHA20_POLY1305 in non-FIPS modes for its speed, as well as keeping CHACHA20_POLY1305 as a backup for older proxies that only support it.