### PR TITLE
fix(retry): avoid replaying unread body data

### DIFF
--- a/linkerd/http/retry/src/replay.rs
+++ b/linkerd/http/retry/src/replay.rs
@@ -189,6 +189,7 @@ where
                 tracing::trace!("Cannot replay buffered body, maximum buffer length reached");
                 return Poll::Ready(Some(Err(Capped.into())));
             }
+            this.replay_body = false;
         }
         if this.replay_trailers {
             this.replay_trailers = false;

--- a/linkerd/http/retry/src/replay/tests.rs
+++ b/linkerd/http/retry/src/replay/tests.rs
@@ -47,6 +47,23 @@ async fn replays_one_chunk() {
 }
 
 #[tokio::test]
+async fn replays_unpolled_body() {
+    let Test {
+        mut tx,
+        initial,
+        replay,
+        _trace,
+    } = Test::new();
+    tx.send_data("hello world").await;
+    drop(tx);
+    drop(initial);
+
+    let (data, trailers) = body_to_string(replay).await;
+    assert_eq!(data, "hello world");
+    assert_eq!(trailers, None);
+}
+
+#[tokio::test]
 async fn replays_several_chunks() {
     let Test {
         mut tx,


### PR DESCRIPTION
Fixes linkerd/linkerd2#15649

## Background

When a retry starts with an empty replay buffer, `replay_body` remains set while the original body is polled. The first DATA chunk is forwarded and buffered, then replayed on the next poll within the same attempt.

## Changes

- Clear `replay_body` when the replay buffer is empty and uncapped, before polling the original body
- Add a regression test verifying that an unpolled body is returned exactly once

## Validation

- [x] Regression test reproduces duplicated bytes before the fix
- [x] All 24 retry crate tests pass on this branch
- [x] Applying the fix and regression test to upstream `a66af811` passes all 25 retry crate tests
- [x] [Docker reproducer](https://github.com/cprayer/linkerd-replay-body-repro): 10 runs, each with 29–30 duplicated bodies before the fix and zero afterward; consumed-body 503, early 503, and healthy-backend checks also pass

AI tools assisted with the investigation, reproducer, and PR description.