### PR TITLE
chore(build): bump linkerd/dev from 48 to 50

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"DEV_VERSION": "v48",
+			"DEV_VERSION": "v50",
 			"http_proxy": "${localEnv:http_proxy}",
 			"https_proxy": "${localEnv:https_proxy}"
 		}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
     runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
-    container: ghcr.io/linkerd/dev:v48-rust
+    container: ghcr.io/linkerd/dev:v50-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 30
     container:
-      image: docker://ghcr.io/linkerd/dev:v48-rust
+      image: docker://ghcr.io/linkerd/dev:v50-rust
       options: --security-opt seccomp=unconfined # 🤷
     env:
       CXX: "/usr/bin/clang++-19"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ permissions:
 jobs:
   build:
     runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
-    container: ghcr.io/linkerd/dev:v48-rust
+    container: ghcr.io/linkerd/dev:v50-rust
     timeout-minutes: 20
     continue-on-error: true
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -85,7 +85,7 @@ jobs:
     needs: meta
     if: needs.meta.outputs.cargo_changed == 'true' || needs.meta.outputs.rust_changed == 'true'
     runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
-    container: ghcr.io/linkerd/dev:v48-rust
+    container: ghcr.io/linkerd/dev:v50-rust
     permissions:
       contents: read
     timeout-minutes: 20
@@ -108,7 +108,7 @@ jobs:
     if: needs.meta.outputs.cargo_changed == 'true'
     timeout-minutes: 20
     runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
-    container: ghcr.io/linkerd/dev:v48-rust
+    container: ghcr.io/linkerd/dev:v50-rust
     strategy:
       matrix:
         crate: ${{ fromJson(needs.meta.outputs.cargo_crates) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
     continue-on-error: ${{ needs.meta.outputs.publish != 'true' }}
     runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
     timeout-minutes: 40
-    container: docker://ghcr.io/linkerd/dev:v48-rust-musl
+    container: docker://ghcr.io/linkerd/dev:v50-rust-musl
     env:
       LINKERD2_PROXY_VENDOR: ${{ github.repository_owner }}
       LINKERD2_PROXY_VERSION: ${{ needs.meta.outputs.version }}

--- a/.github/workflows/toolchain.yml
+++ b/.github/workflows/toolchain.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   devcontainer:
     runs-on: ${{ vars.LINKERD2_PROXY_RUNNER || 'ubuntu-24.04' }}
-    container: ghcr.io/linkerd/dev:v48-rust
+    container: ghcr.io/linkerd/dev:v50-rust
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - run: git config --global --add safe.directory "$PWD" # actions/runner#2033

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # This is intended **DEVELOPMENT ONLY**, i.e. so that proxy developers can
 # easily test the proxy in the context of the larger `linkerd2` project.
 
-ARG RUST_IMAGE=ghcr.io/linkerd/dev:v48-rust
+ARG RUST_IMAGE=ghcr.io/linkerd/dev:v50-rust
 
 # Use an arbitrary ~recent edge release image to get the proxy
 # identity-initializing and linkerd-await wrappers.


### PR DESCRIPTION
Followup to #4582, addressing those places that dependabot doesn't currently reach.