### PR TITLE
feat(tracing): Set trace service name from workload name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ dependencies = [
  "linkerd-workers",
  "rangemap",
  "regex",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/linkerd/app/Cargo.toml
+++ b/linkerd/app/Cargo.toml
@@ -36,3 +36,6 @@ tokio-stream = { version = "0.1", features = ["time", "sync"] }
 tonic = { workspace = true, default-features = false, features = ["prost"] }
 tower = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -8,12 +8,7 @@ use linkerd_app_core::{
     transport::{DualListenAddr, Keepalive, ListenAddr, UserTimeout},
     AddrMatch, Conditional, IpNet,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    net::SocketAddr,
-    path::PathBuf,
-    time::Duration,
-};
+use std::{collections::HashSet, net::SocketAddr, path::PathBuf, time::Duration};
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 
@@ -154,6 +149,7 @@ const ENV_INBOUND_METRICS_AUTHORITY_LABELS: &str =
     "LINKERD2_PROXY_INBOUND_METRICS_AUTHORITY_LABELS";
 
 const ENV_TRACE_ATTRIBUTES_PATH: &str = "LINKERD2_PROXY_TRACE_ATTRIBUTES_PATH";
+const ENV_TRACE_ANNOTATIONS_PATH: &str = "LINKERD2_PROXY_TRACE_ANNOTATIONS_PATH";
 const ENV_TRACE_SERVICE_NAME: &str = "LINKERD2_PROXY_TRACE_SERVICE_NAME";
 const ENV_TRACE_EXTRA_ATTRIBUTES: &str = "LINKERD2_PROXY_TRACE_EXTRA_ATTRIBUTES";
 // This doesn't have the LINKERD2_ prefix because it is a conventional env var from OpenTelemetry:
@@ -441,9 +437,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let hostname = strings.get(ENV_HOSTNAME);
 
     let trace_attributes_file_path = strings.get(ENV_TRACE_ATTRIBUTES_PATH);
+    let trace_annotations_file_path = strings.get(ENV_TRACE_ANNOTATIONS_PATH);
     let trace_extra_attributes = strings.get(ENV_TRACE_EXTRA_ATTRIBUTES);
     let trace_otel_attributes = strings.get(ENV_OTEL_TRACE_ATTRIBUTES);
-    let trace_service_name = strings.get(ENV_TRACE_SERVICE_NAME);
+    let default_trace_service_name = strings.get(ENV_TRACE_SERVICE_NAME);
 
     let trace_collector_addr = parse_control_addr(strings, ENV_TRACE_COLLECTOR_SVC_BASE);
 
@@ -853,29 +850,18 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
             } else {
                 outbound.http_request_queue.failfast_timeout
             };
-            let mut attributes = trace_attributes_file_path
-                .map(|path| match path.and_then(|p| p.parse::<PathBuf>().ok()) {
-                    Some(path) => trace::read_trace_attributes(&path),
-                    None => HashMap::new(),
-                })
-                .unwrap_or_default();
-            if let Ok(Some(attrs)) = trace_extra_attributes {
-                if !attrs.is_empty() {
-                    attributes.extend(trace::parse_env_trace_attributes(&attrs));
-                }
-            }
-            if let Ok(Some(attrs)) = trace_otel_attributes {
-                if !attrs.is_empty() {
-                    attributes.extend(trace::parse_env_trace_attributes(&attrs));
-                }
-            }
 
