### PR TITLE
chore(meshtls-rustls): Use `aws-lc` as the default crypto backend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
     env:
       LINKERD2_PROXY_VENDOR: ${{ github.repository_owner }}
       LINKERD2_PROXY_VERSION: ${{ needs.meta.outputs.version }}
-      # TODO: add to dev image
+      # TODO: these variables will be included in dev v48
       AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_gnu: "-fuse-ld=/usr/aarch64-linux-gnu/bin/ld"
       AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_musl: "-fuse-ld=/usr/aarch64-linux-gnu/bin/ld"
     steps:
@@ -153,7 +153,7 @@ jobs:
       - name: Install MiniGW
         if: matrix.os == 'windows'
         run: apt-get update && apt-get install mingw-w64 -y
-      # TODO: add to dev image
+      # TODO: these packages will be included in dev v48
       - name: Install cross compilation toolchain
         if: matrix.arch == 'arm64'
         run: apt-get update && apt-get install --no-install-recommends -y \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,11 +145,22 @@ jobs:
     env:
       LINKERD2_PROXY_VENDOR: ${{ github.repository_owner }}
       LINKERD2_PROXY_VERSION: ${{ needs.meta.outputs.version }}
+      # TODO: add to dev image
+      AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_gnu: "-fuse-ld=/usr/aarch64-linux-gnu/bin/ld"
+      AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_musl: "-fuse-ld=/usr/aarch64-linux-gnu/bin/ld"
     steps:
       # TODO: add to dev image
       - name: Install MiniGW
         if: matrix.os == 'windows'
         run: apt-get update && apt-get install mingw-w64 -y
+      # TODO: add to dev image
+      - name: Install cross compilation toolchain
+        if: matrix.arch == 'arm64'
+        run: apt-get update && apt-get install --no-install-recommends -y \
+          g++-aarch64-linux-gnu \
+          gcc-aarch64-linux-gnu \
+          binutils-aarch64-linux-gnu \
+          libc6-dev-arm64-cross
       - name: Configure git
         run: git config --global --add safe.directory "$PWD" # actions/runner#2033
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,9 +145,6 @@ jobs:
     env:
       LINKERD2_PROXY_VENDOR: ${{ github.repository_owner }}
       LINKERD2_PROXY_VERSION: ${{ needs.meta.outputs.version }}
-      # TODO: these variables will be included in dev v48
-      AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_gnu: "-fuse-ld=/usr/aarch64-linux-gnu/bin/ld"
-      AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_musl: "-fuse-ld=/usr/aarch64-linux-gnu/bin/ld"
     steps:
       # TODO: add to dev image
       - name: Install MiniGW
@@ -157,10 +154,7 @@ jobs:
       - name: Install cross compilation toolchain
         if: matrix.arch == 'arm64'
         run: apt-get update && apt-get install --no-install-recommends -y \
-          g++-aarch64-linux-gnu \
-          gcc-aarch64-linux-gnu \
-          binutils-aarch64-linux-gnu \
-          libc6-dev-arm64-cross
+          binutils-aarch64-linux-gnu
       - name: Configure git
         run: git config --global --add safe.directory "$PWD" # actions/runner#2033
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/justfile
+++ b/justfile
@@ -18,6 +18,10 @@ features := ""
 export LINKERD2_PROXY_VERSION := env_var_or_default("LINKERD2_PROXY_VERSION", "0.0.0-dev" + `git rev-parse --short HEAD`)
 export LINKERD2_PROXY_VENDOR := env_var_or_default("LINKERD2_PROXY_VENDOR", `whoami` + "@" + `hostname`)
 
+# TODO: these variables will be included in dev v48
+export AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_gnu := env_var_or_default("AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_gnu", "-fuse-ld=/usr/aarch64-linux-gnu/bin/ld")
+export AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_musl := env_var_or_default("AWS_LC_SYS_CFLAGS_aarch64_unknown_linux_musl", "-fuse-ld=/usr/aarch64-linux-gnu/bin/ld")
+
 # The version name to use for packages.
 package_version := "v" + LINKERD2_PROXY_VERSION
 

--- a/linkerd/meshtls/rustls/Cargo.toml
+++ b/linkerd/meshtls/rustls/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 publish = { workspace = true }
 
 [features]
-default = ["ring"]
+default = ["aws-lc"]
 ring = ["tokio-rustls/ring", "rustls-webpki/ring"]
 aws-lc = ["tokio-rustls/aws-lc-rs", "rustls-webpki/aws-lc-rs"]
 aws-lc-fips = ["aws-lc", "tokio-rustls/fips"]

--- a/linkerd/proxy/transport/Cargo.toml
+++ b/linkerd/proxy/transport/Cargo.toml
@@ -14,7 +14,7 @@ futures = { version = "0.3", default-features = false }
 linkerd-error = { path = "../../error" }
 linkerd-io = { path = "../../io" }
 linkerd-stack = { path = "../../stack" }
-socket2 = "0.5"
+socket2 = { version = "0.5", features = ["all"] }
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -8,7 +8,7 @@ publish = { workspace = true }
 description = "The main proxy executable"
 
 [features]
-default = ["meshtls-rustls-ring"]
+default = ["meshtls-rustls-aws-lc"]
 meshtls-boring = ["linkerd-meshtls/boring"]
 meshtls-boring-fips = ["linkerd-meshtls/boring-fips"]
 meshtls-rustls-aws-lc = ["linkerd-meshtls/rustls-aws-lc"]


### PR DESCRIPTION
The broader ecosystem has mostly moved to `aws-lc-rs` as the primary `rustls` backend, and we should follow suit. This will also simplify the maintenance of the proxy's TLS implementation in the long term.

This requires some extra configuration for successful cross-compilation, ideally we can remove this extra configuration once linkerd/dev v48 is available.

This doesn't remove `ring` as a crypto backend, that can come in a follow-up at https://github.com/linkerd/linkerd2-proxy/pull/4029
