### PR TITLE
refactor(app/inbound): metrics layer accepts `InboundMetrics`

### DIFF
--- a/linkerd/app/inbound/src/http/router.rs
+++ b/linkerd/app/inbound/src/http/router.rs
@@ -245,7 +245,7 @@ impl<C> Inbound<C> {
                 .push(svc::NewOneshotRoute::layer_via(|t: &policy::Permitted<T>| {
                     LogicalPerRequest::from(t)
                 }))
-                .push(self::metrics::layer(rt.metrics.request_count.clone()))
+                .push(self::metrics::layer(&rt.metrics))
                 .check_new_service::<policy::Permitted<T>, http::Request<http::BoxBody>>()
                 .push(svc::ArcNewService::layer())
                 .push(policy::NewHttpPolicy::layer(rt.metrics.http_authz.clone()))


### PR DESCRIPTION
this commit makes a small refactor to the inbound proxy's `metrics::layer()` middleware in the interest of future-proofing it before additional metrics layers are introduced.

this will mean that the call site in `http/router.rs` will not need to be updated repeatedly as we introduce request/response body frame size metrics, duration histograms, and so forth.