### PR TITLE
refactor(load-biaser): store `penalty_secs` as a u16

### DIFF
--- a/linkerd/load-biaser/src/lib.rs
+++ b/linkerd/load-biaser/src/lib.rs
@@ -264,7 +264,7 @@ impl ResponseFailureHint for tokio_test::io::Mock {}
 const RETRY_AFTER_PENALTY_FACTOR: f64 = 0.5;
 
 /// Configuration for LoadBiaser behavior.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct LoadBiaserConfig {
     /// Default RTT to use when no measurements are available
     pub default_rtt: Duration,
@@ -274,7 +274,7 @@ pub struct LoadBiaserConfig {
     pub rtt_decay: Duration,
 
     /// The penalty value to inject on failure responses (429, 503, 5xx) in seconds
-    pub penalty_secs: f64,
+    pub penalty_secs: u16,
 
     /// Decay duration for the penalty EWMA.
     /// Controls how quickly the penalty decays after a failure response
@@ -294,7 +294,7 @@ impl Default for LoadBiaserConfig {
             default_rtt: Duration::from_secs(1),
             rtt_decay: Duration::from_secs(10),
             // 5 second penalty on failure responses (429, 503, 5xx)
-            penalty_secs: 5.0,
+            penalty_secs: 5,
             // 10 second decay for penalty - mostly gone after ~30 seconds
             penalty_decay: Duration::from_secs(10),
             enabled: false,
@@ -316,7 +316,7 @@ struct SharedState {
     /// Count of in-flight requests (up on call, down on response)
     pending: AtomicU32,
     /// Penalty value to inject on failure responses (in seconds)
-    penalty_secs: f64,
+    penalty_secs: u16,
     /// Whether penalty injection is enabled
     enabled: bool,
     /// Maximum Retry-After duration to honor (clamped)
@@ -380,14 +380,7 @@ pub struct LoadBiaserFuture<F, Rsp> {
 impl<S> LoadBiaser<S> {
     /// Creates a new `LoadBiaser` wrapping the given service.
     #[must_use]
-    pub fn new(inner: S, mut config: LoadBiaserConfig) -> Self {
-        if config.penalty_secs.is_nan() || config.penalty_secs < 0.0 {
-            tracing::warn!(
-                penalty_secs = config.penalty_secs,
-                "penalty_secs is NaN or negative, clamping to 0.0"
-            );
-            config.penalty_secs = 0.0;
-        }
+    pub fn new(inner: S, config: LoadBiaserConfig) -> Self {
         if config.penalty_decay < MIN_DECAY {
             tracing::warn!(
                 penalty_decay = ?config.penalty_decay,
@@ -569,7 +562,7 @@ where
 
                 if shared.enabled {
                     if let Some(hint) = resp.failure_hint() {
-                        let base_penalty = shared.penalty_secs;
+                        let base_penalty: f64 = shared.penalty_secs.into();
 
                         // For rate-limited and service-unavailable responses, amplify
                         // the penalty using the Retry-After hint so it remains meaningful
@@ -710,7 +703,7 @@ mod tests {
         LoadBiaserConfig {
             default_rtt: Duration::from_millis(100), // 0.1s default
             rtt_decay: Duration::from_secs(10),
-            penalty_secs: 5.0,
+            penalty_secs: 5,
             penalty_decay: Duration::from_secs(10),
             enabled: true,
             max_duration: DEFAULT_RETRY_AFTER_MAX_DURATION,


### PR DESCRIPTION
this commit is based upon linkerd/linkerd2-proxy#4537, but is written in
part as preemptive review feedback related to linkerd/linkerd2-proxy#4546.

in that change, we must remove the `Hash`, `PartialEq`, and `Eq`
derivations on a number of types throughout the outbound proxy, making
that change fairly involved.

see, for example: https://github.com/linkerd/linkerd2-proxy/commit/8675c7f4f6904a3816ee4d4857d92db5fa2157e3

this commit proposes an alteration to the load biaser crate that can
avoid the need for these changes, both minimizing the size of the
unified circuit breaker integration, and avoiding the risk of future
changes introducing hashing or equality bugs should we add other fields
to these structures in the future and neglect to update the manual
`Hash` implementations.

instead, we can change our model of the load biaser's config. by storing
`penalty_secs` as an unsigned integer, this structure can now be
compared and hashed. this value is then converted to a floating point
f64 only at the site where we need to perform exponential weighted
moving average arithmetic.

finally, this also provides another benefit: by modeling our
configuration in a way that makes illegal states (_negative penalty, NaN
penalty_) impossible to represent, we no longer need to check for such
states when constructing a load biasing layer.

X-Ref: linkerd/linkerd2-proxy#4546
X-Ref: linkerd/linkerd2-proxy#4537
Signed-off-by: katelyn martin <kate@buoyant.io>
