### PR TITLE
refactor(deps): use `linkerd-kubert` git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,8 +1416,7 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 [[package]]
 name = "kubert-prometheus-process"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b89e2a641a3f74c2e7366eb050282ac4a6194b63dae5294084215c457237e47"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert-prometheus-process%2Fv0.2.3#13e7733aad0a2db233592ed4c1341c55d9ec2dea"
 dependencies = [
  "libc",
  "procfs",
@@ -1428,8 +1427,7 @@ dependencies = [
 [[package]]
 name = "kubert-prometheus-tokio"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639670482534c37eb44caf6f4b72cc5da2f2c06aed39d1fb0cba940569428212"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert-prometheus-tokio%2Fv0.2.0#acd081cce5fb85ec745a5e793ab09adf421f8b4f"
 dependencies = [
  "prometheus-client",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,12 +137,16 @@ default-features = false
 features = ["tokio", "tracing"]
 
 [workspace.dependencies.kubert-prometheus-process]
-version = "0.2.0"
+version = "0.2"
 default-features = false
+git = "https://github.com/linkerd/linkerd-kubert.git"
+tag = "kubert-prometheus-process/v0.2.3"
 
 [workspace.dependencies.kubert-prometheus-tokio]
 version = "0.2.0"
 default-features = false
+git = "https://github.com/linkerd/linkerd-kubert.git"
+tag = "kubert-prometheus-tokio/v0.2.0"
 
 [workspace.dependencies.linkerd2-proxy-api]
 version = "0.20.0"

--- a/deny.toml
+++ b/deny.toml
@@ -66,3 +66,7 @@ unknown-git = "deny"
 allow-registry = [
     "https://github.com/rust-lang/crates.io-index",
 ]
+allow-git = [
+    # We accept a git dependency upon linkerd-kubert.
+    "https://github.com/linkerd/linkerd-kubert.git"
+]


### PR DESCRIPTION
see <https://github.com/linkerd/linkerd-kubert>.

we now have a fork of the kubert library. at the time of writing, this
is a 1:1 fork with no additional changes included. soon, we will
introduce some additional changes so that we can (1) pull in changes
like linkerd/linkerd-kubert@b27f147 that migrate away from abandoned
dependencies, and (2) update dependencies so that we can update our
gateway api bindings.

as an initial step towards this tasks, we alter the dependencies upon
`kubert-prometheus-process` and `kubert-prometheus-tokio` so that they
point to our git repository.

NB: this commit does not pull in any new code. we depend upon
kubert-prometheus-process v0.2.3, and kubert-prometheus-tokio v0.2.0,
and we use those exact tags here as well. new changes will be pulled
in within a forthcoming commit after we land this.

Signed-off-by: katelyn martin <kate@buoyant.io>
