### PR TITLE
fix(rustls): Make `ring` and `aws-lc-rs` exclusive features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1640,6 +1640,7 @@ dependencies = [
  "linkerd-app-core",
  "linkerd-app-test",
  "linkerd-meshtls",
+ "linkerd-meshtls-rustls",
  "linkerd-metrics",
  "linkerd-tracing",
  "linkerd2-proxy-api",
@@ -2146,7 +2147,6 @@ dependencies = [
  "linkerd-stack",
  "linkerd-tls",
  "linkerd-tls-test-util",
- "ring",
  "rustls-pemfile",
  "rustls-webpki",
  "thiserror 2.0.12",
@@ -3590,8 +3590,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0068c5b3cab1d4e271e0bb6539c87563c43411cad90b057b15c79958fbeb41f7"
 dependencies = [
+ "aws-lc-rs",
  "pem",
- "ring",
  "rustls-pki-types",
  "time",
  "yasna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,6 @@ prost = { version = "0.13" }
 prost-build = { version = "0.13", default-features = false }
 prost-types = { version = "0.13" }
 tokio-rustls = { version = "0.26", default-features = false, features = [
-    "ring",
     "logging",
 ] }
 tonic = { version = "0.12", default-features = false }

--- a/linkerd/app/inbound/Cargo.toml
+++ b/linkerd/app/inbound/Cargo.toml
@@ -26,7 +26,7 @@ linkerd-app-test = { path = "../test", optional = true }
 linkerd-http-access-log = { path = "../../http/access-log" }
 linkerd-idle-cache = { path = "../../idle-cache" }
 linkerd-meshtls = { path = "../../meshtls", optional = true }
-linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true }
+linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true, default-features = false }
 linkerd-proxy-client-policy = { path = "../../proxy/client-policy" }
 linkerd-tonic-stream = { path = "../../tonic-stream" }
 linkerd-tonic-watch = { path = "../../tonic-watch" }

--- a/linkerd/app/integration/Cargo.toml
+++ b/linkerd/app/integration/Cargo.toml
@@ -28,6 +28,7 @@ ipnet = "2"
 linkerd-app = { path = "..", features = ["allow-loopback"] }
 linkerd-app-core = { path = "../core" }
 linkerd-app-test = { path = "../test" }
+linkerd-meshtls-rustls = { path = "../../meshtls/rustls", features = ["test-util"] }
 linkerd-metrics = { path = "../../metrics", features = ["test_util"] }
 linkerd-tracing = { path = "../../tracing" }
 maplit = "1"

--- a/linkerd/app/outbound/Cargo.toml
+++ b/linkerd/app/outbound/Cargo.toml
@@ -42,7 +42,7 @@ linkerd-http-prom = { path = "../../http/prom" }
 linkerd-http-retry = { path = "../../http/retry" }
 linkerd-http-route = { path = "../../http/route" }
 linkerd-identity = { path = "../../identity" }
-linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true }
+linkerd-meshtls-rustls = { path = "../../meshtls/rustls", optional = true, default-features = false }
 linkerd-opaq-route = { path = "../../opaq-route" }
 linkerd-proxy-client-policy = { path = "../../proxy/client-policy", features = [
     "proto",

--- a/linkerd/meshtls/Cargo.toml
+++ b/linkerd/meshtls/Cargo.toml
@@ -25,14 +25,14 @@ linkerd-error = { path = "../error" }
 linkerd-identity = { path = "../identity" }
 linkerd-io = { path = "../io" }
 linkerd-meshtls-boring = { path = "boring", optional = true }
-linkerd-meshtls-rustls = { path = "rustls", optional = true }
+linkerd-meshtls-rustls = { path = "rustls", optional = true, default-features = false }
 linkerd-stack = { path = "../stack" }
 linkerd-tls = { path = "../tls" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "net", "rt-multi-thread"] }
 tracing = { workspace = true }
-rcgen = "0.14.3"
+rcgen = { version = "0.14.3", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }
 
 linkerd-conditional = { path = "../conditional" }
 linkerd-proxy-transport = { path = "../proxy/transport" }

--- a/linkerd/meshtls/rustls/Cargo.toml
+++ b/linkerd/meshtls/rustls/Cargo.toml
@@ -15,7 +15,6 @@ test-util = ["linkerd-tls-test-util"]
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-ring = { version = "0.17", features = ["std"] }
 rustls-pemfile = "2.2"
 rustls-webpki = { version = "0.103.4", default-features = false, features = ["std"] }
 thiserror = "2"

--- a/linkerd/meshtls/rustls/src/backend.rs
+++ b/linkerd/meshtls/rustls/src/backend.rs
@@ -1,3 +1,10 @@
+#[cfg(all(feature = "aws-lc", feature = "ring"))]
+compile_error!(
+    "Multiple rustls backends enabled. Enabled one of the \"ring\" or \"aws-lc\" features"
+);
+#[cfg(not(any(feature = "aws-lc", feature = "ring")))]
+compile_error!("No rustls backend enabled. Enabled one of the \"ring\" or \"aws-lc\" features");
+
 #[cfg(feature = "aws-lc")]
 mod aws_lc;
 #[cfg(feature = "ring")]
@@ -5,7 +12,5 @@ mod ring;
 
 #[cfg(feature = "aws-lc")]
 pub use aws_lc::{default_provider, SUPPORTED_SIG_ALGS, TLS_SUPPORTED_CIPHERSUITES};
-#[cfg(all(not(feature = "aws-lc"), feature = "ring"))]
+#[cfg(feature = "ring")]
 pub use ring::{default_provider, SUPPORTED_SIG_ALGS, TLS_SUPPORTED_CIPHERSUITES};
-#[cfg(all(not(feature = "aws-lc"), not(feature = "ring")))]
-compile_error!("No rustls backend enabled. Enabled one of the \"ring\" or \"aws-lc\" features");

--- a/linkerd/meshtls/rustls/src/creds.rs
+++ b/linkerd/meshtls/rustls/src/creds.rs
@@ -8,16 +8,11 @@ pub use self::{receiver::Receiver, store::Store};
 use linkerd_dns_name as dns;
 use linkerd_error::Result;
 use linkerd_identity as id;
-use ring::error::KeyRejected;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::watch;
 use tokio_rustls::rustls::{self, crypto::CryptoProvider};
 use tracing::warn;
-
-#[derive(Debug, Error)]
-#[error("{0}")]
-pub struct InvalidKey(#[source] KeyRejected);
 
 #[derive(Debug, Error)]
 #[error("invalid trust roots")]
@@ -92,10 +87,22 @@ pub fn watch(
     Ok((store, rx))
 }
 
-fn default_provider() -> CryptoProvider {
+fn default_provider() -> Arc<CryptoProvider> {
+    if let Some(provider) = CryptoProvider::get_default() {
+        return Arc::clone(provider);
+    }
+
     let mut provider = backend::default_provider();
     provider.cipher_suites = params::TLS_SUPPORTED_CIPHERSUITES.to_vec();
-    provider
+    // Ignore install errors. This is the only place we install a provider, so if we raced with
+    // another thread to set the provider it will be functionally the same as this provider.
+    let _ = provider.install_default();
+    Arc::clone(CryptoProvider::get_default().expect("Just installed a default"))
+}
+
+#[cfg(feature = "test-util")]
+pub fn default_provider_for_test() -> Arc<CryptoProvider> {
+    default_provider()
 }
 
 #[cfg(feature = "test-util")]
@@ -118,12 +125,8 @@ mod params {
     use tokio_rustls::rustls::{self, crypto::WebPkiSupportedAlgorithms};
 
     // These must be kept in sync:
-    pub static SIGNATURE_ALG_RING_SIGNING: &ring::signature::EcdsaSigningAlgorithm =
-        &ring::signature::ECDSA_P256_SHA256_ASN1_SIGNING;
     pub const SIGNATURE_ALG_RUSTLS_SCHEME: rustls::SignatureScheme =
         rustls::SignatureScheme::ECDSA_NISTP256_SHA256;
-    pub const SIGNATURE_ALG_RUSTLS_ALGORITHM: rustls::SignatureAlgorithm =
-        rustls::SignatureAlgorithm::ECDSA;
     pub static SUPPORTED_SIG_ALGS: &WebPkiSupportedAlgorithms = backend::SUPPORTED_SIG_ALGS;
     pub static TLS_VERSIONS: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
     pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] =

--- a/linkerd/meshtls/rustls/src/creds/receiver.rs
+++ b/linkerd/meshtls/rustls/src/creds/receiver.rs
@@ -63,6 +63,7 @@ impl std::fmt::Debug for Receiver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::creds::default_provider;
 
     /// Returns the simplest default rustls server config.
     ///
@@ -70,7 +71,7 @@ mod tests {
     /// incoming handshakes, but that doesn't matter for these tests, where we
     /// don't actually do any TLS.
     fn empty_server_config() -> rustls::ServerConfig {
-        rustls::ServerConfig::builder_with_provider(Arc::new(crate::backend::default_provider()))
+        rustls::ServerConfig::builder_with_provider(default_provider())
             .with_protocol_versions(rustls::ALL_VERSIONS)
             .expect("client config must be valid")
             .with_client_cert_verifier(Arc::new(rustls::server::NoClientAuth))
@@ -83,7 +84,7 @@ mod tests {
     /// it doesn't trust any root certificates. However, that doesn't actually
     /// matter for these tests, which don't actually do TLS.
     fn empty_client_config() -> rustls::ClientConfig {
-        rustls::ClientConfig::builder_with_provider(Arc::new(crate::backend::default_provider()))
+        rustls::ClientConfig::builder_with_provider(default_provider())
             .with_protocol_versions(rustls::ALL_VERSIONS)
             .expect("client config must be valid")
             .with_root_certificates(rustls::RootCertStore::empty())

--- a/linkerd/meshtls/rustls/src/creds/store.rs
+++ b/linkerd/meshtls/rustls/src/creds/store.rs
@@ -1,12 +1,16 @@
-use super::{default_provider, params::*, InvalidKey};
+use super::{default_provider, params::*};
 use linkerd_dns_name as dns;
 use linkerd_error::Result;
 use linkerd_identity as id;
 use linkerd_meshtls_verifier as verifier;
-use ring::{rand, signature::EcdsaKeyPair};
 use std::{convert::TryFrom, sync::Arc};
 use tokio::sync::watch;
-use tokio_rustls::rustls::{self, pki_types::UnixTime, server::WebPkiClientVerifier};
+use tokio_rustls::rustls::{
+    self,
+    pki_types::{PrivatePkcs8KeyDer, UnixTime},
+    server::WebPkiClientVerifier,
+    sign::CertifiedKey,
+};
 use tracing::debug;
 
 pub struct Store {
@@ -16,11 +20,7 @@ pub struct Store {
     server_name: dns::Name,
     client_tx: watch::Sender<Arc<rustls::ClientConfig>>,
     server_tx: watch::Sender<Arc<rustls::ServerConfig>>,
-    random: ring::rand::SystemRandom,
 }
-
-#[derive(Clone, Debug)]
-struct Key(Arc<EcdsaKeyPair>);
 
 #[derive(Clone, Debug)]
 struct CertResolver(Arc<rustls::sign::CertifiedKey>);
@@ -28,7 +28,7 @@ struct CertResolver(Arc<rustls::sign::CertifiedKey>);
 pub(super) fn client_config_builder(
     cert_verifier: Arc<dyn rustls::client::danger::ServerCertVerifier>,
 ) -> rustls::ConfigBuilder<rustls::ClientConfig, rustls::client::WantsClientCert> {
-    rustls::ClientConfig::builder_with_provider(Arc::new(default_provider()))
+    rustls::ClientConfig::builder_with_provider(default_provider())
         .with_protocol_versions(TLS_VERSIONS)
         .expect("client config must be valid")
         // XXX: Rustls's built-in verifiers don't let us tweak things as fully
@@ -55,7 +55,7 @@ pub(super) fn server_config(
     // controlling the set of trusted signature algorithms), but they provide good enough
     // defaults for now.
     // TODO: lock down the verification further.
-    let provider = Arc::new(default_provider());
+    let provider = default_provider();
 
     let client_cert_verifier =
         WebPkiClientVerifier::builder_with_provider(Arc::new(roots), provider.clone())
@@ -90,7 +90,6 @@ impl Store {
             server_name,
             client_tx,
             server_tx,
-            random: ring::rand::SystemRandom::new(),
         }
     }
 
@@ -147,13 +146,11 @@ impl id::Credentials for Store {
         // Use the client's verifier to validate the certificate for our local name.
         self.validate(&chain)?;
 
-        let key = EcdsaKeyPair::from_pkcs8(SIGNATURE_ALG_RING_SIGNING, &key, &self.random)
-            .map_err(InvalidKey)?;
-
-        let resolver = Arc::new(CertResolver(Arc::new(rustls::sign::CertifiedKey::new(
-            chain,
-            Arc::new(Key(Arc::new(key))),
-        ))));
+        let key_der = PrivatePkcs8KeyDer::from(key);
+        let provider = rustls::crypto::CryptoProvider::get_default()
+            .expect("Failed to get default crypto provider");
+        let key = CertifiedKey::from_der(chain, key_der.into(), provider)?;
+        let resolver = Arc::new(CertResolver(Arc::new(key)));
 
         // Build new client and server TLS configs.
         let client = self.client_config(resolver.clone());
@@ -164,39 +161,6 @@ impl id::Credentials for Store {
         let _ = self.server_tx.send(server);
 
         Ok(())
-    }
-}
-
-// === impl Key ===
-
-impl rustls::sign::SigningKey for Key {
-    fn choose_scheme(
-        &self,
-        offered: &[rustls::SignatureScheme],
-    ) -> Option<Box<dyn rustls::sign::Signer>> {
-        if !offered.contains(&SIGNATURE_ALG_RUSTLS_SCHEME) {
-            return None;
-        }
-
-        Some(Box::new(self.clone()))
-    }
-
-    fn algorithm(&self) -> rustls::SignatureAlgorithm {
-        SIGNATURE_ALG_RUSTLS_ALGORITHM
-    }
-}
-
-impl rustls::sign::Signer for Key {
-    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
-        let rng = rand::SystemRandom::new();
-        self.0
-            .sign(&rng, message)
-            .map(|signature| signature.as_ref().to_owned())
-            .map_err(|ring::error::Unspecified| rustls::Error::General("Signing Failed".to_owned()))
-    }
-
-    fn scheme(&self) -> rustls::SignatureScheme {
-        SIGNATURE_ALG_RUSTLS_SCHEME
     }
 }
 

--- a/linkerd/meshtls/verifier/Cargo.toml
+++ b/linkerd/meshtls/verifier/Cargo.toml
@@ -15,4 +15,4 @@ linkerd-identity = { path = "../../identity" }
 
 
 [dev-dependencies]
-rcgen = "0.14.3"
+rcgen = { version = "0.14.3", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }

--- a/linkerd/proxy/spire-client/Cargo.toml
+++ b/linkerd/proxy/spire-client/Cargo.toml
@@ -24,5 +24,5 @@ asn1 = { version = "0.6", package = "simple_asn1" }
 thiserror = "2"
 
 [dev-dependencies]
-rcgen = "0.14.3"
+rcgen = { version = "0.14.3", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }
 tokio-test = "0.4"


### PR DESCRIPTION
Currently, disabling the `ring` feature does not actually disable the dependency across the tree. Doing so requires a couple of tightly coupled steps:

- Making `ring` and `aws-lc` exclusive features, raising a compile error if they are both enabled.
- Removing a direct dependency on some `ring` types, and instead going through `rustls` for equivalent functionality.
- Removing a direct dependency on the `ring` crypto provider for integration tests, and instead using the provider from `linkerd-meshtls`.
- Installing the default crypto provider globally for the process and re-using it when requested, mostly to make the tests pass.

This was tested using a temporary `cargo deny` config that forbid `ring` when `aws-lc-rs` was used, and vice-versa. Note that it doesn't completely remove ring for dev dependencies, but that can be done as a follow-up.