### PR TITLE
refactor(conditional): `Conditional::map()` parametric over `CR`

### DIFF
--- a/linkerd/conditional/src/lib.rs
+++ b/linkerd/conditional/src/lib.rs
@@ -29,6 +29,12 @@ where
 }
 
 impl<C, R> Conditional<C, R> {
+    pub fn map<CR>(self, f: impl FnOnce(C) -> CR) -> Conditional<CR, R> {
+        self.and_then(|c| Conditional::Some(f(c)))
+    }
+}
+
+impl<C, R> Conditional<C, R> {
     pub fn and_then<CR, RR, F>(self, f: F) -> Conditional<CR, RR>
     where
         R: Into<RR>,
@@ -38,14 +44,6 @@ impl<C, R> Conditional<C, R> {
             Conditional::Some(c) => f(c),
             Conditional::None(r) => Conditional::None(r.into()),
         }
-    }
-
-    pub fn map<CR, RR, F>(self, f: F) -> Conditional<CR, RR>
-    where
-        R: Into<RR>,
-        F: FnOnce(C) -> CR,
-    {
-        self.and_then(|c| Conditional::Some(f(c)))
     }
 
     pub fn or_else<CR, RR, F>(self, f: F) -> Conditional<CR, RR>


### PR DESCRIPTION
this commit proposes a small ergonomic tweak to our `Conditional<C, R>`
type's `map()` method.

this maps across the `C` conditional type, but must also infer the
returned values `R`, because it might implicitly invoke
`<R as Into<RR>>::into()`.

we don't in practice rely on that behavior, nor do we ever specify the
`F` type, which is most often an anonymous closure.

to help this method be friendlier to type inference, this commit
proposes reducing `map()` such that it is now parametric only across
`CR`, the type returned by our `(C) -> CR` callback.

Signed-off-by: katelyn martin <kate@buoyant.io>
