### PR TITLE
chore(dependabot): add `arbitrary` group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
       - dependency-name: "web-sys"
       - dependency-name: "windows*"
     groups:
+      arbitrary:
+        patterns:
+          - "arbitrary"
+          - "derive_arbitrary"
       boring:
         patterns:
           - "tokio-boring"


### PR DESCRIPTION
`arbitrary` and `derive_arbitrary` are part of the same repository: <https://github.com/rust-fuzz/arbitrary/>

these should be bumped in lockstep, rather than as separate pull requests. see for example, previously:

- 99f322a9a
- edc35d6e1