### PR TITLE
refactor(app/inbound): consolidate route label encoding

### DIFF
--- a/linkerd/app/inbound/src/http/router/metrics.rs
+++ b/linkerd/app/inbound/src/http/router/metrics.rs
@@ -1,12 +1,9 @@
 use crate::{policy::PermitVariant, InboundMetrics};
 use linkerd_app_core::{
-    metrics::{
-        prom::{
-            self,
-            encoding::{self, EncodeLabelSet, LabelSetEncoder},
-            EncodeLabelSetMut,
-        },
-        RouteLabels, ServerLabel,
+    metrics::prom::{
+        self,
+        encoding::{EncodeLabelSet, LabelSetEncoder},
+        EncodeLabelSetMut,
     },
     svc,
 };
@@ -14,6 +11,10 @@ use linkerd_http_prom::{
     body_data::{self, BodyDataMetrics},
     count_reqs::{self, RequestCount},
 };
+
+pub use self::labels::RouteLabels;
+
+mod labels;
 
 pub(super) fn layer<N>(
     InboundMetrics {
@@ -157,24 +158,9 @@ where
 
 impl EncodeLabelSetMut for RequestCountLabels {
     fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        use encoding::EncodeLabel as _;
+        let Self { route } = self;
 
-        let Self {
-            route:
-                RouteLabels {
-                    server: ServerLabel(parent, port),
-                    route,
-                },
-        } = self;
-
-        ("parent_group", parent.group()).encode(enc.encode_label())?;
-        ("parent_kind", parent.kind()).encode(enc.encode_label())?;
-        ("parent_name", parent.name()).encode(enc.encode_label())?;
-        ("parent_port", *port).encode(enc.encode_label())?;
-
-        ("route_group", route.group()).encode(enc.encode_label())?;
-        ("route_kind", route.kind()).encode(enc.encode_label())?;
-        ("route_name", route.name()).encode(enc.encode_label())?;
+        route.encode_label_set(enc)?;
 
         Ok(())
     }
@@ -221,24 +207,9 @@ impl ResponseBodyFamilies {
 
 impl EncodeLabelSetMut for ResponseBodyDataLabels {
     fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        use encoding::EncodeLabel as _;
+        let Self { route } = self;
 
-        let Self {
-            route:
-                RouteLabels {
-                    server: ServerLabel(parent, port),
-                    route,
-                },
-        } = self;
-
-        ("parent_group", parent.group()).encode(enc.encode_label())?;
-        ("parent_kind", parent.kind()).encode(enc.encode_label())?;
-        ("parent_name", parent.name()).encode(enc.encode_label())?;
-        ("parent_port", *port).encode(enc.encode_label())?;
-
-        ("route_group", route.group()).encode(enc.encode_label())?;
-        ("route_kind", route.kind()).encode(enc.encode_label())?;
-        ("route_name", route.name()).encode(enc.encode_label())?;
+        route.encode_label_set(enc)?;
 
         Ok(())
     }
@@ -302,24 +273,9 @@ impl RequestBodyFamilies {
 
 impl EncodeLabelSetMut for RequestBodyDataLabels {
     fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        use encoding::EncodeLabel as _;
+        let Self { route } = self;
 
-        let Self {
-            route:
-                RouteLabels {
-                    server: ServerLabel(parent, port),
-                    route,
-                },
-        } = self;
-
-        ("parent_group", parent.group()).encode(enc.encode_label())?;
-        ("parent_kind", parent.kind()).encode(enc.encode_label())?;
-        ("parent_name", parent.name()).encode(enc.encode_label())?;
-        ("parent_port", *port).encode(enc.encode_label())?;
-
-        ("route_group", route.group()).encode(enc.encode_label())?;
-        ("route_kind", route.kind()).encode(enc.encode_label())?;
-        ("route_name", route.name()).encode(enc.encode_label())?;
+        route.encode_label_set(enc)?;
 
         Ok(())
     }

--- a/linkerd/app/inbound/src/http/router/metrics/labels.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/labels.rs
@@ -1,0 +1,46 @@
+use linkerd_app_core::metrics::prom::{
+    encoding::{self, EncodeLabelSet, LabelSetEncoder},
+    EncodeLabelSetMut,
+};
+
+/// Labels referencing an inbound server and route.
+///
+/// Provides an [`EncodeLabelSet`] implementation for route labels.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct RouteLabels(linkerd_app_core::metrics::RouteLabels);
+
+// === impl RouteLabels ===
+
+impl From<linkerd_app_core::metrics::RouteLabels> for RouteLabels {
+    fn from(labels: linkerd_app_core::metrics::RouteLabels) -> Self {
+        Self(labels)
+    }
+}
+
+impl EncodeLabelSetMut for RouteLabels {
+    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        use encoding::EncodeLabel as _;
+
+        let Self(linkerd_app_core::metrics::RouteLabels {
+            server: linkerd_app_core::metrics::ServerLabel(parent, port),
+            route,
+        }) = self;
+
+        ("parent_group", parent.group()).encode(enc.encode_label())?;
+        ("parent_kind", parent.kind()).encode(enc.encode_label())?;
+        ("parent_name", parent.name()).encode(enc.encode_label())?;
+        ("parent_port", *port).encode(enc.encode_label())?;
+
+        ("route_group", route.group()).encode(enc.encode_label())?;
+        ("route_kind", route.kind()).encode(enc.encode_label())?;
+        ("route_name", route.name()).encode(enc.encode_label())?;
+
+        Ok(())
+    }
+}
+
+impl EncodeLabelSet for RouteLabels {
+    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(&mut enc)
+    }
+}

--- a/linkerd/app/inbound/src/policy/http.rs
+++ b/linkerd/app/inbound/src/policy/http.rs
@@ -1,11 +1,12 @@
 use super::{RoutePolicy, Routes};
 use crate::{
+    http::router::RouteLabels,
     metrics::authz::HttpAuthzMetrics,
     policy::{AllowPolicy, HttpRoutePermit},
 };
 use futures::{future, TryFutureExt};
 use linkerd_app_core::{
-    metrics::{RouteAuthzLabels, RouteLabels},
+    metrics::RouteAuthzLabels,
     svc::{self, ServiceExt},
     tls::{self, ConditionalServerTls},
     transport::{ClientAddr, OrigDstAddr, Remote, ServerAddr},
@@ -217,7 +218,7 @@ impl<T, N> HttpPolicyService<T, N> {
         let (r#match, route) =
             super::route::find(routes, req).ok_or_else(|| self.mk_route_not_found())?;
 
-        let labels = RouteLabels {
+        let labels = linkerd_app_core::metrics::RouteLabels {
             route: route.meta.clone(),
             server: self.policy.server_label(),
         };
@@ -479,6 +480,6 @@ impl<T> Permitted<T> {
 
     /// Returns the [`RouteLabels`] from the underlying permit.
     pub fn route_labels(&self) -> RouteLabels {
-        self.permit_ref().labels.route.clone()
+        self.permit_ref().labels.route.clone().into()
     }
 }


### PR DESCRIPTION
in linkerd/linkerd2-proxy#4180, we noted during review that encoding
prometheus labels for route and parent metadata entails a slightly
unfortunate amount of repetitive boilerplate.

in the outbound proxy, we define a local `RouteLabels` type that
implements the `EncodeLabelSet` and `EncodeLabelSetMut`, which we use to
integrate label sets with the `prometheus_client` SDK.

this commit introduces an equivalent pattern to the inbound proxy. a
`RouteLabels` newtype wrapper over the shared `linkerd_app_core`
structure is introduced, which in turn simplifies the `EncodeLabelSet`
and `EncodeLabelSetMut` implementations of the `RequestCountLabels`,
`ResponseBodyDataLabels`, and `RequestBodyDataLabels` types.

Signed-off-by: katelyn martin <kate@buoyant.io>
