### PR TITLE
refactor(http/prom): hoist `MkStreamLabel` out of `record_response`

### DIFF
--- a/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend.rs
@@ -1,7 +1,7 @@
 use super::{super::Concrete, filters};
 use crate::{BackendRef, ParentRef, RouteRef};
 use linkerd_app_core::{proxy::http, svc, Error, Result};
-use linkerd_http_prom::record_response::MkStreamLabel;
+use linkerd_http_prom::stream_label::MkStreamLabel;
 use linkerd_http_route as http_route;
 use linkerd_proxy_client_policy as policy;
 use std::{fmt::Debug, hash::Hash, sync::Arc};

--- a/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/backend/metrics.rs
@@ -3,11 +3,12 @@ use linkerd_app_core::{metrics::prom, svc};
 use linkerd_http_prom::{
     body_data::response::{BodyDataMetrics, NewRecordBodyData, ResponseBodyFamilies},
     count_reqs::{NewCountRequests, RequestCount, RequestCountFamilies},
-    record_response::{self, NewResponseDuration, StreamLabel},
+    record_response::{self, NewResponseDuration},
+    stream_label::StreamLabel,
 };
 
 pub use super::super::metrics::*;
-pub use linkerd_http_prom::record_response::MkStreamLabel;
+pub use linkerd_http_prom::stream_label::MkStreamLabel;
 
 #[cfg(test)]
 mod tests;

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
@@ -6,10 +6,11 @@ use linkerd_app_core::{
 };
 use linkerd_http_prom::{
     body_data::request::{BodyDataMetrics, NewRecordBodyData, RequestBodyFamilies},
-    record_response::{self, StreamLabel},
+    record_response,
+    stream_label::StreamLabel,
 };
 
-pub use linkerd_http_prom::record_response::MkStreamLabel;
+pub use linkerd_http_prom::stream_label::MkStreamLabel;
 
 pub mod labels;
 #[cfg(test)]

--- a/linkerd/http/prom/src/lib.rs
+++ b/linkerd/http/prom/src/lib.rs
@@ -4,3 +4,4 @@
 pub mod body_data;
 pub mod count_reqs;
 pub mod record_response;
+pub mod stream_label;

--- a/linkerd/http/prom/src/stream_label.rs
+++ b/linkerd/http/prom/src/stream_label.rs
@@ -1,0 +1,61 @@
+//! Stream labeling facilities.
+
+use linkerd_error::Error;
+use prometheus_client::encoding::EncodeLabelSet;
+
+/// A strategy for labeling request/responses streams for status and duration
+/// metrics.
+///
+/// This is specifically to support higher-cardinality status counters and
+/// lower-cardinality stream duration histograms.
+pub trait MkStreamLabel {
+    type DurationLabels: EncodeLabelSet
+        + Clone
+        + Eq
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Send
+        + Sync
+        + 'static;
+    type StatusLabels: EncodeLabelSet
+        + Clone
+        + Eq
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Send
+        + Sync
+        + 'static;
+
+    type StreamLabel: StreamLabel<
+        DurationLabels = Self::DurationLabels,
+        StatusLabels = Self::StatusLabels,
+    >;
+
+    /// Returns None when the request should not be recorded.
+    fn mk_stream_labeler<B>(&self, req: &http::Request<B>) -> Option<Self::StreamLabel>;
+}
+
+pub trait StreamLabel: Send + 'static {
+    type DurationLabels: EncodeLabelSet
+        + Clone
+        + Eq
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Send
+        + Sync
+        + 'static;
+    type StatusLabels: EncodeLabelSet
+        + Clone
+        + Eq
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Send
+        + Sync
+        + 'static;
+
+    fn init_response<B>(&mut self, rsp: &http::Response<B>);
+    fn end_response(&mut self, trailers: Result<Option<&http::HeaderMap>, &Error>);
+
+    fn status_labels(&self) -> Self::StatusLabels;
+    fn duration_labels(&self) -> Self::DurationLabels;
+}


### PR DESCRIPTION
`linkerd_http_prom::record_response` defines a pair of traits that are
used to derive labels for prometheus metrics. this is used to install
telemetry that inspects the response body, which is helpful for
recording response latency, and inspecting gRPC status codes.

this is a helpful model. to help reuse this trait, we hoist it out of
`record_response` and into a dedicated submodule.

Signed-off-by: katelyn martin <kate@buoyant.io>
