### PR TITLE
fix(app/env): a lower default maximum per-host connection limit

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -343,7 +343,7 @@ const DEFAULT_INBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: Duration = Duration::f
 // TODO(ver) This should be configurable at the load balancer level.
 const DEFAULT_OUTBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(3);
 
-// By default, we don't limit the number of connections a connection pol may
+// By default, we don't limit the number of connections a connection pool may
 // use, as doing so can severely impact CPU utilization for applications with
 // many concurrent requests. It's generally preferable to use the MAX_IDLE_AGE
 // limitations to quickly drop idle connections.

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -348,7 +348,11 @@ const DEFAULT_OUTBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: Duration = Duration::
 // many concurrent requests. It's generally preferable to use the MAX_IDLE_AGE
 // limitations to quickly drop idle connections.
 const DEFAULT_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = usize::MAX;
-const DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = usize::MAX;
+// By default, we limit the number of outbound connections that may be opened
+// per-host. We pick a high number (10k) that shouldn't interfere with most
+// workloads, but will prevent issues with our outbound HTTP client from
+// exhausting the file descriptors available to the process.
+const DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = 10_000;
 
 // These settings limit the number of requests that have not received responses,
 // including those buffered in the proxy and dispatched to the destination


### PR DESCRIPTION
see also:
* https://github.com/linkerd/linkerd2-proxy/pull/4004
* https://github.com/linkerd/linkerd2/issues/14204

in https://github.com/linkerd/linkerd2-proxy/pull/4004 we fixed an issue related to our HTTP/1.1 client's connection
pool.

this further hedges against future issues related to our HTTP client
exhausting resources available to its container. today, the limit by
default is `usize::MAX`, which is dramatically higher than the practical
limit.

this commit changes the limit for outbound idle connections per-host to
10,000.