### PR TITLE
nit(http/prom): remove empty `Option::map(..)` call

### DIFF
--- a/linkerd/http/prom/src/record_response.rs
+++ b/linkerd/http/prom/src/record_response.rs
@@ -268,7 +268,7 @@ where
 
         // Poll the inner body for the next frame.
         let poll = this.inner.as_mut().poll_frame(cx);
-        let frame = futures::ready!(poll).map(|res| res);
+        let frame = futures::ready!(poll);
 
         match &frame {
             Some(Ok(frame)) => {


### PR DESCRIPTION
this commit removes a call to `Option::map()` that provided an identity
closure i.e., mapping the inner value to itself.

this can be removed.

Signed-off-by: katelyn martin <kate@buoyant.io>
