### PR TITLE
refactor(http/prom): consistent middleware reëxports

### DIFF
--- a/linkerd/app/inbound/src/http/router/metrics.rs
+++ b/linkerd/app/inbound/src/http/router/metrics.rs
@@ -10,7 +10,7 @@ use linkerd_app_core::{
     },
     svc,
 };
-use linkerd_http_prom::{NewCountRequests, RequestCount};
+use linkerd_http_prom::count_reqs::{NewCountRequests, RequestCount};
 
 pub(super) fn layer<N>(
     request_count: RequestCountFamilies,
@@ -25,8 +25,8 @@ pub(super) fn layer<N>(
 
 #[derive(Clone, Debug)]
 pub struct RequestCountFamilies {
-    grpc: linkerd_http_prom::RequestCountFamilies<RequestCountLabels>,
-    http: linkerd_http_prom::RequestCountFamilies<RequestCountLabels>,
+    grpc: linkerd_http_prom::count_reqs::RequestCountFamilies<RequestCountLabels>,
+    http: linkerd_http_prom::count_reqs::RequestCountFamilies<RequestCountLabels>,
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
@@ -44,12 +44,12 @@ impl RequestCountFamilies {
     pub fn register(reg: &mut prom::Registry) -> Self {
         let grpc = {
             let reg = reg.sub_registry_with_prefix("grpc");
-            linkerd_http_prom::RequestCountFamilies::register(reg)
+            linkerd_http_prom::count_reqs::RequestCountFamilies::register(reg)
         };
 
         let http = {
             let reg = reg.sub_registry_with_prefix("http");
-            linkerd_http_prom::RequestCountFamilies::register(reg)
+            linkerd_http_prom::count_reqs::RequestCountFamilies::register(reg)
         };
 
         Self { grpc, http }
@@ -59,7 +59,7 @@ impl RequestCountFamilies {
     fn family<T>(
         &self,
         permitted: &Permitted<T>,
-    ) -> &linkerd_http_prom::RequestCountFamilies<RequestCountLabels> {
+    ) -> &linkerd_http_prom::count_reqs::RequestCountFamilies<RequestCountLabels> {
         let Self { grpc, http } = self;
         match permitted {
             Permitted::Grpc { .. } => grpc,

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -2,8 +2,8 @@ use crate::{BackendRef, ParentRef, RouteRef};
 use linkerd_app_core::{metrics::prom, svc};
 use linkerd_http_prom::{
     body_data::response::{BodyDataMetrics, NewRecordBodyData, ResponseBodyFamilies},
+    count_reqs::{NewCountRequests, RequestCount, RequestCountFamilies},
     record_response::{self, NewResponseDuration, StreamLabel},
-    NewCountRequests, RequestCount, RequestCountFamilies,
 };
 
 pub use super::super::metrics::*;
@@ -96,7 +96,7 @@ impl<L: StreamLabel> RouteBackendMetrics<L> {
         p: ParentRef,
         r: RouteRef,
         b: BackendRef,
-    ) -> linkerd_http_prom::RequestCount {
+    ) -> RequestCount {
         self.requests.metrics(&labels::RouteBackend(p, r, b))
     }
 

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
@@ -152,7 +152,7 @@ impl<R: StreamLabel, B: StreamLabel> RouteMetrics<R, B> {
         p: crate::ParentRef,
         r: crate::RouteRef,
         b: crate::BackendRef,
-    ) -> linkerd_http_prom::RequestCount {
+    ) -> linkerd_http_prom::count_reqs::RequestCount {
         self.backend.backend_request_count(p, r, b)
     }
 }

--- a/linkerd/http/prom/src/lib.rs
+++ b/linkerd/http/prom/src/lib.rs
@@ -2,7 +2,5 @@
 #![forbid(unsafe_code)]
 
 pub mod body_data;
-mod count_reqs;
+pub mod count_reqs;
 pub mod record_response;
-
-pub use self::count_reqs::{CountRequests, NewCountRequests, RequestCount, RequestCountFamilies};


### PR DESCRIPTION
this pull request moves towards a consistent surface for the `linkerd-http-prom` library.

```diff
 // linkerd/http/prom/src/lib.rs

 #![forbid(unsafe_code)]
 
 pub mod body_data;
-mod count_reqs;
+pub mod count_reqs;
 pub mod record_response;
-
-pub use self::count_reqs::{CountRequests, NewCountRequests, RequestCount, RequestCountFamilies};
```

this library contains a number of different telemetry middlewares for counting requests, recording request and response durations, and for measuring frames transmitted in request and response bodies.

the `count_reqs` types, unlike the other components in this library, are no longer exported from the top-level of the library. this means that call-sites in the inbound and outbound proxy have consistently shaped imports for using out metrics layers.