### PR TITLE
nit(app/gateway): consolidate `T`'s bounds

### DIFF
--- a/linkerd/app/gateway/src/http.rs
+++ b/linkerd/app/gateway/src/http.rs
@@ -81,57 +81,34 @@ impl Gateway {
         R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
         R::Resolution: Unpin,
     {
-        let http =
-            self.outbound
-                .clone()
-                .with_stack(inner)
-                .push_http_cached(resolve)
-                .into_stack()
-                // Discard `T` and its associated client-specific metadata.
-                .push_map_target(Target::discard_parent)
-                .push(svc::ArcNewService::layer())
-                // Add headers to prevent loops.
-                .push(NewHttpGateway::layer(
-                    self.inbound.identity().local_id().clone(),
-                ))
-                .push_on_service(svc::LoadShed::layer())
-                .lift_new()
-                .push(svc::ArcNewService::layer())
-                // After protocol-downgrade, we need to build an inner stack for
-                // each request-level HTTP version.
-                .push(svc::NewOneshotRoute::layer_via(|t: &Target<T>| {
-                    ByRequestVersion(t.clone())
-                }))
-                // Only permit gateway traffic to endpoints for which we have
-                // discovery information.
-                .push_filter(
-                    |Permitted {
-                         permit: _,
-                         target: parent,
-                     }: Permitted<T>|
-                     -> Result<_, GatewayDomainInvalid> {
-                        let routes = {
-                            let mut profile = svc::Param::<
-                                Option<watch::Receiver<profiles::Profile>>,
-                            >::param(&parent)
-                            .ok_or(GatewayDomainInvalid)?;
-                            let init = mk_routes(&profile.borrow_and_update())
-                                .ok_or(GatewayDomainInvalid)?;
-                            outbound::http::spawn_routes(profile, init, mk_routes)
-                        };
-
-                        Ok(Target {
-                            routes,
-                            addr: parent.param(),
-                            version: parent.param(),
-                            parent,
-                        })
-                    },
-                )
-                .push(svc::ArcNewService::layer())
-                // Authorize requests to the gateway.
-                .push(self.inbound.authorize_http())
-                .arc_new_clone_http();
+        let http = self
+            .outbound
+            .clone()
+            .with_stack(inner)
+            .push_http_cached(resolve)
+            .into_stack()
+            // Discard `T` and its associated client-specific metadata.
+            .push_map_target(Target::discard_parent)
+            .push(svc::ArcNewService::layer())
+            // Add headers to prevent loops.
+            .push(NewHttpGateway::layer(
+                self.inbound.identity().local_id().clone(),
+            ))
+            .push_on_service(svc::LoadShed::layer())
+            .lift_new()
+            .push(svc::ArcNewService::layer())
+            // After protocol-downgrade, we need to build an inner stack for
+            // each request-level HTTP version.
+            .push(svc::NewOneshotRoute::layer_via(|t: &Target<T>| {
+                ByRequestVersion(t.clone())
+            }))
+            // Only permit gateway traffic to endpoints for which we have
+            // discovery information.
+            .push_filter(spawn_routes)
+            .push(svc::ArcNewService::layer())
+            // Authorize requests to the gateway.
+            .push(self.inbound.authorize_http())
+            .arc_new_clone_http();
 
         self.inbound
             .clone()
@@ -144,6 +121,33 @@ impl Gateway {
             .into_stack()
             .arc_new_clone_http()
     }
+}
+
+fn spawn_routes<T>(
+    Permitted {
+        permit: _,
+        target: parent,
+    }: Permitted<T>,
+) -> Result<Target<T>, GatewayDomainInvalid>
+where
+    T: Clone
+        + svc::Param<GatewayAddr>
+        + svc::Param<http::Variant>
+        + svc::Param<Option<watch::Receiver<profiles::Profile>>>,
+{
+    let routes = {
+        let mut profile = svc::Param::<Option<watch::Receiver<profiles::Profile>>>::param(&parent)
+            .ok_or(GatewayDomainInvalid)?;
+        let init = mk_routes(&profile.borrow_and_update()).ok_or(GatewayDomainInvalid)?;
+        outbound::http::spawn_routes(profile, init, mk_routes)
+    };
+
+    Ok(Target {
+        routes,
+        addr: parent.param(),
+        version: parent.param(),
+        parent,
+    })
 }
 
 fn mk_routes(profile: &profiles::Profile) -> Option<outbound::http::Routes> {

--- a/linkerd/app/gateway/src/http.rs
+++ b/linkerd/app/gateway/src/http.rs
@@ -66,17 +66,21 @@ impl Gateway {
     >
     where
         // Target describing an inbound gateway connection.
-        T: svc::Param<GatewayAddr>,
-        T: svc::Param<OrigDstAddr>,
-        T: svc::Param<Remote<ClientAddr>>,
-        T: svc::Param<ServerLabel>,
-        T: svc::Param<tls::ConditionalServerTls>,
-        T: svc::Param<tls::ClientId>,
-        T: svc::Param<inbound::policy::AllowPolicy>,
-        T: svc::Param<Option<watch::Receiver<profiles::Profile>>>,
-        T: svc::Param<http::Variant>,
-        T: svc::Param<http::normalize_uri::DefaultAuthority>,
-        T: Clone + Send + Sync + Unpin + 'static,
+        T: Clone
+            + Send
+            + Sync
+            + Unpin
+            + 'static
+            + svc::Param<GatewayAddr>
+            + svc::Param<OrigDstAddr>
+            + svc::Param<Remote<ClientAddr>>
+            + svc::Param<ServerLabel>
+            + svc::Param<tls::ConditionalServerTls>
+            + svc::Param<tls::ClientId>
+            + svc::Param<inbound::policy::AllowPolicy>
+            + svc::Param<Option<watch::Receiver<profiles::Profile>>>
+            + svc::Param<http::Variant>
+            + svc::Param<http::normalize_uri::DefaultAuthority>,
         // Endpoint resolution.
         R: Resolve<ConcreteAddr, Endpoint = Metadata, Error = Error>,
         R::Resolution: Unpin,


### PR DESCRIPTION
this commit makes a small subjective tweak to the trait bounds in our
gateway proxy's router.

this commit consolidates 11 separate clauses bounding `T` into a single
clause.

Signed-off-by: katelyn martin <kate@buoyant.io>
