### PR TITLE
refactor(http/prom): `NewRecordResponse<L, X, M, N>` consistent generics

### DIFF
--- a/linkerd/http/prom/src/record_response.rs
+++ b/linkerd/http/prom/src/record_response.rs
@@ -150,9 +150,9 @@ impl MetricConstructor<Histogram> for MkDurationHistogram {
 
 // === impl NewRecordResponse ===
 
-impl<M, X, K, N> NewRecordResponse<M, X, K, N>
+impl<L, X, M, N> NewRecordResponse<L, X, M, N>
 where
-    M: MkStreamLabel,
+    L: MkStreamLabel,
 {
     pub fn new(extract: X, inner: N) -> Self {
         Self {
@@ -170,9 +170,9 @@ where
     }
 }
 
-impl<M, K, N> NewRecordResponse<M, (), K, N>
+impl<L, M, N> NewRecordResponse<L, (), M, N>
 where
-    M: MkStreamLabel,
+    L: MkStreamLabel,
 {
     pub fn layer() -> impl svc::layer::Layer<N, Service = Self> + Clone {
         Self::layer_via(())


### PR DESCRIPTION
`NewRecordResponse<L, X, M, N>` is a middleware in our prometheus
components library.

this is a somewhat heady brew, with four type parameters. an `X`-typed
parameter extracts `Params<L, M>` parameters to instrument an `N`-typed
`NewService<T>`.

some of this type's impl blocks are not consistent with their notation,
and in particular, conflate `M` to mean either the metric(s) with which
to record the response, _or_ the `L: MkStreamLabel` used to create
`RecordResponse<L, M, S>`'s `L: StreamLabel`.

this commit changes `linkerd/http/prom/src/record_response.rs` so that
`NewRecordResponse<L, X, M, N>` uses a consistent set of letters for all
of its type parameters.
