### PR TITLE
refactor(tap): simplify client id types

### DIFF
--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -879,8 +879,8 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
     };
 
     let tap = tap?
-        .map(|(addr, ids)| super::tap::Config::Enabled {
-            permitted_client_ids: ids,
+        .map(|(addr, permitted_client_id)| super::tap::Config::Enabled {
+            permitted_client_id,
             config: ServerConfig {
                 addr: DualListenAddr(addr, None),
                 keepalive: inbound.proxy.server.keepalive,
@@ -943,15 +943,12 @@ impl Env {
 ///   ENV_TAP_SVC_NAME.
 fn parse_tap_config(
     strings: &dyn Strings,
-) -> Result<Option<(SocketAddr, HashSet<tls::server::ClientId>)>, EnvError> {
+) -> Result<Option<(SocketAddr, tls::server::ClientId)>, EnvError> {
     let tap_identity = parse(strings, ENV_TAP_SVC_NAME, parse_identity)?;
     let addr = parse(strings, ENV_CONTROL_LISTEN_ADDR, parse_socket_addr)?
         .unwrap_or_else(|| parse_socket_addr(DEFAULT_CONTROL_LISTEN_ADDR).unwrap());
     if let Some(id) = tap_identity {
-        return Ok(Some((
-            addr,
-            vec![id].into_iter().map(tls::ClientId).collect(),
-        )));
+        return Ok(Some((addr, tls::ClientId(id))));
     }
     Ok(None)
 }

--- a/linkerd/app/src/tap.rs
+++ b/linkerd/app/src/tap.rs
@@ -9,7 +9,7 @@ use linkerd_app_core::{
     transport::{addrs::AddrPair, listen::Bind, ClientAddr, Local, Remote, ServerAddr},
     Error,
 };
-use std::{collections::HashSet, pin::Pin};
+use std::pin::Pin;
 use tower::util::{service_fn, ServiceExt};
 
 #[derive(Clone, Debug)]
@@ -18,7 +18,7 @@ pub enum Config {
     Disabled,
     Enabled {
         config: ServerConfig,
-        permitted_client_ids: HashSet<tls::server::ClientId>,
+        permitted_client_id: tls::server::ClientId,
     },
 }
 
@@ -58,13 +58,13 @@ impl Config {
             }
             Config::Enabled {
                 config,
-                permitted_client_ids,
+                permitted_client_id,
             } => {
                 let (listen_addr, listen) = bind.bind(&config)?;
                 let accept = svc::stack(server)
                     .push(svc::layer::mk(move |service| {
                         tap::AcceptPermittedClients::new(
-                            permitted_client_ids.clone().into(),
+                            permitted_client_id.clone().into(),
                             service,
                         )
                     }))

--- a/linkerd/proxy/tap/src/accept.rs
+++ b/linkerd/proxy/tap/src/accept.rs
@@ -8,7 +8,6 @@ use linkerd_io as io;
 use linkerd_meshtls as meshtls;
 use linkerd_tls as tls;
 use std::{
-    collections::HashSet,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -18,7 +17,7 @@ use tower::Service;
 
 #[derive(Clone, Debug)]
 pub struct AcceptPermittedClients {
-    permitted_client_ids: Arc<HashSet<tls::ClientId>>,
+    permitted_client_id: Arc<tls::ClientId>,
     server: Server,
 }
 
@@ -30,9 +29,9 @@ type Connection<T, I> = (
 pub type ServeFuture = Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'static>>;
 
 impl AcceptPermittedClients {
-    pub fn new(permitted_client_ids: Arc<HashSet<tls::ClientId>>, server: Server) -> Self {
+    pub fn new(permitted_client_id: Arc<tls::ClientId>, server: Server) -> Self {
         Self {
-            permitted_client_ids,
+            permitted_client_id,
             server,
         }
     }
@@ -89,7 +88,7 @@ where
                     ..
                 } = tls
                 {
-                    if self.permitted_client_ids.contains(&id) {
+                    if *self.permitted_client_id == id {
                         return future::ok(Box::pin(self.serve_authenticated(io)));
                     }
                 }


### PR DESCRIPTION
this commit performs a small refactor to the tap system.

we represent the client id's that are permitted as a hash set of
TLS identities. however, there is never more than a single identity. see
this line from `linkerd_app::env`:

```rust
vec![id]
    .into_iter()
    .map(tls::ClientId)
    .collect()
```

we take _one_ identity, provided by an environment variable, and then
put it into a HashSet for no discernible reason. this commit changes the
plumbing carrying this identifier so that we faithfully represent it as
a single identifier.

Signed-off-by: katelyn martin <kate@buoyant.io>
