### PR TITLE
refactor(ewma): `last_update()` is a test interface

### DIFF
--- a/linkerd/ewma/src/lib.rs
+++ b/linkerd/ewma/src/lib.rs
@@ -70,11 +70,6 @@ impl Ewma {
         self.value
     }
 
-    /// Returns the timestamp of the most recent update.
-    pub fn last_update(&self) -> time::Instant {
-        self.timestamp
-    }
-
     /// Returns the decayed value projected to the given time, without modifying stored state.
     ///
     /// Instead of returning the raw stored value, this applies exponential decay based
@@ -147,6 +142,13 @@ impl Ewma {
 mod tests {
     use super::*;
     use tokio::time::{Duration, Instant};
+
+    impl Ewma {
+        /// Returns the timestamp of the most recent update.
+        pub fn last_update(&self) -> time::Instant {
+            self.timestamp
+        }
+    }
 
     // Literal value for exp(-1.0), since it's not const
     const EXP_NEG1: f64 = 0.36787944117144233;


### PR DESCRIPTION
this commit makes a refactoring proposal into
linkerd/linkerd2-proxy#4537. as such, this pull request targets the
`amr/load-biaser` branch, not `main`.

`last_update()` is a method that only exists to facilitate unit tests.
accordingly, it does not need to be a public method.

to help present an intuitive interface about how `Ewma` should be used,
and to signal intent for the purpose of this accessor, we move this into
the associated test suite, behind a `#[cfg(test)]` gate.

Signed-off-by: katelyn martin <kate@buoyant.io>
