### PR TITLE
fix(proxy): add max_header_list_size config for HTTP/2 client

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -540,13 +540,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 OUTBOUND_CONNECT_BASE,
                 DEFAULT_OUTBOUND_CONNECT_BACKOFF,
             )?,
-            http2: h2::ClientParams {
-                flow_control: Some(h2::FlowControl::Fixed {
-                    initial_stream_window_size,
-                    initial_connection_window_size,
-                }),
-                ..Default::default()
-            },
+            http2: http2::parse_client(
+                strings,
+                "LINKERD2_PROXY_OUTBOUND_CONNECT_HTTP2",
+            )?,
             http1: h1::PoolSettings {
                 max_idle,
                 idle_timeout: connection_pool_timeout
@@ -634,13 +631,10 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 INBOUND_CONNECT_BASE,
                 DEFAULT_INBOUND_CONNECT_BACKOFF,
             )?,
-            http2: h2::ClientParams {
-                flow_control: Some(h2::FlowControl::Fixed {
-                    initial_stream_window_size,
-                    initial_connection_window_size,
-                }),
-                ..Default::default()
-            },
+            http2: http2::parse_client(
+                strings,
+                "LINKERD2_PROXY_INBOUND_CONNECT_HTTP2",
+            )?,
             http1: h1::PoolSettings {
                 max_idle,
                 idle_timeout: connection_pool_timeout,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -273,6 +273,10 @@ const ENV_INITIAL_STREAM_WINDOW_SIZE: &str = "LINKERD2_PROXY_HTTP2_INITIAL_STREA
 const ENV_INITIAL_CONNECTION_WINDOW_SIZE: &str =
     "LINKERD2_PROXY_HTTP2_INITIAL_CONNECTION_WINDOW_SIZE";
 
+/// Configure the maximum size of header list that the sender is prepared to accept.
+const ENV_HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE: &str =
+    "LINKERD2_PROXY_HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE";
+
 const ENV_INBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: &str =
     "LINKERD2_PROXY_INBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT";
 const ENV_OUTBOUND_HTTP1_CONNECTION_POOL_IDLE_TIMEOUT: &str =
@@ -472,6 +476,11 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     let initial_connection_window_size =
         parse(strings, ENV_INITIAL_CONNECTION_WINDOW_SIZE, parse_number)?
             .unwrap_or(DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE);
+    let settings_max_header_list_size = parse(
+        strings,
+        ENV_HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE,
+        parse_number,
+    )?;
 
     let dst_profile_suffixes = dst_profile_suffixes?
         .unwrap_or_else(|| parse_dns_suffixes(DEFAULT_DESTINATION_PROFILE_SUFFIXES).unwrap());
@@ -540,10 +549,14 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 OUTBOUND_CONNECT_BASE,
                 DEFAULT_OUTBOUND_CONNECT_BACKOFF,
             )?,
-            http2: http2::parse_client(
-                strings,
-                "LINKERD2_PROXY_OUTBOUND_CONNECT_HTTP2",
-            )?,
+            http2: h2::ClientParams {
+                flow_control: Some(h2::FlowControl::Fixed {
+                    initial_stream_window_size,
+                    initial_connection_window_size,
+                }),
+                max_header_list_size: settings_max_header_list_size,
+                ..Default::default()
+            },
             http1: h1::PoolSettings {
                 max_idle,
                 idle_timeout: connection_pool_timeout
@@ -631,10 +644,14 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
                 INBOUND_CONNECT_BASE,
                 DEFAULT_INBOUND_CONNECT_BACKOFF,
             )?,
-            http2: http2::parse_client(
-                strings,
-                "LINKERD2_PROXY_INBOUND_CONNECT_HTTP2",
-            )?,
+            http2: h2::ClientParams {
+                flow_control: Some(h2::FlowControl::Fixed {
+                    initial_stream_window_size,
+                    initial_connection_window_size,
+                }),
+                max_header_list_size: settings_max_header_list_size,
+                ..Default::default()
+            },
             http1: h1::PoolSettings {
                 max_idle,
                 idle_timeout: connection_pool_timeout,

--- a/linkerd/app/src/env/http2.rs
+++ b/linkerd/app/src/env/http2.rs
@@ -29,6 +29,28 @@ pub(super) fn parse_server<S: Strings>(
     })
 }
 
