### PR TITLE
fix(tls): Allow configuration of post-quantum algorithms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1371,6 +1371,7 @@ dependencies = [
  "linkerd-error",
  "linkerd-opencensus",
  "linkerd-opentelemetry",
+ "linkerd-rustls",
  "linkerd-tonic-stream",
  "linkerd-workers",
  "rangemap",

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -27,6 +27,7 @@ linkerd-app-outbound = { path = "./outbound" }
 linkerd-error = { path = "../error" }
 linkerd-opencensus = { path = "../opencensus" }
 linkerd-opentelemetry = { path = "../opentelemetry" }
+linkerd-rustls = { path = "../rustls" }
 linkerd-tonic-stream = { path = "../tonic-stream" }
 linkerd-workers = { path = "../workers" }
 rangemap = "1"

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -279,6 +279,9 @@ const ENV_INBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: &str =
 const ENV_OUTBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: &str =
     "LINKERD2_PROXY_OUTBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT";
 
+/// Configures whether to use post-quantum key exchange algorithms.
+const ENV_POST_QUANTUM_KX: &str = "LINKERD2_PROXY_POST_QUANTUM_KX";
+
 const ENV_SHUTDOWN_GRACE_PERIOD: &str = "LINKERD2_PROXY_SHUTDOWN_GRACE_PERIOD";
 
 // Default values for various configuration fields
@@ -405,6 +408,8 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         parse(strings, ENV_INBOUND_CONNECT_USER_TIMEOUT, parse_duration);
     let outbound_connect_user_timeout =
         parse(strings, ENV_OUTBOUND_CONNECT_USER_TIMEOUT, parse_duration);
+
+    let post_quantum_kx = parse(strings, ENV_POST_QUANTUM_KX, parse_bool);
 
     let shutdown_grace_period = parse(strings, ENV_SHUTDOWN_GRACE_PERIOD, parse_duration);
 
@@ -973,6 +978,12 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         }
     };
 
+    let rustls = {
+        linkerd_rustls::Config {
+            post_quantum: post_quantum_kx?.unwrap_or(true),
+        }
+    };
+
     Ok(super::Config {
         admin,
         dns,
@@ -984,6 +995,7 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         outbound,
         gateway,
         inbound,
+        rustls,
         shutdown_grace_period: shutdown_grace_period?.unwrap_or(DEFAULT_SHUTDOWN_GRACE_PERIOD),
     })
 }

--- a/linkerd/app/src/lib.rs
+++ b/linkerd/app/src/lib.rs
@@ -30,6 +30,7 @@ pub use linkerd_app_core::{metrics, trace, transport::BindTcp, BUILD_INFO};
 use linkerd_app_gateway as gateway;
 use linkerd_app_inbound::{self as inbound, Inbound};
 use linkerd_app_outbound::{self as outbound, Outbound};
+use linkerd_rustls as rustls;
 pub use linkerd_workers::Workers;
 use std::pin::Pin;
 use tokio::{
@@ -63,6 +64,7 @@ pub struct Config {
     pub admin: admin::Config,
     pub tap: tap::Config,
     pub trace_collector: trace_collector::Config,
+    pub rustls: rustls::Config,
 
     /// Grace period for graceful shutdowns.
     ///

--- a/linkerd/rustls/src/lib.rs
+++ b/linkerd/rustls/src/lib.rs
@@ -1,24 +1,28 @@
-pub use crate::crypto::{SIGNATURE_ALG_RUSTLS_SCHEME, SUPPORTED_SIG_ALGS, TLS_VERSIONS};
+pub use crate::crypto::{Config, SIGNATURE_ALG_RUSTLS_SCHEME, SUPPORTED_SIG_ALGS, TLS_VERSIONS};
 use std::sync::Arc;
 use tokio_rustls::rustls::crypto::CryptoProvider;
 
 mod crypto;
 
-pub fn install_default_provider() {
+pub fn install_default_provider(config: Config) {
     if CryptoProvider::get_default().is_some() {
         return;
     }
 
     // Ignore install errors. This is the only place we install a provider, so if we raced with
     // another thread to set the provider it will be functionally the same as this provider.
-    let _ = crate::crypto::default_provider().install_default();
+    let _ = crate::crypto::default_provider(config).install_default();
+}
+
+fn install_default_provider_with_defaults() {
+    install_default_provider(Config::default());
 }
 
 pub fn get_default_provider() -> Arc<CryptoProvider> {
     if let Some(provider) = CryptoProvider::get_default() {
         return Arc::clone(provider);
     }
-    install_default_provider();
+    install_default_provider_with_defaults();
 
     Arc::clone(CryptoProvider::get_default().expect("Default crypto provider must be installed"))
 }

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -35,8 +35,6 @@ fn main() {
         vendor = BUILD_INFO.vendor,
     );
 
-    linkerd_rustls::install_default_provider();
-
     let mut metrics = linkerd_metrics::prom::Registry::default();
 
     // Load configuration from the environment without binding ports.
@@ -47,6 +45,8 @@ fn main() {
             std::process::exit(EX_USAGE);
         }
     };
+
+    linkerd_rustls::install_default_provider(config.rustls);
 
     // Builds a runtime with the appropriate number of cores:
     // `LINKERD2_PROXY_CORES` env or the number of available CPUs (as provided


### PR DESCRIPTION
Post-quantum key exchange algorithms aren't necessarily appropriate for all environments, so this introduces a mechanism for disabling them via the environment.