### PR TITLE
refactor(app/core): remove `EncodeLabelSetMut`

### DIFF
--- a/linkerd/app/core/src/metrics.rs
+++ b/linkerd/app/core/src/metrics.rs
@@ -15,7 +15,7 @@ use crate::{
 use linkerd_addr::Addr;
 pub use linkerd_metrics::*;
 use linkerd_proxy_server_policy as policy;
-use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
+use prometheus_client::encoding::EncodeLabelValue;
 use std::{
     fmt::{self, Write},
     net::SocketAddr,
@@ -356,14 +356,8 @@ impl legacy::FmtLabels for ServerLabel {
     }
 }
 
-impl EncodeLabelSet for ServerLabel {
-    fn encode(&self, enc: &mut prometheus_client::encoding::LabelSetEncoder<'_>) -> fmt::Result {
-        prom::EncodeLabelSetMut::encode_label_set(self, enc)
-    }
-}
-
-impl prom::EncodeLabelSetMut for ServerLabel {
-    fn encode_label_set(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> fmt::Result {
+impl prom::encoding::EncodeLabelSet for ServerLabel {
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> fmt::Result {
         use prometheus_client::encoding::EncodeLabel;
         ("srv_group", self.0.group()).encode(enc.encode_label())?;
         ("srv_kind", self.0.kind()).encode(enc.encode_label())?;

--- a/linkerd/app/inbound/src/direct/metrics.rs
+++ b/linkerd/app/inbound/src/direct/metrics.rs
@@ -1,6 +1,6 @@
 use super::ClientInfo;
 use linkerd_app_core::{
-    metrics::prom::{self, EncodeLabelSetMut},
+    metrics::prom,
     svc, tls,
     transport_header::{SessionProtocol, TransportHeader},
 };
@@ -66,8 +66,8 @@ where
     }
 }
 
-impl prom::EncodeLabelSetMut for Labels {
-    fn encode_label_set(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+impl prom::encoding::EncodeLabelSet for Labels {
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
         use prom::encoding::EncodeLabel;
         (
             "session_protocol",
@@ -81,11 +81,5 @@ impl prom::EncodeLabelSetMut for Labels {
         ("target_name", self.header.name.as_deref()).encode(enc.encode_label())?;
         ("client_id", self.client_id.to_str()).encode(enc.encode_label())?;
         Ok(())
-    }
-}
-
-impl prom::encoding::EncodeLabelSet for Labels {
-    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
-        self.encode_label_set(enc)
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics/count_reqs.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/count_reqs.rs
@@ -4,7 +4,6 @@ use linkerd_app_core::{
     metrics::prom::{
         self,
         encoding::{EncodeLabelSet, LabelSetEncoder},
-        EncodeLabelSetMut,
     },
     svc,
 };
@@ -77,18 +76,12 @@ where
 
 // === impl RequestCountLabels ===
 
-impl EncodeLabelSetMut for RequestCountLabels {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        let Self { route } = self;
-
-        route.encode_label_set(enc)?;
-
-        Ok(())
-    }
-}
-
 impl EncodeLabelSet for RequestCountLabels {
     fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
+        let Self { route } = self;
+
+        route.encode(enc)?;
+
+        Ok(())
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics/labels.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/labels.rs
@@ -1,7 +1,4 @@
-use linkerd_app_core::metrics::prom::{
-    encoding::{self, EncodeLabelSet, LabelSetEncoder},
-    EncodeLabelSetMut,
-};
+use linkerd_app_core::metrics::prom::encoding::{self, EncodeLabelSet, LabelSetEncoder};
 
 /// Labels referencing an inbound server and route.
 ///
@@ -17,8 +14,8 @@ impl From<linkerd_app_core::metrics::RouteLabels> for RouteLabels {
     }
 }
 
-impl EncodeLabelSetMut for RouteLabels {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+impl EncodeLabelSet for RouteLabels {
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
         use encoding::EncodeLabel as _;
 
         let Self(linkerd_app_core::metrics::RouteLabels {
@@ -36,11 +33,5 @@ impl EncodeLabelSetMut for RouteLabels {
         ("route_name", route.name()).encode(enc.encode_label())?;
 
         Ok(())
-    }
-}
-
-impl EncodeLabelSet for RouteLabels {
-    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics/req_body.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/req_body.rs
@@ -4,7 +4,6 @@ use linkerd_app_core::{
     metrics::prom::{
         self,
         encoding::{EncodeLabelSet, LabelSetEncoder},
-        EncodeLabelSetMut,
     },
     svc,
 };
@@ -67,19 +66,13 @@ impl RequestBodyFamilies {
 
 // === impl RequestBodyDataLabels ===
 
-impl EncodeLabelSetMut for RequestBodyDataLabels {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        let Self { route } = self;
-
-        route.encode_label_set(enc)?;
-
-        Ok(())
-    }
-}
-
 impl EncodeLabelSet for RequestBodyDataLabels {
     fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
+        let Self { route } = self;
+
+        route.encode(enc)?;
+
+        Ok(())
     }
 }
 

--- a/linkerd/app/inbound/src/http/router/metrics/req_duration.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/req_duration.rs
@@ -1,9 +1,6 @@
 use super::RouteLabels;
 use crate::policy::PermitVariant;
-use linkerd_app_core::{
-    metrics::prom::{self, EncodeLabelSetMut},
-    svc,
-};
+use linkerd_app_core::{metrics::prom, svc};
 use linkerd_http_prom::{
     record_response::{self, Params},
     stream_label::with::MkWithLabels,
@@ -84,19 +81,10 @@ where
 
 // === impl RequestDurationLabels ===
 
-impl prom::EncodeLabelSetMut for RequestDurationLabels {
-    fn encode_label_set(
-        &self,
-        encoder: &mut prom::encoding::LabelSetEncoder<'_>,
-    ) -> std::fmt::Result {
-        let Self { route } = self;
-        route.encode_label_set(encoder)?;
-        Ok(())
-    }
-}
-
 impl prom::encoding::EncodeLabelSet for RequestDurationLabels {
     fn encode(&self, encoder: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(encoder)
+        let Self { route } = self;
+        route.encode(encoder)?;
+        Ok(())
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics/rsp_body.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/rsp_body.rs
@@ -4,7 +4,6 @@ use linkerd_app_core::{
     metrics::prom::{
         self,
         encoding::{EncodeLabelSet, LabelSetEncoder},
-        EncodeLabelSetMut,
     },
     svc,
 };
@@ -61,19 +60,13 @@ impl ResponseBodyFamilies {
 
 // === impl ResponseBodyDataLabels ===
 
-impl EncodeLabelSetMut for ResponseBodyDataLabels {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        let Self { route } = self;
-
-        route.encode_label_set(enc)?;
-
-        Ok(())
-    }
-}
-
 impl EncodeLabelSet for ResponseBodyDataLabels {
     fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
+        let Self { route } = self;
+
+        route.encode(enc)?;
+
+        Ok(())
     }
 }
 

--- a/linkerd/app/inbound/src/http/router/metrics/rsp_duration.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/rsp_duration.rs
@@ -1,9 +1,6 @@
 use super::RouteLabels;
 use crate::policy::PermitVariant;
-use linkerd_app_core::{
-    metrics::prom::{self, EncodeLabelSetMut},
-    svc,
-};
+use linkerd_app_core::{metrics::prom, svc};
 use linkerd_http_prom::{
     record_response::{self, Params},
     stream_label::with::MkWithLabels,
@@ -84,19 +81,10 @@ where
 
 // === impl ResponseDurationLabels ===
 
-impl prom::EncodeLabelSetMut for ResponseDurationLabels {
-    fn encode_label_set(
-        &self,
-        encoder: &mut prom::encoding::LabelSetEncoder<'_>,
-    ) -> std::fmt::Result {
-        let Self { route } = self;
-        route.encode_label_set(encoder)?;
-        Ok(())
-    }
-}
-
 impl prom::encoding::EncodeLabelSet for ResponseDurationLabels {
     fn encode(&self, encoder: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(encoder)
+        let Self { route } = self;
+        route.encode(encoder)?;
+        Ok(())
     }
 }

--- a/linkerd/app/inbound/src/http/router/metrics/status.rs
+++ b/linkerd/app/inbound/src/http/router/metrics/status.rs
@@ -5,7 +5,6 @@ use linkerd_app_core::{
     metrics::prom::{
         self,
         encoding::{EncodeLabel, EncodeLabelSet, LabelSetEncoder},
-        EncodeLabelSetMut,
     },
     svc, Error,
 };
@@ -135,20 +134,14 @@ where
 
 // === impl StatusCodeLabels ===
 
-impl EncodeLabelSetMut for StatusCodeLabels {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+impl EncodeLabelSet for StatusCodeLabels {
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
         let Self { route, status } = self;
 
-        route.encode_label_set(enc)?;
+        route.encode(enc)?;
         ("status", *status).encode(enc.encode_label())?;
 
         Ok(())
-    }
-}
-
-impl EncodeLabelSet for StatusCodeLabels {
-    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics.rs
@@ -1,9 +1,5 @@
 use super::{backend::metrics as backend, retry};
-use linkerd_app_core::{
-    metrics::prom::{self, EncodeLabelSetMut},
-    proxy::http,
-    svc,
-};
+use linkerd_app_core::{metrics::prom, proxy::http, svc};
 use linkerd_http_prom::{
     body_data::request::{BodyDataMetrics, NewRecordBodyData, RequestBodyFamilies},
     record_response, status,
@@ -329,7 +325,14 @@ impl<P> From<P> for LabelHttpRsp<P> {
 
 impl<P> StreamLabel for LabelHttpRsp<P>
 where
-    P: EncodeLabelSetMut + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+    P: prom::encoding::EncodeLabelSet
+        + Clone
+        + Eq
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Send
+        + Sync
+        + 'static,
 {
     type StatusLabels = labels::Rsp<P, labels::HttpRsp>;
     type DurationLabels = P;
@@ -387,7 +390,14 @@ impl<P> From<P> for LabelGrpcRsp<P> {
 
 impl<P> StreamLabel for LabelGrpcRsp<P>
 where
-    P: EncodeLabelSetMut + Clone + Eq + std::fmt::Debug + std::hash::Hash + Send + Sync + 'static,
+    P: prom::encoding::EncodeLabelSet
+        + Clone
+        + Eq
+        + std::fmt::Debug
+        + std::hash::Hash
+        + Send
+        + Sync
+        + 'static,
 {
     type StatusLabels = labels::Rsp<P, labels::GrpcRsp>;
     type DurationLabels = P;

--- a/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
+++ b/linkerd/app/outbound/src/http/logical/policy/route/metrics/labels.rs
@@ -1,7 +1,5 @@
 //! Prometheus label types.
-use linkerd_app_core::{
-    dns, errors, metrics::prom::EncodeLabelSetMut, proxy::http, Error as BoxError,
-};
+use linkerd_app_core::{dns, errors, proxy::http, Error as BoxError};
 use prometheus_client::encoding::*;
 
 use crate::{BackendRef, ParentRef, RouteRef};
@@ -85,25 +83,19 @@ impl Route {
     }
 }
 
-impl EncodeLabelSetMut for Route {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+impl EncodeLabelSet for Route {
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
         let Self {
             parent,
             route,
             hostname,
         } = self;
 
-        parent.encode_label_set(enc)?;
-        route.encode_label_set(enc)?;
+        parent.encode(enc)?;
+        route.encode(enc)?;
         ("hostname", hostname.as_deref()).encode(enc.encode_label())?;
 
         Ok(())
-    }
-}
-
-impl EncodeLabelSet for Route {
-    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
     }
 }
 
@@ -115,36 +107,24 @@ impl From<(ParentRef, RouteRef, BackendRef)> for RouteBackend {
     }
 }
 
-impl EncodeLabelSetMut for RouteBackend {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        let Self(parent, route, backend) = self;
-        parent.encode_label_set(enc)?;
-        route.encode_label_set(enc)?;
-        backend.encode_label_set(enc)?;
-        Ok(())
-    }
-}
-
 impl EncodeLabelSet for RouteBackend {
     fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
+        let Self(parent, route, backend) = self;
+        parent.encode(enc)?;
+        route.encode(enc)?;
+        backend.encode(enc)?;
+        Ok(())
     }
 }
 
 // === impl Rsp ===
 
-impl<P: EncodeLabelSetMut, L: EncodeLabelSetMut> EncodeLabelSetMut for Rsp<P, L> {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        let Self(route, rsp) = self;
-        route.encode_label_set(enc)?;
-        rsp.encode_label_set(enc)?;
-        Ok(())
-    }
-}
-
-impl<P: EncodeLabelSetMut, L: EncodeLabelSetMut> EncodeLabelSet for Rsp<P, L> {
+impl<P: EncodeLabelSet, L: EncodeLabelSet> EncodeLabelSet for Rsp<P, L> {
     fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
+        let Self(route, rsp) = self;
+        route.encode(enc)?;
+        rsp.encode(enc)?;
+        Ok(())
     }
 }
 
@@ -187,20 +167,14 @@ impl HttpRsp {
     }
 }
 
-impl EncodeLabelSetMut for HttpRsp {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+impl EncodeLabelSet for HttpRsp {
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
         let Self { status, error } = self;
 
         ("http_status", status.map(|c| c.as_u16())).encode(enc.encode_label())?;
         ("error", *error).encode(enc.encode_label())?;
 
         Ok(())
-    }
-}
-
-impl EncodeLabelSet for HttpRsp {
-    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
     }
 }
 
@@ -255,8 +229,8 @@ impl GrpcRsp {
     }
 }
 
-impl EncodeLabelSetMut for GrpcRsp {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+impl EncodeLabelSet for GrpcRsp {
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
         let Self { status, error } = self;
 
         (
@@ -286,12 +260,6 @@ impl EncodeLabelSetMut for GrpcRsp {
         ("error", *error).encode(enc.encode_label())?;
 
         Ok(())
-    }
-}
-
-impl EncodeLabelSet for GrpcRsp {
-    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/outbound/src/metrics.rs
+++ b/linkerd/app/outbound/src/metrics.rs
@@ -9,10 +9,7 @@
 //! `DashMap` as we migrate other metrics registries.
 
 use crate::{policy, BackendRef, ParentRef, RouteRef};
-use linkerd_app_core::{
-    metrics::prom::{encoding::*, EncodeLabelSetMut},
-    svc,
-};
+use linkerd_app_core::{metrics::prom::encoding::*, svc};
 use std::fmt::Write;
 
 pub(crate) mod error;
@@ -56,7 +53,7 @@ struct ScopedKey<'a, 'b>(&'a str, &'b str);
 
 impl<K> BalancerMetricsParams<K>
 where
-    K: EncodeLabelSetMut + Clone + Eq + std::hash::Hash + std::fmt::Debug + Send + Sync + 'static,
+    K: EncodeLabelSet + Clone + Eq + std::hash::Hash + std::fmt::Debug + Send + Sync + 'static,
 {
     pub fn register(reg: &mut prom::registry::Registry) -> Self {
         Self(balance::MetricFamilies::register(reg))
@@ -255,17 +252,11 @@ impl legacy::FmtLabels for ConcreteLabels {
     }
 }
 
-impl EncodeLabelSetMut for ConcreteLabels {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        let Self(parent, backend) = self;
-        parent.encode_label_set(enc)?;
-        backend.encode_label_set(enc)?;
-        Ok(())
-    }
-}
-
 impl EncodeLabelSet for ConcreteLabels {
     fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
+        let Self(parent, backend) = self;
+        parent.encode(enc)?;
+        backend.encode(enc)?;
+        Ok(())
     }
 }

--- a/linkerd/app/outbound/src/metrics/transport.rs
+++ b/linkerd/app/outbound/src/metrics/transport.rs
@@ -1,7 +1,7 @@
 use crate::{opaq, tls};
 use linkerd_app_core::{
     io,
-    metrics::prom::{self, encoding::*, registry::Registry, EncodeLabelSetMut, Family},
+    metrics::prom::{self, encoding::*, registry::Registry, Family},
     svc::{layer, NewService, Param, Service},
     Error,
 };
@@ -69,7 +69,7 @@ where
 
 impl<L> TransportRouteMetricsFamily<L>
 where
-    L: Clone + Hash + Eq + EncodeLabelSetMut + Debug + Send + Sync + 'static,
+    L: Clone + Hash + Eq + EncodeLabelSet + Debug + Send + Sync + 'static,
 {
     pub(crate) fn register(registry: &mut Registry) -> Self {
         let open = prom::Family::<L, prom::Counter>::default();
@@ -137,27 +137,18 @@ impl std::fmt::Display for ErrorKind {
 
 // === impl ConnectionsClosedLabels ===
 
-impl<L> EncodeLabelSetMut for ConnectionsClosedLabels<L>
+impl<L> EncodeLabelSet for ConnectionsClosedLabels<L>
 where
-    L: Clone + Hash + Eq + EncodeLabelSetMut + Debug + Send + Sync + 'static,
+    L: Clone + Hash + Eq + EncodeLabelSet + Debug + Send + Sync + 'static,
 {
-    fn encode_label_set(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.labels.encode_label_set(enc)?;
+    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
+        self.labels.encode(enc)?;
         match self.error {
             Some(error) => ("error", error.to_string()).encode(enc.encode_label())?,
             None => ("error", "").encode(enc.encode_label())?,
         }
 
         Ok(())
-    }
-}
-
-impl<L> EncodeLabelSet for ConnectionsClosedLabels<L>
-where
-    L: Clone + Hash + Eq + EncodeLabelSetMut + Debug + Send + Sync + 'static,
-{
-    fn encode(&self, enc: &mut LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
     }
 }
 
@@ -177,7 +168,7 @@ impl<N, L: Clone> NewTransportRouteMetrics<N, L> {
 impl<T, N, L, S> NewService<T> for NewTransportRouteMetrics<N, L>
 where
     N: NewService<T, Service = S>,
-    L: Clone + Hash + Eq + EncodeLabelSetMut + Debug + Send + Sync + 'static,
+    L: Clone + Hash + Eq + EncodeLabelSet + Debug + Send + Sync + 'static,
     T: Param<L> + Clone,
 {
     type Service = TransportRouteMetricsService<S>;

--- a/linkerd/app/outbound/src/opaq/concrete.rs
+++ b/linkerd/app/outbound/src/opaq/concrete.rs
@@ -8,11 +8,7 @@ use crate::{
 use linkerd_app_core::{
     config::QueueConfig,
     drain, io,
-    metrics::{
-        self,
-        prom::{self, EncodeLabelSetMut},
-        OutboundZoneLocality,
-    },
+    metrics::{self, prom, OutboundZoneLocality},
     proxy::{
         api_resolve::{ConcreteAddr, Metadata},
         core::Resolve,
@@ -81,20 +77,14 @@ pub struct ConcreteLabels {
     concrete: Arc<str>,
 }
 
-impl prom::EncodeLabelSetMut for ConcreteLabels {
-    fn encode_label_set(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+impl prom::encoding::EncodeLabelSet for ConcreteLabels {
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
         use prom::encoding::EncodeLabel;
         self.parent.encode_label_set(enc)?;
         self.backend.encode_label_set(enc)?;
         ("logical", &*self.logical).encode(enc.encode_label())?;
         ("concrete", &*self.concrete).encode(enc.encode_label())?;
         Ok(())
-    }
-}
-
-impl prom::encoding::EncodeLabelSet for ConcreteLabels {
-    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/outbound/src/opaq/logical/route.rs
+++ b/linkerd/app/outbound/src/opaq/logical/route.rs
@@ -147,8 +147,8 @@ where
 
 // === impl RouteLabels ===
 
-impl prom::EncodeLabelSetMut for RouteLabels {
-    fn encode_label_set(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+impl prom::encoding::EncodeLabelSet for RouteLabels {
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
         use prom::encoding::*;
         let Self {
             parent,
@@ -171,12 +171,5 @@ impl prom::EncodeLabelSetMut for RouteLabels {
         ("target_port", addr.port()).encode(enc.encode_label())?;
 
         Ok(())
-    }
-}
-
-impl prom::encoding::EncodeLabelSet for RouteLabels {
-    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
-        use prom::EncodeLabelSetMut;
-        self.encode_label_set(enc)
     }
 }

--- a/linkerd/app/outbound/src/protocol/metrics.rs
+++ b/linkerd/app/outbound/src/protocol/metrics.rs
@@ -1,9 +1,6 @@
 use super::Protocol;
 use crate::ParentRef;
-use linkerd_app_core::{
-    metrics::prom::{self, EncodeLabelSetMut},
-    svc,
-};
+use linkerd_app_core::{metrics::prom, svc};
 
 #[derive(Clone, Debug)]
 pub struct NewRecord<N> {
@@ -99,8 +96,8 @@ where
 
 // === impl Labels ===
 
-impl prom::EncodeLabelSetMut for Labels {
-    fn encode_label_set(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+impl prom::encoding::EncodeLabelSet for Labels {
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
         use prom::encoding::EncodeLabel;
 
         let protocol = match self.protocol {
@@ -115,11 +112,5 @@ impl prom::EncodeLabelSetMut for Labels {
         self.parent_ref.encode_label_set(enc)?;
 
         Ok(())
-    }
-}
-
-impl prom::encoding::EncodeLabelSet for Labels {
-    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> Result<(), std::fmt::Error> {
-        self.encode_label_set(enc)
     }
 }

--- a/linkerd/app/outbound/src/tls/concrete.rs
+++ b/linkerd/app/outbound/src/tls/concrete.rs
@@ -7,11 +7,7 @@ use crate::{
 use linkerd_app_core::{
     config::QueueConfig,
     drain, io,
-    metrics::{
-        self,
-        prom::{self, EncodeLabelSetMut},
-        OutboundZoneLocality,
-    },
+    metrics::{self, prom, OutboundZoneLocality},
     proxy::{
         api_resolve::{ConcreteAddr, Metadata},
         core::Resolve,
@@ -76,18 +72,12 @@ pub struct ConcreteLabels {
     concrete: Arc<str>,
 }
 
-impl prom::EncodeLabelSetMut for ConcreteLabels {
-    fn encode_label_set(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+impl prom::encoding::EncodeLabelSet for ConcreteLabels {
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
         use prom::encoding::EncodeLabel;
 
         ("concrete", &*self.concrete).encode(enc.encode_label())?;
         Ok(())
-    }
-}
-
-impl prom::encoding::EncodeLabelSet for ConcreteLabels {
-    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
-        self.encode_label_set(enc)
     }
 }
 

--- a/linkerd/app/outbound/src/tls/logical/route.rs
+++ b/linkerd/app/outbound/src/tls/logical/route.rs
@@ -157,8 +157,8 @@ where
 
 // === impl RouteLabels ===
 
-impl prom::EncodeLabelSetMut for RouteLabels {
-    fn encode_label_set(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
+impl prom::encoding::EncodeLabelSet for RouteLabels {
+    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
         use prom::encoding::*;
         let Self {
             parent,
@@ -169,12 +169,5 @@ impl prom::EncodeLabelSetMut for RouteLabels {
         route.encode_label_set(enc)?;
         ("hostname", hostname.as_deref().map(|n| n.as_str())).encode(enc.encode_label())?;
         Ok(())
-    }
-}
-
-impl prom::encoding::EncodeLabelSet for RouteLabels {
-    fn encode(&self, enc: &mut prom::encoding::LabelSetEncoder<'_>) -> std::fmt::Result {
-        use prom::EncodeLabelSetMut;
-        self.encode_label_set(enc)
     }
 }

--- a/linkerd/metrics/src/lib.rs
+++ b/linkerd/metrics/src/lib.rs
@@ -66,12 +66,6 @@ pub mod prom {
         *,
     };
 
-    /// TODO(kate): now that we depend upon prometheus_client@v0.24, we no longer need this
-    /// trait thanks to prometheus/client_rust#257. this can be removed.
-    pub trait EncodeLabelSetMut: encoding::EncodeLabelSet {
-        fn encode_label_set(&self, dst: &mut encoding::LabelSetEncoder<'_>) -> std::fmt::Result;
-    }
-
     pub type Report = Arc<Registry>;
 
     impl crate::legacy::FmtMetrics for Report {


### PR DESCRIPTION
in linkerd/linkerd2-proxy#4587, we upgraded our dependency upon kubert
to a new 0.26.0 release. as part of this, our dependency upon the
prometheus sdk was also upgraded from 0.23 to 0.24.

version 0.24.0 included some exciting upstream changes that we drove
last year, particularly prometheus/client_rust#257. from that pr:

> [this pr] alters the signature of the `EncodeLabelSet::encode()`
> trait method, such that it now accepts a mutable reference to its
> encoder.
>
> this change permits distinct label sets to be composed together, now
> that the label set encoder is not consumed. a new implementation for
> tuples `(A, B)` is provided.

we'd been working around this deficiency using an internal trait that
_did_ provide our desired trait signature, originally introduced in
linkerd/linkerd2-proxy#2555.

https://github.com/linkerd/linkerd2-proxy/pull/2555/changes#diff-36a73a9a9de1e34abac85003560b0aea70e9ebb0f1cc29af3dce703bfbef7a89R47-R49

now that we've upgraded to a more recent `prometheus_client` version,
this trait is no longer needed, and all of the glue connecting
`EncodeLabelSet` to our applicative labels via `EncodeLabelSetMut` can
be removed.

no code is changed. function bodies are moved from
`linkerd_app_core::metrics::prom::EncodeLabelSetMut::encode_label_set()`
to `prometheus_client::encoding::EncodeLabelSet::encode()`. invocations
of the former are replaced with the latter where applicable.

Signed-off-by: katelyn martin <kate@buoyant.io>
