### PR TITLE
feat: add outbound mTLS-required default policy

### DIFF
--- a/linkerd/app/outbound/src/lib.rs
+++ b/linkerd/app/outbound/src/lib.rs
@@ -23,7 +23,7 @@ use linkerd_app_core::{
     svc::{self, ServiceExt},
     tls::ConnectMeta as TlsConnectMeta,
     transport::addrs::*,
-    AddrMatch, Error, NameAddr, ProxyRuntime,
+    AddrMatch, Error, IpMatch, NameAddr, ProxyRuntime,
 };
 use linkerd_tonic_stream::ReceiveLimits;
 use std::{
@@ -80,6 +80,17 @@ pub struct Config {
     // forwarded without discovery/routing/mTLS.
     pub ingress_mode: bool,
     pub inbound_ips: Arc<HashSet<IpAddr>>,
+
+    /// The default outbound policy: whether the proxy may fall back to a
+    /// cleartext connection to a target that has no mesh identity. Defaults to
+    /// [`policy::DefaultPolicy::Allow`] (today's behavior). Enforced at connect
+    /// time in the `tcp::connect` module.
+    pub default_policy: policy::DefaultPolicy,
+
+    /// The cluster networks, used to scope the `cluster-authenticated` default
+    /// policy to in-cluster destinations. Empty when
+    /// `LINKERD2_PROXY_POLICY_CLUSTER_NETWORKS` is unset.
+    pub cluster_networks: IpMatch,
 
     // Whether the proxy may include informational headers on HTTP responses.
     pub emit_headers: bool,

--- a/linkerd/app/outbound/src/policy.rs
+++ b/linkerd/app/outbound/src/policy.rs
@@ -12,6 +12,35 @@ pub(crate) use self::api::Api;
 
 pub type Receiver = watch::Receiver<ClientPolicy>;
 
+/// The default outbound policy: whether the proxy may fall back to a cleartext
+/// connection when the target endpoint has no mesh identity.
+///
+/// This is the outbound counterpart to the inbound default policy
+/// (`LINKERD2_PROXY_INBOUND_DEFAULT_POLICY`). Whether a target is "meshed" is
+/// only known once an endpoint is resolved: a meshed endpoint carries a mesh
+/// identity in its discovery metadata (yielding `ConditionalClientTls::Some`),
+/// while an unmeshed one does not (yielding
+/// `ConditionalClientTls::None(NotProvidedByServiceDiscovery)`). This policy is
+/// therefore enforced at connect time (see the `tcp::connect` module), not at
+/// service discovery.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DefaultPolicy {
+    /// Permit cleartext connections to endpoints without a mesh identity
+    /// (today's behavior). Corresponds to `all-unauthenticated`.
+    #[default]
+    Allow,
+
+    /// Require a mesh identity (mTLS) for *every* outbound endpoint, refusing
+    /// the cleartext fallback to non-meshed targets. Corresponds to
+    /// `all-authenticated`.
+    RequireIdentity,
+
+    /// Require a mesh identity only for endpoints within the configured cluster
+    /// networks; endpoints outside the cluster may be reached in cleartext.
+    /// Corresponds to `cluster-authenticated`.
+    RequireIdentityWithinCluster,
+}
+
 pub trait GetPolicy: Clone + Send + Sync + 'static {
     type Future: Future<Output = Result<Receiver, Error>> + Unpin + Send;
 

--- a/linkerd/app/outbound/src/tcp/connect.rs
+++ b/linkerd/app/outbound/src/tcp/connect.rs
@@ -1,8 +1,9 @@
-use crate::Outbound;
+use crate::{policy, Outbound};
 use futures::future;
 use linkerd_app_core::{
     io, svc, tls,
     transport::{addrs::*, ConnectTcp},
+    IpMatch,
 };
 use std::task::{Context, Poll};
 
@@ -17,14 +18,47 @@ pub struct Connect {
 #[derive(Clone, Debug)]
 pub struct PreventLoopback<S>(S);
 
+/// Enforces the outbound default policy's mTLS requirement: refuses a cleartext
+/// connection to a target that discovery did not associate with a mesh
+/// identity.
+///
+/// Whether a target is meshed is expressed by its
+/// [`tls::ConditionalClientTls`]: a meshed endpoint resolves to
+/// `Some(..)` (mTLS), while an unmeshed one resolves to
+/// `None(NotProvidedByServiceDiscovery)`. Only the latter is subject to
+/// enforcement — other cleartext reasons (loopback, identity disabled, ingress
+/// without discovery) are always permitted.
+#[derive(Clone, Debug)]
+pub struct RequireMeshIdentity<S> {
+    inner: S,
+    requirement: Requirement,
+}
+
+#[derive(Clone, Debug)]
+enum Requirement {
+    /// No enforcement; cleartext to unmeshed targets is permitted
+    /// (`all-unauthenticated`).
+    Disabled,
+    /// Every unmeshed target is refused (`all-authenticated`).
+    All,
+    /// Only unmeshed targets within these networks are refused; targets outside
+    /// the cluster are permitted (`cluster-authenticated`).
+    WithinCluster(IpMatch),
+}
+
 // === impl Outbound ===
 
 impl Outbound<()> {
-    pub fn to_tcp_connect(&self) -> Outbound<PreventLoopback<ConnectTcp>> {
-        let connect = PreventLoopback(ConnectTcp::new(
+    pub fn to_tcp_connect(&self) -> Outbound<PreventLoopback<RequireMeshIdentity<ConnectTcp>>> {
+        let connect = ConnectTcp::new(
             self.config.proxy.connect.keepalive,
             self.config.proxy.connect.user_timeout,
-        ));
+        );
+        let requirement = Requirement::new(
+            self.config.default_policy,
+            self.config.cluster_networks.clone(),
+        );
+        let connect = PreventLoopback(RequireMeshIdentity::new(connect, requirement));
         self.clone().with_stack(connect)
     }
 }
@@ -75,6 +109,78 @@ where
     }
 }
 
+// === impl RequireMeshIdentity ===
+
+impl Requirement {
+    fn new(policy: policy::DefaultPolicy, cluster_networks: IpMatch) -> Self {
+        match policy {
+            policy::DefaultPolicy::Allow => Self::Disabled,
+            policy::DefaultPolicy::RequireIdentity => Self::All,
+            policy::DefaultPolicy::RequireIdentityWithinCluster => {
+                Self::WithinCluster(cluster_networks)
+            }
+        }
+    }
+}
+
+impl<S> RequireMeshIdentity<S> {
+    fn new(inner: S, requirement: Requirement) -> Self {
+        Self { inner, requirement }
+    }
+
+    /// Returns `true` if a connection to `addr` with the given TLS status must
+    /// be refused because the target has no mesh identity.
+    fn refuses(
+        &self,
+        Remote(ServerAddr(addr)): Remote<ServerAddr>,
+        tls: tls::ConditionalClientTls,
+    ) -> bool {
+        // Only refuse when discovery declined to provide a mesh identity for
+        // the endpoint. Every other cleartext reason (loopback, identity
+        // administratively disabled, ingress without discovery) is left alone.
+        if !matches!(
+            tls,
+            tls::ConditionalClientTls::None(tls::NoClientTls::NotProvidedByServiceDiscovery)
+        ) {
+            return false;
+        }
+
+        match self.requirement {
+            Requirement::Disabled => false,
+            Requirement::All => true,
+            Requirement::WithinCluster(ref nets) => nets.matches(addr.ip()),
+        }
+    }
+}
+
+impl<T, S> svc::Service<T> for RequireMeshIdentity<S>
+where
+    T: svc::Param<Remote<ServerAddr>>,
+    T: svc::Param<tls::ConditionalClientTls>,
+    S: svc::Service<T, Error = io::Error>,
+{
+    type Response = S::Response;
+    type Error = io::Error;
+    type Future = future::Either<S::Future, future::Ready<io::Result<S::Response>>>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, ep: T) -> Self::Future {
+        if self.refuses(ep.param(), ep.param()) {
+            return future::Either::Right(future::err(io::Error::new(
+                io::ErrorKind::ConnectionRefused,
+                "Refusing cleartext connection to a target without a mesh identity \
+                 (the outbound default policy requires mTLS)",
+            )));
+        }
+
+        future::Either::Left(self.inner.call(ep))
+    }
+}
+
 // === impl Connect ===
 
 impl Connect {
@@ -103,5 +209,105 @@ impl Connect {
 
     pub fn tls(&self) -> &tls::ConditionalClientTls {
         &self.tls
+    }
+}
+
+#[cfg(test)]
+mod require_mesh_identity_tests {
+    use super::*;
+    use linkerd_app_core::{svc::ServiceExt, IpNet};
+    use std::net::SocketAddr;
+
+    /// The discovery signal for an unmeshed endpoint.
+    fn unmeshed() -> tls::ConditionalClientTls {
+        tls::ConditionalClientTls::None(tls::NoClientTls::NotProvidedByServiceDiscovery)
+    }
+
+    /// The discovery signal for a meshed endpoint: discovery provided a mesh
+    /// identity.
+    fn meshed() -> tls::ConditionalClientTls {
+        let server_id = tls::ServerId("server.id".parse().unwrap());
+        let server_name = tls::ServerName("server.name".parse().unwrap());
+        tls::ConditionalClientTls::Some(tls::ClientTls::new(server_id, server_name))
+    }
+
+    fn target(ip: [u8; 4], tls: tls::ConditionalClientTls) -> Connect {
+        Connect::new(Remote(ServerAddr(SocketAddr::new(ip.into(), 8080))), tls)
+    }
+
+    async fn connect(requirement: Requirement, target: Connect) -> io::Result<()> {
+        // A trivial inner connector that always succeeds, so the only outcome
+        // that matters is whether the guard short-circuits.
+        let inner = svc::mk(|_: Connect| future::ok::<(), io::Error>(()));
+        RequireMeshIdentity::new(inner, requirement)
+            .oneshot(target)
+            .await
+    }
+
+    fn cluster() -> IpMatch {
+        IpMatch::new(Some("10.0.0.0/8".parse::<IpNet>().unwrap()))
+    }
+
+    #[tokio::test]
+    async fn all_refuses_unmeshed() {
+        let err = connect(Requirement::All, target([192, 0, 2, 1], unmeshed()))
+            .await
+            .expect_err("unmeshed target must be refused");
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionRefused);
+    }
+
+    #[tokio::test]
+    async fn all_permits_meshed() {
+        // The primary case the feature exists for: under `all-authenticated`,
+        // a meshed target (discovery provided a mesh identity) still connects.
+        connect(Requirement::All, target([10, 1, 2, 3], meshed()))
+            .await
+            .expect("meshed target must be permitted");
+    }
+
+    #[tokio::test]
+    async fn all_permits_non_discovery_cleartext() {
+        // Cleartext reasons other than `NotProvidedByServiceDiscovery` (here,
+        // loopback) are never refused — the guard is specific to the
+        // "discovery gave us no identity" case.
+        connect(
+            Requirement::All,
+            target(
+                [127, 0, 0, 1],
+                tls::ConditionalClientTls::None(tls::NoClientTls::Loopback),
+            ),
+        )
+        .await
+        .expect("loopback (non-discovery) cleartext must be permitted");
+    }
+
+    #[tokio::test]
+    async fn disabled_permits_unmeshed() {
+        connect(Requirement::Disabled, target([192, 0, 2, 1], unmeshed()))
+            .await
+            .expect("with no enforcement, unmeshed targets connect");
+    }
+
+    #[tokio::test]
+    async fn within_cluster_refuses_in_cluster_unmeshed() {
+        let err = connect(
+            Requirement::WithinCluster(cluster()),
+            target([10, 1, 2, 3], unmeshed()),
+        )
+        .await
+        .expect_err("in-cluster unmeshed target must be refused");
+        assert_eq!(err.kind(), io::ErrorKind::ConnectionRefused);
+    }
+
+    #[tokio::test]
+    async fn within_cluster_permits_out_of_cluster_unmeshed() {
+        // Egress outside the cluster networks is permitted even without a mesh
+        // identity ("meshed OR outside the cluster").
+        connect(
+            Requirement::WithinCluster(cluster()),
+            target([192, 0, 2, 1], unmeshed()),
+        )
+        .await
+        .expect("out-of-cluster unmeshed egress must be permitted");
     }
 }

