### PR TITLE
refactor(metrics): introduce a `legacy` namespace

### DIFF
--- a/linkerd/app/admin/src/server.rs
+++ b/linkerd/app/admin/src/server.rs
@@ -32,7 +32,7 @@ pub use self::readiness::{Latch, Readiness};
 
 #[derive(Clone)]
 pub struct Admin<M> {
-    metrics: metrics::Serve<M>,
+    metrics: metrics::legacy::Serve<M>,
     tracing: trace::Handle,
     ready: Readiness,
     shutdown_tx: mpsc::UnboundedSender<()>,
@@ -52,7 +52,7 @@ impl<M> Admin<M> {
         tracing: trace::Handle,
     ) -> Self {
         Self {
-            metrics: metrics::Serve::new(metrics),
+            metrics: metrics::legacy::Serve::new(metrics),
             ready,
             shutdown_tx,
             enable_shutdown,

--- a/linkerd/app/admin/src/server.rs
+++ b/linkerd/app/admin/src/server.rs
@@ -13,7 +13,7 @@
 use futures::future::{self, TryFutureExt};
 use http::StatusCode;
 use linkerd_app_core::{
-    metrics::{self as metrics, FmtMetrics},
+    metrics::{self as metrics, legacy::FmtMetrics},
     proxy::http::{Body, BoxBody, ClientHandle, Request, Response},
     trace, Error, Result,
 };

--- a/linkerd/app/admin/src/stack.rs
+++ b/linkerd/app/admin/src/stack.rs
@@ -2,7 +2,7 @@ use linkerd_app_core::{
     classify,
     config::ServerConfig,
     drain, errors, identity,
-    metrics::{self, FmtMetrics},
+    metrics::{self, legacy::FmtMetrics},
     proxy::http,
     serve,
     svc::{self, ExtractParam, InsertParam, Param},

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -166,7 +166,7 @@ where
 // === impl Metrics ===
 
 impl Metrics {
-    pub fn new(retain_idle: Duration) -> (Self, impl FmtMetrics + Clone + Send + 'static) {
+    pub fn new(retain_idle: Duration) -> (Self, impl legacy::FmtMetrics + Clone + Send + 'static) {
         let (control, control_report) = {
             let m = http_metrics::Requests::<ControlLabels, Class>::default();
             let r = m.clone().into_report(retain_idle).with_prefix("control");
@@ -223,6 +223,7 @@ impl Metrics {
             opentelemetry,
         };
 
+        use legacy::FmtMetrics as _;
         let report = endpoint_report
             .and_report(profile_route_report)
             .and_report(retry_report)

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -249,7 +249,7 @@ impl svc::Param<ControlLabels> for control::ControlAddr {
     }
 }
 
-impl FmtLabels for ControlLabels {
+impl legacy::FmtLabels for ControlLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { addr, server_id } = self;
 
@@ -282,7 +282,7 @@ impl ProfileRouteLabels {
     }
 }
 
-impl FmtLabels for ProfileRouteLabels {
+impl legacy::FmtLabels for ProfileRouteLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             direction,
@@ -315,7 +315,7 @@ impl From<OutboundEndpointLabels> for EndpointLabels {
     }
 }
 
-impl FmtLabels for EndpointLabels {
+impl legacy::FmtLabels for EndpointLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Inbound(i) => (Direction::In, i).fmt_labels(f),
@@ -324,7 +324,7 @@ impl FmtLabels for EndpointLabels {
     }
 }
 
-impl FmtLabels for InboundEndpointLabels {
+impl legacy::FmtLabels for InboundEndpointLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             tls,
@@ -344,7 +344,7 @@ impl FmtLabels for InboundEndpointLabels {
     }
 }
 
-impl FmtLabels for ServerLabel {
+impl legacy::FmtLabels for ServerLabel {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self(meta, port) = self;
         write!(
@@ -375,7 +375,7 @@ impl prom::EncodeLabelSetMut for ServerLabel {
     }
 }
 
-impl FmtLabels for ServerAuthzLabels {
+impl legacy::FmtLabels for ServerAuthzLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { server, authz } = self;
 
@@ -390,7 +390,7 @@ impl FmtLabels for ServerAuthzLabels {
     }
 }
 
-impl FmtLabels for RouteLabels {
+impl legacy::FmtLabels for RouteLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { server, route } = self;
 
@@ -405,7 +405,7 @@ impl FmtLabels for RouteLabels {
     }
 }
 
-impl FmtLabels for RouteAuthzLabels {
+impl legacy::FmtLabels for RouteAuthzLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { route, authz } = self;
 
@@ -426,7 +426,7 @@ impl svc::Param<OutboundZoneLocality> for OutboundEndpointLabels {
     }
 }
 
-impl FmtLabels for OutboundEndpointLabels {
+impl legacy::FmtLabels for OutboundEndpointLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             server_id,
@@ -463,20 +463,20 @@ impl fmt::Display for Direction {
     }
 }
 
-impl FmtLabels for Direction {
+impl legacy::FmtLabels for Direction {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "direction=\"{self}\"")
     }
 }
 
-impl FmtLabels for Authority<'_> {
+impl legacy::FmtLabels for Authority<'_> {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self(authority) = self;
         write!(f, "authority=\"{authority}\"")
     }
 }
 
-impl FmtLabels for Class {
+impl legacy::FmtLabels for Class {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let class = |ok: bool| if ok { "success" } else { "failure" };
 
@@ -524,7 +524,7 @@ impl StackLabels {
     }
 }
 
-impl FmtLabels for StackLabels {
+impl legacy::FmtLabels for StackLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self {
             direction,

--- a/linkerd/app/core/src/transport/labels.rs
+++ b/linkerd/app/core/src/transport/labels.rs
@@ -1,7 +1,7 @@
 use crate::metrics::ServerLabel as PolicyServerLabel;
 pub use crate::metrics::{Direction, OutboundEndpointLabels};
 use linkerd_conditional::Conditional;
-use linkerd_metrics::FmtLabels;
+use linkerd_metrics::legacy::FmtLabels;
 use linkerd_tls as tls;
 use std::{fmt, net::SocketAddr};
 

--- a/linkerd/app/inbound/src/metrics.rs
+++ b/linkerd/app/inbound/src/metrics.rs
@@ -50,7 +50,7 @@ impl InboundMetrics {
     }
 }
 
-impl FmtMetrics for InboundMetrics {
+impl legacy::FmtMetrics for InboundMetrics {
     fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.http_authz.fmt_metrics(f)?;
         self.http_errors.fmt_metrics(f)?;

--- a/linkerd/app/inbound/src/metrics/authz.rs
+++ b/linkerd/app/inbound/src/metrics/authz.rs
@@ -1,9 +1,9 @@
 use crate::policy::{AllowPolicy, HttpRoutePermit, Meta, ServerPermit};
 use linkerd_app_core::{
     metrics::{
-        legacy::{Counter, FmtMetrics},
-        metrics, FmtLabels, RouteAuthzLabels, RouteLabels, ServerAuthzLabels, ServerLabel,
-        TargetAddr, TlsAccept,
+        legacy::{Counter, FmtLabels, FmtMetrics},
+        metrics, RouteAuthzLabels, RouteLabels, ServerAuthzLabels, ServerLabel, TargetAddr,
+        TlsAccept,
     },
     tls,
     transport::OrigDstAddr,

--- a/linkerd/app/inbound/src/metrics/authz.rs
+++ b/linkerd/app/inbound/src/metrics/authz.rs
@@ -1,8 +1,8 @@
 use crate::policy::{AllowPolicy, HttpRoutePermit, Meta, ServerPermit};
 use linkerd_app_core::{
     metrics::{
-        metrics, Counter, FmtLabels, FmtMetrics, RouteAuthzLabels, RouteLabels, ServerAuthzLabels,
-        ServerLabel, TargetAddr, TlsAccept,
+        legacy::Counter, metrics, FmtLabels, FmtMetrics, RouteAuthzLabels, RouteLabels,
+        ServerAuthzLabels, ServerLabel, TargetAddr, TlsAccept,
     },
     tls,
     transport::OrigDstAddr,

--- a/linkerd/app/inbound/src/metrics/authz.rs
+++ b/linkerd/app/inbound/src/metrics/authz.rs
@@ -1,8 +1,9 @@
 use crate::policy::{AllowPolicy, HttpRoutePermit, Meta, ServerPermit};
 use linkerd_app_core::{
     metrics::{
-        legacy::Counter, metrics, FmtLabels, FmtMetrics, RouteAuthzLabels, RouteLabels,
-        ServerAuthzLabels, ServerLabel, TargetAddr, TlsAccept,
+        legacy::{Counter, FmtMetrics},
+        metrics, FmtLabels, RouteAuthzLabels, RouteLabels, ServerAuthzLabels, ServerLabel,
+        TargetAddr, TlsAccept,
     },
     tls,
     transport::OrigDstAddr,

--- a/linkerd/app/inbound/src/metrics/error.rs
+++ b/linkerd/app/inbound/src/metrics/error.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use linkerd_app_core::{
     errors::{FailFastError, LoadShedError},
-    metrics::FmtLabels,
+    metrics::legacy::FmtLabels,
     tls,
 };
 use std::fmt;

--- a/linkerd/app/inbound/src/metrics/error/http.rs
+++ b/linkerd/app/inbound/src/metrics/error/http.rs
@@ -1,6 +1,9 @@
 use super::ErrorKind;
 use linkerd_app_core::{
-    metrics::{legacy::Counter, metrics, FmtMetrics, ServerLabel},
+    metrics::{
+        legacy::{Counter, FmtMetrics},
+        metrics, ServerLabel,
+    },
     svc::{self, stack::NewMonitor},
     transport::{labels::TargetAddr, OrigDstAddr},
     Error,

--- a/linkerd/app/inbound/src/metrics/error/http.rs
+++ b/linkerd/app/inbound/src/metrics/error/http.rs
@@ -1,6 +1,6 @@
 use super::ErrorKind;
 use linkerd_app_core::{
-    metrics::{metrics, Counter, FmtMetrics, ServerLabel},
+    metrics::{legacy::Counter, metrics, FmtMetrics, ServerLabel},
     svc::{self, stack::NewMonitor},
     transport::{labels::TargetAddr, OrigDstAddr},
     Error,

--- a/linkerd/app/inbound/src/metrics/error/tcp.rs
+++ b/linkerd/app/inbound/src/metrics/error/tcp.rs
@@ -1,6 +1,9 @@
 use super::ErrorKind;
 use linkerd_app_core::{
-    metrics::{legacy::Counter, metrics, FmtMetrics},
+    metrics::{
+        legacy::{Counter, FmtMetrics},
+        metrics,
+    },
     svc::{self, stack::NewMonitor},
     transport::{labels::TargetAddr, OrigDstAddr},
     Error,

--- a/linkerd/app/inbound/src/metrics/error/tcp.rs
+++ b/linkerd/app/inbound/src/metrics/error/tcp.rs
@@ -1,6 +1,6 @@
 use super::ErrorKind;
 use linkerd_app_core::{
-    metrics::{metrics, Counter, FmtMetrics},
+    metrics::{legacy::Counter, metrics, FmtMetrics},
     svc::{self, stack::NewMonitor},
     transport::{labels::TargetAddr, OrigDstAddr},
     Error,

--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -130,7 +130,7 @@ impl OutboundMetrics {
     }
 }
 
-impl FmtMetrics for OutboundMetrics {
+impl legacy::FmtMetrics for OutboundMetrics {
     fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.http_errors.fmt_metrics(f)?;
         self.tcp_errors.fmt_metrics(f)?;

--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -243,7 +243,7 @@ impl EncodeLabelSet for RouteRef {
 
 // === impl ConcreteLabels ===
 
-impl FmtLabels for ConcreteLabels {
+impl legacy::FmtLabels for ConcreteLabels {
     fn fmt_labels(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let ConcreteLabels(parent, backend) = self;
 

--- a/linkerd/app/outbound/src/metrics/error.rs
+++ b/linkerd/app/outbound/src/metrics/error.rs
@@ -5,7 +5,7 @@ pub(crate) use self::{http::Http, tcp::Tcp};
 use crate::http::IdentityRequired;
 use linkerd_app_core::{
     errors::{FailFastError, LoadShedError},
-    metrics::FmtLabels,
+    metrics::legacy::FmtLabels,
     proxy::http::ResponseTimeoutError,
 };
 use std::fmt;

--- a/linkerd/app/outbound/src/metrics/error/http.rs
+++ b/linkerd/app/outbound/src/metrics/error/http.rs
@@ -1,6 +1,9 @@
 use super::ErrorKind;
 use linkerd_app_core::{
-    metrics::{legacy::Counter, metrics, FmtMetrics},
+    metrics::{
+        legacy::{Counter, FmtMetrics},
+        metrics,
+    },
     svc, Error,
 };
 use parking_lot::RwLock;

--- a/linkerd/app/outbound/src/metrics/error/http.rs
+++ b/linkerd/app/outbound/src/metrics/error/http.rs
@@ -1,6 +1,6 @@
 use super::ErrorKind;
 use linkerd_app_core::{
-    metrics::{metrics, Counter, FmtMetrics},
+    metrics::{legacy::Counter, metrics, FmtMetrics},
     svc, Error,
 };
 use parking_lot::RwLock;

--- a/linkerd/app/outbound/src/metrics/error/tcp.rs
+++ b/linkerd/app/outbound/src/metrics/error/tcp.rs
@@ -1,6 +1,9 @@
 use super::ErrorKind;
 use linkerd_app_core::{
-    metrics::{legacy::Counter, metrics, FmtMetrics},
+    metrics::{
+        legacy::{Counter, FmtMetrics},
+        metrics,
+    },
     svc,
     transport::{labels::TargetAddr, OrigDstAddr},
     Error,

--- a/linkerd/app/outbound/src/metrics/error/tcp.rs
+++ b/linkerd/app/outbound/src/metrics/error/tcp.rs
@@ -1,6 +1,6 @@
 use super::ErrorKind;
 use linkerd_app_core::{
-    metrics::{metrics, Counter, FmtMetrics},
+    metrics::{legacy::Counter, metrics, FmtMetrics},
     svc,
     transport::{labels::TargetAddr, OrigDstAddr},
     Error,

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -19,7 +19,7 @@ use linkerd_app_core::{
     config::ServerConfig,
     control::{ControlAddr, Metrics as ControlMetrics},
     dns, drain,
-    metrics::{prom, FmtMetrics},
+    metrics::{legacy::FmtMetrics, prom},
     serve,
     svc::Param,
     tls_info,

--- a/linkerd/http/metrics/src/lib.rs
+++ b/linkerd/http/metrics/src/lib.rs
@@ -2,7 +2,7 @@
 #![forbid(unsafe_code)]
 
 pub use self::{requests::Requests, retries::Retries};
-use linkerd_metrics::SharedStore;
+use linkerd_metrics::legacy::SharedStore;
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, time::Duration};
 

--- a/linkerd/http/metrics/src/requests.rs
+++ b/linkerd/http/metrics/src/requests.rs
@@ -4,7 +4,7 @@ mod service;
 pub use self::service::{NewHttpMetrics, ResponseBody};
 use super::Report;
 use linkerd_http_classify::ClassifyResponse;
-use linkerd_metrics::{latency, Counter, FmtMetrics, Histogram, LastUpdate, NewMetrics};
+use linkerd_metrics::{latency, legacy::Counter, FmtMetrics, Histogram, LastUpdate, NewMetrics};
 use linkerd_stack::{self as svc, layer};
 use std::{collections::HashMap, fmt::Debug, hash::Hash};
 use tokio::time::{Duration, Instant};

--- a/linkerd/http/metrics/src/requests.rs
+++ b/linkerd/http/metrics/src/requests.rs
@@ -6,8 +6,7 @@ use super::Report;
 use linkerd_http_classify::ClassifyResponse;
 use linkerd_metrics::{
     latency,
-    legacy::{Counter, FmtMetrics, Histogram, LastUpdate},
-    NewMetrics,
+    legacy::{Counter, FmtMetrics, Histogram, LastUpdate, NewMetrics},
 };
 use linkerd_stack::{self as svc, layer};
 use std::{collections::HashMap, fmt::Debug, hash::Hash};

--- a/linkerd/http/metrics/src/requests.rs
+++ b/linkerd/http/metrics/src/requests.rs
@@ -6,8 +6,8 @@ use super::Report;
 use linkerd_http_classify::ClassifyResponse;
 use linkerd_metrics::{
     latency,
-    legacy::{Counter, FmtMetrics, Histogram},
-    LastUpdate, NewMetrics,
+    legacy::{Counter, FmtMetrics, Histogram, LastUpdate},
+    NewMetrics,
 };
 use linkerd_stack::{self as svc, layer};
 use std::{collections::HashMap, fmt::Debug, hash::Hash};

--- a/linkerd/http/metrics/src/requests.rs
+++ b/linkerd/http/metrics/src/requests.rs
@@ -4,7 +4,11 @@ mod service;
 pub use self::service::{NewHttpMetrics, ResponseBody};
 use super::Report;
 use linkerd_http_classify::ClassifyResponse;
-use linkerd_metrics::{latency, legacy::Counter, FmtMetrics, Histogram, LastUpdate, NewMetrics};
+use linkerd_metrics::{
+    latency,
+    legacy::{Counter, Histogram},
+    FmtMetrics, LastUpdate, NewMetrics,
+};
 use linkerd_stack::{self as svc, layer};
 use std::{collections::HashMap, fmt::Debug, hash::Hash};
 use tokio::time::{Duration, Instant};

--- a/linkerd/http/metrics/src/requests.rs
+++ b/linkerd/http/metrics/src/requests.rs
@@ -6,8 +6,8 @@ use super::Report;
 use linkerd_http_classify::ClassifyResponse;
 use linkerd_metrics::{
     latency,
-    legacy::{Counter, Histogram},
-    FmtMetrics, LastUpdate, NewMetrics,
+    legacy::{Counter, FmtMetrics, Histogram},
+    LastUpdate, NewMetrics,
 };
 use linkerd_stack::{self as svc, layer};
 use std::{collections::HashMap, fmt::Debug, hash::Hash};

--- a/linkerd/http/metrics/src/requests.rs
+++ b/linkerd/http/metrics/src/requests.rs
@@ -150,7 +150,7 @@ impl ClassMetrics {
 mod tests {
     #[test]
     fn expiry() {
-        use linkerd_metrics::FmtLabels;
+        use linkerd_metrics::legacy::FmtLabels;
         use std::fmt;
         use tokio::time::{Duration, Instant};
 

--- a/linkerd/http/metrics/src/requests/report.rs
+++ b/linkerd/http/metrics/src/requests/report.rs
@@ -1,7 +1,7 @@
 use super::{ClassMetrics, Metrics, StatusMetrics};
 use crate::{Prefixed, Report};
 use linkerd_metrics::{
-    latency, Counter, FmtLabels, FmtMetric, FmtMetrics, Histogram, Metric, Store,
+    latency, legacy::Counter, FmtLabels, FmtMetric, FmtMetrics, Histogram, Metric, Store,
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash};

--- a/linkerd/http/metrics/src/requests/report.rs
+++ b/linkerd/http/metrics/src/requests/report.rs
@@ -2,8 +2,8 @@ use super::{ClassMetrics, Metrics, StatusMetrics};
 use crate::{Prefixed, Report};
 use linkerd_metrics::{
     latency,
-    legacy::{Counter, FmtMetric, FmtMetrics, Histogram, Metric},
-    FmtLabels, Store,
+    legacy::{Counter, FmtLabels, FmtMetric, FmtMetrics, Histogram, Metric},
+    Store,
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash};

--- a/linkerd/http/metrics/src/requests/report.rs
+++ b/linkerd/http/metrics/src/requests/report.rs
@@ -2,8 +2,8 @@ use super::{ClassMetrics, Metrics, StatusMetrics};
 use crate::{Prefixed, Report};
 use linkerd_metrics::{
     latency,
-    legacy::{Counter, Histogram, Metric},
-    FmtLabels, FmtMetric, FmtMetrics, Store,
+    legacy::{Counter, FmtMetric, Histogram, Metric},
+    FmtLabels, FmtMetrics, Store,
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash};

--- a/linkerd/http/metrics/src/requests/report.rs
+++ b/linkerd/http/metrics/src/requests/report.rs
@@ -1,7 +1,9 @@
 use super::{ClassMetrics, Metrics, StatusMetrics};
 use crate::{Prefixed, Report};
 use linkerd_metrics::{
-    latency, legacy::Counter, FmtLabels, FmtMetric, FmtMetrics, Histogram, Metric, Store,
+    latency,
+    legacy::{Counter, Histogram},
+    FmtLabels, FmtMetric, FmtMetrics, Metric, Store,
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash};

--- a/linkerd/http/metrics/src/requests/report.rs
+++ b/linkerd/http/metrics/src/requests/report.rs
@@ -2,8 +2,7 @@ use super::{ClassMetrics, Metrics, StatusMetrics};
 use crate::{Prefixed, Report};
 use linkerd_metrics::{
     latency,
-    legacy::{Counter, FmtLabels, FmtMetric, FmtMetrics, Histogram, Metric},
-    Store,
+    legacy::{Counter, FmtLabels, FmtMetric, FmtMetrics, Histogram, Metric, Store},
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash};

--- a/linkerd/http/metrics/src/requests/report.rs
+++ b/linkerd/http/metrics/src/requests/report.rs
@@ -2,8 +2,8 @@ use super::{ClassMetrics, Metrics, StatusMetrics};
 use crate::{Prefixed, Report};
 use linkerd_metrics::{
     latency,
-    legacy::{Counter, Histogram},
-    FmtLabels, FmtMetric, FmtMetrics, Metric, Store,
+    legacy::{Counter, Histogram, Metric},
+    FmtLabels, FmtMetric, FmtMetrics, Store,
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash};

--- a/linkerd/http/metrics/src/requests/report.rs
+++ b/linkerd/http/metrics/src/requests/report.rs
@@ -2,8 +2,8 @@ use super::{ClassMetrics, Metrics, StatusMetrics};
 use crate::{Prefixed, Report};
 use linkerd_metrics::{
     latency,
-    legacy::{Counter, FmtMetric, Histogram, Metric},
-    FmtLabels, FmtMetrics, Store,
+    legacy::{Counter, FmtMetric, FmtMetrics, Histogram, Metric},
+    FmtLabels, Store,
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash};

--- a/linkerd/http/metrics/src/requests/service.rs
+++ b/linkerd/http/metrics/src/requests/service.rs
@@ -3,7 +3,7 @@ use futures::{ready, TryFuture};
 use http_body::{Body, Frame};
 use linkerd_error::Error;
 use linkerd_http_classify::{ClassifyEos, ClassifyResponse};
-use linkerd_metrics::NewMetrics;
+use linkerd_metrics::legacy::NewMetrics;
 use linkerd_stack::Proxy;
 use parking_lot::Mutex;
 use pin_project::{pin_project, pinned_drop};

--- a/linkerd/http/metrics/src/retries.rs
+++ b/linkerd/http/metrics/src/retries.rs
@@ -1,7 +1,7 @@
 use super::{Prefixed, Registry, Report};
 use linkerd_metrics::{
-    legacy::{Counter, FmtMetric, FmtMetrics, Metric},
-    FmtLabels, LastUpdate,
+    legacy::{Counter, FmtLabels, FmtMetric, FmtMetrics, Metric},
+    LastUpdate,
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, sync::Arc};

--- a/linkerd/http/metrics/src/retries.rs
+++ b/linkerd/http/metrics/src/retries.rs
@@ -1,7 +1,7 @@
 use super::{Prefixed, Registry, Report};
 use linkerd_metrics::{
-    legacy::{Counter, Metric},
-    FmtLabels, FmtMetric, FmtMetrics, LastUpdate,
+    legacy::{Counter, FmtMetric, Metric},
+    FmtLabels, FmtMetrics, LastUpdate,
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, sync::Arc};

--- a/linkerd/http/metrics/src/retries.rs
+++ b/linkerd/http/metrics/src/retries.rs
@@ -1,5 +1,8 @@
 use super::{Prefixed, Registry, Report};
-use linkerd_metrics::{legacy::Counter, FmtLabels, FmtMetric, FmtMetrics, LastUpdate, Metric};
+use linkerd_metrics::{
+    legacy::{Counter, Metric},
+    FmtLabels, FmtMetric, FmtMetrics, LastUpdate,
+};
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, sync::Arc};
 use tokio::time::{Duration, Instant};

--- a/linkerd/http/metrics/src/retries.rs
+++ b/linkerd/http/metrics/src/retries.rs
@@ -1,8 +1,5 @@
 use super::{Prefixed, Registry, Report};
-use linkerd_metrics::{
-    legacy::{Counter, FmtLabels, FmtMetric, FmtMetrics, Metric},
-    LastUpdate,
-};
+use linkerd_metrics::legacy::{Counter, FmtLabels, FmtMetric, FmtMetrics, LastUpdate, Metric};
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, sync::Arc};
 use tokio::time::{Duration, Instant};

--- a/linkerd/http/metrics/src/retries.rs
+++ b/linkerd/http/metrics/src/retries.rs
@@ -1,7 +1,7 @@
 use super::{Prefixed, Registry, Report};
 use linkerd_metrics::{
-    legacy::{Counter, FmtMetric, Metric},
-    FmtLabels, FmtMetrics, LastUpdate,
+    legacy::{Counter, FmtMetric, FmtMetrics, Metric},
+    FmtLabels, LastUpdate,
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, sync::Arc};

--- a/linkerd/http/metrics/src/retries.rs
+++ b/linkerd/http/metrics/src/retries.rs
@@ -1,5 +1,5 @@
 use super::{Prefixed, Registry, Report};
-use linkerd_metrics::{Counter, FmtLabels, FmtMetric, FmtMetrics, LastUpdate, Metric};
+use linkerd_metrics::{legacy::Counter, FmtLabels, FmtMetric, FmtMetrics, LastUpdate, Metric};
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, sync::Arc};
 use tokio::time::{Duration, Instant};

--- a/linkerd/metrics/src/counter.rs
+++ b/linkerd/metrics/src/counter.rs
@@ -1,6 +1,6 @@
 use super::{
     fmt::{FmtLabels, FmtMetric},
-    Factor,
+    legacy::Factor,
 };
 use std::fmt::{self, Display};
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/linkerd/metrics/src/histogram.rs
+++ b/linkerd/metrics/src/histogram.rs
@@ -2,7 +2,10 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::{cmp, iter, slice};
 
-use super::{legacy::Counter, Factor, FmtLabels, FmtMetric};
+use super::{
+    legacy::{Counter, FmtMetric},
+    Factor, FmtLabels,
+};
 
 /// A series of latency values and counts.
 #[derive(Debug)]

--- a/linkerd/metrics/src/histogram.rs
+++ b/linkerd/metrics/src/histogram.rs
@@ -3,8 +3,8 @@ use std::marker::PhantomData;
 use std::{cmp, iter, slice};
 
 use super::{
-    legacy::{Counter, FmtMetric},
-    Factor, FmtLabels,
+    legacy::{Counter, FmtLabels, FmtMetric},
+    Factor,
 };
 
 /// A series of latency values and counts.

--- a/linkerd/metrics/src/histogram.rs
+++ b/linkerd/metrics/src/histogram.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::{cmp, iter, slice};
 
-use super::{Counter, Factor, FmtLabels, FmtMetric};
+use super::{legacy::Counter, Factor, FmtLabels, FmtMetric};
 
 /// A series of latency values and counts.
 #[derive(Debug)]

--- a/linkerd/metrics/src/histogram.rs
+++ b/linkerd/metrics/src/histogram.rs
@@ -2,10 +2,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::{cmp, iter, slice};
 
-use super::{
-    legacy::{Counter, FmtLabels, FmtMetric},
-    Factor,
-};
+use super::legacy::{Counter, Factor, FmtLabels, FmtMetric};
 
 /// A series of latency values and counts.
 #[derive(Debug)]

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -19,7 +19,7 @@ pub use kubert_prometheus_process as process;
 #[cfg(feature = "stack")]
 pub use self::new_metrics::NewMetrics;
 pub use self::{
-    fmt::{FmtLabels, FmtMetric, FmtMetrics, Metric},
+    fmt::{FmtLabels, FmtMetric, FmtMetrics},
     serve::Serve,
     store::{LastUpdate, SharedStore, Store},
 };
@@ -32,7 +32,7 @@ pub mod legacy {
     //
     // this will help us differentiate in dependent systems which components rely on our legacy
     // metrics implementation.
-    pub use super::{counter::Counter, gauge::Gauge, histogram::Histogram};
+    pub use super::{counter::Counter, fmt::Metric, gauge::Gauge, histogram::Histogram};
 }
 
 /// Integration with the [`prometheus_client`]` crate.
@@ -72,8 +72,8 @@ macro_rules! metrics {
     { $( $name:ident : $kind:ty { $help:expr } ),+ } => {
         $(
             #[allow(non_upper_case_globals)]
-            const $name: $crate::Metric<'static, &str, $kind> =
-                $crate::Metric {
+            const $name: $crate::legacy::Metric<'static, &str, $kind> =
+                $crate::legacy::Metric {
                     name: stringify!($name),
                     help: $help,
                     _p: ::std::marker::PhantomData,

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -19,7 +19,6 @@ pub use kubert_prometheus_process as process;
 #[cfg(feature = "stack")]
 pub use self::new_metrics::NewMetrics;
 pub use self::{
-    counter::Counter,
     fmt::{FmtLabels, FmtMetric, FmtMetrics, Metric},
     gauge::Gauge,
     histogram::Histogram,
@@ -35,6 +34,7 @@ pub mod legacy {
     //
     // this will help us differentiate in dependent systems which components rely on our legacy
     // metrics implementation.
+    pub use super::counter::Counter;
 }
 
 /// Integration with the [`prometheus_client`]` crate.

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -18,7 +18,7 @@ pub use kubert_prometheus_process as process;
 
 #[cfg(feature = "stack")]
 pub use self::new_metrics::NewMetrics;
-pub use self::{serve::Serve, store::SharedStore};
+pub use self::serve::Serve;
 
 /// A legacy metrics implementation.
 ///
@@ -33,7 +33,7 @@ pub mod legacy {
         fmt::{FmtLabels, FmtMetric, FmtMetrics, Metric},
         gauge::Gauge,
         histogram::Histogram,
-        store::{LastUpdate, Store},
+        store::{LastUpdate, SharedStore, Store},
     };
 }
 

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -19,7 +19,6 @@ pub use kubert_prometheus_process as process;
 #[cfg(feature = "stack")]
 pub use self::new_metrics::NewMetrics;
 pub use self::{
-    fmt::FmtLabels,
     serve::Serve,
     store::{LastUpdate, SharedStore, Store},
 };
@@ -34,7 +33,7 @@ pub mod legacy {
     // metrics implementation.
     pub use super::{
         counter::Counter,
-        fmt::{FmtMetric, FmtMetrics, Metric},
+        fmt::{FmtLabels, FmtMetric, FmtMetrics, Metric},
         gauge::Gauge,
         histogram::Histogram,
     };

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -18,10 +18,7 @@ pub use kubert_prometheus_process as process;
 
 #[cfg(feature = "stack")]
 pub use self::new_metrics::NewMetrics;
-pub use self::{
-    serve::Serve,
-    store::{SharedStore, Store},
-};
+pub use self::{serve::Serve, store::SharedStore};
 
 /// A legacy metrics implementation.
 ///
@@ -36,7 +33,7 @@ pub mod legacy {
         fmt::{FmtLabels, FmtMetric, FmtMetrics, Metric},
         gauge::Gauge,
         histogram::Histogram,
-        store::LastUpdate,
+        store::{LastUpdate, Store},
     };
 }
 

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -18,7 +18,6 @@ pub use kubert_prometheus_process as process;
 
 #[cfg(feature = "stack")]
 pub use self::new_metrics::NewMetrics;
-pub use self::serve::Serve;
 
 /// A legacy metrics implementation.
 ///
@@ -33,6 +32,7 @@ pub mod legacy {
         fmt::{FmtLabels, FmtMetric, FmtMetrics, Metric},
         gauge::Gauge,
         histogram::Histogram,
+        serve::Serve,
         store::{LastUpdate, SharedStore, Store},
     };
 }

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -16,9 +16,6 @@ mod store;
 #[cfg(feature = "process")]
 pub use kubert_prometheus_process as process;
 
-#[cfg(feature = "stack")]
-pub use self::new_metrics::NewMetrics;
-
 /// A legacy metrics implementation.
 ///
 /// New metrics should use the interfaces in [`prom`] instead.
@@ -35,6 +32,9 @@ pub mod legacy {
         serve::Serve,
         store::{LastUpdate, SharedStore, Store},
     };
+
+    #[cfg(feature = "stack")]
+    pub use super::new_metrics::NewMetrics;
 }
 
 /// Integration with the [`prometheus_client`]` crate.

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -20,7 +20,6 @@ pub use kubert_prometheus_process as process;
 pub use self::new_metrics::NewMetrics;
 pub use self::{
     fmt::{FmtLabels, FmtMetric, FmtMetrics, Metric},
-    gauge::Gauge,
     histogram::Histogram,
     serve::Serve,
     store::{LastUpdate, SharedStore, Store},
@@ -34,7 +33,7 @@ pub mod legacy {
     //
     // this will help us differentiate in dependent systems which components rely on our legacy
     // metrics implementation.
-    pub use super::counter::Counter;
+    pub use super::{counter::Counter, gauge::Gauge};
 }
 
 /// Integration with the [`prometheus_client`]` crate.

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -27,6 +27,16 @@ pub use self::{
     store::{LastUpdate, SharedStore, Store},
 };
 
+/// A legacy metrics implementation.
+///
+/// New metrics should use the interfaces in [`prom`] instead.
+pub mod legacy {
+    // TODO(kate): we will move types like `Counter` and `Gauge` into this module.
+    //
+    // this will help us differentiate in dependent systems which components rely on our legacy
+    // metrics implementation.
+}
+
 /// Integration with the [`prometheus_client`]` crate.
 ///
 /// This should be used for all new metrics.

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -19,7 +19,7 @@ pub use kubert_prometheus_process as process;
 #[cfg(feature = "stack")]
 pub use self::new_metrics::NewMetrics;
 pub use self::{
-    fmt::{FmtLabels, FmtMetric, FmtMetrics},
+    fmt::{FmtLabels, FmtMetrics},
     serve::Serve,
     store::{LastUpdate, SharedStore, Store},
 };
@@ -32,7 +32,12 @@ pub mod legacy {
     //
     // this will help us differentiate in dependent systems which components rely on our legacy
     // metrics implementation.
-    pub use super::{counter::Counter, fmt::Metric, gauge::Gauge, histogram::Histogram};
+    pub use super::{
+        counter::Counter,
+        fmt::{FmtMetric, Metric},
+        gauge::Gauge,
+        histogram::Histogram,
+    };
 }
 
 /// Integration with the [`prometheus_client`]` crate.

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -35,6 +35,17 @@ pub mod legacy {
 
     #[cfg(feature = "stack")]
     pub use super::new_metrics::NewMetrics;
+
+    pub trait Factor {
+        fn factor(n: u64) -> f64;
+    }
+
+    impl Factor for () {
+        #[inline]
+        fn factor(n: u64) -> f64 {
+            super::to_f64(n)
+        }
+    }
 }
 
 /// Integration with the [`prometheus_client`]` crate.
@@ -84,8 +95,8 @@ macro_rules! metrics {
     }
 }
 
-pub trait Factor {
-    fn factor(n: u64) -> f64;
+pub fn to_f64(n: u64) -> f64 {
+    n.wrapping_rem(MAX_PRECISE_UINT64 + 1) as f64
 }
 
 /// Largest `u64` that can fit without loss of precision in `f64` (2^53).
@@ -94,14 +105,3 @@ pub trait Factor {
 /// mantissa), thus integer values over 2^53 are not guaranteed to be correctly
 /// exposed.
 const MAX_PRECISE_UINT64: u64 = 0x20_0000_0000_0000;
-
-impl Factor for () {
-    #[inline]
-    fn factor(n: u64) -> f64 {
-        to_f64(n)
-    }
-}
-
-pub fn to_f64(n: u64) -> f64 {
-    n.wrapping_rem(MAX_PRECISE_UINT64 + 1) as f64
-}

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -19,7 +19,7 @@ pub use kubert_prometheus_process as process;
 #[cfg(feature = "stack")]
 pub use self::new_metrics::NewMetrics;
 pub use self::{
-    fmt::{FmtLabels, FmtMetrics},
+    fmt::FmtLabels,
     serve::Serve,
     store::{LastUpdate, SharedStore, Store},
 };
@@ -34,7 +34,7 @@ pub mod legacy {
     // metrics implementation.
     pub use super::{
         counter::Counter,
-        fmt::{FmtMetric, Metric},
+        fmt::{FmtMetric, FmtMetrics, Metric},
         gauge::Gauge,
         histogram::Histogram,
     };
@@ -64,7 +64,7 @@ pub mod prom {
 
     pub type Report = Arc<Registry>;
 
-    impl crate::FmtMetrics for Report {
+    impl crate::legacy::FmtMetrics for Report {
         #[inline]
         fn fmt_metrics(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             encoding::text::encode(f, self)

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -20,7 +20,7 @@ pub use kubert_prometheus_process as process;
 pub use self::new_metrics::NewMetrics;
 pub use self::{
     serve::Serve,
-    store::{LastUpdate, SharedStore, Store},
+    store::{SharedStore, Store},
 };
 
 /// A legacy metrics implementation.
@@ -36,6 +36,7 @@ pub mod legacy {
         fmt::{FmtLabels, FmtMetric, FmtMetrics, Metric},
         gauge::Gauge,
         histogram::Histogram,
+        store::LastUpdate,
     };
 }
 

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -20,7 +20,6 @@ pub use kubert_prometheus_process as process;
 pub use self::new_metrics::NewMetrics;
 pub use self::{
     fmt::{FmtLabels, FmtMetric, FmtMetrics, Metric},
-    histogram::Histogram,
     serve::Serve,
     store::{LastUpdate, SharedStore, Store},
 };
@@ -33,7 +32,7 @@ pub mod legacy {
     //
     // this will help us differentiate in dependent systems which components rely on our legacy
     // metrics implementation.
-    pub use super::{counter::Counter, gauge::Gauge};
+    pub use super::{counter::Counter, gauge::Gauge, histogram::Histogram};
 }
 
 /// Integration with the [`prometheus_client`]` crate.

--- a/linkerd/metrics/src/new_metrics.rs
+++ b/linkerd/metrics/src/new_metrics.rs
@@ -1,4 +1,4 @@
-use crate::SharedStore;
+use crate::legacy::SharedStore;
 use linkerd_stack as svc;
 use std::{fmt, hash::Hash, marker::PhantomData, sync::Arc};
 

--- a/linkerd/metrics/src/serve.rs
+++ b/linkerd/metrics/src/serve.rs
@@ -4,7 +4,7 @@ use linkerd_http_box::BoxBody;
 use std::io::Write;
 use tracing::trace;
 
-use super::FmtMetrics;
+use super::legacy::FmtMetrics;
 
 /// Serve Prometheues metrics.
 #[derive(Debug, Clone)]

--- a/linkerd/metrics/src/store.rs
+++ b/linkerd/metrics/src/store.rs
@@ -1,4 +1,4 @@
-use crate::{FmtLabels, FmtMetric, Metric};
+use crate::{legacy::Metric, FmtLabels, FmtMetric};
 use parking_lot::Mutex;
 use std::{
     borrow::Borrow,

--- a/linkerd/metrics/src/store.rs
+++ b/linkerd/metrics/src/store.rs
@@ -1,7 +1,4 @@
-use crate::{
-    legacy::{FmtMetric, Metric},
-    FmtLabels,
-};
+use crate::legacy::{FmtLabels, FmtMetric, Metric};
 use parking_lot::Mutex;
 use std::{
     borrow::Borrow,

--- a/linkerd/metrics/src/store.rs
+++ b/linkerd/metrics/src/store.rs
@@ -1,4 +1,7 @@
-use crate::{legacy::Metric, FmtLabels, FmtMetric};
+use crate::{
+    legacy::{FmtMetric, Metric},
+    FmtLabels,
+};
 use parking_lot::Mutex;
 use std::{
     borrow::Borrow,

--- a/linkerd/opencensus/src/metrics.rs
+++ b/linkerd/opencensus/src/metrics.rs
@@ -1,4 +1,7 @@
-use linkerd_metrics::{legacy::Counter, metrics, FmtMetrics};
+use linkerd_metrics::{
+    legacy::{Counter, FmtMetrics},
+    metrics,
+};
 use std::fmt;
 use std::sync::Arc;
 

--- a/linkerd/opencensus/src/metrics.rs
+++ b/linkerd/opencensus/src/metrics.rs
@@ -1,4 +1,4 @@
-use linkerd_metrics::{metrics, Counter, FmtMetrics};
+use linkerd_metrics::{legacy::Counter, metrics, FmtMetrics};
 use std::fmt;
 use std::sync::Arc;
 

--- a/linkerd/opentelemetry/src/metrics.rs
+++ b/linkerd/opentelemetry/src/metrics.rs
@@ -1,4 +1,7 @@
-use linkerd_metrics::{legacy::Counter, metrics, FmtMetrics};
+use linkerd_metrics::{
+    legacy::{Counter, FmtMetrics},
+    metrics,
+};
 use std::fmt;
 use std::sync::Arc;
 

--- a/linkerd/opentelemetry/src/metrics.rs
+++ b/linkerd/opentelemetry/src/metrics.rs
@@ -1,4 +1,4 @@
-use linkerd_metrics::{metrics, Counter, FmtMetrics};
+use linkerd_metrics::{legacy::Counter, metrics, FmtMetrics};
 use std::fmt;
 use std::sync::Arc;
 

--- a/linkerd/stack/metrics/src/lib.rs
+++ b/linkerd/stack/metrics/src/lib.rs
@@ -7,8 +7,8 @@ mod service;
 pub use self::layer::TrackServiceLayer;
 pub use self::service::TrackService;
 use linkerd_metrics::{
-    legacy::{Counter, FmtMetrics},
-    metrics, FmtLabels,
+    legacy::{Counter, FmtLabels, FmtMetrics},
+    metrics,
 };
 use parking_lot::Mutex;
 use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};

--- a/linkerd/stack/metrics/src/lib.rs
+++ b/linkerd/stack/metrics/src/lib.rs
@@ -6,7 +6,10 @@ mod service;
 
 pub use self::layer::TrackServiceLayer;
 pub use self::service::TrackService;
-use linkerd_metrics::{legacy::Counter, metrics, FmtLabels, FmtMetrics};
+use linkerd_metrics::{
+    legacy::{Counter, FmtMetrics},
+    metrics, FmtLabels,
+};
 use parking_lot::Mutex;
 use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};
 

--- a/linkerd/stack/metrics/src/lib.rs
+++ b/linkerd/stack/metrics/src/lib.rs
@@ -6,7 +6,7 @@ mod service;
 
 pub use self::layer::TrackServiceLayer;
 pub use self::service::TrackService;
-use linkerd_metrics::{metrics, Counter, FmtLabels, FmtMetrics};
+use linkerd_metrics::{legacy::Counter, metrics, FmtLabels, FmtMetrics};
 use parking_lot::Mutex;
 use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};
 

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -14,7 +14,10 @@ pub use self::{
     server::NewServer,
 };
 use linkerd_errno::Errno;
-use linkerd_metrics::{legacy::Counter, metrics, FmtLabels, Gauge, LastUpdate, Store};
+use linkerd_metrics::{
+    legacy::{Counter, Gauge},
+    metrics, FmtLabels, LastUpdate, Store,
+};
 use parking_lot::Mutex;
 use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};
 use tokio::time::{Duration, Instant};

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -15,8 +15,8 @@ pub use self::{
 };
 use linkerd_errno::Errno;
 use linkerd_metrics::{
-    legacy::{Counter, FmtLabels, Gauge},
-    metrics, LastUpdate, Store,
+    legacy::{Counter, FmtLabels, Gauge, LastUpdate},
+    metrics, Store,
 };
 use parking_lot::Mutex;
 use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -15,8 +15,8 @@ pub use self::{
 };
 use linkerd_errno::Errno;
 use linkerd_metrics::{
-    legacy::{Counter, Gauge},
-    metrics, FmtLabels, LastUpdate, Store,
+    legacy::{Counter, FmtLabels, Gauge},
+    metrics, LastUpdate, Store,
 };
 use parking_lot::Mutex;
 use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};
@@ -116,7 +116,7 @@ impl Default for ByEos {
 mod tests {
     #[test]
     fn expiry() {
-        use linkerd_metrics::FmtLabels;
+        use linkerd_metrics::legacy::FmtLabels;
         use std::fmt;
         use tokio::time::{Duration, Instant};
 

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -14,7 +14,7 @@ pub use self::{
     server::NewServer,
 };
 use linkerd_errno::Errno;
-use linkerd_metrics::{metrics, Counter, FmtLabels, Gauge, LastUpdate, Store};
+use linkerd_metrics::{legacy::Counter, metrics, FmtLabels, Gauge, LastUpdate, Store};
 use parking_lot::Mutex;
 use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};
 use tokio::time::{Duration, Instant};

--- a/linkerd/transport-metrics/src/lib.rs
+++ b/linkerd/transport-metrics/src/lib.rs
@@ -15,8 +15,8 @@ pub use self::{
 };
 use linkerd_errno::Errno;
 use linkerd_metrics::{
-    legacy::{Counter, FmtLabels, Gauge, LastUpdate},
-    metrics, Store,
+    legacy::{Counter, FmtLabels, Gauge, LastUpdate, Store},
+    metrics,
 };
 use parking_lot::Mutex;
 use std::{collections::HashMap, fmt, hash::Hash, sync::Arc};

--- a/linkerd/transport-metrics/src/report.rs
+++ b/linkerd/transport-metrics/src/report.rs
@@ -2,7 +2,10 @@ use super::{
     tcp_close_total, tcp_open_connections, tcp_open_total, tcp_read_bytes_total,
     tcp_write_bytes_total, EosMetrics, Inner,
 };
-use linkerd_metrics::{legacy::Metric, FmtLabels, FmtMetric, FmtMetrics};
+use linkerd_metrics::{
+    legacy::{FmtMetric, Metric},
+    FmtLabels, FmtMetrics,
+};
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, sync::Arc};
 use tokio::time::{Duration, Instant};

--- a/linkerd/transport-metrics/src/report.rs
+++ b/linkerd/transport-metrics/src/report.rs
@@ -2,7 +2,7 @@ use super::{
     tcp_close_total, tcp_open_connections, tcp_open_total, tcp_read_bytes_total,
     tcp_write_bytes_total, EosMetrics, Inner,
 };
-use linkerd_metrics::{FmtLabels, FmtMetric, FmtMetrics, Metric};
+use linkerd_metrics::{legacy::Metric, FmtLabels, FmtMetric, FmtMetrics};
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, sync::Arc};
 use tokio::time::{Duration, Instant};

--- a/linkerd/transport-metrics/src/report.rs
+++ b/linkerd/transport-metrics/src/report.rs
@@ -3,8 +3,8 @@ use super::{
     tcp_write_bytes_total, EosMetrics, Inner,
 };
 use linkerd_metrics::{
-    legacy::{FmtMetric, Metric},
-    FmtLabels, FmtMetrics,
+    legacy::{FmtMetric, FmtMetrics, Metric},
+    FmtLabels,
 };
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, sync::Arc};

--- a/linkerd/transport-metrics/src/report.rs
+++ b/linkerd/transport-metrics/src/report.rs
@@ -2,10 +2,7 @@ use super::{
     tcp_close_total, tcp_open_connections, tcp_open_total, tcp_read_bytes_total,
     tcp_write_bytes_total, EosMetrics, Inner,
 };
-use linkerd_metrics::{
-    legacy::{FmtMetric, FmtMetrics, Metric},
-    FmtLabels,
-};
+use linkerd_metrics::legacy::{FmtLabels, FmtMetric, FmtMetrics, Metric};
 use parking_lot::Mutex;
 use std::{fmt, hash::Hash, sync::Arc};
 use tokio::time::{Duration, Instant};


### PR DESCRIPTION
`linkerd-metrics` contains a suite of facilities for defining, registering, and serving Prometheus metrics. these predate the [`prometheus-client`](https://crates.io/crates/prometheus-client/) crate, which should now be used for our metrics.

`linkerd-metrics` defines a `prom` namespace, which reëxports symbols from the `prometheus-client` library. as the documentation comment for this submodule notes, this should be used for all new metrics.

https://github.com/linkerd/linkerd2-proxy/blob/6b323d84579d5d7774e733052a281602465ccc2c/linkerd/metrics/src/lib.rs#L30-L60

`linkerd-metrics` still provides its legacy types in the public surface of this library today, which can make it difficult to differentiate between our two metrics implementations.

this branch introduces a new `legacy` namespace, to help clarify the distinction between these two Prometheus implementations, and to smooth the road to further adoption of `prometheus-client` interfaces across the proxy.