### PR TITLE
chore(linkerd2-proxy): enable meshtls-rustls-aws-lc by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,6 @@ prost = { version = "0.13" }
 prost-build = { version = "0.13", default-features = false }
 prost-types = { version = "0.13" }
 tokio-rustls = { version = "0.26", default-features = false, features = [
-    "ring",
     "logging",
 ] }
 tonic = { version = "0.12", default-features = false }

--- a/linkerd/meshtls/rustls/Cargo.toml
+++ b/linkerd/meshtls/rustls/Cargo.toml
@@ -7,17 +7,18 @@ edition = "2018"
 publish = { workspace = true }
 
 [features]
-default = ["ring"]
-ring = ["tokio-rustls/ring", "rustls-webpki/ring"]
+ring = ["tokio-rustls/ring", "rustls-webpki/ring", "dep:ring"]
 aws-lc = ["tokio-rustls/aws-lc-rs", "rustls-webpki/aws-lc-rs"]
 aws-lc-fips = ["aws-lc", "tokio-rustls/fips"]
 test-util = ["linkerd-tls-test-util"]
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-ring = { version = "0.17", features = ["std"] }
+ring = { version = "0.17", features = ["std"], optional = true }
 rustls-pemfile = "2.2"
-rustls-webpki = { version = "0.103.1", default-features = false, features = ["std"] }
+rustls-webpki = { version = "0.103.1", default-features = false, features = [
+    "std",
+] }
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "rt", "sync"] }
 tokio-rustls = { workspace = true }

--- a/linkerd/meshtls/rustls/src/backend.rs
+++ b/linkerd/meshtls/rustls/src/backend.rs
@@ -1,3 +1,11 @@
+#[cfg(not(any(feature = "aws-lc", feature = "ring")))]
+compile_error!("No rustls backend enabled. Enabled one of the \"ring\" or \"aws-lc\" features");
+
+#[cfg(all(feature = "aws-lc", feature = "ring"))]
+compile_error!(
+    "Both \"aws-lc\" and \"ring\" features are enabled. Please enable only one of them."
+);
+
 #[cfg(feature = "aws-lc")]
 mod aws_lc;
 #[cfg(feature = "ring")]
@@ -5,7 +13,5 @@ mod ring;
 
 #[cfg(feature = "aws-lc")]
 pub use aws_lc::{default_provider, SUPPORTED_SIG_ALGS, TLS_SUPPORTED_CIPHERSUITES};
-#[cfg(all(not(feature = "aws-lc"), feature = "ring"))]
+#[cfg(feature = "ring")]
 pub use ring::{default_provider, SUPPORTED_SIG_ALGS, TLS_SUPPORTED_CIPHERSUITES};
-#[cfg(all(not(feature = "aws-lc"), not(feature = "ring")))]
-compile_error!("No rustls backend enabled. Enabled one of the \"ring\" or \"aws-lc\" features");

--- a/linkerd/meshtls/rustls/src/creds.rs
+++ b/linkerd/meshtls/rustls/src/creds.rs
@@ -8,16 +8,11 @@ pub use self::{receiver::Receiver, store::Store};
 use linkerd_dns_name as dns;
 use linkerd_error::Result;
 use linkerd_identity as id;
-use ring::error::KeyRejected;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::watch;
 use tokio_rustls::rustls::{self, crypto::CryptoProvider};
 use tracing::warn;
-
-#[derive(Debug, Error)]
-#[error("{0}")]
-pub struct InvalidKey(#[source] KeyRejected);
 
 #[derive(Debug, Error)]
 #[error("invalid trust roots")]
@@ -118,12 +113,8 @@ mod params {
     use tokio_rustls::rustls::{self, crypto::WebPkiSupportedAlgorithms};
 
     // These must be kept in sync:
-    pub static SIGNATURE_ALG_RING_SIGNING: &ring::signature::EcdsaSigningAlgorithm =
-        &ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING;
     pub const SIGNATURE_ALG_RUSTLS_SCHEME: rustls::SignatureScheme =
         rustls::SignatureScheme::ECDSA_NISTP256_SHA256;
-    pub const SIGNATURE_ALG_RUSTLS_ALGORITHM: rustls::SignatureAlgorithm =
-        rustls::SignatureAlgorithm::ECDSA;
     pub static SUPPORTED_SIG_ALGS: &WebPkiSupportedAlgorithms = backend::SUPPORTED_SIG_ALGS;
     pub static TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
     pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] =

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -8,7 +8,7 @@ publish = { workspace = true }
 description = "The main proxy executable"
 
 [features]
-default = ["meshtls-rustls-ring"]
+default = ["meshtls-rustls-aws-lc"]
 meshtls-boring = ["linkerd-meshtls/boring"]
 meshtls-boring-fips = ["linkerd-meshtls/boring-fips"]
 meshtls-rustls-aws-lc = ["linkerd-meshtls/rustls-aws-lc"]


### PR DESCRIPTION
Given the current state of rustls and AWS-LC, we are enabling the aws-lc crypto backend by default, replacing `*ring*`.