### PR TITLE
chore(app/core): remove `dead_code` allowance for `Stack<S>`

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -127,7 +127,6 @@ impl<M, L: Layer<M>> Layer<M> for Layers<L> {
 
 // === impl Stack ===
 
-#[allow(dead_code)]
 impl<S> Stack<S> {
     pub fn push<L: Layer<S>>(self, layer: L) -> Stack<L::Service> {
         Stack(layer.layer(self.0))


### PR DESCRIPTION
this `impl` block is ~350 lines, and contains the majority of our
`linkerd_app_core::svc::Stack<S>` interfaces.

this does not need to be marked with this `dead_code` allowance, because
these are public interfaces.

this commit removes this attribute. if future additions include unused
code, we can more narrowly affix this attribute to particular functions.

Signed-off-by: katelyn martin <kate@buoyant.io>
