### PR TITLE
chore(deps): Manually remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,13 +1514,10 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "hyper-util",
  "ipnet",
  "linkerd-addr",
  "linkerd-conditional",
  "linkerd-dns",
- "linkerd-duplex",
- "linkerd-errno",
  "linkerd-error",
  "linkerd-error-respond",
  "linkerd-exp-backoff",
@@ -1557,13 +1554,9 @@ dependencies = [
  "linkerd-tracing",
  "linkerd-transport-header",
  "linkerd-transport-metrics",
- "parking_lot",
  "pin-project",
  "prometheus-client",
- "quickcheck",
- "regex",
  "semver",
- "serde_json",
  "thiserror 2.0.14",
  "tokio",
  "tokio-rustls",
@@ -1758,7 +1751,6 @@ dependencies = [
  "linkerd-stack",
  "parking_lot",
  "rand 0.9.2",
- "tokio",
  "tokio-test",
  "tower-test",
  "tracing",
@@ -1768,7 +1760,6 @@ dependencies = [
 name = "linkerd-dns"
 version = "0.1.0"
 dependencies = [
- "futures",
  "hickory-resolver",
  "linkerd-dns-name",
  "linkerd-error",
@@ -1917,11 +1908,9 @@ dependencies = [
 name = "linkerd-http-metrics"
 version = "0.1.0"
 dependencies = [
- "bytes",
  "futures",
  "http",
  "http-body",
- "hyper",
  "linkerd-error",
  "linkerd-http-classify",
  "linkerd-metrics",
@@ -1955,7 +1944,6 @@ dependencies = [
  "linkerd-http-box",
  "linkerd-metrics",
  "linkerd-stack",
- "parking_lot",
  "pin-project",
  "prometheus-client",
  "thiserror 2.0.14",
@@ -1982,7 +1970,6 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "hyper",
  "linkerd-error",
  "linkerd-exp-backoff",
  "linkerd-http-box",
@@ -2004,7 +1991,6 @@ version = "0.1.0"
 dependencies = [
  "http",
  "linkerd2-proxy-api",
- "maplit",
  "rand 0.9.2",
  "regex",
  "thiserror 2.0.14",
@@ -2032,7 +2018,6 @@ dependencies = [
 name = "linkerd-http-upgrade"
 version = "0.1.0"
 dependencies = [
- "bytes",
  "drain",
  "futures",
  "http",
@@ -2078,10 +2063,7 @@ dependencies = [
 name = "linkerd-idle-cache"
 version = "0.1.0"
 dependencies = [
- "futures",
- "linkerd-error",
  "linkerd-stack",
- "linkerd-tracing",
  "parking_lot",
  "tokio",
  "tower 0.5.2",
@@ -2130,13 +2112,11 @@ name = "linkerd-meshtls-boring"
 version = "0.1.0"
 dependencies = [
  "boring",
- "futures",
  "hex",
  "linkerd-dns-name",
  "linkerd-error",
  "linkerd-identity",
  "linkerd-io",
- "linkerd-meshtls",
  "linkerd-meshtls-verifier",
  "linkerd-stack",
  "linkerd-tls",
@@ -2185,9 +2165,7 @@ dependencies = [
  "bytes",
  "deflate",
  "http",
- "http-body",
  "http-body-util",
- "hyper",
  "kubert-prometheus-process",
  "linkerd-http-box",
  "linkerd-stack",
@@ -2274,7 +2252,6 @@ dependencies = [
  "ahash",
  "futures",
  "futures-util",
- "indexmap 2.10.0",
  "linkerd-error",
  "linkerd-metrics",
  "linkerd-pool",
@@ -2307,8 +2284,6 @@ dependencies = [
  "linkerd-tls",
  "linkerd-tonic-stream",
  "linkerd2-proxy-api",
- "pin-project",
- "prost 0.13.5",
  "tonic",
  "tower 0.5.2",
  "tracing",
@@ -2326,7 +2301,6 @@ dependencies = [
  "linkerd-proxy-balance-queue",
  "linkerd-proxy-core",
  "linkerd-stack",
- "rand 0.9.2",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -2354,13 +2328,10 @@ dependencies = [
  "linkerd-tracing",
  "parking_lot",
  "pin-project",
- "prometheus-client",
- "thiserror 2.0.14",
  "tokio",
  "tokio-stream",
  "tokio-test",
  "tokio-util",
- "tower-test",
  "tracing",
 ]
 
@@ -2370,19 +2341,15 @@ version = "0.1.0"
 dependencies = [
  "ahash",
  "http",
- "ipnet",
  "linkerd-error",
  "linkerd-exp-backoff",
  "linkerd-http-route",
  "linkerd-opaq-route",
  "linkerd-proxy-api-resolve",
- "linkerd-proxy-core",
  "linkerd-tls-route",
  "linkerd2-proxy-api",
- "maplit",
  "once_cell",
  "prost-types 0.13.5",
- "quickcheck",
  "thiserror 2.0.14",
  "tonic",
 ]
@@ -2416,7 +2383,6 @@ dependencies = [
 name = "linkerd-proxy-http"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "bytes",
  "drain",
  "futures",
@@ -2424,11 +2390,9 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "httparse",
  "hyper",
  "hyper-balance",
  "hyper-util",
- "linkerd-duplex",
  "linkerd-error",
  "linkerd-http-box",
  "linkerd-http-classify",
@@ -2444,32 +2408,25 @@ dependencies = [
  "linkerd-proxy-balance",
  "linkerd-stack",
  "linkerd-tracing",
- "parking_lot",
  "pin-project",
- "rand 0.9.2",
  "thiserror 2.0.14",
  "tokio",
  "tokio-test",
  "tower 0.5.2",
  "tower-test",
  "tracing",
- "try-lock",
 ]
 
 [[package]]
 name = "linkerd-proxy-identity-client"
 version = "0.1.0"
 dependencies = [
- "futures",
  "http-body",
  "linkerd-dns-name",
  "linkerd-error",
  "linkerd-identity",
- "linkerd-metrics",
  "linkerd-stack",
  "linkerd2-proxy-api",
- "parking_lot",
- "pin-project",
  "thiserror 2.0.14",
  "tokio",
  "tonic",
@@ -2515,14 +2472,12 @@ dependencies = [
  "linkerd-exp-backoff",
  "linkerd-identity",
  "linkerd-proxy-http",
- "linkerd-stack",
  "linkerd-tonic-watch",
  "rcgen",
  "simple_asn1",
  "spiffe-proto",
  "thiserror 2.0.14",
  "tokio",
- "tokio-test",
  "tonic",
  "tower 0.5.2",
  "tracing",
@@ -2552,7 +2507,6 @@ dependencies = [
  "pin-project",
  "prost-types 0.13.5",
  "quickcheck",
- "rand 0.9.2",
  "thiserror 2.0.14",
  "tokio",
  "tonic",
@@ -2569,8 +2523,6 @@ dependencies = [
  "linkerd-error",
  "linkerd-proxy-balance",
  "linkerd-stack",
- "pin-project",
- "rand 0.9.2",
  "tokio",
  "tower 0.5.2",
 ]
@@ -2599,11 +2551,9 @@ dependencies = [
  "linkerd-error",
  "linkerd-stack",
  "linkerd-tracing",
- "pin-project",
  "tokio",
  "tokio-stream",
  "tokio-test",
- "tower 0.5.2",
  "tower-test",
  "tracing",
 ]
@@ -2628,7 +2578,6 @@ dependencies = [
  "linkerd-error",
  "linkerd-stack",
  "parking_lot",
- "thiserror 2.0.14",
  "tracing",
 ]
 
@@ -2636,14 +2585,12 @@ dependencies = [
 name = "linkerd-service-profiles"
 version = "0.1.0"
 dependencies = [
- "bytes",
  "futures",
  "http",
  "http-body",
  "linkerd-addr",
  "linkerd-dns-name",
  "linkerd-error",
- "linkerd-http-box",
  "linkerd-proxy-api-resolve",
  "linkerd-stack",
  "linkerd-tonic-stream",
@@ -2703,8 +2650,6 @@ dependencies = [
 name = "linkerd-stack-tracing"
 version = "0.1.0"
 dependencies = [
- "futures",
- "linkerd-error",
  "linkerd-stack",
  "tower 0.5.2",
  "tracing",
@@ -2714,7 +2659,6 @@ dependencies = [
 name = "linkerd-tls"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "bytes",
  "futures",
  "linkerd-conditional",
@@ -2727,7 +2671,6 @@ dependencies = [
  "pin-project",
  "thiserror 2.0.14",
  "tokio",
- "tower 0.5.2",
  "tracing",
  "untrusted",
 ]
@@ -2739,8 +2682,6 @@ dependencies = [
  "linkerd-dns",
  "linkerd-tls",
  "linkerd2-proxy-api",
- "rand 0.9.2",
- "regex",
  "thiserror 2.0.14",
  "tracing",
 ]
@@ -2759,7 +2700,6 @@ dependencies = [
  "pin-project",
  "tokio",
  "tokio-stream",
- "tokio-test",
  "tonic",
  "tracing",
 ]
@@ -2774,7 +2714,6 @@ dependencies = [
  "linkerd-tracing",
  "tokio",
  "tokio-stream",
- "tokio-test",
  "tonic",
  "tower-test",
  "tracing",
@@ -2815,9 +2754,7 @@ name = "linkerd-transport-header"
 version = "0.1.0"
 dependencies = [
  "arbitrary",
- "async-trait",
  "bytes",
- "futures",
  "libfuzzer-sys",
  "linkerd-dns-name",
  "linkerd-error",
@@ -3134,7 +3071,6 @@ dependencies = [
 name = "opencensus-proto"
 version = "0.1.0"
 dependencies = [
- "bytes",
  "prost 0.13.5",
  "prost-types 0.13.5",
  "tonic",
@@ -3935,9 +3871,7 @@ dependencies = [
 name = "spiffe-proto"
 version = "0.1.0"
 dependencies = [
- "bytes",
  "prost 0.13.5",
- "prost-types 0.13.5",
  "tonic",
  "tonic-build",
 ]

--- a/linkerd/app/core/Cargo.toml
+++ b/linkerd/app/core/Cargo.toml
@@ -13,32 +13,24 @@ independently of the inbound and outbound proxy logic.
 """
 
 [dependencies]
-bytes = { workspace = true }
 drain = { workspace = true, features = ["retain"] }
 http = { workspace = true }
 http-body = { workspace = true }
-http-body-util = { workspace = true }
 hyper = { workspace = true, features = ["http1", "http2"] }
-hyper-util = { workspace = true }
 futures = { version = "0.3", default-features = false }
 ipnet = "2.11"
 prometheus-client = { workspace = true }
-regex = "1"
-serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "sync", "parking_lot"] }
 tokio-rustls = { workspace = true }
 tokio-stream = { version = "0.1", features = ["time"] }
 tonic = { workspace = true, default-features = false, features = ["prost"] }
 tracing = { workspace = true }
-parking_lot = "0.12"
 pin-project = "1"
 
 linkerd-addr = { path = "../../addr" }
 linkerd-conditional = { path = "../../conditional" }
 linkerd-dns = { path = "../../dns" }
-linkerd-duplex = { path = "../../duplex" }
-linkerd-errno = { path = "../../errno" }
 linkerd-error = { path = "../../error" }
 linkerd-error-respond = { path = "../../error-respond" }
 linkerd-exp-backoff = { path = "../../exp-backoff" }
@@ -84,5 +76,6 @@ features = ["make", "spawn-ready", "timeout", "util", "limit"]
 semver = "1"
 
 [dev-dependencies]
+bytes = { workspace = true }
+http-body-util = { workspace = true }
 linkerd-mock-http-body = { path = "../../mock/http-body" }
-quickcheck = { version = "1", default-features = false }

--- a/linkerd/distribute/Cargo.toml
+++ b/linkerd/distribute/Cargo.toml
@@ -11,7 +11,6 @@ ahash = "0.8"
 linkerd-stack = { path = "../stack" }
 parking_lot = "0.12"
 rand = { version = "0.9", features = ["small_rng"] }
-tokio = { version = "1", features = ["macros"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/linkerd/dns/Cargo.toml
+++ b/linkerd/dns/Cargo.toml
@@ -7,14 +7,15 @@ edition = { workspace = true }
 publish = { workspace = true }
 
 [dependencies]
-futures = { version = "0.3", default-features = false }
 hickory-resolver = "0.25.2"
 linkerd-dns-name = { path = "./name" }
-linkerd-error = { path = "../error" }
 prometheus-client = { workspace = true }
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+linkerd-error = { path = "../error" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/linkerd/http/classify/Cargo.toml
+++ b/linkerd/http/classify/Cargo.toml
@@ -15,10 +15,10 @@ tokio = { version = "1", default-features = false }
 tracing = { workspace = true }
 
 linkerd-error = { path = "../../error" }
-linkerd-http-box = { path = "../../http/box" }
 linkerd-stack = { path = "../../stack" }
 
 [dev-dependencies]
 tokio-test = "0.4"
 tower-test = { workspace = true }
+linkerd-http-box = { path = "../../http/box" }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }

--- a/linkerd/http/metrics/Cargo.toml
+++ b/linkerd/http/metrics/Cargo.toml
@@ -10,11 +10,9 @@ publish = { workspace = true }
 test-util = []
 
 [dependencies]
-bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
 http-body = { workspace = true }
-hyper = { workspace = true, features = ["http1", "http2"] }
 parking_lot = "0.12"
 pin-project = "1"
 tokio = { version = "1", features = ["time"] }

--- a/linkerd/http/prom/Cargo.toml
+++ b/linkerd/http/prom/Cargo.toml
@@ -17,7 +17,6 @@ bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
 http-body = { workspace = true }
-parking_lot = "0.12"
 pin-project = "1"
 prometheus-client = { workspace = true }
 thiserror = "2"

--- a/linkerd/http/retry/Cargo.toml
+++ b/linkerd/http/retry/Cargo.toml
@@ -14,7 +14,6 @@ http-body-util = { workspace = true }
 http = { workspace = true }
 parking_lot = "0.12"
 pin-project = "1"
-tokio = { version = "1", features = ["macros", "rt"] }
 tower = { workspace = true, features = ["retry"] }
 tracing = { workspace = true }
 thiserror = "2"
@@ -26,7 +25,6 @@ linkerd-metrics = { path = "../../metrics" }
 linkerd-stack = { path = "../../stack" }
 
 [dev-dependencies]
-hyper = { workspace = true }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }
 linkerd-mock-http-body = { path = "../../mock/http-body" }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/linkerd/http/route/Cargo.toml
+++ b/linkerd/http/route/Cargo.toml
@@ -21,6 +21,3 @@ url = "2"
 workspace = true
 features = ["http-route", "grpc-route"]
 optional = true
-
-[dev-dependencies]
-maplit = "1"

--- a/linkerd/http/upgrade/Cargo.toml
+++ b/linkerd/http/upgrade/Cargo.toml
@@ -10,7 +10,6 @@ Facilities for HTTP/1 upgrades.
 """
 
 [dependencies]
-bytes = { workspace = true }
 drain = { workspace = true }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }

--- a/linkerd/idle-cache/Cargo.toml
+++ b/linkerd/idle-cache/Cargo.toml
@@ -10,8 +10,6 @@ publish = { workspace = true }
 test-util = []
 
 [dependencies]
-futures = { version = "0.3", default-features = false }
-linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 parking_lot = "0.12"
 tokio = { version = "1", default-features = false, features = [
@@ -28,4 +26,3 @@ tokio = { version = "1", default-features = false, features = [
     "test-util",
     "time",
 ] }
-linkerd-tracing = { path = "../tracing", features = ["ansi"] }

--- a/linkerd/meshtls/boring/Cargo.toml
+++ b/linkerd/meshtls/boring/Cargo.toml
@@ -8,7 +8,6 @@ publish = { workspace = true }
 
 [dependencies]
 boring = "4"
-futures = { version = "0.3", default-features = false }
 hex = "0.4"                                             # used for debug logging
 tokio = { version = "1", features = ["macros", "sync"] }
 tokio-boring = "4"
@@ -27,4 +26,3 @@ fips = ["boring/fips"]
 
 [dev-dependencies]
 linkerd-tls-test-util = { path = "../../tls/test-util" }
-linkerd-meshtls = { path = "../../meshtls" }

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -16,9 +16,7 @@ test_util = []
 bytes = { workspace = true }
 deflate = { version = "1", features = ["gzip"] }
 http = { workspace = true }
-http-body = { workspace = true }
 http-body-util = { workspace = true }
-hyper = { workspace = true, features = ["http1", "http2"] }
 kubert-prometheus-process = { version = "0.2", optional = true }
 parking_lot = "0.12"
 prometheus-client = { workspace = true }

--- a/linkerd/pool/p2c/Cargo.toml
+++ b/linkerd/pool/p2c/Cargo.toml
@@ -9,10 +9,8 @@ publish = { workspace = true }
 [dependencies]
 ahash = "0.8"
 futures = { version = "0.3", default-features = false }
-indexmap = "2"
 prometheus-client = { workspace = true }
 rand = { version = "0.9", features = ["small_rng"] }
-tokio = { version = "1", features = ["rt", "sync", "time"] }
 tracing = { workspace = true }
 
 linkerd-error = { path = "../../error" }
@@ -30,5 +28,6 @@ futures-util = { version = "0.3", default-features = false }
 linkerd-tracing = { path = "../../tracing" }
 parking_lot = "0.12"
 quickcheck = { version = "1", default-features = false }
+tokio = { version = "1", features = ["rt", "sync", "time"] }
 tokio-test = "0.4"
 tower-test = { workspace = true }

--- a/linkerd/proxy/api-resolve/Cargo.toml
+++ b/linkerd/proxy/api-resolve/Cargo.toml
@@ -22,8 +22,6 @@ linkerd-tls = { path = "../../tls" }
 linkerd-identity = { path = "../../identity" }
 http = { workspace = true }
 http-body = { workspace = true }
-pin-project = "1"
-prost = { workspace = true }
 tonic = { workspace = true, default-features = false }
 tower = { workspace = true, default-features = false }
 tracing = { workspace = true }

--- a/linkerd/proxy/balance/Cargo.toml
+++ b/linkerd/proxy/balance/Cargo.toml
@@ -8,7 +8,6 @@ publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-rand = "0.9"
 tokio = { version = "1", features = ["time"] }
 tracing = { workspace = true }
 

--- a/linkerd/proxy/balance/queue/Cargo.toml
+++ b/linkerd/proxy/balance/queue/Cargo.toml
@@ -10,8 +10,6 @@ publish = { workspace = true }
 futures = { version = "0.3", default-features = false }
 parking_lot = "0.12"
 pin-project = "1"
-prometheus-client = { workspace = true }
-thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 tokio-util = "0.7"
 tracing = { workspace = true }
@@ -25,7 +23,6 @@ linkerd-stack = { path = "../../../stack" }
 [dev-dependencies]
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-test = "0.4"
-tower-test = { workspace = true }
 
 linkerd-pool-mock = { path = "../../../pool/mock" }
 linkerd-tracing = { path = "../../../tracing" }

--- a/linkerd/proxy/client-policy/Cargo.toml
+++ b/linkerd/proxy/client-policy/Cargo.toml
@@ -17,7 +17,6 @@ proto = [
 
 [dependencies]
 ahash = "0.8"
-ipnet = "2"
 http = { workspace = true }
 once_cell = { version = "1" }
 prost-types = { workspace = true, optional = true }
@@ -30,13 +29,8 @@ linkerd-http-route = { path = "../../http/route" }
 linkerd-tls-route = { path = "../../tls/route" }
 linkerd-opaq-route = { path = "../../opaq-route" }
 linkerd-proxy-api-resolve = { path = "../api-resolve" }
-linkerd-proxy-core = { path = "../core" }
 
 [dependencies.linkerd2-proxy-api]
 workspace = true
 optional = true
 features = ["outbound"]
-
-[dev-dependencies]
-maplit = "1"
-quickcheck = { version = "1", default-features = false }

--- a/linkerd/proxy/http/Cargo.toml
+++ b/linkerd/proxy/http/Cargo.toml
@@ -12,14 +12,11 @@ This should probably be decomposed into smaller, decoupled crates.
 """
 
 [dependencies]
-async-trait = "0.1"
-bytes = { workspace = true }
 drain = { workspace = true }
 futures = { version = "0.3", default-features = false }
 h2 = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }
-httparse = "1"
 hyper = { workspace = true, features = [
     "client",
     "http1",
@@ -35,16 +32,12 @@ hyper-util = { workspace = true, default-features = false, features = [
     "tokio",
     "tracing",
 ] }
-parking_lot = "0.12"
 pin-project = "1"
-rand = "0.9"
 thiserror = "2"
 tokio = { version = "1", features = ["rt", "sync", "time"] }
 tower = { workspace = true, default-features = false }
 tracing = { workspace = true }
-try-lock = "0.2"
 
-linkerd-duplex = { path = "../../duplex" }
 linkerd-error = { path = "../../error" }
 linkerd-http-box = { path = "../../http/box" }
 linkerd-http-classify = { path = "../../http/classify" }
@@ -61,8 +54,8 @@ linkerd-proxy-balance = { path = "../balance" }
 linkerd-stack = { path = "../../stack" }
 
 [dev-dependencies]
+bytes = { workspace = true }
 http-body-util = { workspace = true, features = ["channel"] }
-tokio-test = "0.4"
 tower-test = { workspace = true }
 linkerd-tracing = { path = "../../tracing", features = ["ansi"] }
 

--- a/linkerd/proxy/identity-client/Cargo.toml
+++ b/linkerd/proxy/identity-client/Cargo.toml
@@ -7,15 +7,11 @@ edition = { workspace = true }
 publish = { workspace = true }
 
 [dependencies]
-futures = { version = "0.3", default-features = false }
 linkerd2-proxy-api = { workspace = true, features = ["identity"] }
 linkerd-dns-name = { path = "../../dns/name" }
 linkerd-error = { path = "../../error" }
 linkerd-identity = { path = "../../identity" }
-linkerd-metrics = { path = "../../metrics" }
 linkerd-stack = { path = "../../stack" }
-parking_lot = "0.12"
-pin-project = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["time", "sync"] }
 tonic = { workspace = true, default-features = false }

--- a/linkerd/proxy/spire-client/Cargo.toml
+++ b/linkerd/proxy/spire-client/Cargo.toml
@@ -14,7 +14,6 @@ linkerd-identity = { path = "../../identity" }
 spiffe-proto = { path = "../../../spiffe-proto" }
 linkerd-tonic-watch = { path = "../../tonic-watch" }
 linkerd-exp-backoff = { path = "../../exp-backoff" }
-linkerd-stack = { path = "../../stack" }
 tokio = { version = "1", features = ["time", "sync"] }
 tonic = { workspace = true }
 tower = { workspace = true }
@@ -25,4 +24,3 @@ thiserror = "2"
 
 [dev-dependencies]
 rcgen = { version = "0.14.3", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }
-tokio-test = "0.4"

--- a/linkerd/proxy/tap/Cargo.toml
+++ b/linkerd/proxy/tap/Cargo.toml
@@ -24,7 +24,6 @@ linkerd-stack = { path = "../../stack" }
 linkerd-tls = { path = "../../tls" }
 parking_lot = "0.12"
 prost-types = { workspace = true }
-rand = { version = "0.9" }
 thiserror = "2"
 tokio = { version = "1", features = ["time"] }
 tower = { workspace = true, default-features = false }

--- a/linkerd/proxy/tcp/Cargo.toml
+++ b/linkerd/proxy/tcp/Cargo.toml
@@ -12,7 +12,5 @@ linkerd-duplex = { path = "../../duplex" }
 linkerd-error = { path = "../../error" }
 linkerd-proxy-balance = { path = "../../proxy/balance" }
 linkerd-stack = { path = "../../stack" }
-rand = "0.9"
 tokio = { version = "1" }
 tower = { workspace = true, default-features = false }
-pin-project = "1"

--- a/linkerd/reconnect/Cargo.toml
+++ b/linkerd/reconnect/Cargo.toml
@@ -10,9 +10,7 @@ publish = { workspace = true }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 futures = { version = "0.3", default-features = false }
-tower = { workspace = true, default-features = false }
 tracing = { workspace = true }
-pin-project = "1"
 
 [dev-dependencies]
 linkerd-tracing = { path = "../tracing" }

--- a/linkerd/router/Cargo.toml
+++ b/linkerd/router/Cargo.toml
@@ -10,7 +10,6 @@ publish = { workspace = true }
 ahash = "0.8"
 futures = { version = "0.3", default-features = false }
 parking_lot = "0.12"
-thiserror = "2"
 tracing = { workspace = true }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }

--- a/linkerd/service-profiles/Cargo.toml
+++ b/linkerd/service-profiles/Cargo.toml
@@ -10,7 +10,6 @@ Implements client layers for Linkerd ServiceProfiles.
 """
 
 [dependencies]
-bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 http = { workspace = true }
 http-body = { workspace = true }
@@ -28,7 +27,6 @@ tracing = { workspace = true }
 linkerd-addr = { path = "../addr" }
 linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }
-linkerd-http-box = { path = "../http/box" }
 linkerd-proxy-api-resolve = { path = "../proxy/api-resolve" }
 linkerd-stack = { path = "../stack" }
 linkerd-tonic-stream = { path = "../tonic-stream" }

--- a/linkerd/stack/tracing/Cargo.toml
+++ b/linkerd/stack/tracing/Cargo.toml
@@ -7,8 +7,6 @@ edition = { workspace = true }
 publish = { workspace = true }
 
 [dependencies]
-futures = { version = "0.3", default-features = false }
-linkerd-error = { path = "../../error" }
 linkerd-stack = { path = ".." }
 tower = { workspace = true }
 tracing = { workspace = true }

--- a/linkerd/tls/Cargo.toml
+++ b/linkerd/tls/Cargo.toml
@@ -7,7 +7,6 @@ edition = { workspace = true }
 publish = { workspace = true }
 
 [dependencies]
-async-trait = "0.1"
 bytes = { workspace = true }
 futures = { version = "0.3", default-features = false }
 linkerd-conditional = { path = "../conditional" }
@@ -19,7 +18,6 @@ linkerd-stack = { path = "../stack" }
 pin-project = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "time"] }
-tower = { workspace = true }
 tracing = { workspace = true }
 untrusted = "0.9"
 

--- a/linkerd/tls/route/Cargo.toml
+++ b/linkerd/tls/route/Cargo.toml
@@ -10,8 +10,6 @@ publish = { workspace = true }
 proto = ["linkerd2-proxy-api"]
 
 [dependencies]
-regex = "1"
-rand = "0.9"
 thiserror = "2"
 tracing = { workspace = true }
 linkerd-tls = { path = "../" }

--- a/linkerd/tonic-stream/Cargo.toml
+++ b/linkerd/tonic-stream/Cargo.toml
@@ -15,7 +15,6 @@ tokio = { version = "1", features = ["time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros"] }
-tokio-test = "0.4"
+tokio = { version = "1", features = ["macros", "test-util"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 linkerd-tracing = { path = "../tracing" }

--- a/linkerd/tonic-watch/Cargo.toml
+++ b/linkerd/tonic-watch/Cargo.toml
@@ -21,5 +21,4 @@ tracing = { workspace = true }
 linkerd-tracing = { path = "../tracing" }
 tokio = { version = "1", features = ["macros"] }
 tokio-stream = { version = "0.1", features = ["sync", "time"] }
-tokio-test = "0.4"
 tower-test = { workspace = true }

--- a/linkerd/transport-header/Cargo.toml
+++ b/linkerd/transport-header/Cargo.toml
@@ -7,9 +7,7 @@ edition = { workspace = true }
 publish = { workspace = true }
 
 [dependencies]
-async-trait = "0.1"
 bytes = { workspace = true }
-futures = { version = "0.3", default-features = false }
 linkerd-dns-name = { path = "../dns/name" }
 linkerd-error = { path = "../error" }
 linkerd-io = { path = "../io" }

--- a/opencensus-proto/Cargo.toml
+++ b/opencensus-proto/Cargo.toml
@@ -12,7 +12,6 @@ Vendored from https://github.com/census-instrumentation/opencensus-proto/.
 """
 
 [dependencies]
-bytes = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 

--- a/spiffe-proto/Cargo.toml
+++ b/spiffe-proto/Cargo.toml
@@ -7,9 +7,7 @@ edition = { workspace = true }
 publish = { workspace = true }
 
 [dependencies]
-bytes = { workspace = true }
 prost = { workspace = true }
-prost-types = { workspace = true }
 
 [dependencies.tonic]
 workspace = true


### PR DESCRIPTION
This was created by running `$ just clippy -- -D unused_crate_dependencies`, removing any errors that appeared, and checking that the proxy still compiled with that dependency removed.

Ideally, this would be a lint we can leave on and not have to do this kind of cleanup in the future. However, none of the tools in the ecosystem are satisfactory. The `unused_crate_dependencies` lint has a lot of false positives for crates with integration tests, and the most common tool, [cargo-udeps](https://github.com/est31/cargo-udeps), requires a nightly compiler.