### PR TITLE
refactor(app/core): remove unused `gate` reëxport

### DIFF
--- a/linkerd/app/core/src/classify.rs
+++ b/linkerd/app/core/src/classify.rs
@@ -1,5 +1,4 @@
 use crate::profiles;
-pub use classify::gate;
 use linkerd_error::Error;
 use linkerd_proxy_client_policy as client_policy;
 use linkerd_proxy_http::{classify, HasH2Reason, ResponseTimeoutError};


### PR DESCRIPTION
`linkerd_app_core::classify` reëxports symbols from `linkerd_proxy_http::classify::gate`.

nothing makes use of this, and these symbols are already reëxported from `linkerd_proxy_http::classify`. existing callsites in the outbound proxy import this middleware directly, or though the reëxport in `linkerd_proxy_http`.

this commit removes this `pub use` directive, since it does nothing.