### PR TITLE
refactor(http/prom): rename `NewRecordBodyData::layer_via()`

### DIFF
--- a/linkerd/app/inbound/src/http/router/metrics.rs
+++ b/linkerd/app/inbound/src/http/router/metrics.rs
@@ -37,7 +37,7 @@ pub(super) fn layer<N>(
 
     let request = {
         let extract = ExtractRequestBodyDataParams(request_body_data.clone());
-        NewRecordRequestBodyData::new(extract)
+        NewRecordRequestBodyData::layer_via(extract)
     };
 
     svc::layer::mk(move |inner| count.layer(body.layer(request.layer(inner))))

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
@@ -90,7 +90,7 @@ where
     T: svc::ExtractParam<labels::Route, http::Request<http::BoxBody>>,
 {
     let record = NewRecordDuration::layer_via(ExtractRecordDurationParams(metrics.clone()));
-    let body_data = NewRecordBodyData::new(ExtractBodyDataParams(body_data.clone()));
+    let body_data = NewRecordBodyData::layer_via(ExtractBodyDataParams(body_data.clone()));
 
     svc::layer::mk(move |inner| {
         use svc::Layer;

--- a/linkerd/http/prom/src/body_data/request.rs
+++ b/linkerd/http/prom/src/body_data/request.rs
@@ -35,7 +35,7 @@ where
     ///
     /// This uses an `X`-typed [`ExtractParam<P, T>`] implementation to extract service parameters
     /// from a `T`-typed target.
-    pub fn new(extract: X) -> impl Layer<N, Service = Self> {
+    pub fn layer_via(extract: X) -> impl Layer<N, Service = Self> {
         svc::layer::mk(move |inner| Self {
             inner,
             extract: extract.clone(),


### PR DESCRIPTION
in linkerd/linkerd2-proxy#4174, we refactored this middleware so that it
is now agnostic to the particular metrics structure used by the
extractor, meaning that the constructor no longer accepts a
`RequestBodyFamilies<L>` parameter.

in the wake of this change, our request body frame size metrics
middleware has a constructor with a type signature like `X -> impl
Layer`.

elsewhere throughout the project, constructors that accept an extractor
and return a `svc::Layer` are typically called `layer_via()`.

this commit renames `NewRecordBodyData::new()` to
`NewRecordBodyData::layer_via()`.

Signed-off-by: katelyn martin <kate@buoyant.io>
