### PR TITLE
refactor(app/inbound): move `into_tcp_connect()` to `server`

### DIFF
--- a/linkerd/app/inbound/src/lib.rs
+++ b/linkerd/app/inbound/src/lib.rs
@@ -24,7 +24,7 @@ pub use self::{
     detect::MetricsFamilies as DetectMetrics, metrics::InboundMetrics, policy::DefaultPolicy,
 };
 use linkerd_app_core::{
-    config::{ConnectConfig, ProxyConfig, QueueConfig},
+    config::{ProxyConfig, QueueConfig},
     drain,
     http_tracing::SpanSink,
     identity, io,
@@ -182,52 +182,6 @@ impl Inbound<()> {
 
     pub fn with_stack<S>(self, stack: S) -> Inbound<S> {
         self.map_stack(move |_, _, _| svc::stack(stack))
-    }
-
-    /// Readies the inbound stack to make TCP connections (for both TCP
-    // forwarding and HTTP proxying).
-    pub fn into_tcp_connect<T>(
-        self,
-        proxy_port: u16,
-    ) -> Inbound<
-        impl svc::MakeConnection<
-                T,
-                Connection = impl Send + Unpin,
-                Metadata = impl Send + Unpin,
-                Error = Error,
-                Future = impl Send,
-            > + Clone,
-    >
-    where
-        T: svc::Param<Remote<ServerAddr>> + 'static,
-    {
-        self.map_stack(|config, _, _| {
-            // Establishes connections to remote peers (for both TCP
-            // forwarding and HTTP proxying).
-            let ConnectConfig {
-                ref keepalive,
-                ref user_timeout,
-                ref timeout,
-                ..
-            } = config.proxy.connect;
-
-            #[derive(Debug, thiserror::Error)]
-            #[error("inbound connection must not target port {0}")]
-            struct Loop(u16);
-
-            svc::stack(transport::ConnectTcp::new(*keepalive, *user_timeout))
-                // Limits the time we wait for a connection to be established.
-                .push_connect_timeout(*timeout)
-                // Prevent connections that would target the inbound proxy port from looping.
-                .push_filter(move |t: T| {
-                    let addr = t.param();
-                    let port = addr.port();
-                    if port == proxy_port {
-                        return Err(Loop(port));
-                    }
-                    Ok(addr)
-                })
-        })
     }
 }
 


### PR DESCRIPTION
`Inbound::into_tcp_connect()` is a method that takes the inbound proxy,
and prepares it for making TCP connections.

this is an implementation detail of the `Inbound::mk()` function, which
we call in the app's `Config::build()` startup code. it is not used by
any external callers.

this commit moves this method into the `server` submodule, next to the
four call-sites where it is invoked. the body of the function is
unchanged.

the `pub` directive is removed now that it lives alongside its dependent
code.

the doc comment for this function is fixed, which was previously a
fragment. the second line was a regular comment.

Signed-off-by: katelyn martin <kate@buoyant.io>