-            let trace_service_name = trace_service_name.ok().flatten();
+            let attributes = trace::generate_trace_service_labels(trace::TraceLabelConfig {
+                labels_path: trace_attributes_file_path.ok().flatten(),
+                annotations_path: trace_annotations_file_path.ok().flatten(),
+                extra_attrs: trace_extra_attributes.ok().flatten(),
+                otel_attrs: trace_otel_attributes.ok().flatten(),
+                service_name: default_trace_service_name.ok().flatten(),
+            });
 
             trace_collector::Config::Enabled(Box::new(trace_collector::EnabledConfig {
                 attributes,
                 hostname: hostname?,
-                service_name: trace_service_name,
                 control: ControlConfig {
                     addr,
                     connect,

--- a/linkerd/app/src/env/trace.rs
+++ b/linkerd/app/src/env/trace.rs
@@ -1,6 +1,76 @@
 use std::collections::HashMap;
+use std::path::Path;
 
-pub(super) fn read_trace_attributes(path: &std::path::Path) -> HashMap<String, String> {
+static ROOT_PARENT_LABELS: &[&str] = &[
+    "app.kubernetes.io/instance",
+    "app.kubernetes.io/name",
+    "linkerd.io/proxy-root-parent",
+    "linkerd.io/proxy-deployment",
+    "linkerd.io/proxy-daemonset",
+    "linkerd.io/proxy-statefulset",
+    "linkerd.io/proxy-cronjob",
+    "linkerd.io/proxy-job",
+    "linkerd.io/proxy-replicaset",
+    "linkerd.io/proxy-replicationcontroller",
+];
+
+static OTEL_ANNOTATION_RESOURCE_PREFIX: &str = "resource.opentelemetry.io/";
+
+pub(super) struct TraceLabelConfig {
+    pub labels_path: Option<String>,
+    pub annotations_path: Option<String>,
+    pub extra_attrs: Option<String>,
+    pub otel_attrs: Option<String>,
+    pub service_name: Option<String>,
+}
+
+pub(super) fn generate_trace_service_labels(config: TraceLabelConfig) -> HashMap<String, String> {
+    let mut trace_labels = HashMap::new();
+
+    if let Some(labels_path) = config.labels_path {
+        let labels = read_trace_attributes(&labels_path);
+        if let Some(service_name) = get_trace_service_name(&labels, config.service_name) {
+            trace_labels.insert("service.name".to_string(), service_name);
+        }
+        trace_labels.extend(read_trace_attributes(&labels_path));
+    }
+
+    if let Some(annotations_path) = config.annotations_path {
+        trace_labels.extend(
+            read_trace_attributes(&annotations_path)
+                .into_iter()
+                .filter_map(|(k, v)| {
+                    k.strip_prefix(OTEL_ANNOTATION_RESOURCE_PREFIX)
+                        .map(|k| (k.to_string(), v))
+                }),
+        )
+    }
+
+    if let Some(extra_attrs) = config.extra_attrs {
+        trace_labels.extend(parse_env_trace_attributes(&extra_attrs));
+    }
+
+    if let Some(otel_attrs) = config.otel_attrs {
+        trace_labels.extend(parse_env_trace_attributes(&otel_attrs));
+    }
+
+    trace_labels
+}
+
+fn get_trace_service_name(
+    attrs: &HashMap<String, String>,
+    default_trace_service_name: Option<String>,
+) -> Option<String> {
+    for &label in ROOT_PARENT_LABELS {
+        if let Some(name) = attrs.get(label) {
+            return Some(format!("{name}-linkerd-proxy"));
+        }
+    }
+    default_trace_service_name
+}
+
+fn read_trace_attributes(path: &str) -> HashMap<String, String> {
+    let path = Path::new(path);
     match std::fs::read_to_string(path) {
         Ok(attrs) => parse_attrs(&attrs),
         Err(error) => {
@@ -14,7 +84,7 @@ pub(super) fn read_trace_attributes(path: &std::path::Path) -> HashMap<String, S
     }
 }
 
-pub(super) fn parse_env_trace_attributes(attrs: &str) -> HashMap<String, String> {
+fn parse_env_trace_attributes(attrs: &str) -> HashMap<String, String> {
     parse_attrs(attrs)
 }
 
@@ -33,9 +103,12 @@ fn parse_attrs(attrs: &str) -> HashMap<String, String> {
 }
 
 #[cfg(test)]
-#[test]
-fn parse_attrs_different_values() {
-    let attrs = "\
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_attrs_different_values() {
+        let attrs = "\
         cluster=\"test-cluster1\"\n\
         rack=\"rack-22\"\n\
         zone=us-est-coast\n\
@@ -49,27 +122,93 @@ fn parse_attrs_different_values() {
         =key4\n\
         ";
 
-    let expected = [
-        ("cluster".to_string(), "test-cluster1".to_string()),
-        ("rack".to_string(), "rack-22".to_string()),
-        ("zone".to_string(), "us-est-coast".to_string()),
-        (
-            "linkerd.io/control-plane-component".to_string(),
-            "controller".to_string(),
-        ),
-        (
-            "linkerd.io/proxy-deployment".to_string(),
-            "linkerd-controller".to_string(),
-        ),
-        ("workload".to_string(), "".to_string()),
-        ("kind".to_string(), "".to_string()),
-        ("key1".to_string(), "=".to_string()),
-        ("key2".to_string(), "=value2".to_string()),
-        ("".to_string(), "key4".to_string()),
-    ]
-    .iter()
-    .cloned()
-    .collect();
+        let expected = [
+            ("cluster".to_string(), "test-cluster1".to_string()),
+            ("rack".to_string(), "rack-22".to_string()),
+            ("zone".to_string(), "us-est-coast".to_string()),
+            (
+                "linkerd.io/control-plane-component".to_string(),
+                "controller".to_string(),
+            ),
+            (
+                "linkerd.io/proxy-deployment".to_string(),
+                "linkerd-controller".to_string(),
+            ),
+            ("workload".to_string(), "".to_string()),
+            ("kind".to_string(), "".to_string()),
+            ("key1".to_string(), "=".to_string()),
+            ("key2".to_string(), "=value2".to_string()),
+            ("".to_string(), "key4".to_string()),
+        ]
+        .iter()
+        .cloned()
+        .collect();
 
-    assert_eq!(parse_attrs(attrs), expected);
+        assert_eq!(parse_attrs(attrs), expected);
+    }
+
+    #[test]
+    fn generate_traces() -> linkerd_error::Result<()> {
+        let labels = r#"app="web-svc"
+linkerd.io/control-plane-ns="linkerd"
+linkerd.io/proxy-deployment="web"
+linkerd.io/workload-ns="emojivoto"
+pod-template-hash="66bdd4d96d"
+version="v11""#;
+        let labels_file = tempfile::NamedTempFile::new()?;
+        std::fs::write(labels_file.path(), labels)?;
+
+        let annotations = r#"linkerd.io/created-by="linkerd/proxy-injector"
+linkerd.io/inject="enabled"
+linkerd.io/proxy-version="edge"
+linkerd.io/trust-root-sha256="0000000000000000000000000000000000000000000000000000000000000000""#;
+        let annotations_file = tempfile::NamedTempFile::new()?;
+        std::fs::write(annotations_file.path(), annotations)?;
+
+        let extra = r#"k8s.pod.ip="0.0.0.0"
+k8s.pod.uid="00000000-0000-0000-0000-000000000000"
+k8s.container.name="linkerd-proxy"
+"#;
+        let service_name = "linkerd-proxy";
+
+        let expected = [
+            ("app".to_string(), "web-svc".to_string()),
+            (
+                "linkerd.io/control-plane-ns".to_string(),
+                "linkerd".to_string(),
+            ),
+            ("linkerd.io/proxy-deployment".to_string(), "web".to_string()),
+            (
+                "linkerd.io/workload-ns".to_string(),
+                "emojivoto".to_string(),
+            ),
+            ("pod-template-hash".to_string(), "66bdd4d96d".to_string()),
+            ("version".to_string(), "v11".to_string()),
+            ("k8s.pod.ip".to_string(), "0.0.0.0".to_string()),
+            (
+                "k8s.pod.uid".to_string(),
+                "00000000-0000-0000-0000-000000000000".to_string(),
+            ),
+            (
+                "k8s.container.name".to_string(),
+                "linkerd-proxy".to_string(),
+            ),
+            ("service.name".to_string(), "web-linkerd-proxy".to_string()),
+        ]
+        .iter()
+        .cloned()
+        .collect::<HashMap<_, _>>();
+
+        let actual = generate_trace_service_labels(TraceLabelConfig {
+            labels_path: Some(labels_file.path().to_string_lossy().to_string()),
+            annotations_path: Some(annotations_file.path().to_string_lossy().to_string()),
+            extra_attrs: Some(extra.to_string()),
+            otel_attrs: None,
+            service_name: Some(service_name.to_string()),
+        });
+
+        assert_eq!(expected, actual);
+
+        Ok(())
+    }
 }

--- a/linkerd/app/src/trace_collector.rs
+++ b/linkerd/app/src/trace_collector.rs
@@ -9,7 +9,6 @@ use std::{collections::HashMap, future::Future, pin::Pin};
 pub mod otel_collector;
 
 const SPAN_BUFFER_CAPACITY: usize = 100;
-const SERVICE_NAME: &str = "linkerd-proxy";
 
 #[derive(Clone, Debug)]
 pub enum Config {
@@ -22,7 +21,6 @@ pub struct EnabledConfig {
     pub control: control::Config,
     pub attributes: HashMap<String, String>,
     pub hostname: Option<String>,
-    pub service_name: Option<String>,
 }
 
 pub type Task = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
@@ -71,14 +69,10 @@ impl Config {
                     .control
                     .build(dns, client_metrics, control_metrics, identity)
                     .new_service(());
-                let svc_name = inner
-                    .service_name
-                    .unwrap_or_else(|| SERVICE_NAME.to_string());
 
                 let collector = {
                     let attributes = OtelCollectorAttributes {
                         hostname: inner.hostname,
-                        service_name: svc_name,
                         extra: inner.attributes,
                     };
                     otel_collector::create_collector(

--- a/linkerd/app/src/trace_collector/otel_collector.rs
+++ b/linkerd/app/src/trace_collector/otel_collector.rs
@@ -18,7 +18,6 @@ use tracing::Instrument;
 
 pub(super) struct OtelCollectorAttributes {
     pub hostname: Option<String>,
-    pub service_name: String,
     pub extra: HashMap<String, String>,
 }
 
@@ -40,10 +39,6 @@ where
 
     let mut resources = ResourceAttributesWithSchema::default();
 
-    resources
-        .attributes
-        .0
-        .push(attributes.service_name.with_key("service.name"));
     resources
         .attributes
         .0


### PR DESCRIPTION
Currently, all proxies must share the same trace service name, which makes querying for proxy traces much less useful.

This updates the trace service name to be set via pod annotations, populated by the downward API. If none of those annotations are available, we can fallback to the global trace name.

This also does some considerable refactoring to the trace label population, simplifying the flow and making it much clearer where values are set and overridden by other values.