### PR TITLE
refactor(http/prom): remove `NewRecordBodyData` extractor

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
@@ -68,7 +68,6 @@ pub fn layer<T, N>(
     N,
     Service = NewRecordBodyData<
         NewRecordDuration<T, RequestMetrics<T::StreamLabel>, N>,
-        (),
         T,
         labels::Route,
     >,
@@ -78,7 +77,7 @@ where
     T: svc::ExtractParam<labels::Route, http::Request<http::BoxBody>>,
 {
     let record = NewRecordDuration::layer_via(ExtractRecordDurationParams(metrics.clone()));
-    let body_data = NewRecordBodyData::new((), body_data.clone());
+    let body_data = NewRecordBodyData::new(body_data.clone());
 
     svc::layer::mk(move |inner| {
         use svc::Layer;


### PR DESCRIPTION
this commit removes the `X` parameter from `linkerd-http-prom`'s request
body data frame size metrics layer.

today, this layer is only used in the outbound proxy. there is a generic
`X` parameter, which exists to invoke `ExtractParam<P, T>`. in practice
however, we only use an uninhabited `()` extractor.

this means that we do not use `X` for anything. rather, we are relying
on the blanket implementation `(): ExtractParam<P, T>` for cases where
`P: Param<T>`.

in other words, if we don't have an extractor (`X: ()`) we can still get
parameters `P` from the target `T`.

this commit refactors this middleware to do this directly: remove the
unused `X` parameter, and instead use `T: Param<_>` directly to get our
request label extractor.

X-ref: linkerd/linkerd2-proxy/#3604
Signed-off-by: katelyn martin <kate@buoyant.io>
