### PR TITLE
fix(app/env): limit default inbound connection pool size

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -343,15 +343,11 @@ const DEFAULT_INBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: Duration = Duration::f
 // TODO(ver) This should be configurable at the load balancer level.
 const DEFAULT_OUTBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(3);
 
-// By default, we don't limit the number of connections a connection pool may
-// use, as doing so can severely impact CPU utilization for applications with
-// many concurrent requests. It's generally preferable to use the MAX_IDLE_AGE
-// limitations to quickly drop idle connections.
-const DEFAULT_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = usize::MAX;
 // By default, we limit the number of outbound connections that may be opened
 // per-host. We pick a high number (10k) that shouldn't interfere with most
 // workloads, but will prevent issues with our outbound HTTP client from
 // exhausting the file descriptors available to the process.
+const DEFAULT_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = 10_000;
 const DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = 10_000;
 
 // These settings limit the number of requests that have not received responses,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -343,10 +343,10 @@ const DEFAULT_INBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: Duration = Duration::f
 // TODO(ver) This should be configurable at the load balancer level.
 const DEFAULT_OUTBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(3);
 
-// By default, we limit the number of outbound connections that may be opened
-// per-host. We pick a high number (10k) that shouldn't interfere with most
-// workloads, but will prevent issues with our outbound HTTP client from
-// exhausting the file descriptors available to the process.
+// By default, we limit the number of connections that may be opened per-host.
+// We pick a high number (10k) that shouldn't interfere with most workloads, but
+// will prevent issues with our outbound HTTP client from exhausting the file
+// descriptors available to the process.
 const DEFAULT_INBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = 10_000;
 const DEFAULT_OUTBOUND_MAX_IDLE_CONNS_PER_ENDPOINT: usize = 10_000;
 


### PR DESCRIPTION
The inbound connection pool is effectively unlimited. This change configures a default limit of 10K.