--- a/linkerd/app/outbound/src/test_util.rs
+++ b/linkerd/app/outbound/src/test_util.rs
@@ -50,6 +50,8 @@ pub(crate) fn default_config() -> Config {
             detect_protocol_timeout: Duration::from_secs(3),
         },
         inbound_ips: Default::default(),
+        default_policy: Default::default(),
+        cluster_networks: Default::default(),
         discovery_idle_timeout: Duration::from_secs(60),
         tcp_connection_queue: buffer,
         http_request_queue: buffer,

--- a/linkerd/app/src/env.rs
+++ b/linkerd/app/src/env.rs
@@ -6,7 +6,7 @@ use linkerd_app_core::{
     proxy::http::{h1, h2},
     tls,
     transport::{Backlog, DualListenAddr, Keepalive, ListenAddr, UserTimeout},
-    AddrMatch, Conditional, IpNet,
+    AddrMatch, Conditional, IpMatch, IpNet,
 };
 use std::{collections::HashSet, net::SocketAddr, path::PathBuf, time::Duration};
 use thiserror::Error;
@@ -204,6 +204,19 @@ pub const ENV_INBOUND_PORTS_REQUIRE_TLS: &str = "LINKERD2_PROXY_INBOUND_PORTS_RE
 ///
 /// By default, this is `unauthenticated`.
 pub const ENV_INBOUND_DEFAULT_POLICY: &str = "LINKERD2_PROXY_INBOUND_DEFAULT_POLICY";
