### PR TITLE
build(deps): update linkerd2-proxy-api from 0.18.0 to 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2667,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "linkerd2-proxy-api"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9e3b341ca4992feaf43a4d2bdbfe2081aa3e2b9a503753544ce55242af6342"
+checksum = "de4e1c9b974df0a6c27e436310aecdbe6686ee911100deb44ac6343e206a9f0c"
 dependencies = [
  "h2",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ default-features = false
 features = ["tokio", "tracing"]
 
 [workspace.dependencies.linkerd2-proxy-api]
-version = "0.18.0"
+version = "0.20.0"
 
 [workspace.dependencies.rand]
 version = "0.9"

--- a/linkerd/exp-backoff/src/lib.rs
+++ b/linkerd/exp-backoff/src/lib.rs
@@ -11,6 +11,8 @@ use thiserror::Error;
 use tokio::time;
 
 /// A jittered exponential backoff strategy.
+//
+// TODO(kate): add respect_retry_after_hint field here.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct ExponentialBackoff {
     /// The minimum amount of time to wait before resuming an operation.
@@ -52,6 +54,7 @@ impl ExponentialBackoff {
         min: time::Duration,
         max: time::Duration,
         jitter: f64,
+        // TODO(kate): add respect_retry_after_hint parameter here.
     ) -> Result<Self, InvalidBackoff> {
         if min > max {
             return Err(InvalidBackoff("maximum must not be less than minimum"));

--- a/linkerd/proxy/client-policy/src/lib.rs
+++ b/linkerd/proxy/client-policy/src/lib.rs
@@ -103,6 +103,7 @@ pub enum BackendDispatcher {
     Forward(SocketAddr, Arc<EndpointMetadata>),
     BalanceP2c(Load, EndpointDiscovery),
     Fail { message: Arc<str> },
+    // TODO(kate): add a `PenaltyPeakEwma` variant here.
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -135,6 +136,7 @@ pub enum FailureAccrual {
         /// Backoff for probing the endpoint when it is in a failed state.
         backoff: linkerd_exp_backoff::ExponentialBackoff,
     },
+    // TODO(kate): add a `Unified` variant here.
 }
 
 // === impl ClientPolicy ===
@@ -394,6 +396,9 @@ pub mod proto {
 
         #[error("invalid backend metadata: {0}")]
         Meta(#[from] InvalidMeta),
+
+        #[error("penalty peak ewma mode is not yet supported")]
+        PenaltyPeakEwmaUnsupported,
     }
 
     #[derive(Debug, thiserror::Error)]
@@ -423,6 +428,8 @@ pub mod proto {
         Backoff(#[from] InvalidBackoff),
         #[error("missing {0}")]
         Missing(&'static str),
+        #[error("unified failure accrual is not yet supported")]
+        UnifiedUnsupported,
     }
 
     #[derive(Debug, thiserror::Error)]
@@ -667,6 +674,10 @@ pub mod proto {
                             default_rtt: duration("peak EWMA default RTT", default_rtt)?,
                             decay: duration("peak EWMA decay", decay)?,
                         }),
+                        balance_p2c::Load::PenaltyPeakEwma(_) => {
+                            // TODO(kate): marshal `PenaltyPeakEwma` here.
+                            return Err(InvalidBackend::PenaltyPeakEwmaUnsupported);
+                        }
                     };
                     BackendDispatcher::BalanceP2c(load, discovery)
                 }
@@ -733,6 +744,8 @@ pub mod proto {
                         InvalidFailureAccrual::Missing("consecutive failures backoff"),
                     )?,
                 }),
+                // TODO(kate): marshal `Unified` here.
+                failure_accrual::Kind::Unified(_) => Err(InvalidFailureAccrual::UnifiedUnsupported),
             }
         }
     }
@@ -751,6 +764,7 @@ pub mod proto {
             min_backoff,
             max_backoff,
             jitter_ratio,
+            respect_retry_after_hint: _, // TODO(kate): use respect_retry_after_hint
         }: outbound::ExponentialBackoff,
     ) -> Result<linkerd_exp_backoff::ExponentialBackoff, InvalidBackoff> {
         let min = min_backoff


### PR DESCRIPTION
see:

* https://github.com/linkerd/linkerd2-proxy-api/releases/tag/v0.20.0
* https://github.com/linkerd/linkerd2-proxy-api/pull/562
* https://github.com/linkerd/linkerd2-proxy-api/pull/559
* https://github.com/linkerd/linkerd2-proxy-api/pull/565
* https://github.com/linkerd/linkerd2-proxy/pull/4537
* https://github.com/linkerd/linkerd2-proxy/pull/4546
* https://github.com/linkerd/linkerd2-proxy/pull/4544

this commit updates linkerd2-proxy-api, pulling in the latest release.

aside from a slew of dependency updates, this new version most
importantly includes changes to set the state for forthcoming
load-balancing work.

these new fields are marked with "todo" comments to indicate where
future work in `linkerd-proxy-client-policy` in that vein will introduce
future enum variants, fields, marshalling and validation, etc.

this new version also includes an update to the most recent version of
rand, which will allow us to properly update to the latest version of
hickory-resolver without introducing breakage in our audit job in CI.

Signed-off-by: katelyn martin <kate@buoyant.io>
