### PR TITLE
nit: consolidate rustls-webpki dependency

### DIFF
--- a/linkerd/rustls/Cargo.toml
+++ b/linkerd/rustls/Cargo.toml
@@ -10,5 +10,5 @@ publish = { workspace = true }
 rustls-aws-lc-fips = ["tokio-rustls/fips"]
 
 [dependencies]
-rustls-webpki = { version = "0.103.13", default-features = false, features = ["std", "aws-lc-rs"] }
+rustls-webpki = { workspace = true, features = ["std", "aws-lc-rs"] }
 tokio-rustls = { workspace = true, features = ["aws-lc-rs"] }


### PR DESCRIPTION
we have a workspace-level dependency upon rustls-webpki@0.103.13.

this crate defines that same dependency separately. we can instead
depend on the workspace dependency.

Signed-off-by: katelyn martin <kate@buoyant.io>
