### PR TITLE
chore(ci): enable overriding the runner in workflows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-rust
     timeout-minutes: 20
     continue-on-error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   meta:
     timeout-minutes: 5
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - id: changed
@@ -40,7 +40,7 @@ jobs:
   codecov:
     needs: meta
     if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.meta.outputs.any_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 30
     container:
       image: docker://ghcr.io/linkerd/dev:v46-rust

--- a/.github/workflows/fuzzers.yml
+++ b/.github/workflows/fuzzers.yml
@@ -26,7 +26,7 @@ permissions:
 jobs:
   list-changed:
     timeout-minutes: 3
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     container: docker://rust:1.88.0
     steps:
       - run: apt update && apt install -y jo
@@ -47,7 +47,7 @@ jobs:
   build:
     needs: [list-changed]
     timeout-minutes: 40
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     container: docker://rust:1.88.0
     strategy:
       matrix:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   markdownlint:
     timeout-minutes: 5
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-rust
     timeout-minutes: 20
     continue-on-error: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   meta:
     timeout-minutes: 5
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - id: build
@@ -57,7 +57,7 @@ jobs:
   info:
     timeout-minutes: 3
     needs: meta
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     steps:
       - name: Info
         run: |
@@ -74,7 +74,7 @@ jobs:
   actions:
     needs: meta
     if: needs.meta.outputs.actions_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: linkerd/dev/actions/setup-tools@v46
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -84,7 +84,7 @@ jobs:
   rust:
     needs: meta
     if: needs.meta.outputs.cargo_changed == 'true' || needs.meta.outputs.rust_changed == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-rust
     permissions:
       contents: read
@@ -107,7 +107,7 @@ jobs:
     needs: meta
     if: needs.meta.outputs.cargo_changed == 'true'
     timeout-minutes: 20
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-rust
     strategy:
       matrix:
@@ -123,7 +123,7 @@ jobs:
     needs: meta
     if: needs.meta.outputs.cargo_changed == 'true' || needs.meta.outputs.rust_changed == 'true'
     timeout-minutes: 20
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     env:
       WAIT_TIMEOUT: 2m
     steps:
@@ -149,7 +149,7 @@ jobs:
     timeout-minutes: 3
     needs: [meta, actions, rust, rust-crates, linkerd-install]
     if: always()
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
 
     permissions:
       contents: write

--- a/.github/workflows/release-weekly.yml
+++ b/.github/workflows/release-weekly.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   last-release:
     if: github.repository == 'linkerd/linkerd2-proxy' # Don't run this in forks.
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
     env:
       GH_REPO: ${{ github.repository }}
@@ -41,7 +41,7 @@ jobs:
 
   last-commit:
     needs: last-release
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -62,7 +62,7 @@ jobs:
   trigger-release:
     needs: [last-release, last-commit]
     if: needs.last-release.outputs.recent == 'false' && needs.last-commit.outputs.after-release == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
     permissions:
       actions: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ concurrency:
 jobs:
   meta:
     timeout-minutes: 5
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     steps:
       - id: meta
         env:
@@ -108,7 +108,7 @@ jobs:
 
   info:
     needs: meta
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 3
     steps:
       - name: Inputs
@@ -140,7 +140,7 @@ jobs:
     # If we're not actually building on a release tag, don't short-circuit on
     # errors. This helps us know whether a failure is platform-specific.
     continue-on-error: ${{ needs.meta.outputs.publish != 'true' }}
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 40
     container: docker://ghcr.io/linkerd/dev:v46-rust-musl
     env:
@@ -170,7 +170,7 @@ jobs:
 
   publish:
     needs: [meta, package]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 5
     permissions:
       actions: write
@@ -225,7 +225,7 @@ jobs:
     needs: publish
     if: always()
     timeout-minutes: 3
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     steps:
       - name: Results
         run: |

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   sh-lint:
     timeout-minutes: 5
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: linkerd/dev/actions/setup-tools@v46
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   devcontainer:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     container: ghcr.io/linkerd/dev:v46-rust
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -35,7 +35,7 @@ jobs:
 
 
   workflows:
-    runs-on: ubuntu-24.04
+    runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     steps:
       - uses: linkerd/dev/actions/setup-tools@v46
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
We use the ubuntu-24.04 runner by default, but in forks this may not be appropriate. This change updates the runners to support overriding via the LINKERD2_PROXY_RUNNER variable.