### PR TITLE
fix(route-http-match): adjust route matching to more closely align to…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2098,6 +2098,7 @@ dependencies = [
  "linkerd2-proxy-api",
  "rand 0.10.2",
  "regex",
+ "rstest",
  "thiserror",
  "tracing",
  "url",
@@ -3369,6 +3370,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3685,6 +3695,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3702,6 +3718,35 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.115",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4282,6 +4327,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4845,6 +4920,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/linkerd/app/inbound/src/policy/http/tests.rs
+++ b/linkerd/app/inbound/src/policy/http/tests.rs
@@ -243,6 +243,158 @@ async fn http_route() {
     assert_eq!(permit.labels.route.route, rmeta);
 }
 
+// Route selection picks the most specific match, not the first that matches.
+// The lower-precedence rule is listed first so list order cannot explain a
+// pass.
+#[tokio::test(flavor = "current_thread")]
+async fn http_route_precedence() {
+    use linkerd_proxy_server_policy::http::{
+        r#match::{MatchPath, MatchRequest},
+        Policy, Route, Rule,
+    };
+
+    let prefix = Arc::new(Meta::Resource {
+        group: "gateway.networking.k8s.io".into(),
+        kind: "httproute".into(),
+        name: "prefix".into(),
+    });
+    let exact = Arc::new(Meta::Resource {
+        group: "gateway.networking.k8s.io".into(),
+        kind: "httproute".into(),
+        name: "exact".into(),
+    });
+    let authorizations: Arc<[Authorization]> = Arc::new([Authorization {
+        authentication: Authentication::Unauthenticated,
+        networks: vec![std::net::IpAddr::from([192, 168, 3, 3]).into()],
+        meta: Arc::new(Meta::Resource {
+            group: "policy.linkerd.io".into(),
+            kind: "AuthorizationPolicy".into(),
+            name: "test".into(),
+        }),
+    }]);
+
+    let (mut svc, _tx) = new_svc!(Protocol::Http1(Arc::new([Route {
+        hosts: vec![],
+        rules: vec![
+            Rule {
+                matches: vec![MatchRequest {
+                    path: Some(MatchPath::Prefix("/a".to_string())),
+                    ..MatchRequest::default()
+                }],
+                policy: Policy {
+                    authorizations: authorizations.clone(),
+                    filters: vec![],
+                    meta: prefix,
+                },
+            },
+            Rule {
+                matches: vec![MatchRequest {
+                    path: Some(MatchPath::Exact("/a/b".to_string())),
+                    ..MatchRequest::default()
+                }],
+                policy: Policy {
+                    authorizations: authorizations.clone(),
+                    filters: vec![],
+                    meta: exact.clone(),
+                },
+            },
+        ],
+    }])));
+
+    let rsp = svc
+        .call(
+            ::http::Request::builder()
+                .uri("/a/b")
+                .body(BoxBody::default())
+                .unwrap(),
+        )
+        .await
+        .expect("serves");
+    let permit = rsp
+        .extensions()
+        .get::<HttpRoutePermit>()
+        .expect("permitted");
+    assert_eq!(
+        permit.labels.route.route, exact,
+        "an exact path match must outrank a prefix match"
+    );
+}
+
+/// When two rules match equivalently, the first wins.
+#[tokio::test(flavor = "current_thread")]
+async fn http_route_tie_selects_first() {
+    use linkerd_proxy_server_policy::http::{
+        r#match::{MatchPath, MatchRequest},
+        Policy, Route, Rule,
+    };
+
+    let first = Arc::new(Meta::Resource {
+        group: "gateway.networking.k8s.io".into(),
+        kind: "httproute".into(),
+        name: "first".into(),
+    });
+    let second = Arc::new(Meta::Resource {
+        group: "gateway.networking.k8s.io".into(),
+        kind: "httproute".into(),
+        name: "second".into(),
+    });
+    let authorizations: Arc<[Authorization]> = Arc::new([Authorization {
+        authentication: Authentication::Unauthenticated,
+        networks: vec![std::net::IpAddr::from([192, 168, 3, 3]).into()],
+        meta: Arc::new(Meta::Resource {
+            group: "policy.linkerd.io".into(),
+            kind: "AuthorizationPolicy".into(),
+            name: "test".into(),
+        }),
+    }]);
+
+    let (mut svc, _tx) = new_svc!(Protocol::Http1(Arc::new([Route {
+        hosts: vec![],
+        rules: vec![
+            Rule {
+                matches: vec![MatchRequest {
+                    path: Some(MatchPath::Prefix("/a".to_string())),
+                    ..MatchRequest::default()
+                }],
+                policy: Policy {
+                    authorizations: authorizations.clone(),
+                    filters: vec![],
+                    meta: first.clone(),
+                },
+            },
+            Rule {
+                matches: vec![MatchRequest {
+                    path: Some(MatchPath::Prefix("/a".to_string())),
+                    ..MatchRequest::default()
+                }],
+                policy: Policy {
+                    authorizations: authorizations.clone(),
+                    filters: vec![],
+                    meta: second,
+                },
+            },
+        ],
+    }])));
+
+    let rsp = svc
+        .call(
+            ::http::Request::builder()
+                .uri("/a/b")
+                .body(BoxBody::default())
+                .unwrap(),
+        )
+        .await
+        .expect("serves");
+    let permit = rsp
+        .extensions()
+        .get::<HttpRoutePermit>()
+        .expect("permitted");
+    assert_eq!(
+        permit.labels.route.route, first,
+        "the first of two tied rules must win"
+    );
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn http_filter_header() {
     use linkerd_proxy_server_policy::http::{

--- a/linkerd/app/integration/src/tests/client_policy.rs
+++ b/linkerd/app/integration/src/tests/client_policy.rs
@@ -255,30 +255,7 @@ async fn header_based_routing() {
     let policy = controller::policy()
         // stop the admin server from entering an infinite retry loop
         .with_inbound_default(policy::all_unauthenticated())
-        .outbound(
-            srv.addr,
-            outbound::OutboundPolicy {
-                metadata: Some(api::meta::Metadata {
-                    kind: Some(api::meta::metadata::Kind::Default("test".to_string())),
-                }),
-                protocol: Some(outbound::ProxyProtocol {
-                    kind: Some(proxy_protocol::Kind::Detect(proxy_protocol::Detect {
-                        timeout: Some(Duration::from_secs(10).try_into().unwrap()),
-                        http1: Some(proxy_protocol::Http1 {
-                            routes: vec![route.clone()],
-                            ..Default::default()
-                        }),
-                        http2: Some(proxy_protocol::Http2 {
-                            routes: vec![route],
-                            ..Default::default()
-                        }),
-                        opaque: Some(proxy_protocol::Opaque {
-                            routes: vec![policy::outbound_default_opaque_route(&dst_world)],
-                        }),
-                    })),
-                }),
-            },
-        );
+        .outbound(srv.addr, http_routes_policy(vec![route], &dst_world));
 
     let proxy = proxy::new()
         .controller(ctrl.run().await)
@@ -437,30 +414,7 @@ async fn path_based_routing() {
     let policy = controller::policy()
         // stop the admin server from entering an infinite retry loop
         .with_inbound_default(policy::all_unauthenticated())
-        .outbound(
-            srv.addr,
-            outbound::OutboundPolicy {
-                metadata: Some(api::meta::Metadata {
-                    kind: Some(api::meta::metadata::Kind::Default("test".to_string())),
-                }),
-                protocol: Some(outbound::ProxyProtocol {
-                    kind: Some(proxy_protocol::Kind::Detect(proxy_protocol::Detect {
-                        timeout: Some(Duration::from_secs(10).try_into().unwrap()),
-                        http1: Some(proxy_protocol::Http1 {
-                            routes: vec![route.clone()],
-                            ..Default::default()
-                        }),
-                        http2: Some(proxy_protocol::Http2 {
-                            routes: vec![route],
-                            ..Default::default()
-                        }),
-                        opaque: Some(proxy_protocol::Opaque {
-                            routes: vec![policy::outbound_default_opaque_route(&dst_world)],
-                        }),
-                    })),
-                }),
-            },
-        );
+        .outbound(srv.addr, http_routes_policy(vec![route], &dst_world));
 
     let proxy = proxy::new()
         .controller(ctrl.run().await)
@@ -496,6 +450,544 @@ async fn path_based_routing() {
 
     // ensure panics from the server are propagated
     proxy.join_servers().await;
+}
+
+#[tokio::test]
+async fn route_precedence_ordering() {
+    let _trace = trace_init();
+
+    // The body served by the backend a request is *expected* to be routed to.
+    const EXPECTED: &str = "expected";
+    // The body served by the backend a request must *not* be routed to. A response
+    // with this body means the proxy picked a lower-precedence rule.
+    const UNEXPECTED: &str = "unexpected";
+    const AUTHORITY_EXPECTED: &str = "expected.test.svc.cluster.local";
+    const AUTHORITY_UNEXPECTED: &str = "unexpected.test.svc.cluster.local";
+
+    // Every path used below is served by *both* backends, so a request's body
+    // tells us which rule the proxy selected -- never whether the backend
+    // happens to know the path.
+    const PATHS: &[&str] = &["/a/b", "/b/long/path", "/c", "/d", "/e", "/f"];
+
+    let srv_expected = mk_server(PATHS, EXPECTED).await;
+    let srv_unexpected = mk_server(PATHS, UNEXPECTED).await;
+
+    let ctrl = controller::new();
+    let dst_expected = format!("{AUTHORITY_EXPECTED}:{}", srv_expected.addr.port());
+    let dst_unexpected = format!("{AUTHORITY_UNEXPECTED}:{}", srv_unexpected.addr.port());
+    let _dst_expected_tx = {
+        let tx = ctrl.destination_tx(&dst_expected);
+        tx.send_addr(srv_expected.addr);
+        tx
+    };
+    let _dst_unexpected_tx = {
+        let tx = ctrl.destination_tx(&dst_unexpected);
+        tx.send_addr(srv_unexpected.addr);
+        tx
+    };
+    let _profile_tx = ctrl.profile_tx_default(srv_expected.addr, AUTHORITY_EXPECTED);
+
+    // In every pair below the *lower*-precedence rule is listed first, so that
+    // a passing assertion cannot be explained by list order alone.
+    let route = outbound::HttpRoute {
+        metadata: Some(httproute_meta("precedence")),
+        hosts: Vec::new(),
+        rules: vec![
+            // (1) Exact path beats prefix path -- even though the prefix rule
+            //     also matches two headers and the exact rule matches none.
+            //     Path outranks every lower-precedence field.
+            rule(
+                vec![MatchBuilder::prefix("/a")
+                    .header("x-1", "1")
+                    .header("x-2", "2")
+                    .build()],
+                &dst_unexpected,
+            ),
+            rule(vec![MatchBuilder::exact("/a/b").build()], &dst_expected),
+            // (2) Between two prefix matches, more matching characters wins.
+            rule(vec![MatchBuilder::prefix("/b").build()], &dst_unexpected),
+            rule(vec![MatchBuilder::prefix("/b/long").build()], &dst_expected),
+            // (3) With paths tied, a rule that matches the method outranks one
+            //     that does not consider the method at all.
+            rule(vec![MatchBuilder::exact("/c").build()], &dst_unexpected),
+            rule(
+                vec![MatchBuilder::exact("/c").method_get().build()],
+                &dst_expected,
+            ),
+            // (4) With path and method tied, more header matches wins.
+            rule(
+                vec![MatchBuilder::exact("/d").header("x-1", "1").build()],
+                &dst_unexpected,
+            ),
+            rule(
+                vec![MatchBuilder::exact("/d")
+                    .header("x-1", "1")
+                    .header("x-2", "2")
+                    .build()],
+                &dst_expected,
+            ),
+            // (5) With path, method, and headers tied, more query param
+            //     matches wins.
+            rule(
+                vec![MatchBuilder::exact("/e").query("p", "1").build()],
+                &dst_unexpected,
+            ),
+            rule(
+                vec![MatchBuilder::exact("/e")
+                    .query("p", "1")
+                    .query("q", "2")
+                    .build()],
+                &dst_expected,
+            ),
+            // (6) Method outranks *both* headers and query params: a rule
+            //     matching only the method beats one matching two headers and
+            //     two query params.
+            rule(
+                vec![MatchBuilder::exact("/f")
+                    .header("x-1", "1")
+                    .header("x-2", "2")
+                    .query("p", "1")
+                    .query("q", "2")
+                    .build()],
+                &dst_unexpected,
+            ),
+            rule(
+                vec![MatchBuilder::exact("/f").method_get().build()],
+                &dst_expected,
+            ),
+        ],
+    };
+
+    let policy = controller::policy()
+        // stop the admin server from entering an infinite retry loop
+        .with_inbound_default(policy::all_unauthenticated())
+        .outbound(
+            srv_expected.addr,
+            http_routes_policy(vec![route], &dst_expected),
+        );
+
+    let proxy = proxy::new()
+        .controller(ctrl.run().await)
+        .policy(policy.run().await)
+        .outbound(srv_expected)
+        .run()
+        .await;
+
+    let client = client::http1(proxy.outbound, AUTHORITY_EXPECTED);
+
+    let both_headers = &[("x-1", "1"), ("x-2", "2")][..];
+
+    // (1) exact path > prefix path (with more headers).
+    assert_eq!(
+        get(&client, "/a/b", both_headers).await,
+        EXPECTED,
+        "an exact path match must outrank a prefix match with more header matches",
+    );
+
+    // (2) longer prefix > shorter prefix.
+    assert_eq!(
+        get(&client, "/b/long/path", &[]).await,
+        EXPECTED,
+        "the prefix match with more matching characters must win",
+    );
+
+    // (3) method match > no method match, with paths tied.
+    assert_eq!(
+        get(&client, "/c", &[]).await,
+        EXPECTED,
+        "with paths tied, a matching method must outrank no method match",
+    );
+    // ...and a request whose method does *not* match falls through to the rule
+    // that does not consider the method, which confirms the method match is
+    // actually being evaluated rather than ignored.
+    assert_eq!(
+        send(&client, client.request_builder("/c").method("POST"))
+            .await
+            .1,
+        UNEXPECTED,
+        "a method match must exclude requests using a different method",
+    );
+
+    // (4) more header matches wins, with path and method tied.
+    assert_eq!(
+        get(&client, "/d", both_headers).await,
+        EXPECTED,
+        "with path and method tied, more header matches must win",
+    );
+
+    // (5) more query param matches wins, with path, method, and headers tied.
+    assert_eq!(
+        get(&client, "/e?p=1&q=2", &[]).await,
+        EXPECTED,
+        "with path, method, and headers tied, more query param matches must win",
+    );
+
+    // (6) method outranks headers and query params.
+    assert_eq!(
+        get(&client, "/f?p=1&q=2", both_headers).await,
+        EXPECTED,
+        "a method match must outrank more header and query param matches",
+    );
+
+    proxy.join_servers().await;
+}
+
+#[tokio::test]
+async fn tie_between_routes_selects_first() {
+    let _trace = trace_init();
+
+    const AUTHORITY_FOO: &str = "foo.test.svc.cluster.local";
+    const AUTHORITY_BAR: &str = "bar.test.svc.cluster.local";
+    const PATHS: &[&str] = &["/a/b"];
+
+    let srv_foo = mk_server(PATHS, "foo").await;
+    let srv_bar = mk_server(PATHS, "bar").await;
+
+    let ctrl = controller::new();
+    let dst_foo = format!("{AUTHORITY_FOO}:{}", srv_foo.addr.port());
+    let dst_bar = format!("{AUTHORITY_BAR}:{}", srv_bar.addr.port());
+    let _dst_foo_tx = {
+        let tx = ctrl.destination_tx(&dst_foo);
+        tx.send_addr(srv_foo.addr);
+        tx
+    };
+    let _dst_bar_tx = {
+        let tx = ctrl.destination_tx(&dst_bar);
+        tx.send_addr(srv_bar.addr);
+        tx
+    };
+    let _profile_tx = ctrl.profile_tx_default(srv_foo.addr, AUTHORITY_FOO);
+
+    // The first-listed route is named so that it sorts *last*, so that list
+    // order and name order predict different winners.
+    let routes = vec![
+        outbound::HttpRoute {
+            metadata: Some(httproute_meta("z")),
+            hosts: Vec::new(),
+            rules: vec![rule(vec![MatchBuilder::prefix("/a").build()], &dst_foo)],
+        },
+        outbound::HttpRoute {
+            metadata: Some(httproute_meta("a")),
+            hosts: Vec::new(),
+            rules: vec![rule(vec![MatchBuilder::prefix("/a").build()], &dst_bar)],
+        },
+    ];
+
+    let policy = controller::policy()
+        // stop the admin server from entering an infinite retry loop
+        .with_inbound_default(policy::all_unauthenticated())
+        .outbound(srv_foo.addr, http_routes_policy(routes, &dst_foo));
+
+    let proxy = proxy::new()
+        .controller(ctrl.run().await)
+        .policy(policy.run().await)
+        .outbound(srv_foo)
+        .run()
+        .await;
+
+    let client = client::http1(proxy.outbound, AUTHORITY_FOO);
+
+    assert_eq!(get(&client, "/a/b", &[]).await, "foo");
+
+    proxy.join_servers().await;
+}
+
+#[tokio::test]
+async fn tie_broken_by_first_matching_rule() {
+    let _trace = trace_init();
+
+    // The body served by the backend a request is *expected* to be routed to.
+    const EXPECTED: &str = "expected";
+    // The body served by the backend a request must *not* be routed to. A response
+    // with this body means the proxy picked a lower-precedence rule.
+    const UNEXPECTED: &str = "unexpected";
+    const AUTHORITY_EXPECTED: &str = "expected.test.svc.cluster.local";
+    const AUTHORITY_UNEXPECTED: &str = "unexpected.test.svc.cluster.local";
+    const PATHS: &[&str] = &["/tie", "/implicit"];
+
+    let srv_expected = mk_server(PATHS, EXPECTED).await;
+    let srv_unexpected = mk_server(PATHS, UNEXPECTED).await;
+
+    let ctrl = controller::new();
+    let dst_expected = format!("{AUTHORITY_EXPECTED}:{}", srv_expected.addr.port());
+    let dst_unexpected = format!("{AUTHORITY_UNEXPECTED}:{}", srv_unexpected.addr.port());
+    let _dst_expected_tx = {
+        let tx = ctrl.destination_tx(&dst_expected);
+        tx.send_addr(srv_expected.addr);
+        tx
+    };
+    let _dst_unexpected_tx = {
+        let tx = ctrl.destination_tx(&dst_unexpected);
+        tx.send_addr(srv_unexpected.addr);
+        tx
+    };
+    let _profile_tx = ctrl.profile_tx_default(srv_expected.addr, AUTHORITY_EXPECTED);
+
+    let route = outbound::HttpRoute {
+        metadata: Some(httproute_meta("first-matching-rule")),
+        hosts: Vec::new(),
+        rules: vec![
+            // Three rules with byte-identical matches: every specificity
+            // criterion ties, so the first must win.
+            rule(
+                vec![MatchBuilder::exact("/tie").header("x-1", "1").build()],
+                &dst_expected,
+            ),
+            rule(
+                vec![MatchBuilder::exact("/tie").header("x-1", "1").build()],
+                &dst_unexpected,
+            ),
+            rule(
+                vec![MatchBuilder::exact("/tie").header("x-1", "1").build()],
+                &dst_unexpected,
+            ),
+            // Rules with *no* matches carry the spec's implicit "prefix /"
+            // match, so they tie with each other too.
+            rule(Vec::new(), &dst_expected),
+            rule(Vec::new(), &dst_unexpected),
+        ],
+    };
+
+    let policy = controller::policy()
+        // stop the admin server from entering an infinite retry loop
+        .with_inbound_default(policy::all_unauthenticated())
+        .outbound(
+            srv_expected.addr,
+            http_routes_policy(vec![route], &dst_expected),
+        );
+
+    let proxy = proxy::new()
+        .controller(ctrl.run().await)
+        .policy(policy.run().await)
+        .outbound(srv_expected)
+        .run()
+        .await;
+
+    let client = client::http1(proxy.outbound, AUTHORITY_EXPECTED);
+
+    assert_eq!(
+        get(&client, "/tie", &[("x-1", "1")]).await,
+        EXPECTED,
+        "with all criteria tied, the first matching rule in list order must win",
+    );
+    assert_eq!(
+        get(&client, "/implicit", &[]).await,
+        EXPECTED,
+        "rules with no matches tie on the implicit \"prefix /\" match, so the \
+         first must win",
+    );
+
+    proxy.join_servers().await;
+}
+
+// A request that matches no rule in any route is not routable, and must not be
+// silently sent to some arbitrary backend.
+#[tokio::test]
+async fn no_matching_route_returns_404() {
+    let _trace = trace_init();
+
+    // The body served by the backend a request is *expected* to be routed to.
+    const EXPECTED: &str = "expected";
+    const AUTHORITY: &str = "policy.test.svc.cluster.local";
+    const PATHS: &[&str] = &["/matches", "/does-not-match"];
+
+    let srv = mk_server(PATHS, EXPECTED).await;
+
+    let ctrl = controller::new();
+    let dst = format!("{AUTHORITY}:{}", srv.addr.port());
+    let _dst_tx = {
+        let tx = ctrl.destination_tx(&dst);
+        tx.send_addr(srv.addr);
+        tx
+    };
+    let _profile_tx = ctrl.profile_tx_default(srv.addr, AUTHORITY);
+
+    // The route has rules, but none of them match `/does-not-match`. The
+    // backend *does* serve that path, so a 2xx would mean the proxy routed a
+    // request it should have rejected.
+    let route = outbound::HttpRoute {
+        metadata: Some(httproute_meta("no-match")),
+        hosts: Vec::new(),
+        rules: vec![
+            rule(vec![MatchBuilder::exact("/matches").build()], &dst),
+            rule(
+                vec![MatchBuilder::exact("/does-not-match")
+                    .header("x-required", "1")
+                    .build()],
+                &dst,
+            ),
+        ],
+    };
+
+    let policy = controller::policy()
+        // stop the admin server from entering an infinite retry loop
+        .with_inbound_default(policy::all_unauthenticated())
+        .outbound(srv.addr, http_routes_policy(vec![route], &dst));
+
+    let proxy = proxy::new()
+        .controller(ctrl.run().await)
+        .policy(policy.run().await)
+        .outbound(srv)
+        .run()
+        .await;
+
+    let client = client::http1(proxy.outbound, AUTHORITY);
+
+    // A path no rule matches at all.
+    let (status, _) = send(&client, client.request_builder("/does-not-match")).await;
+    assert_eq!(
+        status,
+        http::StatusCode::NOT_FOUND,
+        "a request matching no rule must be rejected with 404",
+    );
+
+    // A path whose rule matches, but whose required header is absent.
+    let (status, _) = send(
+        &client,
+        client.request_builder("/does-not-match").header("x-1", "1"),
+    )
+    .await;
+    assert_eq!(
+        status,
+        http::StatusCode::NOT_FOUND,
+        "a request that fails a rule's header match must be rejected with 404",
+    );
+
+    // The rule that *does* match still works, proving the 404s above are caused
+    // by matching and not by a broken fixture.
+    let (status, body) = send(&client, client.request_builder("/matches")).await;
+    assert_eq!(status, http::StatusCode::OK);
+    assert_eq!(body, EXPECTED);
+
+    proxy.join_servers().await;
+}
+
+// Builds a server that serves `body` at each of `paths`.
+async fn mk_server(paths: &[&str], body: &str) -> server::Listening {
+    let mut srv = server::http1();
+    for path in paths {
+        srv = srv.route(path, body);
+    }
+    srv.run().await
+}
+
+// Sends a request, asserting it succeeded, and returns the response body.
+async fn get(client: &client::Client, path: &str, headers: &[(&str, &str)]) -> String {
+    let mut builder = client.request_builder(path);
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    let (status, body) = send(client, builder).await;
+    assert!(
+        status.is_success(),
+        "GET {path} expected 2xx, got {status} (body: {body:?})",
+    );
+    body
+}
+
+// Sends a request and returns its status and body, without asserting on either.
+async fn send(
+    client: &client::Client,
+    builder: http::request::Builder,
+) -> (http::StatusCode, String) {
+    let rsp = client.request(builder).await.expect("request");
+    let status = rsp.status();
+    let body = http_util::body_to_string(rsp.into_parts().1)
+        .await
+        .expect("body");
+    (status, body)
+}
+
+// Builds a rule routing `matches` to a single backend at `dst`.
+fn rule(matches: Vec<api::http_route::HttpRouteMatch>, dst: &str) -> outbound::http_route::Rule {
+    outbound::http_route::Rule {
+        matches,
+        filters: Vec::new(),
+        backends: Some(policy::http_first_available(std::iter::once(
+            policy::backend(dst),
+        ))),
+        ..Default::default()
+    }
+}
+
+// Builds an outbound policy serving `routes` over both HTTP/1 and HTTP/2.
+fn http_routes_policy(
+    routes: Vec<outbound::HttpRoute>,
+    opaque_dst: &str,
+) -> outbound::OutboundPolicy {
+    outbound::OutboundPolicy {
+        metadata: Some(api::meta::Metadata {
+            kind: Some(api::meta::metadata::Kind::Default("test".to_string())),
+        }),
+        protocol: Some(outbound::ProxyProtocol {
+            kind: Some(proxy_protocol::Kind::Detect(proxy_protocol::Detect {
+                timeout: Some(Duration::from_secs(10).try_into().unwrap()),
+                http1: Some(proxy_protocol::Http1 {
+                    routes: routes.clone(),
+                    ..Default::default()
+                }),
+                http2: Some(proxy_protocol::Http2 {
+                    routes,
+                    ..Default::default()
+                }),
+                opaque: Some(proxy_protocol::Opaque {
+                    routes: vec![policy::outbound_default_opaque_route(opaque_dst)],
+                }),
+            })),
+        }),
+    }
+}
+
+struct MatchBuilder(api::http_route::HttpRouteMatch);
+
+impl MatchBuilder {
+    fn path(kind: api::http_route::path_match::Kind) -> Self {
+        Self(api::http_route::HttpRouteMatch {
+            path: Some(api::http_route::PathMatch { kind: Some(kind) }),
+            ..Default::default()
+        })
+    }
+
+    fn exact(path: &str) -> Self {
+        Self::path(api::http_route::path_match::Kind::Exact(path.to_string()))
+    }
+
+    fn prefix(path: &str) -> Self {
+        Self::path(api::http_route::path_match::Kind::Prefix(path.to_string()))
+    }
+
+    fn method_get(mut self) -> Self {
+        self.0.method = Some(api::http_types::HttpMethod {
+            r#type: Some(api::http_types::http_method::Type::Registered(
+                api::http_types::http_method::Registered::Get as i32,
+            )),
+        });
+        self
+    }
+
+    fn header(mut self, name: &str, value: &str) -> Self {
+        self.0.headers.push(api::http_route::HeaderMatch {
+            name: name.to_string(),
+            value: Some(api::http_route::header_match::Value::Exact(
+                value.to_string().into_bytes(),
+            )),
+        });
+        self
+    }
+
+    fn query(mut self, name: &str, value: &str) -> Self {
+        self.0.query_params.push(api::http_route::QueryParamMatch {
+            name: name.to_string(),
+            value: Some(api::http_route::query_param_match::Value::Exact(
+                value.to_string(),
+            )),
+        });
+        self
+    }
+
+    fn build(self) -> api::http_route::HttpRouteMatch {
+        self.0
+    }
 }
 
 fn httproute_meta(name: impl ToString) -> api::meta::Metadata {

--- a/linkerd/http/route/Cargo.toml
+++ b/linkerd/http/route/Cargo.toml
@@ -21,3 +21,6 @@ url = "2"
 workspace = true
 features = ["http-route", "grpc-route"]
 optional = true
+
+[dev-dependencies]
+rstest = "0.26.1"

--- a/linkerd/http/route/src/http/match.rs
+++ b/linkerd/http/route/src/http/match.rs
@@ -97,9 +97,9 @@ impl std::cmp::Ord for RequestMatch {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.path_match
             .cmp(&other.path_match)
+            .then_with(|| self.method.cmp(&other.method))
             .then_with(|| self.headers.cmp(&other.headers))
             .then_with(|| self.query_params.cmp(&other.query_params))
-            .then_with(|| self.method.cmp(&other.method))
     }
 }
 

--- a/linkerd/http/route/src/http/match/path.rs
+++ b/linkerd/http/route/src/http/match/path.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use http::Uri;
 use regex::Regex;
 
@@ -98,7 +100,17 @@ impl std::cmp::PartialOrd for PathMatch {
 
 impl std::cmp::Ord for PathMatch {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.len().cmp(&other.len())
+        // Exact paths take higher precedence than
+        // other path matching options
+        let is_self_exact_match = matches!(self, PathMatch::Exact(_));
+        let is_other_exact_match = matches!(other, PathMatch::Exact(_));
+        if is_self_exact_match && !is_other_exact_match {
+            Ordering::Greater
+        } else if !is_self_exact_match && is_other_exact_match {
+            Ordering::Less
+        } else {
+            self.len().cmp(&other.len())
+        }
     }
 }
 

--- a/linkerd/http/route/src/http/match/tests.rs
+++ b/linkerd/http/route/src/http/match/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::Match;
 use http::header::{HeaderName, HeaderValue};
+use rstest::rstest;
 
 // Empty matches apply to all requests.
 #[test]
@@ -157,4 +158,244 @@ fn multiple() {
         .body(())
         .unwrap();
     assert_eq!(m.match_request(&req), None);
+}
+
+#[rstest]
+#[case::exact_beats_prefix_by_length(
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo/bar".to_string())),
+        ..MatchRequest::default()
+    },
+    MatchRequest {
+        path: Some(MatchPath::Prefix("/foo".to_string())),
+        ..MatchRequest::default()
+    },
+    http::Request::builder()
+        .uri("http://example.com/foo/bar")
+        .body(())
+        .unwrap(),
+)]
+// Path precedence overrides every lower-precedence field, even when the
+// lower-precedence match wins on method, headers, *and* query params.
+#[case::path_precedence_overrides_lower_precedence_fields(
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        ..MatchRequest::default()
+    },
+    MatchRequest {
+        path: Some(MatchPath::Prefix("/".to_string())),
+        method: Some(http::Method::GET),
+        headers: vec![
+            MatchHeader::Exact(HeaderName::from_static("x-a"), HeaderValue::from_static("1")),
+            MatchHeader::Exact(HeaderName::from_static("x-b"), HeaderValue::from_static("2")),
+        ],
+        query_params: vec![
+            MatchQueryParam::Exact("a".to_string(), "1".to_string()),
+            MatchQueryParam::Exact("b".to_string(), "2".to_string()),
+        ],
+    },
+    http::Request::builder()
+        .method(http::Method::GET)
+        .uri("http://example.com/foo?a=1&b=2")
+        .header("x-a", "1")
+        .header("x-b", "2")
+        .body(())
+        .unwrap(),
+)]
+#[case::longer_prefix_outranks_shorter_prefix(
+    MatchRequest {
+        path: Some(MatchPath::Prefix("/foo/bar".to_string())),
+        ..MatchRequest::default()
+    },
+    MatchRequest {
+        path: Some(MatchPath::Prefix("/foo".to_string())),
+        ..MatchRequest::default()
+    },
+    http::Request::builder()
+        .uri("http://example.com/foo/bar/baz")
+        .body(())
+        .unwrap(),
+)]
+// With paths tied, a match that also requires (and gets) a method match
+// outranks one that doesn't consider the method at all.
+#[case::method_match_outranks_no_method(
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        method: Some(http::Method::GET),
+        ..MatchRequest::default()
+    },
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        ..MatchRequest::default()
+    },
+    http::Request::builder()
+        .method(http::Method::GET)
+        .uri("http://example.com/foo")
+        .body(())
+        .unwrap(),
+)]
+// Method precedence overrides headers and query params: fewer of each,
+// but a method match, still outranks more of each without one.
+#[case::method_precedence_overrides_headers_and_query_params(
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        method: Some(http::Method::GET),
+        ..MatchRequest::default()
+    },
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        headers: vec![
+            MatchHeader::Exact(HeaderName::from_static("x-a"), HeaderValue::from_static("1")),
+            MatchHeader::Exact(HeaderName::from_static("x-b"), HeaderValue::from_static("2")),
+        ],
+        query_params: vec![
+            MatchQueryParam::Exact("a".to_string(), "1".to_string()),
+            MatchQueryParam::Exact("b".to_string(), "2".to_string()),
+        ],
+        ..MatchRequest::default()
+    },
+    http::Request::builder()
+        .method(http::Method::GET)
+        .uri("http://example.com/foo?a=1&b=2")
+        .header("x-a", "1")
+        .header("x-b", "2")
+        .body(())
+        .unwrap(),
+)]
+// With path and method tied, more header matches wins.
+#[case::more_header_matches_outranks_fewer(
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        headers: vec![
+            MatchHeader::Exact(HeaderName::from_static("x-foo"), HeaderValue::from_static("bar")),
+            MatchHeader::Exact(HeaderName::from_static("x-baz"), HeaderValue::from_static("qux")),
+        ],
+        ..MatchRequest::default()
+    },
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        headers: vec![MatchHeader::Exact(
+            HeaderName::from_static("x-foo"),
+            HeaderValue::from_static("bar"),
+        )],
+        ..MatchRequest::default()
+    },
+    http::Request::builder()
+        .uri("http://example.com/foo")
+        .header("x-foo", "bar")
+        .header("x-baz", "qux")
+        .body(())
+        .unwrap(),
+)]
+// Header precedence overrides query params: fewer query param matches,
+// but more header matches, still outranks more query params but fewer
+// headers.
+#[case::header_precedence_overrides_query_params(
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        headers: vec![MatchHeader::Exact(
+            HeaderName::from_static("x-foo"),
+            HeaderValue::from_static("bar"),
+        )],
+        ..MatchRequest::default()
+    },
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        query_params: vec![
+            MatchQueryParam::Exact("a".to_string(), "1".to_string()),
+            MatchQueryParam::Exact("b".to_string(), "2".to_string()),
+        ],
+        ..MatchRequest::default()
+    },
+    http::Request::builder()
+        .uri("http://example.com/foo?a=1&b=2")
+        .header("x-foo", "bar")
+        .body(())
+        .unwrap(),
+)]
+// With path, method, and headers all tied, more query param matches wins.
+#[case::more_query_param_matches_outranks_fewer(
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        query_params: vec![
+            MatchQueryParam::Exact("a".to_string(), "1".to_string()),
+            MatchQueryParam::Exact("b".to_string(), "2".to_string()),
+        ],
+        ..MatchRequest::default()
+    },
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        query_params: vec![MatchQueryParam::Exact("a".to_string(), "1".to_string())],
+        ..MatchRequest::default()
+    },
+    http::Request::builder()
+        .uri("http://example.com/foo?a=1&b=2")
+        .body(())
+        .unwrap(),
+)]
+// Edge case: an exact path match and a prefix match can only tie in
+// character count when the prefix is the request's entire path (a prefix
+// can never match more characters than the full path, and an exact match's
+// length *is* the full path's length). Per the spec, "Exact" must still
+// outrank "Prefix" here even though the counted lengths are equal.
+#[case::exact_beats_prefix_of_equal_length(
+    MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        ..MatchRequest::default()
+    },
+    MatchRequest {
+        path: Some(MatchPath::Prefix("/foo".to_string())),
+        ..MatchRequest::default()
+    },
+    http::Request::builder()
+        .uri("http://example.com/foo")
+        .body(())
+        .unwrap(),
+)]
+fn gateway_api_precedence(
+    #[case] higher: MatchRequest,
+    #[case] lower: MatchRequest,
+    #[case] req: http::Request<()>,
+) {
+    let higher_match = higher
+        .match_request(&req)
+        .expect("higher-precedence `MatchRequest` must match the request");
+    let lower_match = lower
+        .match_request(&req)
+        .expect("lower-precedence `MatchRequest` must match the request");
+    assert!(
+        higher_match > lower_match,
+        "higher-precedence match {higher_match:?} should outrank {lower_match:?}",
+    );
+}
+
+#[test]
+fn gateway_api_precedence_ties_are_equal() {
+    let a = MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        headers: vec![MatchHeader::Exact(
+            HeaderName::from_static("x-a"),
+            HeaderValue::from_static("1"),
+        )],
+        ..MatchRequest::default()
+    };
+    let b = MatchRequest {
+        path: Some(MatchPath::Exact("/foo".to_string())),
+        headers: vec![MatchHeader::Exact(
+            HeaderName::from_static("x-b"),
+            HeaderValue::from_static("2"),
+        )],
+        ..MatchRequest::default()
+    };
+
+    let req = http::Request::builder()
+        .uri("http://example.com/foo")
+        .header("x-a", "1")
+        .header("x-b", "2")
+        .body(())
+        .unwrap();
+
+    let am = a.match_request(&req).unwrap();
+    let bm = b.match_request(&req).unwrap();
+    assert_eq!(am.cmp(&bm), std::cmp::Ordering::Equal);
 }

