### PR TITLE
fix(http/route): fix prefix path validation

### DIFF
--- a/linkerd/http/route/src/http/filter/redirect.rs
+++ b/linkerd/http/route/src/http/filter/redirect.rs
@@ -259,7 +259,7 @@ pub mod proto {
                         Ok(ModifyPath::ReplaceFullPath(path))
                     }
                     api::path_modifier::Replace::Prefix(prefix) => {
-                        if prefix.starts_with('/') {
+                        if !prefix.starts_with('/') {
                             return Err(InvalidRequestRedirect::RelativePath);
                         }
                         Ok(ModifyPath::ReplacePrefixMatch(prefix))


### PR DESCRIPTION
Fixes https://github.com/linkerd/linkerd2/issues/14110

When using a `HTTPRoute` `RequestRedirect` filter with a `ReplacePrefixMatch`, the proxy incorrectly returns an error: `redirect paths must be absolute`.  This is because the validation logic is backwards and it returns this error when the redirect path IS absolute.

We correct the validation logic by inverting it.