### PR TITLE
feat(tls): Include rustls crypto provider metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tonic",
  "tower 0.5.2",

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -27,6 +27,7 @@ regex = "1"
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "sync", "parking_lot"] }
+tokio-rustls = { workspace = true }
 tokio-stream = { version = "0.1", features = ["time"] }
 tonic = { workspace = true, default-features = false, features = ["prost"] }
 tracing = { workspace = true }

--- a/linkerd/app/core/src/lib.rs
+++ b/linkerd/app/core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod metrics;
 pub mod proxy;
 pub mod serve;
 pub mod svc;
+pub mod tls_info;
 pub mod transport;
 
 pub use self::build_info::{BuildInfo, BUILD_INFO};

--- a/linkerd/app/core/src/tls_info.rs
+++ b/linkerd/app/core/src/tls_info.rs
@@ -1,0 +1,76 @@
+use linkerd_metrics::prom;
+use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue, LabelValueEncoder};
+use std::{
+    fmt::{Error, Write},
+    sync::{Arc, OnceLock},
+};
+use tracing::error;
+
+static TLS_INFO: OnceLock<Arc<TlsInfo>> = OnceLock::new();
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq, EncodeLabelSet)]
+pub struct TlsInfo {
+    tls_suites: MetricValueList,
+    tls_kx_groups: MetricValueList,
+    tls_rand: String,
+    tls_key_provider: String,
+    tls_fips: bool,
+}
+
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+struct MetricValueList {
+    values: Vec<&'static str>,
+}
+
+impl FromIterator<&'static str> for MetricValueList {
+    fn from_iter<T: IntoIterator<Item = &'static str>>(iter: T) -> Self {
+        MetricValueList {
+            values: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl EncodeLabelValue for MetricValueList {
+    fn encode(&self, encoder: &mut LabelValueEncoder<'_>) -> Result<(), Error> {
+        for value in &self.values {
+            value.encode(encoder)?;
+            encoder.write_char(',')?;
+        }
+        Ok(())
+    }
+}
+
+pub fn metric() -> prom::Family<TlsInfo, prom::ConstGauge> {
+    let fam = prom::Family::<TlsInfo, prom::ConstGauge>::new_with_constructor(|| {
+        prom::ConstGauge::new(1)
+    });
+
+    let Some(provider) = tokio_rustls::rustls::crypto::CryptoProvider::get_default() else {
+        // If the crypto provider hasn't been initialized, we return the metrics family with an
+        // empty set of metrics.
+        error!("Initializing TLS info metric before crypto provider initialized, this is a bug!");
+        return fam;
+    };
+
+    let tls_info = TLS_INFO.get_or_init(|| {
+        let tls_suites = provider
+            .cipher_suites
+            .iter()
+            .flat_map(|cipher_suite| cipher_suite.suite().as_str())
+            .collect::<MetricValueList>();
+        let tls_kx_groups = provider
+            .kx_groups
+            .iter()
+            .flat_map(|suite| suite.name().as_str())
+            .collect::<MetricValueList>();
+        Arc::new(TlsInfo {
+            tls_suites,
+            tls_kx_groups,
+            tls_rand: format!("{:?}", provider.secure_random),
+            tls_key_provider: format!("{:?}", provider.key_provider),
+            tls_fips: provider.fips(),
+        })
+    });
+    let _ = fam.get_or_create(tls_info);
+    fam
+}

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -22,6 +22,7 @@ use linkerd_app_core::{
     metrics::{prom, FmtMetrics},
     serve,
     svc::Param,
+    tls_info,
     transport::{addrs::*, listen::Bind},
     Error, ProxyRuntime,
 };
@@ -304,6 +305,7 @@ impl Config {
             error!(%error, "Failed to register process metrics");
         }
         registry.register("proxy_build_info", "Proxy build info", BUILD_INFO.metric());
+        registry.register("rustls_info", "Proxy TLS info", tls_info::metric());
 
         let admin = {
             let identity = identity.receiver().server();


### PR DESCRIPTION
This includes a small set of metrics about the currently installed rustls crypto provider and the algorithms it is configured to use.

We don't have 100% assurance that a default crypto provider has been installed before registering the metric, but in local testing it never appeared to be a problem. When we refactor the rustls initialization we can add an extra guarantee that we've initialized it by this point.

Example metric:
```
# HELP rustls_info Proxy TLS info.
# TYPE rustls_info gauge
rustls_info{tls_suites="TLS13_AES_128_GCM_SHA256,TLS13_AES_256_GCM_SHA384,TLS13_CHACHA20_POLY1305_SHA256,",tls_kx_groups="X25519,secp256r1,secp384r1,X25519MLKEM768,",tls_rand="AwsLcRs",tls_key_provider="AwsLcRs",tls_fips="false"} 1
```