### PR TITLE
chore(deps): bump kubert from 0.25.0 to 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,8 +1415,8 @@ checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "kubert-prometheus-process"
-version = "0.2.3"
-source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert-prometheus-process%2Fv0.2.3#13e7733aad0a2db233592ed4c1341c55d9ec2dea"
+version = "0.2.4"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert-prometheus-process%2Fv0.2.4#cb414cccb5099a0246f4b9b3f298f66e1bf21318"
 dependencies = [
  "libc",
  "procfs",
@@ -1426,8 +1426,8 @@ dependencies = [
 
 [[package]]
 name = "kubert-prometheus-tokio"
-version = "0.2.0"
-source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert-prometheus-tokio%2Fv0.2.0#acd081cce5fb85ec745a5e793ab09adf421f8b4f"
+version = "0.2.1"
+source = "git+https://github.com/linkerd/linkerd-kubert.git?tag=kubert-prometheus-tokio%2Fv0.2.1#cb414cccb5099a0246f4b9b3f298f66e1bf21318"
 dependencies = [
  "prometheus-client",
  "tokio",
@@ -2868,12 +2868,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -3328,21 +3322,20 @@ dependencies = [
 
 [[package]]
 name = "procfs"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5b72d8145275d844d4b5f6d4e1eef00c8cd889edb6035c21675d1bb1f45c9f"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
 dependencies = [
  "bitflags 2.9.4",
- "hex",
  "procfs-core",
- "rustix 0.38.44",
+ "rustix",
 ]
 
 [[package]]
 name = "procfs-core"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239df02d8349b06fc07398a3a1697b06418223b1c7725085e801e7c0fc6a12ec"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
 dependencies = [
  "bitflags 2.9.4",
  "hex",
@@ -3350,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
+checksum = "cca3d75b4566b9a29fe1ed623587fb058e826eb329a0be4b7c4da1ebb2d7a6ca"
 dependencies = [
  "dtoa",
  "itoa",
@@ -3362,9 +3355,9 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client-derive-encode"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+checksum = "9adf1691c04c0a5ff46ff8f262b58beb07b0dbb61f96f9f54f6cbd82106ed87f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3686,19 +3679,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.4",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -3706,7 +3686,7 @@ dependencies = [
  "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.1",
 ]
 
@@ -4029,7 +4009,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.3",
+ "rustix",
  "windows-sys 0.61.1",
 ]
 
@@ -4178,9 +4158,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-metrics"
-version = "0.4.9"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0410015c6db7b67b9c9ab2a3af4d74a942d637ff248d0d055073750deac6f9"
+checksum = "d9e81d53caf955549b1dec7af4ac2149e94cc25ed97b4a545151140281e2f528"
 dependencies = [
  "futures-util",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ http = { version = "1" }
 http-body = { version = "1" }
 httpdate = { version = "1.0" }
 hyper = { version = "1", default-features = false }
-prometheus-client = { version = "0.23" }
+prometheus-client = { version = "0.24" }
 prost = { version = "0.14" }
 prost-build = { version = "0.14", default-features = false }
 prost-types = { version = "0.14" }
@@ -140,13 +140,13 @@ features = ["tokio", "tracing"]
 version = "0.2"
 default-features = false
 git = "https://github.com/linkerd/linkerd-kubert.git"
-tag = "kubert-prometheus-process/v0.2.3"
+tag = "kubert-prometheus-process/v0.2.4"
 
 [workspace.dependencies.kubert-prometheus-tokio]
-version = "0.2.0"
+version = "0.2"
 default-features = false
 git = "https://github.com/linkerd/linkerd-kubert.git"
-tag = "kubert-prometheus-tokio/v0.2.0"
+tag = "kubert-prometheus-tokio/v0.2.1"
 
 [workspace.dependencies.linkerd2-proxy-api]
 version = "0.20.0"

--- a/linkerd/app/core/src/dns/metrics.rs
+++ b/linkerd/app/core/src/dns/metrics.rs
@@ -65,7 +65,7 @@ impl Dns {
 // === impl Labels ===
 
 impl EncodeLabelSet for Labels {
-    fn encode(&self, mut encoder: LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
+    fn encode(&self, encoder: &mut LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
         let Self {
             client,
             record_type,

--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -357,8 +357,8 @@ impl legacy::FmtLabels for ServerLabel {
 }
 
 impl EncodeLabelSet for ServerLabel {
-    fn encode(&self, mut enc: prometheus_client::encoding::LabelSetEncoder<'_>) -> fmt::Result {
-        prom::EncodeLabelSetMut::encode_label_set(self, &mut enc)
+    fn encode(&self, enc: &mut prometheus_client::encoding::LabelSetEncoder<'_>) -> fmt::Result {
+        prom::EncodeLabelSetMut::encode_label_set(self, enc)
     }
 }
 

--- a/linkerd/app/inbound/src/direct/metrics.rs
+++ b/linkerd/app/inbound/src/direct/metrics.rs
@@ -85,7 +85,7 @@ impl prom::EncodeLabelSetMut for Labels {
 }
 
 impl prom::encoding::EncodeLabelSet for Labels {
-    fn encode(&self, mut enc: prom::encoding::LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
+        self.encode_label_set(enc)
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics/count_reqs.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/count_reqs.rs
@@ -88,7 +88,7 @@ impl EncodeLabelSetMut for RequestCountLabels {
 }
 
 impl EncodeLabelSet for RequestCountLabels {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics/labels.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/labels.rs
@@ -40,7 +40,7 @@ impl EncodeLabelSetMut for RouteLabels {
 }
 
 impl EncodeLabelSet for RouteLabels {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics/req_body.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/req_body.rs
@@ -78,8 +78,8 @@ impl EncodeLabelSetMut for RequestBodyDataLabels {
 }
 
 impl EncodeLabelSet for RequestBodyDataLabels {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/inbound/src/http/router/metrics/req_duration.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/req_duration.rs
@@ -96,7 +96,7 @@ impl prom::EncodeLabelSetMut for RequestDurationLabels {
 }
 
 impl prom::encoding::EncodeLabelSet for RequestDurationLabels {
-    fn encode(&self, mut encoder: prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut encoder)
+    fn encode(&self, encoder: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(encoder)
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics/rsp_body.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/rsp_body.rs
@@ -72,8 +72,8 @@ impl EncodeLabelSetMut for ResponseBodyDataLabels {
 }
 
 impl EncodeLabelSet for ResponseBodyDataLabels {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/inbound/src/http/router/metrics/rsp_duration.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/rsp_duration.rs
@@ -96,7 +96,7 @@ impl prom::EncodeLabelSetMut for ResponseDurationLabels {
 }
 
 impl prom::encoding::EncodeLabelSet for ResponseDurationLabels {
-    fn encode(&self, mut encoder: prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut encoder)
+    fn encode(&self, encoder: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(encoder)
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics/status.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/status.rs
@@ -147,8 +147,8 @@ impl EncodeLabelSetMut for StatusCodeLabels {
 }
 
 impl EncodeLabelSet for StatusCodeLabels {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
@@ -102,8 +102,8 @@ impl EncodeLabelSetMut for Route {
 }
 
 impl EncodeLabelSet for Route {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 
@@ -126,8 +126,8 @@ impl EncodeLabelSetMut for RouteBackend {
 }
 
 impl EncodeLabelSet for RouteBackend {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 
@@ -143,8 +143,8 @@ impl<P: EncodeLabelSetMut, L: EncodeLabelSetMut> EncodeLabelSetMut for Rsp<P, L>
 }
 
 impl<P: EncodeLabelSetMut, L: EncodeLabelSetMut> EncodeLabelSet for Rsp<P, L> {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 
@@ -199,8 +199,8 @@ impl EncodeLabelSetMut for HttpRsp {
 }
 
 impl EncodeLabelSet for HttpRsp {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 
@@ -290,8 +290,8 @@ impl EncodeLabelSetMut for GrpcRsp {
 }
 
 impl EncodeLabelSet for GrpcRsp {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -208,8 +208,8 @@ impl ParentRef {
 }
 
 impl EncodeLabelSet for ParentRef {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 
@@ -222,8 +222,8 @@ impl BackendRef {
 }
 
 impl EncodeLabelSet for BackendRef {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 
@@ -236,8 +236,8 @@ impl RouteRef {
 }
 
 impl EncodeLabelSet for RouteRef {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 
@@ -265,7 +265,7 @@ impl EncodeLabelSetMut for ConcreteLabels {
 }
 
 impl EncodeLabelSet for ConcreteLabels {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }

--- a/linkerd/app/outbound/src/metrics/transport.rs
+++ b/linkerd/app/outbound/src/metrics/transport.rs
@@ -156,8 +156,8 @@ impl<L> EncodeLabelSet for ConnectionsClosedLabels<L>
 where
     L: Clone + Hash + Eq + EncodeLabelSetMut + Debug + Send + Sync + 'static,
 {
-    fn encode(&self, mut enc: LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/outbound/src/opaq/concrete.rs
+++ b/linkerd/app/outbound/src/opaq/concrete.rs
@@ -93,8 +93,8 @@ impl prom::EncodeLabelSetMut for ConcreteLabels {
 }
 
 impl prom::encoding::EncodeLabelSet for ConcreteLabels {
-    fn encode(&self, mut enc: prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/outbound/src/opaq/logical/route.rs
+++ b/linkerd/app/outbound/src/opaq/logical/route.rs
@@ -175,8 +175,8 @@ impl prom::EncodeLabelSetMut for RouteLabels {
 }
 
 impl prom::encoding::EncodeLabelSet for RouteLabels {
-    fn encode(&self, mut enc: prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
         use prom::EncodeLabelSetMut;
-        self.encode_label_set(&mut enc)
+        self.encode_label_set(enc)
     }
 }

--- a/linkerd/app/outbound/src/protocol/metrics.rs
+++ b/linkerd/app/outbound/src/protocol/metrics.rs
@@ -119,7 +119,7 @@ impl prom::EncodeLabelSetMut for Labels {
 }
 
 impl prom::encoding::EncodeLabelSet for Labels {
-    fn encode(&self, mut enc: prom::encoding::LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
+        self.encode_label_set(enc)
     }
 }

--- a/linkerd/app/outbound/src/tls/concrete.rs
+++ b/linkerd/app/outbound/src/tls/concrete.rs
@@ -86,8 +86,8 @@ impl prom::EncodeLabelSetMut for ConcreteLabels {
 }
 
 impl prom::encoding::EncodeLabelSet for ConcreteLabels {
-    fn encode(&self, mut enc: prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(&mut enc)
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/outbound/src/tls/logical/route.rs
+++ b/linkerd/app/outbound/src/tls/logical/route.rs
@@ -173,8 +173,8 @@ impl prom::EncodeLabelSetMut for RouteLabels {
 }
 
 impl prom::encoding::EncodeLabelSet for RouteLabels {
-    fn encode(&self, mut enc: prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
         use prom::EncodeLabelSetMut;
-        self.encode_label_set(&mut enc)
+        self.encode_label_set(enc)
     }
 }

--- a/linkerd/http/detect/src/metrics.rs
+++ b/linkerd/http/detect/src/metrics.rs
@@ -164,7 +164,7 @@ where
 {
     fn encode(
         &self,
-        mut enc: prometheus_client::encoding::LabelSetEncoder,
+        enc: &mut prometheus_client::encoding::LabelSetEncoder,
     ) -> Result<(), std::fmt::Error> {
         use prometheus_client::encoding::EncodeLabel;
 

--- a/linkerd/http/prom/src/status/tests.rs
+++ b/linkerd/http/prom/src/status/tests.rs
@@ -505,7 +505,7 @@ mod util {
     impl EncodeLabelSet for Labels {
         fn encode(
             &self,
-            mut encoder: prometheus_client::encoding::LabelSetEncoder<'_>,
+            encoder: &mut prometheus_client::encoding::LabelSetEncoder<'_>,
         ) -> Result<(), std::fmt::Error> {
             let Self { grpc, http } = self;
 

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -66,6 +66,8 @@ pub mod prom {
         *,
     };
 
+    /// TODO(kate): now that we depend upon prometheus_client@v0.24, we no longer need this
+    /// trait thanks to prometheus/client_rust#257. this can be removed.
     pub trait EncodeLabelSetMut: encoding::EncodeLabelSet {
         fn encode_label_set(&self, dst: &mut encoding::LabelSetEncoder<'_>) -> std::fmt::Result;
     }

--- a/linkerd/pool/p2c/src/lib.rs
+++ b/linkerd/pool/p2c/src/lib.rs
@@ -355,7 +355,7 @@ where
 // === impl P2cMetrics ===
 
 impl<L: prom::encoding::EncodeLabelSet> prom::encoding::EncodeLabelSet for UpdateLabels<L> {
-    fn encode(&self, mut enc: prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
         use prom::encoding::EncodeLabel;
         ("op", self.op).encode(enc.encode_label())?;
         self.labels.encode(enc)

--- a/linkerd/proxy/balance/gauge-endpoints/src/lib.rs
+++ b/linkerd/proxy/balance/gauge-endpoints/src/lib.rs
@@ -95,7 +95,7 @@ impl<L: prometheus_client::encoding::EncodeLabelSet> prometheus_client::encoding
 {
     fn encode(
         &self,
-        mut enc: prometheus_client::encoding::LabelSetEncoder<'_>,
+        enc: &mut prometheus_client::encoding::LabelSetEncoder<'_>,
     ) -> std::fmt::Result {
         use prometheus_client::encoding::EncodeLabel;
         ("endpoint_state", self.state).encode(enc.encode_label())?;


### PR DESCRIPTION
note that because this kubert release includes a new version of
prometheus_client, changes from prometheus/client_rust#257 are now in
our tree.

a todo comment is left in place to note that we can remove the
`EncodeLabelSetMut` trait. that will happen in a subsequent pull
request.

Signed-off-by: katelyn martin <kate@buoyant.io>
