### PR TITLE
fix(http): fix HTTP/1 client idle timeouts

### DIFF
--- a/linkerd/proxy/http/src/h1.rs
+++ b/linkerd/proxy/http/src/h1.rs
@@ -127,6 +127,7 @@ where
                     hyper_util::client::legacy::Client::builder(TokioExecutor::new())
                         .pool_max_idle_per_host(self.pool.max_idle)
                         .pool_idle_timeout(self.pool.idle_timeout)
+                        .pool_timer(hyper_util::rt::TokioTimer::default())
                         .set_host(use_absolute_form)
                         .build(HyperConnect::new(
                             self.connect.clone(),


### PR DESCRIPTION
When constructing the HTTP/1 client, we configure connection pooling, but notably do not provide a timer implementation to Hyper. This causes hyper's connection pool to be configured without idle timeouts, which may lead to resource leaks, especially for clients that communicate with many virtual hosts.

This change updates the HTTP/1 client builder to use a Tokio timer, which allows Hyper to manage idle timeouts correctly.