### PR TITLE
feat(app/inbound): request body frame size metrics

### DIFF
--- a/linkerd/app/inbound/src/metrics.rs
+++ b/linkerd/app/inbound/src/metrics.rs
@@ -11,7 +11,7 @@
 pub(crate) mod authz;
 pub(crate) mod error;
 
-use crate::http::router::{RequestCountFamilies, ResponseBodyFamilies};
+use crate::http::router::{RequestBodyFamilies, RequestCountFamilies, ResponseBodyFamilies};
 pub use linkerd_app_core::metrics::*;
 
 /// Holds LEGACY inbound proxy metrics.
@@ -30,6 +30,7 @@ pub struct InboundMetrics {
     pub detect: crate::detect::MetricsFamilies,
     pub direct: crate::direct::MetricsFamilies,
     pub request_count: RequestCountFamilies,
+    pub request_body_data: RequestBodyFamilies,
     pub response_body_data: ResponseBodyFamilies,
 }
 
@@ -41,6 +42,7 @@ impl InboundMetrics {
             reg.sub_registry_with_prefix("tcp_transport_header"),
         );
         let request_count = RequestCountFamilies::register(reg);
+        let request_body_data = RequestBodyFamilies::register(reg);
         let response_body_data = ResponseBodyFamilies::register(reg);
 
         Self {
@@ -52,6 +54,7 @@ impl InboundMetrics {
             detect,
             direct,
             request_count,
+            request_body_data,
             response_body_data,
         }
     }


### PR DESCRIPTION
this commit introduces an additional layer of telemetry to the inbound
proxy's http router.

either http and grpc metrics are used, depending upon the policy that
authorized a given request.

this is based upon linkerd/linkerd2-proxy#4174, which refactored the
request body telemetry middleware to be metrics agnostic.

this change is based upon a collection of small prerequisite changes:
* linkerd/linkerd2-proxy#4189
* linkerd/linkerd2-proxy#4188
* linkerd/linkerd2-proxy#4187
* linkerd/linkerd2-proxy#4186
* linkerd/linkerd2-proxy#4174

related previous work:
* linkerd/linkerd2-proxy#4165
* linkerd/linkerd2-proxy#4166
* linkerd/linkerd2-proxy#4127
    

Signed-off-by: katelyn martin <kate@buoyant.io>
