### PR TITLE
fix(grpc-route-match): allow undefined rpc match in MatchRoute defini…

### DIFF
--- a/linkerd/http/route/src/grpc/match.rs
+++ b/linkerd/http/route/src/grpc/match.rs
@@ -113,9 +113,6 @@ pub mod proto {
     pub enum InvalidRouteMatch {
         #[error("invalid header match: {0}")]
         Header(#[from] InvalidHeaderMatch),
-
-        #[error("missing RPC match")]
-        MissingRpc,
     }
 
     impl TryFrom<api::GrpcRouteMatch> for MatchRoute {
@@ -123,7 +120,9 @@ pub mod proto {
 
         fn try_from(pb: api::GrpcRouteMatch) -> Result<Self, Self::Error> {
             Ok(MatchRoute {
-                rpc: pb.rpc.ok_or(InvalidRouteMatch::MissingRpc)?.into(),
+                // Note that the MatchRpc default represents an "empty"
+                // rpc value.
+                rpc: pb.rpc.map(MatchRpc::from).unwrap_or_default(),
                 headers: pb
                     .headers
                     .into_iter()

--- a/linkerd/http/route/src/grpc/match/tests.rs
+++ b/linkerd/http/route/src/grpc/match/tests.rs
@@ -185,3 +185,98 @@ fn multiple() {
         .unwrap();
     assert_eq!(m.match_request(&req), None);
 }
+
+// A route may match on headers alone, leaving the service and method
+// unconstrained. Such a route applies to every RPC that carries the headers.
+// See linkerd/linkerd2#14047.
+#[test]
+fn headers_without_rpc() {
+    let m = MatchRoute {
+        rpc: MatchRpc {
+            service: None,
+            method: None,
+        },
+        headers: vec![MatchHeader::Exact(
+            HeaderName::from_static("session-id"),
+            HeaderValue::from_static("user-1"),
+        )],
+    };
+
+    // No service or method characters are matched, so the summary is decided
+    // entirely by the header count...
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://example.com/foo/bar")
+        .header("session-id", "user-1")
+        .body(())
+        .unwrap();
+    assert_eq!(
+        m.match_request(&req),
+        Some(RouteMatch {
+            rpc: RpcMatch {
+                service: 0,
+                method: 0
+            },
+            headers: 1
+        })
+    );
+
+    // ...and any other service and method matches just the same.
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("https://example.org/bah/baz")
+        .header("session-id", "user-1")
+        .body(())
+        .unwrap();
+    assert_eq!(
+        m.match_request(&req),
+        Some(RouteMatch {
+            rpc: RpcMatch {
+                service: 0,
+                method: 0
+            },
+            headers: 1
+        })
+    );
+
+    // The header is still required.
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://example.com/foo/bar")
+        .body(())
+        .unwrap();
+    assert_eq!(m.match_request(&req), None);
+}
+
+// An unconstrained RPC match matches zero characters, so it is less specific
+// than any match on a service or method, and ties are broken by header count.
+#[test]
+fn rpc_precedence() {
+    let unconstrained = RouteMatch {
+        rpc: RpcMatch {
+            service: 0,
+            method: 0,
+        },
+        headers: 3,
+    };
+    let service = RouteMatch {
+        rpc: RpcMatch {
+            service: 3,
+            method: 0,
+        },
+        headers: 0,
+    };
+    assert!(service > unconstrained, "a service match is more specific");
+
+    let fewer_headers = RouteMatch {
+        rpc: RpcMatch {
+            service: 0,
+            method: 0,
+        },
+        headers: 1,
+    };
+    assert!(
+        unconstrained > fewer_headers,
+        "header count breaks ties between unconstrained matches"
+    );
+}

--- a/linkerd/http/route/src/grpc/tests.rs
+++ b/linkerd/http/route/src/grpc/tests.rs
@@ -161,6 +161,60 @@ fn header_count_precedence() {
     assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
 }
 
+/// A rule may leave the service and method unset and constrain only the
+/// headers. Such a rule matches any RPC that carries those headers.
+#[test]
+fn headers_without_rpc() {
+    let rts = vec![Route {
+        hosts: vec![],
+        rules: vec![
+            Rule {
+                matches: vec![MatchRoute {
+                    rpc: MatchRpc {
+                        service: None,
+                        method: None,
+                    },
+                    headers: vec![MatchHeader::Exact(
+                        "session-id".parse().unwrap(),
+                        "user-1".parse().unwrap(),
+                    )],
+                }],
+                policy: Policy::Expected,
+            },
+            // Matches every request.
+            Rule::default(),
+        ],
+    }];
+
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://foo.example.com/foo/bar")
+        .header("session-id", "user-1")
+        .body(())
+        .unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+
+    // Any other service and method matches just the same.
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://foo.example.com/bah/baz")
+        .header("session-id", "user-1")
+        .body(())
+        .unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Expected, "incorrect rule matched");
+
+    // Without the header, the rule does not apply and the fallback is used.
+    let req = http::Request::builder()
+        .method(http::Method::POST)
+        .uri("http://foo.example.com/foo/bar")
+        .body(())
+        .unwrap();
+    let (_, policy) = find(&rts, &req).expect("must match");
+    assert_eq!(*policy, Policy::Unexpected, "header match must be required");
+}
+
 /// Given two routes with header matches, use the one that matches more
 /// headers.
 #[test]


### PR DESCRIPTION
…tion

prior to this change, linkerd2-proxy required that the service + method were defined on a GRPCRouteMatch. however, the official GRPCRouteMatch spec (https://gateway-api.sigs.k8s.io/reference/api-spec/main/spec/#grpcroutematch) makes the service and/or method fields optional. after this commit, the proxy will correctly implement the optional nature of the service/method fields on the GRPCRouteMatch.

also, the `InvalidRouteMatch::MissingRPC` error variant is being removed since it is no longer constructed

fixes linkerd/linkerd2#14047