### PR TITLE
feat(allocator): enable jemalloc on aarch64-unknown-linux-gnu

### DIFF
--- a/linkerd2-proxy/Cargo.toml
+++ b/linkerd2-proxy/Cargo.toml
@@ -32,5 +32,8 @@ tracing = { workspace = true }
 [target.x86_64-unknown-linux-gnu.dependencies]
 tikv-jemallocator = "0.6"
 
+[target.aarch64-unknown-linux-gnu.dependencies]
+tikv-jemallocator = "0.6"
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/linkerd2-proxy/src/main.rs
+++ b/linkerd2-proxy/src/main.rs
@@ -9,7 +9,11 @@ use linkerd_signal as signal;
 use tokio::{sync::mpsc, time};
 use tracing::{debug, info, warn};
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64", target_env = "gnu"))]
+#[cfg(all(
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64"),
+    target_env = "gnu"
+))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
jemalloc is currently compiled in as the global allocator only for x86_64-unknown-linux-gnu. On arm64 the proxy silently falls back to glibc malloc, which sizes its per-CPU arena budget from the host core count rather than the cgroup limit and in practice does not return freed memory to the OS. Proxy RSS on arm64 therefore ratchets up with peak load and stays there until the pod restarts, and any MALLOC_CONF tuning users apply is a silent no-op.

Measured on an arm64 cluster with ~300 pooled HTTP/2 connections per pod: closing all connections released no RSS at all with glibc, and 211MB -> ~20MB (-91%) with jemalloc, same proxy version and traffic.

The x86_64-only gate dates to #1321, which restricted it to the only platform the then-current jemallocator readme listed as fully tested. tikv-jemallocator 0.6 supports aarch64-unknown-linux-gnu, so widen the gate to cover it. Cargo.lock is unchanged.