### PR TITLE
refactor: `kubert-prometheus-*` crates are workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,14 @@ version = "0.1"
 default-features = false
 features = ["tokio", "tracing"]
 
+[workspace.dependencies.kubert-prometheus-process]
+version = "0.2.0"
+default-features = false
+
+[workspace.dependencies.kubert-prometheus-tokio]
+version = "0.2.0"
+default-features = false
+
 [workspace.dependencies.linkerd2-proxy-api]
 version = "0.20.0"
 

--- a/linkerd/metrics/Cargo.toml
+++ b/linkerd/metrics/Cargo.toml
@@ -17,7 +17,7 @@ bytes = { workspace = true }
 deflate = { version = "1", features = ["gzip"] }
 http = { workspace = true }
 http-body-util = { workspace = true }
-kubert-prometheus-process = { version = "0.2", optional = true }
+kubert-prometheus-process = { workspace = true, optional = true }
 parking_lot = "0.12"
 prometheus-client = { workspace = true }
 tokio = { version = "1", features = ["time"] }

--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -20,7 +20,7 @@ jemalloc-profiling = [
 
 [dependencies]
 futures = { version = "0.3", default-features = false }
-kubert-prometheus-tokio = { version = "0.2.0", features = ["rt"] }
+kubert-prometheus-tokio = { workspace = true, features = ["rt"] }
 linkerd-app = { path = "../linkerd/app" }
 linkerd-metrics = { path = "../linkerd/metrics" }
 linkerd-rustls = { path = "../linkerd/rustls" }


### PR DESCRIPTION
this commit performs a small organizational tweak to our package
manifests. we have some dependencies upon crates from the `kubert`
workspace.

this prepares us for a switch over to our `linkerd-kubert` fork
[here](https://github.com/linkerd/linkerd-kubert) by simplifying the
task of using `[patch.crates-io]` to override these dependencies or
of redefining these to use a git-based dependency.

Signed-off-by: katelyn martin <kate@buoyant.io>
