### PR TITLE
refactor(app/outbound): remove frivolous `NewService<T>` bounds

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -38,6 +38,7 @@ pub fn layer<T, N>(
 > + Clone
 where
     T: MkStreamLabel,
+    N: svc::NewService<T>,
 {
     let RouteBackendMetrics {
         requests,


### PR DESCRIPTION
these bounds are extensive, but don't serve a mechanical purpose at the
moment.

we can simplify our route metrics layer in the outbound proxy by
removing them.

Signed-off-by: katelyn martin <kate@buoyant.io>
