### PR TITLE
refactor(app/inbound): router metrics middleware are `T`-agnostic

### DIFF
--- a/linkerd/app/inbound/src/http/router/metrics.rs
+++ b/linkerd/app/inbound/src/http/router/metrics.rs
@@ -216,11 +216,16 @@ impl EncodeLabelSet for ResponseBodyDataLabels {
 
 // === impl ExtractRecordBodyDataMetrics ===
 
-impl<T> svc::ExtractParam<BodyDataMetrics, Permitted<T>> for ExtractRecordBodyDataMetrics {
-    fn extract_param(&self, permitted: &Permitted<T>) -> BodyDataMetrics {
+impl<T> svc::ExtractParam<BodyDataMetrics, T> for ExtractRecordBodyDataMetrics
+where
+    T: svc::Param<PermitVariant> + svc::Param<RouteLabels>,
+{
+    fn extract_param(&self, target: &T) -> BodyDataMetrics {
         let Self(families) = self;
-        let family = families.family(permitted.variant());
-        let route = permitted.route_labels();
+        let variant = target.param();
+        let route = target.param();
+
+        let family = families.family(variant);
 
         family.metrics(&ResponseBodyDataLabels { route })
     }

--- a/linkerd/app/inbound/src/http/router/metrics.rs
+++ b/linkerd/app/inbound/src/http/router/metrics.rs
@@ -1,4 +1,7 @@
-use crate::{policy::Permitted, InboundMetrics};
+use crate::{
+    policy::{PermitVariant, Permitted},
+    InboundMetrics,
+};
 use linkerd_app_core::{
     metrics::{
         prom::{
@@ -95,9 +98,9 @@ impl RequestCountFamilies {
         permitted: &Permitted<T>,
     ) -> &linkerd_http_prom::count_reqs::RequestCountFamilies<RequestCountLabels> {
         let Self { grpc, http } = self;
-        match permitted {
-            Permitted::Grpc { .. } => grpc,
-            Permitted::Http { .. } => http,
+        match permitted.variant() {
+            PermitVariant::Grpc => grpc,
+            PermitVariant::Http => http,
         }
     }
 }
@@ -171,9 +174,9 @@ impl ResponseBodyFamilies {
         permitted: &Permitted<T>,
     ) -> &linkerd_http_prom::body_data::response::ResponseBodyFamilies<ResponseBodyDataLabels> {
         let Self { grpc, http } = self;
-        match permitted {
-            Permitted::Grpc { .. } => grpc,
-            Permitted::Http { .. } => http,
+        match permitted.variant() {
+            PermitVariant::Grpc => grpc,
+            PermitVariant::Http => http,
         }
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics.rs
+++ b/linkerd/app/inbound/src/http/router/metrics.rs
@@ -93,12 +93,12 @@ impl RequestCountFamilies {
     }
 
     /// Fetches the proper request counting family, given a permitted target.
-    fn family<T>(
+    fn family(
         &self,
-        permitted: &Permitted<T>,
+        variant: PermitVariant,
     ) -> &linkerd_http_prom::count_reqs::RequestCountFamilies<RequestCountLabels> {
         let Self { grpc, http } = self;
-        match permitted.variant() {
+        match variant {
             PermitVariant::Grpc => grpc,
             PermitVariant::Http => http,
         }
@@ -110,7 +110,7 @@ impl RequestCountFamilies {
 impl<T> svc::ExtractParam<RequestCount, Permitted<T>> for ExtractRequestCount {
     fn extract_param(&self, permitted: &Permitted<T>) -> RequestCount {
         let Self(families) = self;
-        let family = families.family(permitted);
+        let family = families.family(permitted.variant());
         let route = permitted.route_labels();
 
         family.metrics(&RequestCountLabels { route })
@@ -169,12 +169,12 @@ impl ResponseBodyFamilies {
     }
 
     /// Fetches the proper body frame metrics family, given a permitted target.
-    fn family<T>(
+    fn family(
         &self,
-        permitted: &Permitted<T>,
+        variant: PermitVariant,
     ) -> &linkerd_http_prom::body_data::response::ResponseBodyFamilies<ResponseBodyDataLabels> {
         let Self { grpc, http } = self;
-        match permitted.variant() {
+        match variant {
             PermitVariant::Grpc => grpc,
             PermitVariant::Http => http,
         }
@@ -219,7 +219,7 @@ impl EncodeLabelSet for ResponseBodyDataLabels {
 impl<T> svc::ExtractParam<BodyDataMetrics, Permitted<T>> for ExtractRecordBodyDataMetrics {
     fn extract_param(&self, permitted: &Permitted<T>) -> BodyDataMetrics {
         let Self(families) = self;
-        let family = families.family(permitted);
+        let family = families.family(permitted.variant());
         let route = permitted.route_labels();
 
         family.metrics(&ResponseBodyDataLabels { route })

--- a/linkerd/app/inbound/src/policy.rs
+++ b/linkerd/app/inbound/src/policy.rs
@@ -12,7 +12,7 @@ pub use self::{
     config::Config,
     http::{
         HttpInvalidPolicy, HttpRouteInvalidRedirect, HttpRouteNotFound, HttpRouteRedirect,
-        HttpRouteUnauthorized, NewHttpPolicy, Permitted,
+        HttpRouteUnauthorized, NewHttpPolicy, PermitVariant, Permitted,
     },
     tcp::NewTcpPolicy,
 };

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -409,16 +409,6 @@ fn apply_grpc_filters<B>(route: &grpc::Policy, req: &mut ::http::Request<B>) -> 
 
 // === impl Permitted ===
 
-/// An authorized `T`-typed target can produce `P`-typed parameters.
-impl<T, P> svc::Param<P> for Permitted<T>
-where
-    T: svc::Param<P>,
-{
-    fn param(&self) -> P {
-        self.target_ref().param()
-    }
-}
-
 impl<T> Permitted<T> {
     /// Returns a reference to the [`HttpRoutePermit`] authorizing this `T`.
     pub fn permit_ref(&self) -> &HttpRoutePermit {


### PR DESCRIPTION
https://github.com/linkerd/linkerd2-proxy/pull/4119 introduced a `Permitted<T>` structure, to provide a more formal notion of a `(HttpRoutePermit, T)` tuple.

during review of https://github.com/linkerd/linkerd2-proxy/pull/4180, we had a discussion about how the inbound proxy's http router had metrics layers which were tightly coupled to the notion of a `Permitted<T>`:

> This isn't a hard blocker--but this is unfortunate that we're coupling this impl to the Permitted target type -- target types are usually an _internal implementation detail_ and not a public api that is depended on elsewhere.
> 
> The typical pattern for this would be to have a dump bespoke param in this module like:
> 
> ```rust
> pub enum MetricsVariant { Http, Grpc }
> ```
> 
> and then have our Permitted impl `Param<MetricsVariant> for Permitted<T>`.
> 
> then this module remains decoupled from the concrete target types.
> 
> That is, the metrics module is decoupled from _where it's called_--as long as the caller provides a target that can give us what we need to build our extractors, we're good to go.

this branch performs a series of changes to explore what appears to be a promising alternative to the existing model of `Permitted<T>`. importantly, this has the effect of leaving the inbound metrics layers' extractors agnostic to their target: they now provide implementations like `svc::ExtractParam<BodyDataMetrics, T>` rather than `svc::ExtractParam<BodyDataMetrics, Permitted<T>>`.

* https://github.com/linkerd/linkerd2-proxy/pull/4180