### PR TITLE
chore(deps): introduce a `serde` dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,10 @@ updates:
           - "tokio-rustls"
           - "rustls*"
           - "ring"
+      serde:
+        patterns:
+          - "serde"
+          - "serde_*"
       symbolic:
         patterns:
           - "symbolic-*"


### PR DESCRIPTION
this commit introduces a dependabot group that will manage `serde`, and
its constituent crates like `serde_json`, `serde_core`, and
`serde_derive`, in unison.

see redundant pull requests such as linkerd/linkerd2-proxy#4158 and
linkerd/linkerd2-proxy#4159 for a motivating example.

Signed-off-by: katelyn martin <kate@buoyant.io>
