### PR TITLE
feat(app/inbound): response body frame size metrics

### DIFF
--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -10,7 +10,7 @@ use linkerd_app_core::{
 use std::{fmt, net::SocketAddr};
 use tracing::{debug, debug_span};
 
-pub use self::metrics::RequestCountFamilies;
+pub use self::metrics::*;
 
 mod metrics;
 

--- a/linkerd/app/inbound/src/metrics.rs
+++ b/linkerd/app/inbound/src/metrics.rs
@@ -11,7 +11,7 @@
 pub(crate) mod authz;
 pub(crate) mod error;
 
-use crate::http::router::RequestCountFamilies;
+use crate::http::router::{RequestCountFamilies, ResponseBodyFamilies};
 pub use linkerd_app_core::metrics::*;
 
 /// Holds LEGACY inbound proxy metrics.
@@ -30,6 +30,7 @@ pub struct InboundMetrics {
     pub detect: crate::detect::MetricsFamilies,
     pub direct: crate::direct::MetricsFamilies,
     pub request_count: RequestCountFamilies,
+    pub response_body_data: ResponseBodyFamilies,
 }
 
 impl InboundMetrics {
@@ -40,6 +41,7 @@ impl InboundMetrics {
             reg.sub_registry_with_prefix("tcp_transport_header"),
         );
         let request_count = RequestCountFamilies::register(reg);
+        let response_body_data = ResponseBodyFamilies::register(reg);
 
         Self {
             http_authz: authz::HttpAuthzMetrics::default(),
@@ -50,6 +52,7 @@ impl InboundMetrics {
             detect,
             direct,
             request_count,
+            response_body_data,
         }
     }
 }


### PR DESCRIPTION
https://github.com/linkerd/linkerd2-proxy/pull/3308 introduced tower
middleware to the outbound proxy that records the size and number of
response body's data frames.

this commit introduces an equivalent layer to the inbound proxy's
prometheus metrics.

this is based on https://github.com/linkerd/linkerd2-proxy/pull/4166.