### PR TITLE
fix(tls): Remove post-quantum algorithms from FIPS

### DIFF
--- a/linkerd/rustls/src/crypto.rs
+++ b/linkerd/rustls/src/crypto.rs
@@ -46,7 +46,6 @@ fn kx_groups() -> Vec<&'static dyn SupportedKxGroup> {
 #[cfg(feature = "rustls-aws-lc-fips")]
 fn kx_groups() -> Vec<&'static dyn SupportedKxGroup> {
     vec![
-        aws_lc_rs::kx_group::SECP256R1MLKEM768,
         aws_lc_rs::kx_group::SECP256R1,
         aws_lc_rs::kx_group::SECP384R1,
     ]


### PR DESCRIPTION
This removes `SECP256R1MLKEM768` as a supported algorithm when FIPS mode is enabled in the proxy.