### PR TITLE
chore: remove stale skip-tree root from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -53,8 +53,6 @@ skip-tree = [
     { name = "pprof" },
     # zerocopy v0.8 is still propagating through the ecosystem
     { name = "zerocopy", version = "0.7" },
-    # socket2 v0.6 is still propagating through the ecosystem
-    { name = "socket2", version = "0.5" },
 ]
 
 [sources]


### PR DESCRIPTION
a warning is observed when we run the following `cargo deny` command:

```
$ cargo deny --all-features check bans licenses sources
warning[unmatched-skip-root]: skip tree root was not found in the dependency graph
   ┌─ /linkerd/linkerd2-proxy/deny.toml:57:15
   │
57 │     { name = "socket2", version = "0.5" },
   │               ━━━━━━━ no crate matched these criteria

bans ok, licenses ok, sources ok
```

this commit removes this skip-tree root, now that this crate and version
are no longer in our dependency tree. after applying this change:

```
$ cargo deny --all-features check bans licenses sources
bans ok, licenses ok, sources ok
```

Signed-off-by: katelyn martin <kate@buoyant.io>
