### PR TITLE
refactor(tls): do not export `detect_sni`

### DIFF
--- a/linkerd/tls/src/server.rs
+++ b/linkerd/tls/src/server.rs
@@ -205,7 +205,7 @@ where
 }
 
 /// Peek or buffer the provided stream to determine an SNI value.
-pub(crate) async fn detect_sni<I>(mut io: I) -> io::Result<(Option<ServerName>, DetectIo<I>)>
+async fn detect_sni<I>(mut io: I) -> io::Result<(Option<ServerName>, DetectIo<I>)>
 where
     I: io::Peek + io::AsyncRead + io::AsyncWrite + Send + Sync + Unpin,
 {


### PR DESCRIPTION
this function is an implementation detail for TLS detection middleware.

this does not need to be `pub(crate)`, thereby exposing it to the rest of the `linkerd-tls` crate.

this commit removes this visibility from the `detect_sni()` function.