### PR TITLE
nit(app/core): add banners to `impl` groups

### DIFF
--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -238,7 +238,7 @@ impl Metrics {
     }
 }
 
-// === impl CtlLabels ===
+// === impl ControlLabels ===
 
 impl svc::Param<ControlLabels> for control::ControlAddr {
     fn param(&self) -> ControlLabels {
@@ -344,6 +344,8 @@ impl legacy::FmtLabels for InboundEndpointLabels {
     }
 }
 
+// === impl ServerLabel ===
+
 impl legacy::FmtLabels for ServerLabel {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self(meta, port) = self;
@@ -375,6 +377,8 @@ impl prom::EncodeLabelSetMut for ServerLabel {
     }
 }
 
+// === impl ServerAuthzLabels ===
+
 impl legacy::FmtLabels for ServerAuthzLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { server, authz } = self;
@@ -389,6 +393,8 @@ impl legacy::FmtLabels for ServerAuthzLabels {
         )
     }
 }
+
+// === impl RouteLabels ===
 
 impl legacy::FmtLabels for RouteLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -405,6 +411,8 @@ impl legacy::FmtLabels for RouteLabels {
     }
 }
 
+// === impl RouteAuthzLabels ===
+
 impl legacy::FmtLabels for RouteAuthzLabels {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self { route, authz } = self;
@@ -419,6 +427,8 @@ impl legacy::FmtLabels for RouteAuthzLabels {
         )
     }
 }
+
+// === impl OutboundEndpointLabels ===
 
 impl svc::Param<OutboundZoneLocality> for OutboundEndpointLabels {
     fn param(&self) -> OutboundZoneLocality {
@@ -454,6 +464,8 @@ impl legacy::FmtLabels for OutboundEndpointLabels {
     }
 }
 
+// === impl Direction ===
+
 impl fmt::Display for Direction {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -469,12 +481,16 @@ impl legacy::FmtLabels for Direction {
     }
 }
 
+// === impl Authority ===
+
 impl legacy::FmtLabels for Authority<'_> {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let Self(authority) = self;
         write!(f, "authority=\"{authority}\"")
     }
 }
+
+// === impl Class ===
 
 impl legacy::FmtLabels for Class {
     fn fmt_labels(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
we follow a convention in this codebase where `// === impl T ===`
comments dilineate groups of `impl` blocks for different types.

this style is particularly helpful when code is folded in a file,
because it helps clarify where traits for a given type are implemented.

this style is also helpful for grep'ing for interfaces, trait
implementations, etc., for a given type, since these may not always live
within a single file.

this commit adds some missing banner comments to our metric label types
in `linkerd_app_core`.

Signed-off-by: katelyn martin <kate@buoyant.io>