+pub(super) fn parse_client<S: Strings>(
+    strings: &S,
+    base: &str,
+) -> Result<h2::ClientParams, EnvError> {
+    Ok(h2::ClientParams {
+        flow_control: Some(parse_flow_control(strings, base)?),
+        keep_alive: parse_client_keep_alive(strings, &format!("{base}_KEEP_ALIVE"))?,
+        max_concurrent_reset_streams: parse(
+            strings,
+            &format!("{base}_MAX_CONCURRENT_RESET_STREAMS"),
+            parse_number,
+        )?,
+        max_frame_size: parse(strings, &format!("{base}_MAX_FRAME_SIZE"), parse_number)?,
+        max_header_list_size: parse(
+            strings,
+            &format!("{base}_MAX_HEADER_LIST_SIZE"),
+            parse_number,
+        )?,
+        max_send_buf_size: parse(strings, &format!("{base}_MAX_SEND_BUF_SIZE"), parse_number)?,
+    })
+}
+
 fn parse_flow_control<S: Strings>(strings: &S, base: &str) -> Result<h2::FlowControl, EnvError> {
     if let Some(true) = parse(
         strings,
@@ -72,6 +94,25 @@ fn parse_keep_alive<S: Strings>(
         parse(strings, &format!("{base}_INTERVAL"), parse_duration)?,
     ) {
         return Ok(Some(h2::KeepAlive { interval, timeout }));
+    }
+
+    Ok(None)
+}
+
+fn parse_client_keep_alive<S: Strings>(
+    strings: &S,
+    base: &str,
+) -> Result<Option<h2::ClientKeepAlive>, EnvError> {
+    if let (Some(timeout), Some(interval)) = (
+        parse(strings, &format!("{base}_TIMEOUT"), parse_duration)?,
+        parse(strings, &format!("{base}_INTERVAL"), parse_duration)?,
+    ) {
+        let while_idle = parse(
+            strings,
+            &format!("{base}_WHILE_IDLE"),
+            parse_bool,
+        )?.unwrap_or(false);
+        return Ok(Some(h2::ClientKeepAlive { interval, timeout, while_idle }));
     }
 
     Ok(None)
@@ -144,6 +185,58 @@ mod tests {
             h2::ServerParams {
                 flow_control: default.flow_control,
                 ..expected
+            }
+        );
+    }
+
+    #[test]
+    fn client_params() {
+        let mut env = HashMap::default();
+
+        // Produces empty params if no relevant env vars are set.
+        let default = h2::ClientParams {
+            flow_control: Some(h2::FlowControl::Fixed {
+                initial_stream_window_size: super::super::DEFAULT_INITIAL_STREAM_WINDOW_SIZE,
+                initial_connection_window_size:
+                    super::super::DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE,
+            }),
+            ..Default::default()
+        };
+        assert_eq!(parse_client(&env, "TEST").unwrap(), default);
+
+        // Set all the fields.
+        env.insert("TEST_MAX_FRAME_SIZE", "4");
+        env.insert("TEST_MAX_HEADER_LIST_SIZE", "5");
+        env.insert("TEST_MAX_SEND_BUF_SIZE", "7");
+        env.insert("TEST_KEEP_ALIVE_TIMEOUT", "1s");
+        env.insert("TEST_KEEP_ALIVE_INTERVAL", "2s");
+        env.insert("TEST_KEEP_ALIVE_WHILE_IDLE", "true");
+        env.insert("TEST_INITIAL_STREAM_WINDOW_SIZE", "1");
+        env.insert("TEST_INITIAL_CONNECTION_WINDOW_SIZE", "2");
+        let expected = h2::ClientParams {
+            flow_control: Some(h2::FlowControl::Fixed {
+                initial_stream_window_size: 1,
+                initial_connection_window_size: 2,
+            }),
+            keep_alive: Some(h2::ClientKeepAlive {
+                interval: Duration::from_secs(2),
+                timeout: Duration::from_secs(1),
+                while_idle: true,
+            }),
+            max_frame_size: Some(4),
+            max_header_list_size: Some(5),
+            max_send_buf_size: Some(7),
+            ..Default::default()
+        };
+        assert_eq!(parse_client(&env, "TEST").unwrap(), expected);
+
+        // Enable adaptive flow control, overriding other flow control settings.
+        env.insert("TEST_ADAPTIVE_FLOW_CONTROL", "true");
+        assert_eq!(
+            parse_client(&env, "TEST").unwrap(),
+            h2::ClientParams {
+                flow_control: Some(h2::FlowControl::Adaptive),
+                ..expected.clone()
             }
         );
     }

--- a/linkerd/app/src/env/http2.rs
+++ b/linkerd/app/src/env/http2.rs
@@ -29,28 +29,6 @@ pub(super) fn parse_server<S: Strings>(
     })
 }
 
