### PR TITLE
chore(ci): exercise all release platforms on workflow change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
           ref: ${{ needs.meta.outputs.ref }}
       - uses: Swatinem/rust-cache@98c8021b550208e191a6a3145459bfc9fb29c4c0
         with:
-          key: ${{ matrix.arch }}
+          key: ${{ matrix.os }}-${{ matrix.arch }}
       - run: just fetch
       - run: just arch=${{ matrix.arch }} libc=${{ matrix.libc }} os=${{ matrix.os }} rustup
       - run: just arch=${{ matrix.arch }} libc=${{ matrix.libc }} os=${{ matrix.os }} profile=${{ needs.meta.outputs.profile }} build


### PR DESCRIPTION
We only build linux/amd64 during typical release CI runs. This means we only execute cross-platform builds during releases, which is fragile.

This change updates the release workflow to build all platforms whenever the workflow changes.