### PR TITLE
feat(http): add max connection age for HTTP/2 server connections

### DIFF
--- a/linkerd/app/src/env/http2.rs
+++ b/linkerd/app/src/env/http2.rs
@@ -9,6 +9,11 @@ pub(super) fn parse_server<S: Strings>(
     Ok(ServerParams {
         flow_control: Some(parse_flow_control(strings, base)?),
         keep_alive: parse_keep_alive(strings, &format!("{base}_KEEP_ALIVE"))?,
+        max_connection_age: parse(
+            strings,
+            &format!("{base}_MAX_CONNECTION_AGE"),
+            parse_duration,
+        )?,
         max_concurrent_streams: parse(
             strings,
             &format!("{base}_MAX_CONCURRENT_STREAMS"),
@@ -107,6 +112,7 @@ mod tests {
         env.insert("TEST_KEEP_ALIVE_INTERVAL", "2s");
         env.insert("TEST_INITIAL_STREAM_WINDOW_SIZE", "1");
         env.insert("TEST_INITIAL_CONNECTION_WINDOW_SIZE", "2");
+        env.insert("TEST_MAX_CONNECTION_AGE", "900s");
         let expected = h2::ServerParams {
             flow_control: Some(h2::FlowControl::Fixed {
                 initial_stream_window_size: 1,
@@ -116,6 +122,7 @@ mod tests {
                 interval: Duration::from_secs(2),
                 timeout: Duration::from_secs(1),
             }),
+            max_connection_age: Some(Duration::from_secs(900)),
             max_concurrent_streams: Some(3),
             max_frame_size: Some(4),
             max_header_list_size: Some(5),

--- a/linkerd/app/src/env/http2.rs
+++ b/linkerd/app/src/env/http2.rs
@@ -154,4 +154,31 @@ mod tests {
             }
         );
     }
+
+    /// Like every other SERVER_HTTP2 setting, max connection age is parsed
+    /// under both the inbound and outbound server prefixes.
+    #[test]
+    fn max_connection_age_parses_for_both_servers() {
+        let mut env = HashMap::default();
+        env.insert(
+            "LINKERD2_PROXY_INBOUND_SERVER_HTTP2_MAX_CONNECTION_AGE",
+            "15m",
+        );
+        env.insert(
+            "LINKERD2_PROXY_OUTBOUND_SERVER_HTTP2_MAX_CONNECTION_AGE",
+            "1h",
+        );
+
+        let inbound = parse_server(&env, "LINKERD2_PROXY_INBOUND_SERVER_HTTP2").unwrap();
+        assert_eq!(
+            inbound.max_connection_age,
+            Some(Duration::from_secs(15 * 60))
+        );
+
+        let outbound = parse_server(&env, "LINKERD2_PROXY_OUTBOUND_SERVER_HTTP2").unwrap();
+        assert_eq!(
+            outbound.max_connection_age,
+            Some(Duration::from_secs(60 * 60))
+        );
+    }
 }

--- a/linkerd/http/h2/src/lib.rs
+++ b/linkerd/http/h2/src/lib.rs
@@ -5,6 +5,11 @@ pub struct ServerParams {
     pub flow_control: Option<FlowControl>,
     pub keep_alive: Option<KeepAlive>,
     pub max_concurrent_streams: Option<u32>,
+    /// If set, server connections are gracefully shut down (GOAWAY) after this
+    /// age, bounding how long a pooled peer connection (and the buffer
+    /// high-water memory it retains) can live. A per-connection jitter of up
+    /// to +10% is applied to avoid synchronized shutdowns.
+    pub max_connection_age: Option<Duration>,
 
     // Internals
     pub max_frame_size: Option<u32>,

--- a/linkerd/http/h2/src/lib.rs
+++ b/linkerd/http/h2/src/lib.rs
@@ -5,10 +5,6 @@ pub struct ServerParams {
     pub flow_control: Option<FlowControl>,
     pub keep_alive: Option<KeepAlive>,
     pub max_concurrent_streams: Option<u32>,
-    /// If set, server connections are gracefully shut down (GOAWAY) after this
-    /// age, bounding how long a pooled peer connection (and the buffer
-    /// high-water memory it retains) can live. A per-connection jitter of up
-    /// to +10% is applied to avoid synchronized shutdowns.
     pub max_connection_age: Option<Duration>,
 
     // Internals

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -8,9 +8,10 @@ use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
+    time::Duration,
 };
 use tower::Service;
-use tracing::{debug, Instrument};
+use tracing::{debug, info, Instrument};
 
 #[cfg(test)]
 mod tests;
@@ -36,6 +37,7 @@ pub struct ServeHttp<N> {
     version: Variant,
     http1: hyper::server::conn::http1::Builder,
     http2: hyper::server::conn::http2::Builder<TokioExecutor>,
+    max_connection_age: Option<Duration>,
     inner: N,
     drain: drain::Watch,
 }
@@ -70,6 +72,7 @@ where
             keep_alive,
             flow_control,
             max_concurrent_streams,
+            max_connection_age,
             max_frame_size,
             max_header_list_size,
             max_send_buf_size,
@@ -124,6 +127,7 @@ where
             drain,
             http1,
             http2,
+            max_connection_age,
         }
     }
 }
@@ -154,17 +158,18 @@ where
         let drain = self.drain.clone();
         let http1 = self.http1.clone();
         let http2 = self.http2.clone();
+        let max_connection_age = self.max_connection_age;
 
         let res = io.peer_addr().map(|pa| {
             let (handle, closed) = ClientHandle::new(pa);
             let svc = self.inner.new_service(handle.clone());
             let svc = SetClientHandle::new(handle, svc);
-            (svc, closed)
+            (svc, closed, pa)
         });
 
         Box::pin(
             async move {
-                let (svc, closed) = res?;
+                let (svc, closed, peer) = res?;
                 debug!(?version, "Handling as HTTP");
                 match version {
                     Variant::Http1 => {
@@ -201,6 +206,24 @@ where
                         let io = hyper_util::rt::TokioIo::new(io);
                         let mut conn = http2.serve_connection(io, svc);
 
+                        // Bound the connection's lifetime if a max age is
+                        // configured, so long-lived pooled peer connections
+                        // (and the buffer high-water memory they retain) are
+                        // periodically recycled. A deterministic per-connection
+                        // jitter of up to +10%, derived from the client's
+                        // ephemeral port, avoids synchronized shutdowns.
+                        let max_age = async move {
+                            match max_connection_age {
+                                Some(age) => {
+                                    let jitter =
+                                        age.mul_f64(f64::from(peer.port() % 128) / 1280.0);
+                                    tokio::time::sleep(age + jitter).await;
+                                }
+                                None => std::future::pending().await,
+                            }
+                        };
+                        tokio::pin!(max_age);
+
                         tokio::select! {
                             res = &mut conn => {
                                 debug!(?res, "The client is shutting down the connection");
@@ -213,6 +236,11 @@ where
                             }
                             () = closed => {
                                 debug!("The stack is tearing down the connection");
+                                Pin::new(&mut conn).graceful_shutdown();
+                                conn.await?;
+                            }
+                            () = &mut max_age => {
+                                info!(client.addr = %peer, "Max connection age reached; gracefully shutting down the connection");
                                 Pin::new(&mut conn).graceful_shutdown();
                                 conn.await?;
                             }

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -31,6 +31,19 @@ pub struct NewServeHttp<X, N> {
     params: X,
 }
 
+/// How a served connection is being torn down, as decided by the serve loop's
+/// completion branches.
+enum Teardown {
+    /// The client closed the connection; nothing left to do.
+    ClientClosed,
+    /// The process is draining: shut down gracefully, holding the drain
+    /// release guard until the connection closes.
+    Drain(drain::ReleaseShutdown),
+    /// Stack teardown or max connection age: shut down gracefully, then wait
+    /// for the connection to close.
+    Graceful,
+}
+
 /// Serves HTTP connections with an inner service.
 #[derive(Clone, Debug)]
 pub struct ServeHttp<N> {
@@ -160,16 +173,16 @@ where
         let http2 = self.http2.clone();
         let max_connection_age = self.max_connection_age;
 
-        let res = io.peer_addr().map(|pa| {
-            let (handle, closed) = ClientHandle::new(pa);
+        let res = io.peer_addr().map(|peer_addr| {
+            let (handle, closed) = ClientHandle::new(peer_addr);
             let svc = self.inner.new_service(handle.clone());
             let svc = SetClientHandle::new(handle, svc);
-            (svc, closed, pa)
+            (svc, closed, peer_addr)
         });
 
         Box::pin(
             async move {
-                let (svc, closed, peer) = res?;
+                let (svc, closed, peer_addr) = res?;
                 debug!(?version, "Handling as HTTP");
                 match version {
                     Variant::Http1 => {
@@ -216,7 +229,7 @@ where
                             match max_connection_age {
                                 Some(age) => {
                                     let jitter =
-                                        age.mul_f64(f64::from(peer.port() % 128) / 1280.0);
+                                        age.mul_f64(f64::from(peer_addr.port() % 128) / 1280.0);
                                     tokio::time::sleep(age + jitter).await;
                                 }
                                 None => std::future::pending().await,
@@ -224,23 +237,33 @@ where
                         };
                         tokio::pin!(max_age);
 
-                        tokio::select! {
+                        let teardown = tokio::select! {
                             res = &mut conn => {
                                 debug!(?res, "The client is shutting down the connection");
-                                res?
+                                res?;
+                                Teardown::ClientClosed
                             }
                             shutdown = drain.signaled() => {
                                 debug!("The process is shutting down the connection");
-                                Pin::new(&mut conn).graceful_shutdown();
-                                shutdown.release_after(conn).await?;
+                                Teardown::Drain(shutdown)
                             }
                             () = closed => {
                                 debug!("The stack is tearing down the connection");
-                                Pin::new(&mut conn).graceful_shutdown();
-                                conn.await?;
+                                Teardown::Graceful
                             }
                             () = &mut max_age => {
-                                debug!(client.addr = %peer, "Max connection age reached; gracefully shutting down the connection");
+                                debug!(client.addr = %peer_addr, "Max connection age reached; gracefully shutting down the connection");
+                                Teardown::Graceful
+                            }
+                        };
+
+                        match teardown {
+                            Teardown::ClientClosed => {}
+                            Teardown::Drain(shutdown) => {
+                                Pin::new(&mut conn).graceful_shutdown();
+                                shutdown.release_after(conn).await?;
+                            }
+                            Teardown::Graceful => {
                                 Pin::new(&mut conn).graceful_shutdown();
                                 conn.await?;
                             }

--- a/linkerd/proxy/http/src/server.rs
+++ b/linkerd/proxy/http/src/server.rs
@@ -11,7 +11,7 @@ use std::{
     time::Duration,
 };
 use tower::Service;
-use tracing::{debug, info, Instrument};
+use tracing::{debug, Instrument};
 
 #[cfg(test)]
 mod tests;
@@ -240,7 +240,7 @@ where
                                 conn.await?;
                             }
                             () = &mut max_age => {
-                                info!(client.addr = %peer, "Max connection age reached; gracefully shutting down the connection");
+                                debug!(client.addr = %peer, "Max connection age reached; gracefully shutting down the connection");
                                 Pin::new(&mut conn).graceful_shutdown();
                                 conn.await?;
                             }

--- a/linkerd/proxy/http/src/server/tests.rs
+++ b/linkerd/proxy/http/src/server/tests.rs
@@ -159,6 +159,76 @@ async fn h2_stream_window_exhaustion() {
     */
 }
 
+/// Tests that a server connection is gracefully shut down after its max
+/// connection age elapses: in-flight streams complete, but the connection is
+/// then closed so the client must reconnect.
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn h2_max_connection_age() {
+    let _trace = linkerd_tracing::test::with_default_filter(LOG_LEVEL);
+
+    const MAX_AGE: time::Duration = time::Duration::from_secs(10);
+    // The effective age includes a deterministic per-connection jitter of up
+    // to +10%; sleep comfortably past it.
+    const PAST_AGE: time::Duration = time::Duration::from_secs(12);
+
+    let mut server = TestServer::connect_h2(
+        h2::ServerParams {
+            max_connection_age: Some(MAX_AGE),
+            ..Default::default()
+        },
+        hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+            .timer(hyper_util::rt::TokioTimer::new()),
+    )
+    .await;
+
+    let bytes = Bytes::from_static(b"hello");
+
+    tracing::info!("Before the age elapses, requests are served normally");
+    let rx = timeout(server.respond(bytes.clone()))
+        .await
+        .expect("timed out");
+    let body = timeout(rx.collect())
+        .await
+        .expect("response timed out")
+        .expect("response");
+    assert_eq!(body.to_bytes(), bytes);
+
+    tracing::info!("A stream that is in flight when the age elapses still completes");
+    let (mut tx, mut body) = timeout(server.get()).await.expect("timed out");
+    time::sleep(PAST_AGE).await;
+    tx.send_data(bytes.clone())
+        .await
+        .expect("in-flight stream remains writable after the age elapses");
+    drop(tx);
+    let data = body
+        .frame()
+        .await
+        .expect("yields a result")
+        .expect("yields a frame")
+        .into_data()
+        .expect("yields data");
+    assert_eq!(data, bytes);
+    // Drain the body to its end; only an empty end-of-stream frame may remain.
+    while let Some(frame) = timeout(body.frame()).await.expect("body ends") {
+        let frame = frame.expect("body yields frames until end");
+        if let Ok(data) = frame.into_data() {
+            assert!(data.is_empty(), "no more data expected");
+        }
+    }
+
+    tracing::info!("Once in-flight streams complete, the connection is closed");
+    timeout(async {
+        loop {
+            if server.client.ready().await.is_err() {
+                return;
+            }
+            time::sleep(time::Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("client should observe the connection closing");
+}
+
 // === Utilities ===
 
 const LOG_LEVEL: &str = "h2::proto=trace,hyper=trace,linkerd=trace,info";


### PR DESCRIPTION
Addresses linkerd/linkerd2#15623.

## Problem

Pooled proxy-to-proxy HTTP/2 connections currently live forever: TCP and HTTP/2 keepalives keep them healthy indefinitely, `MAX_IDLE_CONNS_PER_ENDPOINT` (default 10,000) only caps the count, the HTTP/1 pool idle timeout doesn't apply to them, and the outbound discovery idle timeout only fires when a service receives no traffic at all. As far as we can tell there is no setting that closes a pooled connection for being idle or bounds its lifetime (checked `linkerd/app/src/env.rs` on `main` and back through `v2.311.0`).

This matters for memory: each held server-side connection retains its receive-buffer high-water mark — bounded by the connection window (1MB default) — for its entire lifetime. In our mesh (arm64 EKS), a large caller fleet holds ~300 pooled connections into each server pod; after ~300 rps load bursts we measured ~700KB retained per connection, i.e. ~200MB of proxy RSS per pod that was only ever released when peer pods restarted. Verified via `tcp_open_total`/`tcp_close_total` accounting on the admin endpoint — the pooling itself works as designed; the cost is the unbounded buffer lifetime.

## Change

Adds a `max_connection_age` setting to the shared HTTP/2 `ServerParams`, configurable per server prefix like every other `SERVER_HTTP2` setting:

- `LINKERD2_PROXY_INBOUND_SERVER_HTTP2_MAX_CONNECTION_AGE` (duration) — the inbound proxy-to-proxy listener, where pooled peer connections accumulate;
- `LINKERD2_PROXY_OUTBOUND_SERVER_HTTP2_MAX_CONNECTION_AGE` (duration) — the outbound (app-facing) listener, for symmetry with the other paired settings.

**Unset (the default) preserves current behavior exactly.** The admin server builds its params with `Default::default()` and is unaffected regardless of environment.

When set, the HTTP/2 serve loop arms a timer as an additional `select!` branch alongside the existing drain/teardown triggers, reusing the same `graceful_shutdown()` (GOAWAY) path: no new streams are accepted, in-flight streams run to completion, then the connection closes and the client reconnects transparently — the identical sequence every pod drain already exercises. A deterministic per-connection jitter of up to +10% (derived from the client's ephemeral port; no new dependency) prevents synchronized shutdown storms. Each shutdown is logged at DEBUG with the client address.

Includes an integration test covering: requests served normally before the age elapses, an in-flight stream completing across the age boundary, and the connection closing once drained — plus an env test asserting the setting parses independently under both server prefixes.

## Results from our environment (15m age, production-like mesh)

- Proxy RSS became a bounded ~15-minute sawtooth instead of a monotonic plateau — buffers released every cycle with no pod restarts. (Observed on a build with jemalloc enabled on aarch64 — see #4613 — so freed memory was actually returned to the OS.)
- Zero failed requests across many recycle cycles; p50/p99 unchanged through recycle waves.
- Cost: one TLS handshake per connection per age period, spread over ~90s by the jitter — below measurement noise in-cluster.

Similar in spirit to gRPC's `MAX_CONNECTION_AGE`; follows the same params/env plumbing pattern as #4542.