-pub(super) fn parse_client<S: Strings>(
-    strings: &S,
-    base: &str,
-) -> Result<h2::ClientParams, EnvError> {
-    Ok(h2::ClientParams {
-        flow_control: Some(parse_flow_control(strings, base)?),
-        keep_alive: parse_client_keep_alive(strings, &format!("{base}_KEEP_ALIVE"))?,
-        max_concurrent_reset_streams: parse(
-            strings,
-            &format!("{base}_MAX_CONCURRENT_RESET_STREAMS"),
-            parse_number,
-        )?,
-        max_frame_size: parse(strings, &format!("{base}_MAX_FRAME_SIZE"), parse_number)?,
-        max_header_list_size: parse(
-            strings,
-            &format!("{base}_MAX_HEADER_LIST_SIZE"),
-            parse_number,
-        )?,
-        max_send_buf_size: parse(strings, &format!("{base}_MAX_SEND_BUF_SIZE"), parse_number)?,
-    })
-}
-
 fn parse_flow_control<S: Strings>(strings: &S, base: &str) -> Result<h2::FlowControl, EnvError> {
     if let Some(true) = parse(
         strings,
@@ -94,25 +72,6 @@ fn parse_keep_alive<S: Strings>(
         parse(strings, &format!("{base}_INTERVAL"), parse_duration)?,
     ) {
         return Ok(Some(h2::KeepAlive { interval, timeout }));
-    }
-
-    Ok(None)
-}
-
-fn parse_client_keep_alive<S: Strings>(
-    strings: &S,
-    base: &str,
-) -> Result<Option<h2::ClientKeepAlive>, EnvError> {
-    if let (Some(timeout), Some(interval)) = (
-        parse(strings, &format!("{base}_TIMEOUT"), parse_duration)?,
-        parse(strings, &format!("{base}_INTERVAL"), parse_duration)?,
-    ) {
-        let while_idle = parse(
-            strings,
-            &format!("{base}_WHILE_IDLE"),
-            parse_bool,
-        )?.unwrap_or(false);
-        return Ok(Some(h2::ClientKeepAlive { interval, timeout, while_idle }));
     }
 
     Ok(None)
@@ -185,58 +144,6 @@ mod tests {
             h2::ServerParams {
                 flow_control: default.flow_control,
                 ..expected
-            }
-        );
-    }
-
-    #[test]
-    fn client_params() {
-        let mut env = HashMap::default();
-
-        // Produces empty params if no relevant env vars are set.
-        let default = h2::ClientParams {
-            flow_control: Some(h2::FlowControl::Fixed {
-                initial_stream_window_size: super::super::DEFAULT_INITIAL_STREAM_WINDOW_SIZE,
-                initial_connection_window_size:
-                    super::super::DEFAULT_INITIAL_CONNECTION_WINDOW_SIZE,
-            }),
-            ..Default::default()
-        };
-        assert_eq!(parse_client(&env, "TEST").unwrap(), default);
-
-        // Set all the fields.
-        env.insert("TEST_MAX_FRAME_SIZE", "4");
-        env.insert("TEST_MAX_HEADER_LIST_SIZE", "5");
-        env.insert("TEST_MAX_SEND_BUF_SIZE", "7");
-        env.insert("TEST_KEEP_ALIVE_TIMEOUT", "1s");
-        env.insert("TEST_KEEP_ALIVE_INTERVAL", "2s");
-        env.insert("TEST_KEEP_ALIVE_WHILE_IDLE", "true");
-        env.insert("TEST_INITIAL_STREAM_WINDOW_SIZE", "1");
-        env.insert("TEST_INITIAL_CONNECTION_WINDOW_SIZE", "2");
-        let expected = h2::ClientParams {
-            flow_control: Some(h2::FlowControl::Fixed {
-                initial_stream_window_size: 1,
-                initial_connection_window_size: 2,
-            }),
-            keep_alive: Some(h2::ClientKeepAlive {
-                interval: Duration::from_secs(2),
-                timeout: Duration::from_secs(1),
-                while_idle: true,
-            }),
-            max_frame_size: Some(4),
-            max_header_list_size: Some(5),
-            max_send_buf_size: Some(7),
-            ..Default::default()
-        };
-        assert_eq!(parse_client(&env, "TEST").unwrap(), expected);
-
-        // Enable adaptive flow control, overriding other flow control settings.
-        env.insert("TEST_ADAPTIVE_FLOW_CONTROL", "true");
-        assert_eq!(
-            parse_client(&env, "TEST").unwrap(),
-            h2::ClientParams {
-                flow_control: Some(h2::FlowControl::Adaptive),
-                ..expected.clone()
             }
         );
     }

--- a/linkerd/http/h2/src/lib.rs
+++ b/linkerd/http/h2/src/lib.rs
@@ -22,6 +22,7 @@ pub struct ClientParams {
     pub max_concurrent_reset_streams: Option<usize>,
     pub max_frame_size: Option<u32>,
     pub max_send_buf_size: Option<usize>,
+    pub max_header_list_size: Option<u32>,
 }
 
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
@@ -58,6 +59,9 @@ impl ClientParams {
                 .or(self.max_concurrent_reset_streams),
             max_frame_size: overrides.max_frame_size.or(self.max_frame_size),
             max_send_buf_size: overrides.max_send_buf_size.or(self.max_send_buf_size),
+            max_header_list_size: overrides
+                .max_header_list_size
+                .or(self.max_header_list_size),
         }
     }
 }

