### PR TITLE
fix(http): only emit exact size of unary bodies without trailers

### DIFF
--- a/linkerd/http/retry/src/peek_trailers.rs
+++ b/linkerd/http/retry/src/peek_trailers.rs
@@ -373,6 +373,8 @@ mod tests {
         let peek = PeekTrailersBody::read_body(empty).await;
         assert!(peek.peek_trailers().is_none());
         assert!(peek.is_end_stream());
+        assert_eq!(peek.size_hint().lower(), 0);
+        assert_eq!(peek.size_hint().upper(), None);
 
         let (data, trailers) = collect(peek).await;
         assert_eq!(data, "");
@@ -386,6 +388,8 @@ mod tests {
         let peek = PeekTrailersBody::read_body(only_trailers).await;
         assert!(peek.peek_trailers().is_some());
         assert!(peek.is_end_stream().not());
+        assert_eq!(peek.size_hint().lower(), 0);
+        assert_eq!(peek.size_hint().upper(), None);
 
         let (data, trailers) = collect(peek).await;
         assert_eq!(data, "");
@@ -401,6 +405,8 @@ mod tests {
         let peek = PeekTrailersBody::read_body(body).await;
         assert!(peek.peek_trailers().is_some());
         assert!(peek.is_end_stream().not());
+        assert_eq!(peek.size_hint().lower(), 5);
+        assert_eq!(peek.size_hint().upper(), Some(5));
 
         let (data, trailers) = collect(peek).await;
         assert_eq!(data, "hello");
@@ -417,6 +423,8 @@ mod tests {
         let peek = PeekTrailersBody::read_body(body).await;
         assert!(peek.peek_trailers().is_none());
         assert!(peek.is_end_stream().not());
+        assert_eq!(peek.size_hint().lower(), 5);
+        assert_eq!(peek.size_hint().upper(), None);
 
         let (data, trailers) = collect(peek).await;
         assert_eq!(data, "hello");
@@ -433,6 +441,8 @@ mod tests {
         let peek = PeekTrailersBody::read_body(body).await;
         assert!(peek.peek_trailers().is_some());
         assert!(peek.is_end_stream().not());
+        assert_eq!(peek.size_hint().lower(), 5);
+        assert_eq!(peek.size_hint().upper(), Some(5));
 
         let (data, trailers) = collect(peek).await;
         assert_eq!(data, "hello");
@@ -449,6 +459,8 @@ mod tests {
         let peek = PeekTrailersBody::read_body(body).await;
         assert!(peek.peek_trailers().is_none());
         assert!(peek.is_end_stream().not());
+        assert_eq!(peek.size_hint().lower(), 10);
+        assert_eq!(peek.size_hint().upper(), None);
 
         let (data, trailers) = collect(peek).await;
         assert_eq!(data, "hellohello");
@@ -467,6 +479,8 @@ mod tests {
         let peek = PeekTrailersBody::read_body(body).await;
         assert!(peek.peek_trailers().is_none());
         assert!(peek.is_end_stream().not());
+        assert_eq!(peek.size_hint().lower(), 5);
+        assert_eq!(peek.size_hint().upper(), None);
 
         let (data, trailers) = collect(peek).await;
         assert_eq!(data, "hellohello");

--- a/linkerd/http/retry/src/peek_trailers.rs
+++ b/linkerd/http/retry/src/peek_trailers.rs
@@ -486,4 +486,22 @@ mod tests {
         assert_eq!(data, "hellohello");
         assert_eq!(trailers.unwrap().get("trailer").unwrap(), "shiny");
     }
+
+    /// Regression test for linkerd/linkerd2-proxy#15414.
+    #[tokio::test]
+    async fn peeking_data_with_trailers_does_not_report_exact_size() {
+        let body = MockBody::default()
+            .then_yield_data(Poll::Ready(data()))
+            .then_yield_trailer(Poll::Ready(trailers()));
+
+        let peek = PeekTrailersBody::read_body(body).await;
+
+        assert!(peek.peek_trailers().is_some());
+        assert_eq!(peek.size_hint().lower(), 5);
+        assert_eq!(peek.size_hint().exact(), None);
+
+        let (data, trailers) = collect(peek).await;
+        assert_eq!(data, "hello");
+        assert_eq!(trailers.unwrap().get("trailer").unwrap(), "shiny");
+    }
 }

--- a/linkerd/http/retry/src/peek_trailers.rs
+++ b/linkerd/http/retry/src/peek_trailers.rs
@@ -299,10 +299,26 @@ where
             Inner::Passthru { inner } => inner.size_hint(),
             Inner::Unary {
                 data: Some(Ok(data)),
-                ..
+                trailers: None,
             } => {
                 let size = data.remaining() as u64;
                 http_body::SizeHint::with_exact(size)
+            }
+            Inner::Unary {
+                data: Some(Ok(data)),
+                trailers: Some(_),
+            } => {
+                // NB: An exact size hint is not provided if we have any trailers to emit.
+                // Protocols like grpc-web encode the response status as part of the response body,
+                // so providing an exact hint would might cause clients to see errors related to
+                // missing trailers.
+                //
+                // For more information, see:
+                // https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2.
+                let size = data.remaining() as u64;
+                let mut hint = http_body::SizeHint::new();
+                hint.set_lower(size);
+                hint
             }
             Inner::Unary {
                 data: None | Some(Err(_)),
@@ -406,7 +422,7 @@ mod tests {
         assert!(peek.peek_trailers().is_some());
         assert!(peek.is_end_stream().not());
         assert_eq!(peek.size_hint().lower(), 5);
-        assert_eq!(peek.size_hint().upper(), Some(5));
+        assert_eq!(peek.size_hint().upper(), None);
 
         let (data, trailers) = collect(peek).await;
         assert_eq!(data, "hello");
@@ -442,7 +458,7 @@ mod tests {
         assert!(peek.peek_trailers().is_some());
         assert!(peek.is_end_stream().not());
         assert_eq!(peek.size_hint().lower(), 5);
-        assert_eq!(peek.size_hint().upper(), Some(5));
+        assert_eq!(peek.size_hint().upper(), None);
 
         let (data, trailers) = collect(peek).await;
         assert_eq!(data, "hello");

--- a/linkerd/http/retry/src/peek_trailers.rs
+++ b/linkerd/http/retry/src/peek_trailers.rs
@@ -503,7 +503,7 @@ mod tests {
         assert_eq!(trailers.unwrap().get("trailer").unwrap(), "shiny");
     }
 
-    /// Regression test for linkerd/linkerd2-proxy#15414.
+    /// Regression test for linkerd/linkerd2#15414.
     #[tokio::test]
     async fn peeking_data_with_trailers_does_not_report_exact_size() {
         let body = MockBody::default()


### PR DESCRIPTION
   ## background
  
  fixes linkerd/linkerd2#15414.
  
  we received reports where grpc-web clients would intermittently receive
  responses where the trailers were missing.
  
  while RFC 9113 § 8.1.1 states:
  
  > A request or response that includes message content can include a
  content-length header field. A request or response is also malformed if
  the value of a content-length header field does not equal the sum of the
  DATA frame payload lengths that form the content, unless the message is
  defined as having no content.
  
  grpc-web is a separate protocol that can be sent over any HTTP/*
  version, and has some differences from HTTP/2 that are outlined in more
  detail here:
  
  <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md>
  
  importantly, there is "no dependency on HTTP/2 specific framing", and
  "response statuses [are] encoded as part of the response body".
  
  moreover, many HTTP/1.1 implementations, including intermediary "middle
  boxes", might not support trailers in practice. RFC 9110 § 6.5.1
  "_Limitations on Use of Trailers_" says:
  
  > Trailer fields can be difficult to process by intermediaries that
  forward messages from one protocol version to another. If the entire
  message can be buffered in transit, some intermediaries could merge
  trailer fields into the header section (as appropriate) before it is
  forwarded. However, in most cases, the trailers are simply discarded.
  
  the latter part of this directly affects the `PeekTrailersBody<B>`
  middleware, which does attempt to buffer an entire message in transit.
  
   ## changes
  
  this commit adds an additional arm to the `match` block in
  `<PeekTrailersBody<B> as Body>::size_hint()`.
  
  this has an important effect: we no longer emit an *exact* size hint about
  the size of a peeked body when trailers are present. this preserves a
  lower-bound, so that the proxy can still performantly reserve a
  reasonable amount of memory for the inner body in advance.
  
  test coverage introduced in this branch is updated to show that unary
  bodies affected by this change no longer hint about an upper-bound if
  trailers are present. furthermore, the regression test provided now also
  passes.
  