### PR TITLE
chore(deps): define `rand` as a workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ prometheus-client = { version = "0.23" }
 prost = { version = "0.14" }
 prost-build = { version = "0.14", default-features = false }
 prost-types = { version = "0.14" }
+rand = { version = "0.9", default-features = false }
 rustls-pki-types = { version = "1.14" }
 rustls-webpki = { version = "0.103.13", default-features = false }
 tokio-rustls = { version = "0.26", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,6 @@ prometheus-client = { version = "0.23" }
 prost = { version = "0.14" }
 prost-build = { version = "0.14", default-features = false }
 prost-types = { version = "0.14" }
-rand = { version = "0.9", default-features = false }
 rustls-pki-types = { version = "1.14" }
 rustls-webpki = { version = "0.103.13", default-features = false }
 tokio-rustls = { version = "0.26", default-features = false, features = [
@@ -136,3 +135,8 @@ features = ["tokio", "tracing"]
 
 [workspace.dependencies.linkerd2-proxy-api]
 version = "0.18.0"
+
+[workspace.dependencies.rand]
+version = "0.9"
+default-features = false
+features = ["std", "std_rng", "os_rng"]

--- a/linkerd/distribute/Cargo.toml
+++ b/linkerd/distribute/Cargo.toml
@@ -10,7 +10,7 @@ publish = { workspace = true }
 ahash = "0.8"
 linkerd-stack = { path = "../stack" }
 parking_lot = "0.12"
-rand = { version = "0.9", features = ["small_rng"] }
+rand = { workspace = true, features = ["small_rng", "thread_rng"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/linkerd/exp-backoff/Cargo.toml
+++ b/linkerd/exp-backoff/Cargo.toml
@@ -8,7 +8,7 @@ publish = { workspace = true }
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-rand = { version = "0.9", features = ["small_rng"] }
+rand = { workspace = true, features = ["small_rng", "thread_rng"] }
 thiserror = "2"
 tokio = { version = "1", features = ["time"] }
 pin-project = "1"

--- a/linkerd/http/route/Cargo.toml
+++ b/linkerd/http/route/Cargo.toml
@@ -12,7 +12,7 @@ proto = ["linkerd2-proxy-api"]
 [dependencies]
 http = { workspace = true }
 regex = "1"
-rand = "0.9"
+rand = { workspace = true, features = ["thread_rng"] }
 thiserror = "2"
 tracing = { workspace = true }
 url = "2"

--- a/linkerd/pool/p2c/Cargo.toml
+++ b/linkerd/pool/p2c/Cargo.toml
@@ -10,7 +10,7 @@ publish = { workspace = true }
 ahash = "0.8"
 futures = { version = "0.3", default-features = false }
 prometheus-client = { workspace = true }
-rand = { version = "0.9", features = ["small_rng"] }
+rand = { workspace = true, features = ["small_rng", "thread_rng"] }
 tracing = { workspace = true }
 
 linkerd-error = { path = "../../error" }

--- a/linkerd/trace-context/Cargo.toml
+++ b/linkerd/trace-context/Cargo.toml
@@ -16,7 +16,7 @@ http = { workspace = true }
 linkerd-error = { path = "../error" }
 linkerd-stack = { path = "../stack" }
 opentelemetry-semantic-conventions = { version = "0.31", default-features = false, features = ["semconv_experimental"] }
-rand = "0.9"
+rand = { workspace = true, features = ["thread_rng"] }
 thiserror = "2"
 tower = { workspace = true, default-features = false, features = ["util"] }
 tracing = { workspace = true }


### PR DESCRIPTION
this commit defines our dependencies on rand throughout the cargo
workspace in terms of a single workspace-level dependency. no changes to
Cargo.lock are included here because this is a noöp like-for-like
change.

Signed-off-by: katelyn martin <kate@buoyant.io>