--- a/linkerd/http/h2/src/lib.rs
+++ b/linkerd/http/h2/src/lib.rs
@@ -59,9 +59,7 @@ impl ClientParams {
                 .or(self.max_concurrent_reset_streams),
             max_frame_size: overrides.max_frame_size.or(self.max_frame_size),
             max_send_buf_size: overrides.max_send_buf_size.or(self.max_send_buf_size),
-            max_header_list_size: overrides
-                .max_header_list_size
-                .or(self.max_header_list_size),
+            max_header_list_size: overrides.max_header_list_size.or(self.max_header_list_size),
         }
     }
 }

--- a/linkerd/proxy/api-resolve/src/pb.rs
+++ b/linkerd/proxy/api-resolve/src/pb.rs
@@ -207,6 +207,9 @@ fn to_http2_client_params(pb: Http2ClientParams) -> linkerd_http_h2::ClientParam
             .as_ref()
             .map(|i| i.max_send_buf_size as usize)
             .filter(|n| *n > 0),
+        // The API doesn't set this value, it's only ever configured
+        // via the linkerd ENV.
+        max_header_list_size: None,
     }
 }
 

--- a/linkerd/proxy/http/src/h2.rs
+++ b/linkerd/proxy/http/src/h2.rs
@@ -75,6 +75,7 @@ where
             max_concurrent_reset_streams,
             max_frame_size,
             max_send_buf_size,
+            max_header_list_size,
         } = self.params;
 
         let connect = self
@@ -121,6 +122,9 @@ where
                 }
                 if let Some(sz) = max_send_buf_size {
                     builder.max_send_buf_size(sz);
+                }
+                if let Some(sz) = max_header_list_size {
+                    builder.max_header_list_size(sz);
                 }
 
                 let (tx, conn) = builder


### PR DESCRIPTION
After the Hyper 0.14→1.x migration, the HTTP/2 client defaults to `DEFAULT_MAX_HEADER_LIST_SIZE = 16 KiB`, which is too restrictive for gRPC services with large trailers.

This change adds client-side configurability of the max header list size via the `LINKERD2_PROXY_HTTP2_SETTINGS_MAX_HEADER_LIST_SIZE` proxy environment variable.

Note that the new config is not set through the API. However, the setting can be configured through the `config.linkerd.io/proxy-additional-env` annotation

fixes linkerd/linkerd2#15199