--- a/linkerd/http/route/src/http/tests.rs
+++ b/linkerd/http/route/src/http/tests.rs
@@ -126,6 +126,52 @@ fn header_count_precedence() {
     assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
 }
 
+// If, within a single rule, several matches may tie. The "first"
+// element should be preserved.
+#[test]
+fn first_tied_match_in_rule_wins() {
+    let prefix = MatchRequest {
+        path: Some(MatchPath::Prefix("/abc".to_string())),
+        ..MatchRequest::default()
+    };
+    let regex = MatchRequest {
+        path: Some(MatchPath::Regex("/abc".parse().unwrap())),
+        ..MatchRequest::default()
+    };
+    let req = http::Request::builder()
+        .uri("http://www.example.com/abc")
+        .body(())
+        .unwrap();
+
+    let rts = vec![Route {
+        hosts: vec![],
+        rules: vec![Rule {
+            matches: vec![prefix.clone(), regex.clone()],
+            policy: Policy::Expected,
+        }],
+    }];
+    let (m, _) = find(&rts, &req).expect("must match");
+    assert_eq!(
+        *m.route.path(),
+        PathMatch::Prefix(4),
+        "the first-listed match's summary must survive"
+    );
+
+    let rts = vec![Route {
+        hosts: vec![],
+        rules: vec![Rule {
+            matches: vec![regex, prefix],
+            policy: Policy::Expected,
+        }],
+    }];
+    let (m, _) = find(&rts, &req).expect("must match");
+    assert_eq!(
+        *m.route.path(),
+        PathMatch::Regex(4),
+        "the first-listed match's summary must survive here too"
+    );
+}
+
 /// Given two routes with header matches, use the one that matches more
 /// headers.
 #[test]

