### PR TITLE
refactor(http/classify): remove unused classification middleware

### DIFF
--- a/linkerd/http/classify/src/lib.rs
+++ b/linkerd/http/classify/src/lib.rs
@@ -4,12 +4,12 @@
 use linkerd_error::Error;
 
 pub use self::{
-    channel::{BroadcastClassification, NewBroadcastClassification, Tx},
+    channel::BroadcastClassification,
     gate::{NewClassifyGate, NewClassifyGateSet},
     insert::{InsertClassifyResponse, NewInsertClassifyResponse},
 };
 
-pub mod channel;
+mod channel;
 pub mod gate;
 mod insert;
 


### PR DESCRIPTION
`NewBroadcastClassification<C, X, N>` is not used.

`BroadcastClassification<C, S>` is only used by the `gate` submodule in this crate.

this commit removes `NewBroadcastClassification`, since it is unused. this commit demotes `channel` to an internal submodule, since it has no external users.

the reëxport of `BroadcastClassification` is unused, though it is left intact because it _is_ exposed by `NewClassifyGateSet`'s implementation of `NewService<T>`.