### PR TITLE
nit(app): remove frivolous code

### DIFF
--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -252,9 +252,6 @@ impl Config {
             export_hostname_labels,
         );
 
-        let dst_addr = dst.addr.clone();
-        // registry.sub_registry_with_prefix("gateway"),
-
         let gateway = gateway::Gateway::new(gateway, inbound.clone(), outbound.clone()).stack(
             dst.resolve.clone(),
             dst.profiles.clone(),
@@ -332,7 +329,7 @@ impl Config {
 
         Ok(App {
             admin,
-            dst: dst_addr,
+            dst: dst.addr,
             drain: drain_tx,
             identity,
             inbound_addr,


### PR DESCRIPTION
this commit removes a piece of code that has been commented out.

it additionally removes a variable binding that is not needed. `dst` is not moved, so we do not need to bind the address of the destination service to a variable, nor do we need to clone it.