+
+/// Configures the default policy for outbound connections: whether the proxy
+/// may fall back to a cleartext connection to a target endpoint that has no
+/// mesh identity.
+///
+/// The proxy accepts only the subset of the inbound value vocabulary that maps
+/// to meaningful outbound behavior: `all-unauthenticated` (permit cleartext to
+/// unmeshed targets — today's behavior), `all-authenticated` (require a mesh
+/// identity for every outbound endpoint), and `cluster-authenticated` (require
+/// a mesh identity only for endpoints within the cluster networks).
+///
+/// By default, this is `all-unauthenticated`.
+pub const ENV_OUTBOUND_DEFAULT_POLICY: &str = "LINKERD2_PROXY_OUTBOUND_DEFAULT_POLICY";
 
 pub const ENV_INBOUND_PORTS: &str = "LINKERD2_PROXY_INBOUND_PORTS";
 pub const ENV_POLICY_SVC_BASE: &str = "LINKERD2_PROXY_POLICY_SVC";
@@ -496,6 +509,14 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         std::sync::Arc::new(ips)
     };
 
+    // The cluster networks scope both the inbound and outbound cluster-scoped
+    // default policies.
+    let cluster_nets =
+        parse(strings, ENV_POLICY_CLUSTER_NETWORKS, parse_networks)?.unwrap_or_else(|| {
+            info!("{ENV_POLICY_CLUSTER_NETWORKS} not set; cluster-scoped modes are unsupported",);
+            Default::default()
+        });
+
     let outbound = {
         let ingress_mode = parse(strings, ENV_INGRESS_MODE, parse_bool)?.unwrap_or(false);
 
@@ -576,9 +597,28 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         let http_failfast_timeout =
             outbound_http_failfast_timeout?.unwrap_or(DEFAULT_OUTBOUND_HTTP_FAILFAST_TIMEOUT);
 
+        // The default outbound policy: whether the proxy may fall back to a
+        // cleartext connection to a target with no mesh identity. When unset,
+        // cleartext is permitted (preserving today's behavior).
+        let default_policy = parse(strings, ENV_OUTBOUND_DEFAULT_POLICY, |s| {
+            parse_outbound_default_policy(s, &cluster_nets)
+        })?
+        .unwrap_or_else(|| {
+            // TODO: promote to `warn!` (mirroring the inbound default policy)
+            // once the control plane always injects a value.
+            debug!(
+                "{} was not set; using `all-unauthenticated`",
+                ENV_OUTBOUND_DEFAULT_POLICY
+            );
+            outbound::policy::DefaultPolicy::Allow
+        });
+        let cluster_networks = IpMatch::new(cluster_nets.clone());
+
         outbound::Config {
             ingress_mode,
             emit_headers: !disable_headers,
+            default_policy,
+            cluster_networks,
             allow_discovery: AddrMatch::new(dst_profile_suffixes.clone(), dst_profile_networks),
             proxy: ProxyConfig {
                 server,
@@ -676,14 +716,6 @@ pub fn parse_config<S: Strings>(strings: &S) -> Result<super::Config, EnvError> 
         // identity is disabled).
         let policy = {
             let inbound_port = ListenAddr(server.addr.0).port();
-
-            let cluster_nets = parse(strings, ENV_POLICY_CLUSTER_NETWORKS, parse_networks)?
-                .unwrap_or_else(|| {
-                    info!(
-                        "{ENV_POLICY_CLUSTER_NETWORKS} not set; cluster-scoped modes are unsupported",
-                    );
-                    Default::default()
-                });
 
             // We always configure a default policy. This policy applies when no other policy is
             // configured, especially when the port is not documented in via `ENV_INBOUND_PORTS`.
@@ -1040,6 +1072,40 @@ fn parse_default_policy(
     }
 }
 
+/// Parses the default *outbound* policy.
+///
+/// The outbound default policy expresses an *mTLS requirement*: whether the
+/// proxy may fall back to a cleartext connection to a target that has no mesh
+/// identity. The accepted subset of the inbound value vocabulary is:
+///
+/// * `all-unauthenticated` (the default) permits cleartext to unmeshed targets
+///   (today's behavior).
+/// * `all-authenticated` requires a mesh identity for every outbound endpoint.
+/// * `cluster-authenticated` requires a mesh identity only for endpoints within
+///   the cluster networks; it is only accepted when
+///   `LINKERD2_PROXY_POLICY_CLUSTER_NETWORKS` is non-empty (mirroring inbound).
+///
+/// The remaining inbound values (`deny`, `cluster-unauthenticated`, `audit`)
+/// have no meaningful outbound mapping and are rejected as invalid.
+fn parse_outbound_default_policy(
+    s: &str,
+    cluster_nets: &HashSet<IpNet>,
+) -> Result<outbound::policy::DefaultPolicy, ParseError> {
+    use outbound::policy::DefaultPolicy;
+    match s {
+        "all-unauthenticated" => Ok(DefaultPolicy::Allow),
+        "all-authenticated" => Ok(DefaultPolicy::RequireIdentity),
+
+        // Cluster-scoped enforcement requires knowing the cluster networks.
+        "cluster-authenticated" if cluster_nets.is_empty() => {
+            Err(ParseError::InvalidPortPolicy(s.to_string()))
+        }
+        "cluster-authenticated" => Ok(DefaultPolicy::RequireIdentityWithinCluster),
+
+        name => Err(ParseError::InvalidPortPolicy(name.to_string())),
+    }
+}
+
 pub fn parse_backoff<S: Strings>(
     strings: &S,
     base: &str,
@@ -1097,5 +1163,102 @@ pub fn parse_control_addr<S: Strings>(
 impl Strings for std::collections::HashMap<&'static str, &'static str> {
     fn get(&self, key: &str) -> Result<Option<String>, EnvError> {
         Ok(self.get(key).map(ToString::to_string))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use outbound::policy::DefaultPolicy;
+    use std::collections::HashMap;
+
+    fn cluster_nets() -> HashSet<IpNet> {
+        Some("10.0.0.0/8".parse::<IpNet>().unwrap())
+            .into_iter()
+            .collect()
+    }
+
+    #[test]
+    fn outbound_default_policy_accepted_values() {
+        let nets = cluster_nets();
+        assert_eq!(
+            parse_outbound_default_policy("all-unauthenticated", &nets),
+            Ok(DefaultPolicy::Allow),
+        );
+        assert_eq!(
+            parse_outbound_default_policy("all-authenticated", &nets),
+            Ok(DefaultPolicy::RequireIdentity),
+        );
+        assert_eq!(
+            parse_outbound_default_policy("cluster-authenticated", &nets),
+            Ok(DefaultPolicy::RequireIdentityWithinCluster),
+        );
+    }
+
+    #[test]
+    fn outbound_default_policy_cluster_requires_cluster_networks() {
+        // `cluster-authenticated` needs cluster networks to scope enforcement;
+        // without them it is rejected (mirroring the inbound behavior).
+        let empty = HashSet::new();
+        assert_eq!(
+            parse_outbound_default_policy("cluster-authenticated", &empty),
+            Err(ParseError::InvalidPortPolicy(
+                "cluster-authenticated".to_string()
+            )),
+        );
+        // `all-unauthenticated` / `all-authenticated` do not need them.
+        assert_eq!(
+            parse_outbound_default_policy("all-unauthenticated", &empty),
+            Ok(DefaultPolicy::Allow),
+        );
+        assert_eq!(
+            parse_outbound_default_policy("all-authenticated", &empty),
+            Ok(DefaultPolicy::RequireIdentity),
+        );
+    }
+
+    #[test]
+    fn outbound_default_policy_rejects_unsupported_values() {
+        // These inbound values have no meaningful outbound mTLS mapping.
+        let nets = cluster_nets();
+        for value in ["deny", "cluster-unauthenticated", "audit", "bogus"] {
+            assert_eq!(
+                parse_outbound_default_policy(value, &nets),
+                Err(ParseError::InvalidPortPolicy(value.to_string())),
+                "{value} must be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn outbound_default_policy_env() {
+        let nets = cluster_nets();
+
+        // Unset yields `None` so the caller applies the `all-unauthenticated`
+        // default (preserving today's behavior).
+        let env = HashMap::<&'static str, &'static str>::default();
+        assert_eq!(
+            parse(&env, ENV_OUTBOUND_DEFAULT_POLICY, |s| {
+                parse_outbound_default_policy(s, &nets)
+            })
+            .unwrap(),
+            None,
+        );
+
+        let mut env = HashMap::default();
+        env.insert(ENV_OUTBOUND_DEFAULT_POLICY, "all-authenticated");
+        assert_eq!(
+            parse(&env, ENV_OUTBOUND_DEFAULT_POLICY, |s| {
+                parse_outbound_default_policy(s, &nets)
+            })
+            .unwrap(),
+            Some(DefaultPolicy::RequireIdentity),
+        );
+
+        env.insert(ENV_OUTBOUND_DEFAULT_POLICY, "nonsense");
+        assert!(parse(&env, ENV_OUTBOUND_DEFAULT_POLICY, |s| {
+            parse_outbound_default_policy(s, &nets)
+        })
+        .is_err());
     }
 }


### PR DESCRIPTION
### Problem

The outbound proxy always falls back to a cleartext connection when a target endpoint has no mesh identity (i.e. is not meshed). Operators who want to restrict a workload to only communicate with meshed targets (or targets outside the cluster) cannot enforce this: unmeshed, in-cluster destinations are silently reached in the clear.

### Solution

Add `LINKERD2_PROXY_OUTBOUND_DEFAULT_POLICY`, the outbound counterpart to `LINKERD2_PROXY_INBOUND_DEFAULT_POLICY`. Whether a target is meshed is only known once an endpoint is resolved (a meshed endpoint carries a mesh identity in its discovery metadata), so the policy is enforced at connect time by a new `RequireMeshIdentity` guard in the shared TCP connect stack. The guard refuses a cleartext connection when discovery provided no mesh identity for the endpoint
(`ConditionalClientTls::None(NotProvidedByServiceDiscovery)`).

Supported values:
- `all-unauthenticated` (default): unchanged; cleartext permitted.
- `all-authenticated`: require mTLS for every outbound endpoint.
- `cluster-authenticated`: require mTLS only for endpoints within `LINKERD2_PROXY_POLICY_CLUSTER_NETWORKS`; egress outside the cluster is permitted in the clear.

Other cleartext reasons (loopback, identity disabled, ingress without discovery) are never refused, and the default (`all-unauthenticated`) is byte-for-byte unchanged.

### Validation

Added unit tests for env parsing (accepted values, the cluster-networks requirement, rejected values, unset) and behavioral tests for the connect-time guard (in-cluster unmeshed refused; out-of-cluster unmeshed permitted under cluster-authenticated; `all-authenticated` refuses any unmeshed target; non-discovery cleartext permitted; default never refuses).

---

Fixes linkerd/linkerd2#15615
