### PR TITLE
fix(tls): Update preferred cipher suite order

### DIFF
--- a/linkerd/meshtls/rustls/src/backend/aws_lc.rs
+++ b/linkerd/meshtls/rustls/src/backend/aws_lc.rs
@@ -6,16 +6,15 @@ use tokio_rustls::rustls::{
 
 #[cfg(not(feature = "aws-lc-fips"))]
 pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] = &[
-    aws_lc_rs::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
     aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
     aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
+    aws_lc_rs::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
 ];
-// Prefer aes-256-gcm if fips is enabled, with chaha20-poly1305 as a fallback
+// Prefer aes-256-gcm if fips is enabled
 #[cfg(feature = "aws-lc-fips")]
 pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] = &[
     aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
     aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
-    aws_lc_rs::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
 ];
 pub static SUPPORTED_SIG_ALGS: &WebPkiSupportedAlgorithms = &WebPkiSupportedAlgorithms {
     all: &[

--- a/linkerd/meshtls/rustls/src/backend/ring.rs
+++ b/linkerd/meshtls/rustls/src/backend/ring.rs
@@ -5,9 +5,9 @@ use tokio_rustls::rustls::{
 };
 
 pub static TLS_SUPPORTED_CIPHERSUITES: &[rustls::SupportedCipherSuite] = &[
-    ring::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
     ring::cipher_suite::TLS13_AES_128_GCM_SHA256,
     ring::cipher_suite::TLS13_AES_256_GCM_SHA384,
+    ring::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
 ];
 // A subset of the algorithms supported by rustls+ring, imported from
 // https://github.com/rustls/rustls/blob/v/0.23.21/rustls/src/crypto/ring/mod.rs#L107


### PR DESCRIPTION
This makes two changes to the preferred cipher suite order.
- Prefer AES algorithms over ChaCha20. AES is significantly faster when AES hardware is present, and AES hardware is on all x86 CPUs since ~2010, and all ARM server CPUs for a similar amount of time. For these reasons it's reasonable to default to AES for modern deployments, and it's the same default that `aws-lc-rs` makes anyway.
- Remove ChaCha20 when FIPS is enabled. It's no longer a supported algorithm, so we shouldn't have it as an option.