### PR TITLE
nit(app/inbound): fix `InboundMetrics` doc comment

### DIFF
--- a/linkerd/app/inbound/src/metrics.rs
+++ b/linkerd/app/inbound/src/metrics.rs
@@ -13,7 +13,7 @@ pub(crate) mod error;
 
 pub use linkerd_app_core::metrics::*;
 
-/// Holds outbound proxy metrics.
+/// Holds LEGACY inbound proxy metrics.
 #[derive(Clone, Debug)]
 pub struct InboundMetrics {
     pub http_authz: authz::HttpAuthzMetrics,


### PR DESCRIPTION
this comment changes this comment in two ways:

1. fix a copy-paste typo. this should say "inbound", not "outbound".
2. add note that this is a "legacy" structure.

the equivalent structure in the outbound proxy was labeled as such in https://github.com/linkerd/linkerd2-proxy/pull/2887.

see:

<https://github.com/linkerd/linkerd2-proxy/blob/dce6b611919d243b57113c1efae68ad302879fc0/linkerd/app/outbound/src/metrics.rs#L22-L35>

`authz::HttpAuthzMetrics`, `error::HttpErrorMetrics`, `authz::TcpAuthzMetrics`, and `error::TcpErrorMetrics` all make use of the "legacy" metrics implementation defined in `linkerd_metrics`.