### PR TITLE
feat(app/core): add `Layers::into_inner()`

### DIFF
--- a/linkerd/app/core/src/svc.rs
+++ b/linkerd/app/core/src/svc.rs
@@ -112,6 +112,10 @@ impl<L> Layers<L> {
     pub fn push_instrument<G: Clone>(self, get_span: G) -> Layers<Pair<L, NewInstrumentLayer<G>>> {
         self.push(NewInstrumentLayer::new(get_span))
     }
+
+    pub fn into_inner(self) -> L {
+        self.0
+    }
 }
 
 impl<M, L: Layer<M>> Layer<M> for Layers<L> {


### PR DESCRIPTION
this commit introduces an `into_inner()` method to `Layers<L>`.

like the equivalent method for `Stack<S>`, it provides a way to consume
the stack or layer, returning the inner `L`-typed layers.

Signed-off-by: katelyn martin <kate@buoyant.io>
