### PR TITLE
refactor(app/inbound): remove unused `proxy_metrics()` method

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -113,10 +113,6 @@ impl<S> Inbound<S> {
         &self.runtime.identity
     }
 
-    pub fn proxy_metrics(&self) -> &metrics::Proxy {
-        &self.runtime.metrics.proxy
-    }
-
     /// A helper for gateways to instrument policy checks.
     pub fn authorize_http<N>(
         &self,


### PR DESCRIPTION
this commit removes `linkerd_app_inbound::Inbound::proxy_metrics()`.

this accessor is not used anywhere.