### PR TITLE
refactor(app/core): remove unused `MakeService<T, U>` bounds

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -9,10 +9,7 @@ use std::{
     task::{Context, Poll},
     time::Duration,
 };
-use tower::{
-    layer::util::{Identity, Stack as Pair},
-    make::MakeService,
-};
+use tower::layer::util::{Identity, Stack as Pair};
 pub use tower::{
     layer::Layer, limit::GlobalConcurrencyLimitLayer as ConcurrencyLimitLayer, service_fn as mk,
     spawn_ready::SpawnReady, Service, ServiceExt,
@@ -438,23 +435,6 @@ impl<S> Stack<S> {
     pub fn check_service_response<T, U>(self) -> Self
     where
         S: Service<T, Response = U>,
-    {
-        self
-    }
-
-    /// Validates that this stack serves T-typed targets.
-    pub fn check_make_service<T, U>(self) -> Self
-    where
-        S: MakeService<T, U>,
-    {
-        self
-    }
-
-    /// Validates that this stack serves T-typed targets.
-    pub fn check_make_service_clone<T, U>(self) -> Self
-    where
-        S: MakeService<T, U> + Clone,
-        S::Service: Clone,
     {
         self
     }


### PR DESCRIPTION
`Stack<S>` provides a family of interfaces that are used as "fences"
for particular trait bounds. these `check_*` methods have builder-style
signatures that both accept and return `Self` transparently, but
applying bounds upon the inner `S`-typed stack.

this is particularly useful to help bound compilation errors when
building stacks of tower middleware, to enforce particular `T`-typed
targets, and so forth.

these interfaces check that `S` is a `tower::make::MakeService`, which
we do not use. rather, we use `linkerd_stack::NewService<T>`, whose
bounds can be checked via other `Stack<S>` methods like `check_new()`,
`check_new_new()`, `check_new_service()`, `check_new_new_service()`,
`check_new_accept()`, and so forth.

these `check_make_service()` and `check_make_service_clone()` methods
are never called, now that we use `NewService<T>` in the wake of #435.

this commit removes these.

Signed-off-by: katelyn martin <kate@buoyant.io>