--- a/linkerd/http/route/src/lib.rs
+++ b/linkerd/http/route/src/lib.rs
@@ -67,11 +67,7 @@ pub fn find<'r, M: Match + 'r, P, B>(
         } else {
             let uri = req.uri();
             trace!(%uri, "matching host");
-            let hm = rt
-                .hosts
-                .iter()
-                .filter_map(|a| a.summarize_match(uri))
-                .max()?;
+            let hm = first_max(rt.hosts.iter().filter_map(|a| a.summarize_match(uri)))?;
             Some(hm)
         };
 
@@ -84,13 +80,10 @@ pub fn find<'r, M: Match + 'r, P, B>(
                 return Some((M::Summary::default(), &rule.policy));
             }
             // Find the best match to compare against other rules/routes
-            // (if any apply). The order/precedence of matches is not
-            // relevant.
-            let summary = rule
-                .matches
-                .iter()
-                .filter_map(|m| m.match_request(req))
-                .max()?;
+            // (if any apply). The order/precedence of matches is based on
+            // sorting done in the control plane. Older rules are
+            // at the front of the list and take precedence under a tie.
+            let summary = first_max(rule.matches.iter().filter_map(|m| m.match_request(req)))?;
             trace!("matches!");
             Some((summary, &rule.policy))
         }))?;
@@ -104,4 +97,14 @@ fn best<M: Ord, P>(matches: impl Iterator<Item = (M, P)>) -> Option<(M, P)> {
     // This is roughly equivalent to `max_by(...)` but we want to ensure
     // that the first match wins.
     matches.reduce(|(m0, p0), (m1, p1)| if m0 >= m1 { (m0, p0) } else { (m1, p1) })
+}
+
+// Returns the max of items, keeping the first entry that ties.
+//
+// This function is similar to `Iterator::max`. However,
+// instead of tie breaking by using the "last" element, first_max
+// breaks ties by propagating the "first" element in the tie.
+#[inline]
+fn first_max<T: Ord>(items: impl Iterator<Item = T>) -> Option<T> {
+    items.reduce(|a, b| if a >= b { a } else { b })
 }


### PR DESCRIPTION
… gateway api httproute spec

also address edge case around ties between exact and prefix match