### PR TITLE
feat!(ci): Remove arm/v7 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
             exit 1
           fi
           ( echo version="${VERSION#v}"
-            echo archs='["amd64", "arm64", "arm"]'
+            echo archs='["amd64", "arm64"]'
             echo oses='["linux", "windows"]'
           ) >> "$GITHUB_OUTPUT"
 
@@ -135,8 +135,6 @@ jobs:
         exclude:
           - os: windows
             arch: arm64
-          - os: windows
-            arch: arm  
 
     # If we're not actually building on a release tag, don't short-circuit on
     # errors. This helps us know whether a failure is platform-specific.

--- a/deny.toml
+++ b/deny.toml
@@ -2,7 +2,6 @@
 targets = [
     { triple = "x86_64-unknown-linux-gnu" },
     { triple = "aarch64-unknown-linux-gnu" },
-    { triple = "armv7-unknown-linux-gnu" },
 ]
 
 [advisories]

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ docker-repo := "localhost/linkerd/proxy"
 docker-tag := `git rev-parse --abbrev-ref HEAD | sed 's|/|.|g'` + "." + `git rev-parse --short HEAD`
 docker-image := docker-repo + ":" + docker-tag
 
-# The architecture name to use for packages. Either 'amd64', 'arm64', or 'arm'.
+# The architecture name to use for packages. Either 'amd64' or 'arm64'.
 arch := "amd64"
 # The OS name to use for packages. Either 'linux' or 'windows'.
 os := "linux"
@@ -39,8 +39,6 @@ _target := if os + '-' + arch == "linux-amd64" {
         "x86_64-unknown-linux-" + libc
     } else if os + '-' + arch == "linux-arm64" {
         "aarch64-unknown-linux-" + libc
-    } else if os + '-' + arch == "linux-arm" {
-        "armv7-unknown-linux-" + libc + "eabihf"
     } else if os + '-' + arch == "windows-amd64" {
         "x86_64-pc-windows-" + libc
     } else {
@@ -139,7 +137,7 @@ _strip:
 
 _package_bin := _package_dir / "bin" / "linkerd2-proxy"
 
-# XXX {aarch64,arm}-musl builds do not enable PIE, so we use target-specific
+# XXX aarch64-musl builds do not enable PIE, so we use target-specific
 # files to document those differences.
 _expected_checksec := '.checksec' / arch + '-' + libc + '.json'
 


### PR DESCRIPTION
This architecture has become too significant of a maintenance burden, and isn't used often enough to justify the associated maintenance cost.

This removes arm/v7 from all the build infrastructure/dockerfiles/etc. Note that arm64 targets are still widely used and well supported.

Related: https://github.com/linkerd/linkerd2/pull/14308